### PR TITLE
[LWD] fix(desktop): prevent InputCurrency from ignoring prop updates when focused without typing

### DIFF
--- a/.changeset/calm-inputs-refresh.md
+++ b/.changeset/calm-inputs-refresh.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix InputCurrency not reflecting external value updates when focused without typing

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
@@ -73,6 +73,26 @@ describe("InputCurrency — caret preservation", () => {
     expect(input.selectionStart).toBe(11); // caret stays at the end, no jump
   });
 
+  it("reflects an external value update when the input is focused but the user has not typed", async () => {
+    const firstValue = new BigNumber("1000000000"); // 1 Gwei
+    const secondValue = new BigNumber("5000000000"); // 5 Gwei
+
+    const { rerender } = render(
+      <InputCurrency defaultUnit={gweiUnit} value={firstValue} onChange={() => {}} />,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("1");
+
+    // Simulate the Input container's handleClick focusing the field without the user typing.
+    input.focus();
+
+    rerender(<InputCurrency defaultUnit={gweiUnit} value={secondValue} onChange={() => {}} />);
+
+    // The display must update immediately — no second click required.
+    expect(input.value).toBe("5");
+  });
+
   it("forwards a ref to the underlying input element", () => {
     const ref = React.createRef<HTMLInputElement>();
     render(

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -145,7 +145,7 @@ function InputCurrency(props: Props) {
   // Synchronously reformat display when value/unit change while not focused
   useLayoutEffect(() => {
     setState(prev => {
-      if (prev.isFocused && !disabled) return prev;
+      if (prev.isFocused && prev.rawValue && !disabled) return prev;
       const displayValue =
         !value || value.isNaN() || value.isZero()
           ? ""


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - EVM staking amount input (undelegation flow) — verify clicking Max/amount buttons updates the display immediately without requiring a second click
  - Gas tracker advanced mode fee inputs — verify the caret fix from #19234 still works (mid-string edits stay in place)

### 📝 Description

PR [#19234](https://github.com/LedgerHQ/ledger-live/pull/19234) introduced a caret-preservation fix for advanced gas fee inputs. A follow-up copilot review (commit `53f06e2c`) replaced the callback ref (`setRefs`) with an object ref (`innerRef`) on `<Input>`. This activated a latent behavior in `Input.tsx`: `handleClick` calls `inputRef.current?.focus()` only when `inputRef` is an object ref (the `"current" in inputRef` guard). The callback ref silently bypassed this.

**Result:** on every container click (e.g. clicking a "Max" button in EVM staking), the input received focus before the parent's new value reached the `useLayoutEffect`. Since the effect guards with `isFocused && !disabled`, it skipped the update — leaving the amount display stalled until the user clicked elsewhere to trigger blur.

**Fix:** add `&& prev.rawValue` to the guard so it only blocks external value updates when the user has an actual in-progress edit (typed characters). An input that gained focus via a click without typing will now always reflect the latest prop value.

```ts
// before
if (prev.isFocused && !disabled) return prev;

// after
if (prev.isFocused && prev.rawValue && !disabled) return prev;
```

A regression test was added that focuses the input programmatically (simulating the container click path) then re-renders with a new value and asserts the display updates immediately.

https://github.com/user-attachments/assets/258adca0-d5e6-4501-9a51-7e362524ac17


### ❓ Context

- **JIRA or GitHub link**: [LIVE-34610](https://ledgerhq.atlassian.net/browse/LIVE-34610)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34610]: https://ledgerhq.atlassian.net/browse/LIVE-34610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ