### PR TITLE
[LWDM] fix(platform-currencies): declare @reduxjs/toolkit as a runtime dependency

### DIFF
--- a/.changeset/platform-currencies-rtk-runtime-dep.md
+++ b/.changeset/platform-currencies-rtk-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-currencies": minor
+---
+
+Declare `@reduxjs/toolkit` as a runtime dependency (moved from `devDependencies`). `buildStandaloneCryptoAssetsStore` calls `configureStore` at runtime, so consumers building a standalone store need RTK resolvable as a real dependency.

--- a/features/platform/currencies/package.json
+++ b/features/platform/currencies/package.json
@@ -24,14 +24,14 @@
     "@domain/api-currency-token": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:^",
     "@domain/entity-currency-token": "workspace:^",
-    "@features/platform-feature-flags": "workspace:^"
+    "@features/platform-feature-flags": "workspace:^",
+    "@reduxjs/toolkit": "catalog:"
   },
   "peerDependencies": {
     "react": ">=19.0.0",
     "react-redux": ">=9.0.0"
   },
   "devDependencies": {
-    "@reduxjs/toolkit": "catalog:",
     "@shared/feature-flags": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4552,10 +4552,10 @@ importers:
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../feature-flags
-    devDependencies:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    devDependencies:
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags


### PR DESCRIPTION
### 📝 Description

`@features/platform-currencies` declared `@reduxjs/toolkit` as a `devDependency`, but `buildStandaloneCryptoAssetsStore` calls `configureStore` (a runtime value) — so it must be a runtime `dependency`. This moves it `devDependencies` → `dependencies` (+ the matching `pnpm-lock.yaml` importer entry).

`buildCryptoAssetsStore` only imported RTK **types**, which is why a devDep sufficed until the standalone builder landed (#19693 / LIVE-34513). In-repo it resolves via hoisting today (no crash), but the declaration was wrong.

The fix was authored in #19710 (LIVE-34548), which was closed as superseded by #19731 (LIVE-34570); this micro-PR extracts the one still-needed commit.

### 🔗 Context

- **JIRA**: [LIVE-34513](https://ledgerhq.atlassian.net/browse/LIVE-34513) (added `buildStandaloneCryptoAssetsStore`) — follow-up hygiene fix.


[LIVE-34513]: https://ledgerhq.atlassian.net/browse/LIVE-34513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ