### PR TITLE
test(e2e-mobile): verify swap form shown after closing swap success screen

### DIFF
--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -150,6 +150,14 @@ export default class SwapPage extends CommonPage {
     await tapById(app.common.proceedButtonId);
   }
 
+  @Step("Wait for swap success and close")
+  async waitForSuccessAndClose() {
+    await waitForElementById(this.swapSuccessTitleId, 120000, {
+      errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
+    });
+    await app.common.closePage();
+  }
+
   @Step("Selected provider: $0")
   async logSelectedProvider(providerName: string) {
     jestExpect(providerName).toBeDefined();

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -65,7 +65,8 @@ export function runSwapTest(
         await app.common.disableSynchronizationForiOS();
         await app.swapLiveApp.tapExecuteSwap(provider.uiName);
         await app.swap.verifyAmountsAndAcceptSwap(swap, swapAmount);
-        await app.swap.waitForSuccessAndContinue();
+        await app.swap.waitForSuccessAndClose();
+        await app.swap.expectSwapPage();
       }
     });
   });


### PR DESCRIPTION
## Summary
- Adds `SwapPage.waitForSuccessAndClose()` (`e2e/mobile/page/trade/swap.page.ts`) which waits for the swap success screen and closes it via the header X (`NavigationHeaderCloseButton`, reusing `app.common.closePage()`), instead of tapping "proceed" (which navigates to Swap History).
- `runSwapTest` (`e2e/mobile/specs/swap/swap.ts`) now uses this close path and asserts `app.swap.expectSwapPage()` afterward, verifying the initial swap input form is shown again — matching real app behavior where closing (vs. continuing) returns to the swap form.

## Test plan
- [ ] Run a Detox swap spec that uses `runSwapTest` (e.g. `swapETH_SOL.spec.ts`) against Speculos and confirm the close tap + `expectSwapPage()` pass.
- [ ] Confirm `otherTestCases/swap.other.ts` (still using the old `waitForSuccessAndContinue()`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)