### PR TITLE
[LWDM] fix(lwdm): fix wrong memo label i18n id new send flow

### DIFF
--- a/.changeset/fluffy-lobsters-look.md
+++ b/.changeset/fluffy-lobsters-look.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(lwdm): fix wrong memo label i18n id

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -12,6 +12,7 @@ import {
   type SendFlowBusinessContext,
   type SendFlowStep,
 } from "@ledgerhq/live-common/flows/send/types";
+import { getMemoFamilyCurrencyId } from "@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId";
 import { useAvailableBalance } from "../hooks/useAvailableBalance";
 import { useSendHeaderModel } from "../hooks/useSendHeaderModel";
 import { MemoTypeSelect } from "../screens/Recipient/components/Memo/MemoTypeSelect";
@@ -31,7 +32,7 @@ export function SendHeader() {
   const headerDisplayMode = currentStep === SEND_FLOW_STEP.COIN_CONTROL ? "crypto" : displayMode;
   const availableText = useAvailableBalance(state.account.account, headerDisplayMode);
 
-  const currencyId = state.account.currency?.id;
+  const currencyId = getMemoFamilyCurrencyId(state.account.currency);
 
   const sendFlowTrackingProperties = useMemo(
     () => getSendFlowTrackingProperties(state.account.account, state.account.parentAccount),

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModalView.tsx
@@ -5,6 +5,7 @@ import type {
   AddressSearchResult,
   AddressValidationError as AddressValidationErrorType,
 } from "@ledgerhq/live-common/flows/send/recipient/types";
+import { shouldShowMatchedAddress } from "@ledgerhq/live-common/flows/send/recipient/utils/shouldShowMatchedAddress";
 import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
 import EmptyList from "./EmptyList";
@@ -67,10 +68,16 @@ export function RecipientAddressModalView({
       showBridgeRecipientWarning);
 
   const isWaitingForMemo = hasMemo && isAddressComplete && !hasFilledMemo;
+  const showMatched = shouldShowMatchedAddress({
+    showMatchedAddress,
+    hasMemo,
+    hasFilledMemo,
+    hasMemoError: hasMemoValidationError,
+  });
 
   return (
     <DialogBody className={cn("flex flex-col py-16", !isWaitingForMemo && "min-h-[156px]")}>
-      {isLoading && (
+      {isLoading && !showMatched && (
         <div className="flex flex-1 items-center">
           <LoadingState />
         </div>
@@ -78,7 +85,7 @@ export function RecipientAddressModalView({
 
       {showInitialState && <RecipientIntroCard />}
 
-      {showMatchedAddress && (!hasMemo || (hasFilledMemo && !hasMemoValidationError)) && (
+      {showMatched && (
         <AddressMatchedSection
           searchResult={result}
           searchValue={searchValue}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useMemoViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/hooks/useMemoViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import type { Memo } from "@ledgerhq/live-common/flows/send/types";
+import { getMemoFamilyCurrencyId } from "@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId";
 import { useTranslation } from "~/context/Locale";
 import { useSendFlowActions, useSendFlowData } from "../../../context/SendFlowContext";
 import { useRecipientMemo } from "./useRecipientMemo";
@@ -16,7 +17,7 @@ export function useMemoViewModel({ address, onSkip }: UseMemoViewModelProps) {
   const { transaction } = useSendFlowActions();
 
   const currency = state.account.currency;
-  const currencyId = currency?.id ?? "";
+  const currencyId = getMemoFamilyCurrencyId(currency) ?? "";
 
   const memoLabel = t([
     `send.newSendFlow.memoLabel.${currencyId}`,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -130,7 +130,7 @@ export const RecipientScreenView = ({
   return (
     <SendFlowLayout>
       <Box style={{ flex: 1, marginHorizontal: -8 }}>
-        {isLoading && <LoadingState />}
+        {isLoading && !showMatched && <LoadingState />}
 
         {showInitialState && clipboardAddress && (
           <PasteFromClipboard address={clipboardAddress} onPaste={handlePasteFromClipboard} />

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -654,6 +654,7 @@
     "src/flows/send/utils/feePresetLegends.ts",
     "src/flows/send/utils/feesStrategy.ts",
     "src/flows/send/utils/gas.ts",
+    "src/flows/send/utils/memoFamilyCurrencyId.ts",
     "src/flows/send/utils/networkFeesDisplay.ts",
     "src/flows/send/utils.ts",
     "src/flows/wizard/types.ts",

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/memoFamilyCurrencyId.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/memoFamilyCurrencyId.test.ts
@@ -1,0 +1,23 @@
+import { getMemoFamilyCurrencyId } from "../memoFamilyCurrencyId";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+describe("getMemoFamilyCurrencyId", () => {
+  it("returns undefined when currency is missing", () => {
+    expect(getMemoFamilyCurrencyId(undefined)).toBeUndefined();
+    expect(getMemoFamilyCurrencyId(null)).toBeUndefined();
+  });
+
+  it("returns the currency id for a crypto currency", () => {
+    const stellar = { type: "CryptoCurrency", id: "stellar" } as CryptoCurrency;
+    expect(getMemoFamilyCurrencyId(stellar)).toBe("stellar");
+  });
+
+  it("returns the parent currency id for a token currency", () => {
+    const usdc = {
+      type: "TokenCurrency",
+      id: "stellar/asset/USDC/GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KBX3IMXAIXG4LSOGSZNHQ",
+      parentCurrencyId: "stellar",
+    } as TokenCurrency;
+    expect(getMemoFamilyCurrencyId(usdc)).toBe("stellar");
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/utils/memoFamilyCurrencyId.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/memoFamilyCurrencyId.ts
@@ -1,0 +1,12 @@
+import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+
+/**
+ * Currency id for family memo i18n keys
+ * Tokens must resolve to their parent crypto currency
+ */
+export function getMemoFamilyCurrencyId(
+  currency: CryptoOrTokenCurrency | null | undefined,
+): string | undefined {
+  if (!currency) return undefined;
+  return currency.type === "TokenCurrency" ? currency.parentCurrencyId : currency.id;
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes the Stellar USDC (and other token subaccounts) send flow where the memo type dropdown showed raw i18n keys instead of readable labels

Also fixes the loading skeleton showing alongside the "Address matched" row during memo re-validation. Applies to LWDM.

Now fixed for all subaccounts memos:

<img width="521" height="507" alt="image" src="https://github.com/user-attachments/assets/e74025fb-856f-474c-9140-db0dd9cc7781" />


### 🔗 Context

- **JIRA / GitHub issue** <!-- e.g. [LLD-1234] or #456 -->
   - https://github.com/LedgerHQ/ledger-live/issues/19768
   - https://ledgerhq.atlassian.net/browse/LIVE-34636
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
