### PR TITLE
[LWDM] refactor(coin-hedera): drop @ledgerhq/cryptoassets dep — inline USD fiat constant

### DIFF
--- a/.changeset/silent-fiats-drop.md
+++ b/.changeset/silent-fiats-drop.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+Drop @ledgerhq/cryptoassets dependency — USD fiat currency lookup inlined as a local constant

--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -85,7 +85,6 @@
   "dependencies": {
     "@hashgraph/sdk": "2.78.0",
     "@ledgerhq/coin-module-framework": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,12 +1,15 @@
 import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets/fiats";
 import { InvalidAddress } from "@ledgerhq/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";
-import type { TokenCurrency, Currency } from "@ledgerhq/ledger-wallet-framework/types";
+import type {
+  FiatCurrency,
+  TokenCurrency,
+  Currency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 import type { Operation, OperationType } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import type { HederaCoinConfig } from "../config";
@@ -24,6 +27,14 @@ import type {
 import { apiClient } from "./api";
 import { hgraphClient } from "./hgraph";
 import { rpcClient } from "./rpc";
+
+const USD_FIAT: FiatCurrency = {
+  type: "FiatCurrency",
+  ticker: "USD",
+  name: "US Dollar",
+  symbol: "$",
+  units: [{ code: "$", name: "US Dollar", magnitude: 2, showAllDigits: true, prefixCode: true }],
+};
 
 export async function createTransactionId(
   accountId: string,
@@ -196,7 +207,7 @@ export const getCurrencyToUSDRate = makeLRUCache(
       const [rate] = await cvsApi.fetchLatest([
         {
           from: currency,
-          to: getFiatCurrencyByTicker("USD"),
+          to: USD_FIAT,
           startDate: new Date(),
         },
       ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6010,9 +6010,6 @@ importers:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
         version: 4.0.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/cryptoassets
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -66020,7 +66017,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66144,6 +66141,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Removes the last `@ledgerhq/cryptoassets` import from `coin-hedera` so the package can drop the dependency entirely.

`network/utils.ts` imported `getFiatCurrencyByTicker("USD")` from `@ledgerhq/cryptoassets/fiats` solely to build the countervalue fetch target in `getCurrencyToUSDRate`. Since USD is a fixed, well-known constant and no other coin module needs fiat lookups, the call is replaced by an inlined `USD_FIAT` constant typed against `FiatCurrency` from `@ledgerhq/ledger-wallet-framework/types` (already in scope after [#19683](https://github.com/LedgerHQ/ledger-live/pull/19683)).

All other `@ledgerhq/cryptoassets` imports in `coin-hedera` (`/currencies`, `/state`) were already repointed to the wallet-framework in #19683.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34597](https://ledgerhq.atlassian.net/browse/LIVE-34597) — part of the [Crypto Assets DA epic (LIVE-31901)](https://ledgerhq.atlassian.net/browse/LIVE-31901)
- **ADR** (if any): —

[LIVE-34597]: https://ledgerhq.atlassian.net/browse/LIVE-34597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ