### PR TITLE
[LWDM] chore(errors): replace instanceof guards with .name string checks (phase 1)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
@@ -19,7 +19,6 @@ import { trackPage } from "~/renderer/analytics/segment";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import LockedDeviceDrawer from "~/renderer/components/SyncOnboarding/Manual/LockedDeviceDrawer";
-import { LockedDeviceError } from "@ledgerhq/errors";
 import { useRecoverRestoreOnboarding } from "~/renderer/hooks/useRecoverRestoreOnboarding";
 import { useTrackOnboardingFlow } from "~/renderer/analytics/hooks/useTrackOnboardingFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
@@ -413,7 +412,7 @@ const useSyncOnboardingCompanionViewModel = ({
   useEffect(() => {
     let desyncTimer: NodeJS.Timeout | null = null;
 
-    if (allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (allowedError && allowedError?.name !== "LockedDeviceError") {
       setIsDesyncOverlayOpen(true);
       desyncTimer = setTimeout(handleDesyncTimerRunsOut, desyncTimeout);
     } else {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowOperation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowOperation.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -42,7 +41,7 @@ export function useSendFlowOperation({
 
   const onTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       stateActions.dispatchSetError(error);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
 import { Banner, Button } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { openURL } from "~/renderer/linking";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
@@ -53,7 +52,7 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (!error) return null;
 
-  if (excludeRecipientRequired && error instanceof RecipientRequired) return null;
+  if (excludeRecipientRequired && error?.name === "RecipientRequired") return null;
 
   if (!translatedError) return null;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
@@ -139,7 +139,7 @@ export function useAddressValidation({
   });
 
   const hasInvalidBridgeRecipient =
-    bridgeValidation.errors.recipient instanceof InvalidAddress && !ensResolution;
+    bridgeValidation.errors.recipient?.name === "InvalidAddress" && !ensResolution;
   const canMatchValidatedRecipient = Boolean(searchValue) && !hasInvalidBridgeRecipient;
 
   const userAccountsForCurrency = useMemo(() => {
@@ -306,7 +306,7 @@ export function useAddressValidation({
     }));
 
     const filteredBridgeErrors: BridgeValidationErrors = { ...bridgeValidation.errors };
-    if (ensResolution && filteredBridgeErrors.recipient instanceof InvalidAddress) {
+    if (ensResolution && filteredBridgeErrors.recipient?.name === "InvalidAddress") {
       delete filteredBridgeErrors.recipient;
     }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -9,10 +9,6 @@ import { Flow, Step, walletSyncOnboardingNewDeviceSelector } from "~/renderer/re
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { TrustchainResult, TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { track } from "~/renderer/analytics/segment";
 import { AnalyticsPage } from "./useLedgerSyncAnalytics";
 import { saveSettings, setLastOnboardedDevice } from "~/renderer/actions/settings";
@@ -104,9 +100,10 @@ export function useAddMember({
 
         transitionToNextScreen(trustchainResult);
       } catch (error) {
-        if (error instanceof TrustchainAlreadyInitialized) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "TrustchainAlreadyInitialized") {
           dispatch(setFlow({ flow: Flow.Synchronize, step: Step.AlreadySecuredSameSeed }));
-        } else if (error instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           dispatch(setFlow({ flow: Flow.Synchronize, step: Step.AlreadySecuredOtherSeed }));
         } else {
           setError(error as Error);

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
@@ -6,7 +6,6 @@ import {
   TrustchainSDK,
 } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { setTrustchain, resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { log } from "@ledgerhq/logs";
 import { track } from "~/renderer/analytics/segment";
 
@@ -23,7 +22,7 @@ export function useOnTrustchainRefreshNeeded(
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         dispatch(setTrustchain(newTrustchain));
       } catch (e) {
-        if (e instanceof TrustchainEjected) {
+        if ((e as { name?: string })?.name === "TrustchainEjected") {
           dispatch(resetTrustchainStore());
           track("ledgersync_deactivated");
         }

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
@@ -1,11 +1,6 @@
 import { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  QRCodeWSClosed,
-  TrustchainAlreadyInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { setDrawerVisibility, setFlow, setQrCodePinCode } from "~/renderer/actions/walletSync";
@@ -71,17 +66,17 @@ export function useQRCode({ sourcePage }: { sourcePage?: AnalyticsPage }) {
 
     // Don't use retry here because it always uses a delay despite setting it to 0
     onError(e) {
-      if (e instanceof QRCodeWSClosed) {
+      if (e?.name === "QRCodeWSClosed") {
         const { time } = e as unknown as { time: number };
         if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
       }
-      if (e instanceof InvalidDigitsError) {
+      if (e?.name === "InvalidDigitsError") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCodeError }));
       }
-      if (e instanceof NoTrustchainInitialized) {
+      if (e?.name === "NoTrustchainInitialized") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.UnbackedError }));
       }
-      if (e instanceof TrustchainAlreadyInitialized) {
+      if (e?.name === "TrustchainAlreadyInitialized") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeWithQRCode }));
       }
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
@@ -9,7 +9,6 @@ import { Flow, Step } from "~/renderer/reducers/walletSync";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { TrustchainMember, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 type Props = {
   device: Device | null;
@@ -71,7 +70,7 @@ export function useRemoveMember({ device, member }: Props) {
         transitionToNextScreen(newTrustchain);
       } catch (error) {
         if (error instanceof Error) setError(error);
-        if (error instanceof TrustchainNotAllowed) {
+        if ((error as { name?: string })?.name === "TrustchainNotAllowed") {
           dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.UnsecuredLedger }));
         }
       }

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -38,7 +38,6 @@ import { useOnTrustchainRefreshNeeded } from "./useOnTrustchainRefreshNeeded";
 import { Dispatch } from "redux";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(walletSelector(s));
 
@@ -146,8 +145,8 @@ export function useWatchWalletSync(): WalletSyncUserState {
 
   useEffect(() => {
     if (walletSyncError) {
-      if (walletSyncError instanceof TrustchainNotAllowed) resetLedgerSync();
-      if (walletSyncError instanceof TrustchainEjected) resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainNotAllowed") resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainEjected") resetLedgerSync();
     }
   }, [dispatch, resetLedgerSync, walletSyncError]);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
@@ -4,11 +4,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { ErrorType } from "./type.hooks";
 import { setFlow } from "~/renderer/actions/walletSync";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
-import {
-  TrustchainEjected,
-  TrustchainNotAllowed,
-  TrustchainOutdated,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { useRestoreTrustchain } from "./useRestoreTrustchain";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 
@@ -32,10 +27,10 @@ export const useLifeCycle = () => {
   function handleError(error: Error) {
     console.error("GetMember :" + error);
 
-    if (error instanceof TrustchainEjected) reset();
-    if (error instanceof TrustchainNotAllowed) reset();
+    if (error?.name === "TrustchainEjected") reset();
+    if (error?.name === "TrustchainNotAllowed") reset();
 
-    if (error instanceof TrustchainOutdated) restoreTrustchain();
+    if (error?.name === "TrustchainOutdated") restoreTrustchain();
 
     const errorToHandle = Object.entries(includesErrorActions).find(([err, _action]) =>
       error.message.includes(err),

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -91,7 +91,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "open success", data: { descriptor } });
       return new IPCTransport(descriptor, requestId);
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;
@@ -133,7 +133,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "exchange success", data: { apdu: apduHex } });
       return Buffer.from(result.data, "hex");
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
@@ -1,13 +1,6 @@
 import { useRef, useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -67,22 +60,22 @@ export const useTrackAddAccountModal = ({
       page: "Add account modal",
     };
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during account creation
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition during account creation
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during account creation
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested.current && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app during account creation
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
@@ -92,7 +85,7 @@ export const useTrackAddAccountModal = ({
       track("Device connection lost", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during account creation
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
@@ -1,12 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerError } from "~/renderer/components/DeviceAction";
@@ -71,30 +63,30 @@ export const useTrackExchangeFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open exchange app
       track("Open app denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedAllowManager) {
+    } else if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -83,7 +76,7 @@ export const useTrackGenericDAppTransactionSend = ({
       track("Secure Channel approved", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
@@ -100,22 +93,22 @@ export const useTrackGenericDAppTransactionSend = ({
       previousOpenAppRequested.current.clear();
     }
 
-    if (previousOpenAppRequested.current.size && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current.size && error?.name === "UserRefusedOnDevice") {
       // user refused to open add during generic DApp transaction flow (send)
       track("User refused to open app", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during generic DApp transaction flow (send)
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during generic DApp transaction flow (send)
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during generic DApp transaction flow (send)
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
@@ -1,9 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedDeviceNameChange,
-  UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
@@ -69,13 +64,13 @@ export const useTrackManagerSectionEvents = ({
       track("Deleted Custom Lock Screen", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedFirmwareUpdate) {
+    } else if (error?.name === "UserRefusedFirmwareUpdate") {
       // user refused OS update
       track("User refused OS update via LL", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
@@ -1,14 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
@@ -69,32 +61,32 @@ export const useTrackReceiveFlow = ({
       page: "Receive",
     };
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if ((verifyAddressError as unknown) instanceof UserRefusedAddress) {
+    if (verifyAddressError?.name === "UserRefusedAddress") {
       // user refused to confirm address
       track("Address confirmation rejected", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
@@ -1,13 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -65,27 +58,27 @@ export const useTrackSendFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -87,27 +80,27 @@ export const useTrackSyncFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested && error?.name === "UserRefusedOnDevice") {
       // user refused to open Ledger Sync app
       track("User refused to open Ledger Sync app", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { setLastSeenCustomImage } from "~/renderer/actions/settings";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/customLockScreenLoad";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { getEnv } from "@ledgerhq/live-env";
 import { useTranslation } from "react-i18next";
@@ -43,7 +42,8 @@ const action = createAction(getEnv("MOCK") ? mockedEventEmitter : customLockScre
 const mockedDevice = { deviceId: "", modelId: DeviceModelId.stax, wired: true };
 
 function checkIfIsRefusedOnStaxError(e: unknown): boolean {
-  return e instanceof ImageLoadRefusedOnDevice || e instanceof ImageCommitRefusedOnDevice;
+  const eName = (e as { name?: string })?.name;
+  return eName === "ImageLoadRefusedOnDevice" || eName === "ImageCommitRefusedOnDevice";
 }
 
 const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props => {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -4,25 +4,8 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Action } from "@ledgerhq/live-common/hw/actions/types";
 import type { Theme } from "@ledgerhq/react-ui";
-import {
-  EConnResetError,
-  ImageDoesNotExistOnDevice,
-  LanguageInstallRefusedOnDevice,
-  NoSuchAppOnProvider,
-  OutdatedApp,
-} from "@ledgerhq/live-common/errors";
-import {
-  LatestFirmwareVersionRequired,
-  ManagerNotEnoughSpaceError,
-  TransportRaceCondition,
-  UnresponsiveDeviceError,
-  UpdateYourApp,
-  UserRefusedAddress,
-  UserRefusedAllowManager,
-  UserRefusedDeviceNameChange,
-  UserRefusedFirmwareUpdate,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { EConnResetError } from "@ledgerhq/live-common/errors";
+import { UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import {
   addNewDeviceModel,
@@ -509,8 +492,8 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     return renderAllowLanguageInstallation({ modelId, type, t });
   }
   if (imageRemoveRequested) {
-    const refused = error instanceof UserRefusedOnDevice;
-    const noImage = error instanceof ImageDoesNotExistOnDevice;
+    const refused = error?.name === "UserRefusedOnDevice";
+    const noImage = error?.name === "ImageDoesNotExistOnDevice";
     if (error) {
       if (refused || noImage) {
         return renderError({
@@ -600,7 +583,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     return renderInWrongAppForAccount({ t, onRetry });
   }
 
-  if (unresponsive || error instanceof TransportRaceCondition) {
+  if (unresponsive || error?.name === "TransportRaceCondition") {
     return renderError({
       t,
       error: new UnresponsiveDeviceError(),
@@ -610,11 +593,11 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (!isLoading && error) {
-    const e = error as unknown;
+    const e = error as { name?: string };
     if (
-      e instanceof ManagerNotEnoughSpaceError ||
-      e instanceof OutdatedApp ||
-      e instanceof UpdateYourApp
+      e.name === "ManagerNotEnoughSpace" ||
+      e.name === "OutdatedApp" ||
+      e.name === "UpdateYourApp"
     ) {
       return renderError({
         t,
@@ -623,7 +606,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       });
     }
 
-    if (e instanceof LatestFirmwareVersionRequired) {
+    if (e.name === "LatestFirmwareVersionRequired") {
       return renderError({
         t,
         error,
@@ -637,7 +620,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       return <DeviceNotOnboardedErrorComponent t={t} device={device} location={location} />;
     }
 
-    if (e instanceof NoSuchAppOnProvider) {
+    if (e.name === "NoSuchAppOnProvider") {
       return renderError({
         t,
         error,
@@ -665,18 +648,18 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     // All the error rendering needs to be unified, the same way we do for ErrorIcon
     // not handled here.
     if (
-      (error as unknown) instanceof UserRefusedFirmwareUpdate ||
-      (error as unknown) instanceof UserRefusedAllowManager ||
-      (error as unknown) instanceof UserRefusedOnDevice ||
-      (error as unknown) instanceof UserRefusedAddress ||
-      (error as unknown) instanceof UserRefusedDeviceNameChange ||
-      (error as unknown) instanceof LanguageInstallRefusedOnDevice
+      error?.name === "UserRefusedFirmwareUpdate" ||
+      error?.name === "UserRefusedAllowManager" ||
+      error?.name === "UserRefusedOnDevice" ||
+      error?.name === "UserRefusedAddress" ||
+      error?.name === "UserRefusedDeviceNameChange" ||
+      error?.name === "LanguageInstallRefusedOnDevice"
     ) {
       withExportLogs = false;
       warning = true;
     }
 
-    if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    if (error?.name === "UserRefusedDeviceNameChange") {
       withDescription = false;
     }
     return renderError({

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -20,25 +20,13 @@ import {
   Text,
   Theme,
 } from "@ledgerhq/react-ui";
-import {
-  FirmwareNotRecognized,
-  LockedDeviceError,
-  UpdateYourApp,
-  LatestFirmwareVersionRequired,
-  WrongDeviceForAccount,
-  DisconnectedDevice,
-  UnsupportedFeatureError,
-} from "@ledgerhq/errors";
+import { WrongDeviceForAccount, DisconnectedDevice } from "@ledgerhq/errors";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { getNoticeType, getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { CompleteExchangeError } from "@ledgerhq/live-common/exchange/error";
 import { useFeature } from "@features/platform-feature-flags";
-import {
-  DeviceNotOnboarded,
-  NoSuchAppOnProvider,
-  TransactionRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
+import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
@@ -926,6 +914,7 @@ export const renderError = ({
   currencyName?: string;
 }) => {
   let tmpError = error;
+  const eName = (error as { name?: string })?.name;
   // Redirects from renderError and not from DeviceActionDefaultRendering because renderError
   // can be used directly by other component
   if (
@@ -933,9 +922,9 @@ export const renderError = ({
     ("name" in error && error.name === "AlreadySendingApduError")
   ) {
     return renderAlreadySendingApduError({ t, onRetry, inlineRetry });
-  } else if (tmpError instanceof LockedDeviceError) {
+  } else if (eName === "LockedDeviceError") {
     return renderLockedDeviceError({ t, onRetry, device, inlineRetry });
-  } else if (tmpError instanceof DeviceNotOnboarded) {
+  } else if (eName === "DeviceNotOnboarded") {
     return <DeviceNotOnboardedErrorComponent t={t} device={device} />;
   } else if (isCounterfeitError(tmpError)) {
     return (
@@ -944,12 +933,12 @@ export const renderError = ({
       />
     );
   } else if (
-    tmpError instanceof FirmwareNotRecognized ||
+    eName === "FirmwareNotRecognized" ||
     isInvalidGetFirmwareMetadataResponseError(tmpError)
   ) {
     return <FirmwareNotRecognizedErrorComponent onRetry={onRetry} />;
-  } else if (tmpError instanceof CompleteExchangeError) {
-    if (tmpError.title === "userRefused") {
+  } else if (eName === "CompleteExchangeError") {
+    if ((tmpError as CompleteExchangeError).title === "userRefused") {
       tmpError = new TransactionRefusedOnDevice();
     }
   } else if (isDmkError(error) && error._tag === "DeviceDeprecationError") {
@@ -960,16 +949,16 @@ export const renderError = ({
         coinName={currencyName}
       />
     );
-  } else if (tmpError instanceof NoSuchAppOnProvider) {
+  } else if (eName === "NoSuchAppOnProvider") {
     return (
       <NoSuchAppOnProviderErrorComponent
-        error={tmpError}
+        error={tmpError as Error}
         productName={getDeviceModel(device?.modelId as DeviceModelId)?.productName}
         learnMoreLink={learnMoreLink}
         learnMoreTextKey={learnMoreTextKey}
       />
     );
-  } else if (tmpError instanceof UnsupportedFeatureError) {
+  } else if (eName === "UnsupportedFeatureError") {
     return <UnsupportedFeatureErrorComponent />;
   } else if (isDisconnectedWhileSendingApduError(tmpError)) {
     tmpError = new DisconnectedDevice();
@@ -1014,8 +1003,8 @@ export const renderError = ({
         {managerAppName || requireFirmwareUpdate ? (
           <OpenManagerButton
             appName={managerAppName}
-            updateApp={tmpError instanceof UpdateYourApp}
-            firmwareUpdate={tmpError instanceof LatestFirmwareVersionRequired}
+            updateApp={eName === "UpdateYourApp"}
+            firmwareUpdate={eName === "LatestFirmwareVersionRequired"}
           />
         ) : (
           <>

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
@@ -1,9 +1,3 @@
-import {
-  ManagerNotEnoughSpaceError,
-  UpdateYourApp,
-  LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
-import { OutdatedApp } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { renderError } from "~/renderer/components/DeviceAction/rendering";
 import { DmkError } from "@ledgerhq/live-dmk-desktop";
@@ -29,10 +23,9 @@ const ErrorDisplay = ({
 }: ErrorDisplayProps) => {
   const { t } = useTranslation();
 
+  const eName = (error as { name?: string })?.name;
   const managerAppName =
-    error instanceof ManagerNotEnoughSpaceError ||
-    (error as unknown) instanceof OutdatedApp ||
-    (error as unknown) instanceof UpdateYourApp
+    eName === "ManagerNotEnoughSpace" || eName === "OutdatedApp" || eName === "UpdateYourApp"
       ? (error as unknown as { managerAppName: string }).managerAppName
       : undefined;
 
@@ -41,7 +34,7 @@ const ErrorDisplay = ({
     error,
     onRetry,
     managerAppName,
-    requireFirmwareUpdate: error instanceof LatestFirmwareVersionRequired,
+    requireFirmwareUpdate: eName === "LatestFirmwareVersionRequired",
     withExportLogs,
     list,
     supportLink,

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
@@ -3,22 +3,6 @@ import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import Lock from "~/renderer/icons/LockCircle";
-import {
-  UserRefusedAllowManager,
-  UserRefusedFirmwareUpdate,
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  ManagerDeviceLockedError,
-  UserRefusedDeviceNameChange,
-} from "@ledgerhq/errors";
-import {
-  SwapGenericAPIError,
-  DeviceNotOnboarded,
-  NoSuchAppOnProvider,
-  LanguageInstallRefusedOnDevice,
-  ImageDoesNotExistOnDevice,
-  ImageLoadRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 import { IconsLegacy } from "@ledgerhq/react-ui";
 
 export type ErrorIconProps = {
@@ -28,29 +12,30 @@ export type ErrorIconProps = {
 
 const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
   if (!error) return null;
+  const errorName = (error as { name?: string })?.name;
 
-  if (error instanceof DeviceNotOnboarded) {
+  if (errorName === "DeviceNotOnboarded") {
     return <InfoCircle size={size} />;
   }
 
   if (
-    error instanceof UserRefusedFirmwareUpdate ||
-    error instanceof UserRefusedAllowManager ||
-    error instanceof UserRefusedOnDevice ||
-    error instanceof UserRefusedAddress ||
-    error instanceof LanguageInstallRefusedOnDevice ||
-    error instanceof ImageDoesNotExistOnDevice ||
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof UserRefusedDeviceNameChange
+    errorName === "UserRefusedFirmwareUpdate" ||
+    errorName === "UserRefusedAllowManager" ||
+    errorName === "UserRefusedOnDevice" ||
+    errorName === "UserRefusedAddress" ||
+    errorName === "LanguageInstallRefusedOnDevice" ||
+    errorName === "ImageDoesNotExistOnDevice" ||
+    errorName === "ImageLoadRefusedOnDevice" ||
+    errorName === "UserRefusedDeviceNameChange"
   ) {
     return <IconsLegacy.InfoMedium size={size} color="primary.c80" />;
   }
 
-  if (error instanceof SwapGenericAPIError || error instanceof NoSuchAppOnProvider) {
+  if (errorName === "SwapGenericAPIError" || errorName === "NoSuchAppOnProvider") {
     return <CrossCircle size={size} />;
   }
 
-  if (error instanceof ManagerDeviceLockedError) {
+  if (errorName === "ManagerDeviceLocked") {
     return <Lock size={size} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/Input.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Input.tsx
@@ -16,7 +16,6 @@ import Box from "~/renderer/components/Box";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import BigSpinner from "~/renderer/components/BigSpinner";
 import { BoxProps } from "./Box/Box";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 export type InputError = Error | boolean | null | undefined;
 
@@ -302,7 +301,7 @@ const Input = function Input(
               <ErrorDisplay id="input-error" data-testid="input-error">
                 <TranslatedError
                   error={error}
-                  field={error instanceof AddressesSanctionedError ? "description" : undefined}
+                  field={error?.name === "AddressesSanctionedError" ? "description" : undefined}
                 />
               </ErrorDisplay>
             )

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
@@ -5,7 +5,6 @@ import type { Action, Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SkipReason } from "@ledgerhq/live-common/apps/types";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useTranslation } from "react-i18next";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
 import AppInstallItem, { ItemState } from "./AppInstallItem";
 import AllowManagerModal from "./AllowManagerModal";
 import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";
@@ -59,7 +58,7 @@ const InstallSetOfApps = ({
   } = status;
 
   useEffect(() => {
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       onCancel();
     } else if (onError && error) {
       onError(error);

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -21,7 +21,6 @@ import { useChangeLanguagePrompt } from "./EarlySecurityChecks/useChangeLanguage
 import DeviceAction from "../../DeviceAction";
 import TroubleshootingDrawer from "./TroubleshootingDrawer";
 import LockedDeviceDrawer from "./LockedDeviceDrawer";
-import { LockedDeviceError, UnexpectedBootloader } from "@ledgerhq/errors";
 import { FinalFirmware } from "@ledgerhq/types-live";
 import { useConnectManagerAction } from "~/renderer/hooks/useConnectAppAction";
 
@@ -201,7 +200,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
 
   // A fatal error during polling triggers directly an error message
   useEffect(() => {
-    if ((fatalError as unknown) instanceof UnexpectedBootloader) {
+    if (fatalError?.name === "UnexpectedBootloader") {
       setIsBootloader(true);
     } else if (fatalError) {
       setIsPollingOn(false);
@@ -213,7 +212,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
 
-    if (allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (allowedError && allowedError?.name !== "LockedDeviceError") {
       timeout = setTimeout(() => {
         setIsPollingOn(false);
         setTroubleshootingDrawerOpen(true);

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -107,7 +106,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
@@ -1,7 +1,6 @@
 import { getOriginalTxFeeRateSatVb } from "@ledgerhq/live-common/families/bitcoin/editTransaction/rbfValidation";
 import { fromTransactionRaw } from "@ledgerhq/coin-bitcoin/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-bitcoin/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -190,7 +189,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import {
   ZCASH_ACTIVATION_DATE,
   ZCASH_ACTIVATION_DATE_STRING,
@@ -62,7 +61,7 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   };
 
   const handleUfvkChanged = (ufvk: string, error?: Error | undefined | null) => {
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setUfvkExportError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
@@ -1,5 +1,4 @@
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getDefaultAccountNameForCurrencyIndex } from "@ledgerhq/live-wallet/accountName";
 import { isAxiosError } from "axios";
 import React from "react";
@@ -112,8 +111,8 @@ const getStatusMessage = (status?: OnboardStatus): string => {
 };
 
 const getErrorMessage = (error: Error | null) => {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return <Trans i18nKey={error.message} />;
+  if (error?.name === "UserRefusedOnDevice" || error?.name === "LockedDeviceError") {
+    return <Trans i18nKey={error?.message} />;
   }
   return <Trans i18nKey="families.canton.addAccount.onboard.error" />;
 };

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -12,7 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import { handleTopologyChangeError, TopologyChangeError } from "../hooks/topologyChangeError";
+import { handleTopologyChangeError } from "../hooks/topologyChangeError";
 import PendingTransferProposalsDetails from "./PendingTransferProposalsDetails";
 import type { GroupedProposals, Modal, ProcessedProposal, TransferProposalAction } from "./types";
 import {
@@ -113,7 +113,7 @@ export function usePendingTransferProposalsViewModel(
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           if (device) {
             handleTopologyChangeError(dispatch, {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
@@ -1,4 +1,3 @@
-import { TooManyUtxosCritical, TooManyUtxosWarning } from "@ledgerhq/coin-canton";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import {
   CantonAccount,
@@ -15,7 +14,7 @@ import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { modalsStateSelector } from "~/renderer/reducers/modals";
-import { handleTopologyChangeError, TopologyChangeError } from "./hooks/topologyChangeError";
+import { handleTopologyChangeError } from "./hooks/topologyChangeError";
 import CommentField from "./CommentField";
 import ExpiryDurationField from "./ExpiryDurationField";
 
@@ -38,9 +37,9 @@ const Root = (props: {
   const cantonAccount = account as CantonAccount;
   const mainAccount = getMainAccount(account, parentAccount);
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   useEffect(() => {
     if (topologyChangeError) {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -136,7 +135,7 @@ const Body = ({
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -122,7 +121,7 @@ const Body = ({
     onChangeStepId("summary");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -14,7 +14,6 @@ import BigNumber from "bignumber.js";
 import Alert from "~/renderer/components/Alert";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
 
 const FromToWrapper = styled.div``;
@@ -30,7 +29,7 @@ function StepSummary(props: StepProps) {
   const { estimatedFees, errors, warnings } = status;
   const { feeTooHigh } = warnings;
   const displayError = errors.amount?.message ? errors.amount : "";
-  const notEnoughFundsError = error && error instanceof CardanoNotEnoughFunds;
+  const notEnoughFundsError = error && error?.name === "CardanoNotEnoughFunds";
 
   const accountUnit = useMaybeAccountUnit(account);
   if (!account || !transaction || !account.cardanoResources.delegation) return null;

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -103,7 +102,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("vote");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -100,7 +99,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NotEnoughBalanceFees } from "@ledgerhq/errors";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { DefaultStepAmount } from "~/renderer/modals/Send/steps/StepAmount";
 import type { StepProps } from "~/renderer/modals/Send/types";
@@ -9,7 +8,7 @@ export const FEES_BANNER_TESTID = "celo-send-fees-error-banner";
 const SendStepAmount = (props: StepProps) => {
   const { status, error, bridgePending } = props;
   const feesError = status.errors.fees;
-  const showFeesBanner = !error && !bridgePending && feesError instanceof NotEnoughBalanceFees;
+  const showFeesBanner = !error && !bridgePending && feesError?.name === "NotEnoughBalanceFees";
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
@@ -12,7 +12,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AmountField from "../fields/AmountField";
 import { StepProps } from "../types";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export const StepAmountFooter = ({
   transitionTo,
@@ -58,7 +57,7 @@ const StepAmount = ({
 }: StepProps) => {
   invariant(account && transaction, "account and transaction required");
   const notEnoughFundsError =
-    status.errors.amount && status.errors.amount instanceof NotEnoughBalance;
+    status.errors.amount && status.errors.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -112,7 +111,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
@@ -3,8 +3,6 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -51,9 +49,8 @@ export const StepAmountFooter = ({
 };
 
 const isTransactionRefuse = (error: unknown) => {
-  return (
-    error && (error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-  );
+  const eName = (error as { name?: string })?.name;
+  return eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice";
 };
 
 const StepAmount = ({

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { isAxiosError } from "axios";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import Alert from "~/renderer/components/Alert";
 
 type Props = Readonly<{
@@ -18,8 +17,9 @@ export default function OnboardError({ error, context }: Props) {
 }
 
 function resolveMessageKey(error: Error | null, context: "onboard" | "create"): string {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return error.message;
+  const eName = (error as { name?: string })?.name;
+  if (eName === "UserRefusedOnDevice" || eName === "LockedDeviceError") {
+    return error?.message ?? "";
   }
 
   if (context === "create" && isAxiosError(error) && error.status === 429) {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
@@ -3,7 +3,6 @@ import {
   ConcordiumPairingProgress,
   ConcordiumPairingStatus,
 } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 
 export const MAX_EXPIRED_RETRIES = 3;
 export const CONFIRMATION_CODE_LENGTH = 4;
@@ -22,7 +21,7 @@ export function shouldRetryPairing(error: unknown, retryCount: number): boolean 
     return false;
   }
 
-  return error instanceof ConcordiumPairingExpiredError;
+  return (error as { name?: string })?.name === "ConcordiumPairingExpiredError";
 }
 
 export type PairingStateUpdate = {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { firstValueFrom } from "rxjs";
 import { Account } from "@ledgerhq/types-live";
-import { ConcordiumTrustedMetadataServiceError, DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -146,7 +146,7 @@ const StepReceiveFunds = ({
     } catch (err) {
       // Trusted-metadata-service failures (network/5xx) are transient — route
       // to the fallback UI instead of the hard error screen.
-      if (err instanceof ConcordiumTrustedMetadataServiceError) {
+      if ((err as { name?: string })?.name === "ConcordiumTrustedMetadataServiceError") {
         onChangeAddressVerified(false, null);
       } else if (err instanceof Error) {
         onChangeAddressVerified(false, err);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -120,7 +119,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -126,7 +125,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
@@ -9,7 +9,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -136,7 +135,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
@@ -19,7 +19,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepAmount({
   account,
@@ -75,7 +74,7 @@ export default function StepAmount({
   );
   const amount = useMemo(() => (validator ? validator.amount : BigNumber(0)), [validator]);
   const crypto = cryptoFactory(account.currency.id);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -139,7 +138,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
@@ -1,6 +1,5 @@
 import { fromTransactionRaw } from "@ledgerhq/live-common/families/evm/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -172,7 +171,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -28,8 +28,7 @@ describe("EVM TransactionErrorBanner", () => {
   });
 
   it("hides generic description for NotEnoughGas gasPrice errors", () => {
-    const notEnoughGasError = new Error("not enough gas");
-    Object.setPrototypeOf(notEnoughGasError, NotEnoughGas.prototype);
+    const notEnoughGasError = new NotEnoughGas("not enough gas");
 
     render(
       <TransactionErrorBanner

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 
@@ -13,7 +13,7 @@ export const TransactionErrorBanner = ({
     return <ErrorBanner error={new TransactionHasBeenValidatedError()} />;
   }
 
-  if (errors.gasPrice instanceof NotEnoughGas) {
+  if (errors.gasPrice?.name === "NotEnoughGas") {
     return <ErrorBanner error={errors.gasPrice} fallback={{ description: <></> }} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
@@ -144,7 +143,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -129,7 +128,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -116,7 +115,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
@@ -127,7 +126,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -11,7 +11,6 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isTokenAssociationRequired } from "@ledgerhq/live-common/families/hedera/utils";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
@@ -242,7 +241,7 @@ const Body = ({
   }, [onChangeAddressVerified, setDisabledSteps, steps, onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -108,7 +107,7 @@ const Body = (props: Props) => {
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -123,7 +122,7 @@ const Body = (props: Props) => {
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
@@ -5,7 +5,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ const Body = (props: Props) => {
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -109,7 +108,7 @@ const Body = (props: Props) => {
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
@@ -14,7 +14,6 @@ import Alert from "~/renderer/components/Alert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 export default function StepAmount({
   account,
   transaction,
@@ -66,7 +65,7 @@ export default function StepAmount({
     };
   }, [transaction]);
   const amount = useMemo(() => (validator ? validator.amount : new BigNumber(0)), [validator]);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("castNominations");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -21,7 +21,6 @@ import {
   PolkadotValidator,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/polkadot/types";
-import { PolkadotValidatorsRequired } from "@ledgerhq/live-common/families/polkadot/errors";
 import { radii } from "~/renderer/styles/theme";
 import { openURL } from "~/renderer/linking";
 import Box from "~/renderer/components/Box";
@@ -189,8 +188,8 @@ const ValidatorField = ({
   if (!status) return null;
   const error = getStatusError(status, "errors");
   const warning = getStatusError(status, "warnings");
-  const maybeChill = error instanceof PolkadotValidatorsRequired;
-  const ignoreError = error instanceof PolkadotValidatorsRequired && !nominations.length; // Do not show error on first nominate
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length; // Do not show error on first nominate
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -96,7 +95,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St, Mode } from "./types";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -113,7 +112,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -15,7 +15,6 @@ import ValidatorRow from "../../shared/components/ValidatorRow";
 import { StepProps } from "../types";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepValidator({
   account,
@@ -45,7 +44,7 @@ export default function StepValidator({
   if (validator === undefined) {
     return null;
   }
-  const notEnoughFundsError = status.errors?.fee instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.fee?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
@@ -9,7 +9,6 @@ import {
   SolanaAccount,
 } from "@ledgerhq/live-common/families/solana/types";
 import { useFeature } from "@features/platform-feature-flags";
-import { SolanaRecipientMemoIsRequired } from "@ledgerhq/live-common/errors";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 
 type Props = {
@@ -44,7 +43,7 @@ const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: P
   );
 
   const InputField = lldMemoTag?.enabled ? MemoTagField : Input;
-  const isRecipientMemoRequired = status?.errors?.memo instanceof SolanaRecipientMemoIsRequired;
+  const isRecipientMemoRequired = status?.errors?.memo?.name === "SolanaRecipientMemoIsRequired";
 
   return transaction.model.kind === "transfer" || transaction.model.kind === "token.transfer" ? (
     <InputField

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, StepId, St } from "./types";
@@ -105,7 +104,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -106,7 +105,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice" as St["id"]);
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -11,7 +11,6 @@ import { getMainAccount, addPendingOperation } from "@ledgerhq/live-common/accou
 import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import logger from "~/renderer/logger";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import Track from "~/renderer/analytics/Track";
@@ -178,7 +177,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
@@ -3,7 +3,6 @@ import { bindActionCreators } from "redux";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
 import invariant from "invariant";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -146,7 +145,7 @@ const Body = ({ stepId, params, onClose, onChangeStepId }: Props) => {
 
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from "react";
 import invariant from "invariant";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -87,7 +86,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { repairChoices } from "@ledgerhq/live-common/hw/firmwareUpdate-repair";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
 import Button from "~/renderer/components/Button";
@@ -169,7 +168,7 @@ const RepairModal = ({
 
   const onClose = !cancellable && isLoading ? undefined : onReject;
   const disableRepair =
-    isLoading || !selectedOption || !!(error && error instanceof MCUNotGenuineToDashboard);
+    isLoading || !selectedOption || !!(error && error?.name === "MCUNotGenuineToDashboard");
 
   return (
     <Modal

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -6,7 +6,6 @@ import invariant from "invariant";
 import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import {
   addPendingOperation,
   getMainAccount,
@@ -257,7 +256,7 @@ const Body = ({
     setSigned(false);
   }, []);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { DomainServiceResponseError } from "@ledgerhq/domain-service/hooks/types";
 import Alert from "~/renderer/components/Alert";
 import { useTranslation } from "react-i18next";
@@ -11,7 +10,7 @@ type DomainErrorsProps = {
 };
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
-  if (domainError.error instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <div data-testid="domain-error-invalid-domain">
         <Alert
@@ -28,7 +27,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
   }
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return (
       <div data-testid="domain-error-no-resolution">
         <Alert

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { TFunction } from "i18next";
@@ -49,7 +48,7 @@ const RecipientFieldBase = ({
         autoFocus={autoFocus}
         withQrCode={!status.recipientIsReadOnly}
         readOnly={status.recipientIsReadOnly}
-        error={hideError || recipientError instanceof RecipientRequired ? null : recipientError}
+        error={hideError || recipientError?.name === "RecipientRequired" ? null : recipientError}
         warning={recipientWarning}
         value={value}
         onChange={onChange}

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { getRegistriesForDomain } from "@ledgerhq/domain-service/registries/index";
 import { isLoaded, isError } from "@ledgerhq/domain-service/hooks/logic";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
@@ -67,15 +66,15 @@ const RecipientFieldDomainService = <T extends Transaction, TS extends Transacti
 
   const domainErrorHandled = useMemo(() => {
     if (domainError) {
-      if (!isForwardResolution && domainError.error instanceof NoResolution) {
+      if (!isForwardResolution && domainError.error?.name === "NoResolution") {
         return false;
       }
 
       if (
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof NoResolution ||
+        domainError.error?.name === "NoResolution" ||
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof InvalidDomain
+        domainError.error?.name === "InvalidDomain"
       ) {
         return true;
       }

--- a/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -102,7 +101,7 @@ export default function Body({ onChangeStepId, onClose, setError, params, stepId
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import Stepper from "~/renderer/components/Stepper";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { isTokenAccount } from "@ledgerhq/live-common/account/index";
@@ -171,7 +170,7 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
@@ -5,12 +5,6 @@ import { useNavigate } from "react-router";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import { context } from "~/renderer/drawers/Provider";
 import UpdateFirmwareError from ".";
-import { LockedDeviceError, UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
-import {
-  ImageCommitRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  LanguageInstallRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 type Props = {
   error: Error;
@@ -33,18 +27,18 @@ const DeviceCancel = ({
   const onCloseReload = useCallback(() => {
     onDrawerClose();
 
-    if (error instanceof UserRefusedFirmwareUpdate && shouldReloadManagerOnCloseIfUpdateRefused) {
+    if (error?.name === "UserRefusedFirmwareUpdate" && shouldReloadManagerOnCloseIfUpdateRefused) {
       navigate("/manager/reload");
       setDrawer();
     }
   }, [error, navigate, onDrawerClose, setDrawer, shouldReloadManagerOnCloseIfUpdateRefused]);
 
-  const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
-  const isDeviceLockedError = error instanceof LockedDeviceError;
+  const isUserRefusedFirmwareUpdate = error?.name === "UserRefusedFirmwareUpdate";
+  const isDeviceLockedError = error?.name === "LockedDeviceError";
   const isRestoreStepRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof ImageCommitRefusedOnDevice ||
-    error instanceof LanguageInstallRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" ||
+    error?.name === "ImageCommitRefusedOnDevice" ||
+    error?.name === "LanguageInstallRefusedOnDevice";
   const isRetryableError =
     isUserRefusedFirmwareUpdate || isDeviceLockedError || isRestoreStepRefusedOnDevice;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -10,7 +10,6 @@ import { Flex, FlowStepper, Text } from "@ledgerhq/react-ui";
 import Disclaimer from "./Disclaimer";
 import Cancel from "./errors/Cancel";
 import DeviceCancel from "./errors/DeviceError";
-import { DisconnectedDevice, DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
 import SideDrawerHeader from "~/renderer/components/SideDrawerHeader";
 import { createFirmwareUpdateSteps } from "./helpers/createFirmwareUpdateSteps";
 import { StepId, STEPS } from "./types";
@@ -59,8 +58,9 @@ const UpdateModal = ({
   const withFinal = useMemo(() => hasFinalFirmware(firmware.final), [firmware]);
   const [cancel, setCancel] = useState<boolean>(false);
 
-  const isDisconnectedDeviceError = err instanceof DisconnectedDevice;
-  const isDisconnectedDeviceDuringOperationError = err instanceof DisconnectedDeviceDuringOperation;
+  const isDisconnectedDeviceError = err?.name === "DisconnectedDevice";
+  const isDisconnectedDeviceDuringOperationError =
+    err?.name === "DisconnectedDeviceDuringOperation";
   const isDeviceDisconnected =
     isDisconnectedDeviceError ||
     isDisconnectedDeviceDuringOperationError ||

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
@@ -3,7 +3,6 @@ import { ProcessorResult } from "~/renderer/components/CustomImage/dithering/typ
 import { Step, StepProps } from "./types";
 import { useTranslation } from "react-i18next";
 import { Flex } from "@ledgerhq/react-ui";
-import { ImageCommitRefusedOnDevice, ImageLoadRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 import StepFooter from "./StepFooter";
 import StepContainer from "./StepContainer";
@@ -50,9 +49,9 @@ const StepTransfer: React.FC<Props> = props => {
 
   // User refused loading the image OR committing the image
   const userRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
+    error?.name === "ImageLoadRefusedOnDevice" ||
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageCommitRefusedOnDevice";
 
   return (
     <StepContainer

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
@@ -7,7 +7,6 @@ import removeImage from "@ledgerhq/live-common/hw/customLockScreenRemove";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { useTranslation } from "react-i18next";
 import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 const action = createAction(removeImage);
@@ -40,14 +39,14 @@ const RemoveCustomImage: React.FC<Props> = ({ onClose, onRemoved }) => {
   const onError = useCallback(
     (error: Error) => {
       setError(error);
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         dispatch(clearLastSeenCustomImage());
       }
     },
     [dispatch],
   );
 
-  const showRetry = error && !(error instanceof ImageDoesNotExistOnDevice);
+  const showRetry = error && error?.name !== "ImageDoesNotExistOnDevice";
 
   return (
     <Flex

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackAddAccountFlow = {
@@ -52,17 +45,21 @@ export const useTrackAddAccountFlow = ({
       page: "Add account",
     };
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during add account flow
       track("Transport error", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
@@ -70,23 +67,23 @@ export const useTrackAddAccountFlow = ({
     if (
       previousAllowOpeningGranted.current &&
       !allowOpeningGranted &&
-      error instanceof CantOpenDevice
+      error?.name === "CantOpenDevice"
     ) {
       // user lost connection after opening app
       track("Device connection lost", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (previousAllowOpeningGranted.current && error instanceof LockedDeviceError) {
+    if (previousAllowOpeningGranted.current && error?.name === "LockedDeviceError") {
       // device is locked while scanning for new accounts
       track("Device locked", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (isScanningForNewAccounts && error instanceof CantOpenDevice) {
+    if (isScanningForNewAccounts && error?.name === "CantOpenDevice") {
       // user lost connection while scanning for new accounts
       track("Device connection lost", defaultPayload);
-    } else if (error instanceof CantOpenDevice) {
+    } else if (error?.name === "CantOpenDevice") {
       // device is detected but connection failed
       track("Connection failed", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackLedgerSyncFlow = {
@@ -74,7 +67,7 @@ export const useTrackLedgerSyncFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && error instanceof UserRefusedOnDevice) {
+    if (previousRequestOpenApp.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -82,22 +75,22 @@ export const useTrackLedgerSyncFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import { UserRefusedAllowManager, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackMyLedgerSectionEvents = {
@@ -70,10 +69,10 @@ export const useTrackMyLedgerSectionEvents = ({
       track("Custom Lock Screen Image removed", defaultPayload);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", { ...defaultPayload, page: "Manager RenamedDevice" });
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedAddress,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackReceiveFlow = {
@@ -58,32 +50,36 @@ export const useTrackReceiveFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAddress) {
+    if (error?.name === "UserRefusedAddress") {
       // user refused to verify address
       track("Address confirmation rejected", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSendFlow = {
@@ -49,7 +42,11 @@ export const useTrackSendFlow = ({
       page: "Send",
     };
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -57,22 +54,22 @@ export const useTrackSendFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSwapFlow = {
@@ -62,32 +54,36 @@ export const useTrackSwapFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap flow
       track("Transport error", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap flow
       track("Device locked", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
@@ -4,7 +4,6 @@ import { Flex } from "@ledgerhq/native-ui";
 import { useBleDevicePairing } from "@ledgerhq/live-dmk-mobile";
 import { Device } from "@ledgerhq/types-devices";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleFailedPairing } from "~/components/BleDevicePairingFlow/BleDevicePairingContent/BleFailedPairing";
 import { BleDevicePairingProgress } from "./BleDevicePairingContent/BleDevicePairingProgress";
 import { BleDevicePaired } from "./BleDevicePairingContent/BleDevicePaired";
@@ -37,7 +36,7 @@ export const DmkBleDevicePairing = ({
   let content;
 
   const needsToForgetDevice = useMemo(() => {
-    return pairingError instanceof PeerRemovedPairing;
+    return (pairingError as { name?: string })?.name === "PeerRemovedPairing";
   }, [pairingError]);
 
   useEffect(() => {
@@ -46,9 +45,10 @@ export const DmkBleDevicePairing = ({
     }
   }, [isPaired, device, onPaired]);
 
+  const pairingErrorName = (pairingError as { name?: string })?.name;
   if (isPaired) {
     content = <BleDevicePaired device={device} productName={productName} />;
-  } else if (pairingError instanceof PeerRemovedPairing) {
+  } else if (pairingErrorName === "PeerRemovedPairing") {
     content = (
       <BleForgetDeviceDrawer
         isOpen={needsToForgetDevice}
@@ -56,7 +56,7 @@ export const DmkBleDevicePairing = ({
         onRetry={onRetry}
       />
     );
-  } else if (pairingError && !(pairingError instanceof LockedDeviceError)) {
+  } else if (pairingError && pairingErrorName !== "LockedDeviceError") {
     content = (
       <BleFailedPairing productName={productName} onRetry={onRetry} onOpenHelp={onOpenHelp} />
     );

--- a/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
@@ -5,7 +5,6 @@ import { Flex, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { setLastSeenCustomImage, clearLastSeenCustomImage } from "~/actions/settings";
 import { DeviceActionDefaultRendering } from "../DeviceAction";
 import { ImageSourceContext } from "../CustomImage/FramedPicture";
@@ -117,12 +116,11 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   }, [CLSError]);
   const isError = !!error;
   const refusedOnDevice =
-    (error as unknown) instanceof ImageLoadRefusedOnDevice ||
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" || error?.name === "ImageCommitRefusedOnDevice";
 
   useEffect(() => {
     // Once transferred the old image is wiped, we need to clear it from the data.
-    if (error instanceof ImageCommitRefusedOnDevice) {
+    if (error?.name === "ImageCommitRefusedOnDevice") {
       dispatch(clearLastSeenCustomImage());
     }
   }, [dispatch, error]);

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -18,7 +18,6 @@ import Confirmation from "./Confirmation";
 import Restore from "./Restore";
 import { lastSeenDeviceSelector } from "~/reducers/settings";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
 
 type Props = {
   restore?: boolean;
@@ -179,7 +178,7 @@ const InstallSetOfApps = ({
         onClose={onWrappedError}
         onModalHide={onWrappedError}
       >
-        {error instanceof UserRefusedAllowManager ? (
+        {error?.name === "UserRefusedAllowManager" ? (
           <TrackScreen
             category="App restoration cancelled on device"
             refreshSource={false}

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -1,15 +1,3 @@
-import {
-  TransportStatusError,
-  UserRefusedDeviceNameChange,
-  UserRefusedOnDevice,
-  LatestFirmwareVersionRequired,
-  UnsupportedFeatureError,
-} from "@ledgerhq/errors";
-import {
-  DeviceNotOnboarded,
-  ImageDoesNotExistOnDevice,
-  NoSuchAppOnProvider,
-} from "@ledgerhq/live-common/errors";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
@@ -533,8 +521,8 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   // level instead of being an exception here.
   if (imageRemoveRequested) {
     if (error) {
-      const refused = (error as Status["error"]) instanceof UserRefusedOnDevice;
-      const noImage = (error as Status["error"]) instanceof ImageDoesNotExistOnDevice;
+      const refused = error?.name === "UserRefusedOnDevice";
+      const noImage = error?.name === "ImageDoesNotExistOnDevice";
       if (refused || noImage) {
         return renderError({
           t,
@@ -652,30 +640,30 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
     // into another handled case.
     if (
       device &&
-      (error instanceof DeviceNotOnboarded ||
-        ((error as unknown) instanceof TransportStatusError &&
+      (error?.name === "DeviceNotOnboarded" ||
+        (error?.name === "TransportStatusError" &&
           ((error as Error).message.includes("0x6d06") ||
             (error as Error).message.includes("0x6d07"))))
     ) {
       return renderDeviceNotOnboarded({ t, device, navigation });
     }
 
-    if (error instanceof LatestFirmwareVersionRequired) {
+    if (error?.name === "LatestFirmwareVersionRequired") {
       return <RequiredFirmwareUpdate navigation={navigation} device={selectedDevice} />;
     }
 
-    if (error instanceof UnsupportedFeatureError) {
+    if (error?.name === "UnsupportedFeatureError") {
       return <UnsupportedFeatureComponent error={error} />;
     }
 
-    if (error instanceof NoSuchAppOnProvider && device?.modelId === DeviceModelId.nanoS) {
+    if (error?.name === "NoSuchAppOnProvider" && device?.modelId === DeviceModelId.nanoS) {
       // This should be only happening for Nano S devices, but in order to make sure we don't miss any
       // use case for other devices we keep the check and will consider to remove it later after complete
       // checks.
       return <NanoSNotSupportedComponent />;
     }
 
-    if ((error as Status["error"]) instanceof UserRefusedDeviceNameChange) {
+    if (error?.name === "UserRefusedDeviceNameChange") {
       return renderError({
         t,
         navigation,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -9,15 +9,7 @@ import { ParamListBase, T } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import { getDeviceModel } from "@ledgerhq/devices";
-import {
-  BluetoothRequired,
-  LockedDeviceError,
-  PeerRemovedPairing,
-  WrongDeviceForAccount,
-  FirmwareNotRecognized,
-  UnsupportedFeatureError,
-  NanoSNotSupported,
-} from "@ledgerhq/errors";
+import { WrongDeviceForAccount, NanoSNotSupported } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -603,9 +595,9 @@ export function renderError({
   currencyName?: string;
   hasExportLogButton?: boolean;
 }) {
-  if (error instanceof LockedDeviceError) {
+  if (error?.name === "LockedDeviceError") {
     return renderLockedDeviceError({ t, onRetry, device });
-  } else if (error instanceof PeerRemovedPairing) {
+  } else if (error?.name === "PeerRemovedPairing") {
     // User needs to forget the device on their phone settings
     const productName = device ? getDeviceModel(device?.modelId).productName : "Ledger Device";
     return (
@@ -629,10 +621,10 @@ export function renderError({
       const getCTA = (error: Error, hasRetry: boolean): CTA => {
         if (
           isInvalidGetFirmwareMetadataResponseError(error) ||
-          error instanceof FirmwareNotRecognized
+          error?.name === "FirmwareNotRecognized"
         ) {
           return "OpenExperimentalSettings";
-        } else if (!(error instanceof PeerRemovedPairing) && hasRetry) {
+        } else if (error?.name !== "PeerRemovedPairing" && hasRetry) {
           return "Retry";
         }
         return "None";
@@ -688,7 +680,7 @@ export function renderError({
             }
           };
           return (
-            <Flex alignSelf="stretch" mb={0} mt={error instanceof BluetoothRequired ? 0 : 8}>
+            <Flex alignSelf="stretch" mb={0} mt={error?.name === "BluetoothRequired" ? 0 : 8}>
               <StyledButton
                 event="DeviceActionErrorRetry"
                 type="main"
@@ -706,7 +698,7 @@ export function renderError({
     };
     return (
       <Wrapper>
-        {error instanceof UnsupportedFeatureError ? (
+        {error?.name === "UnsupportedFeatureError" ? (
           <TrackScreen category="Unsupported Feature" name="Error: App Unavailable" />
         ) : null}
         <GenericErrorView

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -8,7 +8,6 @@ import { PartialNullable } from "~/types/helpers";
 import QueuedDrawer from "./QueuedDrawer";
 import DeviceAction from "./DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 
 const DeviceActionContainer = styled(Flex).attrs({
@@ -74,7 +73,7 @@ export default function DeviceActionModal<Req, Stt, Res>({
 
   const onDeviceActionError = useCallback(
     (e: Error) => {
-      if (e instanceof PeerRemovedPairing || isCounterfeitError(e)) {
+      if (e?.name === "PeerRemovedPairing" || isCounterfeitError(e)) {
         setShowInfo(false);
       }
       onError?.(e);

--- a/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
@@ -2,7 +2,6 @@ import React, { memo } from "react";
 import { useTranslation } from "~/context/Locale";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Link } from "@ledgerhq/native-ui";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { NewIconType } from "@ledgerhq/native-ui/components/Icon/type";
 import useExportLogs from "./useExportLogs";
 import TranslatedError from "./TranslatedError";
@@ -53,7 +52,7 @@ const GenericErrorView = ({
   const subtitleError = outerError ? error : null;
 
   // In case bluetooth was necessary but the `RequiresBle` component could not be used directly
-  if (error instanceof BluetoothRequired) {
+  if ((error as { name?: string })?.name === "BluetoothRequired") {
     return (
       <>
         <BluetoothDisabled />

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
@@ -10,10 +10,8 @@ import { useStuckDeviceActionHint } from "../StuckDeviceActionHint/useStuckDevic
 import QueuedDrawer from "../QueuedDrawer";
 import { useIsDeviceLockedPolling } from "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling";
 import { IsDeviceLockedResultType } from "~/hooks/useIsDeviceLockedPolling/types";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleForgetDeviceIllustration } from "../BleDevicePairingFlow/BleDevicePairingContent/BleForgetDeviceIllustration";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { AlreadySendingApduError } from "@ledgerhq/device-management-kit";
 
 type Props = {
   isOpen: boolean;
@@ -29,9 +27,9 @@ export const DeviceLockedCheckDrawer = ({ isOpen, device, onDeviceUnlocked, onCl
   const isLocked = isLockedResult.type === IsDeviceLockedResultType.locked;
   const isUnlocked = isLockedResult.type === IsDeviceLockedResultType.unlocked;
   const isError = isLockedResult.type === IsDeviceLockedResultType.error;
-  const isPeerRemovedPairingError = isError && isLockedResult.error instanceof PeerRemovedPairing;
+  const isPeerRemovedPairingError = isError && isLockedResult.error?.name === "PeerRemovedPairing";
   const isAlreadySendingApduError =
-    isError && isLockedResult.error instanceof AlreadySendingApduError;
+    isError && isLockedResult.error?.name === "AlreadySendingApduError";
   const isOtherError = isError && !isPeerRemovedPairingError && !isAlreadySendingApduError;
   const isLockedStateCannotBeDetermined =
     isLockedResult.type === IsDeviceLockedResultType.lockedStateCannotBeDetermined;

--- a/apps/ledger-live-mobile/src/components/ValidateError.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateError.tsx
@@ -8,7 +8,6 @@ import NeedHelp from "./NeedHelp";
 import { BaseNavigation } from "./RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { MANAGER_TABS } from "~/const/manager";
-import { UpdateYourApp, LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 import { RequiredFirmwareUpdate } from "./DeviceAction/rendering";
 import { useSelector } from "~/context/hooks";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
@@ -25,7 +24,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
   const { t } = useTranslation();
   const { colors } = useTheme();
 
-  const managerAppName = error instanceof UpdateYourApp ? error.managerAppName : undefined;
+  const managerAppName = error?.name === "UpdateYourApp" ? error.managerAppName : undefined;
 
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
 
@@ -60,7 +59,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
       ]}
     >
       <View style={styles.container}>
-        {error instanceof LatestFirmwareVersionRequired && lastConnectedDevice ? (
+        {error?.name === "LatestFirmwareVersionRequired" && lastConnectedDevice ? (
           <RequiredFirmwareUpdate navigation={navigation} device={lastConnectedDevice} />
         ) : (
           <>

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
@@ -1,4 +1,3 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Alert, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import React from "react";
@@ -44,7 +43,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof UserRefusedOnDevice) {
+  if (error?.name === "UserRefusedOnDevice") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,
@@ -53,7 +52,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof LockedDeviceError) {
+  if (error?.name === "LockedDeviceError") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,

--- a/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -1,5 +1,4 @@
 import { isCantonAccount } from "@ledgerhq/coin-canton";
-import { TopologyChangeError } from "@ledgerhq/coin-canton/types/errors";
 import type { Sync } from "@ledgerhq/live-common/bridge/react/types";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -190,7 +189,7 @@ export function usePendingTransferProposalsViewModel({
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           redirectToReonboarding(action, contractId);
           return;

--- a/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
@@ -1,8 +1,3 @@
-import {
-  TooManyUtxosCritical,
-  TooManyUtxosWarning,
-  TopologyChangeError,
-} from "@ledgerhq/coin-canton";
 import { CantonAccount, TransactionStatus } from "@ledgerhq/live-common/families/canton/types";
 import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
 import { useFeature } from "@features/platform-feature-flags";
@@ -35,9 +30,9 @@ function StepRecipientCustomAlert({
   const route = useRoute<ScreenRoute>();
   const llmModularDrawer = useFeature("llmModularDrawer");
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   const redirectToReonboarding = useCallback(() => {
     if (!account) return;

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -33,7 +33,6 @@ import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
 import RetryButton from "~/components/RetryButton";
 import CancelButton from "~/components/CancelButton";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = StackNavigatorProps<
@@ -104,7 +103,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, bridge, transaction]);
 
-  const hasNotEnoughtBalanceError = bridgeError instanceof CardanoNotEnoughFunds;
+  const hasNotEnoughtBalanceError = bridgeError?.name === "CardanoNotEnoughFunds";
 
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
@@ -22,7 +22,6 @@ import type { BaseComposite, StackNavigatorProps } from "~/components/RootNaviga
 import { CeloRevokeFlowFlowParamList } from "./types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<
@@ -95,7 +94,7 @@ export default function VoteAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
 
-  const isRevokingWithFeesError = error instanceof NotEnoughBalance;
+  const isRevokingWithFeesError = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -30,7 +30,6 @@ import ErrorAndWarning from "../components/ErrorAndWarning";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { CeloWithdrawFlowParamList } from "./types";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -162,7 +161,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
       <View style={styles.footer}>
         <View style={styles.errors}>
           {!!(error && error instanceof Error) && <ErrorAndWarning error={error} />}
-          {error && error instanceof AddressesSanctionedError && (
+          {error && error?.name === "AddressesSanctionedError" && (
             <SupportLinkError error={error} type="alert" />
           )}
           {!!(warning && warning instanceof Error) && <ErrorAndWarning warning={warning} />}

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import {
-  ConcordiumPairingExpiredError,
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
@@ -90,11 +85,11 @@ export function useOnboarding(
             message: error instanceof Error ? error.message : String(error),
           });
           unsubscribe();
-          if (error instanceof LockedDeviceError) {
+          if (error?.name === "LockedDeviceError") {
             setCreateStatus(CreateStatus.DEVICE_LOCKED);
           } else if (
-            error instanceof ConcordiumSessionExpiredError ||
-            error instanceof ConcordiumPairingExpiredError
+            error?.name === "ConcordiumSessionExpiredError" ||
+            error?.name === "ConcordiumPairingExpiredError"
           ) {
             onSessionExpired();
           } else {

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ConcordiumPairingProgress } from "@ledgerhq/coin-concordium/types";
 import { ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { Subscription } from "rxjs";
@@ -70,7 +69,7 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
         },
         error: (error: unknown) => {
           if (
-            error instanceof ConcordiumPairingExpiredError &&
+            (error as { name?: string })?.name === "ConcordiumPairingExpiredError" &&
             retryCountRef.current < MAX_EXPIRED_RETRIES
           ) {
             retryCountRef.current++;

--- a/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
@@ -4,10 +4,6 @@ import { filter, first, map } from "rxjs/operators";
 import { TouchableOpacity, Linking, LayoutChangeEvent } from "react-native";
 import { useSelector } from "~/context/hooks";
 import { useTranslation, Trans } from "~/context/Locale";
-import {
-  ConcordiumAddressVerificationFailedError,
-  ConcordiumTrustedMetadataServiceError,
-} from "@ledgerhq/errors";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -122,7 +118,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
           // malformed response). Route to Confirmation with verified: false —
           // the native "skipped verification" path that shows the cached
           // address with the security modal prompt.
-          if (error instanceof ConcordiumTrustedMetadataServiceError) {
+          if (error?.name === "ConcordiumTrustedMetadataServiceError") {
             navigation.navigate(ScreenName.ReceiveConfirmation, {
               ...route.params,
               verified: false,
@@ -178,7 +174,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
 
   // Retrying a terminal address-verification refusal would just hit the same
   // 4xx again — hide the button for that class of error.
-  const canRetry = !(error instanceof ConcordiumAddressVerificationFailedError);
+  const canRetry = error?.name !== "ConcordiumAddressVerificationFailedError";
 
   return (
     <SafeAreaViewFixed isFlex edges={["left", "right", "bottom"]}>

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -34,7 +34,6 @@ import { CosmosDelegationFlowParamList } from "./types";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -223,7 +222,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
         </View>
       </View>
       <View style={styles.footer}>
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender && status.errors.sender?.name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
@@ -6,7 +6,6 @@
 
 import { Transaction as EvmTransaction, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
-import { NotEnoughGas } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -106,7 +105,7 @@ function EditTransactionSummaryContent({ navigation, route, transactionToUpdate 
   const firstError = errors[Object.keys(errors)[0]] ?? bridgeError ?? undefined;
 
   let footerAction;
-  if (firstError && firstError instanceof NotEnoughGas) {
+  if (firstError && firstError?.name === "NotEnoughGas") {
     footerAction = isCurrencySupported(currencyOrToken as CryptoCurrency) ? (
       <Button
         event="SummaryBuyEth"

--- a/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
@@ -32,7 +32,6 @@ import { NearWithdrawingFlowParamList } from "../WithdrawingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
     behaviorParam = "padding";
   }
 
-  const errorDuringUnstaking = error instanceof NotEnoughBalance && transaction.mode === "unstake";
+  const errorDuringUnstaking = error?.name === "NotEnoughBalance" && transaction.mode === "unstake";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -26,7 +26,6 @@ import {
   MAX_NOMINATIONS,
   hasMinimumBondBalance,
 } from "@ledgerhq/live-common/families/polkadot/logic";
-import * as PolkadotErrors from "@ledgerhq/live-common/families/polkadot/errors";
 import {
   usePolkadotPreloadData,
   useSortedValidators,
@@ -245,9 +244,8 @@ function NominateSelectValidator({ navigation, route }: Props) {
   const error = getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const maxSelected = validators.length === MAX_NOMINATIONS;
-  const maybeChill = error instanceof PolkadotErrors.PolkadotValidatorsRequired;
-  const ignoreError =
-    error instanceof PolkadotErrors.PolkadotValidatorsRequired && !nominations.length;
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length;
   // Do not show error on first nominate
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -24,7 +24,6 @@ import SendRowsFee from "../SendRowsFee";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { PolkadotUnbondFlowParamList } from "./type";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -105,7 +104,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const hasErrors = hasStatusError(status);
-  const hasErrorDuringUnbonding = error instanceof NotEnoughBalance;
+  const hasErrorDuringUnbonding = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -36,9 +36,7 @@ import { DelegationAction, SolanaDelegationFlowParamList } from "./types";
 import TranslatedError from "../../../components/TranslatedError";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -139,7 +137,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const error = Object.values(status.errors)[0];
   const feeError = status.errors.fee;
   const isUndelagating = transaction.model.kind === "stake.undelegate";
-  const hasErrorWhileDesactivating = isUndelagating && feeError instanceof NotEnoughBalance;
+  const hasErrorWhileDesactivating = isUndelagating && feeError?.name === "NotEnoughBalance";
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
@@ -206,7 +204,8 @@ export default function DelegationSummary({ navigation, route }: Props) {
       <View style={styles.footer}>
         {hasErrorWhileDesactivating && <NotEnoughFundFeesAlert account={account} />}
 
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender &&
+        (status.errors.sender as { name?: string })?.name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
@@ -31,7 +31,6 @@ import { SuiUnstakingFlowParamList } from "../UnstakingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import Alert from "~/components/Alert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
   }
 
   const errorDuringUnstaking =
-    error instanceof NotEnoughBalance && transaction.mode === "undelegate";
+    error?.name === "NotEnoughBalance" && transaction.mode === "undelegate";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -13,7 +13,6 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type {
@@ -172,7 +171,7 @@ export default function SelectValidator({ navigation, route }: Props) {
   invariant(transaction, "transaction is undefined");
   let error: Error | null = bridgeError || status.errors.recipient;
 
-  if (error instanceof RecipientRequired) {
+  if (error?.name === "RecipientRequired") {
     error = null;
   }
 

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -40,7 +40,6 @@ import type { TezosDelegationFlowParamList } from "./types";
 import { useAccountName } from "~/reducers/wallet";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalanceToDelegate } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "~/families/shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import TranslatedError from "~/components/TranslatedError";
@@ -191,7 +190,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     });
   }, [navigation, route.params, account.id, transaction, status]);
 
-  const notEnoughBalance = status.errors.amount instanceof NotEnoughBalanceToDelegate;
+  const notEnoughBalance = status.errors.amount?.name === "NotEnoughBalanceToDelegate";
   const isUndelagating = route.params?.mode === "undelegate";
   const hasNotEnoughBalanceWhenUndelegating = notEnoughBalance && isUndelagating;
 

--- a/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
+++ b/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
@@ -1,5 +1,5 @@
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport, { StatusCodes, type TransportStatusError } from "@ledgerhq/hw-transport";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getAppAndVersion from "@ledgerhq/live-common/hw/getAppAndVersion";
 import { useCallback, useEffect, useState } from "react";
@@ -32,12 +32,12 @@ export function isLockedDevicePolling(
       map<unknown, IsDeviceLockedResult>(() => ({ type: IsDeviceLockedResultType.unlocked })),
       catchError((error: Error) => {
         if (
-          error instanceof TransportStatusError &&
+          error?.name === "TransportStatusError" &&
           [
             StatusCodes.CLA_NOT_SUPPORTED,
             StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER,
             StatusCodes.INS_NOT_SUPPORTED,
-          ].includes(error.statusCode)
+          ].includes((error as TransportStatusError).statusCode)
         ) {
           return of<IsDeviceLockedResult>({
             type: IsDeviceLockedResultType.lockedStateCannotBeDetermined,
@@ -49,8 +49,9 @@ export function isLockedDevicePolling(
         }
 
         if (
-          error instanceof TransportStatusError &&
-          error.statusCode === StatusCodes.LOCKED_DEVICE
+          error?.name === "LockedDeviceError" ||
+          (error?.name === "TransportStatusError" &&
+            (error as TransportStatusError).statusCode === StatusCodes.LOCKED_DEVICE)
         ) {
           return of<IsDeviceLockedResult>({ type: IsDeviceLockedResultType.locked });
         }

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -20,10 +20,7 @@ import {
   formatOperation,
   formatAccount,
 } from "@ledgerhq/live-common/account/index";
-import {
-  createTransactionBroadcastError,
-  TransactionBroadcastError,
-} from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
+import { createTransactionBroadcastError } from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
 import { formatTransaction } from "@ledgerhq/live-common/transaction/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -32,7 +29,6 @@ import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { broadcastLogger } from "~/datadog";
 import { getEnv } from "@ledgerhq/live-env";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { updateAccountWithUpdater } from "../actions/accounts";
 import logger from "../logger";
@@ -368,16 +364,12 @@ export function useSignedTxHandler({
           dispatch,
         });
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 
-        if (
-          error instanceof TransactionBroadcastError &&
-          route.name === ScreenName.SendConnectDevice
-        ) {
+        if (eName === "TransactionBroadcastError" && route.name === ScreenName.SendConnectDevice) {
           return (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
             ScreenName.SendBroadcastError,
             { ...route.params, error },

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -4,7 +4,6 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Linking } from "react-native";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
@@ -137,7 +136,7 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   }, []);
 
   const onDeviceActionError = useCallback((error: Error) => {
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setSelectedDevice(null);
     }
   }, []);

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -4,7 +4,6 @@ import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { RouteProp } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
@@ -86,7 +85,7 @@ function MyLedgerSectionContent({ onPairingStateChanged }: MyLedgerSectionProps)
   };
 
   const onError = (error: Error) => {
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react";
 import { Banner, Button } from "@ledgerhq/lumen-ui-rnative";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { useTranslation } from "~/context/Locale";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
@@ -53,7 +52,7 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (!error) return null;
 
-  if (excludeRecipientRequired && error instanceof RecipientRequired) return null;
+  if (excludeRecipientRequired && error?.name === "RecipientRequired") return null;
 
   if (!translatedError) return null;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getAccountCurrency,
   getMainAccount,
@@ -285,7 +285,7 @@ export function useAddressValidation({
     }));
 
     const filteredBridgeErrors: BridgeValidationErrors = { ...bridgeValidation.errors };
-    if (ensResolution && filteredBridgeErrors.recipient instanceof InvalidAddress) {
+    if (ensResolution && filteredBridgeErrors.recipient?.name === "InvalidAddress") {
       delete filteredBridgeErrors.recipient;
     }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect } from "react";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SimplifiedTransactionConfirm } from "../../SimplifiedTransactionConfirm";
 import { SignatureCancelledState } from "./SignatureCancelledState";
@@ -36,7 +34,7 @@ export function SigningBody({ device, action, request, onResult, onClose }: Sign
 
   if (signError) {
     const isUserRefused =
-      signError instanceof UserRefusedOnDevice || signError instanceof TransactionRefusedOnDevice;
+      signError?.name === "UserRefusedOnDevice" || signError?.name === "TransactionRefusedOnDevice";
 
     return isUserRefused ? (
       <SignatureCancelledState onClose={onClose} onRetry={status.onRetry} />

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -5,12 +5,7 @@ import {
 } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTrustchainSdk } from "./useTrustchainSdk";
-import {
-  NoTrustchainInitialized,
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-  TrustchainNotAllowed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TrustchainResult, TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useRef } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -23,7 +18,6 @@ import { ScreenName } from "~/const";
 import { hasCompletedOnboardingSelector, onboardingTypeSelector } from "~/reducers/settings";
 import { DrawerProps, SceneKind, useFollowInstructionDrawer } from "./useFollowInstructionDrawer";
 import { OnboardingType } from "~/reducers/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { CONNECTION_TYPES } from "~/analytics/hooks/variables";
 
 export function useAddMember({ device }: { device: Device | null }): DrawerProps {
@@ -79,16 +73,17 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
           transitionToNextScreen(trustchainResult);
         }
       } catch (error) {
-        if (error instanceof TrustchainNotAllowed) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "TrustchainNotAllowed") {
           setScene({ kind: SceneKind.KeyError });
-        } else if (error instanceof TrustchainAlreadyInitialized) {
+        } else if (eName === "TrustchainAlreadyInitialized") {
           setScene({ kind: SceneKind.AlreadySecuredSameSeed });
-        } else if (error instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           setScene({ kind: SceneKind.AlreadySecuredOtherSeed });
-        } else if (error instanceof NoTrustchainInitialized) {
+        } else if (eName === "NoTrustchainInitialized") {
           setScene({ kind: SceneKind.UnbackedError });
         } else if (error instanceof Error) {
-          if (error instanceof UserRefusedOnDevice) {
+          if (eName === "UserRefusedOnDevice") {
             track(AnalyticsEvents.LedgerSyncRejectedOnDevice, {
               page: "Ledger Sync",
               modelId: device?.modelId,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLifeCycle.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLifeCycle.ts
@@ -1,10 +1,5 @@
 import { resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useDispatch } from "~/context/hooks";
-import {
-  TrustchainEjected,
-  TrustchainNotAllowed,
-  TrustchainOutdated,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { ErrorType } from "./type.hooks";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
@@ -34,10 +29,10 @@ export const useLifeCycle = () => {
   };
 
   function handleError(error: Error) {
-    if (error instanceof TrustchainEjected) reset();
-    if (error instanceof TrustchainNotAllowed) reset();
+    if (error?.name === "TrustchainEjected") reset();
+    if (error?.name === "TrustchainNotAllowed") reset();
 
-    if (error instanceof TrustchainOutdated) restoreTrustchain();
+    if (error?.name === "TrustchainOutdated") restoreTrustchain();
 
     const errorToHandle = Object.entries(includesErrorActions).find(([err, _action]) =>
       error.message.includes(err),

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
@@ -6,7 +6,6 @@ import {
   TrustchainSDK,
 } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { setTrustchain, resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { log } from "@ledgerhq/logs";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
 import { track } from "~/analytics";
@@ -24,7 +23,8 @@ export function useOnTrustchainRefreshNeeded(
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         dispatch(setTrustchain(newTrustchain));
       } catch (e) {
-        if (e instanceof TrustchainEjected || e instanceof TrustchainNotAllowed) {
+        const eName = (e as { name?: string })?.name;
+        if (eName === "TrustchainEjected" || eName === "TrustchainNotAllowed") {
           dispatch(resetTrustchainStore());
           track(AnalyticsEvents.LedgerSyncDeactivated);
         }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  QRCodeWSClosed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useSelector, useDispatch } from "~/context/hooks";
 import {
@@ -92,14 +88,14 @@ export function useQRCodeHost({ currentOption }: Props) {
 
     // Don't use retry here because it always uses a delay despite setting it to 0
     onError: e => {
-      if (e instanceof QRCodeWSClosed) {
+      if (e?.name === "QRCodeWSClosed") {
         const { time } = e as unknown as { time: number };
         if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
       }
-      if (e instanceof InvalidDigitsError) {
+      if (e?.name === "InvalidDigitsError") {
         setCurrentStep(Steps.SyncError);
       }
-      if (e instanceof NoTrustchainInitialized) {
+      if (e?.name === "NoTrustchainInitialized") {
         setCurrentStep(Steps.UnbackedError);
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
@@ -5,7 +5,7 @@ import {
 } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTrustchainSdk } from "./useTrustchainSdk";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TrustchainMember, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -60,7 +60,7 @@ export function useRemoveMember({ device, member }: Props): DrawerProps {
 
         transitionToNextScreen(newTrustchain);
       } catch (error) {
-        if (error instanceof TrustchainNotAllowed) {
+        if ((error as { name?: string })?.name === "TrustchainNotAllowed") {
           setScene({ kind: SceneKind.KeyError });
         } else if (error instanceof Error) {
           setScene({ kind: SceneKind.GenericError, error });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
@@ -1,14 +1,7 @@
 import { useCallback, useState, useRef } from "react";
 import { MemberCredentials, TrustchainMember } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { createQRCodeCandidateInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  ScannedOldImportQrCode,
-  ScannedInvalidQrCode,
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { setTrustchain, trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/native";
@@ -77,26 +70,27 @@ export const useSyncWithQrCode = () => {
         onSyncFinished();
         return true;
       } catch (e) {
-        if (e instanceof ScannedOldImportQrCode) {
+        const eName = (e as { name?: string })?.name;
+        if (eName === "ScannedOldImportQrCode") {
           setCurrentStep(Steps.ScannedOldImportQrCode);
           return;
-        } else if (e instanceof ScannedInvalidQrCode) {
+        } else if (eName === "ScannedInvalidQrCode") {
           setCurrentStep(Steps.ScannedInvalidQrCode);
           return;
-        } else if (e instanceof InvalidDigitsError) {
+        } else if (eName === "InvalidDigitsError") {
           setCurrentStep(Steps.SyncError);
           return;
-        } else if (e instanceof NoTrustchainInitialized) {
+        } else if (eName === "NoTrustchainInitialized") {
           setCurrentStep(Steps.UnbackedError);
           return;
-        } else if (e instanceof TrustchainAlreadyInitialized) {
-          if (e.message === trustchain?.rootId) {
+        } else if (eName === "TrustchainAlreadyInitialized") {
+          if ((e as Error)?.message === trustchain?.rootId) {
             setCurrentStep(Steps.AlreadyBacked);
           } else {
             setCurrentStep(Steps.BackedWithDifferentSeeds);
           }
           return;
-        } else if (e instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           setCurrentStep(Steps.BackedWithDifferentSeeds);
           return;
         }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -38,7 +38,6 @@ import { bridgeCache } from "~/bridge/cache";
 import { replaceAccounts } from "~/actions/accounts";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { TrustchainNotAllowed, TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(walletSelector(s));
 
@@ -146,8 +145,8 @@ export function useWatchWalletSync(): WalletSyncUserState {
 
   useEffect(() => {
     if (walletSyncError) {
-      if (walletSyncError instanceof TrustchainNotAllowed) resetLedgerSync();
-      if (walletSyncError instanceof TrustchainEjected) resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainNotAllowed") resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainEjected") resetLedgerSync();
     }
   }, [dispatch, resetLedgerSync, walletSyncError]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, memo } from "react";
 import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { Trans } from "~/context/Locale";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { ScreenName } from "~/const";
 import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
@@ -75,7 +74,7 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
     // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
     // and avoids a duplicated error drawers/messages.
     // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       selectDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Manage/index.tsx
@@ -19,7 +19,6 @@ import { Steps } from "../../types/Activation";
 import { TrackScreen } from "~/analytics";
 import { AlertLedgerSyncDown } from "../../components/AlertLedgerSyncDown";
 import { useLedgerSyncStatus } from "../../hooks/useLedgerSyncStatus";
-import { TrustchainNotFound } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { useCustomTimeOut } from "../../hooks/useCustomTimeOut";
 import { useDispatch } from "~/context/hooks";
 import { blockPasswordLock } from "~/actions/appstate";
@@ -141,9 +140,7 @@ const WalletSyncManage = () => {
               key={index}
               disabled={
                 props.id === "manageKey"
-                  ? hasError && error instanceof TrustchainNotFound
-                    ? false
-                    : hasError
+                  ? hasError && error?.name !== "TrustchainNotFound"
                   : hasError
               }
             />

--- a/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
@@ -3,7 +3,6 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { CustomImageNavigatorParamList } from "~/components/RootNavigator/types/CustomImageNavigator";
 import { ScreenName } from "~/const";
 import { useRemoveImageDeviceAction } from "~/hooks/deviceActions";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useTranslation } from "~/context/Locale";
 import DeviceAction from "~/components/DeviceAction";
@@ -47,7 +46,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
 
   const onError = useCallback(
     (error: Error) => {
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         setDeviceHasImage?.(false);
       }
       setError(error);
@@ -76,7 +75,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
             <Flex flex={1} justifyContent="center">
               <GenericErrorView error={error} hasExportLogButton={false} />
             </Flex>
-            {!(error instanceof ImageDoesNotExistOnDevice) && (
+            {error?.name !== "ImageDoesNotExistOnDevice" && (
               <Button type="main" size="large" onPress={handleTryAgain} my={4}>
                 {t("common.tryAgain")}
               </Button>

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -3,7 +3,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import { connect } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
 import { Button, Text, IconsLegacy, Flex } from "@ledgerhq/native-ui";
 import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import { TrackScreen } from "~/analytics";
@@ -22,6 +21,7 @@ import { BleSaveDeviceNamePayload } from "~/actions/types";
 import { useRenameDeviceAction } from "~/hooks/deviceActions";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useToastsActions } from "~/actions/toast";
+import { DeviceNameInvalid } from "@ledgerhq/errors";
 
 const mapDispatchToProps = {
   saveBleDeviceName,

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
@@ -6,12 +6,6 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import Button from "~/components/wrappedUi/Button";
 import Link from "~/components/wrappedUi/Link";
 import { TrackScreen } from "~/analytics";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
-import {
-  LanguageInstallRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  ImageCommitRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 export const RestoreStepDenied = ({
   t,
@@ -26,15 +20,20 @@ export const RestoreStepDenied = ({
   onPressSkip: () => void;
   stepDeniedError: Error;
 }) => {
-  const analyticsDrawerName =
-    stepDeniedError instanceof LanguageInstallRefusedOnDevice
-      ? `Error: the language change was cancelled on the device`
-      : (stepDeniedError as Error) instanceof ImageLoadRefusedOnDevice ||
-          (stepDeniedError as Error) instanceof ImageCommitRefusedOnDevice
-        ? `Error: the restoration of lock screen picture was cancelled on the device`
-        : (stepDeniedError as Error) instanceof UserRefusedAllowManager
-          ? `Error: the restoration of apps was cancelled on the device`
-          : `Error: ${(stepDeniedError as Error).name}`;
+  const errorName = stepDeniedError?.name;
+  let analyticsDrawerName: string;
+  if (errorName === "LanguageInstallRefusedOnDevice") {
+    analyticsDrawerName = `Error: the language change was cancelled on the device`;
+  } else if (
+    errorName === "ImageLoadRefusedOnDevice" ||
+    errorName === "ImageCommitRefusedOnDevice"
+  ) {
+    analyticsDrawerName = `Error: the restoration of lock screen picture was cancelled on the device`;
+  } else if (errorName === "UserRefusedAllowManager") {
+    analyticsDrawerName = `Error: the restoration of apps was cancelled on the device`;
+  } else {
+    analyticsDrawerName = `Error: ${errorName}`;
+  }
   return (
     <Flex alignItems="center" justifyContent="center" px={1}>
       <TrackScreen category={analyticsDrawerName} refreshSource={false} />

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -17,8 +17,6 @@ import {
   UserRefusedAllowManager,
   WebsocketConnectionError,
   WebsocketConnectionFailed,
-  CustomErrorClassType,
-  TransportStatusErrorClassType,
 } from "@ledgerhq/errors";
 import {
   ConnectManagerTimeout,
@@ -36,9 +34,7 @@ import {
 import { isCustomLockScreenSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 
 // Errors related to the device connection
-export const reconnectDeviceErrorClasses: Array<
-  CustomErrorClassType | TransportStatusErrorClassType
-> = [
+export const reconnectDeviceErrorClasses: Array<new (...args: never) => Error> = [
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
@@ -48,17 +44,16 @@ export const reconnectDeviceErrorClasses: Array<
 ];
 
 // Errors that could be solved by the user: either on their phone or on their device
-export const userSolvableErrorClasses: Array<CustomErrorClassType | TransportStatusErrorClassType> =
-  [
-    ...reconnectDeviceErrorClasses,
-    WebsocketConnectionError,
-    UserRefusedAllowManager,
-    LanguageInstallRefusedOnDevice,
-    ImageCommitRefusedOnDevice,
-    ImageLoadRefusedOnDevice,
-    WebsocketConnectionFailed,
-    DisconnectedDeviceDuringOperation,
-  ];
+export const userSolvableErrorClasses: Array<new (...args: never) => Error> = [
+  ...reconnectDeviceErrorClasses,
+  WebsocketConnectionError,
+  UserRefusedAllowManager,
+  LanguageInstallRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
+  WebsocketConnectionFailed,
+  DisconnectedDeviceDuringOperation,
+];
 
 export type FirmwareUpdateParams = {
   device: Device;
@@ -413,7 +408,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "languageRestore" &&
       installLanguageState.error &&
-      installLanguageState.error instanceof LanguageInstallRefusedOnDevice
+      installLanguageState.error?.name === "LanguageInstallRefusedOnDevice"
     ) {
       return installLanguageState.error;
     }
@@ -421,8 +416,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "imageRestore" &&
       loadImageState.error &&
-      (loadImageState.error instanceof ImageLoadRefusedOnDevice ||
-        (loadImageState.error as unknown) instanceof ImageCommitRefusedOnDevice)
+      (loadImageState.error?.name === "ImageLoadRefusedOnDevice" ||
+        loadImageState.error?.name === "ImageCommitRefusedOnDevice")
     ) {
       return loadImageState.error;
     }
@@ -430,7 +425,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "appsRestore" &&
       restoreAppsState.error &&
-      restoreAppsState.error instanceof UserRefusedAllowManager
+      restoreAppsState.error?.name === "UserRefusedAllowManager"
     ) {
       return restoreAppsState.error;
     }

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { Flex } from "@ledgerhq/native-ui";
 import { ScreenName } from "~/const";
@@ -88,7 +87,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
     // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
     // and avoids a duplicated error drawers/messages.
     // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -1,5 +1,4 @@
 import { isConfirmedOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Text } from "@ledgerhq/native-ui";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
@@ -51,7 +50,7 @@ import LText from "~/components/LText";
 import SupportLinkError from "~/components/SupportLinkError";
 
 const withoutHiddenError = (error: Error): Error | null =>
-  error instanceof RecipientRequired ? null : error;
+  error?.name === "RecipientRequired" ? null : error;
 
 type Navigation = BaseComposite<
   StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendSelectRecipient>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -153,7 +153,7 @@ function SendSummary({ navigation, route }: Props) {
 
     if (
       senderError?.name === recipientError?.name &&
-      senderError instanceof AddressesSanctionedError
+      senderError?.name === "AddressesSanctionedError"
     ) {
       return new AddressesSanctionedError("AddressesSanctionedError", {
         addresses: [

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
@@ -2,7 +2,6 @@ import React, { memo } from "react";
 import { DomainServiceResponseError } from "@ledgerhq/domain-service/hooks/types";
 import { View, StyleSheet, Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import TranslatedError from "~/components/TranslatedError";
 import SupportLinkError from "~/components/SupportLinkError";
 import LText from "~/components/LText";
@@ -31,7 +30,7 @@ export const BasicErrorsView = memo(
     if (!error && !warning) return null;
 
     const hasNoResolutionButIsReverseResolution =
-      domainErrorHandled && domainError?.error instanceof NoResolution && !isForwardResolution;
+      domainErrorHandled && domainError?.error?.name === "NoResolution" && !isForwardResolution;
 
     if (!domainErrorHandled || hasNoResolutionButIsReverseResolution) {
       return (
@@ -69,7 +68,7 @@ type DomainErrorsProps = {
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
 
-  if ((domainError.error as Error) instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <Alert
         title={t("send.recipient.domainService.invalidDomain.title")}
@@ -82,7 +81,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
     );
   }
 
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return <Alert title={t("send.recipient.domainService.noResolution.title")} type="secondary" />;
   }
 

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
@@ -8,7 +8,6 @@ import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { Platform, StyleSheet, View } from "react-native";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import Clipboard from "@react-native-clipboard/clipboard";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { Trans } from "~/context/Locale";
 import { BasicErrorsView, DomainErrorsView } from "./DomainErrorHandlers";
 import RecipientInput from "~/components/RecipientInput";
@@ -16,7 +15,6 @@ import Alert from "~/components/Alert";
 import { urls } from "~/utils/urls";
 import LText from "~/components/LText";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 
 type Props = {
@@ -57,8 +55,7 @@ const DomainServiceRecipientInput = ({
   );
   const domainErrorHandled = useMemo(
     () =>
-      (domainError?.error as Error) instanceof InvalidDomain ||
-      (domainError?.error as Error) instanceof NoResolution,
+      domainError?.error?.name === "InvalidDomain" || domainError?.error?.name === "NoResolution",
     [domainError],
   );
 
@@ -126,9 +123,9 @@ const DomainServiceRecipientInput = ({
         domainError={domainError}
         domainErrorHandled={domainErrorHandled}
         isForwardResolution={isForwardResolution}
-        noLink={error instanceof AddressesSanctionedError}
+        noLink={error?.name === "AddressesSanctionedError"}
       />
-      {error instanceof AddressesSanctionedError ? (
+      {error?.name === "AddressesSanctionedError" ? (
         <>
           <LText
             testID="send-recipient-error-description"

--- a/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
@@ -6,7 +6,6 @@ import TranslatedError from "~/components/TranslatedError";
 import SupportLinkError from "~/components/SupportLinkError";
 import LText from "~/components/LText";
 import RecipientInput from "~/components/RecipientInput";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 type Props = {
   onChangeText: (value: string) => void;
@@ -48,7 +47,7 @@ const RecipientRow = ({
           >
             <TranslatedError error={error || warning} />
           </LText>
-          {error instanceof AddressesSanctionedError && (
+          {error?.name === "AddressesSanctionedError" && (
             <LText style={[styles.warningBox]} color="alert">
               <TranslatedError error={error} field="description" />
             </LText>

--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
@@ -8,8 +8,6 @@ import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app"
 import { isSwapDisableAppsInstall } from "@ledgerhq/live-common/exchange/swap/utils/isIntegrationTestEnv";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignRawTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignRawTransactionNavigator";
@@ -48,9 +46,8 @@ function ConnectDevice({ navigation, route }: SignRawTransactionConnectDevicePro
 
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -9,8 +9,6 @@ import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignTransactionNavigator";
@@ -56,9 +54,8 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
 
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
@@ -5,7 +5,6 @@ import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen, track } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { GenericInformationBody } from "~/components/GenericInformationBody";
-import { BluetoothRequired, FirmwareNotRecognized } from "@ledgerhq/errors";
 import { useNavigation } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import type { SyncOnboardingScreenProps } from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/types";
@@ -60,11 +59,12 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const navigation = useNavigation<SyncOnboardingScreenProps["navigation"]>();
+  const eName = (error as { name?: string })?.name;
 
   // Depending from where the device was not recognized we can a FirmwareNotRecognized or a simple Error
   const isNotFoundEntity =
     error &&
-    (error instanceof FirmwareNotRecognized ||
+    (eName === "FirmwareNotRecognized" ||
       (error instanceof Error && error.message === "not found entity"));
 
   const onGoToSettings = useCallback(() => {
@@ -85,7 +85,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
   const screenName = isNotFoundEntity
     ? "Error: Device OS version not recognized"
     : error
-      ? `Error: ${isDmkError(error) ? error._tag : (error as Error).name}`
+      ? `Error: ${isDmkError(error) ? error._tag : eName}`
       : "Error: unknown error";
 
   const handleRetry = () => {
@@ -140,7 +140,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
         />
         <Button
           type="main"
-          mt={(error as unknown as Error) instanceof BluetoothRequired ? 6 : 8}
+          mt={eName === "BluetoothRequired" ? 6 : 8}
           mb={7}
           size={"large"}
           onPress={handleRetry}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -6,7 +6,6 @@ import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState"
 import { useToggleOnboardingEarlyCheck } from "@ledgerhq/live-common/deviceSDK/hooks/useToggleOnboardingEarlyChecks";
 import { log } from "@ledgerhq/logs";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, UnexpectedBootloader } from "@ledgerhq/errors";
 import { NORMAL_DESYNC_OVERLAY_DISPLAY_DELAY_MS } from "./constants";
 import { EarlySecurityCheck } from "./EarlySecurityCheck";
 import DesyncDrawer from "./DesyncDrawer";
@@ -232,7 +231,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   // A fatal error during polling triggers directly an error message (or the auto repair)
   useEffect(() => {
     if (isFocused && fatalError) {
-      if (fatalError instanceof UnexpectedBootloader) {
+      if (fatalError?.name === "UnexpectedBootloader") {
         log("SyncOnboardingIndex", "Device in bootloader mode. Trying to auto repair", {
           fatalError,
         });
@@ -250,7 +249,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
 
-    if (isFocused && allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (isFocused && allowedError && allowedError?.name !== "LockedDeviceError") {
       log("SyncOnboardingIndex", "Polling allowed error", { allowedError });
 
       timeout = setTimeout(() => {

--- a/apps/wallet-cli/src/commands/genuine-check.ts
+++ b/apps/wallet-cli/src/commands/genuine-check.ts
@@ -1,5 +1,4 @@
 import { defineCommand } from "@bunli/core";
-import { DeviceOnDashboardExpected, UserRefusedAllowManager } from "@ledgerhq/errors";
 import { getGenuineCheckFromDeviceId } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
 import type { GetGenuineCheckFromDeviceIdResult } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
@@ -27,10 +26,10 @@ function mapGenuineCheckError(error: unknown): unknown {
   if (isCounterfeitError(error)) {
     return new NonGenuineDeviceError();
   }
-  if (error instanceof UserRefusedAllowManager) {
+  if ((error as { name?: string })?.name === "UserRefusedAllowManager") {
     return new WalletCliDeviceError({ code: "rejected", context: "open_app" }, { cause: error });
   }
-  if (error instanceof DeviceOnDashboardExpected) {
+  if ((error as { name?: string })?.name === "DeviceOnDashboardExpected") {
     return new WalletCliDeviceError(
       { code: "wrong_app", expected: "Ledger dashboard" },
       { cause: error },

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -1,7 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { createInterface } from "node:readline";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import type { Spinner } from "yocto-spinner";
 import { Session, trustchainFromMeta, type TrustchainMeta } from "../../session/session-store";
 import {
@@ -122,7 +121,7 @@ async function performRemoteDestroy(
     destroySpin?.stop();
     return { remoteSucceeded: true, trustchainDestroyed, memberEjected: false };
   } catch (e) {
-    if (e instanceof TrustchainEjected) {
+    if ((e as { name?: string })?.name === "TrustchainEjected") {
       // destroyApplication is idempotent on an already-closed stream (returns without throwing), so
       // TrustchainEjected means this member is no longer on the ring: it was removed by another
       // owner, or the trustchain was destroyed remotely. Either way there's nothing left for us to

--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
@@ -460,9 +460,9 @@ export async function runFullSwapPipeline(
     const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
     const errorMessageWithCause = rawErrorMessage + causeSuffix;
 
-    const completeExchangeError =
-      error instanceof CompleteExchangeError
-        ? error
+    const completeExchangeError: CompleteExchangeError =
+      (error as { name?: string })?.name === "CompleteExchangeError"
+        ? (error as CompleteExchangeError)
         : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
 
     if (swapId) {

--- a/apps/wallet-cli/src/device/classify-device-error.ts
+++ b/apps/wallet-cli/src/device/classify-device-error.ts
@@ -7,12 +7,6 @@
  */
 
 import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-  LockedDeviceError,
-  ManagerDeviceLockedError,
-} from "@ledgerhq/errors";
 import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { EmptyError } from "rxjs";
 import type { DeviceState, RejectedContext } from "./device-state";
@@ -54,17 +48,19 @@ function getErrorCode(error: unknown): string | undefined {
 }
 
 function isDisconnectedError(error: unknown): boolean {
+  const eName = (error as { name?: string })?.name;
   return (
     error instanceof EmptyError ||
-    error instanceof DisconnectedDevice ||
-    error instanceof DisconnectedDeviceDuringOperation
+    eName === "DisconnectedDevice" ||
+    eName === "DisconnectedDeviceDuringOperation"
   );
 }
 
 function isLockedError(error: unknown): boolean {
+  const eName = (error as { name?: string })?.name;
   return (
-    error instanceof ManagerDeviceLockedError ||
-    error instanceof LockedDeviceError ||
+    eName === "ManagerDeviceLocked" ||
+    eName === "LockedDeviceError" ||
     hasTag(error, "DeviceLockedError")
   );
 }
@@ -96,6 +92,9 @@ function classifyTransportStatusError(
 }
 
 export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): DeviceState {
+  // Null/undefined can't be classified by name; fall through to unknown.
+  if (error == null) return { code: "unknown", cause: error };
+
   // Device-not-detected: rxjs EmptyError is thrown when lastValueFrom sees no emission,
   // @ledgerhq/errors Disconnected* covers USB unplug / transport close.
   if (isDisconnectedError(error)) {
@@ -108,8 +107,8 @@ export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): 
   }
 
   // User-rejection / wrong-app / locked via legacy SW codes.
-  if (error instanceof TransportStatusError) {
-    const state = classifyTransportStatusError(error, ctx);
+  if ((error as { name?: string })?.name === "TransportStatusError") {
+    const state = classifyTransportStatusError(error as TransportStatusError, ctx);
     if (state) {
       return state;
     }

--- a/apps/wallet-cli/src/key-ring/load-key-ring.ts
+++ b/apps/wallet-cli/src/key-ring/load-key-ring.ts
@@ -1,5 +1,4 @@
 import type { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
 import { loadMemberCredentials } from "./keychain";
 import { createLkrpSdk } from "./lkrp-sdk";
@@ -57,7 +56,7 @@ export async function loadDomainKey(
     // The wallet-cli application stream was closed (deactivated from another device, or this member
     // was removed): restoreTrustchain rejects a closed stream with TrustchainEjected. Point the user
     // at the recovery path rather than surfacing the raw protocol error.
-    if (e instanceof TrustchainEjected) {
+    if ((e as { name?: string })?.name === "TrustchainEjected") {
       throw new Error(
         "The wallet-cli application is no longer active on this Ledger Key Ring (deactivated " +
           "elsewhere, or this member was removed). Run `wallet-cli ring destroy` then " +

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -33,7 +33,6 @@ import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/f
 import { listCryptoCurrencies, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { Loading } from "./Loading";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Tick } from "./Tick";
 import { State } from "./types";
 import { Actionable } from "./Actionable";
@@ -149,7 +148,7 @@ export default function AppAccountsSync({
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         setTrustchain(newTrustchain);
       } catch (e) {
-        if (e instanceof TrustchainEjected) {
+        if ((e as { name?: string })?.name === "TrustchainEjected") {
           setTrustchain(null);
         }
       }

--- a/apps/web-tools/src/trustchain/components/AppQRCodeCandidate.tsx
+++ b/apps/web-tools/src/trustchain/components/AppQRCodeCandidate.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeCandidateInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TextInput } from "@ledgerhq/lumen-ui-react";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { Actionable } from "./Actionable";
@@ -56,7 +53,7 @@ export function AppQRCodeCandidate({
           return true;
         })
         .catch(e => {
-          if (e instanceof InvalidDigitsError) {
+          if (e?.name === "InvalidDigitsError") {
             alert("Invalid digits");
             return;
           }

--- a/apps/web-tools/src/trustchain/components/AppQRCodeHost.tsx
+++ b/apps/web-tools/src/trustchain/components/AppQRCodeHost.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { RenderActionable } from "./Actionable";
 import QRCode from "./QRCode";
@@ -44,7 +41,7 @@ export function AppQRCodeHost({
       initialTrustchainId: trustchain.rootId,
     })
       .catch(e => {
-        if (e instanceof InvalidDigitsError) {
+        if (e?.name === "InvalidDigitsError") {
           return;
         }
         setError(e);

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,7 +1,6 @@
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import {
@@ -250,7 +249,10 @@ export async function accessProvableApi({
   try {
     status = await apiClient.getRecordScannerStatus(currency, uuid);
   } catch (error) {
-    if (error instanceof LedgerAPI4xx && error.status === 422) {
+    if (
+      (error as { name?: string; status?: number }).name === "LedgerAPI4xx" &&
+      (error as { status?: number }).status === 422
+    ) {
       throw new AleoApiConfigurationResetError();
     }
     throw error;

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/signOperation.test.ts
@@ -11,8 +11,8 @@ import BigNumber from "bignumber.js";
 import { Observable, firstValueFrom, lastValueFrom, toArray } from "rxjs";
 import type { Account, SignOperationEvent } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { setZcashShieldedEnabled } from "../constants";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { ZcashUtxoNotInAccount } from "../../../errors";
 // Transaction lives in src/types.ts (coin-bitcoin), not in chain-adapters/types.ts
 import type { Transaction } from "../../../types";

--- a/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
+++ b/libs/coin-modules/coin-bitcoin/src/wallet-btc/utils.ts
@@ -89,7 +89,7 @@ function fixedWeight(currency: ICrypto, derivationMode: string): number {
 function inputWeight(derivationMode: string): number {
   const spec = INPUT_WEIGHT_SPECS[derivationMode];
   if (!spec) {
-    throw UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
+    throw new UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
   }
 
   // base non-witness weight for every input
@@ -115,7 +115,7 @@ function outputWeight(derivationMode: string): number {
   } else if (derivationMode === DerivationModes.LEGACY) {
     outputSize += 25; // DUP + HASH160 + PUSH20 + <20 bytes> + EQUALVERIFY + CHECKSIG
   } else {
-    throw UnsupportedDerivation(derivationMode);
+    throw new UnsupportedDerivation(derivationMode);
   }
 
   return outputSize * 4;

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -1,4 +1,4 @@
-import { TransportStatusError, UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
@@ -240,12 +240,13 @@ export const buildAuthorizePreapproval =
  * Check if an error is a LockedDeviceError or UserRefusedOnDevice and create user-friendly error messages
  */
 const handleDeviceErrors = (error: Error): Error | null => {
-  if (error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6985) {
+  if (error.name === "TransportStatusError") {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    if (statusCode === 0x6985) {
       const userRefusedError = new UserRefusedOnDevice("errors.UserRefusedOnDevice.description");
       return userRefusedError;
     }
-    if (error.statusCode === 0x5515) {
+    if (statusCode === 0x5515) {
       const lockedDeviceError = new LockedDeviceError("errors.LockedDeviceError.description");
       return lockedDeviceError;
     }

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import coinConfig from "../config";
@@ -9,6 +8,7 @@ import {
   createMockPendingTransferProposal,
   setupMockCoinConfig,
 } from "../test/fixtures";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { TopologyChangeError } from "../types/errors";
 import type { GetBalanceResponse } from "../types/gateway";
 import { TransactionType } from "../types/gateway";

--- a/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
@@ -101,7 +101,7 @@ export const createNewTransaction = async (
   log("debug", `Creating new Transaction: ${sender}, ${recipient}, ${network}`);
 
   if (recipient && !isAddressValid(recipient)) {
-    throw InvalidAddress(`Invalid recipient Address ${recipient}`);
+    throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
   const client = getCasperNodeRpcClient();

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -3,7 +3,6 @@ import {
   ConcordiumPairingExpiredError,
   ConcordiumSessionExpiredError,
   LockedDeviceError,
-  TransportStatusError,
   UserRefusedOnDevice,
 } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -158,13 +157,14 @@ export const buildOnboardAccount =
       main().then(
         () => o.complete(),
         error => {
-          if (error instanceof TransportStatusError) {
-            if (error.statusCode === 0x6985) {
+          if ((error as { name?: string })?.name === "TransportStatusError") {
+            const statusCode = (error as { statusCode?: number }).statusCode;
+            if (statusCode === 0x6985) {
               o.error(new UserRefusedOnDevice("errors.UserRefusedOnDevice.description"));
               return;
             }
 
-            if (error.statusCode === 0x5515) {
+            if (statusCode === 0x5515) {
               o.error(new LockedDeviceError("errors.LockedDeviceError.description"));
               return;
             }

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -12,13 +12,13 @@ import { HEDERA_TRANSACTION_MODES } from "../constants";
 import {
   HederaInsufficientFundsForAssociation,
   HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
   HederaNoStakingRewardsError,
   HederaRecipientEvmAddressVerificationRequired,
   HederaRecipientInvalidChecksum,
   HederaRecipientTokenAssociationRequired,
   HederaRecipientTokenAssociationUnverified,
   HederaRedundantStakingNodeIdError,
-  HederaMemoExceededSizeError,
 } from "../errors";
 import * as estimateFees from "../logic/estimateFees";
 import * as logicUtils from "../logic/utils";

--- a/libs/coin-modules/coin-mina/src/network/index.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI5xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 
@@ -53,14 +52,12 @@ const isAbortOrTimeoutError = (error: unknown): error is Error & { code?: string
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([502, 503, 504]);
 
-type LedgerAPI5xxInstance = InstanceType<typeof LedgerAPI5xx>;
-
 const isRetryableServerError = (
   error: unknown,
-): error is LedgerAPI5xxInstance & { status: number } =>
-  error instanceof LedgerAPI5xx &&
-  typeof (error as LedgerAPI5xxInstance & { status?: number }).status === "number" &&
-  RETRYABLE_HTTP_STATUS_CODES.has((error as LedgerAPI5xxInstance & { status: number }).status);
+): error is { name: string; status: number; message: string } =>
+  (error as { name?: string })?.name === "LedgerAPI5xx" &&
+  typeof (error as { status?: number }).status === "number" &&
+  RETRYABLE_HTTP_STATUS_CODES.has((error as { status: number }).status);
 
 const backoffDelay = (attempt: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt)));

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -77,7 +77,7 @@ const getSendTransactionStatus: AccountBridge<
     errors.amount = new AmountRequired();
   }
 
-  if (!(errors.amount instanceof AmountRequired)) {
+  if (errors.amount?.name !== "AmountRequired") {
     if (
       (!transaction.useAllAmount && account.spendableBalance.isZero()) ||
       totalSpent.gt(account.spendableBalance)
@@ -308,7 +308,7 @@ export const getTransactionStatus: AccountBridge<
     errors.amount = new NotEnoughBalance();
   }
 
-  if (!(errors.amount instanceof AmountRequired) && totalSpent.gt(account.spendableBalance)) {
+  if (errors.amount?.name !== "AmountRequired" && totalSpent.gt(account.spendableBalance)) {
     errors.amount = new NotEnoughBalance();
   }
 

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -1,7 +1,4 @@
 import { NotEnoughGas } from "@ledgerhq/errors";
-import { Account, VersionedMessage } from "@solana/web3.js";
-import BigNumber from "bignumber.js";
-import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import {
   SolanaMemoIsTooLong,
   SolanaRecipientAccountNotFunded,
@@ -9,6 +6,9 @@ import {
   SolanaStakeAccountNothingToWithdraw,
   SolanaStakeNoWithdrawAuth,
 } from "./errors";
+import { Account, VersionedMessage } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import { estimateFeeAndSpendable } from "./estimateMaxSpendable";
 import * as logicValidateMemo from "./logic/validateMemo";
 import { ChainAPI } from "./network";

--- a/libs/coin-tester-modules/coin-tester-cardano/src/negativeCases.test.ts
+++ b/libs/coin-tester-modules/coin-tester-cardano/src/negativeCases.test.ts
@@ -83,6 +83,8 @@ describe("Cardano negative cases (Yaci devnet)", () => {
 
   it("rejects a below-min-UTXO amount at craft", async () => {
     const tx = build({ recipient, amount: new BigNumber(100), nonce: 0 });
-    await expect(accountBridge.prepareTransaction(account, tx)).rejects.toThrow(/minimum/i);
+    await expect(accountBridge.prepareTransaction(account, tx)).rejects.toMatchObject({
+      name: "CardanoMinAmountError",
+    });
   });
 });

--- a/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
@@ -1,7 +1,7 @@
 import { from, lastValueFrom } from "rxjs";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { ApduDevice } from "@ledgerhq/hw-ledger-key-ring-protocol/ApduDevice";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { StatusCodes } from "@ledgerhq/hw-transport";
 import { crypto, device } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import getApi from "./api";
 import { genericWithJWT } from "./auth";
@@ -57,10 +57,10 @@ export class HWDeviceProvider {
     try {
       return await lastValueFrom(runWithDevice(transport => from(job(device.apdu(transport)))));
     } catch (error) {
-      if (!(error instanceof TransportStatusError)) {
+      if ((error as { name?: string })?.name !== "TransportStatusError") {
         throw error;
       }
-      switch (error.statusCode) {
+      switch ((error as { statusCode?: number })?.statusCode) {
         case StatusCodes.USER_REFUSED_ON_DEVICE:
         case StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED:
           throw new UserRefusedOnDevice();

--- a/libs/ledger-key-ring-protocol/src/auth.ts
+++ b/libs/ledger-key-ring-protocol/src/auth.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { AuthCachePolicy, JWT } from "./types";
 import { TrustchainNotAllowed, TrustchainOutdated } from "./errors";
@@ -81,13 +80,14 @@ function networkCheckJwtExpiration(error: unknown): JwtExpirationCheck {
   let isTrustchainOutdated = false;
   let isUncaughtClientError = false;
   // this assume live-network is used and we adapt to its error's format
-  if (error instanceof LedgerAPI4xx) {
-    if (error.message.includes("JWT is expired")) {
+  if ((error as { name?: string })?.name === "LedgerAPI4xx") {
+    const message = (error as Error)?.message ?? "";
+    if (message.includes("JWT is expired")) {
       hasExpired = true;
-      canBeRefreshed = error.message.includes("/refresh");
-    } else if (error.message.includes("JWT contains no permission")) {
+      canBeRefreshed = message.includes("/refresh");
+    } else if (message.includes("JWT contains no permission")) {
       isNotPermitted = true;
-    } else if (error.message.includes("path does not match")) {
+    } else if (message.includes("path does not match")) {
       isTrustchainOutdated = true;
     } else {
       isUncaughtClientError = true;

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -25,7 +25,6 @@ import {
 import getApi from "./api";
 import { KeyPair as CryptoKeyPair } from "@ledgerhq/hw-ledger-key-ring-protocol/Crypto";
 import { log } from "@ledgerhq/logs";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import {
   TrustchainAlreadyInitialized,
   TrustchainAlreadyInitializedWithOtherSeed,
@@ -450,11 +449,11 @@ export class SDK implements TrustchainSDK {
       })
       .catch(e => {
         if (
-          e instanceof LedgerAPI4xx &&
-          (e.message.includes("Not a member of trustchain") ||
-            e.message.includes("You are not member"))
+          (e as { name?: string })?.name === "LedgerAPI4xx" &&
+          ((e as Error)?.message.includes("Not a member of trustchain") ||
+            (e as Error)?.message.includes("You are not member"))
         ) {
-          throw new TrustchainEjected(e.message);
+          throw new TrustchainEjected((e as Error)?.message);
         }
         throw e;
       });

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
@@ -1,4 +1,4 @@
-import { TrustchainEjected, TrustchainNotAllowed } from "../../src/errors";
+import { TrustchainEjected } from "../../src/errors";
 import { ScenarioOptions } from "../test-helpers/types";
 
 // Deactivating one application (Ledger Sync, app 16) must close only that
@@ -58,10 +58,8 @@ export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions
       () => null,
       (e: unknown) => e,
     );
-  expect(
-    sync2RestoreError instanceof TrustchainNotAllowed ||
-      sync2RestoreError instanceof TrustchainEjected,
-  ).toBe(true);
+  const eName = (sync2RestoreError as { name?: string })?.name;
+  expect(eName === "TrustchainNotAllowed" || eName === "TrustchainEjected").toBe(true);
 
   // cleanup
   await sdkSync1.destroyTrustchain(reactivated.trustchain, sync1creds);

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -155,7 +155,7 @@ export const reducer = (state: State, action: Action): State => {
 
         /*
           const error = event.error;
-          if (error instanceof ManagerDeviceLockedError) {
+          if ((error as { name?: string })?.name === "ManagerDeviceLocked") {
             return {
               ...state,
               currentError: {

--- a/libs/ledger-live-common/src/device-action/utils.ts
+++ b/libs/ledger-live-common/src/device-action/utils.ts
@@ -1,5 +1,3 @@
-import { TransportStatusError } from "@ledgerhq/errors";
-import { DeviceNotOnboarded } from "../errors";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 
@@ -46,11 +44,12 @@ export function getFlowNameFromMapping<TLocation extends string | number | symbo
 
 // remap transport status 6d06/6d07 as DeviceNotOnboarded for UX handling consistency.
 export function isDeviceNotOnboardedError(e: unknown) {
+  const eName = (e as { name?: string })?.name;
   const maybeMessage = (e as { message?: string })?.message;
 
   return (
-    e instanceof DeviceNotOnboarded ||
-    (e instanceof TransportStatusError &&
+    eName === "DeviceNotOnboarded" ||
+    (eName === "TransportStatusError" &&
       (maybeMessage?.includes("0x6d06") || maybeMessage?.includes("0x6d07")))
   );
 }

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/restoreAppData.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/restoreAppData.ts
@@ -1,6 +1,5 @@
 import {
   AppNotFound,
-  UserRefusedOnDevice,
   restoreAppStorage,
   restoreAppStorageCommit,
   restoreAppStorageInit,
@@ -67,7 +66,7 @@ export function restoreAppData(
           }
 
           // User refused on device
-          if (e instanceof UserRefusedOnDevice) {
+          if ((e as { name?: string })?.name === "UserRefusedOnDevice") {
             // NOTE: Display a message to the user to retry the restore process
             // If he does not, we should delete the app data (in another flow)
             subscriber.next({

--- a/libs/ledger-live-common/src/deviceSDK/actions/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/core.ts
@@ -1,4 +1,3 @@
-import { LockedDeviceError, UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { SharedTaskEvent } from "../tasks/core";
 
 // Represents the state that is shared with any action
@@ -41,10 +40,7 @@ export function sharedReducer({ event }: { event: SharedTaskEvent }): Partial<Sh
       const { error, retrying } = event;
       const { name, message } = error;
 
-      if (
-        error instanceof LockedDeviceError ||
-        (error as unknown) instanceof UnresponsiveDeviceError
-      ) {
+      if (name === "LockedDeviceError" || name === "UnresponsiveDeviceError") {
         // Propagates the error so the consumer can distinguish locked (from error response) and unresponsive error.
         return { lockedDevice: true, error: { type: "SharedError", name, message, retrying } };
       }

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
@@ -1,6 +1,6 @@
 import { Observable, of, throwError } from "rxjs";
 import URL from "url";
-import Transport, { TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 import type { FinalFirmware, OsuFirmware, DeviceInfo, SocketEvent } from "@ledgerhq/types-live";
 import { version as livecommonversion } from "../../../../package.json";
 import { getEnv } from "@ledgerhq/live-env";
@@ -11,7 +11,6 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   UserRefusedFirmwareUpdate,
   DeviceOnDashboardExpected,
-  ManagerDeviceLockedError,
 } from "@ledgerhq/errors";
 import { LOG_TYPE, UnresponsiveCmdEvent } from "../core";
 
@@ -122,7 +121,7 @@ export function installFirmwareCommand(
 const remapSocketUnresponsiveError: (
   e: Error,
 ) => Observable<InstallFirmwareCommandEvent> | Observable<never> = (e: Error) => {
-  if (e instanceof ManagerDeviceLockedError) {
+  if ((e as { name?: string })?.name === "ManagerDeviceLocked") {
     return of({ type: "unresponsive" });
   }
 
@@ -137,10 +136,11 @@ const remapSocketFirmwareError: (e: Error) => Observable<never> = (e: Error) => 
     return throwError(() => new DeviceOnDashboardExpected());
   }
 
+  const statusCode = (e as { statusCode?: number }).statusCode;
   const status =
-    e instanceof TransportStatusError
-      ? e.statusCode.toString(16)
-      : (e as Error).message.slice((e as Error).message.length - 4);
+    (e as { name?: string })?.name === "TransportStatusError" && statusCode !== undefined
+      ? statusCode.toString(16)
+      : (e as { message?: string })?.message?.slice(-4);
 
   switch (status) {
     case "6a84":

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -1,12 +1,4 @@
-import {
-  CantOpenDevice,
-  DisconnectedDevice,
-  LockedDeviceError,
-  TransportRaceCondition,
-  UnresponsiveDeviceError,
-  TransportStatusErrorClassType,
-  CustomErrorClassType,
-} from "@ledgerhq/errors";
+import { TransportStatusErrorClassType, CustomErrorClassType } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
 import { catchError, concatMap, retry, switchMap, timeout } from "rxjs/operators";
 import { Transport, TransportRef } from "../transports/core";
@@ -44,12 +36,13 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
               // - LockedDeviceError and UnresponsiveDeviceError: on every transport if there is a device but it is locked
               // - CantOpenDevice: it can come from a transport when no device is found
               // - DisconnectedDevice: it can come from a transport while switching app
+              const eName = (error as { name?: string })?.name;
               if (
-                error instanceof LockedDeviceError ||
-                error instanceof UnresponsiveDeviceError ||
-                error instanceof CantOpenDevice ||
-                error instanceof DisconnectedDevice ||
-                error instanceof TransportRaceCondition
+                eName === "LockedDeviceError" ||
+                eName === "UnresponsiveDeviceError" ||
+                eName === "CantOpenDevice" ||
+                eName === "DisconnectedDevice" ||
+                eName === "TransportRaceCondition"
               ) {
                 // Emits to the action an error event so it is aware of it (for ex locked device) before retrying
                 const event: SharedTaskEvent = {
@@ -73,7 +66,10 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
   };
 }
 
-type ErrorClass = CustomErrorClassType | TransportStatusErrorClassType;
+type ErrorClass =
+  | (new (...args: any[]) => Error)
+  | CustomErrorClassType
+  | TransportStatusErrorClassType;
 
 // To be able to retry a command, the command needs to take an object containing a transport as its argument
 type CommandTransportArgs = { transport: Transport };

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -1,4 +1,4 @@
-import { DisconnectedDevice, StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { DisconnectedDevice, StatusCodes } from "@ledgerhq/errors";
 import type { DeviceId } from "@ledgerhq/types-live";
 
 import { Observable, concat, of, throwError } from "rxjs";
@@ -67,7 +67,10 @@ function internalGetBatteryStatusesTask({
           return { type: "data" as const, batteryStatus };
         }),
         catchError((err: Error) => {
-          if (err instanceof TransportStatusError && err.statusCode === StatusCodes.UNKNOWN_APDU)
+          if (
+            (err as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+            (err as { statusCode?: number }).statusCode === StatusCodes.UNKNOWN_APDU
+          )
             return of<GetBatteryStatusesTaskEvent>({ type: "taskError", error: "UnknownApdu" });
 
           return throwError(() => err);

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
@@ -7,7 +7,7 @@ import {
   toggleOnboardingEarlyCheckCmd,
   ToggleTypeP2,
 } from "../commands/toggleOnboardingEarlyCheck";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/errors";
 
 export type ToggleOnboardingEarlyCheckTaskError =
   | "DeviceInInvalidState"
@@ -55,16 +55,17 @@ function internalToggleOnboardingEarlyCheckTask({
     ).subscribe({
       next: _ => subscriber.next({ type: "success" }),
       error: (error: unknown) => {
-        if (error instanceof TransportStatusError) {
+        if ((error as { name?: string })?.name === "TransportStatusError") {
           tracer.trace("A TransportStatusError error occurred", { error });
+          const statusCode = (error as { statusCode?: number }).statusCode;
 
-          if (error.statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED) {
+          if (statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED) {
             subscriber.next({
               type: "taskError",
               error: "DeviceInInvalidState",
             });
             return;
-          } else if (error.statusCode === StatusCodes.INCORRECT_LENGTH) {
+          } else if (statusCode === StatusCodes.INCORRECT_LENGTH) {
             subscriber.next({
               type: "taskError",
               error: "InternalError",

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -3,8 +3,6 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   UnresponsiveDeviceError,
-  UserRefusedAllowManager,
-  UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 import type {
@@ -167,9 +165,10 @@ function internalUpdateFirmwareTask({
       error: error => {
         tracer.trace(`Error: ${error}`, { error });
 
-        if (error instanceof UserRefusedFirmwareUpdate) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "UserRefusedFirmwareUpdate") {
           subscriber.next({ type: "installOsuDevicePermissionDenied" });
-        } else if (error instanceof UserRefusedAllowManager) {
+        } else if (eName === "UserRefusedAllowManager") {
           subscriber.next({ type: "allowSecureChannelDenied" });
         } else {
           subscriber.next({ type: "error", error, retrying: false });

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -2,17 +2,7 @@ import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  BluetoothRequired,
-  CantOpenDevice,
-  DeviceHalted,
-  FirmwareOrAppUpdateRequired,
-  PairingFailed,
-  PeerRemovedPairing,
-  TransportInterfaceNotAvailable,
-  TransportStatusError,
-  TransportWebUSBGestureRequired,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, DeviceHalted, FirmwareOrAppUpdateRequired } from "@ledgerhq/errors";
 import { open, close } from "../../hw/index";
 
 export { Transport };
@@ -105,11 +95,12 @@ export const withTransport = (
       // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
       const onErrorDuringTransportSetup = (error: unknown) => {
         tracer.trace("Error while setting up a transport: ", { error });
-        if (error instanceof BluetoothRequired) throw error;
-        if (error instanceof TransportWebUSBGestureRequired) throw error;
-        if (error instanceof TransportInterfaceNotAvailable) throw error;
-        if (error instanceof PeerRemovedPairing) throw error;
-        if (error instanceof PairingFailed) throw error;
+        const errorName = (error as { name?: string })?.name;
+        if (errorName === "BluetoothRequired") throw error;
+        if (errorName === "TransportWebUSBGestureRequired") throw error;
+        if (errorName === "TransportInterfaceNotAvailable") throw error;
+        if (errorName === "PeerRemovedPairing") throw error;
+        if (errorName === "PairingFailed") throw error;
         if (error instanceof Error) throw new CantOpenDevice(error.message);
         else throw new CantOpenDevice("Unknown error");
       };
@@ -230,11 +221,12 @@ const transportFinally =
 const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
   let mappedError = error;
 
-  if (error && error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6faa) {
-      mappedError = new DeviceHalted(error.message);
-    } else if (error.statusCode === 0x6b00) {
-      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+  if ((error as { name?: string })?.name === "TransportStatusError") {
+    const tse = error as { statusCode?: number; message?: string };
+    if (tse.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(tse.message);
+    } else if (tse.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(tse.message);
     }
   }
 

--- a/libs/ledger-live-common/src/exchange/error.ts
+++ b/libs/ledger-live-common/src/exchange/error.ts
@@ -1,4 +1,3 @@
-import { TransportStatusError } from "@ledgerhq/errors";
 import { getExchangeErrorMessage } from "@ledgerhq/hw-app-exchange";
 import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
 import get from "lodash/get";
@@ -41,11 +40,12 @@ export function convertTransportError(
   step: CompleteExchangeStep,
   err: unknown,
 ): CompleteExchangeError | unknown {
-  if (err instanceof TransportStatusError) {
-    const errorCode =
-      step === "CHECK_REFUND_ADDRESS" && err.statusCode == null
+  if ((err as { name?: string })?.name === "TransportStatusError") {
+    const tse = err as { statusCode?: number | null };
+    const errorCode: number =
+      step === "CHECK_REFUND_ADDRESS" && tse.statusCode == null
         ? ErrorStatus.INVALID_ADDRESS
-        : err.statusCode;
+        : (tse.statusCode ?? ErrorStatus.INVALID_ADDRESS);
 
     const { errorName, errorMessage } = getExchangeErrorMessage(errorCode, step);
     return new CompleteExchangeError(step, errorName, errorMessage);

--- a/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { firstValueFrom, from, Observable } from "rxjs";
-import { TransportStatusError, WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
 
 import { delay } from "../../../promise";
 import {
@@ -149,7 +149,8 @@ const completeExchange = (
             payoutAddressParameters,
           );
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const tse1 = e as { name?: string; statusCode?: number };
+          if (tse1?.name === "TransportStatusError" && tse1?.statusCode === 0x6a83) {
             throw new WrongDeviceForAccount();
           }
 
@@ -163,16 +164,18 @@ const completeExchange = (
       }).catch(e => {
         if (ignoreTransportError) return;
 
+        const tse2 = e as { name?: string; statusCode?: number };
         if (
-          e instanceof TransportStatusError &&
-          (e.statusCode === 0x6a84 || e.statusCode === 0x5501)
+          tse2?.name === "TransportStatusError" &&
+          (tse2?.statusCode === 0x6a84 || tse2?.statusCode === 0x5501)
         ) {
           throw new TransactionRefusedOnDevice();
         }
 
-        // Preserve known error types checked by instanceof downstream
-        if (e instanceof CompleteExchangeError) throw e;
-        if (e instanceof WrongDeviceForAccount || e instanceof TransactionRefusedOnDevice) throw e;
+        // Preserve known error types checked by .name downstream
+        const eName = (e as { name?: string })?.name;
+        if (eName === "CompleteExchangeError") throw e;
+        if (eName === "WrongDeviceForAccount" || eName === "TransactionRefusedOnDevice") throw e;
         // Wrap any remaining unknown errors with the current step context
         throw new CompleteExchangeError(
           currentStep,

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -1,7 +1,6 @@
 import type { Account } from "@ledgerhq/types-live";
 import {
   DisconnectedDeviceDuringOperation,
-  TransportStatusError,
   WrongDeviceForAccountPayout,
   WrongDeviceForAccountRefund,
 } from "@ledgerhq/errors";
@@ -252,9 +251,10 @@ const completeExchange = (
             payoutAddressParameters,
           );
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const tse1 = e as { name?: string; statusCode?: number };
+          if (tse1.name === "TransportStatusError" && tse1.statusCode === 0x6a83) {
             throw new WrongDeviceForAccountPayout(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(tse1.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(payoutAccount),
               },
@@ -293,10 +293,11 @@ const completeExchange = (
           );
           log(COMPLETE_EXCHANGE_LOG, "checkrefund address");
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const tse2 = e as { name?: string; statusCode?: number };
+          if (tse2.name === "TransportStatusError" && tse2.statusCode === 0x6a83) {
             log(COMPLETE_EXCHANGE_LOG, "transport error");
             throw new WrongDeviceForAccountRefund(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(tse2.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(refundAccount),
               },
@@ -316,9 +317,10 @@ const completeExchange = (
         // During signature delegation, Exchange does not remap refusal errors from the coin app/OS.
         // 0x6a84: user refused the proposal for an owned destination address.
         // 0x5501: BOLOS/OS-level refusal (not an Exchange app error code).
+        const tse3 = e as { name?: string; statusCode?: number };
         if (
-          e instanceof TransportStatusError &&
-          (e.statusCode === 0x6a84 || e.statusCode === 0x5501)
+          tse3.name === "TransportStatusError" &&
+          (tse3.statusCode === 0x6a84 || tse3.statusCode === 0x5501)
         ) {
           throw new TransactionRefusedOnDevice();
         }

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -1,12 +1,6 @@
 import { getAccountCurrency, getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
-import {
-  AmountRequired,
-  FeeNotLoaded,
-  NotEnoughBalanceSwap,
-  NotEnoughGas,
-  NotEnoughGasSwap,
-} from "@ledgerhq/errors";
+import { NotEnoughBalanceSwap, NotEnoughGasSwap } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { useEffect, useMemo, useState } from "react";
 import useBridgeTransaction, { Result } from "../../../bridge/useBridgeTransaction";
@@ -62,10 +56,11 @@ export const useFromAmountStatusMessage = (
     // don't return an error/warning if we have no transaction or if transaction.amount <= 0
     if (transaction?.amount.lte(0)) return undefined;
 
-    const [relevantStatus] = statusEntries
+    const relevantStatus = statusEntries
       .filter(maybeError => maybeError instanceof Error)
-      .filter(errorOrWarning => !(errorOrWarning instanceof AmountRequired));
-    const isRelevantStatus = (relevantStatus as Error) instanceof NotEnoughGas;
+      .find(errorOrWarning => (errorOrWarning as { name?: string })?.name !== "AmountRequired");
+    const relevantStatusName = (relevantStatus as { name?: string })?.name;
+    const isRelevantStatus = relevantStatusName === "NotEnoughGas";
 
     // Skip gas validation for sponsored transactions since gas fees are covered by sponsor
 
@@ -85,7 +80,7 @@ export const useFromAmountStatusMessage = (
     }
 
     // convert to swap variation of error to display correct message to frontend.
-    if (relevantStatus instanceof FeeNotLoaded) {
+    if (relevantStatusName === "FeeNotLoaded") {
       return new NotEnoughBalanceSwap();
     }
 

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
@@ -1,7 +1,6 @@
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { catchError, concatMap, defer, from, map, of, scan, type Observable } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import type { GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
@@ -60,7 +59,7 @@ export const getViewKeyExec = (
           return { accountId: account.id, viewKey };
         }),
         catchError(e => {
-          if (e instanceof UserRefusedOnDevice) {
+          if ((e as { name?: string })?.name === "UserRefusedOnDevice") {
             return of({ accountId: account.id, viewKey: null });
           }
 

--- a/libs/ledger-live-common/src/families/hedera/exchange.ts
+++ b/libs/ledger-live-common/src/families/hedera/exchange.ts
@@ -1,4 +1,4 @@
-import { LatestFirmwareVersionRequired, TransportStatusError } from "@ledgerhq/errors";
+import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 import Exchange from "@ledgerhq/hw-app-exchange";
 import { loadPKI } from "@ledgerhq/hw-bolos";
 import calService from "@ledgerhq/ledger-cal-service";
@@ -7,8 +7,12 @@ import { getEnv } from "@ledgerhq/live-env";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Account } from "@ledgerhq/types-live";
 
-function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+function isPKIUnsupportedError(err: unknown): boolean {
+  const errName = (err as { name?: string })?.name;
+  return (
+    errName === "TransportStatusError" &&
+    !!(err as { message?: string })?.message?.includes("0x6a81")
+  );
 }
 
 export async function handleHederaTrustedFlow({

--- a/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
@@ -145,7 +145,7 @@ const getTransactionStatus = (a: Account, t: Transaction) => {
     }
   } else {
     // delegation case, we remap NotEnoughBalance to a more precise error
-    if (errors.amount instanceof NotEnoughBalance) {
+    if (errors.amount?.name === "NotEnoughBalance") {
       errors.amount = new NotEnoughBalanceToDelegate();
     }
   }

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
@@ -1,5 +1,4 @@
 import type { Unit } from "@ledgerhq/types-cryptoassets";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import type { SendFlowTransactionActions, SendFlowUiConfig } from "../../types";
@@ -154,7 +153,7 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
       rows != null &&
       rows.length > 0 &&
       utxoData.totalExcludedUTXOS === rows.length;
-    const isInsufficientFundsBridgeError = status.errors?.amount instanceof NotEnoughBalance;
+    const isInsufficientFundsBridgeError = status.errors?.amount?.name === "NotEnoughBalance";
 
     return isInsufficientFundsBridgeError || hasNoSelectedUtxo;
   }, [customStrategyValue, status, transaction, utxoDisplayData]);
@@ -224,7 +223,7 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
     const hasFilledAmount = transaction.useAllAmount || transaction.amount?.gt(0);
     if (isCustomStrategy && !hasFilledAmount) return undefined;
 
-    const isInsufficientFundsBridgeError = status.errors?.amount instanceof NotEnoughBalance;
+    const isInsufficientFundsBridgeError = status.errors?.amount?.name === "NotEnoughBalance";
     // Transaction patches (e.g. toggling custom exclusions) apply before the next bridge sync;
     // status can briefly still reflect the previous pick and show a stale NotEnoughBalance.
     if (isCustomStrategy && hasFilledAmount && bridgePending && isInsufficientFundsBridgeError) {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -1,4 +1,3 @@
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import { useMemo } from "react";
 import type { AddressSearchResult } from "../types";
 
@@ -23,9 +22,9 @@ export function useRecipientSearchState({
   const bridgeSenderError = result.bridgeErrors?.sender;
 
   const isSelfTransferError =
-    bridgeRecipientError instanceof InvalidAddressBecauseDestinationIsAlsoSource;
+    bridgeRecipientError?.name === "InvalidAddressBecauseDestinationIsAlsoSource";
   const isBridgeInvalidAddress =
-    bridgeRecipientError instanceof InvalidAddress && !isSelfTransferError;
+    bridgeRecipientError?.name === "InvalidAddress" && !isSelfTransferError;
 
   const hasValidatedAddress =
     result.status === "valid" || result.status === "ens_resolved" || result.status === "sanctioned";

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -59,13 +59,11 @@ type PollingImplementationParams<Request, EmittedEvents> = {
   config?: PollingImplementationConfig;
   // retryableWithDelayDisconnectedErrors has default value of [DisconnectedDevice, DisconnectedDeviceDuringOperation]
   // used to filter which error(s) retry polling after a delay, reconnectWaitTime
-  retryableWithDelayDisconnectedErrors?: ReadonlyArray<ErrorConstructor>;
+  retryableWithDelayDisconnectedErrors?: ReadonlyArray<new (message?: string) => Error>;
 };
 
-const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<ErrorConstructor> = [
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-];
+const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<new (message?: string) => Error> =
+  [DisconnectedDevice, DisconnectedDeviceDuringOperation];
 
 export const defaultImplementationConfig: PollingImplementationConfig = {
   pollingFrequency: 2000,

--- a/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
@@ -2,7 +2,6 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
@@ -91,7 +90,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -129,7 +129,7 @@ export const createAction = (
             if (
               productName &&
               e.type === "error" &&
-              e.error instanceof UserRefusedDeviceNameChange
+              (e.error as { name?: string })?.name === "UserRefusedDeviceNameChange"
             ) {
               e.error = new UserRefusedDeviceNameChange(undefined, {
                 productName,

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -2,7 +2,6 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
 import type { Transaction, TransactionStatus } from "../../coin-modules/transaction-types";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
@@ -92,7 +91,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -2,15 +2,10 @@ import semver from "semver";
 import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
 import {
-  TransportStatusError,
   FirmwareOrAppUpdateRequired,
   UserRefusedOnDevice,
-  BtcUnmatchedApp,
   UpdateYourApp,
-  DisconnectedDeviceDuringOperation,
-  DisconnectedDevice,
   StatusCodes,
-  LockedDeviceError,
   LatestFirmwareVersionRequired,
 } from "@ledgerhq/errors";
 import type Transport from "@ledgerhq/hw-transport";
@@ -212,8 +207,9 @@ export const openAppFromDashboard = (
               }),
             ),
             catchError(e => {
-              if (e && e instanceof TransportStatusError) {
-                switch (e.statusCode) {
+              const tse = e as { name?: string; statusCode?: number };
+              if (tse.name === "TransportStatusError") {
+                switch (tse.statusCode) {
                   case 0x6984: // No StatusCodes definition
                   case 0x6807: // No StatusCodes definition
                     return inlineAppInstall({
@@ -225,7 +221,7 @@ export const openAppFromDashboard = (
                   case 0x5501: // No StatusCodes definition
                     return throwError(() => new UserRefusedOnDevice());
                 }
-              } else if (e instanceof LockedDeviceError) {
+              } else if (tse.name === "LockedDeviceError") {
                 // openAppFromDashboard is exported, so LockedDeviceError should be handled here too
                 return of({
                   type: "lockedDevice",
@@ -285,20 +281,21 @@ const derivationLogic = (
     catchError(e => {
       if (!e) return throwError(() => e);
 
-      if (e instanceof BtcUnmatchedApp) {
+      const tse = e as { name?: string; statusCode?: number };
+      if (tse.name === "BtcUnmatchedApp") {
         return of<ConnectAppEvent>({
           type: "ask-open-app",
           appName,
         });
       }
 
-      if (e instanceof TransportStatusError) {
-        const { statusCode } = e;
+      if (tse.name === "TransportStatusError") {
+        const statusCode = tse.statusCode;
 
         if (
           statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED ||
           statusCode === StatusCodes.INCORRECT_LENGTH ||
-          (0x6600 <= statusCode && statusCode <= 0x67ff)
+          (statusCode !== undefined && 0x6600 <= statusCode && statusCode <= 0x67ff)
         ) {
           return of<ConnectAppEvent>({
             type: "ask-open-app",
@@ -313,7 +310,7 @@ const derivationLogic = (
             // this is likely because it's the wrong app (LNS 1.3.1)
             return attemptToQuitApp(transport, appAndVersion);
         }
-      } else if (e instanceof LockedDeviceError) {
+      } else if (tse.name === "LockedDeviceError") {
         // derivationLogic is also called inside the catchError of cmd below
         // so it needs to handle LockedDeviceError too
         return of({
@@ -479,21 +476,23 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
           }
         }),
         catchError((e: unknown) => {
+          const eName = (e as { name?: string })?.name;
           if (
             (typeof e === "object" &&
               e !== null &&
               "_tag" in e &&
               e._tag === "DeviceDisconnectedWhileSendingError") ||
-            e instanceof DisconnectedDeviceDuringOperation ||
-            e instanceof DisconnectedDevice
+            eName === "DisconnectedDeviceDuringOperation" ||
+            eName === "DisconnectedDevice"
           ) {
             return of(<ConnectAppEvent>{
               type: "disconnected",
             });
           }
 
-          if (e && e instanceof TransportStatusError) {
-            switch (e.statusCode) {
+          const tse2 = e as { name?: string; statusCode?: number };
+          if (tse2.name === "TransportStatusError") {
+            switch (tse2.statusCode) {
               case StatusCodes.CLA_NOT_SUPPORTED: // in 1.3.1 dashboard
               case StatusCodes.INS_NOT_SUPPORTED: // in 1.3.1 and bitcoin app
                 // fallback on "old way" because device does not support getAppAndVersion
@@ -507,7 +506,7 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
                   appName,
                 });
             }
-          } else if (e instanceof LockedDeviceError) {
+          } else if (eName === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectAppEvent);

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -1,11 +1,6 @@
 import { Observable, concat, concatWith, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import {
-  TransportStatusError,
-  DeviceOnDashboardExpected,
-  StatusCodes,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/errors";
 import { isCharonSupported } from "@ledgerhq/device-core";
 import { identifyTargetId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";
@@ -103,21 +98,21 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectManage
           );
         }),
         catchError((e: unknown) => {
-          if (e instanceof LockedDeviceError) {
+          const eName = (e as { name?: string })?.name;
+          if (eName === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectManagerEvent);
           } else if (
-            e instanceof DeviceOnDashboardExpected ||
-            (e &&
-              e instanceof TransportStatusError &&
+            eName === "DeviceOnDashboardExpected" ||
+            (eName === "TransportStatusError" &&
               [
                 StatusCodes.CLA_NOT_SUPPORTED,
                 StatusCodes.INS_NOT_SUPPORTED,
                 StatusCodes.UNKNOWN_APDU,
                 0x6e01, // No StatusCodes definition
                 0x6d01, // No StatusCodes definition
-              ].includes(e.statusCode))
+              ].includes((e as { statusCode: number }).statusCode))
           ) {
             return from(getAppAndVersion(transport)).pipe(
               concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
@@ -1,11 +1,6 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import {
-  DeviceOnDashboardExpected,
-  TransportError,
-  TransportStatusError,
-  StatusCodes,
-} from "@ledgerhq/errors";
+import { TransportError, StatusCodes } from "@ledgerhq/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
@@ -162,11 +157,14 @@ export default function fetchImage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
@@ -1,11 +1,9 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 import {
-  DeviceOnDashboardExpected,
   ManagerNotEnoughSpaceError,
   StatusCodes,
   TransportError,
-  TransportStatusError,
   DisconnectedDevice,
 } from "@ledgerhq/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
@@ -200,11 +198,14 @@ export default function loadImage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transportRef.current)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -2,18 +2,10 @@ import { firstValueFrom, from, Observable, throwError, timer } from "rxjs";
 import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
 import {
-  WrongDeviceForAccount,
-  WrongAppForCurrency,
   CantOpenDevice,
-  UpdateYourApp,
-  BluetoothRequired,
-  TransportWebUSBGestureRequired,
-  TransportInterfaceNotAvailable,
   FirmwareOrAppUpdateRequired,
   TransportStatusError,
   DeviceHalted,
-  PeerRemovedPairing,
-  PairingFailed,
 } from "@ledgerhq/errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@ledgerhq/live-env";
@@ -24,11 +16,12 @@ const LOG_TYPE = "hw";
 const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
   let mappedError = error;
 
-  if (error && error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6faa) {
-      mappedError = new DeviceHalted(error.message);
-    } else if (error.statusCode === 0x6b00) {
-      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+  const tse = error as { name?: string; statusCode?: number; message?: string };
+  if (tse.name === "TransportStatusError") {
+    if (tse.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(tse.message);
+    } else if (tse.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(tse.message);
     }
   }
 
@@ -153,13 +146,14 @@ export const withDevice =
         // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
         .catch(e => {
           tracer.trace(`Error while opening Transport: ${e}`, { error: e });
-          if (e instanceof BluetoothRequired) throw e;
-          if (e instanceof TransportWebUSBGestureRequired) throw e;
-          if (e instanceof TransportInterfaceNotAvailable) throw e;
-          if (e instanceof PeerRemovedPairing) throw e;
-          if (e instanceof PairingFailed) throw e;
+          const eName = (e as { name?: string })?.name;
+          if (eName === "BluetoothRequired") throw e;
+          if (eName === "TransportWebUSBGestureRequired") throw e;
+          if (eName === "TransportInterfaceNotAvailable") throw e;
+          if (eName === "PeerRemovedPairing") throw e;
+          if (eName === "PairingFailed") throw e;
           console.error(e);
-          throw new CantOpenDevice(e.message);
+          throw new CantOpenDevice((e as { message?: string })?.message);
         })
         // Executes the job
         .then(transport => {
@@ -222,15 +216,16 @@ export const withDevicePromise = <T>(deviceId: string, fn: (Transport) => Promis
   firstValueFrom(withDevice(deviceId)(transport => from(fn(transport))));
 
 export const genericCanRetryOnError = (err: unknown): boolean => {
-  if (err instanceof WrongAppForCurrency) return false;
-  if (err instanceof WrongDeviceForAccount) return false;
-  if (err instanceof CantOpenDevice) return false;
-  if (err instanceof BluetoothRequired) return false;
-  if (err instanceof UpdateYourApp) return false;
-  if (err instanceof FirmwareOrAppUpdateRequired) return false;
-  if (err instanceof DeviceHalted) return false;
-  if (err instanceof TransportWebUSBGestureRequired) return false;
-  if (err instanceof TransportInterfaceNotAvailable) return false;
+  const errName = (err as { name?: string })?.name;
+  if (errName === "WrongAppForCurrency") return false;
+  if (errName === "WrongDeviceForAccount") return false;
+  if (errName === "CantOpenDevice") return false;
+  if (errName === "BluetoothRequired") return false;
+  if (errName === "UpdateYourApp") return false;
+  if (errName === "FirmwareOrAppUpdateRequired") return false;
+  if (errName === "DeviceHalted") return false;
+  if (errName === "TransportWebUSBGestureRequired") return false;
+  if (errName === "TransportInterfaceNotAvailable") return false;
   return true;
 };
 

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
@@ -1,7 +1,7 @@
 import { log } from "@ledgerhq/logs";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import { concatMap, delay, scan, distinctUntilChanged, throttleTime } from "rxjs/operators";
-import { CantOpenDevice, DeviceInOSUExpected } from "@ledgerhq/errors";
+import { DeviceInOSUExpected } from "@ledgerhq/errors";
 import { withDevicePolling, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
 import flash from "./flash";
@@ -30,7 +30,7 @@ const main = (
   const withDeviceInstall = install =>
     withDevicePolling(deviceId)(
       install,
-      e => e instanceof CantOpenDevice, // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
+      e => (e as { name?: string })?.name === "CantOpenDevice", // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
     );
 
   const waitForBootloader = withDeviceInfo.pipe(

--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import { DeviceOnDashboardExpected, StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { DeviceOnDashboardExpected, StatusCodes } from "@ledgerhq/errors";
 import { LocalTracer, log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
@@ -24,15 +24,16 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
     .then(({ name }) => isDashboardName(name))
     .catch(e => {
       tracer.trace(`Error from getAppAndVersion: ${e}`, { error: e });
-      if (e instanceof TransportStatusError) {
+      if ((e as { name?: string })?.name === "TransportStatusError") {
+        const statusCode = (e as { statusCode?: number }).statusCode;
         if (
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
         ) {
           return true;
         }
 
-        if (e.statusCode === StatusCodes.INS_NOT_SUPPORTED) {
+        if (statusCode === StatusCodes.INS_NOT_SUPPORTED) {
           return false;
         }
       }
@@ -47,8 +48,9 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
 
   const res = await getVersion(transport).catch(e => {
     tracer.trace(`Error from getVersion: ${e}`, { error: e });
-    if (e instanceof TransportStatusError) {
-      if (e.statusCode === 0x6d06 || e.statusCode === 0x6d07) {
+    if ((e as { name?: string })?.name === "TransportStatusError") {
+      const statusCode = (e as { statusCode?: number }).statusCode;
+      if (statusCode === 0x6d06 || statusCode === 0x6d07) {
         throw new DeviceNotOnboarded();
       }
     }

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
@@ -1,6 +1,5 @@
-import { CantOpenDevice, LockedDeviceError } from "@ledgerhq/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
-import { from, Observable, TimeoutError } from "rxjs";
+import { from, Observable } from "rxjs";
 import { retryWhen, timeout } from "rxjs/operators";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -61,7 +60,7 @@ export const getDeviceRunningMode = ({
               return false;
             }
 
-            if (e instanceof CantOpenDevice) {
+            if ((e as { name?: string })?.name === "CantOpenDevice") {
               if (cantOpenDeviceRetryCount < cantOpenDeviceRetryLimit) {
                 cantOpenDeviceRetryCount++;
                 return true;
@@ -88,7 +87,7 @@ export const getDeviceRunningMode = ({
           if (isLockedDeviceError(e)) {
             o.next({ type: "lockedDevice" });
             o.complete();
-          } else if (e instanceof CantOpenDevice) {
+          } else if ((e as { name?: string })?.name === "CantOpenDevice") {
             o.next({ type: "disconnectedOrlockedDevice" });
             o.complete();
           } else {
@@ -100,5 +99,6 @@ export const getDeviceRunningMode = ({
   });
 
 const isLockedDeviceError = (e: Error) => {
-  return e && (e instanceof TimeoutError || e instanceof LockedDeviceError);
+  const eName = (e as { name?: string })?.name;
+  return e && (eName === "TimeoutError" || eName === "LockedDeviceError");
 };

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
@@ -1,7 +1,6 @@
 import type { SocketEvent } from "@ledgerhq/types-live";
 import { from, Observable } from "rxjs";
 import { mergeMap, retryWhen } from "rxjs/operators";
-import { LockedDeviceError } from "@ledgerhq/errors";
 import getDeviceInfo from "./getDeviceInfo";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import genuineCheck from "./genuineCheck";
@@ -63,7 +62,7 @@ export const getGenuineCheckFromDeviceId = ({
               // Cancels the locked-device unresponsive/timeout strategy if received any response/error
               clearTimeout(lockedDeviceTimeout);
 
-              if (e instanceof LockedDeviceError) {
+              if ((e as { name?: string })?.name === "LockedDeviceError") {
                 subscriber.next({ socketEvent: null, lockedDevice: true });
                 return true;
               }

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -1,19 +1,11 @@
-import { defer, from, of, throwError, Observable, TimeoutError, timer } from "rxjs";
+import { defer, from, of, throwError, Observable, timer } from "rxjs";
 import { map, catchError, first, timeout, repeat, switchMap } from "rxjs/operators";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { withDevice } from "./deviceAccess";
 import {
-  TransportStatusError,
   StatusCodes,
   DeviceOnboardingStatePollingError,
-  DeviceExtractOnboardingStateError,
-  DisconnectedDevice,
-  CantOpenDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
   UnexpectedBootloader,
-  TransportExchangeTimeoutError,
-  DisconnectedDeviceDuringOperation,
 } from "@ledgerhq/errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
@@ -74,9 +66,9 @@ export const getOnboardingStatePolling = ({
       return getVersionObs.pipe(
         catchError((error: unknown) => {
           const isApduNotSupported =
-            error instanceof TransportStatusError &&
+            (error as { name?: string })?.name === "TransportStatusError" &&
             [StatusCodes.CLA_NOT_SUPPORTED, StatusCodes.INS_NOT_SUPPORTED].includes(
-              (error as TransportStatusError).statusCode,
+              (error as { statusCode: number }).statusCode,
             );
 
           if (isApduNotSupported && !hasQuitAppAlreadyRun) {
@@ -113,10 +105,10 @@ export const getOnboardingStatePolling = ({
           try {
             onboardingState = extractOnboardingState(firmwareInfo.flags, firmwareInfo.charonState);
           } catch (error: unknown) {
-            if (error instanceof DeviceExtractOnboardingStateError) {
+            if ((error as { name?: string })?.name === "DeviceExtractOnboardingStateError") {
               return {
                 onboardingState: null,
-                allowedError: error,
+                allowedError: error as Error,
                 lockedDevice: false,
               };
             } else {
@@ -149,7 +141,7 @@ export const getOnboardingStatePolling = ({
           return {
             onboardingState: null,
             allowedError: allowedError,
-            lockedDevice: allowedError instanceof LockedDeviceError,
+            lockedDevice: (allowedError as { name?: string })?.name === "LockedDeviceError",
           };
         }
       }),
@@ -164,19 +156,20 @@ export const getOnboardingStatePolling = ({
 };
 
 export const isAllowedOnboardingStatePollingError = (error: unknown): boolean => {
+  const eName = (error as { name?: string })?.name;
   if (
     error &&
     // Timeout error is thrown by rxjs's timeout
-    (error instanceof TimeoutError ||
-      error instanceof TransportExchangeTimeoutError ||
-      error instanceof DisconnectedDevice ||
-      error instanceof DisconnectedDeviceDuringOperation ||
+    (eName === "TimeoutError" ||
+      eName === "TransportExchangeTimeoutError" ||
+      eName === "DisconnectedDevice" ||
+      eName === "DisconnectedDeviceDuringOperation" ||
       error instanceof DeviceDisconnectedWhileSendingError ||
-      error instanceof CantOpenDevice ||
-      error instanceof TransportRaceCondition ||
-      error instanceof TransportStatusError ||
+      eName === "CantOpenDevice" ||
+      eName === "TransportRaceCondition" ||
+      eName === "TransportStatusError" ||
       // A locked device is handled as an allowed error
-      error instanceof LockedDeviceError)
+      eName === "LockedDeviceError")
   ) {
     return true;
   }

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { UnresponsiveDeviceError, UserRefusedAllowManager } from "@ledgerhq/errors";
+import { UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { isCounterfeitError } from "../isCounterfeitError";
 import type { DeviceId } from "@ledgerhq/types-live";
 import { getGenuineCheckFromDeviceId as defaultGetGenuineCheckFromDeviceId } from "../getGenuineCheckFromDeviceId";
@@ -133,7 +133,7 @@ export const useGenuineCheck = ({
       },
       error: (e: any) => {
         clearTimeoutRef(timeoutRef);
-        if (e instanceof UserRefusedAllowManager) {
+        if ((e as { name?: string })?.name === "UserRefusedAllowManager") {
           setDevicePermissionState("refused");
         } else if (isCounterfeitError(e)) {
           setGenuineState("non-genuine");

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -1,11 +1,6 @@
 import { Observable, throwError, timer } from "rxjs";
 import { throttleTime, filter, map, catchError, retry, switchMap } from "rxjs/operators";
-import {
-  LockedDeviceError,
-  ManagerAppDepInstallRequired,
-  ManagerDeviceLockedError,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";
@@ -68,11 +63,12 @@ export default function installApp(
         retry({
           count: retryLimit,
           delay: (error: unknown, retryCount: number) => {
+            const eName = (error as { name?: string })?.name;
             // Not retrying on locked device errors
             if (
-              error instanceof LockedDeviceError ||
-              error instanceof ManagerDeviceLockedError ||
-              error instanceof UnresponsiveDeviceError
+              eName === "LockedDeviceError" ||
+              eName === "ManagerDeviceLocked" ||
+              eName === "UnresponsiveDeviceError"
             ) {
               tracer.trace(`Not retrying on error: ${error}`, {
                 error,

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -1,10 +1,8 @@
 import {
-  DeviceOnDashboardExpected,
   LanguageNotFound,
   ManagerNotEnoughSpaceError,
   StatusCodes,
   TransportError,
-  TransportStatusError,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
@@ -131,11 +129,14 @@ export default function installLanguage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode?: number })?.statusCode ?? -1,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/renameDevice.ts
@@ -1,6 +1,5 @@
 import { concat, defer, from, Observable, of, throwError } from "rxjs";
 import { catchError, concatMap } from "rxjs/operators";
-import { DisconnectedDevice } from "@ledgerhq/errors";
 import { withDevice } from "./deviceAccess";
 import editDeviceName from "./editDeviceName";
 import getAppAndVersion from "./getAppAndVersion";
@@ -92,7 +91,7 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
             /**
              * If the error is that the device is not on the dashboard, we retry the innerSub
              */
-            if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+            if (error.message === "not on dashboard" || error.name === "DisconnectedDevice") {
               return innerSub;
             }
 
@@ -117,7 +116,7 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
        * We do have a global timeout so that we are not in a infinite loop
        *
        */
-      if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+      if (error.message === "not on dashboard" || error.name === "DisconnectedDevice") {
         return of<RenameDeviceEvent>({
           type: "disconnected",
           expected: true,

--- a/libs/ledger-live-common/src/hw/uninstallLanguage.ts
+++ b/libs/ledger-live-common/src/hw/uninstallLanguage.ts
@@ -1,6 +1,5 @@
 import { Observable, from, of, throwError, EMPTY } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import { DeviceOnDashboardExpected, TransportStatusError } from "@ledgerhq/errors";
 
 import { withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -80,11 +79,14 @@ export default function unistallLanguage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode?: number })?.statusCode ?? -1,
+                  ))
               ) {
                 const quitAppObservable = from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
@@ -1,10 +1,8 @@
-import { TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { DeviceConnectionResult, Job } from "@ledgerhq/device-intent";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getMainAccount } from "../../account/index";
 import { getAccountBridge } from "../../bridge/index";
 import { sendFeatures } from "../../bridge/descriptor/send/features";
-import { TransactionRefusedOnDevice } from "../../errors";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { SignOperationEvent } from "@ledgerhq/types-live";
 import { Observable, type Subscription } from "rxjs";
@@ -25,9 +23,10 @@ function buildSigningDevice(connectionResult: DeviceConnectionResult): SigningDe
 function isUserRefusalError(error: unknown, currency: CryptoOrTokenCurrency | undefined): boolean {
   return (
     sendFeatures.isUserRefusedTransactionError(currency, error) ||
-    error instanceof TransactionRefusedOnDevice ||
-    error instanceof UserRefusedOnDevice ||
-    (error instanceof TransportStatusError && error.statusCode === 0x6985)
+    (error as { name?: string })?.name === "TransactionRefusedOnDevice" ||
+    (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+    ((error as { name?: string; statusCode?: number })?.name === "TransportStatusError" &&
+      (error as { statusCode?: number })?.statusCode === 0x6985)
   );
 }
 

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -7,7 +7,6 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   ManagerNotEnoughSpaceError,
   NetworkDown,
-  TransportStatusError,
   UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
@@ -60,10 +59,11 @@ const remapSocketError = (context?: string) =>
       return throwError(() => new DeviceOnDashboardExpected());
     }
 
+    const statusCode = (e as { statusCode?: number }).statusCode;
     const status =
-      e instanceof TransportStatusError
-        ? e.statusCode.toString(16)
-        : (e as Error).message.slice((e as Error).message.length - 4);
+      (e as { name?: string })?.name === "TransportStatusError" && statusCode !== undefined
+        ? statusCode.toString(16)
+        : (e as { message?: string })?.message?.slice(-4);
 
     // TODO use StatusCode instead of this.
     switch (status) {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.ts
@@ -701,10 +701,10 @@ export const handlers = ({
               const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
               const errorMessageWithCause = rawErrorMessage + causeSuffix;
 
-              const completeExchangeError =
+              const completeExchangeError: CompleteExchangeError =
                 // step provided in libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
-                error instanceof CompleteExchangeError
-                  ? error
+                (error as { name?: string })?.name === "CompleteExchangeError"
+                  ? (error as CompleteExchangeError)
                   : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
 
               postSwapCancelled({

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -7,7 +7,6 @@ import { WalletHandlers, ServerConfig, WalletAPIServer } from "@ledgerhq/wallet-
 import { Transport, Permission } from "@ledgerhq/wallet-api-core";
 import { first } from "rxjs/operators";
 import { getEnv } from "@ledgerhq/live-env";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { cryptoAssetsApi } from "@domain/api-currency-token";
 import { ThunkDispatch, UnknownAction } from "@reduxjs/toolkit";
@@ -24,6 +23,7 @@ import {
   setWalletApiIdForAccountId,
 } from "./converters";
 import { AccountPublicKeyUnavailable } from "../errors";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { isWalletAPISupportedCurrency } from "./helpers";
 import {
   WalletAPICurrency,

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -39,7 +39,6 @@ import {
 } from "../account/balanceHistoryCache";
 import { shouldRetainPendingOperation } from "../account/pending";
 import { shouldShowNewAccount } from "../account/support";
-import { UnsupportedDerivation } from "../errors";
 import getAddressWrapper, { GetAddressFn } from "./getAddressWrapper";
 import type { GetAddressResult } from "../derivation";
 import type { CryptoCurrency } from "../types";
@@ -536,7 +535,7 @@ export const makeScanAccounts =
 
                 derivationsCache[seedCacheKey] = result;
               } catch (e) {
-                if (e instanceof UnsupportedDerivation) {
+                if ((e as { name?: string })?.name === "UnsupportedDerivation") {
                   log("scanAccounts", "ignore derivationMode=" + derivationMode);
                   continue;
                 }

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
-import { DisconnectedDevice } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
+import { DisconnectedDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { Subject } from "rxjs";
 

--- a/libs/live-dmk-mobile/src/connectDevice/utils.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/utils.ts
@@ -10,7 +10,6 @@ import {
   type MatchedDevice,
 } from "@ledgerhq/live-dmk-shared";
 import { isPeerRemovedPairingError } from "../errors";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { BaseConnectionErrorTypes, ConnectionErrorTypes, MobileConnectionError } from "./types";
 import { findMatchingNewDevice } from "../utils/matchDevicesByNameOrId";
 import { buildUsbCompatDeviceId } from "../transport/usbCompatDeviceId";
@@ -66,7 +65,10 @@ export const createConnectionError = (error: unknown): MobileConnectionError => 
     };
   }
 
-  if (error instanceof PeerRemovedPairing || isPeerRemovedPairingError(error)) {
+  if (
+    (error as { name?: string })?.name === "PeerRemovedPairing" ||
+    isPeerRemovedPairingError(error)
+  ) {
     return {
       type: ConnectionErrorTypes.BlePairingPeerRemovedPairing,
     };

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -5,12 +5,8 @@ import {
   type DeviceSessionState,
   DeviceStatus,
   DiscoveredDevice,
-  OpeningConnectionError,
 } from "@ledgerhq/device-management-kit";
-import {
-  PairingRefusedError,
-  rnBleTransportIdentifier,
-} from "@ledgerhq/device-transport-kit-react-native-ble";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
 import { activeDeviceSessionSubject, dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer, TraceContext } from "@ledgerhq/logs";
 import {
@@ -230,13 +226,11 @@ export class DeviceManagementKitBLETransport extends Transport {
             getDeviceManagementKit().stopDiscovering();
 
             tracer.trace("[DMKTransport] [open2] error", error);
-            if (error instanceof PairingRefusedError) {
+            const eName = (error as { name?: string })?.name;
+            if (eName === "PairingRefusedError") {
               // NB: in LLM, we don't have a specific error for pairing refused, so we remap it to PairingFailed
               return throwError(() => new PairingFailed());
-            } else if (
-              error instanceof PeerRemovedPairing ||
-              error instanceof OpeningConnectionError
-            ) {
+            } else if (eName === "PeerRemovedPairing" || eName === "OpeningConnectionError") {
               return throwError(() => error);
             }
 

--- a/libs/live-signer-solana/src/LegacySignerSolana.ts
+++ b/libs/live-signer-solana/src/LegacySignerSolana.ts
@@ -7,7 +7,7 @@ import {
   SolanaSigner,
 } from "@ledgerhq/coin-solana/signer";
 import Solana from "@ledgerhq/hw-app-solana";
-import Transport, { TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId } from "@ledgerhq/devices";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";
@@ -25,8 +25,12 @@ import { LatestFirmwareVersionRequired, UpdateYourApp } from "@ledgerhq/errors";
 const MIN_VERSION = "1.9.2";
 const MANAGER_APP_NAME = "Solana";
 
-function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+function isPKIUnsupportedError(err: unknown): boolean {
+  const errName = (err as { name?: string })?.name;
+  return (
+    errName === "TransportStatusError" &&
+    !!(err as { message?: string })?.message?.includes("0x6a81")
+  );
 }
 
 async function tryLoadPKI(...args: Parameters<typeof loadPKI>) {

--- a/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
+++ b/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
@@ -3,7 +3,6 @@ import { CloudSyncSDKInterface } from "../cloudsync";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { WalletSyncDataManager } from "./types";
 import { log } from "@ledgerhq/logs";
-import { TrustchainEjected, TrustchainOutdated } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Subscription } from "rxjs";
 
 export type WatchConfig = {
@@ -152,7 +151,8 @@ export function createWalletSyncWatchLoop<UserState, LocalState, Update, Schema 
         await walletSyncSdk.push(trustchain, memberCredentials, diff.nextState);
       }
     } catch (e) {
-      const shouldRefresh = e instanceof TrustchainEjected || e instanceof TrustchainOutdated;
+      const eName = (e as { name?: string })?.name;
+      const shouldRefresh = eName === "TrustchainEjected" || eName === "TrustchainOutdated";
       if (shouldRefresh) {
         await onTrustchainRefreshNeeded(trustchain);
         return;


### PR DESCRIPTION
STATUS: PHASE 1 has been rolled out by a lot of PR splits.

### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across ~280 files in all packages.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** 

This is also toward what comes next: Phase 2 moves error classes to per-package `errors.ts` files (native ES classes, no longer registered via `createCustomErrorClass`) and overall we will will fully drop  `@ledgerhq/errors`

But also:

- We are decoupling the error from their actual class creator: we no longer need to import the error class to query if it's an error of this class.
- We allow them to be matchable even if the class don't equal by reference. Notably as we will drop the serialization/deserialization mechanism (that cache the classes), `instanceof` could have silently failed across serialization/deserialization boundaries. Switching to `.name` checks now makes the codebase safe before any import migration happens. 

**NB: @ledger/errors library already documented this pattern as well as deprecating the old approaches.**

### 🔗 Context

- **JIRA**: [LIVE-32915]
- **Big picture**: #19723

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ