### PR TITLE
feat: add shared add-contact scenario state

### DIFF
--- a/.changeset/flow-contacts-add-contact-model.md
+++ b/.changeset/flow-contacts-add-contact-model.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared add-contact scenario state and save hook for Contacts flows

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -9,6 +9,7 @@ Shared Contacts flow package for Desktop and Mobile.
 
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
+- `useAddContactViewModel` hook (this package; app wiring injects `ContactCreationPort`)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 
@@ -35,6 +36,7 @@ entry point. The native entry also exports `ContactsAddContactHeaderButton` via 
 src/
 ├── components/
 │   └── ContactsButton/   # My Wallet entry
+├── add/                  # Shared add-contact scenario state
 ├── hooks/
 ├── list/                 # Shared list view models and page shells
 │   ├── components/

--- a/features/flow/contacts/src/add/controller.test.ts
+++ b/features/flow/contacts/src/add/controller.test.ts
@@ -1,0 +1,46 @@
+import { contact } from "@domain/entity-contact";
+import { createAddContactController } from "./controller";
+import type { ContactCreationPort } from "./ports";
+
+function createContactCreationPort(
+  implementation: ContactCreationPort["createContact"],
+): ContactCreationPort {
+  return { createContact: implementation };
+}
+
+describe("createAddContactController", () => {
+  it("keeps save disabled until the draft name is valid", () => {
+    const controller = createAddContactController(
+      createContactCreationPort(jest.fn()),
+    );
+
+    expect(controller.getViewModel("").isSaveEnabled).toBe(false);
+    expect(controller.getViewModel("Ben").isSaveEnabled).toBe(true);
+  });
+
+  it("rejects save when the draft name is empty", async () => {
+    const controller = createAddContactController(createContactCreationPort(jest.fn()));
+
+    await expect(controller.save("")).rejects.toThrow();
+  });
+
+  it("creates a contact through the injected creation port", async () => {
+    const createContact = jest.fn(async ({ name }) =>
+      contact({
+        id: "contact-olivia",
+        isMe: false,
+        name,
+        addresses: [],
+      }),
+    );
+    const controller = createAddContactController(createContactCreationPort(createContact));
+
+    await expect(controller.save("Olivia")).resolves.toMatchObject({
+      id: "contact-olivia",
+      isMe: false,
+      name: "Olivia",
+      addresses: [],
+    });
+    expect(createContact).toHaveBeenCalledWith({ name: "Olivia" });
+  });
+});

--- a/features/flow/contacts/src/add/controller.ts
+++ b/features/flow/contacts/src/add/controller.ts
@@ -1,0 +1,22 @@
+import { ContactNameSchema, type Contact } from "@domain/entity-contact";
+import type { ContactCreationPort } from "./ports";
+import { createAddContactViewModel } from "./viewModel";
+import type { AddContactViewModel } from "./types";
+
+export type AddContactController = Readonly<{
+  getViewModel: (draftName: string) => AddContactViewModel;
+  save: (draftName: string) => Promise<Contact>;
+}>;
+
+export function createAddContactController(
+  contactCreation: ContactCreationPort,
+): AddContactController {
+  return {
+    getViewModel: draftName => createAddContactViewModel(draftName),
+    save: async draftName => {
+      const parsedName = ContactNameSchema.parse(draftName.trim());
+
+      return contactCreation.createContact({ name: parsedName });
+    },
+  };
+}

--- a/features/flow/contacts/src/add/index.ts
+++ b/features/flow/contacts/src/add/index.ts
@@ -1,0 +1,4 @@
+export type { ContactCreationInput, ContactCreationPort } from "./ports";
+export type { AddContactViewModel } from "./types";
+export { createAddContactViewModel } from "./viewModel";
+export { createAddContactController, type AddContactController } from "./controller";

--- a/features/flow/contacts/src/add/ports.ts
+++ b/features/flow/contacts/src/add/ports.ts
@@ -1,0 +1,10 @@
+import type { Contact, ContactInput } from "@domain/entity-contact";
+
+export type ContactCreationInput = Readonly<{
+  name: ContactInput["name"];
+}>;
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactCreationPort = Readonly<{
+  createContact(input: ContactCreationInput): Promise<Contact>;
+}>;

--- a/features/flow/contacts/src/add/types.ts
+++ b/features/flow/contacts/src/add/types.ts
@@ -1,0 +1,5 @@
+export type AddContactViewModel = Readonly<{
+  draftName: string;
+  avatarInitial: string;
+  isSaveEnabled: boolean;
+}>;

--- a/features/flow/contacts/src/add/viewModel.test.ts
+++ b/features/flow/contacts/src/add/viewModel.test.ts
@@ -1,0 +1,39 @@
+import { createAddContactViewModel } from "./viewModel";
+
+describe("createAddContactViewModel", () => {
+  it("disables save for an empty draft name", () => {
+    expect(createAddContactViewModel("")).toEqual({
+      draftName: "",
+      avatarInitial: "",
+      isSaveEnabled: false,
+    });
+  });
+
+  it("enables save for a valid draft name", () => {
+    expect(createAddContactViewModel("Ben")).toEqual({
+      draftName: "Ben",
+      avatarInitial: "B",
+      isSaveEnabled: true,
+    });
+  });
+
+  it("disables save for an invalid draft name", () => {
+    expect(createAddContactViewModel("Olive2")).toMatchObject({
+      draftName: "Olive2",
+      isSaveEnabled: false,
+    });
+  });
+
+  it("derives the avatar initial from the trimmed draft name", () => {
+    expect(createAddContactViewModel("  Ben")).toMatchObject({
+      draftName: "  Ben",
+      avatarInitial: "B",
+      isSaveEnabled: true,
+    });
+  });
+
+  it("computes the avatar initial from the current draft name", () => {
+    expect(createAddContactViewModel("olive").avatarInitial).toBe("O");
+    expect(createAddContactViewModel("élodie").avatarInitial).toBe("É");
+  });
+});

--- a/features/flow/contacts/src/add/viewModel.ts
+++ b/features/flow/contacts/src/add/viewModel.ts
@@ -1,0 +1,13 @@
+import { ContactNameSchema } from "@domain/entity-contact";
+import { getContactInitial } from "../list/internals";
+import type { AddContactViewModel } from "./types";
+
+export function createAddContactViewModel(draftName: string): AddContactViewModel {
+  const trimmedDraftName = draftName.trim();
+
+  return {
+    draftName,
+    avatarInitial: getContactInitial(trimmedDraftName),
+    isSaveEnabled: ContactNameSchema.safeParse(trimmedDraftName).success,
+  };
+}

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -1,4 +1,6 @@
 export { useContacts } from "./useContacts";
+export { useAddContactViewModel } from "./useAddContactViewModel";
+export type { UseAddContactViewModelResult } from "./useAddContactViewModel";
 export { useContactsListViewModel } from "./useContactsListViewModel";
 export { useContactsMeContact } from "./useContactsMeContact";
 export { useContactsSearchViewModel } from "./useContactsSearchViewModel";

--- a/features/flow/contacts/src/hooks/useAddContactViewModel.test.ts
+++ b/features/flow/contacts/src/hooks/useAddContactViewModel.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, act } from "@testing-library/react";
+import { contact } from "@domain/entity-contact";
+import type { ContactCreationPort } from "../add/ports";
+import { useAddContactViewModel } from "./useAddContactViewModel";
+
+describe("useAddContactViewModel", () => {
+  it("updates derived state when the draft name changes", () => {
+    const contactCreation: ContactCreationPort = {
+      createContact: jest.fn(),
+    };
+
+    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+
+    expect(result.current.isSaveEnabled).toBe(false);
+
+    act(() => {
+      result.current.setDraftName("Ben");
+    });
+
+    expect(result.current).toMatchObject({
+      draftName: "Ben",
+      avatarInitial: "B",
+      isSaveEnabled: true,
+    });
+  });
+
+  it("delegates save to the injected creation port", async () => {
+    const createContact = jest.fn(async ({ name }) =>
+      contact({
+        id: "contact-olivia",
+        isMe: false,
+        name,
+        addresses: [],
+      }),
+    );
+    const contactCreation: ContactCreationPort = { createContact };
+    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+
+    act(() => {
+      result.current.setDraftName("Olivia");
+    });
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(createContact).toHaveBeenCalledWith({ name: "Olivia" });
+  });
+
+  it("rejects save when the draft name is invalid", async () => {
+    const createContact = jest.fn();
+    const contactCreation: ContactCreationPort = { createContact };
+    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+
+    act(() => {
+      result.current.setDraftName("Olive2");
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.save();
+      }),
+    ).rejects.toThrow();
+    expect(createContact).not.toHaveBeenCalled();
+  });
+});

--- a/features/flow/contacts/src/hooks/useAddContactViewModel.ts
+++ b/features/flow/contacts/src/hooks/useAddContactViewModel.ts
@@ -1,0 +1,36 @@
+import type { Contact } from "@domain/entity-contact";
+import { useCallback, useMemo, useState } from "react";
+import { createAddContactController } from "../add/controller";
+import type { ContactCreationPort } from "../add/ports";
+import type { AddContactViewModel } from "../add/types";
+
+export type UseAddContactViewModelResult = AddContactViewModel &
+  Readonly<{
+    setDraftName: (draftName: string) => void;
+    save: () => Promise<Contact>;
+  }>;
+
+/**
+ * Shared add-contact scenario state for Contacts UI.
+ * Pass a stable `ContactCreationPort`; a new reference each render recreates the controller.
+ */
+export function useAddContactViewModel(
+  contactCreation: ContactCreationPort,
+): UseAddContactViewModelResult {
+  const [draftName, setDraftName] = useState("");
+  const controller = useMemo(
+    () => createAddContactController(contactCreation),
+    [contactCreation],
+  );
+  const viewModel = useMemo(
+    () => controller.getViewModel(draftName),
+    [controller, draftName],
+  );
+  const save = useCallback(() => controller.save(draftName), [controller, draftName]);
+
+  return {
+    ...viewModel,
+    setDraftName,
+    save,
+  };
+}

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -1,3 +1,4 @@
+export * from "./add";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./add";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";

--- a/features/flow/contacts/src/jest.native.ts
+++ b/features/flow/contacts/src/jest.native.ts
@@ -1,3 +1,4 @@
+export * from "./add";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description
This pull request introduces a shared "Add Contact" scenario state and supporting logic for the Contacts flow, making it easier to add contacts in both Desktop and Mobile environments. The main changes include a new controller, view model, React hook, and their associated types and tests. These updates are now exported for use throughout the application.

**Add Contact Flow Implementation:**

* Introduced the `add` module containing the core logic for adding a contact, including `controller`, `viewModel`, types, and ports for dependency injection. 
* Added comprehensive tests for the controller and view model to ensure correct behavior, including validation and integration with the injected creation port. 

**React Integration:**

* Added the `useAddContactViewModel` React hook, which manages the add contact state and exposes actions and derived state for UI integration, along with its test. 
* Exported the new add-contact logic and hook from the main entry points for both web and native, making them available for use in the rest of the application. 

**Documentation and Project Structure:**

* Updated the `README.md` to document the new add-contact flow, its hooks, and the new directory structure. 

**Release Note:**

* Added a changeset to document the addition of the shared add-contact scenario state and save hook for Contacts flows.

### 🔗 Context

[LIVE-33895](https://ledgerhq.atlassian.net/browse/LIVE-33895)

[LIVE-33895]: https://ledgerhq.atlassian.net/browse/LIVE-33895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ