### PR TITLE
[LWDM] feat(LIVE-33229): limit aleo swaps to public balance only

### DIFF
--- a/.changeset/eleven-otters-fix.md
+++ b/.changeset/eleven-otters-fix.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/types-live": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: limit aleo swaps to public balance only

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -463,6 +463,7 @@
     "src/e2e/enum/TransactionStatus.ts",
     "src/e2e/models/BuySell.ts",
     "src/exchange/swap/const/blockchain.ts",
+    "src/families/aleo/bridgeExtensions.ts",
     "src/families/aleo/constants.ts",
     "src/families/aleo/errors.ts",
     "src/families/aleo/hw/getViewKey/index.ts",

--- a/libs/ledger-live-common/src/bridge/defaultBridgeExtensions.ts
+++ b/libs/ledger-live-common/src/bridge/defaultBridgeExtensions.ts
@@ -60,4 +60,5 @@ export const defaultBridgeExtensions: Required<AccountBridgeExtensions> = {
   isTransactionConfirmed: async () => {
     throw new Error("isTransactionConfirmed is not supported for this currency");
   },
+  getWalletApiSpendableBalance: account => account.spendableBalance,
 };

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -8,6 +8,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadTransaction: () => import("@ledgerhq/coin-aleo/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-aleo/deviceTransactionConfig").then(m => m.default),
+    loadBridgeExtensions: () => import("../families/aleo/bridgeExtensions").then(m => m.default),
   },
   {
     family: "algorand",

--- a/libs/ledger-live-common/src/families/aleo/bridgeExtensions.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/bridgeExtensions.test.ts
@@ -1,0 +1,55 @@
+import BigNumber from "bignumber.js";
+import type { AleoAccount, AleoTokenAccount } from "@ledgerhq/coin-aleo/types";
+import extensions from "./bridgeExtensions";
+import { makeAleoAccount } from "./__mocks__/account.mock";
+
+describe("aleo bridgeExtensions", () => {
+  const mockAccount = makeAleoAccount();
+
+  describe("getWalletApiSpendableBalance", () => {
+    it("returns the token account's transparentBalance for a TokenAccount", () => {
+      const tokenAccount = {
+        type: "TokenAccount",
+        token: { parentCurrencyId: mockAccount.currency.id },
+        transparentBalance: new BigNumber(123),
+      } as AleoTokenAccount;
+
+      const result = extensions.getWalletApiSpendableBalance?.(tokenAccount);
+
+      expect(result).toEqual(new BigNumber(123));
+    });
+
+    it("returns the account's aleoResources.transparentBalance for a main Account", () => {
+      const account: AleoAccount = {
+        ...mockAccount,
+        aleoResources: {
+          ...mockAccount.aleoResources!,
+          transparentBalance: new BigNumber(456),
+        },
+      };
+
+      const result = extensions.getWalletApiSpendableBalance?.(account);
+
+      expect(result).toEqual(new BigNumber(456));
+    });
+
+    it("falls back to zero when the main Account has no aleoResources", () => {
+      const account = { ...mockAccount, aleoResources: undefined };
+
+      const result = extensions.getWalletApiSpendableBalance?.(account);
+
+      expect(result).toEqual(new BigNumber(0));
+    });
+
+    it("throws an error when the account is not an aleo account", () => {
+      const account = {
+        ...mockAccount,
+        currency: { ...mockAccount.currency, family: "bitcoin" },
+      };
+
+      expect(() => extensions.getWalletApiSpendableBalance?.(account)).toThrow(
+        "aleo: invalid account in bridgeExtensions",
+      );
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
+++ b/libs/ledger-live-common/src/families/aleo/bridgeExtensions.ts
@@ -1,0 +1,18 @@
+import BigNumber from "bignumber.js";
+import invariant from "invariant";
+import { isAleoAccount } from "@ledgerhq/coin-aleo/logic/utils";
+import type { AccountBridgeExtensions } from "@ledgerhq/types-live";
+
+const extensions: AccountBridgeExtensions = {
+  getWalletApiSpendableBalance: account => {
+    invariant(isAleoAccount(account), "aleo: invalid account in bridgeExtensions");
+
+    if (account.type === "TokenAccount") {
+      return account.transparentBalance;
+    }
+
+    return account.aleoResources?.transparentBalance ?? new BigNumber(0);
+  },
+};
+
+export default extensions;

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
@@ -59,6 +59,7 @@ const mockBridge = {
   hasMinimumFundsToSpeedUp: jest.fn(),
   isStrategyDisabled: jest.fn(),
   isTransactionConfirmed: jest.fn(),
+  getWalletApiSpendableBalance: jest.fn(),
 };
 
 describe("useBridgeRecipientValidation", () => {

--- a/libs/ledger-live-common/src/wallet-api/converters.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.test.ts
@@ -1,8 +1,13 @@
-import { Account } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import "../__tests__/test-helpers/setup";
 import type { Transaction } from "../coin-modules/transaction-types";
-import { getWalletAPITransactionSignFlowInfos } from "./converters";
+import { getAccountBridge } from "../bridge";
+import {
+  getWalletAPITransactionSignFlowInfos,
+  resolveWalletApiSpendableBalance,
+} from "./converters";
 import type { WalletAPITransaction } from "./types";
 
 const evmBridge = jest.fn();
@@ -19,6 +24,18 @@ jest.mock("../coin-modules/registry", () => ({
     }
   },
 }));
+
+jest.mock("../bridge", () => ({
+  getAccountBridge: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/logs", () => ({
+  ...jest.requireActual("@ledgerhq/logs"),
+  log: jest.fn(),
+}));
+
+const mockLog = jest.mocked(log);
+const mockGetAccountBridge = jest.mocked(getAccountBridge);
 
 describe("getWalletAPITransactionSignFlowInfos", () => {
   beforeEach(() => {
@@ -92,5 +109,46 @@ describe("getWalletAPITransactionSignFlowInfos", () => {
     expect(canEditFees).toBe(false);
     expect(hasFeesProvided).toBe(false);
     expect(liveTx).toEqual(expectedLiveTx);
+  });
+});
+
+describe("resolveWalletApiSpendableBalance", () => {
+  const account = { spendableBalance: new BigNumber(100) } as AccountLike;
+
+  beforeEach(() => {
+    mockGetAccountBridge.mockReset();
+    mockLog.mockClear();
+  });
+
+  it("returns the bridge's getWalletApiSpendableBalance result", async () => {
+    // Given
+    const bridgeSpendableBalance = new BigNumber(42);
+
+    mockGetAccountBridge.mockResolvedValue({
+      getWalletApiSpendableBalance: jest.fn().mockReturnValue(bridgeSpendableBalance),
+    } as never);
+
+    // When
+    const result = await resolveWalletApiSpendableBalance(account);
+
+    // Then
+    expect(result).toEqual(bridgeSpendableBalance);
+  });
+
+  it("falls back to account.spendableBalance and logs when the bridge lookup fails", async () => {
+    // Given
+    mockGetAccountBridge.mockRejectedValue(new Error("unsupported family"));
+
+    // When
+    const result = await resolveWalletApiSpendableBalance(account);
+
+    // Then
+    expect(result).toEqual(account.spendableBalance);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledWith(
+      "wallet-api/converters",
+      expect.stringContaining("falling back to account.spendableBalance"),
+      { error: "unsupported family" },
+    );
   });
 });

--- a/libs/ledger-live-common/src/wallet-api/converters.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.ts
@@ -1,10 +1,13 @@
-import { Account, AccountLike } from "@ledgerhq/types-live";
+import type BigNumber from "bignumber.js";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import { log } from "@ledgerhq/logs";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { v5 as uuidv5 } from "uuid";
 import { WalletState, accountNameWithDefaultSelector } from "@ledgerhq/live-wallet/store";
 import { loadWalletApiAdapterForFamily } from "../coin-modules/registry";
 import type { Transaction } from "../coin-modules/transaction-types";
 import { isTokenAccount } from "../account";
+import { getAccountBridge } from "../bridge";
 import {
   WalletAPIAccount,
   WalletAPICurrency,
@@ -135,3 +138,20 @@ export const getWalletAPITransactionSignFlowInfos = async ({
     hasFeesProvided: false,
   };
 };
+
+export async function resolveWalletApiSpendableBalance(
+  account: AccountLike,
+  parentAccount?: Account | null,
+): Promise<BigNumber> {
+  try {
+    const bridge = await getAccountBridge(account, parentAccount);
+    return bridge.getWalletApiSpendableBalance(account);
+  } catch (error) {
+    log(
+      "wallet-api/converters",
+      "resolveWalletApiSpendableBalance: falling back to account.spendableBalance",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+    return account.spendableBalance;
+  }
+}

--- a/libs/ledger-live-common/src/wallet-api/react.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.test.ts
@@ -2,13 +2,15 @@
  * @jest-environment jsdom
  */
 import { renderHook, act, cleanup } from "@testing-library/react";
+import BigNumber from "bignumber.js";
+import type { WalletHandlers } from "@ledgerhq/wallet-api-server";
 import { initialState as walletState } from "@ledgerhq/live-wallet/store";
 import { createFixtureAccount } from "../mock/fixtures/cryptoCurrencies";
 import type { TrackingAPI } from "./tracking";
 import type { useWalletAPIServerOptions } from "./react";
 import { AccountPublicKeyUnavailable } from "../errors";
 import { accountGetPublicKeyLogic } from "./logic";
-import { getAccountIdFromWalletAccountId } from "./converters";
+import { getAccountIdFromWalletAccountId, resolveWalletApiSpendableBalance } from "./converters";
 
 const mockSetHandler = jest.fn();
 const mockSetConfig = jest.fn();
@@ -47,6 +49,7 @@ jest.mock("./converters", () => ({
   ...jest.requireActual("./converters"),
   setWalletApiIdForAccountId: jest.fn(),
   getAccountIdFromWalletAccountId: jest.fn(),
+  resolveWalletApiSpendableBalance: jest.fn(),
 }));
 
 jest.mock("./logic", () => ({
@@ -79,6 +82,11 @@ jest.mock("../currencies", () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { useWalletAPIServer } = require("./react");
+
+function getRegisteredHandler<Name extends keyof WalletHandlers>(name: Name): WalletHandlers[Name] {
+  const calls = mockSetHandler.mock.calls.filter(([handlerName]) => handlerName === name);
+  return calls[calls.length - 1]?.[1];
+}
 
 function createDefaultOptions(
   overrides?: Partial<useWalletAPIServerOptions>,
@@ -272,11 +280,69 @@ describe("useWalletAPIServer", () => {
   });
 });
 
+describe("account.list handler", () => {
+  const getHandler = () => getRegisteredHandler("account.list");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("resolves accounts with the spendableBalance from resolveWalletApiSpendableBalance", async () => {
+    const account = createFixtureAccount("01");
+    const spendableBalance = new BigNumber(999);
+    const options = createDefaultOptions({ accounts: [account] });
+
+    jest.mocked(resolveWalletApiSpendableBalance).mockResolvedValue(spendableBalance);
+
+    renderHook(() => useWalletAPIServer(options));
+    const result = await getHandler()({});
+
+    expect(result).toEqual([expect.objectContaining({ spendableBalance })]);
+    expect(resolveWalletApiSpendableBalance).toHaveBeenCalledTimes(1);
+    expect(resolveWalletApiSpendableBalance).toHaveBeenCalledWith(account, account);
+  });
+});
+
+describe("account.request handler", () => {
+  const getHandler = () => getRegisteredHandler("account.request");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("resolves with the spendableBalance from resolveWalletApiSpendableBalance", async () => {
+    const account = createFixtureAccount("01");
+    const spendableBalance = new BigNumber(777);
+
+    jest.mocked(resolveWalletApiSpendableBalance).mockResolvedValue(spendableBalance);
+    const uiAccountRequest = jest.fn(({ onSuccess }) => {
+      onSuccess(account, undefined);
+    });
+
+    const options = createDefaultOptions({
+      accounts: [account],
+      uiHook: { "account.request": uiAccountRequest },
+    });
+
+    renderHook(() => useWalletAPIServer(options));
+    const result = await getHandler()({});
+
+    expect(result).toEqual(expect.objectContaining({ spendableBalance }));
+    expect(resolveWalletApiSpendableBalance).toHaveBeenCalledTimes(1);
+    expect(resolveWalletApiSpendableBalance).toHaveBeenCalledWith(account, undefined);
+  });
+});
+
 describe("account.getPublicKey handler", () => {
-  const getHandler = () => {
-    const calls = mockSetHandler.mock.calls.filter(([name]) => name === "account.getPublicKey");
-    return calls[calls.length - 1]?.[1] as (arg: { accountId: string }) => Promise<string>;
-  };
+  const getHandler = () => getRegisteredHandler("account.getPublicKey");
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -22,6 +22,7 @@ import {
   currencyToWalletAPICurrency,
   getAccountIdFromWalletAccountId,
   setWalletApiIdForAccountId,
+  resolveWalletApiSpendableBalance,
 } from "./converters";
 import { AccountPublicKeyUnavailable } from "../errors";
 import { isWalletAPISupportedCurrency } from "./helpers";
@@ -507,7 +508,7 @@ export function useWalletAPIServer({
   }, [walletState, manifest, server, tracking, dispatch, deactivatedCurrencyIds]);
 
   useEffect(() => {
-    server.setHandler("account.list", ({ currencyIds }) => {
+    server.setHandler("account.list", async ({ currencyIds }) => {
       // 1. Parse manifest currency patterns to determine what to include
       const manifestCurrencyIds = manifest.currencies === "*" ? ["**"] : manifest.currencies;
 
@@ -554,25 +555,31 @@ export function useWalletAPIServer({
       }
 
       // 4. Filter accounts based on effective currency IDs
-      const wapiAccounts = accounts.reduce<WalletAPIAccount[]>((acc, account) => {
-        const parentAccount = getParentAccount(account, accounts);
+      const filteredAccounts = accounts.filter(account => {
         const accountCurrencyId =
           account.type === "TokenAccount" ? account.token.id : account.currency.id;
         const parentCurrencyId =
           account.type === "TokenAccount" ? account.token.parentCurrencyId : account.currency.id;
 
         // Check if account currency ID matches the effective patterns
-        const isAllowed =
+        return (
           includeAllCurrencies ||
           allowedCurrencyIds.has(accountCurrencyId) ||
-          tokenFamilyPrefixes.has(parentCurrencyId);
+          tokenFamilyPrefixes.has(parentCurrencyId)
+        );
+      });
 
-        if (isAllowed) {
-          acc.push(accountToWalletAPIAccount(walletState, account, parentAccount));
-        }
+      const wapiAccounts = await Promise.all(
+        filteredAccounts.map(async (account): Promise<WalletAPIAccount> => {
+          const parentAccount = getParentAccount(account, accounts);
+          const spendableBalance = await resolveWalletApiSpendableBalance(account, parentAccount);
 
-        return acc;
-      }, []);
+          return {
+            ...accountToWalletAPIAccount(walletState, account, parentAccount),
+            spendableBalance,
+          };
+        }),
+      );
 
       return wapiAccounts;
     });
@@ -594,11 +601,24 @@ export function useWalletAPIServer({
               areCurrenciesFiltered,
               useCase,
               uiUseCase,
-              onSuccess: (account: AccountLike, parentAccount: Account | undefined) => {
+              onSuccess: async (account: AccountLike, parentAccount: Account | undefined) => {
                 if (done) return;
                 done = true;
-                tracking.requestAccountSuccess(manifest);
-                resolve(accountToWalletAPIAccount(walletState, account, parentAccount));
+                try {
+                  const spendableBalance = await resolveWalletApiSpendableBalance(
+                    account,
+                    parentAccount,
+                  );
+
+                  tracking.requestAccountSuccess(manifest);
+                  resolve({
+                    ...accountToWalletAPIAccount(walletState, account, parentAccount),
+                    spendableBalance,
+                  });
+                } catch (error) {
+                  tracking.requestAccountFail(manifest);
+                  reject(error);
+                }
               },
               onCancel: () => {
                 if (done) return;

--- a/libs/ledgerjs/packages/types-live/src/bridge.ts
+++ b/libs/ledgerjs/packages/types-live/src/bridge.ts
@@ -328,6 +328,7 @@ export interface AccountBridgeExtensions<T extends TransactionCommon = Transacti
   }) => Promise<boolean>;
   isStrategyDisabled?: (args: { transaction: T; feeData: unknown }) => boolean;
   isTransactionConfirmed?: (args: { account: AccountLike; hash: string }) => Promise<boolean>;
+  getWalletApiSpendableBalance?: (account: AccountLike) => BigNumber;
 }
 
 export type AccountBridge<


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds a `getWalletApiSpendableBalance` bridge extension so wallet-api consumers (live apps, e.g. Swap) can report a currency-specific spendable balance instead of always using `account.spendableBalance`. The default implementation preserves current behavior for every currency. Aleo gets a dedicated implementation that returns only the transparent (public) balance. `account.list` and `account.request` in the wallet-api server now resolve this value asynchronously per account, with a fallback to `account.spendableBalance` if bridge resolution fails.

Impact of changes

- Aleo account exposed via wallet-api account.list/account.request (e.g. in the Swap live app) reports only the public/transparent balance as spendable — private balance must not be offered for swap.
- Aleo token accounts via wallet-api report their own transparentBalance, not total balance.
- All non-Aleo currencies: spendable balance in account.list/account.request responses is unchanged from before (falls through to account.spendableBalance).
- Bridge-resolution failure path: spendable balance still populates via fallback, no crash/hang in account.list.


| account state | develop | this branch |
|----|--|--|
| <img width="1800" height="1169" alt="acc-state" src="https://github.com/user-attachments/assets/73090baa-e725-465f-ab6d-d26c42b75af9" /> | <img width="1800" height="1169" alt="swap-send-max-before-fix" src="https://github.com/user-attachments/assets/14d7bfa9-3b14-440d-80d7-c35aebb51604" /> | <img width="1800" height="1169" alt="swap-send-max-after-fix" src="https://github.com/user-attachments/assets/ce6b0ef9-f1ba-4cba-ab16-7db6fb56f5f4" /> |

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-33229