### PR TITLE
tests(lwd): add e2e coverage for the new send flow

### DIFF
--- a/.changeset/curvy-camels-compete.md
+++ b/.changeset/curvy-camels-compete.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+"@ledgerhq/live-e2e-shared": minor
+---
+
+tests(lwd): add e2e coverage for the new send flow (incl. memo on Speculos)

--- a/e2e/desktop/tests/page/drawer/send.drawer.ts
+++ b/e2e/desktop/tests/page/drawer/send.drawer.ts
@@ -47,6 +47,11 @@ export class SendDrawer extends Drawer {
     expect(displayedAmount).toEqual(expect.stringContaining(tx.accountToDebit.currency.ticker));
   }
 
+  @step("Verify memo is visible in transaction details: $0")
+  async expectMemoVisible(memo: string) {
+    await expect(this.sendDrawer.getByText(memo, { exact: true })).toBeVisible();
+  }
+
   @step("Verify transaction status")
   async expectTransactionStatus(transactionStatus: string) {
     const displayedTransactionStatus = await this.transactionStatus.innerText();

--- a/e2e/desktop/tests/page/modal/new.send.modal.ts
+++ b/e2e/desktop/tests/page/modal/new.send.modal.ts
@@ -13,9 +13,9 @@ export class NewSendModal extends Modal {
   readonly matchedAddressButtons = this.dialog
     .locator('[data-testid="send-matched-address-button"]')
     .filter({ visible: true });
+  readonly memoInput = this.dialog.getByTestId("send-memo-input");
   readonly skipMemoLink = this.dialog.getByTestId("send-skip-memo-link");
   readonly skipMemoConfirmButton = this.dialog.getByTestId("send-skip-memo-confirm-button");
-  readonly memoInput = this.dialog.getByTestId("send-memo-input");
   readonly amountInput = this.dialog.getByTestId("send-amount-input");
   readonly feesMenuTrigger = this.dialog.getByTestId("send-network-fees-menu-trigger");
   readonly reviewButton = this.dialog.getByTestId("send-review-button");
@@ -34,6 +34,7 @@ export class NewSendModal extends Modal {
     .or(this.confirmationErrorContent)
     .or(this.confirmationInfoContent);
   readonly successConfirmationTitle = this.dialog.getByTestId("send-confirmation-success-title");
+  readonly viewDetailsButton = this.dialog.getByTestId("send-confirmation-view-details-button");
   readonly deviceActionLoader = this.page.getByTestId("device-action-loader");
   readonly signaturePrompt = this.dialog.getByTestId("send-signature-prompt");
 
@@ -73,6 +74,13 @@ export class NewSendModal extends Modal {
     await button.click();
   }
 
+  @step("Type memo: $0")
+  async typeMemo(memo: string) {
+    await this.memoInput.waitFor({ state: "visible" });
+    await this.memoInput.fill(memo);
+    await expect(this.memoInput).toHaveValue(memo);
+  }
+
   @step("Skip memo")
   async skipMemo({ confirm = true }: { confirm?: boolean } = {}) {
     await this.skipMemoLink.click();
@@ -81,9 +89,9 @@ export class NewSendModal extends Modal {
     }
   }
 
-  @step("Fill memo/tag: $0")
-  async fillMemo(memo: string) {
-    await this.memoInput.fill(memo);
+  @step("Click View details")
+  async clickViewDetails() {
+    await this.viewDetailsButton.click();
   }
 
   @step("Fill crypto amount: $0 (switches to crypto mode first)")

--- a/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
+++ b/e2e/desktop/tests/specs/newSendFlow.tx.spec.ts
@@ -124,6 +124,30 @@ const nativeSendTransactions: NewSendFlowEntry[] = [
   },
 ];
 
+const memoSendTransactions: NewSendFlowEntry[] = [
+  {
+    transaction: new Transaction(Account.XRP_1, Account.XRP_2, "0.0001", undefined, "123456"),
+    xrayTicket: "B2CQA-6037",
+  },
+  {
+    transaction: new Transaction(Account.XLM_1, Account.XLM_2, "0.0001", undefined, "memoText"),
+    xrayTicket: "B2CQA-6038",
+    bugTicket: "LIVE-29554",
+  },
+  {
+    transaction: new Transaction(Account.ATOM_1, Account.ATOM_2, "0.00001", undefined, "memo123"),
+    xrayTicket: "B2CQA-6039",
+  },
+  {
+    transaction: new Transaction(Account.SOL_1, Account.SOL_2, "0.000001", undefined, "memo123"),
+    xrayTicket: "B2CQA-6040",
+  },
+];
+
 test.describe("New Send Flow - Native Send", () => {
   registerNewSendFlowTests(nativeSendTransactions);
+});
+
+test.describe("New Send Flow - Memo field", () => {
+  registerNewSendFlowTests(memoSendTransactions);
 });

--- a/e2e/desktop/tests/utils/newSendFlowUtils.ts
+++ b/e2e/desktop/tests/utils/newSendFlowUtils.ts
@@ -71,6 +71,7 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
   for (const entry of entries) {
     const tx = entry.transaction;
     const family = getFamilyByCurrencyId(tx.accountToDebit.currency.id);
+    const validMemoTag = tx.memoTag !== "noTag" ? tx.memoTag : undefined;
 
     test.describe(tx.accountToDebit.accountName, () => {
       test.use({
@@ -89,7 +90,9 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
       test(
         `Send ${tx.amount} ${tx.accountToDebit.currency.ticker}${
           tx.accountToDebit.derivationMode ? ` [${tx.accountToDebit.derivationMode}]` : ""
-        } from ${tx.accountToDebit.accountName} to ${tx.accountToCredit.accountName}`,
+        }${validMemoTag ? " with memo" : ""} from ${tx.accountToDebit.accountName} to ${
+          tx.accountToCredit.accountName
+        }`,
         {
           tag: buildTags({ currencyId: tx.accountToDebit.currency.id }),
           annotation: { type: "TMS", description: entry.xrayTicket },
@@ -126,7 +129,12 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
           await app.newSendFlow.typeAddress(recipientAddress);
 
           if (requiresMemoStep) {
-            await app.newSendFlow.skipMemo();
+            if (validMemoTag) {
+              await app.newSendFlow.typeMemo(validMemoTag);
+              await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
+            } else {
+              await app.newSendFlow.skipMemo();
+            }
           } else {
             await app.newSendFlow.clickOnSendToButton(tx.accountToCredit);
           }
@@ -142,6 +150,12 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
           await app.newSendFlow.waitForSignature();
           await app.speculos.signSendTransaction(tx);
           await app.newSendFlow.waitForSuccessConfirmation();
+
+          await app.newSendFlow.clickViewDetails();
+          await app.sendDrawer.addressValueIsVisible(tx.accountToCredit.address);
+          if (validMemoTag && tx.accountToDebit.currency.id === Currency.SOL.id) {
+            await app.sendDrawer.expectMemoVisible(validMemoTag);
+          }
         },
       );
     });

--- a/libs/live-e2e-shared/src/families/cosmos.ts
+++ b/libs/live-e2e-shared/src/families/cosmos.ts
@@ -1,7 +1,12 @@
 import expect from "expect";
 import { Delegate } from "../models/Delegate";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getDelegateEvents, getSendEvents } from "../speculos";
+import {
+  containsSubstringInEvent,
+  expectMemoTagInEvents,
+  getDelegateEvents,
+  getSendEvents,
+} from "../speculos";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { isTouchDevice } from "../speculosAppVersion";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -38,6 +43,7 @@ export const sendCosmos = withDeviceController(
       }
       const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
       expect(isAddressCorrect).toBeTruthy();
+      expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/stellar.ts
+++ b/libs/live-e2e-shared/src/families/stellar.ts
@@ -1,6 +1,6 @@
 import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { containsSubstringInEvent, expectMemoTagInEvents, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -20,6 +20,7 @@ export const sendStellar = withDeviceController(
       }
       const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
       expect(isAddressCorrect).toBeTruthy();
+      expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/families/xrp.ts
+++ b/libs/live-e2e-shared/src/families/xrp.ts
@@ -1,6 +1,6 @@
 import expect from "expect";
 import { Transaction } from "../models/Transaction";
-import { containsSubstringInEvent, getSendEvents } from "../speculos";
+import { containsSubstringInEvent, expectMemoTagInEvents, getSendEvents } from "../speculos";
 import { isTouchDevice } from "../speculosAppVersion";
 import { DeviceLabels } from "../enum/DeviceLabels";
 import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
@@ -19,6 +19,7 @@ export const sendXRP = withDeviceController(
       }
       const isAddressCorrect = containsSubstringInEvent(tx.accountToCredit.address, events);
       expect(isAddressCorrect).toBeTruthy();
+      expectMemoTagInEvents(tx, events);
 
       if (isTouchDevice()) {
         await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -699,6 +699,14 @@ export function containsSubstringInEvent(targetString: string, events: string[])
   return result;
 }
 
+/** Asserts memo/tag appears on Speculos screens when the tx includes one. */
+export function expectMemoTagInEvents(tx: Transaction, events: string[]) {
+  if (!tx.memoTag || tx.memoTag === "noTag") {
+    return;
+  }
+  expect(containsSubstringInEvent(tx.memoTag, events)).toBeTruthy();
+}
+
 export async function takeScreenshot(port?: number): Promise<Buffer | undefined> {
   const speculosAddress = getSpeculosAddress();
   const speculosApiPort = port ?? getEnv("SPECULOS_API_PORT");


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds E2E tests (Speculos, LWD nightly) for the New Send Flow **memo field** on XRP, Stellar, Cosmos and Solana

- New `New Send Flow - Memo field` suite in `newSendFlow.tx.spec.ts` covering a full send **with memo filled**, linked to Xray TCs B2CQA-6037 (XRP), B2CQA-6038 (Stellar), B2CQA-6039 (Cosmos), B2CQA-6040 (Solana).
- Added `cosmos` to the `newSendFlow` feature flag families and to the memo-step families.
- Added `memoInput` locator + `typeMemo()` in the `NewSendModal` page object.

The no-memo (skip) path was already covered for XRP/XLM/SOL.

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34326)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
