### PR TITLE
[LWM] fix(mobile): add android nav bar inset to read-only portfolio bottom padding

### DIFF
--- a/.changeset/silent-maps-rest.md
+++ b/.changeset/silent-maps-rest.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix android navigation bar inset on read-only portfolio screen bottom padding

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/screens/ReadOnly/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Flex } from "@ledgerhq/native-ui";
 import TrackScreen from "~/analytics/TrackScreen";
 import CheckLanguageAvailability from "~/components/CheckLanguageAvailability";
@@ -26,6 +27,7 @@ type NavigationProps = BaseComposite<
 function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
   const { safeAreaTop, isLNSUpsellBannerShown, source, onBackFromUpdate } =
     useReadOnlyPortfolioViewModel(navigation);
+  const { bottom } = useSafeAreaInsets();
 
   const data = useMemo(
     () => [
@@ -53,7 +55,7 @@ function ReadOnlyPortfolioScreen({ navigation }: NavigationProps) {
       <TrackScreen category="Wallet" source={source} />
       <CollapsibleHeaderFlatList<React.JSX.Element>
         data={data}
-        contentContainerStyle={{ paddingBottom: TAB_BAR_SAFE_HEIGHT }}
+        contentContainerStyle={{ paddingBottom: TAB_BAR_SAFE_HEIGHT + bottom }}
         renderItem={({ item }) => item}
         keyExtractor={(_: unknown, index: number) => String(index)}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
### ✅ Checklist

- [x] \`npx changeset\` was attached.
- [ ] **Covered by automatic tests.** _Layout/spacing fix — no unit test applicable; requires device verification on Android with gesture navigation._
- [x] **Impact of the changes:**
  - Read-only (watch-only) portfolio screen on Android
  - Stocks section spacing from the Android system navigation bar

### 📝 Description

On Android devices with gesture navigation enabled, the stocks section at the bottom of the read-only portfolio screen was rendered flush against the system navigation bar, making the content feel clipped and visually tight.

The read-only portfolio screen uses `useSafeArea={false}` on its `CollapsibleHeaderFlatList` and relies on a static `paddingBottom: TAB_BAR_SAFE_HEIGHT` (103 px). This value does not account for the dynamic Android system navigation bar inset. In the normal portfolio mode the inset is applied inside `WalletAssetsView` (`paddingBottom: bottom + 24`), but that code path is guarded by `variant !== "readOnly"` and was never reached.

Fix: pull `useSafeAreaInsets().bottom` directly in `ReadOnlyPortfolioScreen` and add it to the static constant — `paddingBottom: TAB_BAR_SAFE_HEIGHT + bottom` — mirroring how every other screen in the codebase handles this inset.

| Before | After |
| ------ | ----- |
|<img width="379" height="781" alt="image" src="https://github.com/user-attachments/assets/744ea073-6e63-4741-8d51-d35dd8cc7f68" />|<img width="354" height="781" alt="Screenshot 2026-07-20 at 3 21 49 PM" src="https://github.com/user-attachments/assets/fefaa1d3-dd02-4ece-b4c9-4336c3c26216" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-32921](https://ledgerhq.atlassian.net/browse/LIVE-32921)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32921]: https://ledgerhq.atlassian.net/browse/LIVE-32921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ