### PR TITLE
[LWM] fix(mobile): remove SafeAreaInsetsContext.Provider, introduce useAdjustedSafeAreaInsets

### DIFF
--- a/.changeset/clean-shoes-fix.md
+++ b/.changeset/clean-shoes-fix.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+fix: remove SafeAreaInsetsContext.Provider global override, replace with useAdjustedSafeAreaInsets hook

--- a/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/MainNavigatorTopBarHeader.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from "react";
 import { View, Platform } from "react-native";
 import { useRoute } from "@react-navigation/native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { TopBar } from "LLM/components/TopBar";
 import { ProgressiveBlurView } from "@sbaiahmed1/react-native-blur";
 import { LinearGradient } from "@ledgerhq/lumen-ui-rnative";
 import {
   useNavigationBarHeights,
+  useAdjustedSafeAreaInsets,
   TOP_BAR_CONTENT_HEIGHT,
   TOP_BAR_WRAPPER_PADDING_TOP,
 } from "LLM/hooks/useNavigationBarHeights";
@@ -28,7 +28,7 @@ const TOP_BAR_CONTAINER_BASE = {
 
 export const MainNavigatorTopBarHeader = () => {
   const route = useRoute();
-  const insets = useSafeAreaInsets();
+  const insets = useAdjustedSafeAreaInsets();
   const { top: headerHeight } = useNavigationBarHeights();
 
   const topBarContainerStyle = useMemo(

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -7,11 +7,7 @@ import "./utils/tanstack-setup";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import React, { Component, useMemo, useEffect, useRef } from "react";
 import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";
-import {
-  SafeAreaProvider,
-  SafeAreaInsetsContext,
-  useSafeAreaInsets,
-} from "react-native-safe-area-context";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
 import Transport from "@ledgerhq/hw-transport";
 import { NotEnoughBalance } from "@ledgerhq/errors";
@@ -46,9 +42,7 @@ import SegmentSetup from "~/analytics/SegmentSetup";
 import HookNotifications from "~/notifications/HookNotifications";
 import RootNavigator from "~/components/RootNavigator";
 import SetEnvsFromSettings from "~/components/SetEnvsFromSettings";
-import ExperimentalHeader, {
-  useIsExperimentalHeaderVisible,
-} from "~/screens/Settings/Experimental/ExperimentalHeader";
+import ExperimentalHeader from "~/screens/Settings/Experimental/ExperimentalHeader";
 import Modals from "~/screens/Modals";
 import NavBarColorHandler from "~/components/NavBarColorHandler";
 import { TermsAndConditionMigrateLegacyData } from "~/logic/terms";
@@ -271,16 +265,6 @@ function App() {
  * SafeAreaView).
  */
 function AppView() {
-  const insets = useSafeAreaInsets();
-  const isExperimentalHeaderVisible = useIsExperimentalHeaderVisible();
-
-  // When ExperimentalHeader is visible it occupies the top safe-area space so
-  // components inside the navigator must not re-apply insets.top.
-  const adjustedInsets = useMemo(
-    () => (isExperimentalHeaderVisible ? { ...insets, top: 0 } : insets),
-    [insets, isExperimentalHeaderVisible],
-  );
-
   // TODO: Normally, we should use a SafeAreaView as root view to avoid
   // importing it everywhere and recalculating the insets.
   return (
@@ -293,11 +277,9 @@ function AppView() {
       }}
     >
       <ExperimentalHeader />
-      <SafeAreaInsetsContext.Provider value={adjustedInsets}>
-        <View style={{ flex: 1 }}>
-          <RootNavigator />
-        </View>
-      </SafeAreaInsetsContext.Provider>
+      <View style={{ flex: 1 }}>
+        <RootNavigator />
+      </View>
     </View>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/usePortfolioHeaderSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioHeaderSection/usePortfolioHeaderSectionViewModel.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAdjustedSafeAreaInsets } from "LLM/hooks/useNavigationBarHeights";
 import {
   CONTENT_AREA_HEIGHT,
   MIN_CONTENT_AREA_HEIGHT,
@@ -14,7 +14,7 @@ interface PortfolioHeaderSectionViewModel {
 }
 
 export function usePortfolioHeaderSectionViewModel(): PortfolioHeaderSectionViewModel {
-  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { top: safeAreaTop } = useAdjustedSafeAreaInsets();
 
   const [bannerHeight, setBannerHeight] = useState(0);
   const onBannerHeightChange = useCallback((height: number) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/useReadOnlyPortfolioViewModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from "react";
 import { useFocusEffect } from "@react-navigation/native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAdjustedSafeAreaInsets } from "LLM/hooks/useNavigationBarHeights";
 
 import { useRefreshAccountsOrderingAfterInteractions } from "~/actions/general";
 import usePortfolioAnalyticsOptInPrompt from "~/hooks/analyticsOptInPrompt/usePortfolioAnalyticsOptInPrompt";
@@ -18,7 +18,7 @@ const useReadOnlyPortfolioViewModel = (navigation: {
   goBack: () => void;
   navigate: (name: string, params?: object) => void;
 }): UseReadOnlyPortfolioViewModelResult => {
-  const { top: safeAreaTop } = useSafeAreaInsets();
+  const { top: safeAreaTop } = useAdjustedSafeAreaInsets();
   const isLNSUpsellBannerShown = useLNSUpsellBannerState("wallet").isShown;
 
   usePortfolioAnalyticsOptInPrompt();

--- a/apps/ledger-live-mobile/src/mvvm/hooks/useNavigationBarHeights.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/useNavigationBarHeights.ts
@@ -4,6 +4,17 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useSelector } from "~/context/hooks";
 import { isMainNavigatorVisibleSelector } from "~/reducers/appstate";
 import { TAB_BAR_HEIGHT } from "~/components/TabBar/shared";
+import { useIsExperimentalHeaderVisible } from "~/screens/Settings/Experimental/ExperimentalHeader";
+
+/**
+ * Returns safe area insets with `top` zeroed when the experimental header is
+ * visible, because the header already occupies that space.
+ */
+export function useAdjustedSafeAreaInsets() {
+  const insets = useSafeAreaInsets();
+  const isExperimentalHeaderVisible = useIsExperimentalHeaderVisible();
+  return isExperimentalHeaderVisible ? { ...insets, top: 0 } : insets;
+}
 
 export const TOP_BAR_CONTENT_HEIGHT = 48;
 export const TOP_BAR_WRAPPER_PADDING_TOP = 8;
@@ -46,7 +57,7 @@ export interface NavigationBarHeights {
  * @returns `bottomBarHeight` - The height of the bottom bar
  */
 export function useNavigationBarHeights(): NavigationBarHeights {
-  const insets = useSafeAreaInsets();
+  const insets = useAdjustedSafeAreaInsets();
   const isTabBarVisible = useSelector(isMainNavigatorVisibleSelector);
 
   const topBarHeightWithBlur =

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapOpaqueHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapOpaqueHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { StyleSheet } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box, IconButton, Text } from "@ledgerhq/lumen-ui-rnative";
 import { type LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
@@ -9,6 +8,7 @@ import { useTranslation } from "~/context/Locale";
 import {
   TOP_BAR_CONTENT_HEIGHT,
   TOP_BAR_WRAPPER_PADDING_TOP,
+  useAdjustedSafeAreaInsets,
 } from "LLM/hooks/useNavigationBarHeights";
 
 type SwapOpaqueHeaderProps = {
@@ -28,7 +28,7 @@ export function SwapOpaqueHeader({
   showBackButton = true,
   titleKey,
 }: Readonly<SwapOpaqueHeaderProps>) {
-  const insets = useSafeAreaInsets();
+  const insets = useAdjustedSafeAreaInsets();
   const { theme: lumenTheme } = useLumenTheme();
   const { t } = useTranslation();
   const containerStyle = useMemo(

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/components/SwapTopBarHeader.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from "react";
 import { StyleSheet } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import {
   TOP_BAR_CONTENT_HEIGHT,
   TOP_BAR_WRAPPER_PADDING_TOP,
+  useAdjustedSafeAreaInsets,
 } from "LLM/hooks/useNavigationBarHeights";
 import { useSwapTopBarHeaderViewModel } from "./useSwapTopBarHeaderViewModel";
 import {
@@ -17,7 +17,7 @@ import { MyWalletTopBarAction } from "LLM/components/TopBar/components/MyWalletT
 import { Clock } from "@ledgerhq/lumen-ui-rnative/symbols";
 
 export function SwapTopBarHeader() {
-  const insets = useSafeAreaInsets();
+  const insets = useAdjustedSafeAreaInsets();
   const {
     onMyLedgerPress,
     onMyWalletPress,

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapWebviewProps.ts
@@ -6,7 +6,7 @@ import { useFeature } from "@features/platform-feature-flags";
 import { WalletAPICustomHandlers } from "@ledgerhq/live-common/wallet-api/types";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTheme } from "styled-components/native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useAdjustedSafeAreaInsets } from "LLM/hooks/useNavigationBarHeights";
 import { getCountryLocale } from "~/helpers/getStakeLabelLocaleBased";
 import { useSettings } from "~/hooks";
 import {
@@ -58,7 +58,7 @@ export function useSwapWebviewProps({ manifest, params, resetWebview }: UseSwapW
 
   const isLlmModularDrawer = llmModularDrawerFF?.enabled && llmModularDrawerFF?.params?.live_app;
 
-  const insets = useSafeAreaInsets();
+  const insets = useAdjustedSafeAreaInsets();
 
   // Capture the initial source to prevent webview refreshes.
   // currentRouteNameRef.current updates when going back and forth inside the navigation stack and returning to the webview


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Layout regression — no automated test covers this. Verified manually on device with experimental header on/off._
- [x] **Impact of the changes:**
  - Portfolio header section (paddingTop positioning)
  - Main navigator TopBar (marginTop + wrapper height)
  - Swap LiveApp TopBar (SwapTopBarHeader, SwapOpaqueHeader)
  - Swap webview safe area inputs (safeAreaTop)
  - Send numeric keypad layout on small-screen devices

### 📝 Description

A global `SafeAreaInsetsContext.Provider` had been added in `AppView` (`index.tsx`) to zero out `insets.top` when the experimental header is visible. Because the experimental header already occupies the top safe-area space, all downstream consumers of `useSafeAreaInsets()` were receiving the real notch value (e.g. 47 px on iPhone) **in addition** to the space already taken — producing a double offset.

On small-screen devices this extra offset pushed the numeric keypad down enough to clip the bottom row (`0`, `.`, delete), making it impossible to enter decimal amounts or correct input via backspace.

The global Provider was replaced with a focused `useAdjustedSafeAreaInsets` hook (exported from `LLM/hooks/useNavigationBarHeights`) that zeroes `insets.top` only in the places that actually use it for layout positioning:

- `MainNavigatorTopBarHeader` — `marginTop` + wrapper height via `useNavigationBarHeights`
- `usePortfolioHeaderSectionViewModel` — `paddingTop` on the header container
- `useReadOnlyPortfolioViewModel` — same
- `SwapTopBarHeader` / `SwapOpaqueHeader` — `marginTop` on their containers
- `useSwapWebviewProps` — `safeAreaTop` passed to the Swap webview

Screens using `SafeAreaView` from `react-native-safe-area-context` directly are unaffected by this PR — they will be migrated to `~/components/SafeAreaView` in a separate epic (one ticket per team).

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34472](https://ledgerhq.atlassian.net/browse/LIVE-34472)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34472]: https://ledgerhq.atlassian.net/browse/LIVE-34472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ