### PR TITLE
[LWM] fix(LIVE-34673): show quick amount selector for token transfers

### DIFF
--- a/.changeset/quiet-plums-attend.md
+++ b/.changeset/quiet-plums-attend.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix quick amount selector not showing for token transfers

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
@@ -6,7 +6,7 @@ import { ScreenName } from "~/const";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
-import { ALEO_ACCOUNT_1 } from "~/families/aleo/__mocks__/account.mock";
+import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "~/families/aleo/__mocks__/account.mock";
 import SendAmountCoin from "./03a-AmountCoin";
 
 jest.mock("LLM/hooks/useAccountScreen", () => ({
@@ -86,6 +86,22 @@ describe("SendAmountCoin — custom send flow", () => {
 
     render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
 
+    expect(screen.getByTestId("after-amount-input")).toBeOnTheScreen();
+  });
+
+  it("resolves the custom send flow from the parent chain's family when sending a token", () => {
+    mockUseAccountScreen.mockReturnValue({
+      account: ALEO_TOKEN_ACCOUNT_1,
+      parentAccount: ALEO_ACCOUNT_1,
+    });
+    mockGetCustomSendFlow.mockReturnValue({
+      screens: [],
+      AfterAmountInput: () => <View testID="after-amount-input" />,
+    });
+
+    render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    expect(mockGetCustomSendFlow).toHaveBeenCalledWith("aleo");
     expect(screen.getByTestId("after-amount-input")).toBeOnTheScreen();
   });
 });

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -10,8 +10,7 @@ import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AccountLike, Account } from "@ledgerhq/types-live";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
-import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
-import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/index";
+import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import { ScreenName } from "~/const";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
@@ -153,8 +152,8 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
   const { useAllAmount } = transaction;
   const { amount } = status;
   const currency = getAccountCurrency(account);
-  const family = getFamilyByCurrencyId(currency.id);
-  const familySendFlow = family ? getCustomSendFlow(family) : null;
+  const mainAccount = getMainAccount(account, parentAccount);
+  const familySendFlow = getCustomSendFlow(mainAccount.currency.family);
 
   const transferFee =
     "model" in transaction && transaction.model.commandDescriptor?.command.kind === "token.transfer"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix quick amount selector not showing for token transfers.

<img width="440" alt="Simulator Screenshot - iOS Simulator - 2026-07-20 at 17 43 55" src="https://github.com/user-attachments/assets/42afb89b-ac30-4f10-b1a5-1c129f22c707" />

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-34673