### PR TITLE
[LWM] refactor(mobile): drop residual @ledgerhq/cryptoassets value imports

### DIFF
--- a/.changeset/shiny-foxes-dance.md
+++ b/.changeset/shiny-foxes-dance.md
@@ -1,0 +1,6 @@
+---
+"@features/platform-currencies": minor
+"live-mobile": minor
+---
+
+Add useCurrencyById and useTokenByAddressInCurrency hooks; repoint mobile from @ledgerhq/cryptoassets to @features/platform-currencies and @domain/entity-currency-crypto

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from "@tests/test-renderer";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { State } from "~/reducers/types";
 import { ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
+++ b/apps/ledger-live-mobile/src/components/MarketQuickActions/MarketQuickActions.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderWithReactQuery, withFlagOverrides } from "@tests/test-renderer";
 import { MarketQuickActions } from "./";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { ScreenName } from "~/const";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export const aleoCurrency = getCryptoCurrencyById("aleo");

--- a/apps/ledger-live-mobile/src/families/celo/__tests__/operationDetails.test.ts
+++ b/apps/ledger-live-mobile/src/families/celo/__tests__/operationDetails.test.ts
@@ -14,7 +14,7 @@ jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
-jest.mock("@ledgerhq/cryptoassets/hooks", () => ({
+jest.mock("@features/platform-currencies", () => ({
   useTokenByAddressInCurrency: (...args: unknown[]) => mockUseTokenByAddressInCurrency(...args),
 }));
 

--- a/apps/ledger-live-mobile/src/families/celo/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/operationDetails.tsx
@@ -17,7 +17,7 @@ import {
   NATIVE_FEE_CURRENCY_MARKER,
 } from "@ledgerhq/live-common/families/celo/constants";
 import { getCeloTransactionFeeCurrency } from "@ledgerhq/live-common/families/celo/network";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useTokenByAddressInCurrency } from "@features/platform-currencies";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useQuery } from "@tanstack/react-query";
 import { useRoute } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/AccountBalanceSummaryFooter.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import AccountBalanceFooter from "./AccountBalanceSummaryFooter";

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/currency.mock.ts
@@ -1,7 +1,7 @@
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
-export const hederaCurrency = cryptocurrenciesById["hedera"];
+export const hederaCurrency = getCryptoCurrencyById("hedera");
 
 export const htsToken: TokenCurrency = {
   type: "TokenCurrency",

--- a/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/operationDetails.tsx
@@ -13,7 +13,7 @@ import Alert from "~/components/Alert";
 import { NavigatorName, ScreenName } from "~/const";
 import Section from "~/screens/OperationDetails/Section";
 import { urls } from "~/utils/urls";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useTokenByAddressInCurrency } from "@features/platform-currencies";
 
 interface OperationDetailsPostAccountSectionProps {
   operation: HederaOperation;

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-ValidationSuccess.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-ValidationSuccess.tsx
@@ -14,7 +14,7 @@ import type {
 import type { StellarAddAssetFlowParamList } from "./types";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import invariant from "invariant";
-import { useTokenByAddressInCurrency } from "@ledgerhq/cryptoassets/hooks";
+import { useTokenByAddressInCurrency } from "@features/platform-currencies";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<

--- a/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
+++ b/apps/ledger-live-mobile/src/helpers/useCurrency.tsx
@@ -1,6 +1,6 @@
 import { useRoute } from "@react-navigation/native";
 import { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
-import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
+import { useCurrencyById } from "@features/platform-currencies";
 
 type NavigationProps = StackNavigatorProps<{
   [key: string]: { currencyId: string };

--- a/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TransactionalIcon/__tests__/TransactionalIcon.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { render, screen } from "@tests/test-renderer";
 import TransactionalIcon from "../index";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCustomFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/ScanDeviceAccountsCustomFlow.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { of, EMPTY } from "rxjs";
 import type { Account } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { sameAccountIdentity } from "@ledgerhq/live-wallet/addAccounts";
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { act } from "@testing-library/react-native";

--- a/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Accounts/screens/ScanDeviceAccounts/__tests__/shared.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { Observable, EMPTY } from "rxjs";
 import type { Account, ScanAccountEvent } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 type Mocks = {
   replace: jest.Mock;

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/__integrations__/shared.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Navigator from "../Navigator";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/__tests__/useAllocationsViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/Allocations/__tests__/useAllocationsViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@tests/test-renderer";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { DistributionResult } from "@ledgerhq/live-common/portfolio/useAssetDistribution";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/ChartSection/__tests__/ChartSection.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { State } from "~/reducers/types";

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/PnlSection.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { State } from "~/reducers/types";

--- a/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Analytics/screens/AnalyticsMain/components/PnlSection/__tests__/usePnlSectionViewModel.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genMockAccount } from "@ledgerhq/live-common/mock/account";
 import type { Account } from "@ledgerhq/types-live";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/PnLSection.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/PnLSection.integration.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import type { DistributionItem } from "@ledgerhq/types-live";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/components/PnLSection/__tests__/useAssetPnlViewModel.test.ts
@@ -1,4 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genMockAccount } from "@ledgerhq/live-common/mock/account";
 import type { Account, DistributionItem } from "@ledgerhq/types-live";
 import * as walletPnlHooks from "@ledgerhq/wallet-pnl/hooks";

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
+import { useCurrencyById } from "@features/platform-currencies";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useFeature } from "@features/platform-feature-flags";
 import { useRoute } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/OperationsList.test.tsx
@@ -8,7 +8,7 @@ import type { OperationsHistoryNavigatorParamsList } from "LLM/features/Operatio
 import type { State } from "~/reducers/types";
 import { ScreenName } from "~/const/navigation";
 import OperationsList from "../index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 function withTwoCalendarDaySections(account: Account): Account {
   const newerDayMs = new Date("2020-06-15T15:00:00.000Z").getTime();

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/__tests__/useOperationsListViewModel.test.ts
@@ -1,7 +1,7 @@
 import { act } from "@testing-library/react-native";
 import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken, maticEth } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/components/OperationsListItem/__tests__/OperationsListItem.test.tsx
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { render } from "@tests/test-renderer";
 import { track } from "~/analytics";
 import { ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/__tests__/useOperationsSections.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/OperationsHistory/screens/OperationsList/hooks/__tests__/useOperationsSections.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { Account, AccountLike, DailyOperationsSection, Operation } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { buildOperationsSections } from "../useOperationsSections";
 import type { CurrencySettings } from "~/reducers/types";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/hooks/__tests__/useOnboardingWidgetVisibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/hooks/__tests__/useOnboardingWidgetVisibility.test.ts
@@ -2,7 +2,7 @@ import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import BigNumber from "bignumber.js";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import type { Account } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { usePostOnboardingEntryPointVisibleOnWallet } from "@ledgerhq/live-common/postOnboarding/hooks/usePostOnboardingEntryPointVisibleOnWallet";
 import { useOnboardingWidgetVisibility } from "../useOnboardingWidgetVisibility";

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/__integrations__/shared.tsx
@@ -3,7 +3,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { screen, within, withFlagOverrides } from "@tests/test-renderer";
 import { QuickActionsCtas } from "../components/QuickActionsCtas";
 import { TransferDrawer } from "../screens/TransferDrawer";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/live-common/mock/account";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/useQuickActionsCtasViewModel.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import type { State } from "~/reducers/types";
 import { useQuickActionsCtasViewModel } from "../useQuickActionsCtasViewModel";

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useAccountsByCryptoCurrency.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useAccountsByCryptoCurrency.test.ts
@@ -8,7 +8,7 @@ import { State } from "~/reducers/types";
 import { AccountRaw } from "@ledgerhq/types-live";
 import { fromAccountRaw } from "@ledgerhq/ledger-wallet-framework/serialization/account";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const ethereumAccountRaw: AccountRaw = {
   id: "js:2:ethereum:0x01:",

--- a/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCurrencySettings.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/hooks/__tests__/useCurrencySettings.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { renderHook } from "@tests/test-renderer";
 import { useCurrencySettings } from "LLM/hooks/useCurrencySettings";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
 setCryptoAssetsStore({

--- a/apps/ledger-live-mobile/src/reducers/__tests__/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/accounts.test.ts
@@ -1,5 +1,5 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import { renderHook, act } from "@tests/test-renderer";
 import {

--- a/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
+++ b/apps/ledger-live-mobile/src/reducers/__tests__/history.test.ts
@@ -1,7 +1,7 @@
 import { FEATURE_FLAGS_INITIAL_STATE } from "@shared/feature-flags";
 import BigNumber from "bignumber.js";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import type { Account, AccountLike, Operation, TokenAccount } from "@ledgerhq/types-live";
 import historyReducer, {

--- a/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ReadOnly/ReadOnlyAccount.tsx
@@ -22,7 +22,7 @@ import { AnalyticsContext } from "~/analytics/AnalyticsContext";
 import type { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { ScreenName } from "~/const";
-import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
+import { useCurrencyById } from "@features/platform-currencies";
 
 type Props = StackNavigatorProps<AccountsNavigatorParamList, ScreenName.Account>;
 

--- a/apps/ledger-live-mobile/src/screens/Accounts/AddAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/Accounts/AddAccount.tsx
@@ -4,7 +4,7 @@ import { PlusMedium } from "@ledgerhq/native-ui/assets/icons";
 import Touchable from "~/components/Touchable";
 import { track } from "~/analytics";
 import AddAccountDrawer from "LLM/features/Accounts/screens/AddAccount";
-import { useCurrencyById } from "@ledgerhq/cryptoassets/hooks";
+import { useCurrencyById } from "@features/platform-currencies";
 
 function AddAccount({ currencyId }: { currencyId?: string }) {
   const { currency } = useCurrencyById(currencyId || "");

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import { renderHook, withFlagOverrides } from "@tests/test-renderer";

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__tests__/OperationsList.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__tests__/OperationsList.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/__tests__/SelectAccount.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import BigNumber from "bignumber.js";
 import { View, Pressable, Text } from "react-native";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { render, screen } from "@tests/test-renderer";

--- a/features/platform/currencies/src/hooks/index.ts
+++ b/features/platform/currencies/src/hooks/index.ts
@@ -1,5 +1,7 @@
 export * from "./useCryptoCurrencyById";
+export * from "./useCurrencyById";
 export * from "./useFeatureFlaggedCurrencies";
 export * from "./useSupportedCurrencies";
+export * from "./useTokenByAddressInCurrency";
 export * from "./useTokenById";
 export * from "./useTokensData";

--- a/features/platform/currencies/src/hooks/useCurrencyById.test.tsx
+++ b/features/platform/currencies/src/hooks/useCurrencyById.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook } from "@testing-library/react";
+import { useFindTokenByIdQuery } from "@domain/api-currency-token";
+import { CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
+import { useCurrencyById } from "./useCurrencyById";
+
+jest.mock("@domain/api-currency-token", () => ({
+  useFindTokenByIdQuery: jest.fn(() => ({ data: undefined, isLoading: false, error: null })),
+}));
+
+const mockQuery = useFindTokenByIdQuery as unknown as jest.Mock;
+
+describe("useCurrencyById", () => {
+  beforeEach(() => mockQuery.mockClear());
+
+  describe("when id matches a crypto currency", () => {
+    it("returns the registry entry without querying the token API", () => {
+      const { result } = renderHook(() => useCurrencyById("bitcoin"));
+      expect(result.current.currency).toBe(CRYPTO_CURRENCIES_REGISTRY.bitcoin);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(mockQuery).toHaveBeenCalledWith({ id: "bitcoin" }, { skip: true });
+    });
+  });
+
+  describe("when id does not match a crypto currency", () => {
+    it("queries the token API and forwards the result", () => {
+      const token = { id: "ethereum/erc20/usdc", type: "TokenCurrency" };
+      mockQuery.mockReturnValue({ data: token, isLoading: false, error: null });
+      const { result } = renderHook(() => useCurrencyById("ethereum/erc20/usdc"));
+      expect(mockQuery).toHaveBeenCalledWith({ id: "ethereum/erc20/usdc" }, { skip: false });
+      expect(result.current.currency).toBe(token);
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("exposes loading state while the token query is in flight", () => {
+      mockQuery.mockReturnValue({ data: undefined, isLoading: true, error: null });
+      const { result } = renderHook(() => useCurrencyById("ethereum/erc20/usdc"));
+      expect(result.current.loading).toBe(true);
+      expect(result.current.currency).toBeUndefined();
+    });
+
+    it("exposes the query error", () => {
+      const err = new Error("fetch failed");
+      mockQuery.mockReturnValue({ data: undefined, isLoading: false, error: err });
+      const { result } = renderHook(() => useCurrencyById("unknown/token"));
+      expect(result.current.error).toBe(err);
+    });
+  });
+
+  describe("when id is empty", () => {
+    it("skips the token query and returns undefined currency", () => {
+      const { result } = renderHook(() => useCurrencyById(""));
+      expect(mockQuery).toHaveBeenCalledWith({ id: "" }, { skip: true });
+      expect(result.current.currency).toBeUndefined();
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/features/platform/currencies/src/hooks/useCurrencyById.ts
+++ b/features/platform/currencies/src/hooks/useCurrencyById.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { CRYPTO_CURRENCIES_REGISTRY, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import { useFindTokenByIdQuery } from "@domain/api-currency-token";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+export type CurrencyResult = {
+  currency: CryptoCurrency | TokenCurrency | undefined;
+  loading: boolean;
+  error: unknown;
+};
+
+/**
+ * Resolves a currency (crypto or token) by id.
+ *
+ * Checks the static crypto registry first; only queries the CAL API when the id
+ * is not a known crypto currency.
+ */
+export function useCurrencyById(id: string): CurrencyResult {
+  const maybeCryptoCurrency = useMemo(
+    () => (id ? CRYPTO_CURRENCIES_REGISTRY[id] : undefined),
+    [id],
+  );
+  const tokenResult = useFindTokenByIdQuery({ id }, { skip: !!maybeCryptoCurrency || !id });
+
+  if (maybeCryptoCurrency) {
+    return { currency: maybeCryptoCurrency, loading: false, error: null };
+  }
+  return {
+    currency: tokenResult.data,
+    loading: tokenResult.isLoading,
+    error: tokenResult.error ?? null,
+  };
+}

--- a/features/platform/currencies/src/hooks/useTokenByAddressInCurrency.test.tsx
+++ b/features/platform/currencies/src/hooks/useTokenByAddressInCurrency.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook } from "@testing-library/react";
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
+import { useTokenByAddressInCurrency } from "./useTokenByAddressInCurrency";
+
+jest.mock("@domain/api-currency-token", () => ({
+  useFindTokenByAddressInCurrencyQuery: jest.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+const mockQuery = useFindTokenByAddressInCurrencyQuery as unknown as jest.Mock;
+
+describe("useTokenByAddressInCurrency", () => {
+  beforeEach(() => mockQuery.mockClear());
+
+  it("queries with contract_address and network and returns the token", () => {
+    const token = { id: "hedera/hts/0.0.123456", type: "TokenCurrency" };
+    mockQuery.mockReturnValue({ data: token, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useTokenByAddressInCurrency("0.0.123456", "hedera"));
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      { contract_address: "0.0.123456", network: "hedera" },
+      undefined,
+    );
+    expect(result.current.token).toBe(token);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("exposes loading state while the query is in flight", () => {
+    mockQuery.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    const { result } = renderHook(() => useTokenByAddressInCurrency("0x1234", "ethereum"));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.token).toBeUndefined();
+  });
+
+  it("forwards the skip option to the underlying query", () => {
+    renderHook(() => useTokenByAddressInCurrency("0x1234", "ethereum", { skip: true }));
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      { contract_address: "0x1234", network: "ethereum" },
+      { skip: true },
+    );
+  });
+
+  it("exposes the query error", () => {
+    const err = new Error("network error");
+    mockQuery.mockReturnValue({ data: undefined, isLoading: false, error: err });
+
+    const { result } = renderHook(() => useTokenByAddressInCurrency("0x1234", "ethereum"));
+
+    expect(result.current.error).toBe(err);
+    expect(result.current.token).toBeUndefined();
+  });
+});

--- a/features/platform/currencies/src/hooks/useTokenByAddressInCurrency.ts
+++ b/features/platform/currencies/src/hooks/useTokenByAddressInCurrency.ts
@@ -1,0 +1,28 @@
+import { useFindTokenByAddressInCurrencyQuery } from "@domain/api-currency-token";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+
+export type TokenResult = {
+  token: TokenCurrency | undefined;
+  loading: boolean;
+  error: unknown;
+};
+
+/**
+ * Looks up a token by its contract address and parent currency network.
+ * Maps to the CAL `findTokenByAddressInCurrency` query.
+ */
+export function useTokenByAddressInCurrency(
+  address: string,
+  currencyId: string,
+  options?: { skip?: boolean },
+): TokenResult {
+  const result = useFindTokenByAddressInCurrencyQuery(
+    { contract_address: address, network: currencyId },
+    options,
+  );
+  return {
+    token: result.data,
+    loading: result.isLoading,
+    error: result.error ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `useCurrencyById` and `useTokenByAddressInCurrency` to [`@features/platform-currencies`](https://github.com/LedgerHQ/ledger-live/tree/develop/features/platform/currencies) — the two hooks the production code needed but were absent from the package
- Repoint **7 production** hook call-sites in `ledger-live-mobile` from `@ledgerhq/cryptoassets/hooks` → `@features/platform-currencies`
- Repoint **~31 test/mock** accessor imports (`getCryptoCurrencyById` / `cryptocurrenciesById`) from `@ledgerhq/cryptoassets*` → `@domain/entity-currency-crypto`

After this PR: `git grep '@ledgerhq/cryptoassets' -- apps/ledger-live-mobile/src` returns only `live-common-setup.ts` (the injection seam — out of scope).

## Test plan

- [ ] `git grep '@ledgerhq/cryptoassets' -- apps/ledger-live-mobile/src '**/*.ts' '**/*.tsx'` → only `live-common-setup.ts`
- [ ] `pnpm nx run-many -t typecheck` (build `@ledgerhq/live-common` + libs first if needed)
- [ ] Jest suites for affected families (celo/hedera/stellar operationDetails, reducers, MVVM Analytics/AssetDetail/QuickActions/OperationsHistory)
- [ ] `pnpm lint:boundaries`

Closes [LIVE-34646](https://ledgerhq.atlassian.net/browse/LIVE-34646) · Part of [LIVE-31961](https://ledgerhq.atlassian.net/browse/LIVE-31961) Crypto Assets DA sunset

[LIVE-34646]: https://ledgerhq.atlassian.net/browse/LIVE-34646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ