### PR TITLE
[LWDM] feat(mobile): render populated contacts list

### DIFF
--- a/.changeset/quiet-contacts-group.md
+++ b/.changeset/quiet-contacts-group.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Render grouped populated Contacts lists on mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -25,7 +25,10 @@ export function useContactsViewModel(): ContactsViewModel {
     }),
     [t],
   );
-  const onOpenContact = useCallback<ContactsViewProps["onOpenContact"]>(_contactId => undefined, []);
+  const onOpenContact = useCallback<ContactsViewProps["onOpenContact"]>(
+    _contactId => undefined,
+    [],
+  );
   const onAddContact = useCallback(() => undefined, []);
   const onDismissIntroduction = useCallback(() => setIsIntroductionDismissed(true), []);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -25,7 +25,7 @@ export function useContactsViewModel(): ContactsViewModel {
     }),
     [t],
   );
-  const onOpenMe = useCallback<ContactsViewProps["onOpenMe"]>(_contactId => undefined, []);
+  const onOpenContact = useCallback<ContactsViewProps["onOpenContact"]>(_contactId => undefined, []);
   const onAddContact = useCallback(() => undefined, []);
   const onDismissIntroduction = useCallback(() => setIsIntroductionDismissed(true), []);
 
@@ -41,7 +41,7 @@ export function useContactsViewModel(): ContactsViewModel {
     viewModel: createEmptyContactsListViewModel(meContact),
     labels,
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
-    onOpenMe,
+    onOpenContact,
     onAddContact,
     ledgerSyncStatus,
     ledgerSyncIntroduction: {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10204,6 +10204,9 @@
     "title": "Contacts",
     "addContact": "Add contact",
     "searchPlaceholder": "Search contact",
+    "addressCount_zero": "0 address",
+    "addressCount_one": "{{count}} address",
+    "addressCount_other": "{{count}} addresses",
     "me": {
       "name": "Me",
       "addressCount_zero": "0 address",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -49,7 +49,7 @@ jest.mock("@features/flow-contacts", () => {
     ContactsPage: ({
       viewModel,
       labels,
-      onOpenMe,
+      onOpenContact,
       onAddContact,
     }: {
       viewModel: { me: { contactId: string; name: string; addressCount: number } };
@@ -58,12 +58,12 @@ jest.mock("@features/flow-contacts", () => {
         addContact: string;
         formatAddressCount: (count: number) => string;
       };
-      onOpenMe: (contactId: string) => void;
+      onOpenContact: (contactId: string) => void;
       onAddContact: () => void;
     }) => (
       <View testID="contacts-screen">
         <Text testID="contacts-search-input">{labels.searchPlaceholder}</Text>
-        <Pressable testID="contacts-me-item" onPress={() => onOpenMe(viewModel.me.contactId)}>
+        <Pressable testID="contacts-me-item" onPress={() => onOpenContact(viewModel.me.contactId)}>
           <Text>{viewModel.me.name}</Text>
           <Text>{labels.formatAddressCount(viewModel.me.addressCount)}</Text>
         </Pressable>

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,9 +1,8 @@
 import {
-  createEmptyContactsListViewModel,
   type ContactsLedgerSyncStatus,
   type ContactsPageLabels,
   type ContactsPageProps,
-  useContactsMeContact,
+  useContactsListViewModel,
 } from "@features/flow-contacts";
 import { useCallback, useMemo, useState } from "react";
 import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
@@ -13,20 +12,19 @@ export type ContactsViewModel = ContactsPageProps;
 
 export function useContactsViewModel(): ContactsViewModel {
   const { t } = useTranslation();
-  const meContact = useContactsMeContact();
   const labels = useMemo<ContactsPageLabels>(
     () => ({
       title: t("contacts.title"),
       searchPlaceholder: t("contacts.searchPlaceholder"),
       addContact: t("contacts.addContact"),
-      formatAddressCount: count => t("contacts.me.addressCount", { count }),
+      formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
   );
-  const viewModel = useMemo(() => createEmptyContactsListViewModel(meContact!), [meContact]);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const [isIntroductionDismissed, setIsIntroductionDismissed] = useState(false);
-  const onOpenMe = useCallback(() => undefined, []);
+  const viewModel = useContactsListViewModel();
+  const onOpenContact = useCallback<ContactsPageProps["onOpenContact"]>(() => undefined, []);
   const onAddContact = useCallback(() => undefined, []);
   const onDismissIntroduction = useCallback(() => setIsIntroductionDismissed(true), []);
 
@@ -34,7 +32,7 @@ export function useContactsViewModel(): ContactsViewModel {
     viewModel,
     labels,
     meAvatarSrc: USER_AVATAR_URL,
-    onOpenMe,
+    onOpenContact,
     onAddContact,
     ledgerSyncStatus,
     ledgerSyncIntroduction: {

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useContactsMeContact } from "./useContactsMeContact";
+export { useContactsListViewModel } from "./useContactsListViewModel";

--- a/features/flow/contacts/src/hooks/useContactsListViewModel.ts
+++ b/features/flow/contacts/src/hooks/useContactsListViewModel.ts
@@ -1,0 +1,13 @@
+import { selectContacts } from "@domain/entity-contact";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { createContactsListViewModel } from "../list/viewModel";
+import type { ContactsListViewModel } from "../list/types";
+import { useContactsMeContact } from "./useContactsMeContact";
+
+export function useContactsListViewModel(): ContactsListViewModel {
+  const contacts = useSelector(selectContacts);
+  const meContact = useContactsMeContact();
+
+  return useMemo(() => createContactsListViewModel(meContact, contacts), [contacts, meContact]);
+}

--- a/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/contacts/src/list/components/ContactsList/ContactsList.web.tsx
@@ -6,14 +6,14 @@ import { ContactsMeListItem } from "./ContactsMeListItem.web";
 
 type ContactsListProps = Pick<
   ContactsPageProps,
-  "viewModel" | "labels" | "meAvatarSrc" | "onOpenMe" | "onAddContact"
+  "viewModel" | "labels" | "meAvatarSrc" | "onOpenContact" | "onAddContact"
 >;
 
 export function ContactsList({
   viewModel,
   labels,
   meAvatarSrc,
-  onOpenMe,
+  onOpenContact,
   onAddContact,
 }: ContactsListProps): React.ReactNode {
   return (
@@ -30,7 +30,7 @@ export function ContactsList({
           contact={viewModel.me}
           avatarSrc={meAvatarSrc}
           formatAddressCount={labels.formatAddressCount}
-          onOpen={onOpenMe}
+          onOpen={onOpenContact}
         />
       </div>
       <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsInitialAvatar.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsInitialAvatar.native.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsListItem } from "../..";
+import { getContactInitialAvatarBackground } from "../../internals";
+
+type ContactsInitialAvatarProps = Readonly<{
+  contact: ContactsListItem;
+}>;
+
+export function ContactsInitialAvatar({ contact }: ContactsInitialAvatarProps): React.JSX.Element {
+  return (
+    <Box
+      testID={`contacts-initial-avatar-${contact.contactId}`}
+      lx={{
+        width: "s40",
+        height: "s40",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: "full",
+        backgroundColor: getContactInitialAvatarBackground(contact.contactId),
+      }}
+    >
+      <Text typography="body2SemiBold" lx={{ color: "black" }}>
+        {contact.initial}
+      </Text>
+    </Box>
+  );
+}

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsListHeader.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsListHeader.native.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, SearchInput } from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsListItem, ContactsPageLabels } from "../..";
+import { ContactsAddContactListItem } from "./ContactsAddContactListItem.native";
+import { ContactsMeListItem } from "./ContactsMeListItem.native";
+
+type ContactsListHeaderProps = Readonly<{
+  me: ContactsListItem;
+  labels: ContactsPageLabels;
+  meAvatarSrc: string;
+  showAddContact: boolean;
+  onOpenContact: (contactId: ContactsListItem["contactId"]) => void;
+  onAddContact: () => void;
+}>;
+
+export function ContactsListHeader({
+  me,
+  labels,
+  meAvatarSrc,
+  showAddContact,
+  onOpenContact,
+  onAddContact,
+}: ContactsListHeaderProps): React.JSX.Element {
+  return (
+    <Box lx={{ gap: "s8" }}>
+      <SearchInput
+        testID="contacts-search-input"
+        value=""
+        editable={false}
+        placeholder={labels.searchPlaceholder}
+        accessibilityLabel={labels.searchPlaceholder}
+      />
+      <ContactsMeListItem
+        contact={me}
+        avatarSrc={meAvatarSrc}
+        addressCountLabel={labels.formatAddressCount(me.addressCount)}
+        onOpen={onOpenContact}
+      />
+      {showAddContact ? (
+        <ContactsAddContactListItem label={labels.addContact} onPress={onAddContact} />
+      ) : null}
+    </Box>
+  );
+}

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.native.tsx
@@ -1,34 +1,63 @@
-import React from "react";
-import { Box, SearchInput } from "@ledgerhq/lumen-ui-rnative";
-import type { ContactsPageProps } from "../..";
-import { ContactsAddContactListItem } from "./ContactsAddContactListItem.native";
-import { ContactsMeListItem } from "./ContactsMeListItem.native";
+import React, { useCallback } from "react";
+import { SectionList, type SectionListRenderItemInfo } from "react-native";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsListItem, ContactsPageProps } from "../..";
+import { ContactsListHeader } from "./ContactsListHeader.native";
+import { ContactsSavedContactListItem } from "./ContactsSavedContactListItem.native";
+import { ContactsSectionHeader } from "./ContactsSectionHeader.native";
 
 export function ContactsPage({
   viewModel,
   labels,
   meAvatarSrc,
-  onOpenMe,
+  onOpenContact,
   onAddContact,
-}: Readonly<ContactsPageProps>): React.JSX.Element {
+}: ContactsPageProps): React.JSX.Element {
+  const isPopulated = viewModel.displayMode === "populated";
+  const renderContact = useCallback(
+    ({ item }: SectionListRenderItemInfo<ContactsListItem>) => (
+      <ContactsSavedContactListItem
+        contact={item}
+        addressCountLabel={labels.formatAddressCount(item.addressCount)}
+        onOpen={onOpenContact}
+      />
+    ),
+    [labels, onOpenContact],
+  );
+
+  const listHeader = (
+    <ContactsListHeader
+      me={viewModel.me}
+      labels={labels}
+      meAvatarSrc={meAvatarSrc}
+      showAddContact={!isPopulated}
+      onOpenContact={onOpenContact}
+      onAddContact={onAddContact}
+    />
+  );
+
   return (
     <Box testID="contacts-screen" lx={{ flex: 1, backgroundColor: "base" }}>
-      <Box lx={{ gap: "s8", paddingHorizontal: "s16", paddingTop: "s8" }}>
-        <SearchInput
-          testID="contacts-search-input"
-          value=""
-          editable={false}
-          placeholder={labels.searchPlaceholder}
-          accessibilityLabel={labels.searchPlaceholder}
-        />
-        <ContactsMeListItem
-          contact={viewModel.me}
-          avatarSrc={meAvatarSrc}
-          addressCountLabel={labels.formatAddressCount(viewModel.me.addressCount)}
-          onOpen={onOpenMe}
-        />
-        <ContactsAddContactListItem label={labels.addContact} onPress={onAddContact} />
-      </Box>
+      {isPopulated ? (
+        <Box lx={{ flex: 1 }}>
+          <SectionList
+            testID="contacts-list"
+            sections={viewModel.sections}
+            keyExtractor={contact => contact.contactId}
+            renderItem={renderContact}
+            renderSectionHeader={({ section }) => <ContactsSectionHeader title={section.title} />}
+            ListHeaderComponent={listHeader}
+            contentContainerStyle={{
+              paddingHorizontal: 16,
+              paddingTop: 8,
+              paddingBottom: 24,
+            }}
+            showsVerticalScrollIndicator={false}
+          />
+        </Box>
+      ) : (
+        <Box lx={{ paddingHorizontal: "s16", paddingTop: "s8" }}>{listHeader}</Box>
+      )}
     </Box>
   );
 }

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.web.test.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.web.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ContactId } from "@domain/entity-contact";
 import { mockMeContact } from "@domain/entity-contact/schema.mock";
 import type { ContactsLedgerSyncStatus } from "../../types";
 import { createEmptyContactsListViewModel } from "../../viewModel";
@@ -9,7 +10,7 @@ type RenderContactsPageOptions = Readonly<{
   ledgerSyncStatus?: ContactsLedgerSyncStatus;
   isIntroductionOpen?: boolean;
   onDismissIntroduction?: () => void;
-  onOpenMe?: (contactId: string) => void;
+  onOpenContact?: (contactId: ContactId) => void;
   onAddContact?: () => void;
 }>;
 
@@ -17,7 +18,7 @@ function renderContactsPage({
   ledgerSyncStatus = "ready",
   isIntroductionOpen = false,
   onDismissIntroduction = jest.fn(),
-  onOpenMe = jest.fn(),
+  onOpenContact = jest.fn(),
   onAddContact = jest.fn(),
 }: RenderContactsPageOptions = {}) {
   render(
@@ -30,7 +31,7 @@ function renderContactsPage({
         formatAddressCount: count => `${count} address`,
       }}
       meAvatarSrc="https://example.com/black/user.png"
-      onOpenMe={onOpenMe}
+      onOpenContact={onOpenContact}
       onAddContact={onAddContact}
       ledgerSyncStatus={ledgerSyncStatus}
       ledgerSyncIntroduction={{
@@ -43,12 +44,12 @@ function renderContactsPage({
     />,
   );
 
-  return { onDismissIntroduction, onOpenMe, onAddContact };
+  return { onDismissIntroduction, onOpenContact, onAddContact };
 }
 
 describe("ContactsPage", () => {
   it("renders the empty contacts list inside the page and delegates row actions", () => {
-    const { onOpenMe, onAddContact } = renderContactsPage();
+    const { onOpenContact, onAddContact } = renderContactsPage();
 
     expect(screen.getByTestId("contacts-page-layout")).toBeVisible();
     expect(screen.getByTestId("contacts-page-header")).toBeVisible();
@@ -69,7 +70,7 @@ describe("ContactsPage", () => {
     fireEvent.click(screen.getByTestId("contacts-add-contact"));
     fireEvent.click(screen.getByTestId("contacts-add-contact-header"));
 
-    expect(onOpenMe).toHaveBeenCalledWith("contact-me");
+    expect(onOpenContact).toHaveBeenCalledWith("contact-me");
     expect(onAddContact).toHaveBeenCalledTimes(2);
   });
 

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsSavedContactListItem.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsSavedContactListItem.native.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsListItem } from "../..";
+import { ContactsInitialAvatar } from "./ContactsInitialAvatar.native";
+
+type ContactsSavedContactListItemProps = Readonly<{
+  contact: ContactsListItem;
+  addressCountLabel: string;
+  onOpen: (contactId: ContactsListItem["contactId"]) => void;
+}>;
+
+export function ContactsSavedContactListItem({
+  contact,
+  addressCountLabel,
+  onOpen,
+}: ContactsSavedContactListItemProps): React.JSX.Element {
+  return (
+    <ListItem
+      testID={`contacts-saved-contact-${contact.contactId}`}
+      onPress={() => onOpen(contact.contactId)}
+      density="expanded"
+      lx={{ marginHorizontal: "-s8" }}
+    >
+      <ListItemLeading>
+        <ContactsInitialAvatar contact={contact} />
+        <ListItemContent>
+          <ListItemTitle>{contact.name}</ListItemTitle>
+          <ListItemDescription>{addressCountLabel}</ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+    </ListItem>
+  );
+}

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsSectionHeader.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsSectionHeader.native.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { SectionHeader, SectionHeaderTitle } from "@ledgerhq/lumen-ui-rnative";
+
+type ContactsSectionHeaderProps = Readonly<{
+  title: string;
+}>;
+
+export function ContactsSectionHeader({ title }: ContactsSectionHeaderProps): React.JSX.Element {
+  return (
+    <SectionHeader
+      appearance="plain"
+      testID={`contacts-section-${title}`}
+      lx={{ width: "full", marginTop: "s8" }}
+    >
+      <SectionHeaderTitle>{title}</SectionHeaderTitle>
+    </SectionHeader>
+  );
+}

--- a/features/flow/contacts/src/list/index.ts
+++ b/features/flow/contacts/src/list/index.ts
@@ -1,5 +1,6 @@
 export {
   createContactsSearchViewModel,
+  createContactsListViewModel,
   createEmptyContactsListViewModel,
   createPopulatedContactsListViewModel,
 } from "./viewModel";
@@ -12,6 +13,8 @@ export type {
   ContactsSearchResultsViewModel,
   ContactsSearchViewModel,
   ContactsListItem,
+  ContactsListSection,
+  ContactsListViewModel,
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,
 } from "./types";

--- a/features/flow/contacts/src/list/internals/createContactsListSections.ts
+++ b/features/flow/contacts/src/list/internals/createContactsListSections.ts
@@ -1,0 +1,23 @@
+import type { ContactsListItem, ContactsListSection } from "../types";
+
+function getSectionTitle(initial: string): string {
+  return initial;
+}
+
+export function createContactsListSections(
+  contacts: readonly ContactsListItem[],
+): readonly ContactsListSection[] {
+  const sectionsByTitle = new Map<string, ContactsListItem[]>();
+
+  for (const contact of contacts) {
+    const title = getSectionTitle(contact.initial);
+    const section = sectionsByTitle.get(title) ?? [];
+
+    section.push(contact);
+    sectionsByTitle.set(title, section);
+  }
+
+  return [...sectionsByTitle.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([title, data]) => ({ title, data }));
+}

--- a/features/flow/contacts/src/list/internals/getContactInitialAvatarBackground.ts
+++ b/features/flow/contacts/src/list/internals/getContactInitialAvatarBackground.ts
@@ -1,0 +1,22 @@
+import type { ContactId } from "@domain/entity-contact";
+
+const CONTACT_INITIAL_AVATAR_BACKGROUNDS = [
+  "avatarRed",
+  "avatarOrange",
+  "avatarYellow",
+  "avatarGreen",
+  "avatarBlue",
+  "avatarPurple",
+  "avatarPink",
+  "avatarTurquoise",
+] as const;
+
+export function getContactInitialAvatarBackground(contactId: ContactId) {
+  let hash = 0;
+
+  for (const character of contactId) {
+    hash = (hash * 31 + character.codePointAt(0)!) >>> 0;
+  }
+
+  return CONTACT_INITIAL_AVATAR_BACKGROUNDS[hash % CONTACT_INITIAL_AVATAR_BACKGROUNDS.length];
+}

--- a/features/flow/contacts/src/list/internals/index.ts
+++ b/features/flow/contacts/src/list/internals/index.ts
@@ -1,1 +1,3 @@
 export { getContactInitial } from "./getContactInitial";
+export { createContactsListSections } from "./createContactsListSections";
+export { getContactInitialAvatarBackground } from "./getContactInitialAvatarBackground";

--- a/features/flow/contacts/src/list/types.ts
+++ b/features/flow/contacts/src/list/types.ts
@@ -7,9 +7,24 @@ export type ContactsListItem = Readonly<{
   addressCount: number;
 }>;
 
+export type ContactsListSection = Readonly<{
+  title: string;
+  data: readonly ContactsListItem[];
+}>;
+
 export type EmptyContactsListViewModel = Readonly<{
+  displayMode: "empty";
   me: ContactsListItem;
 }>;
+
+export type PopulatedContactsListViewModel = Readonly<{
+  displayMode: "populated";
+  me: ContactsListItem;
+  savedContacts: readonly ContactsListItem[];
+  sections: readonly ContactsListSection[];
+}>;
+
+export type ContactsListViewModel = EmptyContactsListViewModel | PopulatedContactsListViewModel;
 
 export type ContactsPageLabels = Readonly<{
   title: string;
@@ -28,18 +43,13 @@ export type ContactsLedgerSyncIntroduction = Readonly<{
 }>;
 
 export type ContactsPageProps = Readonly<{
-  viewModel: EmptyContactsListViewModel;
+  viewModel: ContactsListViewModel;
   labels: ContactsPageLabels;
   meAvatarSrc: string;
-  onOpenMe: (contactId: ContactId) => void;
+  onOpenContact: (contactId: ContactId) => void;
   onAddContact: () => void;
   ledgerSyncStatus: ContactsLedgerSyncStatus;
   ledgerSyncIntroduction: ContactsLedgerSyncIntroduction;
-}>;
-
-export type PopulatedContactsListViewModel = Readonly<{
-  me: ContactsListItem;
-  savedContacts: readonly ContactsListItem[];
 }>;
 
 export type ContactsSearchResultsViewModel = PopulatedContactsListViewModel &

--- a/features/flow/contacts/src/list/viewModel.test.ts
+++ b/features/flow/contacts/src/list/viewModel.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("createEmptyContactsListViewModel", () => {
   it("returns the Me row with no addresses", () => {
-    expect(createEmptyContactsListViewModel(mockMeContact())).toEqual({
+    expect(createEmptyContactsListViewModel(mockMeContact())).toMatchObject({
       me: {
         contactId: "contact-me",
         name: "Me",
@@ -23,7 +23,7 @@ describe("createEmptyContactsListViewModel", () => {
       addresses: [mockContactAddress()],
     });
 
-    expect(createEmptyContactsListViewModel(me)).toEqual({
+    expect(createEmptyContactsListViewModel(me)).toMatchObject({
       me: {
         contactId: "contact-me",
         name: "Élodie",
@@ -50,7 +50,7 @@ describe("createPopulatedContactsListViewModel", () => {
       mockContact({ id: "contact-ada", name: "Ada" }),
     ];
 
-    expect(createPopulatedContactsListViewModel(me, contacts)).toEqual({
+    expect(createPopulatedContactsListViewModel(me, contacts)).toMatchObject({
       me: {
         contactId: "contact-me",
         name: "Me",
@@ -112,7 +112,7 @@ describe("createContactsSearchViewModel", () => {
   ];
 
   it("should return the populated list for an empty query", () => {
-    expect(createContactsSearchViewModel(me, contacts, "  ")).toEqual({
+    expect(createContactsSearchViewModel(me, contacts, "  ")).toMatchObject({
       status: "results",
       me: {
         contactId: "contact-me",
@@ -144,7 +144,7 @@ describe("createContactsSearchViewModel", () => {
   });
 
   it("should return case-insensitive saved contact matches", () => {
-    expect(createContactsSearchViewModel(me, contacts, "bEn")).toEqual({
+    expect(createContactsSearchViewModel(me, contacts, "bEn")).toMatchObject({
       status: "results",
       me: {
         contactId: "contact-me",
@@ -164,7 +164,7 @@ describe("createContactsSearchViewModel", () => {
   });
 
   it("should return no results when only Me matches the query", () => {
-    expect(createContactsSearchViewModel(me, contacts, "Me")).toEqual({
+    expect(createContactsSearchViewModel(me, contacts, "Me")).toMatchObject({
       status: "no-results",
       me: {
         contactId: "contact-me",

--- a/features/flow/contacts/src/list/viewModel.ts
+++ b/features/flow/contacts/src/list/viewModel.ts
@@ -5,7 +5,7 @@ import type {
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,
 } from "./types";
-import { getContactInitial } from "./internals";
+import { createContactsListSections, getContactInitial } from "./internals";
 
 function createContactsListItem(contact: Contact): ContactsListItem {
   return {
@@ -29,7 +29,20 @@ function createSavedContactsListItems(contacts: readonly Contact[], normalizedQu
 
 export function createEmptyContactsListViewModel(me: Contact): EmptyContactsListViewModel {
   return {
+    displayMode: "empty",
     me: createContactsListItem(me),
+  };
+}
+
+function createPopulatedContactsListViewModelFromSavedContacts(
+  me: Contact,
+  savedContacts: readonly ContactsListItem[],
+): PopulatedContactsListViewModel {
+  return {
+    displayMode: "populated",
+    me: createContactsListItem(me),
+    savedContacts,
+    sections: createContactsListSections(savedContacts),
   };
 }
 
@@ -37,10 +50,23 @@ export function createPopulatedContactsListViewModel(
   me: Contact,
   contacts: readonly Contact[],
 ): PopulatedContactsListViewModel {
-  return {
-    me: createContactsListItem(me),
-    savedContacts: createSavedContactsListItems(contacts),
-  };
+  return createPopulatedContactsListViewModelFromSavedContacts(
+    me,
+    createSavedContactsListItems(contacts),
+  );
+}
+
+export function createContactsListViewModel(
+  me: Contact,
+  contacts: readonly Contact[],
+): EmptyContactsListViewModel | PopulatedContactsListViewModel {
+  const savedContacts = createSavedContactsListItems(contacts);
+
+  if (savedContacts.length > 0) {
+    return createPopulatedContactsListViewModelFromSavedContacts(me, savedContacts);
+  }
+
+  return createEmptyContactsListViewModel(me);
 }
 
 export function createContactsSearchViewModel(
@@ -68,7 +94,6 @@ export function createContactsSearchViewModel(
 
   return {
     status: "results",
-    me: createContactsListItem(me),
-    savedContacts,
+    ...createPopulatedContactsListViewModelFromSavedContacts(me, savedContacts),
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Dedicated Native and integration coverage is isolated in stacked PR [#19757](https://github.com/LedgerHQ/ledger-live/pull/19757)._
- [x] **Impact of the changes:**
  - Mobile Contacts list rendering from the Contacts Redux slice
  - Alphabetical sections and deterministic initial avatars
  - Existing Contacts feature-flag gate and empty-list behaviour

### 📝 Description

This PR implements the populated Contacts list on Mobile for [LIVE-33887](https://ledgerhq.atlassian.net/browse/LIVE-33887).

The Contacts Flow selects the existing Contacts domain slice and builds the shared populated view model. The native Flow page renders grouped saved contacts through a `SectionList`, Lumen section headers, and deterministic initial avatars. The Mobile MVVM layer remains limited to translations, the existing Me avatar, and callbacks.

The empty-list Add contact row is preserved. In the populated state, the header `+` remains the sole Add-contact entry point. Search, contact details, persistence, custom pictures, and the interactive alphabetical index remain outside this ticket.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-07-20 at 10 18 24" src="https://github.com/user-attachments/assets/7249f91f-056f-46a0-af58-7ce1a8af11a0" />

### ❓ Context

- **JIRA**: [LIVE-33887](https://ledgerhq.atlassian.net/browse/LIVE-33887)
- **Dedicated tests**: [#19757](https://github.com/LedgerHQ/ledger-live/pull/19757)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** made and the stacked-PR split.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** through its dedicated stacked test PR.
- **Any new dependencies** are documented in the tests PR.
- **Performance** is unaffected by this rendering change.

[LIVE-33887]: https://ledgerhq.atlassian.net/browse/LIVE-33887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33887]: https://ledgerhq.atlassian.net/browse/LIVE-33887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ