### PR TITLE
[LWDM] chore(coin-evm): store delegation shares

### DIFF
--- a/.changeset/fuzzy-timers-confess.md
+++ b/.changeset/fuzzy-timers-confess.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/types-live": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/live-common": patch
+---
+
+chore(coin-evm): store delegation shares

--- a/libs/coin-modules/coin-evm/src/staking/logic.ts
+++ b/libs/coin-modules/coin-evm/src/staking/logic.ts
@@ -143,11 +143,9 @@ export const getMaxEstimatedBalance = (a: StakingAccount, estimatedFees: BigNumb
 };
 
 export function canUndelegate(account: StakingAccount, delegation?: StakingDelegation): boolean {
-  const { stakingResources } = account;
-  invariant(stakingResources, "stakingResources should exist");
+  invariant(account.stakingResources, "stakingResources should exist");
   // An activating stake is not yet in the active set, so it cannot be undelegated.
-  if (delegation?.status === "activating") return false;
-  return !!stakingResources?.unbondings;
+  return delegation?.status !== "activating";
 }
 
 /**

--- a/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.test.ts
@@ -217,6 +217,25 @@ describe("coin-evm/staking/serialization", () => {
       expect(raw.unbondings[0]).not.toHaveProperty("validatorId");
       expect(raw.unbondings[0]).not.toHaveProperty("validatorName");
     });
+
+    it("roundtrips a 0G delegation `shares` (BigNumber ↔ string), omitting it when absent", () => {
+      const resources: StakingResources = {
+        ...sampleResources,
+        delegations: [
+          { ...sampleResources.delegations[0], shares: new BigNumber("999000000000000000000") },
+        ],
+      };
+
+      const raw = toStakingResourcesRaw(resources);
+      expect(raw.delegations[0]).toHaveProperty("shares", "999000000000000000000");
+
+      const back = fromStakingResourcesRaw(raw);
+      expect(back.delegations[0].shares).toEqual(new BigNumber("999000000000000000000"));
+
+      const rawNoShares = toStakingResourcesRaw(sampleResources);
+      expect(rawNoShares.delegations[0]).not.toHaveProperty("shares");
+      expect(fromStakingResourcesRaw(rawNoShares).delegations[0]).not.toHaveProperty("shares");
+    });
   });
 
   describe("assignToAccountRaw / assignFromAccountRaw", () => {

--- a/libs/coin-modules/coin-evm/src/staking/serialization.ts
+++ b/libs/coin-modules/coin-evm/src/staking/serialization.ts
@@ -22,6 +22,7 @@ function toStakingDelegationRaw(d: StakingDelegation): StakingDelegationRaw {
     amount: d.amount.toString(),
     pendingRewards: d.pendingRewards.toString(),
     status: d.status,
+    ...(BigNumber.isBigNumber(d.shares) ? { shares: d.shares.toString() } : {}),
   };
 }
 
@@ -33,6 +34,7 @@ function fromStakingDelegationRaw(d: StakingDelegationRaw): StakingDelegation {
     amount: new BigNumber(d.amount),
     pendingRewards: new BigNumber(d.pendingRewards),
     status: d.status,
+    ...(typeof d.shares === "string" ? { shares: new BigNumber(d.shares) } : {}),
   };
 }
 

--- a/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
+++ b/libs/coin-modules/coin-evm/src/staking/validators/zero_gravity.ts
@@ -113,7 +113,7 @@ const fetchStakeForValidator = async (
     asset,
     amount,
     actions: [],
-    details: { contractAddress: validatorAddress, validator: validatorAddress },
+    details: { contractAddress: validatorAddress, validator: validatorAddress, shares },
   };
 };
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -408,6 +408,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         const rewarded: bigint = b.stake.amountRewarded ?? 0n;
         const validatorId = b.stake.details?.validatorId;
         const validatorName = b.stake.details?.validatorName;
+        const sharesRaw = b.stake.details?.shares;
         return {
           validatorAddress: b.stake.delegate,
           amount: new BigNumber(delegated.toString()),
@@ -415,6 +416,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
           status: b.stake.state === "activating" ? "activating" : "bonded",
           ...(typeof validatorId === "string" ? { validatorId } : {}),
           ...(typeof validatorName === "string" ? { validatorName } : {}),
+          ...(typeof sharesRaw === "bigint" ? { shares: new BigNumber(sharesRaw.toString()) } : {}),
         };
       });
       const unbondings: StakingUnbonding[] = deactivatingStakes.filter(hasStakeDelegate).map(b => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -1125,6 +1125,79 @@ describe("genericGetAccountShape", () => {
       ]);
     });
 
+    test("propagates stake.details.shares to delegation.shares as BigNumber, omits when absent", async () => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      extractBalanceMock.mockReturnValue({ value: 200n, locked: 0n });
+      getBalanceMock.mockResolvedValue([
+        { asset: { type: "native" }, value: 200n },
+        {
+          asset: { type: "native" },
+          value: 100n,
+          stake: {
+            uid: "s-shares",
+            address: "0xabc",
+            delegate: "0xvalidator",
+            state: "active",
+            asset: { type: "native" },
+            amount: 100n,
+            details: { shares: 999n },
+          },
+        },
+        {
+          asset: { type: "native" },
+          value: 50n,
+          stake: {
+            uid: "s-noshares",
+            address: "0xabc",
+            delegate: "0xvalidator2",
+            state: "active",
+            asset: { type: "native" },
+            amount: 50n,
+          },
+        },
+      ]);
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      inferSubOperationsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: unknown[], newOps: unknown[]) => newOps);
+      cleanedOperationMock.mockImplementation((op: unknown) => op);
+      chainSpecificGetAccountShapeMock.mockImplementation(() => {});
+
+      const getShape = genericGetAccountShape("mainnet", "zero_gravity");
+      const result = await getShape(
+        {
+          address: "0xtest",
+          initialAccount: undefined,
+          currency: { id: "zero_gravity", name: "0G", family: "evm" },
+          derivationMode: "",
+        } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          stakingResources: expect.objectContaining({
+            delegations: [
+              {
+                validatorAddress: "0xvalidator",
+                amount: new BigNumber(100),
+                pendingRewards: new BigNumber(0),
+                status: "bonded",
+                shares: new BigNumber(999),
+              },
+              {
+                validatorAddress: "0xvalidator2",
+                amount: new BigNumber(50),
+                pendingRewards: new BigNumber(0),
+                status: "bonded",
+              },
+            ],
+          }),
+        }),
+      );
+    });
+
     test("usesStakingPositions: surfaces raw Stake[] preserving uid prefixes; no stakingResources", async () => {
       getSyncHashMock.mockReturnValue("sync-hash");
       extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });

--- a/libs/ledgerjs/packages/types-live/src/staking.ts
+++ b/libs/ledgerjs/packages/types-live/src/staking.ts
@@ -15,6 +15,7 @@ export type StakingDelegation = {
   amount: BigNumber;
   pendingRewards: BigNumber;
   status: StakingDelegationStatus;
+  shares?: BigNumber;
 };
 
 export type StakingDelegationRaw = {
@@ -24,6 +25,7 @@ export type StakingDelegationRaw = {
   amount: string;
   pendingRewards: string;
   status: StakingDelegationStatus;
+  shares?: string;
 };
 
 export type StakingRedelegation = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Per-validator vault contracts used for staking in 0g have a concept of shares (proportional ownership of the validator's pool) that must be stored to enable delegation afterward.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34579
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
