### PR TITLE
[LWDM] Fix undelegation completion date

### DIFF
--- a/.changeset/soft-eagles-jog.md
+++ b/.changeset/soft-eagles-jog.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+Fix the Babylon (BABY) undelegation completion date, which showed the chain's 21-day x/staking unbonding time instead of Babylon's ~2-day fast unbonding. On epoched chains the date is now re-anchored to the unbonding's creation height plus the effective unbonding period.

--- a/.changeset/soft-eagles-jog.md
+++ b/.changeset/soft-eagles-jog.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-cosmos": minor
+"@ledgerhq/coin-cosmos": patch
 ---
 
 Fix the Babylon (BABY) undelegation completion date, which showed the chain's 21-day x/staking unbonding time instead of Babylon's ~2-day fast unbonding. On epoched chains the date is now re-anchored to the unbonding's creation height plus the effective unbonding period.

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -18,7 +18,11 @@ import {
   CosmosUnbonding,
   CosmosValidatorItem,
 } from "../types";
-import { fetchQueuedStakingMessages, mergeQueuedMessages } from "./babylonEpoching";
+import {
+  estimateEpochedUnbondingCompletion,
+  fetchQueuedStakingMessages,
+  mergeQueuedMessages,
+} from "./babylonEpoching";
 import * as CosmosSDKTypes from "./types";
 
 const USDC_DENOM = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5";
@@ -82,6 +86,19 @@ export class CosmosAPI {
       let staking = { delegations, redelegations, unbondings };
 
       if (this.chainInstance.epochedStaking) {
+        staking.unbondings = staking.unbondings.map(u =>
+          u.creationHeight === undefined
+            ? u
+            : {
+                ...u,
+                completionDate: estimateEpochedUnbondingCompletion(
+                  u.creationHeight,
+                  blockHeight,
+                  this.chainInstance.unbondingPeriod,
+                ),
+              },
+        );
+
         const queued = await fetchQueuedStakingMessages(
           this.defaultEndpoint,
           address,
@@ -372,11 +389,16 @@ export class CosmosAPI {
     });
 
     for (const { validator_address: validatorAddress, entries } of unbondingResponses) {
-      for (const { initial_balance: initialBalance, completion_time: completionTime } of entries) {
+      for (const {
+        initial_balance: initialBalance,
+        completion_time: completionTime,
+        creation_height: creationHeight,
+      } of entries) {
         unbondings.push({
           validatorAddress,
           amount: new BigNumber(initialBalance),
           completionDate: new Date(completionTime),
+          creationHeight: Number(creationHeight),
         });
       }
     }

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -399,7 +399,6 @@ export class CosmosAPI {
           validatorAddress,
           amount: new BigNumber(initialBalance),
           completionDate: new Date(completionTime),
-          // a non-numeric height is omitted so the re-anchor is skipped (avoids an Invalid Date)
           ...(Number.isFinite(parsedCreationHeight)
             ? { creationHeight: parsedCreationHeight }
             : {}),

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.ts
@@ -394,11 +394,15 @@ export class CosmosAPI {
         completion_time: completionTime,
         creation_height: creationHeight,
       } of entries) {
+        const parsedCreationHeight = Number(creationHeight);
         unbondings.push({
           validatorAddress,
           amount: new BigNumber(initialBalance),
           completionDate: new Date(completionTime),
-          creationHeight: Number(creationHeight),
+          // a non-numeric height is omitted so the re-anchor is skipped (avoids an Invalid Date)
+          ...(Number.isFinite(parsedCreationHeight)
+            ? { creationHeight: parsedCreationHeight }
+            : {}),
         });
       }
     }

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -632,7 +632,6 @@ describe("CosmosApi", () => {
       msg_type: "cosmos.staking.v1beta1.MsgDelegate",
       msg: `delegator_address:"bbn1someoneelse" validator_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"99" >`,
     };
-    // x/staking returns the standard 21-day completion_time; Babylon's real release is ~2 days
     const processedUnbonding = {
       validator_address: "bbnvaloper1active",
       entries: [

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -840,5 +840,19 @@ describe("CosmosApi", () => {
         }),
       ]);
     });
+
+    it("skips the re-anchor and keeps completion_time when creation_height is missing/non-numeric", async () => {
+      const malformed = {
+        validator_address: "bbnvaloper1active",
+        entries: [{ initial_balance: "500000", completion_time: "2026-08-10T07:10:27.684611546Z" }],
+      };
+      mockAccountInfoRoutes({ height: 4_016_182, unbondings: [malformed as never] });
+      const babylonApi = new CosmosAPI("babylon");
+
+      const [unbonding] = (await babylonApi.getAccountInfo(babylonAddress, babylonCurrency))
+        .unbondings;
+      expect(unbonding.completionDate).toEqual(new Date("2026-08-10T07:10:27.684611546Z"));
+      expect(Number.isNaN(unbonding.completionDate.getTime())).toBe(false);
+    });
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -652,7 +652,7 @@ describe("CosmosApi", () => {
       epochingError?: boolean;
       unbondings?: {
         validator_address: string;
-        entries: { initial_balance: string; completion_time: string; creation_height: string }[];
+        entries: { initial_balance: string; completion_time: string; creation_height?: string }[];
       }[];
     }) => {
       const {
@@ -846,7 +846,7 @@ describe("CosmosApi", () => {
         validator_address: "bbnvaloper1active",
         entries: [{ initial_balance: "500000", completion_time: "2026-08-10T07:10:27.684611546Z" }],
       };
-      mockAccountInfoRoutes({ height: 4_016_182, unbondings: [malformed as never] });
+      mockAccountInfoRoutes({ height: 4_016_182, unbondings: [malformed] });
       const babylonApi = new CosmosAPI("babylon");
 
       const [unbonding] = (await babylonApi.getAccountInfo(babylonAddress, babylonCurrency))

--- a/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/Cosmos.unit.test.ts
@@ -632,6 +632,17 @@ describe("CosmosApi", () => {
       msg_type: "cosmos.staking.v1beta1.MsgDelegate",
       msg: `delegator_address:"bbn1someoneelse" validator_address:"bbnvaloper1pending" amount:<denom:"ubbn" amount:"99" >`,
     };
+    // x/staking returns the standard 21-day completion_time; Babylon's real release is ~2 days
+    const processedUnbonding = {
+      validator_address: "bbnvaloper1active",
+      entries: [
+        {
+          initial_balance: "500000",
+          completion_time: "2026-08-10T07:10:27.684611546Z",
+          creation_height: "4016160",
+        },
+      ],
+    };
 
     const mockAccountInfoRoutes = (opts: {
       height?: number;
@@ -639,6 +650,10 @@ describe("CosmosApi", () => {
       epochBoundary?: string;
       msgs?: { msg: string; msg_type: string }[];
       epochingError?: boolean;
+      unbondings?: {
+        validator_address: string;
+        entries: { initial_balance: string; completion_time: string; creation_height: string }[];
+      }[];
     }) => {
       const {
         height = 100,
@@ -646,6 +661,7 @@ describe("CosmosApi", () => {
         epochBoundary = "360",
         msgs = [],
         epochingError = false,
+        unbondings = [],
       } = opts;
       let currentEpochCalls = 0;
       // @ts-expect-error method is mocked
@@ -687,7 +703,7 @@ describe("CosmosApi", () => {
           return respond({ redelegation_responses: [] });
         }
         if (url.includes("/unbonding_delegations")) {
-          return respond({ unbonding_responses: [] });
+          return respond({ unbonding_responses: unbondings });
         }
         if (url.includes("/withdraw_address")) {
           return respond({ withdraw_address: babylonAddress });
@@ -789,6 +805,40 @@ describe("CosmosApi", () => {
       const requestedUrls = mockedNetwork.mock.calls.map(([options]) => options.url);
       expect(requestedUrls.length).toBeGreaterThan(0);
       expect(requestedUrls.some(url => url?.includes("epoching"))).toBe(false);
+    });
+
+    it("re-anchors a processed babylon unbonding to the fast-unbonding period, not the chain's 21-day completion_time", async () => {
+      const height = 4_016_182; // 22 blocks past the unbonding's creation_height (4016160)
+      mockAccountInfoRoutes({ height, unbondings: [processedUnbonding] });
+      const babylonApi = new CosmosAPI("babylon");
+
+      const before = Date.now();
+      const result = await babylonApi.getAccountInfo(babylonAddress, babylonCurrency);
+      const after = Date.now();
+
+      const DAY_MS = 86_400_000;
+      const offsetMs = 2 * DAY_MS - (height - 4_016_160) * 10_000;
+      const [unbonding] = result.unbondings;
+      expect(unbonding.completionDate.getTime()).toBeGreaterThanOrEqual(before + offsetMs);
+      expect(unbonding.completionDate.getTime()).toBeLessThanOrEqual(after + offsetMs);
+      // definitely not the raw ~21-day chain value
+      expect(unbonding.completionDate.toISOString()).not.toBe("2026-08-10T07:10:27.684Z");
+    });
+
+    it("keeps the chain completion_time on non-epoched chains (no re-anchor)", async () => {
+      mockAccountInfoRoutes({ unbondings: [processedUnbonding] });
+
+      const result = await cosmosApi.getAccountInfo("cosmos1myaddress", {
+        id: "cosmos",
+        units: [{}, { code: "uatom" }],
+      } as CryptoCurrency);
+
+      expect(result.unbondings).toEqual([
+        expect.objectContaining({
+          validatorAddress: "bbnvaloper1active",
+          completionDate: new Date("2026-08-10T07:10:27.684611546Z"),
+        }),
+      ]);
     });
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
@@ -110,9 +110,8 @@ const EPOCH_MSGS_PAGE_LIMIT = 200;
 const EPOCH_MSGS_MAX_PAGES = 10;
 const BABYLON_BLOCK_TIME_MS = 10_000;
 
-// The chain reports x/staking's standard 21-day completion_time for unbondings, ignoring Babylon's
-// ~2-day BTC-checkpoint fast unbonding. Re-anchor to the on-chain start (creation_height) + the
-// effective unbonding period so the displayed date reflects the real release.
+// The chain's 21-day x/staking completion_time ignores Babylon's ~2-day BTC-checkpoint fast
+// unbonding, so re-anchor to creation_height + the effective period. See:
 // https://docs.babylonlabs.io/stakers/baby_stakers/staking_mechanism/
 export const estimateEpochedUnbondingCompletion = (
   creationHeight: number,

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
@@ -119,7 +119,8 @@ export const estimateEpochedUnbondingCompletion = (
   unbondingPeriodDays: number,
 ): Date => {
   const elapsedMs = Math.max(0, currentBlockHeight - creationHeight) * BABYLON_BLOCK_TIME_MS;
-  return new Date(Date.now() - elapsedMs + unbondingPeriodDays * 86_400_000);
+  const remainingMs = Math.max(0, unbondingPeriodDays * 86_400_000 - elapsedMs);
+  return new Date(Date.now() + remainingMs);
 };
 
 export const fetchQueuedStakingMessages = async (

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.ts
@@ -110,6 +110,19 @@ const EPOCH_MSGS_PAGE_LIMIT = 200;
 const EPOCH_MSGS_MAX_PAGES = 10;
 const BABYLON_BLOCK_TIME_MS = 10_000;
 
+// The chain reports x/staking's standard 21-day completion_time for unbondings, ignoring Babylon's
+// ~2-day BTC-checkpoint fast unbonding. Re-anchor to the on-chain start (creation_height) + the
+// effective unbonding period so the displayed date reflects the real release.
+// https://docs.babylonlabs.io/stakers/baby_stakers/staking_mechanism/
+export const estimateEpochedUnbondingCompletion = (
+  creationHeight: number,
+  currentBlockHeight: number,
+  unbondingPeriodDays: number,
+): Date => {
+  const elapsedMs = Math.max(0, currentBlockHeight - creationHeight) * BABYLON_BLOCK_TIME_MS;
+  return new Date(Date.now() - elapsedMs + unbondingPeriodDays * 86_400_000);
+};
+
 export const fetchQueuedStakingMessages = async (
   endpoint: string,
   address: string,

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
@@ -3,6 +3,7 @@ import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import { CosmosDelegation } from "../types";
 import {
+  estimateEpochedUnbondingCompletion,
   fetchQueuedStakingMessages,
   mergeQueuedMessages,
   parseQueuedMessage,
@@ -374,5 +375,36 @@ describe("fetchQueuedStakingMessages", () => {
     const result = await fetchQueuedStakingMessages(endpoint, address, "ubbn");
 
     expect(result).toBeNull();
+  });
+});
+
+describe("estimateEpochedUnbondingCompletion", () => {
+  const DAY_MS = 86_400_000;
+  const BLOCK_MS = 10_000;
+
+  it("anchors a just-created unbonding at now + the effective unbonding period", () => {
+    const before = Date.now();
+    const completion = estimateEpochedUnbondingCompletion(4_016_160, 4_016_160, 2);
+    const after = Date.now();
+    expect(completion.getTime()).toBeGreaterThanOrEqual(before + 2 * DAY_MS);
+    expect(completion.getTime()).toBeLessThanOrEqual(after + 2 * DAY_MS);
+  });
+
+  it("subtracts elapsed block time so the completion counts down from the on-chain start", () => {
+    const elapsedBlocks = 4_320; // ~12h at 10s/block
+    const before = Date.now();
+    const completion = estimateEpochedUnbondingCompletion(4_016_160, 4_016_160 + elapsedBlocks, 2);
+    const after = Date.now();
+    const offsetMs = 2 * DAY_MS - elapsedBlocks * BLOCK_MS;
+    expect(completion.getTime()).toBeGreaterThanOrEqual(before + offsetMs);
+    expect(completion.getTime()).toBeLessThanOrEqual(after + offsetMs);
+  });
+
+  it("clamps elapsed time to zero when the current height is behind the creation height", () => {
+    const before = Date.now();
+    const completion = estimateEpochedUnbondingCompletion(4_016_200, 4_016_160, 2);
+    const after = Date.now();
+    expect(completion.getTime()).toBeGreaterThanOrEqual(before + 2 * DAY_MS);
+    expect(completion.getTime()).toBeLessThanOrEqual(after + 2 * DAY_MS);
   });
 });

--- a/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
+++ b/libs/coin-modules/coin-cosmos/src/network/babylonEpoching.unit.test.ts
@@ -407,4 +407,13 @@ describe("estimateEpochedUnbondingCompletion", () => {
     expect(completion.getTime()).toBeGreaterThanOrEqual(before + 2 * DAY_MS);
     expect(completion.getTime()).toBeLessThanOrEqual(after + 2 * DAY_MS);
   });
+
+  it("never returns a completion in the past once elapsed exceeds the unbonding period", () => {
+    const elapsedBlocks = 5 * 24 * 60 * 6; // ~5 days at 10s/block, well past the 2-day period
+    const before = Date.now();
+    const completion = estimateEpochedUnbondingCompletion(1_000, 1_000 + elapsedBlocks, 2);
+    const after = Date.now();
+    expect(completion.getTime()).toBeGreaterThanOrEqual(before);
+    expect(completion.getTime()).toBeLessThanOrEqual(after);
+  });
 });

--- a/libs/coin-modules/coin-cosmos/src/types/index.ts
+++ b/libs/coin-modules/coin-cosmos/src/types/index.ts
@@ -33,6 +33,9 @@ export type CosmosUnbonding = {
   validatorAddress: string;
   amount: BigNumber;
   completionDate: Date;
+  // Set only for on-chain unbondings; drives the completion re-anchor on epoched fast-unbonding
+  // chains (see estimateEpochedUnbondingCompletion).
+  creationHeight?: number;
 };
 
 export type CosmosTx = {

--- a/libs/coin-modules/coin-cosmos/src/types/index.ts
+++ b/libs/coin-modules/coin-cosmos/src/types/index.ts
@@ -33,8 +33,6 @@ export type CosmosUnbonding = {
   validatorAddress: string;
   amount: BigNumber;
   completionDate: Date;
-  // Set only for on-chain unbondings; drives the completion re-anchor on epoched fast-unbonding
-  // chains (see estimateEpochedUnbondingCompletion).
   creationHeight?: number;
 };
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Previous behaviour: Once a BABY undelegation was processed on-chain, the Undelegation(s) panel showed the node's x/staking completion_time — the standard 21-day unbonding ("Next month") — instead of Babylon's ~2-day BTC-checkpoint fast unbonding shown everywhere else (tooltip, pending-queue estimate).

Fix: For epoched chains, re-anchor the unbonding completion date to the entry's on-chain creation_height + the effective unbondingPeriod (the same value already used for still-queued undelegations). Non-epoched Cosmos chains keep the chain's authoritative completion_time.

in 2 days now, instead of Next month.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34217](https://ledgerhq.atlassian.net/browse/LIVE-34217?atlOrigin=eyJpIjoiMjk0ODI5YmFmZDlkNDkzYzhiZTAwYzY5ZTllOTQ0YjMiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34217]: https://ledgerhq.atlassian.net/browse/LIVE-34217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ