### PR TITLE
[LWDM] chore(coin-evm): support chain-specific `canUndelegate`

### DIFF
--- a/.changeset/nine-hats-fetch.md
+++ b/.changeset/nine-hats-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+chore(coin-evm): add per-chain `canUndelegate`

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -194,6 +194,9 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     resolveValidatorAddress: async (_, contractAddress) => {
       return contractAddress ? ethers.getAddress(contractAddress) : null;
     },
+    canUndelegate: delegation => {
+      return delegation.shares?.gt(0) ?? true;
+    },
   },
   somnia: {
     contractAddress: () => "0xBe367d410D96E1cAeF68C0632251072CDf1b8250",

--- a/libs/coin-modules/coin-evm/src/staking/logic.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/logic.test.ts
@@ -159,6 +159,26 @@ describe("evm staking logic", () => {
       const account = makeAccount("monad");
       expect(canUndelegate(account)).toBe(true);
     });
+
+    it("returns false for 0G when shares is zero", () => {
+      const account = makeAccount("zero_gravity");
+      const delegation = { ...makeDelegation("0xvalidator", "bonded"), shares: new BigNumber(0) };
+      expect(canUndelegate(account, delegation)).toBe(false);
+    });
+
+    it("returns true for 0G when shares is positive", () => {
+      const account = makeAccount("zero_gravity");
+      const delegation = {
+        ...makeDelegation("0xvalidator", "bonded"),
+        shares: new BigNumber(1000),
+      };
+      expect(canUndelegate(account, delegation)).toBe(true);
+    });
+
+    it("returns true for 0G when shares is undefined (legacy pre-sync account)", () => {
+      const account = makeAccount("zero_gravity");
+      expect(canUndelegate(account, makeDelegation("0xvalidator", "bonded"))).toBe(true);
+    });
   });
 
   describe("canWithdraw", () => {

--- a/libs/coin-modules/coin-evm/src/staking/logic.ts
+++ b/libs/coin-modules/coin-evm/src/staking/logic.ts
@@ -145,7 +145,10 @@ export const getMaxEstimatedBalance = (a: StakingAccount, estimatedFees: BigNumb
 export function canUndelegate(account: StakingAccount, delegation?: StakingDelegation): boolean {
   invariant(account.stakingResources, "stakingResources should exist");
   // An activating stake is not yet in the active set, so it cannot be undelegated.
-  return delegation?.status !== "activating";
+  if (delegation?.status === "activating") return false;
+  const chainCanUndelegate = STAKING_CONTRACTS[account.currency.id]?.canUndelegate;
+  if (chainCanUndelegate && delegation) return chainCanUndelegate(delegation);
+  return true;
 }
 
 /**

--- a/libs/coin-modules/coin-evm/src/types/staking.ts
+++ b/libs/coin-modules/coin-evm/src/types/staking.ts
@@ -1,5 +1,6 @@
 import type { Stake } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { StakingDelegation } from "@ledgerhq/types-live";
 
 export type StakingOperation =
   | "delegate"
@@ -156,6 +157,8 @@ export type StakingContractConfig = {
     decoded: readonly unknown[],
     contractAddress: string | undefined,
   ) => Promise<string | null>;
+  /** Chain-specific guard called after cross-cutting checks. Returns true when the delegation can be undelegated. */
+  canUndelegate?: (delegation: StakingDelegation) => boolean;
 };
 
 export type StakeCreate = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Different chains have different needs when it comes to undelegation. Adding per chain `canUndelegate` in addition to the global logic.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34580
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
