### PR TITLE
[LWDM] fix(send): accept comma decimal and dismiss keyboard in custom fees

### DIFF
--- a/.changeset/tidy-fees-comma.md
+++ b/.changeset/tidy-fees-comma.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+---
+
+Fix custom fees on iOS in the new send flow: accept a comma decimal separator (normalized to a dot so the value is valid and can be confirmed), and dismiss the keyboard by tapping outside the inputs so the Confirm button is reachable

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/CustomFees/components/CustomFeesScreenView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Keyboard, Pressable } from "react-native";
 import { Box, Button, Text, TextInput } from "@ledgerhq/lumen-ui-rnative";
 import type {
   CustomFeeInputState,
@@ -66,7 +67,7 @@ export function CustomFeesScreenView({
 }: CustomFeesScreenViewProps) {
   return (
     <SendFlowLayout>
-      <Box lx={{ flex: 1 }}>
+      <Pressable style={{ flex: 1 }} onPress={Keyboard.dismiss} accessible={false}>
         <Box lx={{ gap: "s24" }}>
           {hasCustomAssets && assetOptions.length > 0 && (
             <FeeAssetSelector
@@ -109,7 +110,7 @@ export function CustomFeesScreenView({
         <Button appearance="base" size="lg" onPress={onConfirm} disabled={isConfirmDisabled}>
           {confirmLabel}
         </Button>
-      </Box>
+      </Pressable>
     </SendFlowLayout>
   );
 }

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeesViewModelCore.test.ts
@@ -243,6 +243,51 @@ describe("useCustomFeesViewModelCore", () => {
     expect(nextTransaction.fees.toFixed()).toBe("30000000000000000");
   });
 
+  it("normalizes a comma decimal separator typed on the iOS decimal-pad", async () => {
+    const transaction = createTransaction();
+    const transactionActions = createTransactionActions();
+    const calculateCountervalue = jest.fn(() => new BigNumber(0));
+
+    const { result } = renderHook(() =>
+      useCustomFeesViewModelCore({
+        account: createAccount(),
+        parentAccount: null,
+        transaction,
+        status: createStatus(),
+        currency: celoCurrency,
+        transactionActions,
+        onConfirm: jest.fn(),
+        locale: "fr-FR",
+        discreet: false,
+        counterValueCurrency: usdCurrency,
+        calculateCountervalue,
+        labels,
+      }),
+    );
+
+    act(() => {
+      result.current.onInputChange("fees", "0,03");
+    });
+
+    // The comma is normalized to a dot: displayed with a dot, valid (no error).
+    expect(result.current.inputs[0].value).toBe("0.03");
+    expect(result.current.inputs[0].error).toBeNull();
+
+    await act(async () => {
+      await flushBridgeEstimation();
+    });
+
+    // Confirm applies the fee (would early-return if the value were rejected as invalid).
+    act(() => {
+      result.current.onConfirm();
+    });
+
+    const updater = (transactionActions.updateTransaction as jest.Mock).mock.calls[0][0];
+    const nextTransaction = updater(transaction);
+    expect(nextTransaction.feesStrategy).toBe("custom");
+    expect(nextTransaction.fees.toFixed()).toBe("30000000000000000");
+  });
+
   it("derives each asset option's formattedBalance from balance + currency + locale", async () => {
     const transaction = createTransaction();
     const transactionActions = createTransactionActions();

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
@@ -21,6 +21,7 @@ import {
   isValidNumberForInput,
   computeSuggestedRange,
   computeMinValue,
+  normalizeDecimalSeparator,
 } from "../utils/customFeeUtils";
 import { resolveFeeDisplayContext } from "../../utils/networkFeesDisplay";
 
@@ -265,7 +266,8 @@ export function useCustomFeesViewModelCore({
   );
 
   const onInputChange = useCallback((key: string, value: string) => {
-    setValues(prev => ({ ...prev, [key]: value }));
+    const normalized = normalizeDecimalSeparator(value);
+    setValues(prev => ({ ...prev, [key]: normalized }));
     setTouched(prev => ({ ...prev, [key]: true }));
   }, []);
 

--- a/libs/ledger-live-common/src/flows/send/customFees/utils/__tests__/customFeeUtils.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/utils/__tests__/customFeeUtils.test.ts
@@ -1,4 +1,18 @@
-import { isValidNumberForInput } from "../customFeeUtils";
+import { isValidNumberForInput, normalizeDecimalSeparator } from "../customFeeUtils";
+
+describe("normalizeDecimalSeparator", () => {
+  it("converts a comma decimal separator to a dot", () => {
+    expect(normalizeDecimalSeparator("0,0014")).toBe("0.0014");
+  });
+
+  it("leaves a dot separator untouched (idempotent)", () => {
+    expect(normalizeDecimalSeparator("0.0014")).toBe("0.0014");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(normalizeDecimalSeparator("")).toBe("");
+  });
+});
 
 describe("isValidNumberForInput", () => {
   it.each(["Infinity", "-Infinity", "NaN"])("rejects non-finite values for fee inputs", value => {

--- a/libs/ledger-live-common/src/flows/send/customFees/utils/customFeeUtils.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/utils/customFeeUtils.ts
@@ -2,6 +2,10 @@ import { BigNumber } from "bignumber.js";
 import type { Transaction } from "../../../../coin-modules/transaction-types";
 import type { CustomFeeInputDescriptor } from "../../../../bridge/descriptor/types";
 
+export function normalizeDecimalSeparator(value: string): string {
+  return value.replace(",", ".");
+}
+
 export function isValidNumberForInput(inputKey: string, value: string): boolean {
   if (!value.trim()) return false;
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Decimal-separator normalization is covered by unit tests (helper + view-model core). The keyboard-dismiss behaviour is UI-only and validated manually on device._
- [x] **Impact of the changes:**
      - New send flow — Custom fees screen (iOS + Android)
      - Typing a decimal fee value with a comma (localized numpad, e.g. fr/es) — must be accepted and confirmable
      - Dismissing the keyboard by tapping outside the inputs so the Confirm button is reachable
      - Regression check on locales using a dot separator (en)

### 📝 Description

**Problem**: In the new send flow (feature flag `newSendFlow`), the custom fees input uses an iOS `decimal-pad`, which surfaces the locale decimal separator — a **comma** in many locales (fr, es, …). The typed value was parsed directly with `BigNumber`, so `"0,0014"` became `NaN` → the field showed *"Enter a valid number"* (LIVE-34630) and the fee could never be confirmed/applied (LIVE-34629). On top of that, the native `decimal-pad` has no "done" key and tapping outside did not dismiss the keyboard, leaving the Confirm button hidden behind it.

**Solution**:
- Normalize the decimal separator (comma → dot) as the user types, in the platform-agnostic view-model core (`onInputChange`). The field now displays a dot and every downstream consumer (validation, bridge estimation, `buildTransactionPatch`) receives a parsable value. Single choke point → fixes both tickets and benefits desktop too.
- Dismiss the keyboard when tapping outside the inputs on the Custom fees screen (wrap the content in a `Pressable` calling `Keyboard.dismiss`), so the Confirm button becomes reachable.

### 🎥 Demo

| Before | After |
| ------ | ----- |
| https://github.com/user-attachments/assets/cf3c9da1-c803-4bc8-8529-21b9338763f1 | https://github.com/user-attachments/assets/02dc1d38-6434-47d4-8a19-c7006464bfc7|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34630](https://ledgerhq.atlassian.net/browse/LIVE-34630) · [LIVE-34629](https://ledgerhq.atlassian.net/browse/LIVE-34629)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-34630]: https://ledgerhq.atlassian.net/browse/LIVE-34630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ