### PR TITLE
[LWDM] refactor(cryptoassets): clear value-barrel stragglers in wallet-cli + live-common

### DIFF
--- a/.changeset/swift-ravens-repoint.md
+++ b/.changeset/swift-ravens-repoint.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/wallet-cli": minor
+"@ledgerhq/live-common": minor
+---
+
+Repoint remaining @ledgerhq/cryptoassets value-barrel imports to @domain/entity-currency-crypto and @domain/entity-currency-fiat; inline ApiAsset wire-type into the dada-client entities module; drop @ledgerhq/cryptoassets from wallet-cli devDependencies

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -60,7 +60,6 @@
     "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/coin-solana": "workspace:^",
     "@ledgerhq/context-module": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",

--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
@@ -4,7 +4,7 @@ import { getMainAccount, getParentAccount } from "@ledgerhq/ledger-wallet-framew
 import type { Account, AccountLike, SignOperationEvent } from "@ledgerhq/types-live";
 import { getCurrencyForAccount } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { BigNumber } from "bignumber.js";
 import { firstValueFrom } from "rxjs";
 import { filter, tap } from "rxjs/operators";

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -7,17 +7,13 @@ import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
-import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
-  CRYPTO_CURRENCIES_REGISTRY,
-  CRYPTO_CURRENCY_ALIASES,
   getCryptoCurrencyById,
   findCryptoCurrencyById,
   findCryptoCurrencyByScheme,
   listCryptoCurrencies,
   hasCryptoCurrencyId,
 } from "@domain/entity-currency-crypto";
-import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { setCryptoAssetsStore as setFrameworkCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import pkg from "../package.json" with { type: "json" };
@@ -110,9 +106,6 @@ export const WALLET_CLI_SUPPORTED_CRYPTO_CURRENCY_IDS: readonly CryptoCurrencyId
   "solana",
 ];
 
-// The domain registries are the runtime source of truth for currency data.
-setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
-setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
 setCurrenciesResolver({
   getCryptoCurrencyById,
   findCryptoCurrencyById,

--- a/apps/wallet-cli/src/shared/accountDescriptor/adapters.ts
+++ b/apps/wallet-cli/src/shared/accountDescriptor/adapters.ts
@@ -10,7 +10,7 @@
  * @ledgerhq/ledger-wallet-framework/derivation — no hardcoded coin types or path tables.
  */
 
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   getDerivationScheme,
   runDerivationScheme,

--- a/apps/wallet-cli/src/shared/accountDescriptor/network.ts
+++ b/apps/wallet-cli/src/shared/accountDescriptor/network.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 /**
  * A Network identifies a blockchain by name and environment.
@@ -90,7 +90,7 @@ export class UnknownNetworkError extends Error {
  *   "solana_devnet"    → { name: "solana",   env: "devnet" }   (isTestnetFor = "solana")
  *   "ethereum_goerli"  → { name: "ethereum", env: "goerli" }   (isTestnetFor = "ethereum")
  *
- * Throws UnknownNetworkError if the currencyId is not known to @ledgerhq/cryptoassets.
+ * Throws UnknownNetworkError if the currencyId is not found in the currency registry.
  */
 export function networkFromCurrencyId(currencyId: string): Network {
   let currency;
@@ -98,7 +98,7 @@ export function networkFromCurrencyId(currencyId: string): Network {
     currency = getCryptoCurrencyById(currencyId);
   } catch {
     throw new UnknownNetworkError(
-      `Unknown currencyId "${currencyId}": not found in @ledgerhq/cryptoassets`,
+      `Unknown currencyId "${currencyId}": not found in currency registry`,
     );
   }
   if (currency.isTestnetFor) {

--- a/apps/wallet-cli/src/wallet/intents/parse-amount.test.ts
+++ b/apps/wallet-cli/src/wallet/intents/parse-amount.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import { parseAmountWithTicker } from "./parse-amount";
 

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -297,7 +297,6 @@
     "@ledgerhq/coin-vechain": "workspace:^",
     "@ledgerhq/coin-xrp": "catalog:",
     "@ledgerhq/context-module": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-core": "workspace:^",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",

--- a/libs/ledger-live-common/src/dada-client/entities/index.ts
+++ b/libs/ledger-live-common/src/dada-client/entities/index.ts
@@ -1,6 +1,41 @@
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
-import type { ApiAsset } from "@ledgerhq/cryptoassets";
 import { PartialMarketItemResponse } from "../../market/utils/types";
+
+// Raw DADA API wire-format shapes for currency assets
+export interface ApiTokenCurrency {
+  type: "token_currency";
+  id: string;
+  contractAddress: string;
+  name: string;
+  ticker: string;
+  units: Array<{ code: string; name: string; magnitude: number }>;
+  standard: string;
+  parentCurrency?: string | null;
+  tokenIdentifier?: string;
+  symbol?: string;
+  delisted?: boolean;
+  disableCountervalue?: boolean;
+  descriptor?: unknown;
+}
+
+export interface ApiCryptoCurrency {
+  type: "crypto_currency";
+  id: string;
+  name: string;
+  ticker: string;
+  units: Array<{ code: string; name: string; magnitude: number }>;
+  chainId?: string | null;
+  confirmationsNeeded?: number;
+  symbol?: string;
+  coinType?: number;
+  family?: string;
+  hasSegwit?: boolean;
+  hasTokens?: boolean;
+  hrp?: string | null;
+  disableCountervalue?: boolean;
+}
+
+export type ApiAsset = ApiTokenCurrency | ApiCryptoCurrency;
 
 // Types for crypto asset metadata
 export interface CryptoAssetMeta {

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -5,7 +5,7 @@ import {
   FetchBaseQueryMeta,
   QueryReturnValue,
 } from "@reduxjs/toolkit/query/react";
-import type { ApiAsset } from "@ledgerhq/cryptoassets";
+import type { ApiAsset } from "../entities";
 import type { CryptoOrTokenCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { convertApiToken } from "@domain/api-currency-token";

--- a/libs/ledger-live-common/src/families/multiversx/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/multiversx/bridge/api.test.ts
@@ -2,7 +2,7 @@
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getAssetFromToken, getTokenFromAsset, computeIntentType } from "./api";
 
 jest.mock("@ledgerhq/ledger-wallet-framework/cryptoAssetsStore");

--- a/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
+++ b/libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts
@@ -1,4 +1,5 @@
-import { findCryptoCurrencyByTicker, findFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyByTicker } from "@domain/entity-currency-crypto";
+import { findFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import { counterValueFormatter } from "../countervalueFormatter";
 
 const usd = findFiatCurrencyByTicker("USD")!.units[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2383,9 +2383,6 @@ importers:
       '@ledgerhq/context-module':
         specifier: 2.3.0
         version: 2.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent
@@ -65986,7 +65983,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66110,54 +66107,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9043,9 +9043,6 @@ importers:
       '@ledgerhq/context-module':
         specifier: 2.3.0
         version: 2.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/cryptoassets
       '@ledgerhq/device-core':
         specifier: workspace:^
         version: link:../device-core
@@ -65983,7 +65980,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66107,6 +66104,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
## Summary

Clears the remaining `@ledgerhq/cryptoassets` VALUE barrel imports that were left behind after prior repoints. Unblocks [LIVE-31961](https://ledgerhq.atlassian.net/browse/LIVE-31961).

- **wallet-cli** — repoint `getCryptoCurrencyById` / `findCryptoCurrencyById` in `adapters.ts`, `network.ts`, `parse-amount.test.ts`, `cli-swap-pipeline.ts` to `@domain/entity-currency-crypto`
- **wallet-cli** — remove `setCryptoCurrenciesStore` / `setFiatCurrenciesStore` from `live-common-setup.ts`; wallet-cli's coin families (bitcoin, evm, solana) do not read the legacy store, so the seeding calls are dead code
- **live-common** — repoint `findCryptoCurrencyByTicker` / `findFiatCurrencyByTicker` in the countervalue formatter test to domain packages
- **live-common** — repoint `getCryptoCurrencyById` in the multiversx bridge test
- **live-common** — inline `ApiAsset` / `ApiTokenCurrency` / `ApiCryptoCurrency` into the dada-client `entities` module (they are raw DADA API wire-format types; their only consumers are within that module)
- **wallet-cli** — drop `@ledgerhq/cryptoassets` from `devDependencies`

## Verify

```bash
git grep '@ledgerhq/cryptoassets' -- 'apps/wallet-cli/src'         # → 0
git grep '@ledgerhq/cryptoassets' -- \
  'libs/ledger-live-common/src/market/utils/__tests__/countervalueFormatter.test.ts' \
  'libs/ledger-live-common/src/families/multiversx/bridge/api.test.ts' \
  'libs/ledger-live-common/src/dada-client/entities/index.ts' \
  'libs/ledger-live-common/src/dada-client/state-manager/api.ts'   # → 0
```

## Test plan

- [ ] `pnpm --filter @ledgerhq/wallet-cli test` — adapters, network, parse-amount suites
- [ ] `pnpm --filter @ledgerhq/live-common test countervalueFormatter` — countervalue formatter suite
- [ ] `pnpm --filter @ledgerhq/live-common test api.test.ts` — multiversx bridge suite
- [ ] `pnpm --filter @ledgerhq/wallet-cli typecheck`
- [ ] `pnpm --filter @ledgerhq/live-common typecheck`
- [ ] `pnpm lint:boundaries`

[LIVE-31961]: https://ledgerhq.atlassian.net/browse/LIVE-31961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ