### PR TITLE
[LWD] fix(desktop): prevent double Recover upsell on re-onboarding

### DIFF
--- a/.changeset/brave-recover-guard.md
+++ b/.changeset/brave-recover-guard.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix double Ledger Recover upsell trigger after re-onboarding post-onboarding navigation

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/useNavigateToPostOnboardingHubCallback.test.ts
@@ -90,7 +90,7 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     const { result, store } = renderNavigateHook({
       ...featureFlagsWithRecover(),
       postOnboarding: postOnboardingState(),
-      settings: { hasBeenRedirectedToPostOnboarding: false },
+      settings: { hasBeenRedirectedToPostOnboarding: false, hasBeenUpsoldRecover: false },
     });
 
     act(() => {
@@ -116,14 +116,14 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(true);
-    expect(mockNavigate).not.toHaveBeenCalledWith(RECOVER_LANDING_PATH);
+    expect(mockNavigate).not.toHaveBeenCalledWith(RECOVER_LANDING_PATH, expect.anything());
   });
 
   it("should not reopen finish dialog when already redirected with Wallet40 enabled", () => {
     const { result, store } = renderNavigateHook({
       ...featureFlagsWithRecover(),
       postOnboarding: postOnboardingState(),
-      settings: { hasBeenRedirectedToPostOnboarding: true },
+      settings: { hasBeenRedirectedToPostOnboarding: true, hasBeenUpsoldRecover: false },
       dialogs: { FINISH_POST_ONBOARDING: false },
     });
 
@@ -139,7 +139,7 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     const { result } = renderNavigateHook({
       ...featureFlagsWithRecover(),
       postOnboarding: postOnboardingState(),
-      settings: { hasBeenRedirectedToPostOnboarding: false },
+      settings: { hasBeenRedirectedToPostOnboarding: false, hasBeenUpsoldRecover: false },
     });
 
     act(() => {
@@ -147,6 +147,22 @@ describe("useNavigateToPostOnboardingHubCallback", () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(RECOVER_LANDING_PATH, { replace: false });
+  });
+
+  it("should navigate to portfolio and open finish dialog when recover was already upsold", () => {
+    const { result, store } = renderNavigateHook({
+      ...featureFlagsWithRecover(),
+      postOnboarding: postOnboardingState(),
+      settings: { hasBeenRedirectedToPostOnboarding: false, hasBeenUpsoldRecover: true },
+    });
+
+    act(() => {
+      result.current();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
+    expect(store.getState().dialogs.FINISH_POST_ONBOARDING).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalledWith(RECOVER_LANDING_PATH, expect.anything());
   });
 
   it("should navigate to post-onboarding hub when finish widget is disabled", () => {

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/useNavigateToPostOnboardingHubCallback.ts
@@ -5,12 +5,16 @@ import { useFeature } from "@features/platform-feature-flags";
 import { isRecoverDisplayed } from "@ledgerhq/live-common/recover/isRecoverDisplayed";
 import { useUpsellPath } from "@ledgerhq/live-common/hooks/recoverFeatureFlag";
 import { usePostOnboardingHubState } from "@ledgerhq/live-common/postOnboarding/hooks/index";
-import { hasBeenRedirectedToPostOnboardingSelector } from "~/renderer/reducers/settings";
+import {
+  hasBeenRedirectedToPostOnboardingSelector,
+  hasBeenUpsoldRecoverSelector,
+} from "~/renderer/reducers/settings";
 import useFinishOnboardingDialog from "LLD/features/FinishOnboarding/FinishOnboardingDialog/hooks/useFinishOnboardingDialog";
 
 export function useNavigateToPostOnboardingHubCallback() {
   const navigate = useNavigate();
   const hasBeenRedirectedToPostOnboarding = useSelector(hasBeenRedirectedToPostOnboardingSelector);
+  const hasBeenUpsoldRecover = useSelector(hasBeenUpsoldRecoverSelector);
   const onboardingWidgetFeature = useFeature("onboardingWidget");
   const shouldDisplayFinishOnboardingWidget = onboardingWidgetFeature?.enabled ?? false;
   const { handleOpen: openFinishOnboardingDialog } = useFinishOnboardingDialog();
@@ -22,7 +26,9 @@ export function useNavigateToPostOnboardingHubCallback() {
   return useCallback(
     (resetNavigationStack?: boolean) => {
       const shouldNavigateToRecoverLanding =
-        isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) && !!upsellPath;
+        isRecoverDisplayed(recoverServices, deviceModelId ?? undefined) &&
+        !!upsellPath &&
+        !hasBeenUpsoldRecover;
 
       if (shouldDisplayFinishOnboardingWidget) {
         const replace = resetNavigationStack ?? true;
@@ -43,6 +49,7 @@ export function useNavigateToPostOnboardingHubCallback() {
     [
       deviceModelId,
       hasBeenRedirectedToPostOnboarding,
+      hasBeenUpsoldRecover,
       navigate,
       openFinishOnboardingDialog,
       protectId,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

During **re-onboarding** (onboarding a device that was already set up), the Ledger Recover upsell could open **twice**:

1. **Expected:** auto-redirect at end of onboarding opens Recover once and sets `hasBeenUpsoldRecover = true`.
2. **Bug:** when the user closes Recover and the post-onboarding banner/widget runs, `useNavigateToPostOnboardingHubCallback` navigated to Recover again because it only checked `isRecoverDisplayed` and `upsellPath`, not `hasBeenUpsoldRecover`.

**Fix:** gate Recover navigation in `useNavigateToPostOnboardingHubCallback` with `!hasBeenUpsoldRecover`, matching the auto-redirect path (`useShouldRedirect` / `shouldRedirectToPostOnboardingOrRecoverUpsell`).

When Recover was already shown, navigation now goes to `/` and opens the finish onboarding dialog instead of stacking Recover behind the widget.

**Regression check:** unit test in `useNavigateToPostOnboardingHubCallback.test.ts` — with `hasBeenUpsoldRecover: true`, assert navigation to `/` and no Recover landing route.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34385](https://ledgerhq.atlassian.net/browse/LIVE-34385)


[LIVE-34385]: https://ledgerhq.atlassian.net/browse/LIVE-34385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ