### PR TITLE
[LWD] fix(desktop): make nightly layer more visible

### DIFF
--- a/.changeset/clear-nightly-layer-refactor.md
+++ b/.changeset/clear-nightly-layer-refactor.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Extract NightlyLayer into MVVM component and improve prerelease watermark visibility

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/NightlyLayerView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/NightlyLayerView.tsx
@@ -1,0 +1,26 @@
+import React, { memo } from "react";
+import type { NightlyLayerViewProps } from "./types";
+
+export const NightlyLayerView = memo(function NightlyLayerView({
+  appVersion,
+  watermarks,
+}: NightlyLayerViewProps) {
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-[999999999999] opacity-10 text-muted-hover"
+      data-testid="nightly-layer"
+    >
+      {watermarks.map(({ top, left }) => (
+        <div
+          key={`${top}-${left}`}
+          className="absolute text-center -rotate-45 body-3"
+          style={{ top, left }}
+        >
+          PRERELEASE
+          <br />
+          {appVersion}
+        </div>
+      ))}
+    </div>
+  );
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__integrations__/NightlyLayer.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__integrations__/NightlyLayer.integration.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import NightlyLayer from "../index";
+import { useNightlyLayerViewModel } from "../useNightlyLayerViewModel";
+
+jest.mock("../useNightlyLayerViewModel");
+
+const mockUseNightlyLayerViewModel = jest.mocked(useNightlyLayerViewModel);
+
+describe("NightlyLayer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not render the watermark overlay when not visible", () => {
+    mockUseNightlyLayerViewModel.mockReturnValue({
+      isVisible: false,
+      appVersion: "2.0.0",
+      watermarks: [],
+    });
+
+    render(<NightlyLayer />);
+
+    expect(screen.queryByTestId("nightly-layer")).not.toBeInTheDocument();
+  });
+
+  it("renders the watermark overlay when visible", () => {
+    mockUseNightlyLayerViewModel.mockReturnValue({
+      isVisible: true,
+      appVersion: "2.0.0-nightly",
+      watermarks: [{ top: 50, left: 100 }],
+    });
+
+    render(<NightlyLayer />);
+
+    expect(screen.getByTestId("nightly-layer")).toBeInTheDocument();
+    expect(screen.getByTestId("nightly-layer").textContent).toContain("2.0.0-nightly");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/NightlyLayerView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/NightlyLayerView.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { NightlyLayerView } from "../NightlyLayerView";
+
+describe("NightlyLayerView", () => {
+  it("renders prerelease watermarks with the app version", () => {
+    render(
+      <NightlyLayerView
+        appVersion="2.0.0-nightly"
+        watermarks={[
+          { top: 50, left: 100 },
+          { top: 150, left: 300 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("nightly-layer")).toBeInTheDocument();
+    expect(screen.getByTestId("nightly-layer").textContent).toMatch(
+      /PRERELEASE[\s\S]*2\.0\.0-nightly/,
+    );
+    expect(screen.getByTestId("nightly-layer").children).toHaveLength(2);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/useNightlyLayerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/useNightlyLayerViewModel.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from "@testing-library/react";
+import { useNightlyLayerViewModel } from "../useNightlyLayerViewModel";
+import { getWatermarkPositions } from "../utils/getWatermarkPositions";
+
+describe("useNightlyLayerViewModel", () => {
+  it("returns the app version and watermark grid", () => {
+    const { result } = renderHook(() => useNightlyLayerViewModel());
+
+    expect(result.current.appVersion).toBe(__APP_VERSION__);
+    expect(result.current.watermarks).toEqual(getWatermarkPositions());
+    expect(result.current.watermarks).toHaveLength(400);
+  });
+
+  it("reflects prerelease visibility from build constants", () => {
+    const { result } = renderHook(() => useNightlyLayerViewModel());
+    const expectedVisibility =
+      __PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha");
+
+    expect(result.current.isVisible).toBe(expectedVisibility);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/useNightlyLayerViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/__tests__/useNightlyLayerViewModel.test.ts
@@ -1,21 +1,17 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook } from "tests/testSetup";
 import { useNightlyLayerViewModel } from "../useNightlyLayerViewModel";
-import { getWatermarkPositions } from "../utils/getWatermarkPositions";
 
 describe("useNightlyLayerViewModel", () => {
-  it("returns the app version and watermark grid", () => {
+  it("returns the app version", () => {
     const { result } = renderHook(() => useNightlyLayerViewModel());
 
     expect(result.current.appVersion).toBe(__APP_VERSION__);
-    expect(result.current.watermarks).toEqual(getWatermarkPositions());
-    expect(result.current.watermarks).toHaveLength(400);
   });
 
-  it("reflects prerelease visibility from build constants", () => {
+  it("does not compute watermarks when the layer is hidden in test env", () => {
     const { result } = renderHook(() => useNightlyLayerViewModel());
-    const expectedVisibility =
-      __PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha");
 
-    expect(result.current.isVisible).toBe(expectedVisibility);
+    expect(result.current.isVisible).toBe(false);
+    expect(result.current.watermarks).toEqual([]);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/index.tsx
@@ -1,0 +1,15 @@
+import React, { memo } from "react";
+import { NightlyLayerView } from "./NightlyLayerView";
+import { useNightlyLayerViewModel } from "./useNightlyLayerViewModel";
+
+const NightlyLayer = () => {
+  const { isVisible, ...viewProps } = useNightlyLayerViewModel();
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return <NightlyLayerView {...viewProps} />;
+};
+
+export default memo(NightlyLayer);

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/types.ts
@@ -1,0 +1,12 @@
+export type NightlyLayerWatermark = {
+  readonly top: number;
+  readonly left: number;
+};
+
+export type NightlyLayerViewModelResult = {
+  readonly isVisible: boolean;
+  readonly appVersion: string;
+  readonly watermarks: ReadonlyArray<NightlyLayerWatermark>;
+};
+
+export type NightlyLayerViewProps = Omit<NightlyLayerViewModelResult, "isVisible">;

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/useNightlyLayerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/useNightlyLayerViewModel.ts
@@ -1,16 +1,14 @@
 import { useMemo } from "react";
 import type { NightlyLayerViewModelResult } from "./types";
 import { getWatermarkPositions } from "./utils/getWatermarkPositions";
-
-function shouldShowNightlyLayer(): boolean {
-  return __PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha");
-}
+import { shouldShowNightlyLayer } from "./utils/shouldShowNightlyLayer";
 
 export function useNightlyLayerViewModel(): NightlyLayerViewModelResult {
-  const watermarks = useMemo(() => getWatermarkPositions(), []);
+  const isVisible = shouldShowNightlyLayer(__PRERELEASE__, __CHANNEL__);
+  const watermarks = useMemo(() => (isVisible ? getWatermarkPositions() : []), [isVisible]);
 
   return {
-    isVisible: shouldShowNightlyLayer(),
+    isVisible,
     appVersion: __APP_VERSION__,
     watermarks,
   };

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/useNightlyLayerViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/useNightlyLayerViewModel.ts
@@ -1,0 +1,17 @@
+import { useMemo } from "react";
+import type { NightlyLayerViewModelResult } from "./types";
+import { getWatermarkPositions } from "./utils/getWatermarkPositions";
+
+function shouldShowNightlyLayer(): boolean {
+  return __PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha");
+}
+
+export function useNightlyLayerViewModel(): NightlyLayerViewModelResult {
+  const watermarks = useMemo(() => getWatermarkPositions(), []);
+
+  return {
+    isVisible: shouldShowNightlyLayer(),
+    appVersion: __APP_VERSION__,
+    watermarks,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/__tests__/shouldShowNightlyLayer.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/__tests__/shouldShowNightlyLayer.test.ts
@@ -1,0 +1,15 @@
+import { shouldShowNightlyLayer } from "../shouldShowNightlyLayer";
+
+describe("shouldShowNightlyLayer", () => {
+  it.each([
+    [false, "nightly", false],
+    [true, "null", false],
+    [true, "next", false],
+    [true, "nightly-sha", false],
+    [true, "nightly", true],
+    ["null", "nightly", false],
+    [true, null, false],
+  ])("returns visibility for prerelease=%p channel=%p", (isPrerelease, channel, expected) => {
+    expect(shouldShowNightlyLayer(isPrerelease, channel)).toBe(expected);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/getWatermarkPositions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/getWatermarkPositions.ts
@@ -1,0 +1,20 @@
+import type { NightlyLayerWatermark } from "../types";
+
+const WATERMARK_CELL_WIDTH = 200;
+const WATERMARK_CELL_HEIGHT = 100;
+const WATERMARK_GRID_COUNT = 20;
+
+export function getWatermarkPositions(): ReadonlyArray<NightlyLayerWatermark> {
+  const positions: NightlyLayerWatermark[] = [];
+
+  for (let y = 0.5; y < WATERMARK_GRID_COUNT; y++) {
+    for (let x = 0.5; x < WATERMARK_GRID_COUNT; x++) {
+      positions.push({
+        top: y * WATERMARK_CELL_HEIGHT,
+        left: x * WATERMARK_CELL_WIDTH,
+      });
+    }
+  }
+
+  return positions;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/shouldShowNightlyLayer.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/NightlyLayer/utils/shouldShowNightlyLayer.ts
@@ -1,0 +1,11 @@
+export function shouldShowNightlyLayer(isPrerelease: unknown, channel: unknown): boolean {
+  if (!isPrerelease || isPrerelease === "null" || isPrerelease === "false") {
+    return false;
+  }
+
+  if (typeof channel !== "string" || channel === "null") {
+    return false;
+  }
+
+  return channel !== "next" && !channel.includes("sha");
+}

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -24,6 +24,7 @@ import ContextMenuWrapper from "~/renderer/components/ContextMenu/ContextMenuWra
 import DebugUpdater from "~/renderer/components/debug/DebugUpdater";
 import DebugFirmwareUpdater from "~/renderer/components/debug/DebugFirmwareUpdater";
 import Page from "LLD/components/Page";
+import NightlyLayer from "LLD/components/NightlyLayer";
 import { isWallet40Page } from "LLD/components/Page/utils";
 import AnalyticsConsole from "~/renderer/components/AnalyticsConsole";
 import ThemeConsole from "~/renderer/components/ThemeConsole";
@@ -201,50 +202,6 @@ export const TopBannerContainer = styled.div`
   }
 `;
 
-const NightlyLayerR = () => {
-  const children = [];
-  const w = 200;
-  const h = 100;
-  for (let y = 0.5; y < 20; y++) {
-    for (let x = 0.5; x < 20; x++) {
-      children.push(
-        <div
-          style={{
-            position: "absolute",
-            textAlign: "center",
-            top: y * h,
-            left: x * w,
-            transform: "rotate(-45deg)",
-          }}
-        >
-          PRERELEASE
-          <br />
-          {__APP_VERSION__}
-        </div>,
-      );
-    }
-  }
-  return (
-    <div
-      style={{
-        position: "fixed",
-        pointerEvents: "none",
-        opacity: 0.1,
-        color: "#777",
-        width: "100%",
-        height: "100%",
-        top: 0,
-        right: 0,
-        zIndex: 999999999999,
-      }}
-    >
-      {children}
-    </div>
-  );
-};
-
-const NightlyLayer = React.memo(NightlyLayerR);
-
 // Wrapper component for RecoverPlayer with FeatureToggle
 const RecoverPlayerWithFeatureToggle = () => {
   return (
@@ -392,9 +349,7 @@ export const MainAppLayout = () => {
         />
       </div>
 
-      {__PRERELEASE__ && __CHANNEL__ !== "next" && !__CHANNEL__.includes("sha") ? (
-        <NightlyLayer />
-      ) : null}
+      <NightlyLayer />
 
       <KeyboardContent sequence="CRASH_TEST">
         <LetThisCrashForCrashTest />


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Prerelease watermark overlay visibility on desktop builds
  - NightlyLayer rendering on prerelease channels (excluding `next` and `sha` channels)

### 📝 Description

The prerelease watermark overlay in Ledger Wallet Desktop was hard to see because it used hardcoded inline styles (`color: #777`, `opacity: 0.1`) embedded directly in `Default.tsx`.

**Problem:** The nightly/prerelease watermark was not visible enough, making it difficult to distinguish prerelease builds at a glance.

**Solution:** Extracted the overlay into a dedicated MVVM component at `src/mvvm/components/NightlyLayer/` following the Container → ViewModel → View pattern:

- **`useNightlyLayerViewModel`** — owns visibility rules (`__PRERELEASE__`, channel checks) and watermark grid data
- **`NightlyLayerView`** — pure view using Lumen utility classes (`text-muted-hover`, `body-3`, `-rotate-45`)
- **`Default.tsx`** — simplified to a single `<NightlyLayer />` import


https://github.com/user-attachments/assets/7ebb7963-d937-44f6-a79a-2f265cfa9c29


### ❓ Context

- **JIRA or GitHub link**: [LIVE-34638](https://ledgerhq.atlassian.net/browse/LIVE-34638)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34638]: https://ledgerhq.atlassian.net/browse/LIVE-34638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ