### PR TITLE
[LWD] fix(desktop): add exponential backoff to macOS notarization retries

### DIFF
--- a/apps/ledger-live-desktop/scripts/notarize.js
+++ b/apps/ledger-live-desktop/scripts/notarize.js
@@ -46,6 +46,10 @@ async function notarizeApp(context) {
   const keyPath = join(keyDir, `AuthKey_${APPLECONNECT_API_KEY_ID}.p8`);
   writeFileSync(keyPath, Buffer.from(APPLECONNECT_API_KEY_CONTENT, "base64"));
 
+  // Transient notarytool failures: retry with exponential backoff (30s -> 60s -> 120s).
+  const MAX_RETRIES = 3;
+  const RETRY_BASE_DELAY_MS = 30_000;
+
   async function attemptNotarize(retries, path) {
     try {
       await notarize({
@@ -57,8 +61,10 @@ async function notarizeApp(context) {
       });
     } catch (e) {
       if (retries > 0) {
-        console.warn("RETRYING: ATTEMPTS LEFT " + retries);
+        const delayMs = RETRY_BASE_DELAY_MS * 2 ** (MAX_RETRIES - retries);
+        console.warn(`RETRYING: ATTEMPTS LEFT ${retries} (waiting ${delayMs / 1000}s)`);
         console.error(e?.message);
+        await new Promise(resolve => setTimeout(resolve, delayMs));
         await attemptNotarize(retries - 1, path);
       } else {
         throw e;
@@ -71,7 +77,7 @@ async function notarizeApp(context) {
   const path = `${appOutDir}/${appName}.app`;
 
   try {
-    await attemptNotarize(3, path);
+    await attemptNotarize(MAX_RETRIES, path);
   } catch (error) {
     if (error.message?.includes("Failed to staple")) {
       console.warn("LAST TRY: STAPLING MANUALLY");


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Nightly/pre desktop macOS builds intermittently fail at the notarization step with:

Failed to notarize via notarytool.  Failed with unexpected result:

(thrown from @electron/notarize@3.1.1 at notarytool.ts:119). The unexpected result payload is empty, which means xcrun notarytool submit --wait exited non-zero without returning any parseable output — a transport-level flake reaching Apple's notary service

- Add exponential backoff between notarization retries: 30s → 60s → 120s.
- Introduce a MAX_RETRIES constant used for both the delay calculation and the call site so they stay in sync.
- Retry log now reports the wait, e.g. RETRYING: ATTEMPTS LEFT 3 (waiting 30s).

Test run: https://github.com/LedgerHQ/ledger-live-build/actions/runs/29742452944/job/88352187314