### PR TITLE
[LWDM] fix(canton): persist cantonResources so the topology prompt shows

### DIFF
--- a/.changeset/great-elephants-tickle.md
+++ b/.changeset/great-elephants-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-canton": minor
+---
+
+fix(canton): persist cantonResources so the topology prompt shows

--- a/libs/coin-modules/coin-canton/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/serialization.test.ts
@@ -1,0 +1,84 @@
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
+import type { CantonAccount, CantonAccountRaw } from "../types";
+import { createMockCantonAccount } from "../test/fixtures";
+import { assignFromAccountRaw, assignToAccountRaw, isCantonAccount } from "./serialization";
+
+// Hooks receive a freshly-built destination with no cantonResources; a destination
+// guard would drop the block (and with it publicKey → no topology prompt). LIVE-34585
+describe("canton account serialization", () => {
+  const PUBLIC_KEY = "0adf6d966d86e42dc1ed76b466f14a2efd0fcf05b89106b9aec4341e6f6a74ee";
+  const PARTY_ID = "ldg::122087b04005bdc77c9548701ebc4c2df8bc0c37960258ab700d127e5775fc8cde96";
+
+  it("persists cantonResources onto a freshly-built AccountRaw", () => {
+    const account = createMockCantonAccount(
+      {},
+      {
+        isOnboarded: true,
+        publicKey: PUBLIC_KEY,
+        xpub: PARTY_ID,
+      },
+    ) as Account;
+
+    // fresh raw, no cantonResources yet
+    const accountRaw = { id: account.id } as AccountRaw;
+    expect("cantonResources" in accountRaw).toBe(false);
+
+    assignToAccountRaw(account, accountRaw);
+
+    const raw = accountRaw as CantonAccountRaw;
+    expect(raw.cantonResources).toEqual(
+      expect.objectContaining({ publicKey: PUBLIC_KEY, isOnboarded: true, xpub: PARTY_ID }),
+    );
+  });
+
+  it("restores cantonResources onto a freshly-built Account", () => {
+    const accountRaw = { id: "acc" } as CantonAccountRaw;
+    accountRaw.cantonResources = {
+      isOnboarded: true,
+      instrumentUtxoCounts: {},
+      pendingTransferProposals: [],
+      publicKey: PUBLIC_KEY,
+      xpub: PARTY_ID,
+    };
+
+    // fresh account, no cantonResources yet
+    const account = { id: "acc" } as Account;
+    expect("cantonResources" in account).toBe(false);
+
+    assignFromAccountRaw(accountRaw as AccountRaw, account);
+
+    expect(isCantonAccount(account)).toBe(true);
+    expect((account as CantonAccount).cantonResources.publicKey).toBe(PUBLIC_KEY);
+    expect((account as CantonAccount).cantonResources.isOnboarded).toBe(true);
+  });
+
+  it("round-trips publicKey through save and restore", () => {
+    const account = createMockCantonAccount(
+      {},
+      {
+        isOnboarded: true,
+        publicKey: PUBLIC_KEY,
+        xpub: PARTY_ID,
+      },
+    ) as Account;
+
+    const accountRaw = { id: account.id } as AccountRaw;
+    assignToAccountRaw(account, accountRaw);
+
+    const restored = { id: account.id } as Account;
+    assignFromAccountRaw(accountRaw, restored);
+
+    expect((restored as CantonAccount).cantonResources.publicKey).toBe(PUBLIC_KEY);
+  });
+
+  it("omits publicKey from the raw when it is empty", () => {
+    const account = createMockCantonAccount({}, { isOnboarded: true }) as Account;
+    const accountRaw = { id: account.id } as AccountRaw;
+
+    assignToAccountRaw(account, accountRaw);
+
+    const raw = accountRaw as CantonAccountRaw;
+    expect(raw.cantonResources.isOnboarded).toBe(true);
+    expect("publicKey" in raw.cantonResources).toBe(false);
+  });
+});

--- a/libs/coin-modules/coin-canton/src/bridge/serialization.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/serialization.ts
@@ -10,10 +10,6 @@ export function isCantonAccount(account: Account): account is CantonAccount {
   return "cantonResources" in account;
 }
 
-function isCantonAccountRaw(accountRaw: AccountRaw): accountRaw is CantonAccountRaw {
-  return "cantonResources" in accountRaw;
-}
-
 function toResourcesRaw(r: CantonResources): CantonResourcesRaw {
   const { isOnboarded, instrumentUtxoCounts, pendingTransferProposals, publicKey, xpub } = r;
   return {
@@ -35,18 +31,17 @@ function fromResourcesRaw(r: CantonResourcesRaw): CantonResources {
   };
 }
 
+// Guard on the source only: the serializer passes a freshly-built destination
+// with no cantonResources yet, so a destination guard would drop the block. LIVE-34585
 export function assignToAccountRaw(account: Account, accountRaw: AccountRaw): void {
-  if (isCantonAccount(account) && isCantonAccountRaw(accountRaw)) {
-    if (account.cantonResources) {
-      accountRaw.cantonResources = toResourcesRaw(account.cantonResources);
-    }
+  if (isCantonAccount(account) && account.cantonResources) {
+    (accountRaw as CantonAccountRaw).cantonResources = toResourcesRaw(account.cantonResources);
   }
 }
 
 export function assignFromAccountRaw(accountRaw: AccountRaw, account: Account): void {
-  if (isCantonAccountRaw(accountRaw) && isCantonAccount(account)) {
-    if (accountRaw.cantonResources) {
-      account.cantonResources = fromResourcesRaw(accountRaw.cantonResources);
-    }
+  const { cantonResources } = accountRaw as CantonAccountRaw;
+  if (cantonResources) {
+    (account as CantonAccount).cantonResources = fromResourcesRaw(cantonResources);
   }
 }

--- a/libs/coin-modules/coin-canton/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/sync.test.ts
@@ -15,6 +15,7 @@ jest.mock("../network/gateway", () => ({
   ...jest.requireActual("../network/gateway"),
   getLedgerEnd: jest.fn(),
   getOperations: jest.fn(),
+  getPartyById: jest.fn(),
   getPendingTransferProposals: jest.fn(),
   getCalTokensCached: jest.fn(),
   getEnabledInstrumentsCached: jest.fn(),
@@ -37,6 +38,7 @@ const mockedGetBalance = accountBalance.getBalance as jest.Mock;
 const mockedGetLedgerEnd = gateway.getLedgerEnd as jest.Mock;
 const mockedGetOperations = gateway.getOperations as jest.Mock;
 const mockedGetPendingTransferProposals = gateway.getPendingTransferProposals as jest.Mock;
+const mockedGetPartyById = gateway.getPartyById as jest.Mock;
 const mockedGetCalTokensCached = gateway.getCalTokensCached as unknown as jest.Mock;
 const mockedGetEnabledInstrumentsCached =
   gateway.getEnabledInstrumentsCached as unknown as jest.Mock;
@@ -174,6 +176,7 @@ describe("makeGetAccountShape", () => {
     mockedIsAuthorized.mockResolvedValue(true);
     mockedGetLedgerEnd.mockResolvedValue(12345);
     mockedGetPendingTransferProposals.mockResolvedValue([]);
+    mockedGetPartyById.mockResolvedValue({ party_id: "test-party-id", public_key: "" });
     mockedGetCalTokensCached.mockResolvedValue(new Map());
     mockFindTokenByAddressInCurrency.mockResolvedValue(undefined);
     mockFindTokenById.mockResolvedValue(undefined);
@@ -485,6 +488,35 @@ describe("makeGetAccountShape", () => {
     expect(shape.xpub).toBe("test-party-id");
     // Should not call getAddress since we have xpub
     expect(mockedResolver).not.toHaveBeenCalled();
+  });
+
+  it("backfills publicKey from the gateway when account has xpub but no publicKey (LIVE-34585)", async () => {
+    mockedGetBalance.mockResolvedValue([createMockNativeBalance("1000")]);
+    mockedGetOperations.mockResolvedValue({ operations: [createMockOperationView()] });
+    mockedGetPartyById.mockResolvedValue({
+      party_id: "test-party-id",
+      public_key: "backfilled-public-key",
+    });
+
+    const infoWithXpub = createMockCantonAccountShapeInfo({
+      initialAccount: {
+        xpub: "test-party-id",
+        cantonResources: {
+          isOnboarded: true,
+          instrumentUtxoCounts: {},
+          pendingTransferProposals: [],
+        },
+      } as unknown as CantonAccount,
+    });
+    delete infoWithXpub.deviceId;
+
+    const getAccountShape = makeGetAccountShape(fakeSignerContext);
+    const shape = await getAccountShape(infoWithXpub, { paginationConfig: {} });
+
+    // Deviceless backfill: publicKey now resolves, so validateTopology can run.
+    expect(mockedResolver).not.toHaveBeenCalled();
+    expect(mockedGetPartyById).toHaveBeenCalledWith(sampleCurrency, "test-party-id");
+    expect(shape.cantonResources?.publicKey).toBe("backfilled-public-key");
   });
 
   it("should sync without device when account has publicKey but no xpub", async () => {

--- a/libs/coin-modules/coin-canton/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/sync.ts
@@ -16,6 +16,7 @@ import {
   getKey,
   getLedgerEnd,
   getOperations,
+  getPartyById,
   getPendingTransferProposals,
   SEPARATOR,
   type OperationInfo,
@@ -166,6 +167,15 @@ export function makeGetAccountShape(
       if (isOnboarded && result.partyId) {
         xpubOrAddress = result.partyId;
       }
+    }
+
+    // Backfill publicKey for an already-onboarded account (xpub present but no
+    // publicKey — e.g. synced before publicKey was captured). Deviceless: the
+    // gateway party lookup returns it. Without publicKey, validateTopology can't
+    // run and the topology-change prompt never shows. LIVE-34585
+    if (xpubOrAddress && !publicKey) {
+      const { public_key } = await getPartyById(currency, xpubOrAddress);
+      if (public_key) publicKey = public_key;
     }
 
     const accountId = encodeAccountId({


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**Previous behaviour:** already-onboarded Canton accounts (e.g. Ledger + Kiln, threshold 2) were never prompted to sign the topology downgrade, even though the gateway returned the correct transaction.

**Cause:** the prompt (`validateTopology`) is gated on `account.cantonResources.publicKey`, but `cantonResources` was never persisted. Both serialization hooks in `bridge/serialization.ts` guarded on their *destination* object (`isCantonAccountRaw(accountRaw)` on save, `isCantonAccount(account)` on restore). The serializer passes a freshly-built destination with no `cantonResources` yet, so the guard was always false and the block — including `publicKey` — was silently dropped on every save and restore. On reload `publicKey` was `undefined`, so the prompt never showed. Confirmed on disk: 0/40 Canton accounts had a `cantonResources` block, while every other coin (which guards on the source only) persisted theirs.

**Fix:**
- `serialization.ts` — guard both hooks on the source only (matching cardano/concordium).
- `sync.ts` — backfill `publicKey` deviceless-ly from the gateway party lookup (`getPartyById(xpub).public_key`) so accounts already persisted without it self-heal on the next sync.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34585]
- **ADR** (if any): —

[LIVE-34585]: https://ledgerhq.atlassian.net/browse/LIVE-34585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ