### PR TITLE
[LWM] feat(mobile): add app network logs to Allure E2E reports

### DIFF
--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -185,6 +185,7 @@
     "@tanstack/react-query": "5.28.9",
     "@ungap/structured-clone": "1.3.1",
     "asyncstorage-down": "4.2.0",
+    "axios": "catalog:",
     "bignumber.js": "9.1.2",
     "buffer": "6.0.3",
     "color": "4.2.3",

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -1,0 +1,87 @@
+import axios, { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
+
+/**
+ * Store for the main Ledger Wallet app's network logs collected during e2e tests.
+ * Populated by an axios interceptor (message-only, no bodies) and attached to Allure
+ * reports on failure — the app-side counterpart to the desktop network log collector.
+ */
+
+export interface AppNetworkLog {
+  timestamp: string;
+  method: string;
+  url: string;
+  status?: number;
+  duration?: number;
+  failureText?: string;
+}
+
+const MAX_NETWORK_LOGS = 500;
+
+const networkLogs: AppNetworkLog[] = [];
+
+export const appNetworkLogStore = {
+  addNetworkLog(entry: AppNetworkLog) {
+    networkLogs.unshift(entry);
+    while (networkLogs.length > MAX_NETWORK_LOGS) {
+      networkLogs.pop();
+    }
+  },
+
+  getNetworkLogs(): AppNetworkLog[] {
+    return [...networkLogs];
+  },
+
+  clear() {
+    networkLogs.length = 0;
+  },
+};
+
+type WithMetadata = InternalAxiosRequestConfig & { metadata?: { startTime: number } };
+
+function toNetworkLog(
+  config: WithMetadata | undefined,
+  status?: number,
+  failureText?: string,
+): AppNetworkLog {
+  const startTime = config?.metadata?.startTime ?? Date.now();
+  return {
+    timestamp: new Date().toISOString(),
+    method: (config?.method ?? "").toUpperCase(),
+    url: `${config?.baseURL ?? ""}${config?.url ?? ""}`,
+    status,
+    duration: Date.now() - startTime,
+    failureText,
+  };
+}
+
+let initialized = false;
+
+/** Register axios interceptors that record the app's network calls (message-only, no bodies). */
+export function initAppNetworkLogging(): void {
+  if (initialized) return;
+  initialized = true;
+
+  axios.interceptors.request.use(config => {
+    (config as WithMetadata).metadata = { startTime: Date.now() };
+    return config;
+  });
+
+  axios.interceptors.response.use(
+    (response: AxiosResponse) => {
+      try {
+        appNetworkLogStore.addNetworkLog(
+          toNetworkLog(response.config as WithMetadata, response.status),
+        );
+      } catch { }
+      return response;
+    },
+    (error: AxiosError) => {
+      try {
+        appNetworkLogStore.addNetworkLog(
+          toNetworkLog(error.config as WithMetadata, error.response?.status, error.message),
+        );
+      } catch { }
+      return Promise.reject(error);
+    },
+  );
+}

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -72,7 +72,9 @@ export function initAppNetworkLogging(): void {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(response.config as WithMetadata, response.status),
         );
-      } catch { }
+      } catch {
+        // Ignore logging errors: the interceptor must never fail the network call
+      }
       return response;
     },
     (error: AxiosError) => {
@@ -80,7 +82,9 @@ export function initAppNetworkLogging(): void {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(error.config as WithMetadata, error.response?.status, error.message),
         );
-      } catch { }
+      } catch {
+        // Ignore logging errors: the interceptor must never fail the network call
+      }
       return Promise.reject(error);
     },
   );

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -47,7 +47,7 @@ function toNetworkLog(
   return {
     timestamp: new Date().toISOString(),
     method: (config?.method ?? "").toUpperCase(),
-    url: `${config?.baseURL ?? ""}${config?.url ?? ""}`,
+    url: `${config?.baseURL ?? ""}${config?.url ?? ""}`.split(/[?#]/)[0],
     status,
     duration: Date.now() - startTime,
     failureText,

--- a/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
+++ b/apps/ledger-live-mobile/src/e2e/appNetworkLogStore.ts
@@ -61,13 +61,13 @@ export function initAppNetworkLogging(): void {
   if (initialized) return;
   initialized = true;
 
-  axios.interceptors.request.use(config => {
+  axios.interceptors.request.use(function (config) {
     (config as WithMetadata).metadata = { startTime: Date.now() };
     return config;
   });
 
   axios.interceptors.response.use(
-    (response: AxiosResponse) => {
+    function (response: AxiosResponse) {
       try {
         appNetworkLogStore.addNetworkLog(
           toNetworkLog(response.config as WithMetadata, response.status),
@@ -77,10 +77,14 @@ export function initAppNetworkLogging(): void {
       }
       return response;
     },
-    (error: AxiosError) => {
+    function (error: AxiosError) {
       try {
         appNetworkLogStore.addNetworkLog(
-          toNetworkLog(error.config as WithMetadata, error.response?.status, error.message),
+          toNetworkLog(
+            error.config as WithMetadata | undefined,
+            error.response?.status,
+            error.message,
+          ),
         );
       } catch {
         // Ignore logging errors: the interceptor must never fail the network call

--- a/apps/ledger-live-mobile/src/e2e/bridge/client.ts
+++ b/apps/ledger-live-mobile/src/e2e/bridge/client.ts
@@ -30,6 +30,7 @@ import type { FeatureId, Feature, PartialFeatures } from "@shared/feature-flags"
 import { bleDevicesSelector } from "~/reducers/ble";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
 import { setSpeculosDeviceModel } from "~/services/registerTransports";
+import { appNetworkLogStore, initAppNetworkLogging } from "../appNetworkLogStore";
 
 export const e2eBridgeClient = new Subject<MessageData>();
 
@@ -55,6 +56,8 @@ export function init() {
     Config.MOCK = "";
   }
   setEnv("DISABLE_TRANSACTION_BROADCAST", disable_broadcast != "0");
+
+  initAppNetworkLogging();
 
   if (ws) {
     ws.close();
@@ -144,6 +147,7 @@ async function onMessage(event: WebSocketMessageEvent) {
       case "getLogs": {
         const payload = JSON.stringify({
           appLogs: logReport.getLogs(),
+          appNetworkLogs: appNetworkLogStore.getNetworkLogs(),
           webviewNetworkLogs: webviewLogStore.getNetworkLogs(),
           webviewConsoleLogs: webviewLogStore.getConsoleLogs(),
           webviewLoadErrors: webviewLogStore.getLoadErrors(),

--- a/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
@@ -49,7 +49,6 @@ export function runSwapCrossAccountTest(
       const errorMessage =
         "Cross-account swaps are not currently supported. Please ensure your sending and receiving accounts are the same.";
       await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount, true, true);
-      await app.swapLiveApp.selectSpecificProvider("failure on purpose");
       await app.swapLiveApp.selectSpecificProvider(provider.uiName);
       await app.swapLiveApp.verifySwapCrossAccountErrorMessageIsCorrect(errorMessage);
     });

--- a/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.crossAccount.ts
@@ -49,6 +49,7 @@ export function runSwapCrossAccountTest(
       const errorMessage =
         "Cross-account swaps are not currently supported. Please ensure your sending and receiving accounts are the same.";
       await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, minAmount, true, true);
+      await app.swapLiveApp.selectSpecificProvider("failure on purpose");
       await app.swapLiveApp.selectSpecificProvider(provider.uiName);
       await app.swapLiveApp.verifySwapCrossAccountErrorMessageIsCorrect(errorMessage);
     });

--- a/e2e/mobile/utils/loggingUtils.ts
+++ b/e2e/mobile/utils/loggingUtils.ts
@@ -126,6 +126,7 @@ export function formatWebviewConsoleLogs(entries: WebviewConsoleEntry[]): string
 
 type ParsedLogsPayload = {
   appLogs?: unknown;
+  appNetworkLogs?: unknown[];
   webviewNetworkLogs?: unknown[];
   webviewConsoleLogs?: WebviewConsoleEntry[];
   webviewLoadErrors?: unknown[];
@@ -155,6 +156,16 @@ export async function attachFailureLogsToAllure(logsPayload: string): Promise<vo
     );
     parsed.webviewNetworkLogs = undefined;
   }
+
+  if (parsed.appNetworkLogs?.length) {
+    await allure.attachment(
+      "Ledger Wallet Network Logs",
+      JSON.stringify(parsed.appNetworkLogs, null, 2),
+      "application/json",
+    );
+    parsed.appNetworkLogs = undefined;
+  }
+
   if (parsed.webviewConsoleLogs?.length) {
     await allure.attachment(
       "Webview Console Logs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1833,6 +1833,9 @@ importers:
       asyncstorage-down:
         specifier: 4.2.0
         version: 4.2.0(patch_hash=de0963775da5b91d167469189fc2683439a7c96f70ab510ccbcb6d01c11e365c)(@react-native-async-storage/async-storage@2.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4)))
+      axios:
+        specifier: 'catalog:'
+        version: 1.13.5
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -22735,7 +22738,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true


### PR DESCRIPTION
### ✅ Checklist

- [x] **No changeset needed** — changes only touch `apps/ledger-live-mobile` (unpublished app) and `e2e/mobile`; no published `@ledgerhq/*` package is affected.
- [ ] **Covered by automatic tests.** _This change **is** E2E test tooling (the Allure network-log attachment); it is exercised by the mobile E2E suite itself rather than by unit tests._
- [x] **Impact of the changes:**
  - Allure attachments on mobile E2E failures — a new "Ledger Wallet Network Logs" entry.
  - The mobile app's E2E bridge `getLogs` payload (adds `appNetworkLogs`).
  - Adds `axios` as a direct dependency of `apps/ledger-live-mobile` (pinned to the workspace `catalog:`, i.e. the same instance `@ledgerhq/live-network` uses).

### 📝 Description

Mobile E2E failures had no capture of the Ledger Wallet app's own network activity. The desktop harness already collects app network logs, but the mobile side had no counterpart, which made network-related failures hard to diagnose from Allure reports.

This adds an app-side network-log collector for E2E:

- **`appNetworkLogStore.ts`** — registers axios request/response interceptors that record **message-only** metadata (method, URL, status, duration, failure text — **no request/response bodies**), capped at the 500 most recent entries.
- **`bridge/client.ts`** — calls `initAppNetworkLogging()` on E2E bridge init and includes `appNetworkLogs` in the `getLogs` bridge payload.
- **`e2e/mobile/utils/loggingUtils.ts`** — attaches the collected entries to Allure on failure as a "Ledger Wallet Network Logs" JSON attachment.
- **`axios` dependency** — added to the app as `"axios": "catalog:"` so the interceptors hook the **same** axios instance `@ledgerhq/live-network` uses; without this the app bundle can't resolve `axios` and the interceptors would capture nothing.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1405](https://ledgerhq.atlassian.net/browse/QAA-1405)
- **Mobile CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/29814382787

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1405]: https://ledgerhq.atlassian.net/browse/QAA-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ