### PR TITLE
[LWDM] chore(errors): [coin-integration] Phase 1 — replace instanceof with .name checks

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -107,7 +106,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
@@ -1,7 +1,6 @@
 import { getOriginalTxFeeRateSatVb } from "@ledgerhq/live-common/families/bitcoin/editTransaction/rbfValidation";
 import { fromTransactionRaw } from "@ledgerhq/coin-bitcoin/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-bitcoin/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -190,7 +189,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import { render } from "tests/testSetup";
 import ErrorBanner from "~/renderer/components/ErrorBanner";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendRecipientFields.tsx
@@ -1,4 +1,4 @@
-import { PendingOperation } from "@ledgerhq/errors";
+import { PendingOperation } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { BitcoinAccount } from "@ledgerhq/live-common/families/bitcoin/types";
 import { isConfirmedOperation } from "@ledgerhq/live-common/operation";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import {
   ZCASH_ACTIVATION_DATE,
   ZCASH_ACTIVATION_DATE_STRING,
@@ -62,7 +61,7 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   };
 
   const handleUfvkChanged = (ufvk: string, error?: Error | undefined | null) => {
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setUfvkExportError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
@@ -6,7 +6,7 @@ import type { BitcoinAccountBridge } from "@ledgerhq/coin-bitcoin/bridge/js";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
@@ -1,5 +1,4 @@
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getDefaultAccountNameForCurrencyIndex } from "@ledgerhq/live-wallet/accountName";
 import { isAxiosError } from "axios";
 import React from "react";
@@ -112,8 +111,8 @@ const getStatusMessage = (status?: OnboardStatus): string => {
 };
 
 const getErrorMessage = (error: Error | null) => {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return <Trans i18nKey={error.message} />;
+  if (error?.name === "UserRefusedOnDevice" || error?.name === "LockedDeviceError") {
+    return <Trans i18nKey={error?.message} />;
   }
   return <Trans i18nKey="families.canton.addAccount.onboard.error" />;
 };

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -113,7 +113,7 @@ export function usePendingTransferProposalsViewModel(
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           if (device) {
             handleTopologyChangeError(dispatch, {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
@@ -38,9 +38,9 @@ const Root = (props: {
   const cantonAccount = account as CantonAccount;
   const mainAccount = getMainAccount(account, parentAccount);
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   useEffect(() => {
     if (topologyChangeError) {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -136,7 +135,7 @@ const Body = ({
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -122,7 +121,7 @@ const Body = ({
     onChangeStepId("summary");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -14,7 +14,6 @@ import BigNumber from "bignumber.js";
 import Alert from "~/renderer/components/Alert";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
 
 const FromToWrapper = styled.div``;
@@ -30,7 +29,7 @@ function StepSummary(props: StepProps) {
   const { estimatedFees, errors, warnings } = status;
   const { feeTooHigh } = warnings;
   const displayError = errors.amount?.message ? errors.amount : "";
-  const notEnoughFundsError = error && error instanceof CardanoNotEnoughFunds;
+  const notEnoughFundsError = error && error?.name === "CardanoNotEnoughFunds";
 
   const accountUnit = useMaybeAccountUnit(account);
   if (!account || !transaction || !account.cardanoResources.delegation) return null;

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -103,7 +102,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("vote");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -100,7 +99,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
-import { FeeNotLoaded, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { FeeNotLoaded, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import SendStepAmount, { FEES_BANNER_TESTID } from "./SendStepAmount";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NotEnoughBalanceFees } from "@ledgerhq/errors";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { DefaultStepAmount } from "~/renderer/modals/Send/steps/StepAmount";
 import type { StepProps } from "~/renderer/modals/Send/types";
@@ -9,7 +8,7 @@ export const FEES_BANNER_TESTID = "celo-send-fees-error-banner";
 const SendStepAmount = (props: StepProps) => {
   const { status, error, bridgePending } = props;
   const feesError = status.errors.fees;
-  const showFeesBanner = !error && !bridgePending && feesError instanceof NotEnoughBalanceFees;
+  const showFeesBanner = !error && !bridgePending && feesError?.name === "NotEnoughBalanceFees";
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
@@ -12,7 +12,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AmountField from "../fields/AmountField";
 import { StepProps } from "../types";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export const StepAmountFooter = ({
   transitionTo,
@@ -58,7 +57,7 @@ const StepAmount = ({
 }: StepProps) => {
   invariant(account && transaction, "account and transaction required");
   const notEnoughFundsError =
-    status.errors.amount && status.errors.amount instanceof NotEnoughBalance;
+    status.errors.amount && status.errors.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -112,7 +111,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
@@ -3,8 +3,6 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -52,7 +50,9 @@ export const StepAmountFooter = ({
 
 const isTransactionRefuse = (error: unknown) => {
   return (
-    error && (error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
+    error &&
+    ((error as { name?: string })?.name === "UserRefusedOnDevice" ||
+      (error as { name?: string })?.name === "TransactionRefusedOnDevice")
   );
 };
 

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { cleanup, render, screen, waitFor } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumPairingExpiredError,
+} from "@ledgerhq/coin-concordium/types";
 import { Account } from "@ledgerhq/types-live";
 import OnboardModal from "../index";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { isAxiosError } from "axios";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import Alert from "~/renderer/components/Alert";
 
 type Props = Readonly<{
@@ -18,8 +17,11 @@ export default function OnboardError({ error, context }: Props) {
 }
 
 function resolveMessageKey(error: Error | null, context: "onboard" | "create"): string {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return error.message;
+  if (
+    (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+    (error as { name?: string })?.name === "LockedDeviceError"
+  ) {
+    return error?.message ?? "";
   }
 
   if (context === "create" && isAxiosError(error) && error.status === 429) {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/OnboardError.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/OnboardError.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render } from "tests/testSetup";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import OnboardError from "../OnboardError";
 
 describe("OnboardError", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
@@ -1,5 +1,8 @@
-import { AccountOnboardStatus, ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumPairingStatus,
+  ConcordiumPairingExpiredError,
+} from "@ledgerhq/coin-concordium/types";
 import {
   getConfirmationCode,
   shouldRetryPairing,

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
@@ -2,8 +2,8 @@ import {
   AccountOnboardStatus,
   ConcordiumPairingProgress,
   ConcordiumPairingStatus,
+  ConcordiumPairingExpiredError,
 } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 
 export const MAX_EXPIRED_RETRIES = 3;
 export const CONFIRMATION_CODE_LENGTH = 4;
@@ -22,7 +22,7 @@ export function shouldRetryPairing(error: unknown, retryCount: number): boolean 
     return false;
   }
 
-  return error instanceof ConcordiumPairingExpiredError;
+  return (error as { name?: string })?.name === "ConcordiumPairingExpiredError";
 }
 
 export type PairingStateUpdate = {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
@@ -4,7 +4,8 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { firstValueFrom } from "rxjs";
 import { Account } from "@ledgerhq/types-live";
-import { ConcordiumTrustedMetadataServiceError, DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
+import { ConcordiumTrustedMetadataServiceError } from "@ledgerhq/coin-concordium/types";
 import { getEnv } from "@ledgerhq/live-env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -146,7 +147,7 @@ const StepReceiveFunds = ({
     } catch (err) {
       // Trusted-metadata-service failures (network/5xx) are transient — route
       // to the fallback UI instead of the hard error screen.
-      if (err instanceof ConcordiumTrustedMetadataServiceError) {
+      if ((err as { name?: string })?.name === "ConcordiumTrustedMetadataServiceError") {
         onChangeAddressVerified(false, null);
       } else if (err instanceof Error) {
         onChangeAddressVerified(false, err);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -120,7 +119,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -126,7 +125,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
@@ -9,7 +9,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -136,7 +135,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
@@ -19,7 +19,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepAmount({
   account,
@@ -75,7 +74,7 @@ export default function StepAmount({
   );
   const amount = useMemo(() => (validator ? validator.amount : BigNumber(0)), [validator]);
   const crypto = cryptoFactory(account.currency.id);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -139,7 +138,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
@@ -1,6 +1,5 @@
 import { fromTransactionRaw } from "@ledgerhq/live-common/families/evm/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -172,7 +171,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -1,4 +1,5 @@
-import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
+import { NotEnoughGas } from "@ledgerhq/coin-evm/errors";
 import React from "react";
 import { render } from "tests/testSetup";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
@@ -28,8 +29,7 @@ describe("EVM TransactionErrorBanner", () => {
   });
 
   it("hides generic description for NotEnoughGas gasPrice errors", () => {
-    const notEnoughGasError = new Error("not enough gas");
-    Object.setPrototypeOf(notEnoughGasError, NotEnoughGas.prototype);
+    const notEnoughGasError = new NotEnoughGas("not enough gas");
 
     render(
       <TransactionErrorBanner

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 
@@ -13,7 +13,7 @@ export const TransactionErrorBanner = ({
     return <ErrorBanner error={new TransactionHasBeenValidatedError()} />;
   }
 
-  if (errors.gasPrice instanceof NotEnoughGas) {
+  if (errors.gasPrice?.name === "NotEnoughGas") {
     return <ErrorBanner error={errors.gasPrice} fallback={{ description: <></> }} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
@@ -144,7 +143,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -129,7 +128,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -116,7 +115,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
@@ -127,7 +126,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -11,7 +11,6 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isTokenAssociationRequired } from "@ledgerhq/live-common/families/hedera/utils";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
@@ -242,7 +241,7 @@ const Body = ({
   }, [onChangeAddressVerified, setDisabledSteps, steps, onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -108,7 +107,7 @@ const Body = (props: Props) => {
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -123,7 +122,7 @@ const Body = (props: Props) => {
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
@@ -5,7 +5,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ const Body = (props: Props) => {
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -109,7 +108,7 @@ const Body = (props: Props) => {
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
@@ -14,7 +14,6 @@ import Alert from "~/renderer/components/Alert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 export default function StepAmount({
   account,
   transaction,
@@ -66,7 +65,7 @@ export default function StepAmount({
     };
   }, [transaction]);
   const amount = useMemo(() => (validator ? validator.amount : new BigNumber(0)), [validator]);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("castNominations");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -21,7 +21,6 @@ import {
   PolkadotValidator,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/polkadot/types";
-import { PolkadotValidatorsRequired } from "@ledgerhq/live-common/families/polkadot/errors";
 import { radii } from "~/renderer/styles/theme";
 import { openURL } from "~/renderer/linking";
 import Box from "~/renderer/components/Box";
@@ -189,8 +188,8 @@ const ValidatorField = ({
   if (!status) return null;
   const error = getStatusError(status, "errors");
   const warning = getStatusError(status, "warnings");
-  const maybeChill = error instanceof PolkadotValidatorsRequired;
-  const ignoreError = error instanceof PolkadotValidatorsRequired && !nominations.length; // Do not show error on first nominate
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length; // Do not show error on first nominate
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -96,7 +95,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St, Mode } from "./types";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -113,7 +112,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -15,7 +15,6 @@ import ValidatorRow from "../../shared/components/ValidatorRow";
 import { StepProps } from "../types";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepValidator({
   account,
@@ -45,7 +44,7 @@ export default function StepValidator({
   if (validator === undefined) {
     return null;
   }
-  const notEnoughFundsError = status.errors?.fee instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.fee?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
@@ -9,7 +9,6 @@ import {
   SolanaAccount,
 } from "@ledgerhq/live-common/families/solana/types";
 import { useFeature } from "@features/platform-feature-flags";
-import { SolanaRecipientMemoIsRequired } from "@ledgerhq/live-common/errors";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 
 type Props = {
@@ -44,7 +43,7 @@ const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: P
   );
 
   const InputField = lldMemoTag?.enabled ? MemoTagField : Input;
-  const isRecipientMemoRequired = status?.errors?.memo instanceof SolanaRecipientMemoIsRequired;
+  const isRecipientMemoRequired = status?.errors?.memo?.name === "SolanaRecipientMemoIsRequired";
 
   return transaction.model.kind === "transfer" || transaction.model.kind === "token.transfer" ? (
     <InputField

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, StepId, St } from "./types";
@@ -105,7 +104,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -106,7 +105,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice" as St["id"]);
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -11,7 +11,6 @@ import { getMainAccount, addPendingOperation } from "@ledgerhq/live-common/accou
 import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import logger from "~/renderer/logger";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import Track from "~/renderer/analytics/Track";
@@ -178,7 +177,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
@@ -3,7 +3,6 @@ import { bindActionCreators } from "redux";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
 import invariant from "invariant";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -146,7 +145,7 @@ const Body = ({ stepId, params, onClose, onChangeStepId }: Props) => {
 
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { act, fireEvent, render, screen } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { StepProps } from "../types";
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from "react";
 import invariant from "invariant";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -87,7 +86,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { render, waitFor } from "@tests/test-renderer";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { ScreenName } from "~/const";
 import { MethodSelection } from "./MethodSelection";
 

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -4,7 +4,7 @@ import type {
   TransactionRaw,
 } from "@ledgerhq/coin-bitcoin/types";
 import { isOldestBitcoinPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/ErrorSection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/ErrorSection.test.tsx
@@ -1,4 +1,5 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { render, screen } from "@tests/test-renderer";
 import React from "react";
 import { ErrorSection } from "../components/ErrorSection";

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
@@ -1,4 +1,3 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Alert, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import React from "react";
@@ -44,7 +43,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof UserRefusedOnDevice) {
+  if (error?.name === "UserRefusedOnDevice") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,
@@ -53,7 +52,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof LockedDeviceError) {
+  if (error?.name === "LockedDeviceError") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,

--- a/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -1,5 +1,4 @@
 import { isCantonAccount } from "@ledgerhq/coin-canton";
-import { TopologyChangeError } from "@ledgerhq/coin-canton/types/errors";
 import type { Sync } from "@ledgerhq/live-common/bridge/react/types";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -190,7 +189,7 @@ export function usePendingTransferProposalsViewModel({
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           redirectToReonboarding(action, contractId);
           return;

--- a/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
@@ -35,9 +35,9 @@ function StepRecipientCustomAlert({
   const route = useRoute<ScreenRoute>();
   const llmModularDrawer = useFeature("llmModularDrawer");
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   const redirectToReonboarding = useCallback(() => {
     if (!account) return;

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -33,7 +33,6 @@ import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
 import RetryButton from "~/components/RetryButton";
 import CancelButton from "~/components/CancelButton";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = StackNavigatorProps<
@@ -104,7 +103,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, bridge, transaction]);
 
-  const hasNotEnoughtBalanceError = bridgeError instanceof CardanoNotEnoughFunds;
+  const hasNotEnoughtBalanceError = bridgeError?.name === "CardanoNotEnoughFunds";
 
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
@@ -22,7 +22,6 @@ import type { BaseComposite, StackNavigatorProps } from "~/components/RootNaviga
 import { CeloRevokeFlowFlowParamList } from "./types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<
@@ -95,7 +94,7 @@ export default function VoteAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
 
-  const isRevokingWithFeesError = error instanceof NotEnoughBalance;
+  const isRevokingWithFeesError = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -30,7 +30,6 @@ import ErrorAndWarning from "../components/ErrorAndWarning";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { CeloWithdrawFlowParamList } from "./types";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -162,7 +161,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
       <View style={styles.footer}>
         <View style={styles.errors}>
           {!!(error && error instanceof Error) && <ErrorAndWarning error={error} />}
-          {error && error instanceof AddressesSanctionedError && (
+          {error && error?.name === "AddressesSanctionedError" && (
             <SupportLinkError error={error} type="alert" />
           )}
           {!!(warning && warning instanceof Error) && <ErrorAndWarning warning={warning} />}

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
@@ -1,7 +1,10 @@
 import { renderHook, waitFor, act } from "@tests/test-renderer";
 import { Subject } from "rxjs";
-import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumSessionExpiredError, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumSessionExpiredError,
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { CreateStatus, getConfirmationCode, useOnboarding } from "../hooks/useOnboarding";

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import {
-  ConcordiumPairingExpiredError,
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
@@ -90,11 +85,11 @@ export function useOnboarding(
             message: error instanceof Error ? error.message : String(error),
           });
           unsubscribe();
-          if (error instanceof LockedDeviceError) {
+          if (error?.name === "LockedDeviceError") {
             setCreateStatus(CreateStatus.DEVICE_LOCKED);
           } else if (
-            error instanceof ConcordiumSessionExpiredError ||
-            error instanceof ConcordiumPairingExpiredError
+            error?.name === "ConcordiumSessionExpiredError" ||
+            error?.name === "ConcordiumPairingExpiredError"
           ) {
             onSessionExpired();
           } else {

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ConcordiumPairingProgress } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
+import {
+  ConcordiumPairingStatus,
+  ConcordiumPairingExpiredError,
+} from "@ledgerhq/coin-concordium/types";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { Subscription } from "rxjs";
@@ -70,7 +72,7 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
         },
         error: (error: unknown) => {
           if (
-            error instanceof ConcordiumPairingExpiredError &&
+            (error as { name?: string })?.name === "ConcordiumPairingExpiredError" &&
             retryCountRef.current < MAX_EXPIRED_RETRIES
           ) {
             retryCountRef.current++;

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/__integrations__/onboardSignatureFailures.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/__integrations__/onboardSignatureFailures.integration.test.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { Linking } from "react-native";
 import { screen, render, waitFor } from "@tests/test-renderer";
 import { server } from "@tests/server";
-import { TransportStatusError, DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
+import {
+  TransportStatusError,
+  DisconnectedDeviceDuringOperation,
+} from "@ledgerhq/hw-transport/errors";
 import OnboardScreen from "../OnboardScreen";
 import {
   SESSION_TOPIC,

--- a/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
@@ -7,7 +7,7 @@ import { useTranslation, Trans } from "~/context/Locale";
 import {
   ConcordiumAddressVerificationFailedError,
   ConcordiumTrustedMetadataServiceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/coin-concordium/types";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -122,7 +122,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
           // malformed response). Route to Confirmation with verified: false —
           // the native "skipped verification" path that shows the cached
           // address with the security modal prompt.
-          if (error instanceof ConcordiumTrustedMetadataServiceError) {
+          if (error?.name === "ConcordiumTrustedMetadataServiceError") {
             navigation.navigate(ScreenName.ReceiveConfirmation, {
               ...route.params,
               verified: false,
@@ -178,7 +178,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
 
   // Retrying a terminal address-verification refusal would just hit the same
   // 4xx again — hide the button for that class of error.
-  const canRetry = !(error instanceof ConcordiumAddressVerificationFailedError);
+  const canRetry = error?.name !== "ConcordiumAddressVerificationFailedError";
 
   return (
     <SafeAreaViewFixed isFlex edges={["left", "right", "bottom"]}>

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -34,7 +34,6 @@ import { CosmosDelegationFlowParamList } from "./types";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -223,7 +222,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
         </View>
       </View>
       <View style={styles.footer}>
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender && status.errors.sender?.name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import React from "react";
 import { fireEvent, screen } from "@testing-library/react-native";
 import { render } from "@tests/test-renderer";
-import { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+import { ClaimRewardsFeesWarning } from "@ledgerhq/coin-evm/errors";
 import type { Account } from "@ledgerhq/types-live";
 import type { StakingValidatorItem } from "@ledgerhq/live-common/families/evm/staking/types";
 import ClaimRewardsClaim from "./02-Claim";

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
@@ -6,7 +6,6 @@
 
 import { Transaction as EvmTransaction, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
-import { NotEnoughGas } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -106,7 +105,7 @@ function EditTransactionSummaryContent({ navigation, route, transactionToUpdate 
   const firstError = errors[Object.keys(errors)[0]] ?? bridgeError ?? undefined;
 
   let footerAction;
-  if (firstError && firstError instanceof NotEnoughGas) {
+  if (firstError && firstError?.name === "NotEnoughGas") {
     footerAction = isCurrencySupported(currencyOrToken as CryptoCurrency) ? (
       <Button
         event="SummaryBuyEth"

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { render, waitFor } from "@tests/test-renderer";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { ScreenName } from "~/const";
 import { MethodSelection } from "./MethodSelection";
 

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -1,7 +1,7 @@
 import { EditType } from "@ledgerhq/coin-evm/types/editTransaction";
 import { Transaction as EvmTransaction, TransactionRaw } from "@ledgerhq/coin-evm/types/index";
 import { isOldestPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
@@ -32,7 +32,6 @@ import { NearWithdrawingFlowParamList } from "../WithdrawingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
     behaviorParam = "padding";
   }
 
-  const errorDuringUnstaking = error instanceof NotEnoughBalance && transaction.mode === "unstake";
+  const errorDuringUnstaking = error?.name === "NotEnoughBalance" && transaction.mode === "unstake";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -26,7 +26,6 @@ import {
   MAX_NOMINATIONS,
   hasMinimumBondBalance,
 } from "@ledgerhq/live-common/families/polkadot/logic";
-import * as PolkadotErrors from "@ledgerhq/live-common/families/polkadot/errors";
 import {
   usePolkadotPreloadData,
   useSortedValidators,
@@ -245,9 +244,8 @@ function NominateSelectValidator({ navigation, route }: Props) {
   const error = getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const maxSelected = validators.length === MAX_NOMINATIONS;
-  const maybeChill = error instanceof PolkadotErrors.PolkadotValidatorsRequired;
-  const ignoreError =
-    error instanceof PolkadotErrors.PolkadotValidatorsRequired && !nominations.length;
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length;
   // Do not show error on first nominate
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -24,7 +24,6 @@ import SendRowsFee from "../SendRowsFee";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { PolkadotUnbondFlowParamList } from "./type";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -105,7 +104,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const hasErrors = hasStatusError(status);
-  const hasErrorDuringUnbonding = error instanceof NotEnoughBalance;
+  const hasErrorDuringUnbonding = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -36,9 +36,7 @@ import { DelegationAction, SolanaDelegationFlowParamList } from "./types";
 import TranslatedError from "../../../components/TranslatedError";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -139,7 +137,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const error = Object.values(status.errors)[0];
   const feeError = status.errors.fee;
   const isUndelagating = transaction.model.kind === "stake.undelegate";
-  const hasErrorWhileDesactivating = isUndelagating && feeError instanceof NotEnoughBalance;
+  const hasErrorWhileDesactivating = isUndelagating && feeError?.name === "NotEnoughBalance";
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
@@ -206,7 +204,8 @@ export default function DelegationSummary({ navigation, route }: Props) {
       <View style={styles.footer}>
         {hasErrorWhileDesactivating && <NotEnoughFundFeesAlert account={account} />}
 
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender &&
+        (status.errors.sender as Error).name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
@@ -31,7 +31,6 @@ import { SuiUnstakingFlowParamList } from "../UnstakingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import Alert from "~/components/Alert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
   }
 
   const errorDuringUnstaking =
-    error instanceof NotEnoughBalance && transaction.mode === "undelegate";
+    error?.name === "NotEnoughBalance" && transaction.mode === "undelegate";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -13,7 +13,6 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type {
@@ -172,7 +171,7 @@ export default function SelectValidator({ navigation, route }: Props) {
   invariant(transaction, "transaction is undefined");
   let error: Error | null = bridgeError || status.errors.recipient;
 
-  if (error instanceof RecipientRequired) {
+  if (error?.name === "RecipientRequired") {
     error = null;
   }
 

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -40,7 +40,6 @@ import type { TezosDelegationFlowParamList } from "./types";
 import { useAccountName } from "~/reducers/wallet";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalanceToDelegate } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "~/families/shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import TranslatedError from "~/components/TranslatedError";
@@ -191,7 +190,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     });
   }, [navigation, route.params, account.id, transaction, status]);
 
-  const notEnoughBalance = status.errors.amount instanceof NotEnoughBalanceToDelegate;
+  const notEnoughBalance = status.errors.amount?.name === "NotEnoughBalanceToDelegate";
   const isUndelagating = route.params?.mode === "undelegate";
   const hasNotEnoughBalanceWhenUndelegating = notEnoughBalance && isUndelagating;
 

--- a/libs/coin-modules/coin-aleo/.unimportedrc.json
+++ b/libs/coin-modules/coin-aleo/.unimportedrc.json
@@ -22,7 +22,8 @@
   ],
   "ignoreUnimported": [
     "src/bridge/transaction.ts",
-    "src/bridge/buildOptimisticOperation.ts"
+    "src/bridge/buildOptimisticOperation.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   getMockedAccount,
   getMockedTokenAccount,

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -5,7 +5,7 @@ import {
   NotEnoughBalance,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import type {

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import {
   EXPLORER_TRANSFER_TYPES,

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,7 +1,6 @@
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import {
@@ -250,7 +249,10 @@ export async function accessProvableApi({
   try {
     status = await apiClient.getRecordScannerStatus(currency, uuid);
   } catch (error) {
-    if (error instanceof LedgerAPI4xx && error.status === 422) {
+    if (
+      (error as { name?: string; status?: number }).name === "LedgerAPI4xx" &&
+      (error as { status?: number }).status === 422
+    ) {
       throw new AleoApiConfigurationResetError();
     }
     throw error;

--- a/libs/coin-modules/coin-algorand/src/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-algorand/src/buildOptimisticOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { buildOptimisticOperation } from "./buildOptimisticOperation";

--- a/libs/coin-modules/coin-algorand/src/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-algorand/src/buildOptimisticOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import BigNumber from "bignumber.js";
 import { AlgorandAccount, AlgorandOperation, AlgorandTransaction } from "./types";

--- a/libs/coin-modules/coin-algorand/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-algorand/src/getTransactionStatus.ts
@@ -8,15 +8,18 @@ import {
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughBalanceInParentAccount,
   RecipientRequired,
-} from "@ledgerhq/errors";
-import { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { isValidAddress } from "algosdk";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 
 import { computeAlgoMaxSpendable, isAmountValid, recipientHasAsset } from "./bridgeLogic";
-import { AlgorandASANotOptInInRecipient, AlgorandMemoExceededSizeError } from "./errors";
+import {
+  AlgorandASANotOptInInRecipient,
+  AlgorandMemoExceededSizeError,
+  ClaimRewardsFeesWarning,
+} from "./errors";
 
 import { validateMemo } from "./logic/validateMemo";
 import { extractTokenId } from "./tokens";

--- a/libs/coin-modules/coin-algorand/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-algorand/src/logic/validateIntent.ts
@@ -12,7 +12,7 @@ import {
   NotEnoughBalance,
   NotEnoughBalanceInParentAccount,
   NotEnoughBalanceBecauseDestinationNotCreated,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isValidAddress } from "algosdk";
 import { AlgorandASANotOptInInRecipient, AlgorandMemoExceededSizeError } from "../errors";
 import { getAccount } from "../network";

--- a/libs/coin-modules/coin-algorand/src/signOperation.test.ts
+++ b/libs/coin-modules/coin-algorand/src/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { BigNumber } from "bignumber.js";
 import * as buildOptimisticOperationModule from "./buildOptimisticOperation";

--- a/libs/coin-modules/coin-algorand/src/signOperation.ts
+++ b/libs/coin-modules/coin-algorand/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";

--- a/libs/coin-modules/coin-algorand/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-algorand/src/test/bridge.dataset.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   NotEnoughBalanceBecauseDestinationNotCreated,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { AlgorandASANotOptInInRecipient } from "../errors";

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -5,11 +5,9 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   NotEnoughBalanceFees,
-  NotEnoughToRestake,
-  NotEnoughToStake,
-  NotEnoughToUnstake,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughToRestake, NotEnoughToStake, NotEnoughToUnstake } from "../../errors";
 import BigNumber from "bignumber.js";
 import {
   createFixtureAccount,

--- a/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
@@ -1,18 +1,20 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
 import {
   NotEnoughBalance,
-  NotEnoughToStake,
-  UnstakeNotEnoughStakedBalanceLeft,
-  RestakeNotEnoughStakedBalanceLeft,
-  NotEnoughToRestake,
-  NotEnoughToUnstake,
   RecipientRequired,
   InvalidAddress,
   FeeNotLoaded,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalanceFees,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
+  NotEnoughToStake,
+  NotEnoughToUnstake,
+  NotEnoughToRestake,
+  UnstakeNotEnoughStakedBalanceLeft,
+  RestakeNotEnoughStakedBalanceLeft,
+} from "../errors";
 import { TokenAccount } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-bitcoin/src/__tests__/unit/buildTransaction.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/__tests__/unit/buildTransaction.unit.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 
 import { bitcoinPickingStrategy } from "../../types";
 import wallet, { TransactionInfo } from "../../wallet-btc";

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import { broadcast } from "./broadcast";
 import wallet, { getWalletAccount } from "./wallet-btc";
 import { registerChainAdapter } from "./chain-adapters/registry";

--- a/libs/coin-modules/coin-bitcoin/src/broadcast.ts
+++ b/libs/coin-modules/coin-bitcoin/src/broadcast.ts
@@ -1,5 +1,5 @@
 import type { AccountBridge } from "@ledgerhq/types-live";
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
 import wallet, { getWalletAccount } from "./wallet-btc";
 import { Transaction, BtcOperationExtra } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/buildTransaction.ts
+++ b/libs/coin-modules/coin-bitcoin/src/buildTransaction.ts
@@ -6,7 +6,7 @@ import {
   type Account as WalletAccount,
   type TransactionInfo as WalletTxInfo,
 } from "./wallet-btc";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 
 import type { Transaction, UtxoStrategy, BtcOperationExtra } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/cache.ts
+++ b/libs/coin-modules/coin-bitcoin/src/cache.ts
@@ -1,4 +1,4 @@
-import { RecipientRequired } from "@ledgerhq/errors";
+import { RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Account } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
@@ -11,7 +11,7 @@ import BigNumber from "bignumber.js";
 import { Observable, firstValueFrom, lastValueFrom, toArray } from "rxjs";
 import type { Account, SignOperationEvent } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { setZcashShieldedEnabled } from "../constants";
 import { ZcashUtxoNotInAccount } from "../../../errors";
 // Transaction lives in src/types.ts (coin-bitcoin), not in chain-adapters/types.ts

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -46,7 +46,11 @@ import {
   ZcashSigningCancelled,
   ZcashUtxoNotInAccount,
 } from "../../errors";
-import { InvalidAddress, NotEnoughBalance, RecipientRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { toZcashPrivateInfoRaw, fromZcashPrivateInfoRaw } from "./serialization";
 import { buildExtraSyncObservable } from "./sync";
 import { collectSpendableNotes } from "./operations";

--- a/libs/coin-modules/coin-bitcoin/src/datasets/bitcoin.ts
+++ b/libs/coin-modules/coin-bitcoin/src/datasets/bitcoin.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "bignumber.js";
 import type { CurrenciesData } from "@ledgerhq/types-live";
-import { DustLimit } from "@ledgerhq/errors";
+import { DustLimit } from "../errors";
 
 import type { BitcoinAccountRaw, NetworkInfoRaw, Transaction } from "../types";
 import { fromTransactionRaw } from "../transaction";

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.test.ts
@@ -1,9 +1,8 @@
 import { Account } from "@ledgerhq/types-live";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BitcoinInput, Transaction } from "./types";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
-import { DustLimit } from "@ledgerhq/errors";
-import { RbfBuildError, FeeTooLow, ZcashSaplingRecipientNotSupported } from "./errors";
+import { DustLimit, RbfBuildError, FeeTooLow, ZcashSaplingRecipientNotSupported } from "./errors";
 import BigNumber from "bignumber.js";
 
 // Mock modules before importing the module under test

--- a/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getTransactionStatus.ts
@@ -2,12 +2,17 @@ import {
   AmountRequired,
   NotEnoughBalance,
   FeeNotLoaded,
-  DustLimit,
   FeeTooHigh,
   FeeRequired,
-  OpReturnDataSizeLimit,
   InvalidAddress,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
+  DustLimit,
+  FeeTooLow,
+  OpReturnDataSizeLimit,
+  TaprootNotActivated,
+  ZcashSaplingRecipientNotSupported,
+} from "./errors";
 import { BigNumber } from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import type { Account, AccountBridge } from "@ledgerhq/types-live";
@@ -22,7 +27,6 @@ import { calculateFees, validateRecipient, isTaprootRecipient } from "./cache";
 import { OP_RETURN_DATA_SIZE_LIMIT } from "./wallet-btc/crypto/base";
 import cryptoFactory from "./wallet-btc/crypto/factory";
 import { computeDustAmount } from "./wallet-btc/utils";
-import { TaprootNotActivated, FeeTooLow, ZcashSaplingRecipientNotSupported } from "./errors";
 import { classifyZcashRecipient } from "./chain-adapters/zcash/address";
 import { Currency } from "./wallet-btc";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";

--- a/libs/coin-modules/coin-bitcoin/src/logic.ts
+++ b/libs/coin-modules/coin-bitcoin/src/logic.ts
@@ -1,6 +1,6 @@
 import cashaddr from "cashaddrjs";
 import { Currency, isValidAddress } from "./wallet-btc";
-import { RecipientRequired, InvalidAddress } from "@ledgerhq/errors";
+import { RecipientRequired, InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import type {
   BitcoinOutput,
   BitcoinResources,

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/logic.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/__tests__/logic.ts
@@ -1,6 +1,6 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { isValidRecipient } from "../../logic";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 
 describe("Test isValidRecipient", () => {
   function t(address: string, currencyId: string, expectValid: boolean) {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/bitcoin.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/bitcoin.ts
@@ -4,7 +4,7 @@ import * as bech32 from "bech32";
 import { bech32m } from "../../bech32m";
 import * as bjs from "bitcoinjs-lib";
 import { getSecp256k1Instance } from "./secp256k1";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { DerivationModes } from "../types";
 import Base from "./base";
 

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/bitcoincash.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/bitcoincash.ts
@@ -1,7 +1,7 @@
 import bchaddr from "bchaddrjs";
 import { address as btcAddress } from "bitcoinjs-lib";
 import type { BitcoinJS } from "coininfo";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import Base from "./base";
 
 // a mock explorer class that just use js objects

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/decred.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/decred.ts
@@ -1,5 +1,5 @@
 import Base from "./base";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import * as bjs from "bitcoinjs-lib";
 import bs58checkBase from "bs58check/base";
 import bs58check from "bs58check";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/zec.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/zec.ts
@@ -1,7 +1,7 @@
 import bs58check from "bs58check";
 import * as bjs from "bitcoinjs-lib";
 import type { BitcoinJS } from "coininfo";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import Base from "./base";
 
 class ZCash extends Base {

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/zen.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/crypto/zen.ts
@@ -1,6 +1,6 @@
 import bs58check from "bs58check";
 import type { BitcoinJS } from "coininfo";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import Base from "./base";
 import * as bjs from "bitcoinjs-lib";
 

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/CoinSelect.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/CoinSelect.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import flatten from "lodash/flatten";
 import sortBy from "lodash/sortBy";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";
 import { PickingStrategy } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/DeepFirst.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/DeepFirst.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import flatten from "lodash/flatten";
 import sortBy from "lodash/sortBy";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";
 import { PickingStrategy } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/Merge.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/pickingstrategies/Merge.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import flatten from "lodash/flatten";
 import sortBy from "lodash/sortBy";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";
 import { PickingStrategy } from "./types";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
@@ -89,7 +89,7 @@ function fixedWeight(currency: ICrypto, derivationMode: string): number {
 function inputWeight(derivationMode: string): number {
   const spec = INPUT_WEIGHT_SPECS[derivationMode];
   if (!spec) {
-    throw UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
+    throw new UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
   }
 
   // base non-witness weight for every input
@@ -115,7 +115,7 @@ function outputWeight(derivationMode: string): number {
   } else if (derivationMode === DerivationModes.LEGACY) {
     outputSize += 25; // DUP + HASH160 + PUSH20 + <20 bytes> + EQUALVERIFY + CHECKSIG
   } else {
-    throw UnsupportedDerivation(derivationMode);
+    throw new UnsupportedDerivation(derivationMode);
   }
 
   return outputSize * 4;

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/xpub.ts
@@ -3,7 +3,7 @@ import maxBy from "lodash/maxBy";
 import range from "lodash/range";
 import some from "lodash/some";
 import BigNumber from "bignumber.js";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { RbfBuildError } from "../errors";
 import { TX, Address, IStorage } from "./storage/types";
 import { IExplorer } from "./explorer/types";

--- a/libs/coin-modules/coin-canton/.unimportedrc.json
+++ b/libs/coin-modules/coin-canton/.unimportedrc.json
@@ -28,7 +28,8 @@
     "src/network/types.ts",
     "src/test/cantonTestUtils.ts",
     "src/test/fixtures.ts",
-    "src/supportedFeatures.ts"
+    "src/supportedFeatures.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",

--- a/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughSpendableBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import coinConfig from "../config";
 import * as gateway from "../network/gateway";

--- a/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.ts
@@ -9,7 +9,7 @@ import {
   NotEnoughBalanceInParentAccount,
   NotEnoughSpendableBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { isRecipientValid } from "../common-logic/utils";

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { LockedDeviceError } from "../errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
@@ -240,12 +241,13 @@ export const buildAuthorizePreapproval =
  * Check if an error is a LockedDeviceError or UserRefusedOnDevice and create user-friendly error messages
  */
 const handleDeviceErrors = (error: Error): Error | null => {
-  if (error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6985) {
+  if (error.name === "TransportStatusError") {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    if (statusCode === 0x6985) {
       const userRefusedError = new UserRefusedOnDevice("errors.UserRefusedOnDevice.description");
       return userRefusedError;
     }
-    if (error.statusCode === 0x5515) {
+    if (statusCode === 0x5515) {
       const lockedDeviceError = new LockedDeviceError("errors.LockedDeviceError.description");
       return lockedDeviceError;
     }

--- a/libs/coin-modules/coin-canton/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import coinConfig from "../config";

--- a/libs/coin-modules/coin-canton/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-canton/src/test/bridgeDatasetTest.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/delegate.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/delegate.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import { buildTransaction } from "../buildTransaction";
 import {

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.ts
@@ -1,16 +1,16 @@
-import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
+import {
+  AccountAwaitingSendPendingOperations,
+  CardanoFeeHigh,
+  CardanoFeeTooHigh,
+  CardanoMemoExceededSizeError,
+  CardanoNotEnoughFunds,
+} from "../errors";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import coinConfig from "../config";
-import {
-  CardanoNotEnoughFunds,
-  CardanoFeeTooHigh,
-  CardanoFeeHigh,
-  CardanoMemoExceededSizeError,
-} from "../errors";
 import { validateMemo } from "../logic/validateMemo";
 import type { CardanoAccount, CardanoOutput, Transaction, TransactionStatus } from "../types";
 import { getTransactionStatusByTransactionMode } from "./handler";

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import { BigNumber } from "bignumber.js";
 import { decodeTokenAssetId, decodeTokenCurrencyId } from "../buildSubAccounts";

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
@@ -15,14 +15,13 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-  ValAddressRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { CARDANO_MAX_SUPPLY } from "../constants";
-import { CardanoMemoExceededSizeError, CardanoMinAmountError } from "../errors";
+import { CardanoMemoExceededSizeError, CardanoMinAmountError, ValAddressRequired } from "../errors";
 import { getPaymentCredentialKeyHash, isTestnet, isTokenAsset, isValidAddress } from "../logic";
 import { validateMemo } from "./validateMemo";
 

--- a/libs/coin-modules/coin-cardano/src/signOperation.ts
+++ b/libs/coin-modules/coin-cardano/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge, SignOperationEvent } from "@ledgerhq/types-live";
 import { Bip32PublicKey } from "@stricahq/bip32ed25519";

--- a/libs/coin-modules/coin-casper/.unimportedrc.json
+++ b/libs/coin-modules/coin-casper/.unimportedrc.json
@@ -26,6 +26,7 @@
   "ignoreUnused": [],
   "ignoreUnimported": [
     "src/hw-signMessage.ts",
-    "src/supportedFeatures.ts"
+    "src/supportedFeatures.ts",
+    "src/errors.ts"
   ]
 }

--- a/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
@@ -1,5 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { log } from "@ledgerhq/logs";
 import { Unit } from "@ledgerhq/ledger-wallet-framework/types";
@@ -101,7 +101,7 @@ export const createNewTransaction = async (
   log("debug", `Creating new Transaction: ${sender}, ${recipient}, ${network}`);
 
   if (recipient && !isAddressValid(recipient)) {
-    throw InvalidAddress(`Invalid recipient Address ${recipient}`);
+    throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
   const client = getCasperNodeRpcClient();

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import {
   CASPER_MINIMUM_VALID_AMOUNT_MOTES,

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-casper/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-casper/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { AmountRequired, InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  AmountRequired,
+  InvalidAddress,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getEstimatedFees } from "../bridge/bridgeHelpers/fee";

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import type { SignOperationEvent } from "@ledgerhq/types-live";
 import { accountFixture, transactionFixture } from "../../bridge/fixtures";

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -8,7 +8,7 @@ import {
   NotEnoughBalance,
   NotEnoughBalanceFees,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";

--- a/libs/coin-modules/coin-celo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/signOperation.ts
@@ -1,5 +1,5 @@
 import { CeloSignature } from "../signer/signer";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, AccountBridge, DeviceId, SignOperationEvent } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-celo/src/datasets/celo.scanAccounts.1.ts
+++ b/libs/coin-modules/coin-celo/src/datasets/celo.scanAccounts.1.ts
@@ -3,7 +3,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountRaw, CurrenciesData, TransactionStatusCommon } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import TransactionModule from "../bridge/transaction";

--- a/libs/coin-modules/coin-concordium/.unimportedrc.json
+++ b/libs/coin-modules/coin-concordium/.unimportedrc.json
@@ -23,7 +23,8 @@
     "src/test/fixtures.ts",
     "src/test/testHelpers.ts",
     "src/test/walletConnectFixtures.ts",
-    "src/types/errors.ts"
+    "src/types/errors.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "invariant"

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { MAX_MEMO_LENGTH } from "@ledgerhq/concordium-core";
 import {

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { MAX_MEMO_LENGTH, AccountAddress } from "@ledgerhq/concordium-core";

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
@@ -1,4 +1,4 @@
-import { ConcordiumSessionExpiredError } from "@ledgerhq/errors";
+import { ConcordiumSessionExpiredError } from "../types";
 import { firstValueFrom, toArray } from "rxjs";
 import coinConfig from "../config";
 import { submitCredential } from "../network/proxyClient";

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
@@ -1,9 +1,6 @@
-import {
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-  TransportStatusError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { LockedDeviceError, TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ConcordiumSessionExpiredError } from "../types";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountOnboardStatus, ConcordiumPairingStatus } from "../types";
 import {

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -1,11 +1,7 @@
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import {
-  ConcordiumPairingExpiredError,
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-  TransportStatusError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { LockedDeviceError } from "../errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ConcordiumPairingExpiredError, ConcordiumSessionExpiredError } from "../types";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
@@ -158,13 +154,14 @@ export const buildOnboardAccount =
       main().then(
         () => o.complete(),
         error => {
-          if (error instanceof TransportStatusError) {
-            if (error.statusCode === 0x6985) {
+          if ((error as Error).name === "TransportStatusError") {
+            const statusCode = (error as { statusCode?: number }).statusCode;
+            if (statusCode === 0x6985) {
               o.error(new UserRefusedOnDevice("errors.UserRefusedOnDevice.description"));
               return;
             }
 
-            if (error.statusCode === 0x5515) {
+            if (statusCode === 0x5515) {
               o.error(new LockedDeviceError("errors.LockedDeviceError.description"));
               return;
             }

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountAddress } from "@ledgerhq/concordium-core";

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -1,6 +1,6 @@
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge, Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { Observable } from "rxjs";

--- a/libs/coin-modules/coin-concordium/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-concordium/src/test/bridgeDatasetTest.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { DatasetTest } from "@ledgerhq/types-live";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import { fromTransactionRaw } from "../bridge/transaction";
 import { Transaction } from "../types";
 

--- a/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-cosmos/src/getTransactionStatus.ts
@@ -6,13 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-  RecommendUndelegation,
-} from "@ledgerhq/errors";
-import { AccountBridge } from "@ledgerhq/types-live";
-import * as bech32 from "bech32";
-import { BigNumber } from "bignumber.js";
-import invariant from "invariant";
-import cryptoFactory from "./chain/chain";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   ClaimRewardsFeesWarning,
   CosmosDelegateAllFundsWarning,
@@ -20,7 +14,13 @@ import {
   CosmosTooManyRedelegations,
   CosmosTooManyValidators,
   NotEnoughDelegationBalance,
+  RecommendUndelegation,
 } from "./errors";
+import { AccountBridge } from "@ledgerhq/types-live";
+import * as bech32 from "bech32";
+import { BigNumber } from "bignumber.js";
+import invariant from "invariant";
+import cryptoFactory from "./chain/chain";
 import {
   COSMOS_MAX_DELEGATIONS,
   COSMOS_MAX_REDELEGATIONS,

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -1,4 +1,4 @@
-import { SequenceNumberError } from "@ledgerhq/errors";
+import { SequenceNumberError } from "../errors";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
 import { EnvName, EnvValue } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network/network";

--- a/libs/coin-modules/coin-cosmos/src/signOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signOperation.ts
@@ -1,7 +1,8 @@
 import { makeSignDoc, serializeSignDoc } from "@cosmjs/amino";
 import { Secp256k1Signature } from "@cosmjs/crypto";
 import { Coin } from "@keplr-wallet/proto-types/cosmos/base/v1beta1/coin";
-import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ExpertModeRequired } from "./errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge, Operation, OperationType } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.ts
@@ -1,6 +1,7 @@
 import { serializeSignDoc, StdSignDoc } from "@cosmjs/amino";
 import { Secp256k1Signature } from "@cosmjs/crypto";
-import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ExpertModeRequired } from "./errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge, Operation, SignOperationEvent } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/signRawOperation.unit.test.ts
@@ -1,6 +1,7 @@
 import { AminoMsg, makeSignDoc, serializeSignDoc } from "@cosmjs/amino";
 import { Secp256k1, Secp256k1Signature, sha256 } from "@cosmjs/crypto";
-import { ExpertModeRequired, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ExpertModeRequired } from "./errors";
 import { firstValueFrom, toArray } from "rxjs";
 import { buildSignRawOperation } from "./signRawOperation";
 import { CosmosAccount, RETURN_CODES } from "./types";

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -6,23 +6,25 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/types";
 import {
   AmountRequired,
-  ClaimRewardsFeesWarning,
-  ETHAddressNonEIP,
   FeeNotLoaded,
   FeeTooHigh,
-  GasLessThanEstimate,
   InvalidAddress,
-  MaxFeeTooLow,
   NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
+  ClaimRewardsFeesWarning,
+  ETHAddressNonEIP,
+  GasLessThanEstimate,
+  GasPriceTooLow,
+  MaxFeeTooLow,
   NotEnoughGas,
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
   PriorityFeeTooLow,
-  RecipientRequired,
   RedelegateDstValAddressRequired,
   ValAddressRequired,
-} from "@ledgerhq/errors";
-import { GasPriceTooLow } from "../errors";
+} from "../errors";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { EvmCoinConfig, setCoinConfig } from "../config";

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -10,23 +10,25 @@ import type {
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import {
   AmountRequired,
-  ClaimRewardsFeesWarning,
-  ETHAddressNonEIP,
   FeeNotLoaded,
   FeeTooHigh,
-  GasLessThanEstimate,
   InvalidAddress,
-  MaxFeeTooLow,
   NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
+  ClaimRewardsFeesWarning,
+  ETHAddressNonEIP,
+  GasLessThanEstimate,
+  GasPriceTooLow,
+  MaxFeeTooLow,
   NotEnoughGas,
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
   PriorityFeeTooLow,
-  RecipientRequired,
   RedelegateDstValAddressRequired,
   ValAddressRequired,
-} from "@ledgerhq/errors";
-import { GasPriceTooLow } from "../errors";
+} from "../errors";
 import { getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-evm/src/staking/operations/sei.ts
+++ b/libs/coin-modules/coin-evm/src/staking/operations/sei.ts
@@ -1,4 +1,4 @@
-import { RedelegateDstValAddressRequired } from "@ledgerhq/errors";
+import { RedelegateDstValAddressRequired } from "../../errors";
 import { seiEvmAmountToUsei } from "../../utils";
 import type { OperationParamsWithValAddress, StakingProtocol } from "./types";
 

--- a/libs/coin-modules/coin-filecoin/.unimportedrc.json
+++ b/libs/coin-modules/coin-filecoin/.unimportedrc.json
@@ -18,7 +18,8 @@
     "src/test/bridgeDatasetTest.ts",
     "src/test/fixtures.ts",
     "src/test/index.ts",
-    "src/supportedFeatures.ts"
+    "src/supportedFeatures.ts",
+    "src/errors.ts"
   ],
   "entry": [
     "src/index.ts"

--- a/libs/coin-modules/coin-filecoin/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/estimateMaxSpendable.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddress,
   NotEnoughBalanceInParentAccount,
   NotEnoughSpendableBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-filecoin/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getAddress, getSubAccount } from "../common-logic";

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
 import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
+++ b/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
@@ -1,5 +1,5 @@
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { RecipientRequired } from "@ledgerhq/errors";
+import { RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   emptyHistoryCache,
   encodeTokenAccountId,

--- a/libs/coin-modules/coin-filecoin/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-filecoin/src/logic/validateIntent.ts
@@ -10,7 +10,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isRecipientValidForTokenTransfer, validateAddress } from "../network/addresses";
 
 function validateRecipient(

--- a/libs/coin-modules/coin-filecoin/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-filecoin/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { InvalidAddress, NotEnoughBalance, AmountRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  NotEnoughBalance,
+  AmountRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -3,23 +3,23 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalance,
-  ClaimRewardsFeesWarning,
   RecipientRequired,
-} from "@ledgerhq/errors";
-import * as accountHelpers from "@ledgerhq/ledger-wallet-framework/account";
-import BigNumber from "bignumber.js";
-import { HEDERA_TRANSACTION_MODES } from "../constants";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import {
+  ClaimRewardsFeesWarning,
   HederaInsufficientFundsForAssociation,
   HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
   HederaNoStakingRewardsError,
   HederaRecipientEvmAddressVerificationRequired,
   HederaRecipientInvalidChecksum,
   HederaRecipientTokenAssociationRequired,
   HederaRecipientTokenAssociationUnverified,
   HederaRedundantStakingNodeIdError,
-  HederaMemoExceededSizeError,
 } from "../errors";
+import * as accountHelpers from "@ledgerhq/ledger-wallet-framework/account";
+import BigNumber from "bignumber.js";
+import { HEDERA_TRANSACTION_MODES } from "../constants";
 import * as estimateFees from "../logic/estimateFees";
 import * as logicUtils from "../logic/utils";
 import { HEDERA_MAX_MEMO_SIZE } from "../logic/validateMemo";

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -3,24 +3,24 @@ import {
   NotEnoughBalance,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
   ClaimRewardsFeesWarning,
-} from "@ledgerhq/errors";
+  HederaInsufficientFundsForAssociation,
+  HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
+  HederaNoStakingRewardsError,
+  HederaRecipientEvmAddressVerificationRequired,
+  HederaRecipientTokenAssociationRequired,
+  HederaRecipientTokenAssociationUnverified,
+  HederaRedundantStakingNodeIdError,
+} from "../errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account";
 import { getEnv } from "@ledgerhq/live-env";
 import type { Account, AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
-import {
-  HederaInsufficientFundsForAssociation,
-  HederaRecipientTokenAssociationRequired,
-  HederaRecipientTokenAssociationUnverified,
-  HederaRecipientEvmAddressVerificationRequired,
-  HederaInvalidStakingNodeIdError,
-  HederaRedundantStakingNodeIdError,
-  HederaNoStakingRewardsError,
-  HederaMemoExceededSizeError,
-} from "../errors";
 import { estimateFees } from "../logic/estimateFees";
 import {
   isTokenAssociateTransaction,

--- a/libs/coin-modules/coin-hedera/src/bridge/receive.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/receive.ts
@@ -1,4 +1,4 @@
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { isSegwitDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account, AccountBridge, DerivationMode } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import BigNumber from "bignumber.js";
 import hederaCoinConfig from "../config";
 import { HederaAddAccountError } from "../errors";

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -1,8 +1,8 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { HederaAddAccountError } from "../errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import BigNumber from "bignumber.js";
 import { type HederaCoinConfig } from "../config";
-import { HederaAddAccountError } from "../errors";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2 } from "../network/utils";
 import type { HederaERC20TokenBalance, HederaMirrorToken } from "../types";

--- a/libs/coin-modules/coin-hedera/src/network/api.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.test.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import network from "@ledgerhq/live-network";
 import BigNumber from "bignumber.js";
 import { resolveConfig } from "../logic/utils";

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -1,11 +1,11 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { HederaAddAccountError } from "../errors";
 import network from "@ledgerhq/live-network";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
 import BigNumber from "bignumber.js";
 import { encodeFunctionData, erc20Abi } from "viem";
 import { type HederaCoinConfig } from "../config";
 import { HEDERA_TRANSACTION_NAMES } from "../constants";
-import { HederaAddAccountError } from "../errors";
 import { resolveConfig } from "../logic/utils";
 import type {
   HederaMirrorAccountTokensResponse,

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,4 +1,4 @@
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import BigNumber from "bignumber.js";
 import { HederaRecipientInvalidChecksum } from "../errors";

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -2,7 +2,7 @@ import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets/fiats";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";

--- a/libs/coin-modules/coin-hedera/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-hedera/src/test/bridgeDatasetTest.ts
@@ -3,7 +3,7 @@ import {
   NotEnoughBalance,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import { HEDERA_TRANSACTION_MODES } from "../constants";
 import { fromTransactionRaw } from "../transaction";

--- a/libs/coin-modules/coin-icon/src/__test__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-icon/src/__test__/unit/getTransactionStatus.unit.test.ts
@@ -6,7 +6,7 @@ import {
   FeeNotLoaded,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { BigNumber } from "bignumber.js";
 import { IconDoMaxSendInstead } from "../../errors";

--- a/libs/coin-modules/coin-icon/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-icon/src/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   FeeNotLoaded,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 
 import { IconAllFundsWarning, IconDoMaxSendInstead } from "./errors";

--- a/libs/coin-modules/coin-icon/src/signOperation.ts
+++ b/libs/coin-modules/coin-icon/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type {

--- a/libs/coin-modules/coin-icon/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-icon/src/test/bridge.dataset.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   InvalidAddress,
   NotEnoughBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../transaction";

--- a/libs/coin-modules/coin-internet_computer/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { validateAddress } from "@zondax/ledger-live-icp/utils";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-internet_computer/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-internet_computer/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { AmountRequired, InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  AmountRequired,
+  InvalidAddress,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getEstimatedFees } from "../bridge/bridgeHelpers/fee";

--- a/libs/coin-modules/coin-kaspa/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-kaspa/src/bridge/getTransactionStatus.ts
@@ -1,13 +1,13 @@
 import {
   AmountRequired,
-  DustLimit,
   FeeNotLoaded,
   FeeRequired,
   FeeTooHigh,
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "../errors";
 import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-mina/.unimportedrc.json
+++ b/libs/coin-modules/coin-mina/.unimportedrc.json
@@ -20,7 +20,8 @@
     "src/test/helpers/msw-setup.ts",
     "src/supportedFeatures.ts",
     "src/logic/index.ts",
-    "src/test/testUtils.ts"
+    "src/test/testUtils.ts",
+    "src/errors.ts"
   ],
   "ignoreUnresolved": [
     "@jest/expect-utils",

--- a/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import * as logicValidateMemo from "../logic/validateMemo";

--- a/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   FeeNotLoaded,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { isValidAddress, getMaxAmount, getTotalSpent } from "../logic/utils";

--- a/libs/coin-modules/coin-mina/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { BigNumber } from "bignumber.js";
 import { firstValueFrom } from "rxjs";

--- a/libs/coin-modules/coin-mina/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type {

--- a/libs/coin-modules/coin-mina/src/network/index.test.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.test.ts
@@ -3,7 +3,7 @@ jest.mock("@ledgerhq/logs");
 jest.mock("../config");
 
 import { DeepPartial } from "@ledgerhq/coin-module-framework/test/utils";
-import { LedgerAPI5xx } from "@ledgerhq/errors";
+import { LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 import network from "@ledgerhq/live-network";
 import { getCoinConfig } from "../config";
 import {

--- a/libs/coin-modules/coin-mina/src/network/index.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI5xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 
@@ -53,14 +52,12 @@ const isAbortOrTimeoutError = (error: unknown): error is Error & { code?: string
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([502, 503, 504]);
 
-type LedgerAPI5xxInstance = InstanceType<typeof LedgerAPI5xx>;
-
 const isRetryableServerError = (
   error: unknown,
-): error is LedgerAPI5xxInstance & { status: number } =>
-  error instanceof LedgerAPI5xx &&
-  typeof (error as LedgerAPI5xxInstance & { status?: number }).status === "number" &&
-  RETRYABLE_HTTP_STATUS_CODES.has((error as LedgerAPI5xxInstance & { status: number }).status);
+): error is { name: string; status: number; message: string } =>
+  (error as { name?: string })?.name === "LedgerAPI5xx" &&
+  typeof (error as { status?: number }).status === "number" &&
+  RETRYABLE_HTTP_STATUS_CODES.has((error as { status: number }).status);
 
 const backoffDelay = (attempt: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt)));

--- a/libs/coin-modules/coin-mina/src/signer/getAddress.test.ts
+++ b/libs/coin-modules/coin-mina/src/signer/getAddress.test.ts
@@ -1,5 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { DerivationMode } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-mina/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-mina/src/signer/getAddress.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";

--- a/libs/coin-modules/coin-mina/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-mina/src/test/bridgeDatasetTest.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/getTransactionStatus.ts
@@ -9,7 +9,7 @@ import {
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughSpendableBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import coinConfig from "../config";

--- a/libs/coin-modules/coin-module-boilerplate/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge, Operation } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-module-boilerplate/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,4 @@
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import { DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-multiversx/.unimportedrc.json
+++ b/libs/coin-modules/coin-multiversx/.unimportedrc.json
@@ -16,7 +16,8 @@
     "src/helpers/randomizeProviders.ts",
     "src/transaction.ts",
     "src/test/bridge.dataset.ts",
-    "src/supportedFeatures.ts"
+    "src/supportedFeatures.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",

--- a/libs/coin-modules/coin-multiversx/src/buildOptimisticOperation.ts
+++ b/libs/coin-modules/coin-multiversx/src/buildOptimisticOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { Operation, OperationType } from "@ledgerhq/types-live";
 import { Address } from "@multiversx/sdk-core";

--- a/libs/coin-modules/coin-multiversx/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-multiversx/src/getTransactionStatus.ts
@@ -7,7 +7,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   FeeTooHigh,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-multiversx/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-multiversx/src/logic/validateIntent.ts
@@ -11,7 +11,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isValidAddress } from "./validateAddress";
 import { estimateFees } from "./transaction/estimateFees";
 import { NotEnoughEGLDForFees } from "../errors";

--- a/libs/coin-modules/coin-multiversx/src/signOperation.ts
+++ b/libs/coin-modules/coin-multiversx/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { decodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-multiversx/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-multiversx/src/test/bridge.dataset.ts
@@ -1,4 +1,7 @@
-import { InvalidAddressBecauseDestinationIsAlsoSource, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 

--- a/libs/coin-modules/coin-near/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-near/src/getTransactionStatus.ts
@@ -7,7 +7,7 @@ import {
   FeeNotLoaded,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { fetchAccountDetails } from "./api";

--- a/libs/coin-modules/coin-near/src/signOperation.ts
+++ b/libs/coin-modules/coin-near/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";

--- a/libs/coin-modules/coin-near/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-near/src/test/bridge.dataset.ts
@@ -1,4 +1,7 @@
-import { InvalidAddressBecauseDestinationIsAlsoSource, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -8,7 +8,7 @@ import {
   AmountRequired,
   NotEnoughBalanceBecauseDestinationNotCreated,
   FeeNotLoaded,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -77,7 +77,7 @@ const getSendTransactionStatus: AccountBridge<
     errors.amount = new AmountRequired();
   }
 
-  if (!(errors.amount instanceof AmountRequired)) {
+  if (errors.amount?.name !== "AmountRequired") {
     if (
       (!transaction.useAllAmount && account.spendableBalance.isZero()) ||
       totalSpent.gt(account.spendableBalance)
@@ -308,7 +308,10 @@ export const getTransactionStatus: AccountBridge<
     errors.amount = new NotEnoughBalance();
   }
 
-  if (!(errors.amount instanceof AmountRequired) && totalSpent.gt(account.spendableBalance)) {
+  if (
+    (errors.amount as Error).name !== "AmountRequired" &&
+    totalSpent.gt(account.spendableBalance)
+  ) {
     errors.amount = new NotEnoughBalance();
   }
 

--- a/libs/coin-modules/coin-polkadot/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/signOperation.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { hexToU8a } from "@polkadot/util";

--- a/libs/coin-modules/coin-polkadot/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-polkadot/src/test/bridgeDatasetTest.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalanceBecauseDestinationNotCreated,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-solana/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-solana/src/logic/broadcast.ts
@@ -1,4 +1,4 @@
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   BlockhashWithExpiryBlockHeight,
   TransactionError,

--- a/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/broadcast.unit.test.ts
@@ -1,4 +1,4 @@
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   BlockhashWithExpiryBlockHeight,
   TransactionError,

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.integ.test.ts
@@ -5,7 +5,8 @@ import type {
   StringMemo,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
-import { InvalidAddress, NotEnoughBalance, NotEnoughGas } from "@ledgerhq/errors";
+import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughGas } from "../../errors";
 import { getChainAPI } from "../../network";
 import type { ChainAPI } from "../../network";
 import type { FeeEstimation } from "@ledgerhq/coin-module-framework/api/index";

--- a/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/validateIntent.unit.test.ts
@@ -9,10 +9,9 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
   RecipientRequired,
-} from "@ledgerhq/errors";
-import { SolanaStakeAccountAmountTooLow } from "../../errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughGas, SolanaStakeAccountAmountTooLow } from "../../errors";
 import type { ChainAPI } from "../../network";
 import { getMaybeTokenMint } from "../../network/chain/web3";
 import { validateIntent as validateIntentRaw } from "../validateIntent";

--- a/libs/coin-modules/coin-solana/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-solana/src/logic/validateIntent.ts
@@ -13,11 +13,10 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { formatAPIValueWithCode } from "../common";
-import { SolanaStakeAccountAmountTooLow } from "../errors";
+import { NotEnoughGas, SolanaStakeAccountAmountTooLow } from "../errors";
 import { isValidBase58Address, isSolanaStakingTransactionIntent } from "../logic";
 import { getAtaDataLengthForMint } from "../helpers/token";
 import {

--- a/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.test.ts
@@ -1,4 +1,4 @@
-import { NetworkError } from "@ledgerhq/errors";
+import { NetworkError } from "../../errors";
 import { Config, getChainAPI } from ".";
 import { Connection, SendTransactionError } from "@solana/web3.js";
 

--- a/libs/coin-modules/coin-solana/src/network/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.ts
@@ -1,4 +1,4 @@
-import { NetworkError } from "@ledgerhq/errors";
+import { NetworkError } from "../../errors";
 import { getEnv } from "@ledgerhq/live-env";
 import {
   TOKEN_2022_PROGRAM_ID,

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.integ.test.ts
@@ -1,6 +1,6 @@
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { NotEnoughGas } from "@ledgerhq/errors";
+import { NotEnoughGas } from "./errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -1,14 +1,14 @@
-import { NotEnoughGas } from "@ledgerhq/errors";
-import { Account, VersionedMessage } from "@solana/web3.js";
-import BigNumber from "bignumber.js";
-import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import {
+  NotEnoughGas,
   SolanaMemoIsTooLong,
   SolanaRecipientAccountNotFunded,
   SolanaStakeAccountAmountTooLow,
   SolanaStakeAccountNothingToWithdraw,
   SolanaStakeNoWithdrawAuth,
 } from "./errors";
+import { Account, VersionedMessage } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import { estimateFeeAndSpendable } from "./estimateMaxSpendable";
 import * as logicValidateMemo from "./logic/validateMemo";
 import { ChainAPI } from "./network";

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.ts
@@ -4,14 +4,14 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { updateTransaction } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import type { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import {
+  NotEnoughGas,
   SolanaAccountNotFunded,
   SolanaRecipientAccountNotFunded,
   SolanaTokenAccountFrozen,

--- a/libs/coin-modules/coin-solana/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-solana/src/test/bridge.dataset.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { getEnv } from "@ledgerhq/live-env";
 import { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";

--- a/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-stacks/.unimportedrc.json
+++ b/libs/coin-modules/coin-stacks/.unimportedrc.json
@@ -25,7 +25,8 @@
   "ignoreUnimported": [
     "src/network/index.ts",
     "src/signer/signMessage.ts",
-    "src/supportedFeatures.ts"
+    "src/supportedFeatures.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "ripple-address-codec",

--- a/libs/coin-modules/coin-stacks/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/getTransactionStatus.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { StacksMemoTooLong } from "../errors";

--- a/libs/coin-modules/coin-stacks/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/signOperation.ts
@@ -1,4 +1,5 @@
-import { FeeNotLoaded, InvalidAddress, InvalidNonce } from "@ledgerhq/errors";
+import { InvalidNonce } from "../errors";
+import { FeeNotLoaded, InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge } from "@ledgerhq/types-live";
 import invariant from "invariant";

--- a/libs/coin-modules/coin-stacks/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-stacks/src/test/bridgeDatasetTest.ts
@@ -3,7 +3,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CurrenciesData } from "@ledgerhq/types-live";
 import type { DatasetTest } from "@ledgerhq/types-live";
 import { AnchorMode } from "@stacks/transactions";

--- a/libs/coin-modules/coin-sui/.unimportedrc.json
+++ b/libs/coin-modules/coin-sui/.unimportedrc.json
@@ -28,7 +28,8 @@
     "src/network/graphql/graphql-env.d.ts",
     "src/supportedFeatures.ts",
     "src/test/bridge.dataset.ts",
-    "src/test/testUtils.ts"
+    "src/test/testUtils.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "@ledgerhq/live-env",

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   FeeNotLoaded,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 
 import BigNumber from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
@@ -7,7 +7,7 @@ import {
   FeeNotLoaded,
   FeeTooHigh,
   InvalidAddress,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { isValidSuiAddress } from "@mysten/sui/utils";

--- a/libs/coin-modules/coin-sui/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/prepareTransaction.test.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { DEFAULT_COIN_TYPE } from "../network/sdk";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { LedgerSigner } from "@mysten/signers/ledger";
 import { messageWithIntent as mockMessageWithIntent } from "@mysten/sui/cryptography";

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { LedgerSigner } from "@mysten/signers/ledger";

--- a/libs/coin-modules/coin-sui/src/logic/mapDryRunError.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/mapDryRunError.test.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import { mapDryRunError } from "./mapDryRunError";
 
 describe("mapDryRunError", () => {

--- a/libs/coin-modules/coin-sui/src/logic/mapDryRunError.ts
+++ b/libs/coin-modules/coin-sui/src/logic/mapDryRunError.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 
 type ErrorMatcher = {
   pattern: RegExp;

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -1,5 +1,5 @@
 import assert, { fail } from "assert";
-import { NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import type {
   BalanceChange,

--- a/libs/coin-modules/coin-sui/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-sui/src/test/bridge.dataset.ts
@@ -2,7 +2,7 @@ import {
   RecipientRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountRaw, CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -6,7 +6,7 @@ import {
   AmountRequired,
   NotEnoughBalance,
   NotEnoughBalanceToDelegate,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import coinConfig from "../config";
 import {
   InvalidAddressBecauseAlreadyDelegated,

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -9,7 +9,7 @@ import {
   NotEnoughBalanceToDelegate,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import type { APIAccount } from "../network/types";

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { TonCommentInvalid, TonExcessFee } from "../../errors";
 import getTransactionStatus from "../../getTransactionStatus";

--- a/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { toNano } from "@ton/core";

--- a/libs/coin-modules/coin-ton/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-ton/src/test/bridge.dataset.ts
@@ -1,4 +1,4 @@
-import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { TonCommentInvalid } from "../errors";

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
@@ -3,8 +3,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import {
@@ -19,6 +18,7 @@ import {
 import { STANDARD_FEES_TRC_20 } from "../logic/constants";
 import type { NetworkInfo, Transaction, TronAccount } from "../types";
 import {
+  NotEnoughGas,
   TronInvalidFreezeAmount,
   TronInvalidUnDelegateResourceAmount,
   TronNoFrozenForBandwidth,

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -4,9 +4,8 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { getAccountCurrency, getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account";
 import BigNumber from "bignumber.js";
 import sumBy from "lodash/sumBy";
@@ -20,6 +19,7 @@ import {
 } from "../network";
 import { Transaction, TransactionStatus, TronAccount } from "../types";
 import {
+  NotEnoughGas,
   TronInvalidFreezeAmount,
   TronInvalidUnDelegateResourceAmount,
   TronInvalidVoteCount,

--- a/libs/coin-modules/coin-tron/src/network/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.test.ts
@@ -1,4 +1,4 @@
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import network from "@ledgerhq/live-network";
 import { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -1,5 +1,5 @@
 import { stringify } from "querystring";
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import network from "@ledgerhq/live-network";
 import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
 import { log } from "@ledgerhq/logs";

--- a/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-tron/src/test/bridgeDatasetTest.ts
@@ -3,9 +3,8 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-  NotEnoughGas,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, CurrenciesData, DatasetTest, TokenAccount } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
@@ -14,6 +13,7 @@ import { ACTIVATION_FEES, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import { getChainParameters } from "../network";
 import type { Transaction, TransactionStatus, TronAccountRaw } from "../types";
 import {
+  NotEnoughGas,
   TronInvalidFreezeAmount,
   TronInvalidUnDelegateResourceAmount,
   TronInvalidVoteCount,

--- a/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.test.ts
@@ -10,7 +10,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { NotEnoughVTHO } from "../errors";
 
 // Mock dependencies

--- a/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { calculateTransactionInfo, parseAddress } from "../common-logic";
 import type { Transaction } from "../types";

--- a/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import type { Operation } from "@ledgerhq/types-live";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import {
   getAccount,
   getBlockRef,

--- a/libs/coin-modules/coin-vechain/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-vechain/src/test/bridgeDatasetTest.ts
@@ -11,7 +11,7 @@ import { MAINNET_CHAIN_TAG } from "../types";
 import { vechain1, vechain3 } from "../datasets";
 import { generateNonce } from "../common-logic";
 import vechainScanAccounts1 from "../datasets/vechain.scanAccounts.1";
-import { AmountRequired, NotEnoughBalance } from "@ledgerhq/errors";
+import { AmountRequired, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { NotEnoughVTHO } from "../errors";
 import { ABIContract, VIP180_ABI } from "@vechain/sdk-core";
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -1,5 +1,5 @@
 import { AccountBridge } from "@ledgerhq/types-live";
-import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
+import { AccountAwaitingSendPendingOperations } from "../../errors";
 import BigNumber from "bignumber.js";
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -4,7 +4,7 @@ import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledg
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
 import { bigNumberToBigIntDeep, buildOptimisticOperation, transactionToIntent } from "./utils";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { type GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { lastValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { genericSignOperation } from "../signOperation";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCoinModuleApi } from "../api";
 import { buildOptimisticOperation } from "../utils";
 

--- a/libs/ledger-live-common/src/bridge/impl.test.ts
+++ b/libs/ledger-live-common/src/bridge/impl.test.ts
@@ -1,6 +1,7 @@
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
 import { BigNumber } from "bignumber.js";
-import { AccountNotSupported, CurrencyNotSupported } from "@ledgerhq/errors";
+import { AccountNotSupported } from "@ledgerhq/ledger-wallet-framework/errors";
+import { CurrencyNotSupported } from "../errors";
 import { initialBitcoinResourcesValue } from "@ledgerhq/coin-bitcoin/types";
 import type { BitcoinAccount } from "@ledgerhq/coin-bitcoin/types";
 import type { DerivationMode } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -2,7 +2,7 @@ import {
   isAddressSanctioned,
   isCheckSanctionedAddressEnabled,
 } from "@ledgerhq/ledger-wallet-framework/sanction/index";
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { decodeAccountId, getMainAccount, checkAccountSupported } from "../account";
 import { getEnv } from "@ledgerhq/live-env";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
@@ -4,7 +4,7 @@
 import "../__tests__/test-helpers/dom-polyfill";
 import React from "react";
 import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { render, renderHook, act, screen } from "@testing-library/react";
 import { genAccount } from "../mock/account";
 import { useAccountBridge, useAccountBridgeMany } from "./useAccountBridge";

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
@@ -1,4 +1,4 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type Transport from "@ledgerhq/hw-transport";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { catchError, concatMap, defer, from, map, of, scan, type Observable } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import type { GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
@@ -60,7 +60,7 @@ export const getViewKeyExec = (
           return { accountId: account.id, viewKey };
         }),
         catchError(e => {
-          if (e instanceof UserRefusedOnDevice) {
+          if ((e as Error).name === "UserRefusedOnDevice") {
             return of({ accountId: account.id, viewKey: null });
           }
 

--- a/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type {
   AlgorandAccount,
   AlgorandTransaction,

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
@@ -1,4 +1,4 @@
-import { FeeEstimationFailed } from "@ledgerhq/errors";
+import { FeeEstimationFailed } from "../../../errors";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
@@ -5,8 +5,8 @@ import {
   InvalidAddress,
   FeeTooHigh,
   AmountRequired,
-  DustLimit,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "@ledgerhq/coin-bitcoin/errors";
 import type { FeeItems, Transaction } from "@ledgerhq/coin-bitcoin/types";
 import {
   makeAccountBridgeReceive,

--- a/libs/ledger-live-common/src/families/bitcoin/descriptor/coinControl.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/descriptor/coinControl.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import type { TransactionStatus as BtcTransactionStatus } from "@ledgerhq/coin-bitcoin/types";
 import type { AccountLike } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.test.ts
@@ -1,4 +1,4 @@
-import { ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import { BigNumber } from "bignumber.js";
 import { validateEditTransaction, getEditTransactionStatus } from "./getTransactionStatus";
 import type {

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.ts
@@ -1,4 +1,5 @@
-import { AmountRequired, ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import type { TransactionStatusCommon } from "@ledgerhq/types-live";
 import type { BigNumber } from "bignumber.js";
 import { getMinFees } from "./getMinEditTransactionFees";

--- a/libs/ledger-live-common/src/families/cardano/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/cardano/bridge/mock.ts
@@ -14,7 +14,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CardanoMinAmountError, CardanoNotEnoughFunds } from "@ledgerhq/coin-cardano/errors";
 import { buildTransaction } from "@ledgerhq/coin-cardano/buildTransaction";
 import { CARDANO_DUMMY_ADDRESS, CARDANO_MAX_SUPPLY } from "@ledgerhq/coin-cardano/constants";

--- a/libs/ledger-live-common/src/families/casper/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/casper/bridge/mock.ts
@@ -5,7 +5,7 @@ import {
   RecipientRequired,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { CASPER_DUMMY_ADDRESS } from "@ledgerhq/coin-casper/constants";
 import type { Transaction, TransactionStatus } from "../types";

--- a/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
@@ -23,7 +23,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getCosmosDummyRecipient } from "@ledgerhq/coin-cosmos/logic";

--- a/libs/ledger-live-common/src/families/cosmos/datasets/cosmos.ts
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/cosmos.ts
@@ -4,8 +4,8 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   AmountRequired,
-  RecommendUndelegation,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { RecommendUndelegation } from "../../../errors";
 import invariant from "invariant";
 import type { CosmosAccount, Transaction } from "@ledgerhq/coin-cosmos/types/index";
 import { AccountRaw, CurrenciesData } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/cosmos/datasets/osmosis.ts
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/osmosis.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import invariant from "invariant";
 import type { CosmosAccount, Transaction } from "../types";
 import { fromTransactionRaw } from "@ledgerhq/coin-cosmos/transaction";

--- a/libs/ledger-live-common/src/families/evm/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/evm/bridge/api.ts
@@ -7,7 +7,7 @@ import type {
 } from "@ledgerhq/types-live";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import eip55 from "eip55";
 import BigNumber from "bignumber.js";
 import { ethers } from "ethers";

--- a/libs/ledger-live-common/src/families/evm/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/evm/bridge/mock.ts
@@ -1,5 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { InvalidAddress, NotEnoughBalance, RecipientRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/coin-evm/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getEvmDummyAddress } from "@ledgerhq/coin-evm/constants";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
@@ -1,8 +1,5 @@
-import {
-  AmountRequired,
-  RecipientRequired,
-  ReplacementTransactionUnderpriced,
-} from "@ledgerhq/errors";
+import { AmountRequired, RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import BigNumber from "bignumber.js";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";
 import {

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
@@ -1,4 +1,5 @@
-import { AmountRequired, ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import { TransactionStatusCommon } from "@ledgerhq/types-live";
 import { getMinEip1559Fees, getMinLegacyFees } from "./getMinEditTransactionFees";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/isTransactionConfirmed.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/isTransactionConfirmed.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "../../../errors";
 import { getNodeApi } from "@ledgerhq/coin-evm/network/node/index";
 import type { AccountLike } from "@ledgerhq/types-live";
 

--- a/libs/ledger-live-common/src/families/hedera/exchange.ts
+++ b/libs/ledger-live-common/src/families/hedera/exchange.ts
@@ -1,4 +1,5 @@
-import { LatestFirmwareVersionRequired, TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { LatestFirmwareVersionRequired } from "../../errors";
 import Exchange from "@ledgerhq/hw-app-exchange";
 import { loadPKI } from "@ledgerhq/hw-bolos";
 import calService from "@ledgerhq/ledger-cal-service";
@@ -8,7 +9,9 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Account } from "@ledgerhq/types-live";
 
 function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+  return (
+    (err as Error).name === "TransportStatusError" && (err as Error).message.includes("0x6a81")
+  );
 }
 
 export async function handleHederaTrustedFlow({

--- a/libs/ledger-live-common/src/families/icon/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/icon/bridge/mock.ts
@@ -1,5 +1,10 @@
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "../types";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { ICON_DUMMY_ADDRESS } from "@ledgerhq/coin-icon/constants";

--- a/libs/ledger-live-common/src/families/multiversx/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/multiversx/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { MultiversXAccount, Transaction } from "@ledgerhq/coin-multiversx/types";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { MULTIVERSX_DUMMY_ADDRESS } from "@ledgerhq/coin-multiversx/constants";

--- a/libs/ledger-live-common/src/families/polkadot/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/polkadot/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { PolkadotAccount, Transaction } from "@ledgerhq/coin-polkadot/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { POLKADOT_NULL_ADDRESS } from "@ledgerhq/coin-polkadot/constants";

--- a/libs/ledger-live-common/src/families/stellar/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/stellar/bridge/mock.ts
@@ -9,7 +9,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughSpendableBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { STELLAR_DUMMY_ADDRESS } from "@ledgerhq/coin-stellar/constants";
 import { getSerializedAddressParameters } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";

--- a/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
@@ -5,12 +5,11 @@ import {
   InvalidAddress,
   FeeTooHigh,
   InvalidAddressBecauseDestinationIsAlsoSource,
-  NotSupportedLegacyAddress,
   NotEnoughBalanceInParentAccount,
   AmountRequired,
-  RecommendSubAccountsToEmpty,
   NotEnoughBalanceToDelegate,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotSupportedLegacyAddress, RecommendSubAccountsToEmpty } from "../../../errors";
 import type { TezosAccount, Transaction } from "../types";
 import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { TEZOS_DUMMY_ADDRESS } from "@ledgerhq/coin-tezos/constants";
@@ -145,7 +144,7 @@ const getTransactionStatus = (a: Account, t: Transaction) => {
     }
   } else {
     // delegation case, we remap NotEnoughBalance to a more precise error
-    if (errors.amount instanceof NotEnoughBalance) {
+    if (errors.amount?.name === "NotEnoughBalance") {
       errors.amount = new NotEnoughBalanceToDelegate();
     }
   }

--- a/libs/ledger-live-common/src/families/tron/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tron/bridge/mock.ts
@@ -1,5 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/coin-tron/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { TRON_DUMMY_ADDRESS } from "@ledgerhq/coin-tron/constants";

--- a/libs/ledger-live-common/src/families/xrp/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/xrp/bridge/mock.ts
@@ -7,7 +7,7 @@ import {
   RecipientRequired,
   FeeTooHigh,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import {

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -14,7 +14,7 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
 import { catchError, debounce, delayWhen, filter, switchMap, tap, timeout } from "rxjs/operators";
 import { Device } from "./types";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
@@ -59,13 +59,11 @@ type PollingImplementationParams<Request, EmittedEvents> = {
   config?: PollingImplementationConfig;
   // retryableWithDelayDisconnectedErrors has default value of [DisconnectedDevice, DisconnectedDeviceDuringOperation]
   // used to filter which error(s) retry polling after a delay, reconnectWaitTime
-  retryableWithDelayDisconnectedErrors?: ReadonlyArray<ErrorConstructor>;
+  retryableWithDelayDisconnectedErrors?: ReadonlyArray<new (message?: string) => Error>;
 };
 
-const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<ErrorConstructor> = [
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-];
+const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<new (message?: string) => Error> =
+  [DisconnectedDevice, DisconnectedDeviceDuringOperation];
 
 export const defaultImplementationConfig: PollingImplementationConfig = {
   pollingFrequency: 2000,

--- a/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
@@ -2,7 +2,7 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
@@ -91,7 +91,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -3,7 +3,7 @@ import { scan, map, tap } from "rxjs/operators";
 import { useEffect, useMemo, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
-import { UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { UserRefusedDeviceNameChange } from "../../errors";
 import { useReplaySubject } from "../../observable";
 import type { Action, Device } from "./types";
 import {
@@ -129,7 +129,7 @@ export const createAction = (
             if (
               productName &&
               e.type === "error" &&
-              e.error instanceof UserRefusedDeviceNameChange
+              (e.error as Error).name === "UserRefusedDeviceNameChange"
             ) {
               e.error = new UserRefusedDeviceNameChange(undefined, {
                 productName,

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -2,7 +2,7 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import type { Transaction, TransactionStatus } from "../../coin-modules/transaction-types";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
@@ -92,7 +92,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -1,18 +1,13 @@
 import semver from "semver";
 import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
-  TransportStatusError,
   FirmwareOrAppUpdateRequired,
-  UserRefusedOnDevice,
-  BtcUnmatchedApp,
   UpdateYourApp,
-  DisconnectedDeviceDuringOperation,
-  DisconnectedDevice,
-  StatusCodes,
-  LockedDeviceError,
   LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
+} from "../errors";
 import type Transport from "@ledgerhq/hw-transport";
 import { type DerivationMode, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import type { AppOp, SkippedAppOp } from "../apps/types";
@@ -212,8 +207,9 @@ export const openAppFromDashboard = (
               }),
             ),
             catchError(e => {
-              if (e && e instanceof TransportStatusError) {
-                switch (e.statusCode) {
+              const tse = e as { name?: string; statusCode?: number };
+              if (tse.name === "TransportStatusError") {
+                switch (tse.statusCode) {
                   case 0x6984: // No StatusCodes definition
                   case 0x6807: // No StatusCodes definition
                     return inlineAppInstall({
@@ -225,7 +221,7 @@ export const openAppFromDashboard = (
                   case 0x5501: // No StatusCodes definition
                     return throwError(() => new UserRefusedOnDevice());
                 }
-              } else if (e instanceof LockedDeviceError) {
+              } else if ((e as Error).name === "LockedDeviceError") {
                 // openAppFromDashboard is exported, so LockedDeviceError should be handled here too
                 return of({
                   type: "lockedDevice",
@@ -285,20 +281,21 @@ const derivationLogic = (
     catchError(e => {
       if (!e) return throwError(() => e);
 
-      if (e instanceof BtcUnmatchedApp) {
+      if ((e as Error).name === "BtcUnmatchedApp") {
         return of<ConnectAppEvent>({
           type: "ask-open-app",
           appName,
         });
       }
 
-      if (e instanceof TransportStatusError) {
-        const { statusCode } = e;
+      const tse = e as { name?: string; statusCode?: number };
+      if (tse.name === "TransportStatusError") {
+        const statusCode = tse.statusCode;
 
         if (
           statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED ||
           statusCode === StatusCodes.INCORRECT_LENGTH ||
-          (0x6600 <= statusCode && statusCode <= 0x67ff)
+          (statusCode !== undefined && 0x6600 <= statusCode && statusCode <= 0x67ff)
         ) {
           return of<ConnectAppEvent>({
             type: "ask-open-app",
@@ -313,7 +310,7 @@ const derivationLogic = (
             // this is likely because it's the wrong app (LNS 1.3.1)
             return attemptToQuitApp(transport, appAndVersion);
         }
-      } else if (e instanceof LockedDeviceError) {
+      } else if ((e as Error).name === "LockedDeviceError") {
         // derivationLogic is also called inside the catchError of cmd below
         // so it needs to handle LockedDeviceError too
         return of({
@@ -484,16 +481,17 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
               e !== null &&
               "_tag" in e &&
               e._tag === "DeviceDisconnectedWhileSendingError") ||
-            e instanceof DisconnectedDeviceDuringOperation ||
-            e instanceof DisconnectedDevice
+            (e as Error).name === "DisconnectedDeviceDuringOperation" ||
+            (e as Error).name === "DisconnectedDevice"
           ) {
             return of(<ConnectAppEvent>{
               type: "disconnected",
             });
           }
 
-          if (e && e instanceof TransportStatusError) {
-            switch (e.statusCode) {
+          const tse2 = e as { name?: string; statusCode?: number };
+          if (tse2.name === "TransportStatusError") {
+            switch (tse2.statusCode) {
               case StatusCodes.CLA_NOT_SUPPORTED: // in 1.3.1 dashboard
               case StatusCodes.INS_NOT_SUPPORTED: // in 1.3.1 and bitcoin app
                 // fallback on "old way" because device does not support getAppAndVersion
@@ -507,7 +505,7 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
                   appName,
                 });
             }
-          } else if (e instanceof LockedDeviceError) {
+          } else if ((e as Error).name === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectAppEvent);

--- a/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
@@ -22,19 +22,19 @@ import type {
   ConnectAppDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
   LatestFirmwareVersionRequired,
+  NoSuchAppOnProvider,
   UnsupportedFeatureError,
-} from "@ledgerhq/errors";
+  UserRefusedAllowManager,
+} from "../errors";
 import { DeviceId } from "@domain/entity-client-identity";
 
 import type { SkippedAppOp } from "../apps/types";
 import { SkipReason } from "../apps/types";
 import { parseDeviceInfo } from "../deviceSDK/tasks/getDeviceInfo";
 import { ConnectAppEvent } from "./connectApp";
-import { NoSuchAppOnProvider } from "../errors";
 
 export class ConnectAppEventMapper {
   private openAppRequested: boolean = false;

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -1,11 +1,6 @@
 import { Observable, concat, concatWith, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import {
-  TransportStatusError,
-  DeviceOnDashboardExpected,
-  StatusCodes,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { isCharonSupported } from "@ledgerhq/device-core";
 import { identifyTargetId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";
@@ -103,21 +98,21 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectManage
           );
         }),
         catchError((e: unknown) => {
-          if (e instanceof LockedDeviceError) {
+          const eName = (e as Error).name;
+          if (eName === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectManagerEvent);
           } else if (
-            e instanceof DeviceOnDashboardExpected ||
-            (e &&
-              e instanceof TransportStatusError &&
+            eName === "DeviceOnDashboardExpected" ||
+            (eName === "TransportStatusError" &&
               [
                 StatusCodes.CLA_NOT_SUPPORTED,
                 StatusCodes.INS_NOT_SUPPORTED,
                 StatusCodes.UNKNOWN_APDU,
                 0x6e01, // No StatusCodes definition
                 0x6d01, // No StatusCodes definition
-              ].includes(e.statusCode))
+              ].includes((e as { statusCode: number }).statusCode))
           ) {
             return from(getAppAndVersion(transport)).pipe(
               concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
@@ -14,7 +14,7 @@ import type {
   PrepareConnectManagerDAError,
   PrepareConnectManagerDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 
 import { LockedDeviceEvent } from "./actions/types";
 

--- a/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
@@ -1,11 +1,7 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import {
-  DeviceOnDashboardExpected,
-  TransportError,
-  TransportStatusError,
-  StatusCodes,
-} from "@ledgerhq/errors";
+import { TransportError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnDashboardExpected, ImageDoesNotExistOnDevice } from "../errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
@@ -17,7 +13,6 @@ import customLockScreenFetchHash from "./customLockScreenFetchHash";
 import getAppAndVersion from "./getAppAndVersion";
 import { isDashboardName } from "./isDashboardName";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
-import { ImageDoesNotExistOnDevice } from "../errors";
 
 const MAX_APDU_SIZE = 240;
 
@@ -163,10 +158,12 @@ export default function fetchImage({
             }),
             catchError((e: unknown) => {
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                (e as Error).name === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  (e as Error).name === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
@@ -2,8 +2,8 @@ import customLockScreenLoad from "./customLockScreenLoad";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/device-core";
 import { lastValueFrom, of } from "rxjs";
-import { ManagerNotEnoughSpaceError, StatusCodes, TransportError } from "@ledgerhq/errors";
-import { ImageLoadRefusedOnDevice } from "../errors";
+import { StatusCodes, TransportError } from "@ledgerhq/hw-transport/errors";
+import { ImageLoadRefusedOnDevice, ManagerNotEnoughSpaceError } from "../errors";
 
 const mockTransport = {
   send: jest.fn(),

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
@@ -1,17 +1,15 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
+import { StatusCodes, TransportError, DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import {
   DeviceOnDashboardExpected,
+  ImageCommitRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-  TransportStatusError,
-  DisconnectedDevice,
-} from "@ledgerhq/errors";
+} from "../errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "../errors";
 import getAppAndVersion from "./getAppAndVersion";
 import { isDashboardName } from "./isDashboardName";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
@@ -201,10 +199,12 @@ export default function loadImage({
             }),
             catchError((e: unknown) => {
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                (e as Error).name === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  (e as Error).name === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transportRef.current)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
@@ -1,7 +1,8 @@
-import { StatusCodes, UnexpectedBootloader, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import removeImage, { command } from "./customLockScreenRemove";
 import Transport from "@ledgerhq/hw-transport";
-import { ImageDoesNotExistOnDevice } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { from } from "rxjs";
 import getDeviceInfo from "./getDeviceInfo";

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
@@ -1,15 +1,11 @@
-import {
-  TransportStatusError,
-  UnexpectedBootloader,
-  StatusCodes,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of, throwError } from "rxjs";
 import { withDevice } from "./deviceAccess";
 import { catchError, delay, mergeMap } from "rxjs/operators";
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageDoesNotExistOnDevice } from "../errors";
 
 export type RemoveImageEvent =
   | {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -1,20 +1,8 @@
 import { firstValueFrom, from, Observable, throwError, timer } from "rxjs";
 import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  WrongDeviceForAccount,
-  WrongAppForCurrency,
-  CantOpenDevice,
-  UpdateYourApp,
-  BluetoothRequired,
-  TransportWebUSBGestureRequired,
-  TransportInterfaceNotAvailable,
-  FirmwareOrAppUpdateRequired,
-  TransportStatusError,
-  DeviceHalted,
-  PeerRemovedPairing,
-  PairingFailed,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { FirmwareOrAppUpdateRequired, DeviceHalted } from "../errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@ledgerhq/live-env";
 import { open, close, OpenOptions } from ".";
@@ -24,11 +12,12 @@ const LOG_TYPE = "hw";
 const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
   let mappedError = error;
 
-  if (error && error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6faa) {
-      mappedError = new DeviceHalted(error.message);
-    } else if (error.statusCode === 0x6b00) {
-      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+  const tse = error as { name?: string; statusCode?: number; message?: string };
+  if (tse.name === "TransportStatusError") {
+    if (tse.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(tse.message);
+    } else if (tse.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(tse.message);
     }
   }
 
@@ -153,13 +142,14 @@ export const withDevice =
         // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
         .catch(e => {
           tracer.trace(`Error while opening Transport: ${e}`, { error: e });
-          if (e instanceof BluetoothRequired) throw e;
-          if (e instanceof TransportWebUSBGestureRequired) throw e;
-          if (e instanceof TransportInterfaceNotAvailable) throw e;
-          if (e instanceof PeerRemovedPairing) throw e;
-          if (e instanceof PairingFailed) throw e;
+          const eName = (e as Error).name;
+          if (eName === "BluetoothRequired") throw e;
+          if (eName === "TransportWebUSBGestureRequired") throw e;
+          if (eName === "TransportInterfaceNotAvailable") throw e;
+          if (eName === "PeerRemovedPairing") throw e;
+          if (eName === "PairingFailed") throw e;
           console.error(e);
-          throw new CantOpenDevice(e.message);
+          throw new CantOpenDevice((e as Error).message);
         })
         // Executes the job
         .then(transport => {
@@ -222,15 +212,16 @@ export const withDevicePromise = <T>(deviceId: string, fn: (Transport) => Promis
   firstValueFrom(withDevice(deviceId)(transport => from(fn(transport))));
 
 export const genericCanRetryOnError = (err: unknown): boolean => {
-  if (err instanceof WrongAppForCurrency) return false;
-  if (err instanceof WrongDeviceForAccount) return false;
-  if (err instanceof CantOpenDevice) return false;
-  if (err instanceof BluetoothRequired) return false;
-  if (err instanceof UpdateYourApp) return false;
-  if (err instanceof FirmwareOrAppUpdateRequired) return false;
-  if (err instanceof DeviceHalted) return false;
-  if (err instanceof TransportWebUSBGestureRequired) return false;
-  if (err instanceof TransportInterfaceNotAvailable) return false;
+  const errName = (err as Error).name;
+  if (errName === "WrongAppForCurrency") return false;
+  if (errName === "WrongDeviceForAccount") return false;
+  if (errName === "CantOpenDevice") return false;
+  if (errName === "BluetoothRequired") return false;
+  if (errName === "UpdateYourApp") return false;
+  if (errName === "FirmwareOrAppUpdateRequired") return false;
+  if (errName === "DeviceHalted") return false;
+  if (errName === "TransportWebUSBGestureRequired") return false;
+  if (errName === "TransportInterfaceNotAvailable") return false;
   return true;
 };
 

--- a/libs/ledger-live-common/src/hw/editDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/editDeviceName.ts
@@ -1,5 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedDeviceNameChange } from "../errors";
 
 /**
  * Specify a new name for a device. This is technically supported on all models

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { CharonStatus, extractOnboardingState, OnboardingStep } from "./extractOnboardingState";
 
 describe("@hw/extractOnboardingState", () => {

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { SeedPhraseType } from "@ledgerhq/types-live";
 
 const CHARON_STEP_BIT_MASK = 0x1000;

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
@@ -1,7 +1,8 @@
 import { log } from "@ledgerhq/logs";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import { concatMap, delay, scan, distinctUntilChanged, throttleTime } from "rxjs/operators";
-import { CantOpenDevice, DeviceInOSUExpected } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
+import { DeviceInOSUExpected } from "../errors";
 import { withDevicePolling, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
 import flash from "./flash";
@@ -30,7 +31,7 @@ const main = (
   const withDeviceInstall = install =>
     withDevicePolling(deviceId)(
       install,
-      e => e instanceof CantOpenDevice, // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
+      e => (e as Error).name === "CantOpenDevice", // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
     );
 
   const waitForBootloader = withDeviceInfo.pipe(

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
@@ -2,7 +2,7 @@ import { log } from "@ledgerhq/logs";
 import type { FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { Observable, from, of, concat, throwError } from "rxjs";
 import { mergeMap, delay, filter, map } from "rxjs/operators";
-import { DeviceOnDashboardExpected } from "@ledgerhq/errors";
+import { DeviceOnDashboardExpected } from "../errors";
 import getDeviceInfo from "./getDeviceInfo";
 import installOsuFirmware from "./installOsuFirmware";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
@@ -1,5 +1,5 @@
 import { log } from "@ledgerhq/logs";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
+import { MCUNotGenuineToDashboard } from "../errors";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import type { DeviceVersion, FinalFirmware, McuVersion } from "@ledgerhq/types-live";
 import { concatMap, delay, filter, map, mergeMap, throttleTime } from "rxjs/operators";

--- a/libs/ledger-live-common/src/hw/getAddress/index.ts
+++ b/libs/ledger-live-common/src/hw/getAddress/index.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "@ledgerhq/errors";
+import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import { Resolver } from "./types";
 import { loadSetupForFamily } from "../../coin-modules/registry";

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
-import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 
 import { LOG_TYPE } from ".";

--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
-import { DeviceOnDashboardExpected, StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceNotOnboarded, DeviceOnDashboardExpected } from "../errors";
 import { LocalTracer, log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
@@ -7,7 +8,6 @@ import isDevFirmware from "./isDevFirmware";
 import getAppAndVersion from "./getAppAndVersion";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
-import { DeviceNotOnboarded } from "../errors";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 
 const ManagerAllowedFlag = 0x08;
@@ -24,15 +24,16 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
     .then(({ name }) => isDashboardName(name))
     .catch(e => {
       tracer.trace(`Error from getAppAndVersion: ${e}`, { error: e });
-      if (e instanceof TransportStatusError) {
+      if ((e as Error).name === "TransportStatusError") {
+        const statusCode = (e as { statusCode?: number }).statusCode;
         if (
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
         ) {
           return true;
         }
 
-        if (e.statusCode === StatusCodes.INS_NOT_SUPPORTED) {
+        if (statusCode === StatusCodes.INS_NOT_SUPPORTED) {
           return false;
         }
       }
@@ -47,8 +48,9 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
 
   const res = await getVersion(transport).catch(e => {
     tracer.trace(`Error from getVersion: ${e}`, { error: e });
-    if (e instanceof TransportStatusError) {
-      if (e.statusCode === 0x6d06 || e.statusCode === 0x6d07) {
+    if ((e as Error).name === "TransportStatusError") {
+      const statusCode = (e as { statusCode?: number }).statusCode;
+      if (statusCode === 0x6d06 || statusCode === 0x6d07) {
         throw new DeviceNotOnboarded();
       }
     }

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
@@ -1,7 +1,11 @@
 import { firstValueFrom, from, Observable, of, timer } from "rxjs";
 import { delay } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import { CantOpenDevice, DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  CantOpenDevice,
+  DisconnectedDevice,
+  LockedDeviceError,
+} from "@ledgerhq/hw-transport/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import getDeviceInfo from "./getDeviceInfo";
 import { getDeviceRunningMode } from "./getDeviceRunningMode";

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
@@ -1,4 +1,3 @@
-import { CantOpenDevice, LockedDeviceError } from "@ledgerhq/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import { from, Observable, TimeoutError } from "rxjs";
 import { retryWhen, timeout } from "rxjs/operators";
@@ -61,7 +60,7 @@ export const getDeviceRunningMode = ({
               return false;
             }
 
-            if (e instanceof CantOpenDevice) {
+            if ((e as Error).name === "CantOpenDevice") {
               if (cantOpenDeviceRetryCount < cantOpenDeviceRetryLimit) {
                 cantOpenDeviceRetryCount++;
                 return true;
@@ -88,7 +87,7 @@ export const getDeviceRunningMode = ({
           if (isLockedDeviceError(e)) {
             o.next({ type: "lockedDevice" });
             o.complete();
-          } else if (e instanceof CantOpenDevice) {
+          } else if ((e as Error).name === "CantOpenDevice") {
             o.next({ type: "disconnectedOrlockedDevice" });
             o.complete();
           } else {
@@ -100,5 +99,5 @@ export const getDeviceRunningMode = ({
   });
 
 const isLockedDeviceError = (e: Error) => {
-  return e && (e instanceof TimeoutError || e instanceof LockedDeviceError);
+  return e && ((e as Error).name === "TimeoutError" || (e as Error).name === "LockedDeviceError");
 };

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
@@ -8,7 +8,7 @@ import {
   getGenuineCheckFromDeviceId,
   GetGenuineCheckFromDeviceIdResult,
 } from "./getGenuineCheckFromDeviceId";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
@@ -1,7 +1,7 @@
 import type { SocketEvent } from "@ledgerhq/types-live";
 import { from, Observable } from "rxjs";
 import { mergeMap, retryWhen } from "rxjs/operators";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import getDeviceInfo from "./getDeviceInfo";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import genuineCheck from "./genuineCheck";
@@ -63,7 +63,7 @@ export const getGenuineCheckFromDeviceId = ({
               // Cancels the locked-device unresponsive/timeout strategy if received any response/error
               clearTimeout(lockedDeviceTimeout);
 
-              if (e instanceof LockedDeviceError) {
+              if ((e as Error).name === "LockedDeviceError") {
                 subscriber.next({ socketEvent: null, lockedDevice: true });
                 return true;
               }

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -4,13 +4,12 @@ import * as rxjsOperators from "rxjs/operators";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import {
-  DeviceExtractOnboardingStateError,
   DisconnectedDevice,
   LockedDeviceError,
   TransportStatusError,
   StatusCodes,
-  UnexpectedBootloader,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { DeviceExtractOnboardingStateError, UnexpectedBootloader } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { extractOnboardingState, OnboardingState, OnboardingStep } from "./extractOnboardingState";

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -2,19 +2,12 @@ import { defer, from, of, throwError, Observable, TimeoutError, timer } from "rx
 import { map, catchError, first, timeout, repeat, switchMap } from "rxjs/operators";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { withDevice } from "./deviceAccess";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import {
-  TransportStatusError,
-  StatusCodes,
   DeviceOnboardingStatePollingError,
   DeviceExtractOnboardingStateError,
-  DisconnectedDevice,
-  CantOpenDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
   UnexpectedBootloader,
-  TransportExchangeTimeoutError,
-  DisconnectedDeviceDuringOperation,
-} from "@ledgerhq/errors";
+} from "../errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
 import { DeviceDisconnectedWhileSendingError } from "@ledgerhq/device-management-kit";
@@ -74,9 +67,9 @@ export const getOnboardingStatePolling = ({
       return getVersionObs.pipe(
         catchError((error: unknown) => {
           const isApduNotSupported =
-            error instanceof TransportStatusError &&
+            (error as Error).name === "TransportStatusError" &&
             [StatusCodes.CLA_NOT_SUPPORTED, StatusCodes.INS_NOT_SUPPORTED].includes(
-              (error as TransportStatusError).statusCode,
+              (error as { statusCode: number }).statusCode,
             );
 
           if (isApduNotSupported && !hasQuitAppAlreadyRun) {
@@ -113,10 +106,10 @@ export const getOnboardingStatePolling = ({
           try {
             onboardingState = extractOnboardingState(firmwareInfo.flags, firmwareInfo.charonState);
           } catch (error: unknown) {
-            if (error instanceof DeviceExtractOnboardingStateError) {
+            if ((error as Error).name === "DeviceExtractOnboardingStateError") {
               return {
                 onboardingState: null,
-                allowedError: error,
+                allowedError: error as Error,
                 lockedDevice: false,
               };
             } else {
@@ -149,7 +142,7 @@ export const getOnboardingStatePolling = ({
           return {
             onboardingState: null,
             allowedError: allowedError,
-            lockedDevice: allowedError instanceof LockedDeviceError,
+            lockedDevice: (allowedError as Error).name === "LockedDeviceError",
           };
         }
       }),
@@ -167,16 +160,16 @@ export const isAllowedOnboardingStatePollingError = (error: unknown): boolean =>
   if (
     error &&
     // Timeout error is thrown by rxjs's timeout
-    (error instanceof TimeoutError ||
-      error instanceof TransportExchangeTimeoutError ||
-      error instanceof DisconnectedDevice ||
-      error instanceof DisconnectedDeviceDuringOperation ||
+    ((error as Error).name === "TimeoutError" ||
+      (error as Error).name === "TransportExchangeTimeoutError" ||
+      (error as Error).name === "DisconnectedDevice" ||
+      (error as Error).name === "DisconnectedDeviceDuringOperation" ||
       error instanceof DeviceDisconnectedWhileSendingError ||
-      error instanceof CantOpenDevice ||
-      error instanceof TransportRaceCondition ||
-      error instanceof TransportStatusError ||
+      (error as Error).name === "CantOpenDevice" ||
+      (error as Error).name === "TransportRaceCondition" ||
+      (error as Error).name === "TransportStatusError" ||
       // A locked device is handled as an allowed error
-      error instanceof LockedDeviceError)
+      (error as Error).name === "LockedDeviceError")
   ) {
     return true;
   }

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
@@ -3,12 +3,8 @@
  */
 import { renderHook, act } from "@testing-library/react";
 import { of, throwError } from "rxjs";
-import {
-  UserRefusedAllowManager,
-  DisconnectedDeviceDuringOperation,
-  UnresponsiveDeviceError,
-  DeviceSocketFail,
-} from "@ledgerhq/errors";
+import { DisconnectedDeviceDuringOperation } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedAllowManager, UnresponsiveDeviceError, DeviceSocketFail } from "../../errors";
 import { useGenuineCheck } from "./useGenuineCheck";
 import {
   getGenuineCheckFromDeviceId,

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { UnresponsiveDeviceError, UserRefusedAllowManager } from "@ledgerhq/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { isCounterfeitError } from "../isCounterfeitError";
 import type { DeviceId } from "@ledgerhq/types-live";
 import { getGenuineCheckFromDeviceId as defaultGetGenuineCheckFromDeviceId } from "../getGenuineCheckFromDeviceId";
@@ -133,7 +133,7 @@ export const useGenuineCheck = ({
       },
       error: (e: any) => {
         clearTimeoutRef(timeoutRef);
-        if (e instanceof UserRefusedAllowManager) {
+        if ((e as Error).name === "UserRefusedAllowManager") {
           setDevicePermissionState("refused");
         } else if (isCounterfeitError(e)) {
           setGenuineState("non-genuine");

--- a/libs/ledger-live-common/src/hw/index.test.ts
+++ b/libs/ledger-live-common/src/hw/index.test.ts
@@ -1,6 +1,6 @@
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { registerTransportModule, open } from ".";
-import { CantOpenDevice, TransportError } from "@ledgerhq/errors";
+import { CantOpenDevice, TransportError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -4,7 +4,7 @@ import { catchError } from "rxjs/operators";
 import type { DeviceModel } from "@ledgerhq/types-devices";
 import Transport from "@ledgerhq/hw-transport";
 import { TraceContext, trace } from "@ledgerhq/logs";
-import { CantOpenDevice } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
 
 export const LOG_TYPE = "hw";
 

--- a/libs/ledger-live-common/src/hw/installApp.test.ts
+++ b/libs/ledger-live-common/src/hw/installApp.test.ts
@@ -4,11 +4,8 @@ import ManagerAPI from "../manager/api";
 import { defer, of, throwError } from "rxjs";
 import { anAppBuilder } from "../mock/fixtures/anApp";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
-import {
-  LockedDeviceError,
-  ManagerDeviceLockedError,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { ManagerDeviceLockedError, UnresponsiveDeviceError } from "../errors";
 import { quitApp } from "../deviceSDK/commands/quitApp";
 
 // Mocking ManagerAPI

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -1,11 +1,11 @@
 import { Observable, throwError, timer } from "rxjs";
 import { throttleTime, filter, map, catchError, retry, switchMap } from "rxjs/operators";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import {
-  LockedDeviceError,
   ManagerAppDepInstallRequired,
   ManagerDeviceLockedError,
   UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+} from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";
@@ -70,9 +70,9 @@ export default function installApp(
           delay: (error: unknown, retryCount: number) => {
             // Not retrying on locked device errors
             if (
-              error instanceof LockedDeviceError ||
-              error instanceof ManagerDeviceLockedError ||
-              error instanceof UnresponsiveDeviceError
+              (error as Error).name === "LockedDeviceError" ||
+              (error as Error).name === "ManagerDeviceLocked" ||
+              (error as Error).name === "UnresponsiveDeviceError"
             ) {
               tracer.trace(`Not retrying on error: ${error}`, {
                 error,

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -1,18 +1,16 @@
+import { StatusCodes, TransportError, TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import {
   DeviceOnDashboardExpected,
+  LanguageInstallRefusedOnDevice,
   LanguageNotFound,
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-  TransportStatusError,
-} from "@ledgerhq/errors";
+} from "../errors";
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 
 import Transport from "@ledgerhq/hw-transport";
 import network from "@ledgerhq/live-network/network";
 import { Language, LanguagePackage } from "@ledgerhq/types-live";
-import { LanguageInstallRefusedOnDevice } from "../errors";
 import ManagerAPI from "../manager/api";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
 import { withDevice } from "./deviceAccess";
@@ -132,10 +130,12 @@ export default function installLanguage({
             }),
             catchError((e: unknown) => {
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                (e as Error).name === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  (e as Error).name === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
+++ b/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
@@ -1,5 +1,5 @@
 import { isCounterfeitError } from "./isCounterfeitError";
-import { DeviceSocketFail } from "@ledgerhq/errors";
+import { DeviceSocketFail } from "../errors";
 
 describe("isCounterfeitError", () => {
   it("should return true if the error is a DeviceSocketFail", () => {

--- a/libs/ledger-live-common/src/hw/isCounterfeitError.ts
+++ b/libs/ledger-live-common/src/hw/isCounterfeitError.ts
@@ -1,4 +1,4 @@
-import { DeviceSocketFail } from "@ledgerhq/errors";
+import { DeviceSocketFail } from "../errors";
 
 /**
  * Detects whether an error from the HSM socket indicates a counterfeit device.

--- a/libs/ledger-live-common/src/hw/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/renameDevice.ts
@@ -1,6 +1,6 @@
 import { concat, defer, from, Observable, of, throwError } from "rxjs";
 import { catchError, concatMap } from "rxjs/operators";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { withDevice } from "./deviceAccess";
 import editDeviceName from "./editDeviceName";
 import getAppAndVersion from "./getAppAndVersion";
@@ -92,7 +92,10 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
             /**
              * If the error is that the device is not on the dashboard, we retry the innerSub
              */
-            if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+            if (
+              error.message === "not on dashboard" ||
+              (error as Error).name === "DisconnectedDevice"
+            ) {
               return innerSub;
             }
 
@@ -117,7 +120,7 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
        * We do have a global timeout so that we are not in a infinite loop
        *
        */
-      if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+      if (error.message === "not on dashboard" || (error as Error).name === "DisconnectedDevice") {
         return of<RenameDeviceEvent>({
           type: "disconnected",
           expected: true,

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
@@ -1,4 +1,5 @@
-import { StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { command as uninstallAllApps } from "./uninstallAllApps";
 import Transport from "@ledgerhq/hw-transport";
 

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of } from "rxjs";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/uninstallApp.ts
+++ b/libs/ledger-live-common/src/hw/uninstallApp.ts
@@ -1,6 +1,6 @@
 import { ignoreElements, catchError } from "rxjs/operators";
 import { Observable, throwError } from "rxjs";
-import { ManagerAppDepUninstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepUninstallRequired } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import ManagerAPI from "../manager/api";
 import type { App, ApplicationVersion } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/hw/uninstallLanguage.ts
+++ b/libs/ledger-live-common/src/hw/uninstallLanguage.ts
@@ -1,6 +1,7 @@
 import { Observable, from, of, throwError, EMPTY } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import { DeviceOnDashboardExpected, TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnDashboardExpected } from "../errors";
 
 import { withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -81,10 +82,12 @@ export default function unistallLanguage({
             }),
             catchError((e: unknown) => {
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                (e as Error).name === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  (e as Error).name === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 const quitAppObservable = from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-wallet-framework/src/account/support.ts
+++ b/libs/ledger-wallet-framework/src/account/support.ts
@@ -1,4 +1,4 @@
-import { AccountNotSupported } from "@ledgerhq/errors";
+import { AccountNotSupported } from "../errors";
 import { getEnv } from "@ledgerhq/live-env";
 import { getAllDerivationModes, getDerivationModesForCurrency } from "../derivation";
 import type { CryptoCurrency } from "../types";

--- a/libs/ledger-wallet-framework/src/bridge/getAddressWrapper.ts
+++ b/libs/ledger-wallet-framework/src/bridge/getAddressWrapper.ts
@@ -1,4 +1,5 @@
-import { DeviceAppVerifyNotSupported, StatusCodes, UserRefusedAddress } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "../errors";
 import { log } from "@ledgerhq/logs";
 import type { GetAddressResult, GetAddressOptions } from "../derivation";
 

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -15,7 +15,7 @@ import {
   takeUntil,
 } from "rxjs";
 import { log } from "@ledgerhq/logs";
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { UnsupportedDerivation, WrongDeviceForAccount } from "../errors";
 import {
   getSeedIdentifierDerivation,
   getDerivationModesForCurrency,
@@ -39,7 +39,6 @@ import {
 } from "../account/balanceHistoryCache";
 import { shouldRetainPendingOperation } from "../account/pending";
 import { shouldShowNewAccount } from "../account/support";
-import { UnsupportedDerivation } from "../errors";
 import getAddressWrapper, { GetAddressFn } from "./getAddressWrapper";
 import type { GetAddressResult } from "../derivation";
 import type { CryptoCurrency } from "../types";
@@ -536,7 +535,7 @@ export const makeScanAccounts =
 
                 derivationsCache[seedCacheKey] = result;
               } catch (e) {
-                if (e instanceof UnsupportedDerivation) {
+                if ((e as Error).name === "UnsupportedDerivation") {
                   log("scanAccounts", "ignore derivationMode=" + derivationMode);
                   continue;
                 }

--- a/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
+++ b/libs/ledger-wallet-framework/src/test-helpers/bridge-integration-suite.ts
@@ -4,7 +4,7 @@ import { firstValueFrom } from "rxjs";
 import { reduce, filter, map, catchError } from "rxjs/operators";
 import flatMap from "lodash/flatMap";
 import omit from "lodash/omit";
-import { InvalidAddress, RecipientRequired, AmountRequired } from "@ledgerhq/errors";
+import { InvalidAddress, RecipientRequired, AmountRequired } from "../errors";
 import type {
   Account,
   AccountBridge,

--- a/libs/ledgerjs/packages/cryptoassets/.unimportedrc.json
+++ b/libs/ledgerjs/packages/cryptoassets/.unimportedrc.json
@@ -13,7 +13,8 @@
     "src/data/**",
     "src/**/*.test.ts",
     "src/cal-client/**",
-    "src/legacy/legacy-data.ts"
+    "src/legacy/legacy-data.ts",
+    "src/errors.ts"
   ],
   "ignoreUnused": [
     "zod",

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.test.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="jest" />
 import { RtkCryptoAssetsStore, createRtkCryptoAssetsStore } from "./store";
 import { CryptoAssetsApi } from "./api";
-import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
+import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "../../errors";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 // Mock the API

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/state-manager/store.ts
@@ -1,7 +1,7 @@
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { CryptoAssetsStore } from "@ledgerhq/types-live";
 import { CryptoAssetsApi } from "./api";
-import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
+import { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "../../errors";
 
 /**
  * Simple adapter that implements CryptoAssetsStore interface using RTK Query API directly.

--- a/libs/ledgerjs/packages/hw-app-algorand/src/Algorand.ts
+++ b/libs/ledgerjs/packages/hw-app-algorand/src/Algorand.ts
@@ -16,7 +16,7 @@
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { encodeAddress } from "./utils";
 const CHUNK_SIZE = 250;
 // const P1_FIRST = 0x00;

--- a/libs/ledgerjs/packages/hw-app-aptos/src/Aptos.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/src/Aptos.ts
@@ -17,7 +17,7 @@
 
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { bip32asBuffer } from "./bip32";
 
 const MAX_APDU_LEN = 255;

--- a/libs/ledgerjs/packages/hw-app-canton/src/Canton.test.ts
+++ b/libs/ledgerjs/packages/hw-app-canton/src/Canton.test.ts
@@ -1,5 +1,5 @@
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import Canton from "./Canton";
 
 const PATH = "44'/6767'/0'/0'/0'";

--- a/libs/ledgerjs/packages/hw-app-canton/src/Canton.ts
+++ b/libs/ledgerjs/packages/hw-app-canton/src/Canton.ts
@@ -1,4 +1,4 @@
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 

--- a/libs/ledgerjs/packages/hw-app-cosmos/src/Cosmos.ts
+++ b/libs/ledgerjs/packages/hw-app-cosmos/src/Cosmos.ts
@@ -16,7 +16,7 @@
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 const CHUNK_SIZE = 250;
 const CLA = 0x55;
 const APP_KEY = "CSM";

--- a/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
@@ -9,6 +9,9 @@
   "ignoreUnresolved": [
     "@jest/expect-utils",
     "@jest/get-type",
-    "jest-util"],
-  "ignoreUnimported": []
+    "jest-util"
+  ],
+  "ignoreUnimported": [
+    "src/errors.ts"
+  ]
 }

--- a/libs/ledgerjs/packages/hw-app-exchange/src/Exchange.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/Exchange.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BigNumber } from "bignumber.js";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import invariant from "invariant";
 import { type DeviceManagementKit } from "@ledgerhq/device-management-kit";
 

--- a/libs/ledgerjs/packages/hw-app-hedera/src/Hedera.ts
+++ b/libs/ledgerjs/packages/hw-app-hedera/src/Hedera.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice, UserRefusedAddress } from "@ledgerhq/hw-transport/errors";
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
 

--- a/libs/ledgerjs/packages/hw-app-helium/src/Helium.ts
+++ b/libs/ledgerjs/packages/hw-app-helium/src/Helium.ts
@@ -1,5 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import Address from "@helium/address";
 import {
   PaymentV2,

--- a/libs/ledgerjs/packages/hw-app-icon/src/Icon.ts
+++ b/libs/ledgerjs/packages/hw-app-icon/src/Icon.ts
@@ -17,7 +17,7 @@
 
 import { splitPath, foreach, hexToBase64 } from "./utils";
 import type Transport from "@ledgerhq/hw-transport";
-import { UserRefusedOnDevice, UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedOnDevice, UserRefusedAddress } from "@ledgerhq/hw-transport/errors";
 
 const CLA = 0xe0;
 const INS = {

--- a/libs/ledgerjs/packages/hw-app-kaspa/src/Kaspa.ts
+++ b/libs/ledgerjs/packages/hw-app-kaspa/src/Kaspa.ts
@@ -1,5 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 
 import { publicKeyToAddress } from "./kaspa-util";
 import { KaspaHwTransaction } from "./kaspaHwTransaction";
@@ -75,11 +75,7 @@ export default class Kaspa {
 
     const p1 = display ? P1_CONFIRM : P1_NON_CONFIRM;
 
-    const publicKeyBuffer: Buffer = await this.sendToDevice(
-      INS.GET_ADDRESS,
-      p1,
-      pathBuffer,
-    );
+    const publicKeyBuffer: Buffer = await this.sendToDevice(INS.GET_ADDRESS, p1, pathBuffer);
 
     return {
       publicKey: publicKeyBuffer.toString("hex"),
@@ -102,12 +98,7 @@ export default class Kaspa {
     await this.sendToDevice(INS.SIGN_TX, P1_HEADER, header, P2_MORE);
 
     for (const output of transaction.outputs) {
-      await this.sendToDevice(
-        INS.SIGN_TX,
-        P1_OUTPUTS,
-        output.serialize(),
-        P2_MORE,
-      );
+      await this.sendToDevice(INS.SIGN_TX, P1_OUTPUTS, output.serialize(), P2_MORE);
     }
 
     let signatureBuffer: Buffer | null = null;
@@ -115,17 +106,11 @@ export default class Kaspa {
     for (let i = 0; i < transaction.inputs.length; i++) {
       const p2 = i >= transaction.inputs.length - 1 ? P2_LAST : P2_MORE;
       const input = transaction.inputs[i];
-      signatureBuffer = await this.sendToDevice(
-        INS.SIGN_TX,
-        P1_INPUTS,
-        input.serialize(),
-        p2,
-      );
+      signatureBuffer = await this.sendToDevice(INS.SIGN_TX, P1_INPUTS, input.serialize(), p2);
     }
 
     while (signatureBuffer) {
-      const [hasMore, inputIndex, sigLen, ...signatureAndSighash] =
-        signatureBuffer;
+      const [hasMore, inputIndex, sigLen, ...signatureAndSighash] = signatureBuffer;
       const sigBuf = signatureAndSighash.slice(0, sigLen);
       const sighashLen = signatureAndSighash[64];
       const sighashBuf = signatureAndSighash.slice(65, 65 + sighashLen);
@@ -142,12 +127,8 @@ export default class Kaspa {
         );
       }
 
-      transaction.inputs[inputIndex].setSignature(
-        Buffer.from(sigBuf).toString("hex"),
-      );
-      transaction.inputs[inputIndex].setSighash(
-        Buffer.from(sighashBuf).toString("hex"),
-      );
+      transaction.inputs[inputIndex].setSignature(Buffer.from(sigBuf).toString("hex"));
+      transaction.inputs[inputIndex].setSighash(Buffer.from(sighashBuf).toString("hex"));
 
       // Keep going as long as hasMore is true-ish
       if (!hasMore) {
@@ -169,12 +150,7 @@ export default class Kaspa {
    * @example
    * kaspa.signMessage(message).then(r => r.version)
    */
-  async signMessage(
-    message: string,
-    addressType?: 0 | 1,
-    addressIndex?: number,
-    account?: number,
-  ) {
+  async signMessage(message: string, addressType?: 0 | 1, addressIndex?: number, account?: number) {
     account = account ?? 0x80000000;
     addressIndex = addressIndex ?? 0;
     addressType = addressType ?? 0;
@@ -184,9 +160,7 @@ export default class Kaspa {
     }
 
     if (addressIndex < 0 || addressIndex > 0xffffffff) {
-      throw new Error(
-        "Address index must be an integer in range [0, 0xFFFFFFFF]",
-      );
+      throw new Error("Address index must be an integer in range [0, 0xFFFFFFFF]");
     }
 
     const addressTypeBuf = Buffer.alloc(1);
@@ -210,15 +184,9 @@ export default class Kaspa {
       messageBuffer,
     ]);
 
-    const signatureBuffer = await this.sendToDevice(
-      INS.SIGN_MESSAGE,
-      P1_NON_CONFIRM,
-      payload,
-    );
+    const signatureBuffer = await this.sendToDevice(INS.SIGN_MESSAGE, P1_NON_CONFIRM, payload);
     const [sigLen, ...signatureAndMessageHash] = signatureBuffer;
-    const signature = Buffer.from(
-      signatureAndMessageHash.slice(0, sigLen),
-    ).toString("hex");
+    const signature = Buffer.from(signatureAndMessageHash.slice(0, sigLen)).toString("hex");
     const messageHashLen = signatureAndMessageHash[64];
     const messageHash = Buffer.from(
       signatureAndMessageHash.slice(65, 65 + messageHashLen),
@@ -236,10 +204,7 @@ export default class Kaspa {
    * kaspa.getVersion().then(r => r.version)
    */
   async getVersion() {
-    const [major, minor, patch] = await this.sendToDevice(
-      INS.GET_VERSION,
-      P1_NON_CONFIRM,
-    );
+    const [major, minor, patch] = await this.sendToDevice(INS.GET_VERSION, P1_NON_CONFIRM);
 
     return { version: `${major}.${minor}.${patch}` };
   }

--- a/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
@@ -16,7 +16,7 @@
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
 import BIPPath from "bip32-path";
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/hw-transport/errors";
 import { PolkadotGenericApp } from "@zondax/ledger-substrate";
 
 const INS = {

--- a/libs/ledgerjs/packages/hw-app-solana/src/Solana.ts
+++ b/libs/ledgerjs/packages/hw-app-solana/src/Solana.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 
 import BIPPath from "bip32-path";
 import { DescriptorInput, buildDescriptor } from "./descriptor";

--- a/libs/ledgerjs/packages/hw-app-str/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-str/.unimportedrc.json
@@ -1,4 +1,11 @@
 {
-  "entry": ["src/Str.ts"],
-  "ignoreUnused": ["jest-sonar"]
+  "entry": [
+    "src/Str.ts"
+  ],
+  "ignoreUnused": [
+    "jest-sonar"
+  ],
+  "ignoreUnimported": [
+    "src/errors.ts"
+  ]
 }

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -36,47 +36,83 @@ We have written corresponding classes for exceptions that developers should acti
 #### Table of Contents
 
 *   [StellarHashSigningNotEnabledError](#stellarhashsigningnotenablederror)
-*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
-*   [StellarUserRefusedError](#stellaruserrefusederror)
-*   [StellarDataTooLargeError](#stellardatatoolargeerror)
-*   [Str](#str)
     *   [Parameters](#parameters)
+*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
+    *   [Parameters](#parameters-1)
+*   [StellarUserRefusedError](#stellaruserrefusederror)
+    *   [Parameters](#parameters-2)
+*   [StellarDataTooLargeError](#stellardatatoolargeerror)
+    *   [Parameters](#parameters-3)
+*   [Str](#str)
+    *   [Parameters](#parameters-4)
     *   [Examples](#examples)
     *   [getAppConfiguration](#getappconfiguration)
         *   [Examples](#examples-1)
     *   [getPublicKey](#getpublickey)
-        *   [Parameters](#parameters-1)
+        *   [Parameters](#parameters-5)
         *   [Examples](#examples-2)
     *   [signTransaction](#signtransaction)
-        *   [Parameters](#parameters-2)
+        *   [Parameters](#parameters-6)
         *   [Examples](#examples-3)
     *   [signSorobanAuthorization](#signsorobanauthorization)
-        *   [Parameters](#parameters-3)
+        *   [Parameters](#parameters-7)
         *   [Examples](#examples-4)
     *   [signHash](#signhash)
-        *   [Parameters](#parameters-4)
+        *   [Parameters](#parameters-8)
         *   [Examples](#examples-5)
     *   [signMessage](#signmessage)
-        *   [Parameters](#parameters-5)
+        *   [Parameters](#parameters-9)
         *   [Examples](#examples-6)
 
 ### StellarHashSigningNotEnabledError
 
+**Extends Error**
+
 Error thrown when hash signing is not enabled on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **{cause: any?}?**&#x20;
+
 ### StellarDataParsingFailedError
+
+**Extends Error**
 
 Error thrown when data parsing fails.
 
 For example, when parsing the transaction fails, this error is thrown.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **{cause: any?}?**&#x20;
+
 ### StellarUserRefusedError
+
+**Extends Error**
 
 Error thrown when the user refuses the request on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **{cause: any?}?**&#x20;
+
 ### StellarDataTooLargeError
 
+**Extends Error**
+
 Error thrown when the data is too large to be processed by the device.
+
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **{cause: any?}?**&#x20;
 
 ### Str
 

--- a/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
+++ b/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
@@ -6,7 +6,7 @@ import {
   StellarUserRefusedError,
   StellarDataTooLargeError,
 } from "../src/errors";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 
 test("getAppConfiguration (hash signing disabled)", async () => {
   const transport = await openTransportReplayer(

--- a/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
@@ -1,3 +1,8 @@
 {
-  "entry": ["src/Sui.ts"]
+  "entry": [
+    "src/Sui.ts"
+  ],
+  "ignoreUnimported": [
+    "src/errors.ts"
+  ]
 }

--- a/libs/ledgerjs/packages/hw-app-sui/src/Sui.ts
+++ b/libs/ledgerjs/packages/hw-app-sui/src/Sui.ts
@@ -1,6 +1,6 @@
 import SuiUpstream from "@mysten/ledgerjs-hw-app-sui";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "./errors";
 import semver from "semver";
 
 import type { Resolution, SignTransactionResult } from "@mysten/ledgerjs-hw-app-sui";

--- a/libs/ledgerjs/packages/hw-app-sui/tests/Sui.test.ts
+++ b/libs/ledgerjs/packages/hw-app-sui/tests/Sui.test.ts
@@ -1,5 +1,5 @@
 import { DeviceModelId } from "@ledgerhq/devices";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "../src/errors";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import Sui from "../src/Sui";
 

--- a/libs/ledgerjs/packages/hw-transport/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-transport/.unimportedrc.json
@@ -1,3 +1,8 @@
 {
-  "entry": ["src/Transport.ts"]
+  "entry": [
+    "src/Transport.ts"
+  ],
+  "ignoreUnimported": [
+    "src/errors.ts"
+  ]
 }

--- a/libs/ledgerjs/packages/hw-transport/src/Transport.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/Transport.ts
@@ -6,7 +6,7 @@ import {
   StatusCodes,
   getAltStatusMessage,
   TransportStatusError,
-} from "@ledgerhq/errors";
+} from "./errors";
 import { LocalTracer, TraceContext, LogType } from "@ledgerhq/logs";
 export { TransportError, TransportStatusError, StatusCodes, getAltStatusMessage };
 

--- a/libs/live-signer-aleo/src/DmkSignerAleo.ts
+++ b/libs/live-signer-aleo/src/DmkSignerAleo.ts
@@ -14,7 +14,8 @@ import {
   DeviceActionStatus,
   type DeviceManagementKit,
 } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   SignerAleo,
   SignerAleoBuilder,

--- a/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
+++ b/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
@@ -1,5 +1,6 @@
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "../src/errors";
 import { SignerAleoBuilder } from "@ledgerhq/device-signer-kit-aleo";
 import { of } from "rxjs";
 import { DmkSignerAleo } from "../src/DmkSignerAleo";

--- a/libs/live-signer-canton/src/LegacySignerCanton.ts
+++ b/libs/live-signer-canton/src/LegacySignerCanton.ts
@@ -1,6 +1,6 @@
 import semver from "semver";
 import Transport from "@ledgerhq/hw-transport";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "./errors";
 import {
   CantonSigner,
   CantonAddress,

--- a/libs/live-signer-canton/tests/LegacySignerCanton.test.ts
+++ b/libs/live-signer-canton/tests/LegacySignerCanton.test.ts
@@ -1,6 +1,6 @@
 import Canton from "@ledgerhq/hw-app-canton";
 import { LegacySignerCanton } from "../src/LegacySignerCanton";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "../src/errors";
 import Transport from "@ledgerhq/hw-transport";
 
 const PATH = "44'/6767'/0'/0'/0'";

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -19,9 +19,9 @@ import {
   ConcordiumAddressVerificationFailedError,
   ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   type SignerConcordium,
   SignerConcordiumBuilder,

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -3,9 +3,9 @@ import {
   ConcordiumAddressVerificationFailedError,
   ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "../src/errors";
 import { SignerConcordiumBuilder } from "@ledgerhq/device-signer-kit-concordium";
 import { TransactionType, AccountAddress } from "@ledgerhq/concordium-core";
 import type { Transaction, CredentialDeploymentTransaction } from "@ledgerhq/concordium-core";

--- a/libs/live-signer-cosmos/src/DmkSignerCosmos.ts
+++ b/libs/live-signer-cosmos/src/DmkSignerCosmos.ts
@@ -11,7 +11,7 @@ import {
   type SignerCosmos,
 } from "@ledgerhq/device-signer-kit-cosmos";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 
 type DAError = GetAddressDAError | SignTransactionDAError;
 

--- a/libs/live-signer-cosmos/tests/DmkSignerCosmos.test.ts
+++ b/libs/live-signer-cosmos/tests/DmkSignerCosmos.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { DmkSignerCosmos } from "../src/DmkSignerCosmos";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { of, throwError } from "rxjs";
 
 jest.mock("@ledgerhq/device-signer-kit-cosmos", () => ({

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -18,11 +18,9 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
 import { EIP712Message } from "@ledgerhq/types-live";
-import {
-  EthAppPleaseEnableContractData,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { EthAppPleaseEnableContractData } from "./errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { EvmAddress, EvmSigner, EvmSignerEvent } from "./types";
 import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/services/types";
 import {

--- a/libs/live-signer-hyperliquid/src/DmkSignerHyperliquid.ts
+++ b/libs/live-signer-hyperliquid/src/DmkSignerHyperliquid.ts
@@ -4,7 +4,7 @@ import {
   SignerHyperliquid,
 } from "@ledgerhq/device-signer-kit-hyperliquid";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import type { SignActionsActionItem } from "@ledgerhq/device-signer-kit-hyperliquid";
 import { firstValueFrom, filter, map } from "rxjs";
 

--- a/libs/live-signer-hyperliquid/tests/DmkSignerHyperliquid.test.ts
+++ b/libs/live-signer-hyperliquid/tests/DmkSignerHyperliquid.test.ts
@@ -1,7 +1,7 @@
 import { of, throwError } from "rxjs";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import { SignerHyperliquidBuilder } from "@ledgerhq/device-signer-kit-hyperliquid";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { DmkSignerHyperliquid, Action } from "../src/DmkSignerHyperliquid";
 
 jest.mock("@ledgerhq/device-signer-kit-hyperliquid");

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -18,7 +18,7 @@ import {
 } from "@ledgerhq/device-signer-kit-solana";
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import bs58 from "bs58";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 
 export type DAError =
   | GetAddressDAError

--- a/libs/live-signer-solana/src/LegacySignerSolana.ts
+++ b/libs/live-signer-solana/src/LegacySignerSolana.ts
@@ -12,7 +12,7 @@ import { DeviceModelId } from "@ledgerhq/devices";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";
 import { loadPKI } from "@ledgerhq/hw-bolos";
-import { LatestFirmwareVersionRequired, UpdateYourApp } from "@ledgerhq/errors";
+import { LatestFirmwareVersionRequired, UpdateYourApp } from "./errors";
 
 /**
  * Required minimum version of App Solana for non NanoS devices.
@@ -26,7 +26,9 @@ const MIN_VERSION = "1.9.2";
 const MANAGER_APP_NAME = "Solana";
 
 function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+  return (
+    (err as Error).name === "TransportStatusError" && (err as Error).message.includes("0x6a81")
+  );
 }
 
 async function tryLoadPKI(...args: Parameters<typeof loadPKI>) {

--- a/libs/live-signer-solana/tests/DMKSignerSol.test.ts
+++ b/libs/live-signer-solana/tests/DMKSignerSol.test.ts
@@ -4,7 +4,7 @@
 import { DmkSignerSol } from "../src/DmkSignerSol";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
 import { PubKeyDisplayMode, UserInputType, Resolution } from "@ledgerhq/coin-solana/signer";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import bs58 from "bs58";
 import { of, throwError } from "rxjs";
 

--- a/libs/live-signer-solana/tests/LegacySignerSolana.test.ts
+++ b/libs/live-signer-solana/tests/LegacySignerSolana.test.ts
@@ -2,11 +2,8 @@ import Solana from "@ledgerhq/hw-app-solana";
 import { LegacySignerSolana } from "../src/LegacySignerSolana";
 import { PubKeyDisplayMode } from "@ledgerhq/coin-solana/signer";
 import * as loadPKIModule from "@ledgerhq/hw-bolos";
-import {
-  LatestFirmwareVersionRequired,
-  TransportStatusError,
-  UpdateYourApp,
-} from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { LatestFirmwareVersionRequired, UpdateYourApp } from "../src/errors";
 import { DeviceModelId } from "@ledgerhq/devices/index";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -11,7 +11,7 @@ import type {
   SignPcztTransactionResult,
 } from "./types";
 import { lastValueFrom, type Observable } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   DeviceActionStatus,
   type DeviceActionState,


### PR DESCRIPTION
### 📝 Description

Part of the **LIVE-32915** `@ledgerhq/errors` decoupling initiative — **Phase 1** for the `coin-integration` team scope.

Replaces every `instanceof SomeError` guard with `error.name === "SomeError"` across ~393 files owned by the coin-integration team (coin modules, live-common families, bridge helpers). Also migrates error imports away from `@ledgerhq/errors` to the package-local `errors` entry point where applicable.

**Why this matters:** native ES error classes (Phase 2, separate PR) don't register in the `@ledgerhq/errors` deserialization registry, so `instanceof` would silently return `false` after deserialization. The `.name` check is serialization-boundary safe.

```diff
- } catch (e) {
-   if (e instanceof NotEnoughGas) {
+ } catch (e) {
+   if ((e as Error).name === "NotEnoughGas") {
```

> [!NOTE]
> Phase 2 (migrate `createCustomErrorClass` → native ES classes) will follow as a separate PR once this lands.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **Big picture PR**: #19723 — full scope of the `@ledgerhq/errors` decoupling (split into per-team PRs for review)

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ