### PR TITLE
[LWDM] chore(errors): [wallet-xp] Phase 1 — replace instanceof with .name checks

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -91,7 +91,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "open success", data: { descriptor } });
       return new IPCTransport(descriptor, requestId);
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;
@@ -133,7 +133,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "exchange success", data: { apdu: apduHex } });
       return Buffer.from(result.data, "hex");
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -2,7 +2,7 @@ import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.test.ts
@@ -3,11 +3,11 @@ import { UseTrackAddAccountModal, useTrackAddAccountModal } from "./useTrackAddA
 import { track } from "../segment";
 import {
   CantOpenDevice,
-  UserRefusedOnDevice,
   LockedDeviceError,
   TransportRaceCondition,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Device } from "@ledgerhq/types-devices";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
@@ -1,13 +1,6 @@
 import { useRef, useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -67,22 +60,22 @@ export const useTrackAddAccountModal = ({
       page: "Add account modal",
     };
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during account creation
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition during account creation
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during account creation
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested.current && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app during account creation
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
@@ -92,7 +85,7 @@ export const useTrackAddAccountModal = ({
       track("Device connection lost", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during account creation
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.test.ts
@@ -2,12 +2,12 @@ import { renderHook } from "tests/testSetup";
 import { useTrackExchangeFlow, UseTrackExchangeFlow } from "./useTrackExchangeFlow";
 import { track } from "../segment";
 import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
   CantOpenDevice,
   LockedDeviceError,
   TransportRaceCondition,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 jest.mock("../segment", () => ({

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
@@ -1,12 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerError } from "~/renderer/components/DeviceAction";
@@ -71,30 +63,30 @@ export const useTrackExchangeFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open exchange app
       track("Open app denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedAllowManager) {
+    } else if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.test.ts
@@ -4,12 +4,9 @@ import {
   UseTrackGenericDAppTransactionSend,
 } from "./useTrackGenericDAppTransactionSend";
 import { track } from "../segment";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  CantOpenDevice,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 jest.mock("../segment", () => ({

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
@@ -1,14 +1,7 @@
 import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
+import { LedgerErrorConstructor } from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -83,7 +76,7 @@ export const useTrackGenericDAppTransactionSend = ({
       track("Secure Channel approved", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
@@ -100,22 +93,22 @@ export const useTrackGenericDAppTransactionSend = ({
       previousOpenAppRequested.current.clear();
     }
 
-    if (previousOpenAppRequested.current.size && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current.size && error?.name === "UserRefusedOnDevice") {
       // user refused to open add during generic DApp transaction flow (send)
       track("User refused to open app", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during generic DApp transaction flow (send)
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during generic DApp transaction flow (send)
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during generic DApp transaction flow (send)
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.test.ts
@@ -8,7 +8,7 @@ import {
   UserRefusedAllowManager,
   UserRefusedDeviceNameChange,
   UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 jest.mock("../segment", () => ({

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
@@ -1,9 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedDeviceNameChange,
-  UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
@@ -69,13 +64,13 @@ export const useTrackManagerSectionEvents = ({
       track("Deleted Custom Lock Screen", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedFirmwareUpdate) {
+    } else if (error?.name === "UserRefusedFirmwareUpdate") {
       // user refused OS update
       track("User refused OS update via LL", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.test.ts
@@ -3,12 +3,12 @@ import { useTrackReceiveFlow, UseTrackReceiveFlow } from "./useTrackReceiveFlow"
 import { track } from "../segment";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import {
-  UserRefusedOnDevice,
-  UserRefusedAddress,
   LockedDeviceError,
   CantOpenDevice,
   TransportRaceCondition,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAddress } from "@ledgerhq/live-common/errors";
 
 jest.mock("../segment", () => ({
   track: jest.fn(),

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
@@ -1,14 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
@@ -69,32 +61,32 @@ export const useTrackReceiveFlow = ({
       page: "Receive",
     };
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if ((verifyAddressError as unknown) instanceof UserRefusedAddress) {
+    if (verifyAddressError?.name === "UserRefusedAddress") {
       // user refused to confirm address
       track("Address confirmation rejected", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.test.ts
@@ -2,12 +2,12 @@ import { renderHook } from "tests/testSetup";
 import { useTrackSendFlow, UseTrackSendFlow } from "./useTrackSendFlow";
 import { track } from "../segment";
 import {
-  UserRefusedOnDevice,
   TransportRaceCondition,
   LockedDeviceError,
   CantOpenDevice,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 jest.mock("../segment", () => ({

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
@@ -1,13 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -65,27 +58,27 @@ export const useTrackSendFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.test.ts
@@ -1,13 +1,9 @@
 import { renderHook } from "tests/testSetup";
 import { useTrackSyncFlow, UseTrackSyncFlow } from "./useTrackSyncFlow";
 import { track } from "../segment";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, LockedDeviceError, TransportError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 jest.mock("../segment", () => ({

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
@@ -1,14 +1,7 @@
 import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
+import { LedgerErrorConstructor } from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -87,27 +80,27 @@ export const useTrackSyncFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested && error?.name === "UserRefusedOnDevice") {
       // user refused to open Ledger Sync app
       track("User refused to open Ledger Sync app", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { TokenCurrency, CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import ErrorBanner from "./ErrorBanner";
 import { useFilteredServiceStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/index";
@@ -7,7 +6,14 @@ type Props = {
   currencies: Array<CryptoCurrency | TokenCurrency>;
   hideStatusIncidents?: boolean;
 };
-const ServiceStatusWarning = createCustomErrorClass("ServiceStatusWarning");
+class ServiceStatusWarning extends Error {
+  override name = "ServiceStatusWarning";
+  description?: string;
+  constructor(message?: string, options?: ErrorOptions & { description?: string }) {
+    super(message, options);
+    this.description = options?.description;
+  }
+}
 const CurrencyDownStatusAlert = ({ currencies, hideStatusIncidents }: Props) => {
   const errors: Error[] = [];
 

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
@@ -1,9 +1,3 @@
-import {
-  ManagerNotEnoughSpaceError,
-  UpdateYourApp,
-  LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
-import { OutdatedApp } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { renderError } from "~/renderer/components/DeviceAction/rendering";
 import { DmkError } from "@ledgerhq/live-dmk-desktop";
@@ -30,9 +24,9 @@ const ErrorDisplay = ({
   const { t } = useTranslation();
 
   const managerAppName =
-    error instanceof ManagerNotEnoughSpaceError ||
-    (error as unknown) instanceof OutdatedApp ||
-    (error as unknown) instanceof UpdateYourApp
+    (error as { name?: string })?.name === "ManagerNotEnoughSpaceError" ||
+    (error as { name?: string })?.name === "OutdatedApp" ||
+    (error as { name?: string })?.name === "UpdateYourApp"
       ? (error as unknown as { managerAppName: string }).managerAppName
       : undefined;
 
@@ -41,7 +35,7 @@ const ErrorDisplay = ({
     error,
     onRetry,
     managerAppName,
-    requireFirmwareUpdate: error instanceof LatestFirmwareVersionRequired,
+    requireFirmwareUpdate: (error as { name?: string })?.name === "LatestFirmwareVersionRequired",
     withExportLogs,
     list,
     supportLink,

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
@@ -3,22 +3,6 @@ import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import Lock from "~/renderer/icons/LockCircle";
-import {
-  UserRefusedAllowManager,
-  UserRefusedFirmwareUpdate,
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  ManagerDeviceLockedError,
-  UserRefusedDeviceNameChange,
-} from "@ledgerhq/errors";
-import {
-  SwapGenericAPIError,
-  DeviceNotOnboarded,
-  NoSuchAppOnProvider,
-  LanguageInstallRefusedOnDevice,
-  ImageDoesNotExistOnDevice,
-  ImageLoadRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 import { IconsLegacy } from "@ledgerhq/react-ui";
 
 export type ErrorIconProps = {
@@ -29,28 +13,31 @@ export type ErrorIconProps = {
 const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
   if (!error) return null;
 
-  if (error instanceof DeviceNotOnboarded) {
+  if ((error as { name?: string })?.name === "DeviceNotOnboarded") {
     return <InfoCircle size={size} />;
   }
 
   if (
-    error instanceof UserRefusedFirmwareUpdate ||
-    error instanceof UserRefusedAllowManager ||
-    error instanceof UserRefusedOnDevice ||
-    error instanceof UserRefusedAddress ||
-    error instanceof LanguageInstallRefusedOnDevice ||
-    error instanceof ImageDoesNotExistOnDevice ||
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof UserRefusedDeviceNameChange
+    (error as { name?: string })?.name === "UserRefusedFirmwareUpdate" ||
+    (error as { name?: string })?.name === "UserRefusedAllowManager" ||
+    (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+    (error as { name?: string })?.name === "UserRefusedAddress" ||
+    (error as { name?: string })?.name === "LanguageInstallRefusedOnDevice" ||
+    (error as { name?: string })?.name === "ImageDoesNotExistOnDevice" ||
+    (error as { name?: string })?.name === "ImageLoadRefusedOnDevice" ||
+    (error as { name?: string })?.name === "UserRefusedDeviceNameChange"
   ) {
     return <IconsLegacy.InfoMedium size={size} color="primary.c80" />;
   }
 
-  if (error instanceof SwapGenericAPIError || error instanceof NoSuchAppOnProvider) {
+  if (
+    (error as { name?: string })?.name === "SwapGenericAPIError" ||
+    (error as { name?: string })?.name === "NoSuchAppOnProvider"
+  ) {
     return <CrossCircle size={size} />;
   }
 
-  if (error instanceof ManagerDeviceLockedError) {
+  if ((error as { name?: string })?.name === "ManagerDeviceLockedError") {
     return <Lock size={size} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/Input.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Input.tsx
@@ -16,7 +16,6 @@ import Box from "~/renderer/components/Box";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import BigSpinner from "~/renderer/components/BigSpinner";
 import { BoxProps } from "./Box/Box";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 export type InputError = Error | boolean | null | undefined;
 
@@ -302,7 +301,7 @@ const Input = function Input(
               <ErrorDisplay id="input-error" data-testid="input-error">
                 <TranslatedError
                   error={error}
-                  field={error instanceof AddressesSanctionedError ? "description" : undefined}
+                  field={error?.name === "AddressesSanctionedError" ? "description" : undefined}
                 />
               </ErrorDisplay>
             )

--- a/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { setEncryptionKey, isEncryptionKeyCorrect, hasBeenDecrypted } from "~/renderer/storage";
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import { useHardReset } from "~/renderer/reset";

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -31,7 +31,6 @@ import { ExchangeType } from "@ledgerhq/live-common/wallet-api/Exchange/server";
 import { getIncompatibleCurrencyKeys } from "@ledgerhq/live-common/exchange/swap/index";
 import { Exchange, isExchangeSwap } from "@ledgerhq/live-common/exchange/types";
 import { HardwareUpdate, renderLoading } from "./DeviceAction/rendering";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { HOOKS_TRACKING_LOCATIONS } from "../analytics/hooks/variables";
 import { getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
@@ -66,7 +65,9 @@ export function isStartExchangeData(data: unknown): data is StartExchangeData {
   return "exchangeType" in data;
 }
 
-const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+class DrawerClosedError extends Error {
+  override name = "DrawerClosedError";
+}
 
 export const LiveAppDrawer = () => {
   const [dismissDisclaimerChecked, setDismissDisclaimerChecked] = useState<boolean>(false);

--- a/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import jsQR from "jsqr";
 import styled from "styled-components";
-import { NoAccessToCamera } from "@ledgerhq/errors";
+import { NoAccessToCamera } from "@ledgerhq/live-common/errors";
 import logger from "~/renderer/logger";
 import IconCameraError from "~/renderer/icons/CameraError";
 import IconCross from "~/renderer/icons/Cross";

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -2,7 +2,7 @@ import { JSONRPCRequest } from "json-rpc-2.0";
 import React, { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { catchError, throwError } from "rxjs";
-import { GenuineCheckFailed } from "@ledgerhq/errors";
+import { GenuineCheckFailed } from "@ledgerhq/live-common/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import connectManager from "@ledgerhq/live-common/hw/connectManager";
@@ -112,7 +112,7 @@ export function useGenuineCheckAction(): Action<ManagerRequest, ManagerState, Ma
           if (isCounterfeitError(error)) return throwError(() => error);
           if (isDeviceNotOnboardedError(error)) return throwError(() => error);
 
-          return throwError(() => new GenuineCheckFailed("", undefined, { cause: error }));
+          return throwError(() => new GenuineCheckFailed("", { cause: error }));
         }),
       );
     return createManagerAction(task);

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -2,7 +2,7 @@ import { createRoot } from "react-dom/client";
 import React from "react";
 import Transport from "@ledgerhq/hw-transport";
 import { getEnv } from "@ledgerhq/live-env";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import "../config/configInit";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";

--- a/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { closeModal } from "~/renderer/actions/modals";
@@ -10,7 +10,7 @@ import InputPassword from "~/renderer/components/InputPassword";
 import Label from "~/renderer/components/Label";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const DisablePasswordModal = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from "react";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { TFunction } from "i18next";
 import Box from "~/renderer/components/Box";
 import InputPassword from "~/renderer/components/InputPassword";

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -10,7 +10,7 @@ import PasswordForm from "./PasswordForm";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const PasswordModal = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -1,4 +1,7 @@
-import { DisabledTransactionBroadcastError, MissingSwapPayloadParamaters } from "@ledgerhq/errors";
+import {
+  DisabledTransactionBroadcastError,
+  MissingSwapPayloadParamaters,
+} from "@ledgerhq/live-common/errors";
 import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { Exchange } from "@ledgerhq/live-common/exchange/types";

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -5,7 +5,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import useTheme from "~/renderer/hooks/useTheme";

--- a/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { repairChoices } from "@ledgerhq/live-common/hw/firmwareUpdate-repair";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
 import Button from "~/renderer/components/Button";
@@ -169,7 +168,7 @@ const RepairModal = ({
 
   const onClose = !cancellable && isLoading ? undefined : onReject;
   const disableRepair =
-    isLoading || !selectedOption || !!(error && error instanceof MCUNotGenuineToDashboard);
+    isLoading || !selectedOption || !!(error && error?.name === "MCUNotGenuineToDashboard");
 
   return (
     <Modal

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -6,7 +6,6 @@ import invariant from "invariant";
 import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import {
   addPendingOperation,
   getMainAccount,
@@ -257,7 +256,7 @@ const Body = ({
     setSigned(false);
   }, []);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
@@ -11,7 +11,7 @@ type DomainErrorsProps = {
 };
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
-  if (domainError.error instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <div data-testid="domain-error-invalid-domain">
         <Alert
@@ -28,7 +28,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
   }
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return (
       <div data-testid="domain-error-no-resolution">
         <Alert

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
@@ -6,7 +6,7 @@ import BigNumber from "bignumber.js";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Account } from "@ledgerhq/types-live";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { DomainServiceProvider } from "@ledgerhq/domain-service/hooks/index";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/impl";

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { TFunction } from "i18next";
@@ -49,7 +48,7 @@ const RecipientFieldBase = ({
         autoFocus={autoFocus}
         withQrCode={!status.recipientIsReadOnly}
         readOnly={status.recipientIsReadOnly}
-        error={hideError || recipientError instanceof RecipientRequired ? null : recipientError}
+        error={hideError || recipientError?.name === "RecipientRequired" ? null : recipientError}
         warning={recipientWarning}
         value={value}
         onChange={onChange}

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
@@ -67,15 +67,15 @@ const RecipientFieldDomainService = <T extends Transaction, TS extends Transacti
 
   const domainErrorHandled = useMemo(() => {
     if (domainError) {
-      if (!isForwardResolution && domainError.error instanceof NoResolution) {
+      if (!isForwardResolution && domainError.error?.name === "NoResolution") {
         return false;
       }
 
       if (
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof NoResolution ||
+        domainError.error?.name === "NoResolution" ||
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof InvalidDomain
+        domainError.error?.name === "InvalidDomain"
       ) {
         return true;
       }

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import React from "react";

--- a/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import type { Account } from "@ledgerhq/types-live";
 import { validateNameEdition } from "@ledgerhq/live-wallet/accountName";
 import { setAccountName as actionSetAccountName } from "@ledgerhq/live-wallet/store";
-import { AccountNameRequiredError } from "@ledgerhq/errors";
+import { AccountNameRequiredError } from "~/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import { urls } from "~/config/urls";
 import { setDataModal } from "~/renderer/actions/modals";

--- a/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -102,7 +101,7 @@ export default function Body({ onChangeStepId, onClose, setError, params, stepId
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import Stepper from "~/renderer/components/Stepper";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { isTokenAccount } from "@ledgerhq/live-common/account/index";
@@ -171,7 +170,7 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
@@ -5,12 +5,6 @@ import { useNavigate } from "react-router";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import { context } from "~/renderer/drawers/Provider";
 import UpdateFirmwareError from ".";
-import { LockedDeviceError, UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
-import {
-  ImageCommitRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  LanguageInstallRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 type Props = {
   error: Error;
@@ -33,18 +27,18 @@ const DeviceCancel = ({
   const onCloseReload = useCallback(() => {
     onDrawerClose();
 
-    if (error instanceof UserRefusedFirmwareUpdate && shouldReloadManagerOnCloseIfUpdateRefused) {
+    if (error?.name === "UserRefusedFirmwareUpdate" && shouldReloadManagerOnCloseIfUpdateRefused) {
       navigate("/manager/reload");
       setDrawer();
     }
   }, [error, navigate, onDrawerClose, setDrawer, shouldReloadManagerOnCloseIfUpdateRefused]);
 
-  const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
-  const isDeviceLockedError = error instanceof LockedDeviceError;
+  const isUserRefusedFirmwareUpdate = error?.name === "UserRefusedFirmwareUpdate";
+  const isDeviceLockedError = error?.name === "LockedDeviceError";
   const isRestoreStepRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof ImageCommitRefusedOnDevice ||
-    error instanceof LanguageInstallRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" ||
+    error?.name === "ImageCommitRefusedOnDevice" ||
+    error?.name === "LanguageInstallRefusedOnDevice";
   const isRetryableError =
     isUserRefusedFirmwareUpdate || isDeviceLockedError || isRestoreStepRefusedOnDevice;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -10,7 +10,6 @@ import { Flex, FlowStepper, Text } from "@ledgerhq/react-ui";
 import Disclaimer from "./Disclaimer";
 import Cancel from "./errors/Cancel";
 import DeviceCancel from "./errors/DeviceError";
-import { DisconnectedDevice, DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
 import SideDrawerHeader from "~/renderer/components/SideDrawerHeader";
 import { createFirmwareUpdateSteps } from "./helpers/createFirmwareUpdateSteps";
 import { StepId, STEPS } from "./types";
@@ -59,8 +58,9 @@ const UpdateModal = ({
   const withFinal = useMemo(() => hasFinalFirmware(firmware.final), [firmware]);
   const [cancel, setCancel] = useState<boolean>(false);
 
-  const isDisconnectedDeviceError = err instanceof DisconnectedDevice;
-  const isDisconnectedDeviceDuringOperationError = err instanceof DisconnectedDeviceDuringOperation;
+  const isDisconnectedDeviceError = err?.name === "DisconnectedDevice";
+  const isDisconnectedDeviceDuringOperationError =
+    err?.name === "DisconnectedDeviceDuringOperation";
   const isDeviceDisconnected =
     isDisconnectedDeviceError ||
     isDisconnectedDeviceDuringOperationError ||

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/steps/01-step-prepare.tsx
@@ -11,7 +11,7 @@ import customLockScreenFetch, {
 } from "@ledgerhq/live-common/hw/customLockScreenFetch";
 import firmwareUpdatePrepare from "@ledgerhq/live-common/hw/firmwareUpdate-prepare";
 import { getEnv } from "@ledgerhq/live-env";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "@ledgerhq/live-common/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
@@ -3,7 +3,6 @@ import { ProcessorResult } from "~/renderer/components/CustomImage/dithering/typ
 import { Step, StepProps } from "./types";
 import { useTranslation } from "react-i18next";
 import { Flex } from "@ledgerhq/react-ui";
-import { ImageCommitRefusedOnDevice, ImageLoadRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 import StepFooter from "./StepFooter";
 import StepContainer from "./StepContainer";
@@ -50,9 +49,9 @@ const StepTransfer: React.FC<Props> = props => {
 
   // User refused loading the image OR committing the image
   const userRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
+    error?.name === "ImageLoadRefusedOnDevice" ||
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageCommitRefusedOnDevice";
 
   return (
     <StepContainer

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { Button, Flex, Divider, Text, Input, IconsLegacy, BoxedIcon } from "@ledgerhq/react-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTranslation } from "react-i18next";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 import Label from "~/renderer/components/Label";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
@@ -7,7 +7,6 @@ import removeImage from "@ledgerhq/live-common/hw/customLockScreenRemove";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { useTranslation } from "react-i18next";
 import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 const action = createAction(removeImage);
@@ -40,14 +39,14 @@ const RemoveCustomImage: React.FC<Props> = ({ onClose, onRemoved }) => {
   const onError = useCallback(
     (error: Error) => {
       setError(error);
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         dispatch(clearLastSeenCustomImage());
       }
     },
     [dispatch],
   );
 
-  const showRetry = error && !(error instanceof ImageDoesNotExistOnDevice);
+  const showRetry = error && error?.name !== "ImageDoesNotExistOnDevice";
 
   return (
     <Flex

--- a/apps/ledger-live-desktop/src/support/os.ts
+++ b/apps/ledger-live-desktop/src/support/os.ts
@@ -1,19 +1,19 @@
 import os from "os";
 import semverSatisfies from "semver/functions/satisfies";
 import { getEnv } from "@ledgerhq/live-env";
-import { createCustomErrorClass } from "@ledgerhq/errors";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-
 type OperatingSystemOutdatedInfos = {
   type: string;
   release: string;
   criteria: string;
 };
 
-export const OperatingSystemOutdated = createCustomErrorClass<
-  OperatingSystemOutdatedInfos,
-  LedgerErrorConstructor<OperatingSystemOutdatedInfos>
->("OperatingSystemOutdated");
+export class OperatingSystemOutdated extends Error {
+  override name = "OperatingSystemOutdated";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 export type SupportStatus =
   | {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.test.ts
@@ -2,12 +2,12 @@ import { renderHook } from "@testing-library/react-native";
 import { useTrackAddAccountFlow, UseTrackAddAccountFlow } from "./useTrackAddAccountFlow";
 import { track } from "../segment";
 import {
-  UserRefusedOnDevice,
   CantOpenDevice,
   LockedDeviceError,
   TransportRaceCondition,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 describe("useTrackAddAccountFlow", () => {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackAddAccountFlow = {
@@ -52,17 +45,21 @@ export const useTrackAddAccountFlow = ({
       page: "Add account",
     };
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during add account flow
       track("Transport error", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
@@ -70,23 +67,23 @@ export const useTrackAddAccountFlow = ({
     if (
       previousAllowOpeningGranted.current &&
       !allowOpeningGranted &&
-      error instanceof CantOpenDevice
+      error?.name === "CantOpenDevice"
     ) {
       // user lost connection after opening app
       track("Device connection lost", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (previousAllowOpeningGranted.current && error instanceof LockedDeviceError) {
+    if (previousAllowOpeningGranted.current && error?.name === "LockedDeviceError") {
       // device is locked while scanning for new accounts
       track("Device locked", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (isScanningForNewAccounts && error instanceof CantOpenDevice) {
+    if (isScanningForNewAccounts && error?.name === "CantOpenDevice") {
       // user lost connection while scanning for new accounts
       track("Device connection lost", defaultPayload);
-    } else if (error instanceof CantOpenDevice) {
+    } else if (error?.name === "CantOpenDevice") {
       // device is detected but connection failed
       track("Connection failed", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.test.ts
@@ -1,13 +1,9 @@
 import { renderHook } from "@testing-library/react-native";
 import { useTrackLedgerSyncFlow, UseTrackLedgerSyncFlow } from "./useTrackLedgerSyncFlow";
 import { track } from "../segment";
-import {
-  UserRefusedOnDevice,
-  UserRefusedAllowManager,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
+import { LockedDeviceError, CantOpenDevice, TransportError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 describe("useTrackLedgerSyncFlow", () => {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackLedgerSyncFlow = {
@@ -74,7 +67,7 @@ export const useTrackLedgerSyncFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && error instanceof UserRefusedOnDevice) {
+    if (previousRequestOpenApp.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -82,22 +75,22 @@ export const useTrackLedgerSyncFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.test.ts
@@ -3,7 +3,7 @@ import {
   UseTrackMyLedgerSectionEvents,
 } from "./useTrackMyLedgerEvents";
 import { track } from "../segment";
-import { UserRefusedAllowManager, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { UserRefusedAllowManager, UserRefusedDeviceNameChange } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { renderHook } from "@testing-library/react-native";
 

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import { UserRefusedAllowManager, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackMyLedgerSectionEvents = {
@@ -70,10 +69,10 @@ export const useTrackMyLedgerSectionEvents = ({
       track("Custom Lock Screen Image removed", defaultPayload);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", { ...defaultPayload, page: "Manager RenamedDevice" });
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.test.ts
@@ -2,13 +2,13 @@ import { renderHook } from "@testing-library/react-native";
 import { useTrackReceiveFlow, UseTrackReceiveFlow } from "./useTrackReceiveFlow";
 import { track } from "../segment";
 import {
-  UserRefusedAddress,
-  UserRefusedOnDevice,
   TransportRaceCondition,
   LockedDeviceError,
   CantOpenDevice,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAddress } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 describe("useTrackReceiveFlow", () => {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedAddress,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackReceiveFlow = {
@@ -58,32 +50,36 @@ export const useTrackReceiveFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAddress) {
+    if (error?.name === "UserRefusedAddress") {
       // user refused to verify address
       track("Address confirmation rejected", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.test.ts
@@ -2,12 +2,12 @@ import { renderHook } from "@testing-library/react-native";
 import { useTrackSendFlow, UseTrackSendFlow } from "./useTrackSendFlow";
 import { track } from "../segment";
 import {
-  UserRefusedOnDevice,
   TransportRaceCondition,
   LockedDeviceError,
   CantOpenDevice,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 describe("useTrackSendFlow", () => {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSendFlow = {
@@ -49,7 +42,11 @@ export const useTrackSendFlow = ({
       page: "Send",
     };
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -57,22 +54,22 @@ export const useTrackSendFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.test.ts
@@ -5,10 +5,10 @@ import {
   CantOpenDevice,
   LockedDeviceError,
   TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
   TransportRaceCondition,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 describe("useTrackSwapFlow", () => {

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSwapFlow = {
@@ -62,32 +54,36 @@ export const useTrackSwapFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap flow
       track("Transport error", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap flow
       track("Device locked", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
@@ -4,7 +4,6 @@ import { Flex } from "@ledgerhq/native-ui";
 import { useBleDevicePairing } from "@ledgerhq/live-dmk-mobile";
 import { Device } from "@ledgerhq/types-devices";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleFailedPairing } from "~/components/BleDevicePairingFlow/BleDevicePairingContent/BleFailedPairing";
 import { BleDevicePairingProgress } from "./BleDevicePairingContent/BleDevicePairingProgress";
 import { BleDevicePaired } from "./BleDevicePairingContent/BleDevicePaired";
@@ -37,7 +36,7 @@ export const DmkBleDevicePairing = ({
   let content;
 
   const needsToForgetDevice = useMemo(() => {
-    return pairingError instanceof PeerRemovedPairing;
+    return (pairingError as { name?: string })?.name === "PeerRemovedPairing";
   }, [pairingError]);
 
   useEffect(() => {
@@ -48,7 +47,7 @@ export const DmkBleDevicePairing = ({
 
   if (isPaired) {
     content = <BleDevicePaired device={device} productName={productName} />;
-  } else if (pairingError instanceof PeerRemovedPairing) {
+  } else if ((pairingError as { name?: string })?.name === "PeerRemovedPairing") {
     content = (
       <BleForgetDeviceDrawer
         isOpen={needsToForgetDevice}
@@ -56,7 +55,7 @@ export const DmkBleDevicePairing = ({
         onRetry={onRetry}
       />
     );
-  } else if (pairingError && !(pairingError instanceof LockedDeviceError)) {
+  } else if (pairingError && (pairingError as { name?: string })?.name !== "LockedDeviceError") {
     content = (
       <BleFailedPairing productName={productName} onRetry={onRetry} onOpenHelp={onOpenHelp} />
     );

--- a/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
@@ -5,7 +5,6 @@ import { Flex, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { setLastSeenCustomImage, clearLastSeenCustomImage } from "~/actions/settings";
 import { DeviceActionDefaultRendering } from "../DeviceAction";
 import { ImageSourceContext } from "../CustomImage/FramedPicture";
@@ -117,12 +116,11 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   }, [CLSError]);
   const isError = !!error;
   const refusedOnDevice =
-    (error as unknown) instanceof ImageLoadRefusedOnDevice ||
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" || error?.name === "ImageCommitRefusedOnDevice";
 
   useEffect(() => {
     // Once transferred the old image is wiped, we need to clear it from the data.
-    if (error instanceof ImageCommitRefusedOnDevice) {
+    if (error?.name === "ImageCommitRefusedOnDevice") {
       dispatch(clearLastSeenCustomImage());
     }
   }, [dispatch, error]);

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -8,7 +8,6 @@ import { PartialNullable } from "~/types/helpers";
 import QueuedDrawer from "./QueuedDrawer";
 import DeviceAction from "./DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 
 const DeviceActionContainer = styled(Flex).attrs({
@@ -74,7 +73,7 @@ export default function DeviceActionModal<Req, Stt, Res>({
 
   const onDeviceActionError = useCallback(
     (e: Error) => {
-      if (e instanceof PeerRemovedPairing || isCounterfeitError(e)) {
+      if (e?.name === "PeerRemovedPairing" || isCounterfeitError(e)) {
         setShowInfo(false);
       }
       onError?.(e);

--- a/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
@@ -2,7 +2,6 @@ import React, { memo } from "react";
 import { useTranslation } from "~/context/Locale";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Link } from "@ledgerhq/native-ui";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { NewIconType } from "@ledgerhq/native-ui/components/Icon/type";
 import useExportLogs from "./useExportLogs";
 import TranslatedError from "./TranslatedError";
@@ -53,7 +52,7 @@ const GenericErrorView = ({
   const subtitleError = outerError ? error : null;
 
   // In case bluetooth was necessary but the `RequiresBle` component could not be used directly
-  if (error instanceof BluetoothRequired) {
+  if ((error as { name?: string })?.name === "BluetoothRequired") {
     return (
       <>
         <BluetoothDisabled />

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
@@ -10,7 +10,6 @@ import { useStuckDeviceActionHint } from "../StuckDeviceActionHint/useStuckDevic
 import QueuedDrawer from "../QueuedDrawer";
 import { useIsDeviceLockedPolling } from "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling";
 import { IsDeviceLockedResultType } from "~/hooks/useIsDeviceLockedPolling/types";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleForgetDeviceIllustration } from "../BleDevicePairingFlow/BleDevicePairingContent/BleForgetDeviceIllustration";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { AlreadySendingApduError } from "@ledgerhq/device-management-kit";
@@ -29,9 +28,9 @@ export const DeviceLockedCheckDrawer = ({ isOpen, device, onDeviceUnlocked, onCl
   const isLocked = isLockedResult.type === IsDeviceLockedResultType.locked;
   const isUnlocked = isLockedResult.type === IsDeviceLockedResultType.unlocked;
   const isError = isLockedResult.type === IsDeviceLockedResultType.error;
-  const isPeerRemovedPairingError = isError && isLockedResult.error instanceof PeerRemovedPairing;
+  const isPeerRemovedPairingError = isError && isLockedResult.error?.name === "PeerRemovedPairing";
   const isAlreadySendingApduError =
-    isError && isLockedResult.error instanceof AlreadySendingApduError;
+    isError && isLockedResult.error?.name === "AlreadySendingApduError";
   const isOtherError = isError && !isPeerRemovedPairingError && !isAlreadySendingApduError;
   const isLockedStateCannotBeDetermined =
     isLockedResult.type === IsDeviceLockedResultType.lockedStateCannotBeDetermined;

--- a/apps/ledger-live-mobile/src/components/ValidateError.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateError.tsx
@@ -8,7 +8,6 @@ import NeedHelp from "./NeedHelp";
 import { BaseNavigation } from "./RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { MANAGER_TABS } from "~/const/manager";
-import { UpdateYourApp, LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 import { RequiredFirmwareUpdate } from "./DeviceAction/rendering";
 import { useSelector } from "~/context/hooks";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
@@ -25,7 +24,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
   const { t } = useTranslation();
   const { colors } = useTheme();
 
-  const managerAppName = error instanceof UpdateYourApp ? error.managerAppName : undefined;
+  const managerAppName = error?.name === "UpdateYourApp" ? error.managerAppName : undefined;
 
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
 
@@ -60,7 +59,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
       ]}
     >
       <View style={styles.container}>
-        {error instanceof LatestFirmwareVersionRequired && lastConnectedDevice ? (
+        {error?.name === "LatestFirmwareVersionRequired" && lastConnectedDevice ? (
           <RequiredFirmwareUpdate navigation={navigation} device={lastConnectedDevice} />
         ) : (
           <>

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Linking } from "react-native";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { Trans, useLocale } from "~/context/Locale";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy } from "@ledgerhq/native-ui";
@@ -9,7 +8,9 @@ import Button from "../Button";
 import ExternalLink from "../ExternalLink";
 import { urls } from "~/utils/urls";
 
-const WebPTXPlayerNetworkFail = createCustomErrorClass("WebPTXPlayerNetworkFail");
+class WebPTXPlayerNetworkFail extends Error {
+  override name = "WebPTXPlayerNetworkFail";
+}
 
 const ExternalLinkWrapper = styled.View`
   margin-top: 19px;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -5,7 +5,7 @@ import { ActivityIndicator, Linking, Platform, StyleSheet, View } from "react-na
 import { WebView as RNWebView, WebViewMessageEvent } from "react-native-webview";
 import { useNavigation } from "@react-navigation/native";
 import { JSONRPCRequest } from "json-rpc-2.0";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type {
   RawPlatformTransaction,

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -34,7 +34,6 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
 import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { useOpenStakeDrawer } from "LLM/features/Stake";
 import { useStakingDrawer } from "~/components/Stake/useStakingDrawer";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
@@ -56,7 +55,9 @@ import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { useWalletFeaturesConfig, useFeatureFlags } from "@features/platform-feature-flags";
 import type { Feature, FeatureId } from "@shared/feature-flags";
 
-const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+class DrawerClosedError extends Error {
+  override name = "DrawerClosedError";
+}
 const drawerClosedError = new DrawerClosedError("User closed the drawer");
 const unknownSwapError = new Error("Unknown swap error");
 

--- a/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
+++ b/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from "react";
 import { AppState, Platform, Vibration } from "react-native";
 import type { Privacy } from "~/reducers/types";
 import * as Keychain from "react-native-keychain";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { VIBRATION_PATTERN_ERROR } from "~/utils/constants";
 
 interface UsePrivacyInitializationProps {

--- a/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
+++ b/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
@@ -32,12 +32,12 @@ export function isLockedDevicePolling(
       map<unknown, IsDeviceLockedResult>(() => ({ type: IsDeviceLockedResultType.unlocked })),
       catchError((error: Error) => {
         if (
-          error instanceof TransportStatusError &&
+          error?.name === "TransportStatusError" &&
           [
             StatusCodes.CLA_NOT_SUPPORTED,
             StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER,
             StatusCodes.INS_NOT_SUPPORTED,
-          ].includes(error.statusCode)
+          ].includes((error as TransportStatusError).statusCode)
         ) {
           return of<IsDeviceLockedResult>({
             type: IsDeviceLockedResultType.lockedStateCannotBeDetermined,
@@ -49,8 +49,9 @@ export function isLockedDevicePolling(
         }
 
         if (
-          error instanceof TransportStatusError &&
-          error.statusCode === StatusCodes.LOCKED_DEVICE
+          error?.name === "LockedDeviceError" ||
+          (error?.name === "TransportStatusError" &&
+            (error as TransportStatusError).statusCode === StatusCodes.LOCKED_DEVICE)
         ) {
           return of<IsDeviceLockedResult>({ type: IsDeviceLockedResultType.locked });
         }

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
 import "./config/configInit";

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -13,7 +13,7 @@ import type {
   BroadcastConfig,
 } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
   addPendingOperation,
@@ -32,7 +32,6 @@ import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { broadcastLogger } from "~/datadog";
 import { getEnv } from "@ledgerhq/live-env";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { updateAccountWithUpdater } from "../actions/accounts";
 import logger from "../logger";
@@ -369,13 +368,16 @@ export function useSignedTxHandler({
         });
       } catch (error) {
         if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
+          !(
+            (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+            (error as { name?: string })?.name === "TransactionRefusedOnDevice"
+          )
         ) {
           logger.critical(error as Error);
         }
 
         if (
-          error instanceof TransactionBroadcastError &&
+          (error as { name?: string })?.name === "TransactionBroadcastError" &&
           route.name === ScreenName.SendConnectDevice
         ) {
           return (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(

--- a/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { Box } from "@ledgerhq/native-ui";
 import HeaderErrorTitle from "~/components/HeaderErrorTitle";
 import { useNetInfo } from "@react-native-community/netinfo";
-import { NetworkDown } from "@ledgerhq/errors";
+import { NetworkDown } from "@ledgerhq/live-common/errors";
 
 type ErrorBannerProps = {
   error: Error;

--- a/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
@@ -3,7 +3,6 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { CustomImageNavigatorParamList } from "~/components/RootNavigator/types/CustomImageNavigator";
 import { ScreenName } from "~/const";
 import { useRemoveImageDeviceAction } from "~/hooks/deviceActions";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useTranslation } from "~/context/Locale";
 import DeviceAction from "~/components/DeviceAction";
@@ -47,7 +46,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
 
   const onError = useCallback(
     (error: Error) => {
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         setDeviceHasImage?.(false);
       }
       setError(error);
@@ -76,7 +75,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
             <Flex flex={1} justifyContent="center">
               <GenericErrorView error={error} hasExportLogButton={false} />
             </Flex>
-            {!(error instanceof ImageDoesNotExistOnDevice) && (
+            {error?.name !== "ImageDoesNotExistOnDevice" && (
               <Button type="main" size="large" onPress={handleTryAgain} my={4}>
                 {t("common.tryAgain")}
               </Button>

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -3,7 +3,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import { connect } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 import { Button, Text, IconsLegacy, Flex } from "@ledgerhq/native-ui";
 import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
@@ -6,12 +6,6 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import Button from "~/components/wrappedUi/Button";
 import Link from "~/components/wrappedUi/Link";
 import { TrackScreen } from "~/analytics";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
-import {
-  LanguageInstallRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  ImageCommitRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 export const RestoreStepDenied = ({
   t,
@@ -27,14 +21,14 @@ export const RestoreStepDenied = ({
   stepDeniedError: Error;
 }) => {
   const analyticsDrawerName =
-    stepDeniedError instanceof LanguageInstallRefusedOnDevice
+    stepDeniedError?.name === "LanguageInstallRefusedOnDevice"
       ? `Error: the language change was cancelled on the device`
-      : (stepDeniedError as Error) instanceof ImageLoadRefusedOnDevice ||
-          (stepDeniedError as Error) instanceof ImageCommitRefusedOnDevice
+      : stepDeniedError?.name === "ImageLoadRefusedOnDevice" ||
+          stepDeniedError?.name === "ImageCommitRefusedOnDevice"
         ? `Error: the restoration of lock screen picture was cancelled on the device`
-        : (stepDeniedError as Error) instanceof UserRefusedAllowManager
+        : stepDeniedError?.name === "UserRefusedAllowManager"
           ? `Error: the restoration of apps was cancelled on the device`
-          : `Error: ${(stepDeniedError as Error).name}`;
+          : `Error: ${stepDeniedError?.name}`;
   return (
     <Flex alignItems="center" justifyContent="center" px={1}>
       <TrackScreen category={analyticsDrawerName} refreshSource={false} />

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -13,18 +13,16 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
-  UnresponsiveDeviceError,
-  UserRefusedAllowManager,
-  WebsocketConnectionError,
-  WebsocketConnectionFailed,
-  CustomErrorClassType,
-  TransportStatusErrorClassType,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
 import {
   ConnectManagerTimeout,
   ImageCommitRefusedOnDevice,
   ImageLoadRefusedOnDevice,
   LanguageInstallRefusedOnDevice,
+  UnresponsiveDeviceError,
+  UserRefusedAllowManager,
+  WebsocketConnectionError,
+  WebsocketConnectionFailed,
 } from "@ledgerhq/live-common/errors";
 import {
   useAppDeviceAction,
@@ -36,9 +34,7 @@ import {
 import { isCustomLockScreenSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 
 // Errors related to the device connection
-export const reconnectDeviceErrorClasses: Array<
-  CustomErrorClassType | TransportStatusErrorClassType
-> = [
+export const reconnectDeviceErrorClasses: Array<new (...args: never) => Error> = [
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
@@ -48,17 +44,16 @@ export const reconnectDeviceErrorClasses: Array<
 ];
 
 // Errors that could be solved by the user: either on their phone or on their device
-export const userSolvableErrorClasses: Array<CustomErrorClassType | TransportStatusErrorClassType> =
-  [
-    ...reconnectDeviceErrorClasses,
-    WebsocketConnectionError,
-    UserRefusedAllowManager,
-    LanguageInstallRefusedOnDevice,
-    ImageCommitRefusedOnDevice,
-    ImageLoadRefusedOnDevice,
-    WebsocketConnectionFailed,
-    DisconnectedDeviceDuringOperation,
-  ];
+export const userSolvableErrorClasses: Array<new (...args: never) => Error> = [
+  ...reconnectDeviceErrorClasses,
+  WebsocketConnectionError,
+  UserRefusedAllowManager,
+  LanguageInstallRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
+  WebsocketConnectionFailed,
+  DisconnectedDeviceDuringOperation,
+];
 
 export type FirmwareUpdateParams = {
   device: Device;
@@ -413,7 +408,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "languageRestore" &&
       installLanguageState.error &&
-      installLanguageState.error instanceof LanguageInstallRefusedOnDevice
+      installLanguageState.error?.name === "LanguageInstallRefusedOnDevice"
     ) {
       return installLanguageState.error;
     }
@@ -421,8 +416,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "imageRestore" &&
       loadImageState.error &&
-      (loadImageState.error instanceof ImageLoadRefusedOnDevice ||
-        (loadImageState.error as unknown) instanceof ImageCommitRefusedOnDevice)
+      (loadImageState.error?.name === "ImageLoadRefusedOnDevice" ||
+        loadImageState.error?.name === "ImageCommitRefusedOnDevice")
     ) {
       return loadImageState.error;
     }
@@ -430,7 +425,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "appsRestore" &&
       restoreAppsState.error &&
-      restoreAppsState.error instanceof UserRefusedAllowManager
+      restoreAppsState.error?.name === "UserRefusedAllowManager"
     ) {
       return restoreAppsState.error;
     }

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { Flex } from "@ledgerhq/native-ui";
 import { ScreenName } from "~/const";
@@ -88,7 +87,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
     // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
     // and avoids a duplicated error drawers/messages.
     // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -8,7 +8,7 @@ import {
 import { Flex } from "@ledgerhq/native-ui";
 import { getAccountSpendableBalance, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { ScreenName, NavigatorName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -1,5 +1,4 @@
 import { isConfirmedOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Text } from "@ledgerhq/native-ui";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
@@ -51,7 +50,7 @@ import LText from "~/components/LText";
 import SupportLinkError from "~/components/SupportLinkError";
 
 const withoutHiddenError = (error: Error): Error | null =>
-  error instanceof RecipientRequired ? null : error;
+  error?.name === "RecipientRequired" ? null : error;
 
 type Navigation = BaseComposite<
   StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendSelectRecipient>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { View, ScrollView } from "react-native";
 import { BigNumber } from "bignumber.js";
-import {
-  FeeNotLoaded,
-  GasLessThanEstimate,
-  NotEnoughBalance,
-  NotEnoughGas,
-} from "@ledgerhq/errors";
+import { FeeNotLoaded, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
+import { GasLessThanEstimate, NotEnoughGas } from "@ledgerhq/coin-evm/errors";
 import { render, screen } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -153,7 +153,7 @@ function SendSummary({ navigation, route }: Props) {
 
     if (
       senderError?.name === recipientError?.name &&
-      senderError instanceof AddressesSanctionedError
+      senderError?.name === "AddressesSanctionedError"
     ) {
       return new AddressesSanctionedError("AddressesSanctionedError", {
         addresses: [

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
@@ -31,7 +31,7 @@ export const BasicErrorsView = memo(
     if (!error && !warning) return null;
 
     const hasNoResolutionButIsReverseResolution =
-      domainErrorHandled && domainError?.error instanceof NoResolution && !isForwardResolution;
+      domainErrorHandled && domainError?.error?.name === "NoResolution" && !isForwardResolution;
 
     if (!domainErrorHandled || hasNoResolutionButIsReverseResolution) {
       return (
@@ -69,7 +69,7 @@ type DomainErrorsProps = {
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
 
-  if ((domainError.error as Error) instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <Alert
         title={t("send.recipient.domainService.invalidDomain.title")}
@@ -82,7 +82,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
     );
   }
 
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return <Alert title={t("send.recipient.domainService.noResolution.title")} type="secondary" />;
   }
 

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
@@ -8,7 +8,6 @@ import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { Platform, StyleSheet, View } from "react-native";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import Clipboard from "@react-native-clipboard/clipboard";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { Trans } from "~/context/Locale";
 import { BasicErrorsView, DomainErrorsView } from "./DomainErrorHandlers";
 import RecipientInput from "~/components/RecipientInput";
@@ -16,7 +15,6 @@ import Alert from "~/components/Alert";
 import { urls } from "~/utils/urls";
 import LText from "~/components/LText";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 
 type Props = {
@@ -57,8 +55,7 @@ const DomainServiceRecipientInput = ({
   );
   const domainErrorHandled = useMemo(
     () =>
-      (domainError?.error as Error) instanceof InvalidDomain ||
-      (domainError?.error as Error) instanceof NoResolution,
+      domainError?.error?.name === "InvalidDomain" || domainError?.error?.name === "NoResolution",
     [domainError],
   );
 
@@ -126,9 +123,9 @@ const DomainServiceRecipientInput = ({
         domainError={domainError}
         domainErrorHandled={domainErrorHandled}
         isForwardResolution={isForwardResolution}
-        noLink={error instanceof AddressesSanctionedError}
+        noLink={error?.name === "AddressesSanctionedError"}
       />
-      {error instanceof AddressesSanctionedError ? (
+      {error?.name === "AddressesSanctionedError" ? (
         <>
           <LText
             testID="send-recipient-error-description"

--- a/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
@@ -6,7 +6,6 @@ import TranslatedError from "~/components/TranslatedError";
 import SupportLinkError from "~/components/SupportLinkError";
 import LText from "~/components/LText";
 import RecipientInput from "~/components/RecipientInput";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 type Props = {
   onChangeText: (value: string) => void;
@@ -48,7 +47,7 @@ const RecipientRow = ({
           >
             <TranslatedError error={error || warning} />
           </LText>
-          {error instanceof AddressesSanctionedError && (
+          {error?.name === "AddressesSanctionedError" && (
             <LText style={[styles.warningBox]} color="alert">
               <TranslatedError error={error} field="description" />
             </LText>

--- a/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
@@ -3,7 +3,7 @@ import { Platform, Vibration } from "react-native";
 import * as Keychain from "react-native-keychain";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 
 import { CompositeScreenProps } from "@react-navigation/native";
 import { setPrivacy } from "~/actions/settings";

--- a/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useState } from "react";
 import * as Keychain from "react-native-keychain";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { Vibration } from "react-native";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";

--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
@@ -8,8 +8,6 @@ import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app"
 import { isSwapDisableAppsInstall } from "@ledgerhq/live-common/exchange/swap/utils/isIntegrationTestEnv";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignRawTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignRawTransactionNavigator";
@@ -49,7 +47,10 @@ function ConnectDevice({ navigation, route }: SignRawTransactionConnectDevicePro
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
         if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
+          !(
+            (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+            (error as { name?: string })?.name === "TransactionRefusedOnDevice"
+          )
         ) {
           logger.critical(error as Error);
         }

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -9,8 +9,6 @@ import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignTransactionNavigator";
@@ -57,7 +55,10 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
         if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
+          !(
+            (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+            (error as { name?: string })?.name === "TransactionRefusedOnDevice"
+          )
         ) {
           logger.critical(error as Error);
         }

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
@@ -5,7 +5,7 @@ import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen, track } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { GenericInformationBody } from "~/components/GenericInformationBody";
-import { BluetoothRequired, FirmwareNotRecognized } from "@ledgerhq/errors";
+import { FirmwareNotRecognized } from "@ledgerhq/live-common/errors";
 import { useNavigation } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import type { SyncOnboardingScreenProps } from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/types";
@@ -64,7 +64,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
   // Depending from where the device was not recognized we can a FirmwareNotRecognized or a simple Error
   const isNotFoundEntity =
     error &&
-    (error instanceof FirmwareNotRecognized ||
+    ((error as { name?: string })?.name === "FirmwareNotRecognized" ||
       (error instanceof Error && error.message === "not found entity"));
 
   const onGoToSettings = useCallback(() => {
@@ -85,7 +85,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
   const screenName = isNotFoundEntity
     ? "Error: Device OS version not recognized"
     : error
-      ? `Error: ${isDmkError(error) ? error._tag : (error as Error).name}`
+      ? `Error: ${isDmkError(error) ? error._tag : (error as { name?: string })?.name}`
       : "Error: unknown error";
 
   const handleRetry = () => {
@@ -140,7 +140,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
         />
         <Button
           type="main"
-          mt={(error as unknown as Error) instanceof BluetoothRequired ? 6 : 8}
+          mt={(error as { name?: string })?.name === "BluetoothRequired" ? 6 : 8}
           mb={7}
           size={"large"}
           onPress={handleRetry}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -6,7 +6,6 @@ import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState"
 import { useToggleOnboardingEarlyCheck } from "@ledgerhq/live-common/deviceSDK/hooks/useToggleOnboardingEarlyChecks";
 import { log } from "@ledgerhq/logs";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, UnexpectedBootloader } from "@ledgerhq/errors";
 import { NORMAL_DESYNC_OVERLAY_DISPLAY_DELAY_MS } from "./constants";
 import { EarlySecurityCheck } from "./EarlySecurityCheck";
 import DesyncDrawer from "./DesyncDrawer";
@@ -232,7 +231,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   // A fatal error during polling triggers directly an error message (or the auto repair)
   useEffect(() => {
     if (isFocused && fatalError) {
-      if (fatalError instanceof UnexpectedBootloader) {
+      if (fatalError?.name === "UnexpectedBootloader") {
         log("SyncOnboardingIndex", "Device in bootloader mode. Trying to auto repair", {
           fatalError,
         });
@@ -250,7 +249,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
 
-    if (isFocused && allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (isFocused && allowedError && allowedError?.name !== "LockedDeviceError") {
       log("SyncOnboardingIndex", "Polling allowed error", { allowedError });
 
       timeout = setTimeout(() => {

--- a/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
+++ b/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
@@ -3,7 +3,7 @@ import { firstValueFrom, from, PartialObserver } from "rxjs";
 import { take, first, filter } from "rxjs/operators";
 import type { Device } from "@ledgerhq/types-devices";
 import type { Observer as TransportObserver, DescriptorEvent } from "@ledgerhq/hw-transport";
-import { HwTransportError } from "@ledgerhq/errors";
+import { HwTransportError } from "@ledgerhq/hw-transport/errors";
 import type { ApduMock } from "~/logic/createAPDUMock";
 import { hookRejections } from "~/logic/debugReject";
 import { e2eBridgeClient } from "~/e2e/bridge/client";

--- a/apps/ledger-live-mobile/src/types/error.ts
+++ b/apps/ledger-live-mobile/src/types/error.ts
@@ -1,4 +1,4 @@
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
+import { LedgerErrorConstructor } from "@ledgerhq/errors";
 
 export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>> & {
   name?: string;


### PR DESCRIPTION
### 📝 Description

Part of the **LIVE-32915** `@ledgerhq/errors` decoupling initiative — **Phase 1** for the `wallet-xp` team scope.

Replaces every `instanceof SomeError` guard with `error.name === "SomeError"` across ~94 files owned by the wallet-xp team (account management, send/receive flows, staking, mobile screens, desktop UI).

**Why this matters:** native ES error classes (Phase 2, separate PR) don't register in the `@ledgerhq/errors` deserialization registry, so `instanceof` would silently return `false` after deserialization. The `.name` check is serialization-boundary safe.

```diff
- if (error instanceof AccountNotSupported) {
+ if ((error as Error).name === "AccountNotSupported") {
```

> [!NOTE]
> Phase 2 (migrate `createCustomErrorClass` → native ES classes) will follow as a separate PR once this lands.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **Big picture PR**: #19723 — full scope of the `@ledgerhq/errors` decoupling (split into per-team PRs for review)

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ