### PR TITLE
feat(mobile): add contacts section index

### DIFF
--- a/.changeset/interactive-contacts-index.md
+++ b/.changeset/interactive-contacts-index.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add an interactive section index to the Mobile Contacts list

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsPage.native.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback } from "react";
-import { SectionList, type SectionListRenderItemInfo } from "react-native";
+import React, { useCallback, useRef, useState } from "react";
+import { SectionList, type LayoutChangeEvent, type SectionListRenderItemInfo } from "react-native";
 import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
-import type { ContactsListItem, ContactsPageNativeProps } from "../../types";
+import type { ContactsListItem, ContactsListSection, ContactsPageNativeProps } from "../../types";
 import { ContactsListHeader } from "./ContactsListHeader.native";
 import { ContactsSearchNoResults } from "./ContactsSearchNoResults.native";
 import { ContactsSavedContactListItem } from "./ContactsSavedContactListItem.native";
+import { ContactsSectionIndex } from "./ContactsSectionIndex.native";
 import { ContactsSectionHeader } from "./ContactsSectionHeader.native";
+import { useContactsSectionIndex } from "../../internals/useContactsSectionIndex.native";
+
+const noContactsListSections: readonly never[] = [];
 
 export function ContactsPage({
   viewModel,
@@ -21,8 +25,20 @@ export function ContactsPage({
   const hasNoResults = "status" in viewModel && viewModel.status === "no-results";
   const isLedgerSyncChecking = ledgerSyncStatus === "checking";
   const me = "me" in viewModel ? viewModel.me : undefined;
+  const listRef = useRef<SectionList<ContactsListItem, ContactsListSection> | null>(null);
+  const [listHeight, setListHeight] = useState(0);
+  const {
+    activeSectionTitle,
+    sectionIndexEntries,
+    onSelectSection,
+    onViewableItemsChanged,
+    viewabilityConfig,
+  } = useContactsSectionIndex({
+    sections: isPopulated ? viewModel.sections : noContactsListSections,
+    listRef,
+  });
   const renderContact = useCallback(
-    ({ item }: SectionListRenderItemInfo<ContactsListItem>) => (
+    ({ item }: SectionListRenderItemInfo<ContactsListItem, ContactsListSection>) => (
       <ContactsSavedContactListItem
         contact={item}
         addressCountLabel={labels.formatAddressCount(item.addressCount)}
@@ -44,19 +60,28 @@ export function ContactsPage({
       onAddContact={onAddContact}
     />
   );
+  const onListLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+
+    setListHeight(currentHeight => (currentHeight === nextHeight ? currentHeight : nextHeight));
+  }, []);
+  const sectionIndexVerticalCenter = listHeight / 2;
 
   let content: React.JSX.Element;
 
   if (isPopulated) {
     content = (
-      <Box lx={{ flex: 1 }}>
+      <Box lx={{ flex: 1 }} onLayout={onListLayout}>
         <SectionList
+          ref={listRef}
           testID="contacts-list"
           sections={viewModel.sections}
           keyExtractor={contact => contact.contactId}
           renderItem={renderContact}
           renderSectionHeader={({ section }) => <ContactsSectionHeader title={section.title} />}
           ListHeaderComponent={listHeader}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={viewabilityConfig}
           contentContainerStyle={{
             paddingHorizontal: 16,
             paddingTop: 8,
@@ -66,6 +91,14 @@ export function ContactsPage({
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
         />
+        {listHeight > 0 ? (
+          <ContactsSectionIndex
+            sections={sectionIndexEntries}
+            activeSectionTitle={activeSectionTitle}
+            onSelectSection={onSelectSection}
+            verticalCenterOffset={sectionIndexVerticalCenter}
+          />
+        ) : null}
       </Box>
     );
   } else if (hasNoResults) {

--- a/features/flow/contacts/src/list/components/ContactsPage/ContactsSectionIndex.native.tsx
+++ b/features/flow/contacts/src/list/components/ContactsPage/ContactsSectionIndex.native.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { Animated, PanResponder, View, type LayoutChangeEvent } from "react-native";
+import { Box, Pressable, Text } from "@ledgerhq/lumen-ui-rnative";
+
+type ContactsSectionIndexProps = Readonly<{
+  sections: readonly string[];
+  activeSectionTitle: string | undefined;
+  onSelectSection: (title: string) => void;
+  verticalCenterOffset: number;
+}>;
+
+function clampIndex(index: number, length: number): number {
+  return Math.min(Math.max(index, 0), length - 1);
+}
+
+type ContactsSectionIndexItemProps = Readonly<{
+  title: string;
+  isActive: boolean;
+  onPress: (title: string) => void;
+}>;
+
+function ContactsSectionIndexItem({
+  title,
+  isActive,
+  onPress,
+}: ContactsSectionIndexItemProps): React.JSX.Element {
+  const emphasis = useRef(new Animated.Value(isActive ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.spring(emphasis, {
+      toValue: isActive ? 1 : 0,
+      useNativeDriver: true,
+      damping: 16,
+      stiffness: 220,
+    }).start();
+  }, [emphasis, isActive]);
+
+  return (
+    <Pressable
+      testID={`contacts-section-index-${title}`}
+      onPress={() => onPress(title)}
+      accessibilityRole="button"
+      accessibilityLabel={title}
+      accessibilityState={{ selected: isActive }}
+      lx={{ width: "s24", height: "s16", alignItems: "center", justifyContent: "center" }}
+    >
+      <Animated.View
+        style={{
+          opacity: emphasis.interpolate({ inputRange: [0, 1], outputRange: [0.2, 1] }),
+          transform: [
+            {
+              scale: emphasis.interpolate({ inputRange: [0, 1], outputRange: [1, 1.25] }),
+            },
+          ],
+        }}
+      >
+        <Text typography="body4" lx={{ color: "base" }}>
+          {title}
+        </Text>
+      </Animated.View>
+    </Pressable>
+  );
+}
+
+export function ContactsSectionIndex({
+  sections,
+  activeSectionTitle,
+  onSelectSection,
+  verticalCenterOffset,
+}: ContactsSectionIndexProps): React.JSX.Element | null {
+  const heightRef = useRef(0);
+  const draggedSectionTitleRef = useRef<string | undefined>(undefined);
+  const [height, setHeight] = React.useState(0);
+
+  const selectSectionAt = useCallback(
+    (locationY: number) => {
+      if (heightRef.current === 0 || sections.length === 0) {
+        return;
+      }
+
+      const sectionHeight = heightRef.current / sections.length;
+      const sectionIndex = clampIndex(Math.floor(locationY / sectionHeight), sections.length);
+      const section = sections[sectionIndex];
+
+      if (section !== undefined && draggedSectionTitleRef.current !== section) {
+        draggedSectionTitleRef.current = section;
+        onSelectSection(section);
+      }
+    },
+    [onSelectSection, sections],
+  );
+
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextHeight = event.nativeEvent.layout.height;
+
+    heightRef.current = nextHeight;
+    setHeight(currentHeight => (currentHeight === nextHeight ? currentHeight : nextHeight));
+  }, []);
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onMoveShouldSetPanResponder: (_, gestureState) => Math.abs(gestureState.dy) > 2,
+        onPanResponderGrant: event => {
+          draggedSectionTitleRef.current = undefined;
+          selectSectionAt(event.nativeEvent.locationY);
+        },
+        onPanResponderMove: event => selectSectionAt(event.nativeEvent.locationY),
+      }),
+    [selectSectionAt],
+  );
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <View
+      testID="contacts-section-index"
+      onLayout={onLayout}
+      style={{
+        position: "absolute",
+        top: verticalCenterOffset - height / 2,
+        right: -7,
+      }}
+      {...panResponder.panHandlers}
+    >
+      <Box>
+        {sections.map(title => (
+          <ContactsSectionIndexItem
+            key={title}
+            title={title}
+            isActive={title === activeSectionTitle}
+            onPress={onSelectSection}
+          />
+        ))}
+      </Box>
+    </View>
+  );
+}

--- a/features/flow/contacts/src/list/internals/useContactsSectionIndex.native.ts
+++ b/features/flow/contacts/src/list/internals/useContactsSectionIndex.native.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { type SectionList, type ViewToken } from "react-native";
+import type { ContactsListItem, ContactsListSection } from "../types";
+
+const sectionViewabilityConfig = {
+  itemVisiblePercentThreshold: 50,
+} as const;
+
+function getSectionTitle(viewToken: ViewToken<ContactsListItem>): string | undefined {
+  const section = viewToken.section;
+
+  return typeof section === "object" &&
+    section !== null &&
+    "title" in section &&
+    typeof section.title === "string"
+    ? section.title
+    : undefined;
+}
+
+type UseContactsSectionIndexOptions = Readonly<{
+  sections: readonly ContactsListSection[];
+  listRef: RefObject<SectionList<ContactsListItem, ContactsListSection> | null>;
+}>;
+
+export function useContactsSectionIndex({
+  sections,
+  listRef,
+}: UseContactsSectionIndexOptions): Readonly<{
+  activeSectionTitle: string | undefined;
+  sectionIndexEntries: readonly string[];
+  onViewableItemsChanged: (info: { viewableItems: ViewToken<ContactsListItem>[] }) => void;
+  onSelectSection: (title: string) => void;
+  viewabilityConfig: typeof sectionViewabilityConfig;
+}> {
+  const [activeSectionTitle, setActiveSectionTitle] = useState(() => sections[0]?.title);
+  const sectionIndexEntries = useMemo(() => sections.map(section => section.title), [sections]);
+
+  useEffect(() => {
+    setActiveSectionTitle(currentTitle =>
+      sections.some(section => section.title === currentTitle) ? currentTitle : sections[0]?.title,
+    );
+  }, [sections]);
+
+  const onViewableItemsChanged = useRef(
+    ({ viewableItems }: { viewableItems: ViewToken<ContactsListItem>[] }) => {
+      const sectionTitle = viewableItems
+        .filter(viewToken => viewToken.isViewable)
+        .map(getSectionTitle)
+        .find((title): title is string => title !== undefined);
+
+      if (sectionTitle !== undefined) {
+        setActiveSectionTitle(currentTitle =>
+          currentTitle === sectionTitle ? currentTitle : sectionTitle,
+        );
+      }
+    },
+  ).current;
+
+  const onSelectSection = useCallback(
+    (title: string) => {
+      const sectionIndex = sections.findIndex(section => section.title === title);
+
+      if (sectionIndex === -1) {
+        return;
+      }
+
+      setActiveSectionTitle(title);
+      listRef.current?.scrollToLocation({
+        animated: true,
+        itemIndex: 0,
+        sectionIndex,
+        viewOffset: 8,
+      });
+    },
+    [listRef, sections],
+  );
+
+  return {
+    activeSectionTitle,
+    sectionIndexEntries,
+    onViewableItemsChanged,
+    onSelectSection,
+    viewabilityConfig: sectionViewabilityConfig,
+  };
+}

--- a/features/flow/contacts/src/list/internals/useContactsSectionIndex.test.tsx
+++ b/features/flow/contacts/src/list/internals/useContactsSectionIndex.test.tsx
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+import { ContactIdSchema } from "@domain/entity-contact";
+import type { RefObject } from "react";
+import type { SectionList } from "react-native";
+import type { ContactsListItem, ContactsListSection } from "../types";
+import { useContactsSectionIndex } from "./useContactsSectionIndex.native";
+
+const sections: readonly ContactsListSection[] = [
+  {
+    title: "A",
+    data: [
+      {
+        contactId: ContactIdSchema.parse("contact-ada"),
+        name: "Ada",
+        initial: "A",
+        addressCount: 0,
+      },
+    ],
+  },
+  {
+    title: "З",
+    data: [
+      {
+        contactId: ContactIdSchema.parse("contact-zoya"),
+        name: "Зоя",
+        initial: "З",
+        addressCount: 1,
+      },
+    ],
+  },
+  {
+    title: "ع",
+    data: [
+      {
+        contactId: ContactIdSchema.parse("contact-ali"),
+        name: "علي",
+        initial: "ع",
+        addressCount: 2,
+      },
+    ],
+  },
+];
+
+function createListRef() {
+  const scrollToLocation = jest.fn();
+  const listRef = {
+    current: { scrollToLocation },
+  } as unknown as RefObject<SectionList<ContactsListItem, ContactsListSection> | null>;
+
+  return { listRef, scrollToLocation };
+}
+
+describe("useContactsSectionIndex", () => {
+  it("derives the interactive entries from the displayed sections", () => {
+    const { listRef } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    expect(result.current.sectionIndexEntries).toEqual(["A", "З", "ع"]);
+    expect(result.current.activeSectionTitle).toBe("A");
+  });
+
+  it("updates the active section from the visible list items", () => {
+    const { listRef } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [
+          {
+            item: sections[1]?.data[0],
+            key: "contact-zoya",
+            index: 0,
+            isViewable: true,
+            section: sections[1],
+          },
+        ],
+      });
+    });
+
+    expect(result.current.activeSectionTitle).toBe("З");
+  });
+
+  it("ignores visible items without a contacts section", () => {
+    const { listRef } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => {
+      result.current.onViewableItemsChanged({
+        viewableItems: [
+          {
+            item: sections[1]?.data[0],
+            key: "contact-zoya",
+            index: 0,
+            isViewable: true,
+          },
+        ],
+      });
+    });
+
+    expect(result.current.activeSectionTitle).toBe("A");
+  });
+
+  it("scrolls to the selected section", () => {
+    const { listRef, scrollToLocation } = createListRef();
+    const { result } = renderHook(() => useContactsSectionIndex({ sections, listRef }));
+
+    act(() => result.current.onSelectSection("ع"));
+
+    expect(scrollToLocation).toHaveBeenCalledWith({
+      animated: true,
+      itemIndex: 0,
+      sectionIndex: 2,
+      viewOffset: 8,
+    });
+    expect(result.current.activeSectionTitle).toBe("ع");
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Populated Contacts list interaction on Mobile
  - Section selection through tap and drag
  - Visual alignment of the compact right-side index

### 📝 Description

This PR adds the interactive section index to the populated Mobile Contacts list.

The index is derived from the existing rendered sections, keeps non-Latin initials intact, and highlights the section currently visible in the `SectionList`. Users can tap or drag on the compact index to navigate through the list. The flow package owns the scroll state and interaction; Mobile MVVM remains unchanged.

https://github.com/user-attachments/assets/3a87a5e7-fb5c-4dfa-a627-8f2591546226


### ❓ Context

- **JIRA or GitHub link**: [LIVE-34583](https://ledgerhq.atlassian.net/browse/LIVE-34583)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34583]: https://ledgerhq.atlassian.net/browse/LIVE-34583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ