### PR TITLE
[LWDM] feat(cosmos): integrate coin module alpaca api and cover by coin tester

### DIFF
--- a/.changeset/gorgeous-carpets-smash.md
+++ b/.changeset/gorgeous-carpets-smash.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-tester-cosmos": minor
+"@ledgerhq/coin-cosmos": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(cosmos): integrate coin module alpaca api and cover by coin tester

--- a/libs/coin-modules/coin-cosmos/.unimportedrc.json
+++ b/libs/coin-modules/coin-cosmos/.unimportedrc.json
@@ -34,6 +34,7 @@
     "src/createTransaction.ts",
     "src/estimateMaxSpendable.ts",
     "src/getTransactionStatus.ts",
+    "src/logic/staking/getRedelegations.ts",
     "src/prepareTransaction.ts",
     "src/signOperation.ts",
     "src/synchronisation.ts",

--- a/libs/coin-modules/coin-cosmos/src/CosmosValidatorsManager.ts
+++ b/libs/coin-modules/coin-cosmos/src/CosmosValidatorsManager.ts
@@ -1,3 +1,4 @@
+import { EnvName, EnvValue } from "@ledgerhq/live-env";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
@@ -10,7 +11,7 @@ export class CosmosValidatorsManager {
   protected _version: string;
   protected _currency!: CryptoCurrency;
   protected _minDenom!: string;
-  protected _endPoint: string | undefined;
+  protected _endPoint: EnvValue<EnvName> | undefined;
   protected _rewardsState: any | undefined;
   private _crypto: cosmosBase;
 
@@ -18,7 +19,7 @@ export class CosmosValidatorsManager {
     currency: CryptoCurrency,
     options?: {
       namespace?: string;
-      endPoint?: string;
+      endPoint?: EnvValue<EnvName>;
       rewardsState?: any;
     },
   ) {

--- a/libs/coin-modules/coin-cosmos/src/CosmosValidatorsManager.ts
+++ b/libs/coin-modules/coin-cosmos/src/CosmosValidatorsManager.ts
@@ -1,4 +1,3 @@
-import { EnvName, EnvValue } from "@ledgerhq/live-env";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
@@ -11,7 +10,7 @@ export class CosmosValidatorsManager {
   protected _version: string;
   protected _currency!: CryptoCurrency;
   protected _minDenom!: string;
-  protected _endPoint: EnvValue<EnvName> | undefined;
+  protected _endPoint: string | undefined;
   protected _rewardsState: any | undefined;
   private _crypto: cosmosBase;
 
@@ -19,7 +18,7 @@ export class CosmosValidatorsManager {
     currency: CryptoCurrency,
     options?: {
       namespace?: string;
-      endPoint?: EnvValue<EnvName>;
+      endPoint?: string;
       rewardsState?: any;
     },
   ) {

--- a/libs/coin-modules/coin-cosmos/src/api/index.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/api/index.unit.test.ts
@@ -13,6 +13,7 @@ jest.mock("../network/Cosmos", () => ({
     getValidators: jest.fn().mockResolvedValue([]),
     getDelegations: jest.fn().mockResolvedValue([]),
     getUnbondings: jest.fn().mockResolvedValue([]),
+    getStakingPositions: jest.fn().mockResolvedValue({ delegations: [], unbondings: [] }),
     broadcastRawTransaction: jest.fn().mockResolvedValue("HASH"),
   })),
 }));
@@ -69,7 +70,7 @@ describe("api/createApi", () => {
     const api = createApi(config, "cosmos");
 
     await expect(api.getBalance("cosmos1a")).resolves.toEqual([
-      { value: 0n, asset: { type: "native" } },
+      { value: 0n, asset: { type: "native" }, locked: 0n },
     ]);
     await expect(api.getNextSequence("cosmos1a")).resolves.toBe(0n);
     await expect(api.lastBlock()).resolves.toHaveProperty("height", 1);

--- a/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.msw.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.msw.test.ts
@@ -4,6 +4,17 @@ import { getBalance } from "./getBalance";
 
 const ADDR = "cosmos1w2q5xd8nhylu4vj28vpzfgag7msfxf0vx88wfq";
 const BAL = `${TEST_COSMOS_ENDPOINT}/cosmos/bank/v1beta1/balances/${ADDR}`;
+const DELEGATIONS = `${TEST_COSMOS_ENDPOINT}/cosmos/staking/v1beta1/delegations/${ADDR}`;
+const REWARDS = `${TEST_COSMOS_ENDPOINT}/cosmos/distribution/v1beta1/delegators/${ADDR}/rewards`;
+const UNBONDINGS = `${TEST_COSMOS_ENDPOINT}/cosmos/staking/v1beta1/delegators/${ADDR}/unbonding_delegations`;
+
+// getBalance also fetches staking positions to compute `locked`; mock them empty so `locked` = 0
+// and the native value stays the pure liquid balance.
+const emptyStaking = [
+  http.get(DELEGATIONS, () => HttpResponse.json({ delegation_responses: [] })),
+  http.get(REWARDS, () => HttpResponse.json({ rewards: [] })),
+  http.get(UNBONDINGS, () => HttpResponse.json({ unbonding_responses: [] })),
+];
 
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => server.resetHandlers());
@@ -21,6 +32,7 @@ describe("getBalance via MSW", () => {
           ],
         }),
       ),
+      ...emptyStaking,
     );
 
     const [native] = await getBalance(api, ADDR);
@@ -31,7 +43,10 @@ describe("getBalance via MSW", () => {
 
   it("returns zero when the address holds no uatom", async () => {
     const api = makeTestApi("cosmos", TEST_COSMOS_ENDPOINT);
-    server.use(http.get(BAL, () => HttpResponse.json({ balances: [] })));
+    server.use(
+      http.get(BAL, () => HttpResponse.json({ balances: [] })),
+      ...emptyStaking,
+    );
 
     const [native] = await getBalance(api, ADDR);
 
@@ -40,7 +55,10 @@ describe("getBalance via MSW", () => {
 
   it("throws when the balances endpoint errors", async () => {
     const api = makeTestApi("cosmos", TEST_COSMOS_ENDPOINT);
-    server.use(http.get(BAL, () => new HttpResponse(null, { status: 500 })));
+    server.use(
+      http.get(BAL, () => new HttpResponse(null, { status: 500 })),
+      ...emptyStaking,
+    );
 
     await expect(getBalance(api, ADDR)).rejects.toThrow();
   });

--- a/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.ts
@@ -1,15 +1,31 @@
 import { Balance } from "@ledgerhq/coin-module-framework/api/index";
 import { CosmosAPI } from "../../network/Cosmos";
+import { buildStakes } from "../staking/toStakes";
 
-/** Single-asset (native gas token) — returns one native {@link Balance}, no token balances. */
+/**
+ * Native balance plus one stake-carrying balance per delegation/unbonding. `value` = liquid +
+ * staked/unbonding principal; `locked` = that principal, so spendable = liquid.
+ */
 export async function getBalance(api: CosmosAPI, address: string): Promise<Balance[]> {
   const currency = api.getCurrency();
-  const amount = await api.getAllBalances(address, currency);
+  const [liquid, positions] = await Promise.all([
+    api.getAllBalances(address, currency),
+    api.getStakingPositions(address, currency),
+  ]);
 
-  return [
-    {
-      value: BigInt(amount.toFixed()),
-      asset: { type: "native" },
-    },
-  ];
+  const stakes = buildStakes(address, positions);
+  const locked = stakes.reduce((acc, s) => acc + s.amount, 0n);
+
+  const native: Balance = {
+    value: BigInt(liquid.toFixed()) + locked,
+    asset: { type: "native" },
+    locked,
+  };
+  const stakeBalances: Balance[] = stakes.map(stake => ({
+    value: stake.amount,
+    asset: { type: "native" },
+    stake,
+  }));
+
+  return [native, ...stakeBalances];
 }

--- a/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/account/getBalance.unit.test.ts
@@ -7,6 +7,7 @@ describe("logic/account/getBalance", () => {
     const api = {
       getCurrency: () => ({ id: "cosmos", units: [{}, { code: "uatom" }] }),
       getAllBalances: jest.fn().mockResolvedValue(new BigNumber("1500000")),
+      getStakingPositions: jest.fn().mockResolvedValue({ delegations: [], unbondings: [] }),
     } as unknown as CosmosAPI;
 
     const balances = await getBalance(api, "cosmos1abc");
@@ -18,12 +19,14 @@ describe("logic/account/getBalance", () => {
     expect(balances).toHaveLength(1);
     expect(balances[0].value).toBe(1500000n);
     expect(balances[0].asset).toEqual({ type: "native" });
+    expect(balances[0].locked).toBe(0n);
   });
 
   it("returns a zero native balance for a pristine account", async () => {
     const api = {
       getCurrency: () => ({ id: "cosmos", units: [{}, { code: "uatom" }] }),
       getAllBalances: jest.fn().mockResolvedValue(new BigNumber("0")),
+      getStakingPositions: jest.fn().mockResolvedValue({ delegations: [], unbondings: [] }),
     } as unknown as CosmosAPI;
 
     const balances = await getBalance(api, "cosmos1pristine");
@@ -31,5 +34,41 @@ describe("logic/account/getBalance", () => {
     expect(balances).toHaveLength(1);
     expect(balances[0].value).toBe(0n);
     expect(balances[0].asset).toEqual({ type: "native" });
+    expect(balances[0].locked).toBe(0n);
+  });
+
+  it("returns a native balance (value incl staked, locked=staked) plus per-position stake balances", async () => {
+    const api = {
+      getCurrency: () => ({ id: "cosmos", units: [{}, { code: "uatom" }] }),
+      getAllBalances: jest.fn().mockResolvedValue(new BigNumber("7000000")), // liquid
+      getStakingPositions: jest.fn().mockResolvedValue({
+        delegations: [
+          {
+            validatorAddress: "cosmosvaloper1v",
+            amount: new BigNumber("1000000"),
+            pendingRewards: new BigNumber("2500"),
+            status: "bonded",
+          },
+        ],
+        unbondings: [
+          {
+            validatorAddress: "cosmosvaloper1v",
+            amount: new BigNumber("500000"),
+            completionDate: new Date(Date.now() + 86_400_000),
+          },
+        ],
+      }),
+    } as unknown as CosmosAPI;
+
+    const balances = await getBalance(api, "cosmos1a");
+
+    const native = balances[0];
+    expect(native.asset).toEqual({ type: "native" });
+    expect(native.value).toBe(8_500_000n); // 7,000,000 liquid + 1,000,000 delegated + 500,000 unbonding
+    expect(native.locked).toBe(1_500_000n); // delegated + unbonding (rewards excluded)
+    const stakeBalances = balances.slice(1);
+    expect(stakeBalances).toHaveLength(2);
+    expect(stakeBalances[0].stake?.delegate).toBe("cosmosvaloper1v");
+    expect(stakeBalances[0].value).toBe(1_000_000n); // principal
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.msw.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.msw.test.ts
@@ -56,7 +56,7 @@ describe("listOperations via MSW", () => {
     expect(page.items).toHaveLength(1);
     const op = page.items[0];
     expect(op.type).toBe("OUT");
-    expect(op.value).toBe(2_005_000n); // amount (2_000_000) + fee (5_000), sender pays fees
+    expect(op.value).toBe(2_000_000n); // OUT value excludes fee (framework re-adds it, so we avoid double-counting)
     expect(op.senders).toEqual([ADDR]);
     expect(op.recipients).toEqual(["cosmos1recipient00000000000000000000000000"]);
     expect(op.asset).toEqual({ type: "native" });

--- a/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.ts
@@ -7,14 +7,28 @@ import { CosmosTx } from "../../types";
 // Default page size when the caller gives no limit — bounds the fetch instead of the full history.
 const PAGE_SIZE = 100;
 
+// The generic framework re-adds the fee to value for these outgoing native types, but the parser
+// already folds it into op.value — so emit value excluding fee to avoid double-counting.
+const FEE_READDED_BY_FRAMEWORK = new Set(["OUT", "DELEGATE", "UNDELEGATE", "REDELEGATE"]);
+
 function toOperation(op: CosmosParsedOperation): Operation {
   const details = toOperationExtraRaw(op.extra) as Record<string, unknown>;
+  const value = FEE_READDED_BY_FRAMEWORK.has(op.type) ? op.value.minus(op.fee) : op.value;
+  // The generic op adapter forwards only `details.stake`, not cosmos's `validators` array — mirror
+  // validators[0] so the generic-adapter sees the same delegate/undelegate/reward target as legacy.
+  const validator = op.extra.validators?.[0];
+  if (validator) {
+    details.stake = {
+      address: validator.address,
+      amount: BigInt(validator.amount.integerValue().toFixed()),
+    };
+  }
   return {
     id: op.hash,
     type: op.type,
     senders: op.senders,
     recipients: op.recipients,
-    value: BigInt(op.value.integerValue().toFixed()),
+    value: BigInt(value.integerValue().toFixed()),
     // Single-asset module — every op reported native (IBC/token denoms not surfaced).
     asset: { type: "native" },
     ...(Object.keys(details).length > 0 ? { details } : {}),

--- a/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/history/listOperations.unit.test.ts
@@ -84,7 +84,8 @@ describe("logic/history/listOperations", () => {
     expect(page.items).toHaveLength(1);
     const op = page.items[0];
     expect(op.type).toBe("OUT");
-    expect(op.value).toBe(1_000_500n);
+    // value excludes fee (CoinModuleApi convention); the generic framework re-adds it for OUT.
+    expect(op.value).toBe(1_000_000n);
     expect(op.senders).toEqual([ADDR]);
     expect(op.recipients).toEqual(["cosmos1recipient"]);
     expect(op.asset).toEqual({ type: "native" });
@@ -103,6 +104,14 @@ describe("logic/history/listOperations", () => {
     const details = page.items[0].details as { validators: { amount: unknown }[] };
     expect(details.validators[0].amount).toBe("1000000");
     expect(typeof details.validators[0].amount).toBe("string");
+  });
+
+  it("mirrors the first validator into details.stake (bigint) for the generic framework's operation adapter", async () => {
+    const page = await listOperations(apiWith([makeDelegateTx()]), ADDR, {
+      minHeight: 0,
+    });
+    const details = page.items[0].details as { stake: { address: string; amount: bigint } };
+    expect(details.stake).toEqual({ address: "cosmosvaloper1v", amount: 1_000_000n });
   });
 
   it("dedupes a tx returned in both the sender and recipient streams", async () => {

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/getRedelegations.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/getRedelegations.ts
@@ -1,0 +1,16 @@
+import { CosmosAPI } from "../../network/Cosmos";
+import { CosmosRedelegation } from "../../types";
+
+/**
+ * A redelegation (source + destination validator) can't be modelled as a single getBalance `Stake`,
+ * so it's fetched here for the `enrichStakingResources` hook — executed plus, on epoched chains, the
+ * queued x/epoching ones. Returns the neutral `CosmosRedelegation` (structurally a
+ * `StakingRedelegation`) so the logic layer stays free of `@ledgerhq/types-live`.
+ */
+export async function getRedelegations(
+  currencyId: string,
+  address: string,
+): Promise<CosmosRedelegation[]> {
+  const api = new CosmosAPI(currencyId);
+  return api.getRedelegationsWithQueued(address, api.getCurrency());
+}

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/getRedelegations.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/getRedelegations.unit.test.ts
@@ -1,0 +1,39 @@
+import BigNumber from "bignumber.js";
+import { getRedelegations } from "./getRedelegations";
+
+const mockGetRedelegationsWithQueued = jest.fn();
+jest.mock("../../network/Cosmos", () => ({
+  CosmosAPI: jest.fn().mockImplementation(() => ({
+    getCurrency: () => ({ id: "cosmos", units: [{}, { code: "uatom" }] }),
+    getRedelegationsWithQueued: mockGetRedelegationsWithQueued,
+  })),
+}));
+
+describe("logic/staking/getRedelegations", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns executed + queued redelegations from the network layer", async () => {
+    const redelegations = [
+      {
+        validatorSrcAddress: "cosmosvaloper1src",
+        validatorDstAddress: "cosmosvaloper1dst",
+        amount: new BigNumber("1000000"),
+        completionDate: new Date("2026-01-01T00:00:00Z"),
+      },
+    ];
+    mockGetRedelegationsWithQueued.mockResolvedValue(redelegations);
+
+    const result = await getRedelegations("cosmos", "cosmos1a");
+
+    expect(result).toEqual(redelegations);
+    expect(mockGetRedelegationsWithQueued).toHaveBeenCalledWith(
+      "cosmos1a",
+      expect.objectContaining({ id: "cosmos" }),
+    );
+  });
+
+  it("returns an empty array when the account has no redelegations", async () => {
+    mockGetRedelegationsWithQueued.mockResolvedValue([]);
+    expect(await getRedelegations("cosmos", "cosmos1a")).toEqual([]);
+  });
+});

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.msw.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.msw.test.ts
@@ -61,8 +61,8 @@ describe("getStakes via MSW", () => {
     expect(active!.state).toBe("active");
     expect(active!.amountDeposited).toBe(1_000_000n);
     expect(active!.amountRewarded).toBe(500n);
-    // amount = amountDeposited + amountRewarded (getStakes.ts): 1_000_000 + 500 = 1_000_500.
-    expect(active!.amount).toBe(1_000_500n);
+    // amount is principal only (buildStakes) — the framework sums it into delegatedBalance; rewards stay separate.
+    expect(active!.amount).toBe(1_000_000n);
     expect(active!.actions).toEqual(
       expect.arrayContaining(["undelegate", "redelegate", "claim_reward"]),
     );

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.ts
@@ -1,11 +1,11 @@
-import { Cursor, Page, Stake, StakeAction } from "@ledgerhq/coin-module-framework/api/index";
+import { Cursor, Page, Stake } from "@ledgerhq/coin-module-framework/api/index";
 import { CosmosAPI } from "../../network/Cosmos";
+import { buildStakes } from "./toStakes";
 
 /**
- * Current staking positions as framework `Stake`s: each delegation maps to `active`
- * (bonded validator) or `inactive` (otherwise); unbondings → `deactivating`/
- * `withdrawable`; `amount` is principal + rewards. Babylon pending-epoch delegations
- * aren't in the node's delegation set until the epoch applies, so they appear only once bonded.
+ * Current staking positions as framework `Stake`s. Shares `buildStakes` with `getBalance`
+ * so the CoinModuleApi and the account-shape staking views agree; Babylon pending-epoch
+ * delegations are merged in by `getStakingPositions`.
  */
 export async function getStakes(
   api: CosmosAPI,
@@ -13,48 +13,6 @@ export async function getStakes(
   _cursor?: Cursor,
 ): Promise<Page<Stake>> {
   const currency = api.getCurrency();
-  const [delegations, unbondings] = await Promise.all([
-    api.getDelegations(address, currency),
-    api.getUnbondings(address),
-  ]);
-
-  const items: Stake[] = [];
-
-  for (const d of delegations) {
-    const deposited = BigInt(d.amount.integerValue().toFixed());
-    const rewarded = BigInt(d.pendingRewards.integerValue().toFixed());
-    const actions: StakeAction[] = ["undelegate", "redelegate"];
-    if (rewarded > 0n) {
-      actions.push("claim_reward");
-    }
-    items.push({
-      uid: `${address}:${d.validatorAddress}`,
-      address,
-      delegate: d.validatorAddress,
-      state: d.status === "bonded" ? "active" : "inactive",
-      actions,
-      asset: { type: "native" },
-      amount: deposited + rewarded,
-      amountDeposited: deposited,
-      amountRewarded: rewarded,
-    });
-  }
-
-  for (const u of unbondings) {
-    const amount = BigInt(u.amount.integerValue().toFixed());
-    const completed = u.completionDate.getTime() <= Date.now();
-    items.push({
-      uid: `${address}:${u.validatorAddress}:unbonding:${u.completionDate.getTime()}`,
-      address,
-      delegate: u.validatorAddress,
-      state: completed ? "withdrawable" : "deactivating",
-      actions: [],
-      asset: { type: "native" },
-      amount,
-      amountDeposited: amount,
-      amountRewarded: 0n,
-    });
-  }
-
-  return { items };
+  const positions = await api.getStakingPositions(address, currency);
+  return { items: buildStakes(address, positions) };
 }

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/getStakes.unit.test.ts
@@ -5,8 +5,7 @@ import { getStakes } from "./getStakes";
 function mkStakes(delegations: unknown[], unbondings: unknown[]): CosmosAPI {
   return {
     getCurrency: () => ({ id: "cosmos", units: [{}, { code: "uatom" }] }),
-    getDelegations: jest.fn().mockResolvedValue(delegations),
-    getUnbondings: jest.fn().mockResolvedValue(unbondings),
+    getStakingPositions: jest.fn().mockResolvedValue({ delegations, unbondings }),
   } as unknown as CosmosAPI;
 }
 
@@ -32,7 +31,7 @@ describe("logic/staking/getStakes", () => {
     expect(s.delegate).toBe("cosmosvaloper1v");
     expect(s.amountDeposited).toBe(1000000n);
     expect(s.amountRewarded).toBe(2500n);
-    expect(s.amount).toBe(1002500n);
+    expect(s.amount).toBe(1000000n); // principal only
     expect(s.actions).toContain("claim_reward");
     expect(s.actions).toContain("undelegate");
   });

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/toStakes.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/toStakes.ts
@@ -1,0 +1,49 @@
+import { Stake, StakeAction } from "@ledgerhq/coin-module-framework/api/index";
+import { CosmosDelegation, CosmosUnbonding } from "../../types";
+
+export function buildStakes(
+  address: string,
+  positions: { delegations: CosmosDelegation[]; unbondings: CosmosUnbonding[] },
+): Stake[] {
+  const items: Stake[] = [];
+
+  for (const d of positions.delegations) {
+    const deposited = BigInt(d.amount.integerValue().toFixed());
+    const rewarded = BigInt(d.pendingRewards.integerValue().toFixed());
+    const actions: StakeAction[] = ["undelegate", "redelegate"];
+    if (rewarded > 0n) actions.push("claim_reward");
+    items.push({
+      uid: `${address}:${d.validatorAddress}`,
+      address,
+      delegate: d.validatorAddress,
+      // A delegation is an active position — don't gate on d.status (the validator's bond-status,
+      // which the framework's state-derived status can't express anyway).
+      state: "active",
+      actions,
+      asset: { type: "native" },
+      amount: deposited, // principal only — framework sums this into delegatedBalance
+      amountDeposited: deposited,
+      amountRewarded: rewarded,
+    });
+  }
+
+  for (const u of positions.unbondings) {
+    const amount = BigInt(u.amount.integerValue().toFixed());
+    const completed = u.completionDate.getTime() <= Date.now();
+    items.push({
+      uid: `${address}:${u.validatorAddress}:unbonding:${u.completionDate.getTime()}`,
+      address,
+      delegate: u.validatorAddress,
+      state: completed ? "withdrawable" : "deactivating",
+      // framework reads stateUpdatedAt as the unbonding's completionDate (getAccountShape)
+      stateUpdatedAt: u.completionDate,
+      actions: [],
+      asset: { type: "native" },
+      amount,
+      amountDeposited: amount,
+      amountRewarded: 0n,
+    });
+  }
+
+  return items;
+}

--- a/libs/coin-modules/coin-cosmos/src/logic/staking/toStakes.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/logic/staking/toStakes.unit.test.ts
@@ -1,0 +1,58 @@
+import BigNumber from "bignumber.js";
+import { buildStakes } from "./toStakes";
+
+describe("logic/staking/toStakes", () => {
+  it("maps a bonded delegation to an active stake with principal amount", () => {
+    const [s] = buildStakes("cosmos1a", {
+      delegations: [
+        {
+          validatorAddress: "cosmosvaloper1v",
+          amount: new BigNumber("1000000"),
+          pendingRewards: new BigNumber("2500"),
+          status: "bonded",
+        },
+      ],
+      unbondings: [],
+    } as any);
+    expect(s.state).toBe("active");
+    expect(s.delegate).toBe("cosmosvaloper1v");
+    expect(s.amount).toBe(1_000_000n); // principal, excludes rewards
+    expect(s.amountDeposited).toBe(1_000_000n);
+    expect(s.amountRewarded).toBe(2_500n);
+    expect(s.actions).toContain("claim_reward");
+  });
+
+  it("keeps a delegation to a non-bonded validator as an active position (matches legacy inclusion)", () => {
+    const [s] = buildStakes("cosmos1a", {
+      delegations: [
+        {
+          validatorAddress: "cosmosvaloper1v",
+          amount: new BigNumber("1000000"),
+          pendingRewards: new BigNumber("0"),
+          status: "unbonding",
+        },
+      ],
+      unbondings: [],
+    } as any);
+    expect(s.state).toBe("active");
+  });
+
+  it("maps an in-progress unbonding to a deactivating stake carrying its completion date", () => {
+    const completionDate = new Date(Date.now() + 86_400_000);
+    const [s] = buildStakes("cosmos1a", {
+      delegations: [],
+      unbondings: [
+        {
+          validatorAddress: "cosmosvaloper1v",
+          amount: new BigNumber("500000"),
+          completionDate,
+        },
+      ],
+    } as any);
+    expect(s.state).toBe("deactivating");
+    // the framework surfaces stateUpdatedAt as the unbonding's completionDate
+    expect(s.stateUpdatedAt).toEqual(completionDate);
+    expect(s.amount).toBe(500_000n);
+    expect(s.amountRewarded).toBe(0n);
+  });
+});

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -1,7 +1,6 @@
 import { SequenceNumberError } from "../errors";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
-import { EnvName, EnvValue } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network/network";
 import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
@@ -67,10 +66,7 @@ export class CosmosAPI {
     return this._cosmosSDKVersion;
   }
 
-  constructor(
-    currencyId: string,
-    options?: { endpoint: EnvValue<EnvName> | undefined; version: string },
-  ) {
+  constructor(currencyId: string, options?: { endpoint: string | undefined; version: string }) {
     const crypto = cryptoFactory(currencyId);
     this.currencyId = currencyId;
     this.chainInstance = crypto;

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -1,6 +1,7 @@
 import { SequenceNumberError } from "../errors";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
+import { EnvName, EnvValue } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network/network";
 import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
@@ -66,7 +67,10 @@ export class CosmosAPI {
     return this._cosmosSDKVersion;
   }
 
-  constructor(currencyId: string, options?: { endpoint: string | undefined; version: string }) {
+  constructor(
+    currencyId: string,
+    options?: { endpoint: EnvValue<EnvName> | undefined; version: string },
+  ) {
     const crypto = cryptoFactory(currencyId);
     this.currencyId = currencyId;
     this.chainInstance = crypto;
@@ -115,37 +119,12 @@ export class CosmosAPI {
         this.getWithdrawAddress(address),
       ]);
 
-      let staking = { delegations, redelegations, unbondings };
-
-      if (this.chainInstance.epochedStaking) {
-        staking.unbondings = staking.unbondings.map(u =>
-          u.creationHeight === undefined
-            ? u
-            : {
-                ...u,
-                completionDate: estimateEpochedUnbondingCompletion(
-                  u.creationHeight,
-                  blockHeight,
-                  this.chainInstance.unbondingPeriod,
-                ),
-              },
-        );
-
-        const queued = await fetchQueuedStakingMessages(
-          this.defaultEndpoint,
-          address,
-          currency.units[1].code,
-        );
-        // at or past the boundary the queued msgs have already executed into `delegations`
-        // (the queue runs in the boundary block's EndBlocker), so merging would double-count
-        if (queued && queued.messages.length > 0 && blockHeight < queued.epochBoundary) {
-          staking = mergeQueuedMessages(staking, queued.messages, {
-            blockHeight,
-            epochBoundary: queued.epochBoundary,
-            unbondingPeriodDays: this.chainInstance.unbondingPeriod,
-          });
-        }
-      }
+      const staking = await this.mergeQueuedStaking(
+        { delegations, redelegations, unbondings },
+        address,
+        currency,
+        blockHeight,
+      );
 
       return {
         accountInfo,
@@ -165,6 +144,97 @@ export class CosmosAPI {
         throw new Error(`Error during ${currency.id} synchronization: ${error.message}`);
       }
     }
+  };
+
+  /**
+   * Merge Babylon's queued x/epoching staking into the base staking. `blockHeight` is optional —
+   * getAccountInfo passes its own to avoid a second getHeight.
+   */
+  private mergeQueuedStaking = async (
+    staking: {
+      delegations: CosmosDelegation[];
+      redelegations: CosmosRedelegation[];
+      unbondings: CosmosUnbonding[];
+    },
+    address: string,
+    currency: CryptoCurrency,
+    blockHeight?: number,
+  ): Promise<{
+    delegations: CosmosDelegation[];
+    redelegations: CosmosRedelegation[];
+    unbondings: CosmosUnbonding[];
+  }> => {
+    if (!this.chainInstance.epochedStaking) return staking;
+    const denom = currency.units[1]?.code;
+    if (!denom) return staking;
+    const [height, queued] = await Promise.all([
+      blockHeight !== undefined ? Promise.resolve(blockHeight) : this.getHeight(),
+      fetchQueuedStakingMessages(this.defaultEndpoint, address, denom),
+    ]);
+    // re-anchor epoched unbondings to the fast-unbonding estimate — the chain's completion_time is the
+    // full unbonding period and wrong for the fast path; skip when creation_height is missing.
+    const reanchored = {
+      ...staking,
+      unbondings: staking.unbondings.map(u =>
+        u.creationHeight === undefined
+          ? u
+          : {
+              ...u,
+              completionDate: estimateEpochedUnbondingCompletion(
+                u.creationHeight,
+                height,
+                this.chainInstance.unbondingPeriod,
+              ),
+            },
+      ),
+    };
+    // at/after the boundary the queue already executed into the base staking — merging double-counts
+    if (queued && queued.messages.length > 0 && height < queued.epochBoundary) {
+      return mergeQueuedMessages(reanchored, queued.messages, {
+        blockHeight: height,
+        epochBoundary: queued.epochBoundary,
+        unbondingPeriodDays: this.chainInstance.unbondingPeriod,
+      });
+    }
+    return reanchored;
+  };
+
+  getStakingPositions = async (
+    address: string,
+    currency: CryptoCurrency,
+  ): Promise<{ delegations: CosmosDelegation[]; unbondings: CosmosUnbonding[] }> => {
+    const [delegations, unbondings] = await Promise.all([
+      this.getDelegations(address, currency),
+      this.getUnbondings(address),
+    ]);
+    const merged = await this.mergeQueuedStaking(
+      { delegations, redelegations: [], unbondings },
+      address,
+      currency,
+    );
+    return { delegations: merged.delegations, unbondings: merged.unbondings };
+  };
+
+  /**
+   * Executed + (epoched chains only) queued x/epoching redelegations.
+   * Fetches delegations only when epoched — the queued-redelegate merge needs them to clamp.
+   */
+  getRedelegationsWithQueued = async (
+    address: string,
+    currency: CryptoCurrency,
+  ): Promise<CosmosRedelegation[]> => {
+    const executed = await this.getRedelegations(address);
+    if (!this.chainInstance.epochedStaking) return executed;
+    const [delegations, unbondings] = await Promise.all([
+      this.getDelegations(address, currency),
+      this.getUnbondings(address),
+    ]);
+    const merged = await this.mergeQueuedStaking(
+      { delegations, redelegations: executed, unbondings },
+      address,
+      currency,
+    );
+    return merged.redelegations;
   };
 
   private getCosmosSDKVersion = async (): Promise<string> => {

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -923,4 +923,130 @@ describe("CosmosApi", () => {
       expect(Number.isNaN(unbonding.completionDate.getTime())).toBe(false);
     });
   });
+
+  const BABYLON_ADDRESS = "bbn1uwpws077a0a9pclapv3f2fyj5u0mlh6ewmds8n";
+
+  // height 100 < epoch boundary 360, so the caller's queued messages merge.
+  const mockBabylonRoutes = (msgs: { msg_type: string; msg: string }[]) => {
+    // @ts-expect-error method is mocked
+    network.mockImplementation(({ url }: { url: string }) => {
+      const respond = (data: unknown) => Promise.resolve({ data });
+      if (url.includes("current_epoch"))
+        return respond({ current_epoch: "5", epoch_boundary: "360" });
+      if (url.includes("/babylon/epoching/v1/"))
+        return respond({ msgs, pagination: { next_key: null, total: String(msgs.length) } });
+      if (url.includes("blocks/latest")) return respond({ block: { header: { height: "100" } } });
+      if (url.includes("/redelegations")) return respond({ redelegation_responses: [] });
+      if (url.includes("/unbonding_delegations")) return respond({ unbonding_responses: [] });
+      if (url.includes("/rewards")) return respond({ rewards: [] });
+      if (url.includes("/staking/v1beta1/delegations/"))
+        return respond({
+          delegation_responses: [
+            {
+              delegation: { validator_address: "bbnvaloper1active" },
+              balance: { denom: "ubbn", amount: "50" },
+            },
+          ],
+        });
+      if (url.includes("/staking/v1beta1/validators/"))
+        return respond({ validator: { status: "BOND_STATUS_BONDED" } });
+      return Promise.reject(new Error(`unmocked url: ${url}`));
+    });
+  };
+
+  describe("getStakingPositions", () => {
+    const currency = { id: "babylon", units: [{}, { code: "ubbn" }] } as CryptoCurrency;
+
+    it("returns delegations/unbondings with queued epoching messages merged (babylon)", async () => {
+      mockBabylonRoutes([
+        {
+          msg_type: "cosmos.staking.v1beta1.MsgDelegate",
+          msg: `delegator_address:"${BABYLON_ADDRESS}" validator_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"30" >`,
+        },
+      ]);
+
+      const babylonApi = new CosmosAPI("babylon");
+      const { delegations, unbondings } = await babylonApi.getStakingPositions(
+        BABYLON_ADDRESS,
+        currency,
+      );
+
+      expect(unbondings).toEqual([]);
+      expect(delegations).toEqual([
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1active",
+          amount: new BigNumber(50),
+        }),
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1pending",
+          amount: new BigNumber(30),
+        }),
+      ]);
+    });
+  });
+
+  describe("getRedelegationsWithQueued", () => {
+    const babylon = { id: "babylon", units: [{}, { code: "ubbn" }] } as CryptoCurrency;
+    const cosmos = { id: "cosmos", units: [{}, { code: "uatom" }] } as CryptoCurrency;
+
+    it("merges queued redelegations on epoched chains (babylon)", async () => {
+      mockBabylonRoutes([
+        {
+          msg_type: "cosmos.staking.v1beta1.MsgBeginRedelegate",
+          msg: `delegator_address:"${BABYLON_ADDRESS}" validator_src_address:"bbnvaloper1active" validator_dst_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"20" >`,
+        },
+      ]);
+
+      const babylonApi = new CosmosAPI("babylon");
+      const redelegations = await babylonApi.getRedelegationsWithQueued(BABYLON_ADDRESS, babylon);
+
+      expect(redelegations).toEqual([
+        expect.objectContaining({
+          validatorSrcAddress: "bbnvaloper1active",
+          validatorDstAddress: "bbnvaloper1pending",
+          amount: new BigNumber(20),
+        }),
+      ]);
+    });
+
+    it("returns only executed redelegations and skips epoching/delegations on non-epoched chains (cosmos)", async () => {
+      // @ts-expect-error method is mocked
+      network.mockImplementation(({ url }: { url: string }) => {
+        const respond = (data: unknown) => Promise.resolve({ data });
+        if (url.includes("/redelegations"))
+          return respond({
+            redelegation_responses: [
+              {
+                redelegation: {
+                  validator_src_address: "cosmosvaloper1src",
+                  validator_dst_address: "cosmosvaloper1dst",
+                },
+                entries: [
+                  {
+                    redelegation_entry: {
+                      initial_balance: "1000000",
+                      completion_time: "2026-01-01T00:00:00Z",
+                    },
+                  },
+                ],
+              },
+            ],
+          });
+        return Promise.reject(new Error(`unmocked url: ${url}`));
+      });
+
+      const redelegations = await cosmosApi.getRedelegationsWithQueued("cosmos1a", cosmos);
+
+      expect(redelegations).toEqual([
+        expect.objectContaining({
+          validatorSrcAddress: "cosmosvaloper1src",
+          validatorDstAddress: "cosmosvaloper1dst",
+          amount: new BigNumber("1000000"),
+        }),
+      ]);
+      const urls = mockedNetwork.mock.calls.map(([o]) => o.url);
+      expect(urls.some(u => u?.includes("epoching"))).toBe(false);
+      expect(urls.some(u => u?.includes("/staking/v1beta1/delegations/"))).toBe(false);
+    });
+  });
 });

--- a/libs/coin-tester-modules/coin-tester-cosmos/package.json
+++ b/libs/coin-tester-modules/coin-tester-cosmos/package.json
@@ -67,12 +67,13 @@
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/coin-tester": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-common": "workspace:^",
+    "@ledgerhq/live-config": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
     "docker-compose": "^1.1.0",
-    "expect": "catalog:",
-    "msw": "catalog:"
+    "expect": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/coin-tester-modules/coin-tester-cosmos/package.json
+++ b/libs/coin-tester-modules/coin-tester-cosmos/package.json
@@ -73,7 +73,8 @@
     "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
     "docker-compose": "^1.1.0",
-    "expect": "catalog:"
+    "expect": "catalog:",
+    "msw": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/helpers.ts
@@ -1,6 +1,214 @@
+import BigNumber from "bignumber.js";
+import { Secp256k1Signature } from "@cosmjs/crypto";
+import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
+import { getCoinFrameworkAccountBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/accountBridge";
+import { getCoinFrameworkCurrencyBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/currencyBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
+import { createBridges } from "@ledgerhq/coin-cosmos/bridge/index";
+import resolver from "@ledgerhq/coin-cosmos/hw-getAddress";
+import type { CosmosCoinConfig } from "@ledgerhq/coin-cosmos/config";
+import type { CosmosSigner } from "@ledgerhq/coin-cosmos/types/signer";
+import {
+  CosmosCurrencyConfig,
+  Transaction as CosmosTransaction,
+} from "@ledgerhq/coin-cosmos/types/index";
+
+registerCoinModules(coinModuleLoaders);
 
 // Currencies exercised by the scenarios. Babylon (BABY) is x/epoching-wrapped;
 // Cosmos Hub (ATOM) is the canonical, non-wrapped cosmos chain.
 export const babylon = getCryptoCurrencyById("babylon");
 export const cosmos = getCryptoCurrencyById("cosmos");
+
+export interface CosmosBridges {
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<GenericTransaction>;
+  getAddress: GetAddressFn;
+}
+
+/**
+ * Map a GenericTransaction onto the legacy Cosmos transaction.
+ *
+ * The legacy `delegate` build path reads `transaction.amount`, but undelegate/
+ * redelegate/claimReward/compoundReward read `validators[0].amount` — so both are
+ * set to the stake amount. Redelegate: `sourceValidator` = source (`valAddress`),
+ * `validators[0].address` = destination (`dstValAddress`).
+ */
+export function genericToCosmosTransaction(gt: GenericTransaction): CosmosTransaction {
+  const amount = gt.amount ?? new BigNumber(0);
+  const base = {
+    family: "cosmos" as const,
+    amount,
+    memo: gt.memoValue ?? "",
+    useAllAmount: gt.useAllAmount ?? false,
+    fees: null,
+    gas: null,
+    networkInfo: null,
+  };
+  const mode = gt.mode ?? "send";
+
+  if (mode === "send")
+    return {
+      ...base,
+      mode: "send",
+      recipient: gt.recipient,
+      validators: [],
+    } as unknown as CosmosTransaction;
+
+  if (mode === "redelegate")
+    return {
+      ...base,
+      mode,
+      recipient: "",
+      sourceValidator: gt.valAddress,
+      validators: [{ address: gt.dstValAddress ?? "", amount }],
+    } as unknown as CosmosTransaction;
+
+  // delegate / undelegate / claimReward / compoundReward
+  return {
+    ...base,
+    mode,
+    recipient: "",
+    sourceValidator: undefined,
+    validators: [{ address: gt.valAddress ?? "", amount }],
+  } as unknown as CosmosTransaction;
+}
+
+/**
+ * Wrap the Cosmos AccountBridge so it speaks GenericTransaction — letting
+ * one scenario drive both the legacy and generic-adapter strategies.
+ */
+function adaptLegacyBridge(
+  bridge: AccountBridge<CosmosTransaction>,
+): AccountBridge<GenericTransaction> {
+  const preparedTxMap = new WeakMap<GenericTransaction, CosmosTransaction>();
+
+  return {
+    sync: bridge.sync,
+    receive: bridge.receive,
+    broadcast: bridge.broadcast,
+    validateAddress: bridge.validateAddress,
+    getSerializedAddressParameters: bridge.getSerializedAddressParameters,
+    signRawOperation: bridge.signRawOperation,
+    // exactOptionalPropertyTypes rejects assigning the optional-typed
+    // getEstimationRecipient straight through; forward via a non-optional closure.
+    getEstimationRecipient: account => bridge.getEstimationRecipient!(account),
+    createTransaction: () => ({
+      family: "cosmos",
+      mode: "send",
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+      fees: null,
+    }),
+    updateTransaction: (tx, patch) => ({ ...tx, ...patch }),
+    prepareTransaction: async (account, gt) => {
+      const prepared = await bridge.prepareTransaction(account, genericToCosmosTransaction(gt));
+      const result: GenericTransaction = {
+        ...gt,
+        amount: prepared.amount,
+        recipient: prepared.recipient,
+        fees: prepared.fees ?? null,
+      };
+      preparedTxMap.set(result, prepared);
+      return result;
+    },
+    getTransactionStatus: (account, gt) =>
+      bridge.getTransactionStatus(account, preparedTxMap.get(gt) ?? genericToCosmosTransaction(gt)),
+    signOperation: ({ account, transaction: gt, deviceId }) =>
+      bridge.signOperation({
+        account,
+        transaction: preparedTxMap.get(gt) ?? genericToCosmosTransaction(gt),
+        deviceId,
+      }),
+    estimateMaxSpendable: ({ account, parentAccount, transaction: gt }) =>
+      bridge.estimateMaxSpendable({
+        account,
+        parentAccount,
+        transaction: gt ? genericToCosmosTransaction(gt) : undefined,
+      }),
+  };
+}
+
+/**
+ * Parse a BIP32 path into the numeric-index array `CosmosSigner` expects: strips
+ * the `'` hardening markers (the signer re-applies hardening on the first 3 segments).
+ */
+function toIndices(path: string): number[] {
+  return path.split("/").map(p => parseInt(p.replace(/'/g, ""), 10));
+}
+
+type CosmosGenericSigner = {
+  getAddress(path: string): Promise<{ address: string; publicKey: string }>;
+  signTransaction(path: string, message: string): Promise<string>;
+};
+
+/**
+ * Adapt the tester's legacy-shaped `CosmosSigner` (numeric path, DER signature) up
+ * to the `getAddress`/`signTransaction` shape the generic framework's signer needs.
+ *
+ * Only the public key is read here (the address is derived elsewhere via the
+ * top-level `getAddress`), so the hrp is a placeholder. `combine()` wants a hex
+ * 64-byte (r‖s) signature + base64 pubkey, so both are re-encoded from the legacy
+ * bridge's DER + raw form.
+ */
+function toGenericSigner(signer: CosmosSigner): CosmosGenericSigner {
+  return {
+    async getAddress(path) {
+      const { compressed_pk } = await signer.getAddressAndPubKey(toIndices(path), "cosmos");
+      return { address: "", publicKey: Buffer.from(compressed_pk).toString("base64") };
+    },
+    async signTransaction(path, message) {
+      const { signable } = JSON.parse(message) as { signable: string };
+      const { signature } = await signer.sign(toIndices(path), Buffer.from(signable, "base64"));
+      if (!signature) {
+        throw new Error("Cosmos tester signer returned no signature");
+      }
+      return Buffer.from(Secp256k1Signature.fromDer(signature).toFixedLength()).toString("hex");
+    },
+  };
+}
+
+/**
+ * Wire the Cosmos bridges for the requested strategy, both speaking GenericTransaction.
+ * `coinConfig` points the legacy bridge at the local devnet LCD; it is consulted
+ * only on the "legacy" branch (the generic-adapter arm reads config from LiveConfig).
+ */
+export async function getBridges(
+  strategy: BridgeStrategy,
+  signer: CosmosSigner,
+  coinConfig: CosmosCurrencyConfig & { status: { type: "active" } },
+): Promise<CosmosBridges> {
+  const signerContext: SignerContext<CosmosSigner> = (_deviceId, fn) => fn(signer);
+  const getAddress = resolver(signerContext);
+
+  if (strategy === "legacy") {
+    const { currencyBridge, accountBridge } = createBridges(
+      signerContext,
+      () => coinConfig as unknown as CosmosCoinConfig,
+    );
+    return {
+      currencyBridge,
+      accountBridge: adaptLegacyBridge(
+        accountBridge as unknown as AccountBridge<CosmosTransaction>,
+      ),
+      getAddress,
+    };
+  }
+
+  const genericSigner = toGenericSigner(signer);
+  const context: SignerContext<CosmosGenericSigner> = (_deviceId, fn) => fn(genericSigner);
+  const customSigner = { context, getAddress };
+
+  return {
+    currencyBridge: await getCoinFrameworkCurrencyBridge("cosmos", "local", customSigner),
+    accountBridge: await getCoinFrameworkAccountBridge("cosmos", "local", customSigner),
+    getAddress,
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii.test.ts
@@ -8,29 +8,32 @@ import { CosmosScenario } from "./scenarii/Cosmos";
 global.console = console;
 jest.setTimeout(600_000);
 
-describe("Cosmos Tester", () => {
-  it("scenario Babylon", async () => {
-    try {
-      await executeScenario(BabylonScenario);
-    } catch (e) {
-      if (e !== "done") {
-        await killBabylond();
-        throw e;
+describe.each([["legacy"], ["generic-adapter"]] as const)(
+  "Cosmos Tester (%s strategy)",
+  strategy => {
+    it("scenario Babylon", async () => {
+      try {
+        await executeScenario(BabylonScenario, strategy);
+      } catch (e) {
+        if (e !== "done") {
+          await killBabylond();
+          throw e;
+        }
       }
-    }
-  });
+    });
 
-  it("scenario Cosmos", async () => {
-    try {
-      await executeScenario(CosmosScenario);
-    } catch (e) {
-      if (e !== "done") {
-        await killGaiad();
-        throw e;
+    it("scenario Cosmos", async () => {
+      try {
+        await executeScenario(CosmosScenario, strategy);
+      } catch (e) {
+        if (e !== "done") {
+          await killGaiad();
+          throw e;
+        }
       }
-    }
-  });
-});
+    });
+  },
+);
 
 // `exit` (and some signal paths) won't await pending promises, so the handler
 // must trigger teardown synchronously rather than awaiting it. Tear down both

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { setupServer } from "msw/node";
 import { Account, StakingResources } from "@ledgerhq/types-live";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
 import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
@@ -81,6 +82,7 @@ export function makeCosmosScenario(
   const { name, currency, hrp, delegateLabel, spawn, kill, retryInterval, retryLimit } = options;
   const unit = currency.units[0];
 
+  const mockServer = setupServer();
   // Populated in setup() before getTransactions() runs. Closure-scoped per
   // scenario, so two scenarios never share state.
   let recipientAddress = "";
@@ -239,6 +241,13 @@ export function makeCosmosScenario(
     getTransactions,
 
     beforeAll: async account => {
+      mockServer.listen({
+        onUnhandledRequest: request => {
+          const hostname = new URL(request.url).hostname;
+          if (["127.0.0.1", "localhost"].includes(hostname)) return;
+          throw new Error(`Unhandled request: ${request.method} ${request.url}`);
+        },
+      });
       // entrypoint.sh funds the dev account with 1,000,000 units at genesis. The
       // chain leaves it marginally under that after genesis processing (a small,
       // deterministic overhead), so assert it's funded with effectively the full
@@ -249,6 +258,7 @@ export function makeCosmosScenario(
     },
 
     teardown: async () => {
+      mockServer.close();
       await kill();
     },
   };

--- a/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
+++ b/libs/coin-tester-modules/coin-tester-cosmos/src/scenarii/shared.ts
@@ -1,22 +1,21 @@
 import BigNumber from "bignumber.js";
-import { setupServer } from "msw/node";
-import { AccountBridge } from "@ledgerhq/types-live";
+import { Account, StakingResources } from "@ledgerhq/types-live";
 import { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
 import { formatCurrencyUnit, parseCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies";
-import { createBridges } from "@ledgerhq/coin-cosmos/bridge/index";
-import { CosmosCoinConfig } from "@ledgerhq/coin-cosmos/config";
-import resolver from "@ledgerhq/coin-cosmos/hw-getAddress";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import {
   CosmosAccount,
   CosmosCurrencyConfig,
   CosmosOperationExtra,
-  Transaction as CosmosTransaction,
 } from "@ledgerhq/coin-cosmos/types/index";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { makeAccount } from "../fixtures";
 import { buildSigner } from "../signer";
+import { getBridges } from "../helpers";
 
-type CosmosScenarioTransaction = ScenarioTransaction<CosmosTransaction, CosmosAccount>;
+type CosmosScenarioTransaction = ScenarioTransaction<GenericTransaction, Account>;
 
 const LOCAL_LCD = "http://127.0.0.1:1317";
 
@@ -78,19 +77,38 @@ export type CosmosScenarioOptions = {
 // devnet lifecycle, address prefix, and retry budget differ — hence the options.
 export function makeCosmosScenario(
   options: CosmosScenarioOptions,
-): Scenario<CosmosTransaction, CosmosAccount> {
+): Scenario<GenericTransaction, Account> {
   const { name, currency, hrp, delegateLabel, spawn, kill, retryInterval, retryLimit } = options;
   const unit = currency.units[0];
 
   // Populated in setup() before getTransactions() runs. Closure-scoped per
   // scenario, so two scenarios never share state.
-  const mockServer = setupServer();
   let recipientAddress = "";
   let validatorAddress = "";
 
-  const getTransactions = (): CosmosScenarioTransaction[] => [
+  /** The subset of delegation-shaped fields both `CosmosResources` and the generic
+   * framework's `StakingResources` agree on (only `status`'s literal union differs). */
+  interface StakingView {
+    delegations: Array<{ validatorAddress: string; amount: BigNumber }>;
+    delegatedBalance: BigNumber;
+  }
+
+  /**
+   * Legacy exposes `cosmosResources`, generic-adapter `stakingResources` (untyped on Account —
+   * genericGetAccountShape sets it directly), so each is read behind a cast.
+   */
+  const getStakingView = (account: Account, strategy: BridgeStrategy): StakingView | undefined =>
+    strategy === "legacy"
+      ? (account as CosmosAccount).cosmosResources
+      : (account as Account & { stakingResources?: StakingResources }).stakingResources;
+
+  const getTransactions = (
+    _address: string,
+    strategy: BridgeStrategy,
+  ): CosmosScenarioTransaction[] => [
     {
       name: `Send 1 ${currency.ticker}`,
+      family: "cosmos",
       mode: "send",
       recipient: recipientAddress,
       amount: parseCurrencyUnit(unit, "1"),
@@ -109,49 +127,39 @@ export function makeCosmosScenario(
     },
     {
       name: delegateLabel,
+      family: "cosmos",
       mode: "delegate",
-      // Delegate is keyed on transaction.amount across the whole cosmos module:
-      // getTransactionStatus.getDelegateTransactionStatus validates it and
-      // buildTransaction's "delegate" case reads it — unlike redelegate/undelegate,
-      // which read validators[].amount. So the delegated amount goes in
-      // transaction.amount; validators[0] only supplies the target address (its
-      // amount is unused by the delegate build path, kept for symmetry below).
+      // Delegate reads transaction.amount (unlike undelegate/redelegate, which read
+      // validators[].amount); genericToCosmosTransaction sets both — see bridges.ts.
+      valAddress: validatorAddress,
       amount: parseCurrencyUnit(unit, "100"),
-      validators: [
-        {
-          address: validatorAddress,
-          amount: parseCurrencyUnit(unit, "100"),
-        },
-      ],
       expect: (previousAccount, currentAccount) => {
         const [latestOperation] = currentAccount.operations;
         expect(currentAccount.operations.length - previousAccount.operations.length).toBe(1);
         expect(latestOperation.type).toBe("DELEGATE");
         // op.value for DELEGATE is just the fee — principal is bonded, not spent.
         expect(latestOperation.value.toFixed()).toBe(latestOperation.fee.toFixed());
-        // The retry budget gives the delegation time to land (immediately on
-        // Cosmos Hub, at the next epoch boundary on Babylon); once applied, the
-        // LCD reflects it.
-        expect(
-          currentAccount.cosmosResources.delegations.some(
-            d => d.validatorAddress === validatorAddress,
-          ),
-        ).toBe(true);
-        expect(currentAccount.cosmosResources.delegatedBalance.toFixed()).toBe(
-          parseCurrencyUnit(unit, "100").toFixed(),
-        );
-        // Op extras name the validator we delegated to.
-        const extra = latestOperation.extra as CosmosOperationExtra;
-        expect(extra.validators?.[0]?.address).toBe(validatorAddress);
-        expect(extra.validators?.[0]?.amount.toFixed()).toBe(
-          parseCurrencyUnit(unit, "100").toFixed(),
-        );
+        // The retry budget lets the delegation land (immediate on Hub, next epoch on Babylon).
+        const staking = getStakingView(currentAccount, strategy);
+        expect(staking).toBeDefined();
+        expect(staking!.delegations.some(d => d.validatorAddress === validatorAddress)).toBe(true);
+        expect(staking!.delegatedBalance.toFixed()).toBe(parseCurrencyUnit(unit, "100").toFixed());
+        // Legacy's operation.extra carries cosmos's `validators` array; the generic framework's
+        // adaptCoreOperationToLiveOperation only forwards a singular `stake` field (see
+        // listOperations.ts's toOperation, which mirrors validators[0] into details.stake for it).
+        const stakeTarget =
+          strategy === "legacy"
+            ? (latestOperation.extra as CosmosOperationExtra).validators?.[0]
+            : (latestOperation.extra as { stake?: { address: string; amount: BigNumber } }).stake;
+        expect(stakeTarget?.address).toBe(validatorAddress);
+        expect(stakeTarget?.amount.toFixed()).toBe(parseCurrencyUnit(unit, "100").toFixed());
       },
     },
     {
       name: "Claim rewards",
+      family: "cosmos",
       mode: "claimReward",
-      validators: [{ address: validatorAddress, amount: new BigNumber(0) }],
+      valAddress: validatorAddress,
       expect: (previousAccount, currentAccount) => {
         const [latestOperation] = currentAccount.operations;
         expect(currentAccount.operations.length - previousAccount.operations.length).toBe(1);
@@ -177,18 +185,27 @@ export function makeCosmosScenario(
   return {
     name,
 
-    setup: async () => {
+    setup: async strategy => {
       const signer = await buildSigner();
-      const signerContext: Parameters<typeof resolver>[0] = (_, fn) => fn(signer);
-      const { accountBridge, currencyBridge } = createBridges(
-        signerContext,
-        () => coinConfig as unknown as CosmosCoinConfig,
+
+      // generic-adapter reads its config from LiveConfig; harmless for the legacy
+      // arm (which gets coinConfig directly via getBridges below).
+      // Merge into the existing schema instead of replacing it: sibling scenarii (Babylon/Cosmos)
+      // run in the same Jest worker and each register their own currency key.
+      LiveConfig.setConfig({
+        ...LiveConfig.instance.config,
+        [`config_currency_${currency.id}`]: { type: "object" as const, default: coinConfig },
+      });
+
+      const { accountBridge, currencyBridge, getAddress } = await getBridges(
+        strategy,
+        signer,
+        coinConfig,
       );
 
       // Derive the dev account from the (random) seed BEFORE the chain boots, then
       // hand its address to the devnet so genesis pre-funds exactly that account.
       // entrypoint.sh reads DEV_ADDRESS from the environment via docker-compose.
-      const getAddress = resolver(signerContext);
       const { address } = await getAddress("", {
         path: "44'/118'/0'/0/0",
         currency,
@@ -209,10 +226,9 @@ export function makeCosmosScenario(
 
       const account = makeAccount(address, currency);
       return {
-        // Drop the narrower CosmosOperation generic — Scenario expects the
-        // 2-arity AccountBridge; cast is sound because Scenario only exposes
-        // the base interface.
-        accountBridge: accountBridge as AccountBridge<CosmosTransaction, CosmosAccount>,
+        // Typed on the broad `Account`: legacy sets `cosmosResources`, generic-adapter
+        // `stakingResources`, so no single family type fits both — getStakingView reads the right one.
+        accountBridge,
         currencyBridge,
         account,
         retryInterval,
@@ -223,13 +239,6 @@ export function makeCosmosScenario(
     getTransactions,
 
     beforeAll: async account => {
-      mockServer.listen({
-        onUnhandledRequest: request => {
-          const hostname = new URL(request.url).hostname;
-          if (["127.0.0.1", "localhost"].includes(hostname)) return;
-          throw new Error(`Unhandled request: ${request.method} ${request.url}`);
-        },
-      });
       // entrypoint.sh funds the dev account with 1,000,000 units at genesis. The
       // chain leaves it marginally under that after genesis processing (a small,
       // deterministic overhead), so assert it's funded with effectively the full
@@ -240,7 +249,6 @@ export function makeCosmosScenario(
     },
 
     teardown: async () => {
-      mockServer.close();
       await kill();
     },
   };

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -759,6 +759,8 @@
     "src/families/celo/coinModuleApi.ts",
     "src/families/celo/config.ts",
     "src/families/concordium/config.ts",
+    "src/families/cosmos/bridge/api.ts",
+    "src/families/cosmos/coinModuleApi.ts",
     "src/families/cosmos/config.ts",
     "src/families/evm/accountRawAssign.ts",
     "src/families/evm/bridge/api.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
@@ -98,6 +98,18 @@ export function createTransaction(account: Account | TokenAccount): GenericTrans
         // craft, so the default tx is signable without callers having to set it.
         nonce: new BigNumber(0),
       };
+    case "cosmos":
+      return {
+        family: currency.family,
+        mode: "send",
+        amount: new BigNumber(0),
+        recipient: "",
+        fees: null,
+        useAllAmount: false,
+        memoType: null,
+        memoValue: null,
+        networkInfo: null,
+      };
     default:
       throw new Error(`Unsupported currency family: ${currency.family}`);
   }

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -137,6 +137,9 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => import("../families/cosmos/bridge/mock").then(m => m.default),
     loadMockAccount: () => import("@ledgerhq/coin-cosmos/mock").then(m => m.default),
     loadBridgeExtensions: () => import("../families/cosmos/bridgeExtensions").then(m => m.default),
+    loadLocalApi: () =>
+      import("../families/cosmos/coinModuleApi").then(m => m.createLocalCosmosApi),
+    loadBridgeApi: () => import("../families/cosmos/bridge/api").then(m => m.default),
   },
   {
     family: "evm",

--- a/libs/ledger-live-common/src/families/cosmos/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/bridge/api.test.ts
@@ -1,0 +1,76 @@
+import type { StakingResources } from "@ledgerhq/types-live";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import BigNumber from "bignumber.js";
+import cosmosBridge from "./api";
+
+const mockGetRedelegations = jest.fn();
+jest.mock("@ledgerhq/coin-cosmos/logic/staking/getRedelegations", () => ({
+  getRedelegations: (...args: unknown[]) => mockGetRedelegations(...args),
+}));
+
+const cosmos = getCryptoCurrencyById("cosmos");
+
+describe("cosmos bridge", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe("computeIntentType", () => {
+    it.each([
+      [{ mode: "send" }, "send"],
+      [{}, "send"],
+      [{ mode: undefined }, "send"],
+      [{ mode: "delegate" }, "delegate"],
+      [{ mode: "undelegate" }, "undelegate"],
+      [{ mode: "redelegate" }, "redelegate"],
+      [{ mode: "claimReward" }, "claimReward"],
+      [{ mode: "compoundReward" }, "compoundReward"],
+    ])("maps %o to %s", (transaction, expected) => {
+      expect(cosmosBridge(cosmos).computeIntentType!(transaction)).toBe(expected);
+    });
+
+    it("throws for an unsupported mode", () => {
+      expect(() => cosmosBridge(cosmos).computeIntentType!({ mode: "swap" })).toThrow(
+        "Unsupported Cosmos transaction mode: swap",
+      );
+    });
+  });
+
+  describe("bridge surface", () => {
+    it("marks staking supported", () => {
+      expect(cosmosBridge(cosmos).stakingSupported).toBe(true);
+    });
+  });
+
+  describe("enrichStakingResources", () => {
+    const base: StakingResources = {
+      delegations: [],
+      redelegations: [],
+      unbondings: [],
+      delegatedBalance: new BigNumber(0),
+      pendingRewardsBalance: new BigNumber(0),
+      unbondingBalance: new BigNumber(0),
+    };
+
+    it("populates redelegations fetched for the address, preserving the other fields", async () => {
+      const redelegations = [
+        {
+          validatorSrcAddress: "cosmosvaloper1src",
+          validatorDstAddress: "cosmosvaloper1dst",
+          amount: new BigNumber("1000000"),
+          completionDate: new Date("2026-01-01T00:00:00Z"),
+        },
+      ];
+      mockGetRedelegations.mockResolvedValue(redelegations);
+
+      const result = await cosmosBridge(cosmos).enrichStakingResources!(
+        cosmos,
+        "cosmos1a",
+        [],
+        base,
+      );
+
+      expect(mockGetRedelegations).toHaveBeenCalledWith("cosmos", "cosmos1a");
+      expect(result.redelegations).toEqual(redelegations);
+      expect(result.delegatedBalance).toBe(base.delegatedBalance);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/cosmos/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/cosmos/bridge/api.ts
@@ -1,0 +1,30 @@
+import { getRedelegations } from "@ledgerhq/coin-cosmos/logic/staking/getRedelegations";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+
+export default function cosmosBridge(_currency: CryptoCurrency): BridgeApi {
+  return {
+    stakingSupported: true,
+    computeIntentType: (transaction: Record<string, unknown>) => {
+      const mode = transaction.mode as string | undefined;
+      switch (mode) {
+        case "send":
+        case undefined:
+          return "send";
+        case "delegate":
+        case "undelegate":
+        case "redelegate":
+        case "claimReward":
+        case "compoundReward":
+          return mode;
+        default:
+          throw new Error(`Unsupported Cosmos transaction mode: ${mode}`);
+      }
+    },
+    // Redelegations can't be a getBalance `Stake`, so the coin-framework leaves them empty — fetch here.
+    enrichStakingResources: async (currency, address, _operations, stakingResources) => ({
+      ...stakingResources,
+      redelegations: await getRedelegations(currency.id, address),
+    }),
+  };
+}

--- a/libs/ledger-live-common/src/families/cosmos/coinModuleApi.ts
+++ b/libs/ledger-live-common/src/families/cosmos/coinModuleApi.ts
@@ -1,0 +1,10 @@
+import { createApi as createCosmosApi } from "@ledgerhq/coin-cosmos/api/index";
+import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/types";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+import type { CosmosCoinConfig } from "@ledgerhq/coin-cosmos/config";
+import { getCurrencyConfiguration } from "../../config";
+
+export function createLocalCosmosApi(currencyId: string): CoinModuleApi<any> & BridgeApi {
+  const config = getCurrencyConfiguration<CosmosCoinConfig>(currencyId);
+  return createCosmosApi(config, currencyId) as CoinModuleApi<any> & BridgeApi;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8137,6 +8137,12 @@ importers:
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-common':
+        specifier: workspace:^
+        version: link:../../ledger-live-common
+      '@ledgerhq/live-config':
+        specifier: workspace:^
+        version: link:../../live-config
       '@ledgerhq/types-live':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/types-live
@@ -8152,9 +8158,6 @@ importers:
       expect:
         specifier: 'catalog:'
         version: 30.2.0
-      msw:
-        specifier: 'catalog:'
-        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^
@@ -14576,7 +14579,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -29655,7 +29658,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -66304,7 +66307,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66428,6 +66431,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8158,6 +8158,9 @@ importers:
       expect:
         specifier: 'catalog:'
         version: 30.2.0
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
     devDependencies:
       '@ledgerhq/wallet-framework-test-setup':
         specifier: workspace:^


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Integrates the `@ledgerhq/coin-cosmos` CoinModuleApi into the `cosmos` family in `@ledgerhq/live-common` (via coin-module loaders + a BridgeApi adapter) and expands coin-tester coverage to validate parity between the legacy cosmos bridge and the generic-coin-framework adapter. It also updates the coin-cosmos module’s staking/operations shaping (queued epoching merge, stake/balance semantics, fee handling) to align with the generic framework expectations.

**Changes:**
- Add `live-common` cosmos CoinModuleApi loader + BridgeApi (incl. staking redelegations enrichment) and add a cosmos default generic transaction.
- Update `@ledgerhq/coin-cosmos` staking/operations logic to share stake mapping, merge queued epoching staking, and avoid fee double-counting with the generic adapter.
- Update coin-tester-cosmos to run scenarios for both `legacy` and `generic-adapter` strategies (plus Docker multi-arch tweaks) and add/adjust unit tests.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34512
- **ADR** (if any): n/a
