### PR TITLE
[LWDM] fix(jest): CI stability fixes for jest 30

### DIFF
--- a/libs/evm-tools/jest.config.js
+++ b/libs/evm-tools/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  forceExit: true,
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -107,7 +107,10 @@ const defaultConfig = {
       },
     ],
   },
-  transformIgnorePatterns: ["/node_modules/(?!|@babel/runtime/helpers/esm/)"],
+  transformIgnorePatterns: [
+    "/node_modules/(?!|@babel/runtime/helpers/esm/)",
+    "/node_modules/cross-sha256/",
+  ],
   moduleDirectories: ["node_modules", "cli/node_modules"],
   moduleNameMapper: {
     "^buffer$": "<rootDir>/jest.buffer-shim.js",
@@ -125,6 +128,8 @@ const defaultConfig = {
 };
 
 export default {
+  forceExit: true,
+  coverageProvider: "babel",
   globalSetup: process.env.UPDATE_BACKEND_MOCKS
     ? "<rootDir>/src/__tests__/test-helpers/bridgeSetupUpdateMocks.ts"
     : process.env.USE_BACKEND_MOCKS


### PR DESCRIPTION
### 📝 Description

Fixes several CI instabilities introduced by the upgrade to jest 30 + `@swc/jest@0.2.39`:

- **`forceExit: true`** on `@ledgerhq/live-common` and `@ledgerhq/evm-tools` — prevents hanging async ops from causing exit code 1
- **`coverageProvider: "babel"`** on `@ledgerhq/live-common` — avoids a v8-to-istanbul crash in jest 30
- **`cross-sha256` exclusion** in `transformIgnorePatterns` for `@ledgerhq/live-common` — `cross-sha256@1.2.0` ships a `//# sourceMappingURL` pointing to a missing `.map` file; SWC panics when it hits it

> [!NOTE]
> Prerequisite / companion to the LIVE-32915 error-class migration series. The coverage fix was needed to unblock CI on the migration PRs.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **Big picture PR**: #19723 — full scope of the `@ledgerhq/errors` decoupling (split into per-team PRs for review)

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ