### PR TITLE
[LWDM] chore(errors): [ptx] Phase 1 — replace instanceof with .name checks

### DIFF
--- a/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
@@ -3,7 +3,7 @@ import network from "@ledgerhq/live-network";
 import { fetchCurrencyTo } from "../fetchCurrencyTo";
 import { fetchCurrencyToMock } from "../__mocks__/fetchCurrencyTo.mocks";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../../const/timeout";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "../../../../../errors";
 import { flattenV5CurrenciesToAndFrom } from "../../../utils/flattenV5CurrenciesToAndFrom";
 
 jest.mock("@ledgerhq/live-network/network");

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
@@ -1,7 +1,7 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "../../../../errors";
 import { fetchCurrencyAllMock } from "./__mocks__/fetchCurrencyAll.mocks";
 import { ResponseData as ResponseDataTo } from "./fetchCurrencyTo";
 import { ResponseData as ResponseDataFrom } from "./fetchCurrencyFrom";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
@@ -3,7 +3,7 @@ import { fetchCurrencyToMock } from "./__mocks__/fetchCurrencyTo.mocks";
 import { isIntegrationTestEnv } from "../../utils/isIntegrationTestEnv";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "../../../../errors";
 import { flattenV5CurrenciesToAndFrom } from "../../utils/flattenV5CurrenciesToAndFrom";
 import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
 

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
@@ -1,10 +1,9 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx, SwapGenericAPIError } from "../../../../errors";
 import { ExchangeRate, ExchangeRateErrorDefault, ExchangeRateResponseRaw } from "../../types";
 import { Unit } from "@ledgerhq/live-app-sdk";
-import { SwapGenericAPIError } from "../../../../errors";
 import { enrichRatesResponse } from "../../utils/enrichRatesResponse";
 import { isIntegrationTestEnv } from "../../utils/isIntegrationTestEnv";
 import { fetchRatesMock } from "./__mocks__/fetchRates.mocks";

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -1,10 +1,10 @@
 import type { Account } from "@ledgerhq/types-live";
+import { DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
 import {
-  DisconnectedDeviceDuringOperation,
-  TransportStatusError,
+  TransactionRefusedOnDevice,
   WrongDeviceForAccountPayout,
   WrongDeviceForAccountRefund,
-} from "@ledgerhq/errors";
+} from "../../errors";
 import {
   createExchange,
   ExchangeTypes,
@@ -20,7 +20,6 @@ import { secp256k1 } from "@noble/curves/secp256k1";
 import { getCurrencyExchangeConfig } from "../";
 import { getAccountCurrency, getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
-import { TransactionRefusedOnDevice } from "../../errors";
 import { handleHederaTrustedFlow } from "../../families/hedera/exchange";
 import { withDevicePromise } from "../../hw/deviceAccess";
 import { delay } from "../../promise";
@@ -252,9 +251,10 @@ const completeExchange = (
             payoutAddressParameters,
           );
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const tse1 = e as { name?: string; statusCode?: number };
+          if (tse1.name === "TransportStatusError" && tse1.statusCode === 0x6a83) {
             throw new WrongDeviceForAccountPayout(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(tse1.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(payoutAccount),
               },
@@ -293,10 +293,11 @@ const completeExchange = (
           );
           log(COMPLETE_EXCHANGE_LOG, "checkrefund address");
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const tse2 = e as { name?: string; statusCode?: number };
+          if (tse2.name === "TransportStatusError" && tse2.statusCode === 0x6a83) {
             log(COMPLETE_EXCHANGE_LOG, "transport error");
             throw new WrongDeviceForAccountRefund(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(tse2.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(refundAccount),
               },
@@ -316,9 +317,10 @@ const completeExchange = (
         // During signature delegation, Exchange does not remap refusal errors from the coin app/OS.
         // 0x6a84: user refused the proposal for an owned destination address.
         // 0x5501: BOLOS/OS-level refusal (not an Exchange app error code).
+        const tse3 = e as { name?: string; statusCode?: number };
         if (
-          e instanceof TransportStatusError &&
-          (e.statusCode === 0x6a84 || e.statusCode === 0x5501)
+          tse3.name === "TransportStatusError" &&
+          (tse3.statusCode === 0x6a84 || tse3.statusCode === 0x5501)
         ) {
           throw new TransactionRefusedOnDevice();
         }

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.test.ts
@@ -3,7 +3,9 @@
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
 import { renderHook } from "@testing-library/react";
-import { AmountRequired, NotEnoughGas, NotEnoughGasSwap } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughGasSwap } from "../../../errors";
+import { NotEnoughGas } from "@ledgerhq/coin-evm/errors";
 
 import { useFromAmountStatusMessage } from "./useSwapTransaction";
 import type { Result } from "../../../bridge/useBridgeTransaction";

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -1,12 +1,7 @@
 import { getAccountCurrency, getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
-import {
-  AmountRequired,
-  FeeNotLoaded,
-  NotEnoughBalanceSwap,
-  NotEnoughGas,
-  NotEnoughGasSwap,
-} from "@ledgerhq/errors";
+import { AmountRequired, FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughBalanceSwap, NotEnoughGasSwap } from "../../../errors";
 import { Account } from "@ledgerhq/types-live";
 import { useEffect, useMemo, useState } from "react";
 import useBridgeTransaction, { Result } from "../../../bridge/useBridgeTransaction";
@@ -64,8 +59,8 @@ export const useFromAmountStatusMessage = (
 
     const [relevantStatus] = statusEntries
       .filter(maybeError => maybeError instanceof Error)
-      .filter(errorOrWarning => !(errorOrWarning instanceof AmountRequired));
-    const isRelevantStatus = (relevantStatus as Error) instanceof NotEnoughGas;
+      .filter(errorOrWarning => (errorOrWarning as Error).name !== "AmountRequired");
+    const isRelevantStatus = (relevantStatus as Error)?.name === "NotEnoughGas";
 
     // Skip gas validation for sponsored transactions since gas fees are covered by sponsor
 
@@ -85,7 +80,7 @@ export const useFromAmountStatusMessage = (
     }
 
     // convert to swap variation of error to display correct message to frontend.
-    if (relevantStatus instanceof FeeNotLoaded) {
+    if ((relevantStatus as Error)?.name === "FeeNotLoaded") {
       return new NotEnoughBalanceSwap();
     }
 


### PR DESCRIPTION
### 📝 Description

Part of the **LIVE-32915** `@ledgerhq/errors` decoupling initiative — **Phase 1** for the `ptx` team scope.

Replaces every `instanceof SomeError` guard with `error.name === "SomeError"` across ~7 files owned by the ptx team (transaction broadcasting, gas estimation, fee-not-loaded handling).

**Why this matters:** native ES error classes (Phase 2, separate PR) don't register in the `@ledgerhq/errors` deserialization registry, so `instanceof` would silently return `false` after deserialization. The `.name` check is serialization-boundary safe.

```diff
- if (e instanceof FeeNotLoaded) {
+ if ((e as Error).name === "FeeNotLoaded") {
```

> [!NOTE]
> Phase 2 (migrate `createCustomErrorClass` → native ES classes) will follow as a separate PR once this lands.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **Big picture PR**: #19723 — full scope of the `@ledgerhq/errors` decoupling (split into per-team PRs for review)

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ