### PR TITLE
docs: prefer atlassian mcp for jira and confluence links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Prefer commands given in local README files. For example appls like [Ledger Wall
 
 For general test, build and check recipes see [/docs/repo-commands.md](/docs/repo-commands.md), which also contains notes on Nx, filtering and aliases.
 
+## External Work Links
+
+When a task includes Jira or Confluence links, use Atlassian MCP to fetch and read the referenced ticket or page by default before summarizing, planning, or implementing.
+
 ## Validate Before Finishing
 
 Always follow the [validate-before-finishing](/docs/validate-before-finishing.md) instructions before completing code changes.


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached. _Not applicable: root docs-only change._
- [ ] **Covered by automatic tests.** _Not applicable: docs-only change; formatting checked._
- [x] **Impact of the changes:**
  - AI/agent guidance for Jira and Confluence links

### Description

This PR updates the root agent instructions so AI tools default to Atlassian MCP when faced with Jira or Confluence links.

### Context

- **JIRA or GitHub link**: N/A

---

### Checklist for the PR Reviewers

- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.