### PR TITLE
[LWDM] refactor(private-libs): repoint cryptoassets value imports to domain packages

### DIFF
--- a/.changeset/brave-dogs-swim.md
+++ b/.changeset/brave-dogs-swim.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/asset-aggregation": minor
+"@ledgerhq/live-wallet": minor
+"@ledgerhq/wallet-analytics": minor
+---
+
+Repoint cryptoasset/fiat currency lookups off @ledgerhq/cryptoassets onto @domain/entity-currency-crypto and @domain/entity-currency-fiat

--- a/libs/asset-aggregation/package.json
+++ b/libs/asset-aggregation/package.json
@@ -19,7 +19,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/cryptoassets": "workspace:*",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@ledgerhq/types-live": "workspace:*",
     "@ledgerhq/types-cryptoassets": "workspace:*",
     "@ledgerhq/live-countervalues": "workspace:*",

--- a/libs/asset-aggregation/src/assetAggregation/__tests__/calculateProviderTotals.test.ts
+++ b/libs/asset-aggregation/src/assetAggregation/__tests__/calculateProviderTotals.test.ts
@@ -1,6 +1,6 @@
 import { calculateProviderTotals } from "../calculateProviderTotals";
 import { createFixtureAccount } from "./fixtures";
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { CRYPTO_CURRENCIES_REGISTRY as cryptocurrenciesById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 

--- a/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
+++ b/libs/asset-aggregation/src/assetAggregation/__tests__/computeAggregatedAccountsData.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { CRYPTO_CURRENCIES_REGISTRY as cryptocurrenciesById } from "@domain/entity-currency-crypto";
 import type { Account } from "@ledgerhq/types-live";
 import {
   type CalculateCountervalue,

--- a/libs/asset-aggregation/src/assetAggregation/__tests__/groupAccountsByAsset.test.ts
+++ b/libs/asset-aggregation/src/assetAggregation/__tests__/groupAccountsByAsset.test.ts
@@ -1,6 +1,6 @@
 import { groupAccountsByAsset } from "../groupAccountsByAsset";
 import { createFixtureAccount, createFixtureTokenAccount } from "./fixtures";
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { CRYPTO_CURRENCIES_REGISTRY as cryptocurrenciesById } from "@domain/entity-currency-crypto";
 import BigNumber from "bignumber.js";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/libs/asset-aggregation/src/assetCategorization/__tests__/fixtures.ts
+++ b/libs/asset-aggregation/src/assetCategorization/__tests__/fixtures.ts
@@ -1,6 +1,6 @@
 import type { DistributionItem, AccountLike } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { CRYPTO_CURRENCIES_REGISTRY as cryptocurrenciesById } from "@domain/entity-currency-crypto";
 
 export const btc = cryptocurrenciesById["bitcoin"];
 export const eth = cryptocurrenciesById["ethereum"];

--- a/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
+++ b/libs/asset-aggregation/src/assetDistribution/__tests__/buildAssetDistribution.test.ts
@@ -7,7 +7,7 @@ import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 
 const mockFindCryptoCurrencyById = jest.fn();
 
-jest.mock("@ledgerhq/cryptoassets", () => ({
+jest.mock("@domain/entity-currency-crypto", () => ({
   findCryptoCurrencyById: (...args: unknown[]) => mockFindCryptoCurrencyById(...args),
 }));
 

--- a/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
+++ b/libs/asset-aggregation/src/assetDistribution/buildAssetDistribution.ts
@@ -1,4 +1,4 @@
-import { findCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";

--- a/libs/asset-aggregation/src/mocks/categorizedAssets.mock.ts
+++ b/libs/asset-aggregation/src/mocks/categorizedAssets.mock.ts
@@ -1,4 +1,4 @@
-import { cryptocurrenciesById } from "@ledgerhq/cryptoassets";
+import { CRYPTO_CURRENCIES_REGISTRY as cryptocurrenciesById } from "@domain/entity-currency-crypto";
 import type { CategorizedAssetItem, CategorizedAssets } from "../assetCategorization/types";
 import { makeToken } from "../assetCategorization/__tests__/fixtures";
 

--- a/libs/asset-aggregation/tsconfig.json
+++ b/libs/asset-aggregation/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "jsx": "react",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "outDir": "lib",
     "rootDir": "src",
     "types": ["node", "jest"]

--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -19,7 +19,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/cryptoassets": "workspace:*",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-env": "workspace:*",
     "@ledgerhq/live-network": "workspace:*",

--- a/libs/live-wallet/src/accountName.test.ts
+++ b/libs/live-wallet/src/accountName.test.ts
@@ -1,6 +1,6 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getDefaultAccountName, normalizeName, MAX_ACCOUNT_NAME_LENGTH } from "./accountName";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const mockAccount = genAccount("mockAccount", {
   currency: getCryptoCurrencyById("ethereum"),

--- a/libs/live-wallet/src/liveqr/cross.test.ts
+++ b/libs/live-wallet/src/liveqr/cross.test.ts
@@ -1,6 +1,6 @@
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getDerivationModesForCurrency } from "@ledgerhq/ledger-wallet-framework/derivation";
-import { listCryptoCurrencies } from "@ledgerhq/cryptoassets/index";
+import { listCryptoCurrencies } from "@domain/entity-currency-crypto";
 import { accountDataToAccount, accountToAccountData } from "./cross";
 import { accountUserDataExportSelector, initialState } from "../store";
 

--- a/libs/live-wallet/src/liveqr/cross.ts
+++ b/libs/live-wallet/src/liveqr/cross.ts
@@ -9,7 +9,7 @@ import {
   decodeAccountId,
   emptyHistoryCache,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { Account, AccountUserData } from "@ledgerhq/types-live";
 
 export type AccountData = {

--- a/libs/live-wallet/src/store.test.ts
+++ b/libs/live-wallet/src/store.test.ts
@@ -19,7 +19,7 @@ import {
 } from "./store";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type { Account } from "@ledgerhq/types-live";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const ETHEREUM_ACCOUNT = "js:2:ethereum:0x23304541225D9b0BA2368B55ERTYF:";
 const POLKADOT_ACCOUNT =

--- a/libs/live-wallet/src/store.ts
+++ b/libs/live-wallet/src/store.ts
@@ -12,7 +12,7 @@ import {
 } from "@ledgerhq/types-live";
 import { getDefaultAccountName, getDefaultAccountNameForCurrencyIndex } from "./accountName";
 import { AddAccountsAction } from "./addAccounts";
-import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/currencies";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { DistantState } from "./walletsync";
 import { NonImportedAccountInfo } from "./walletsync/modules/accounts";
 

--- a/libs/live-wallet/tsconfig.json
+++ b/libs/live-wallet/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "jsx": "react",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2022", "dom"],
     "outDir": "lib",
     "rootDir": "src",
     "types": ["node", "jest"]

--- a/libs/wallet-analytics/package.json
+++ b/libs/wallet-analytics/package.json
@@ -25,7 +25,8 @@
     "@ledgerhq/types-live": "workspace:*"
   },
   "devDependencies": {
-    "@ledgerhq/cryptoassets": "workspace:*",
+    "@domain/entity-currency-crypto": "workspace:*",
+    "@domain/entity-currency-fiat": "workspace:*",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",
     "@swc/core": "catalog:",

--- a/libs/wallet-analytics/src/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
+++ b/libs/wallet-analytics/src/__tests__/computeAllTimeValueChangeFromFirstReceive.test.ts
@@ -1,4 +1,5 @@
-import { getCryptoCurrencyById, getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { calculate } from "@ledgerhq/live-countervalues/logic";

--- a/libs/wallet-analytics/src/__tests__/resolveAnalyticsValueChange.test.ts
+++ b/libs/wallet-analytics/src/__tests__/resolveAnalyticsValueChange.test.ts
@@ -1,4 +1,4 @@
-import { getFiatCurrencyByTicker } from "@ledgerhq/cryptoassets";
+import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { resolveAnalyticsValueChange } from "../resolveAnalyticsValueChange";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4717,9 +4717,9 @@ importers:
 
   libs/asset-aggregation:
     dependencies:
-      '@ledgerhq/cryptoassets':
+      '@domain/entity-currency-crypto':
         specifier: workspace:*
-        version: link:../ledgerjs/packages/cryptoassets
+        version: link:../../domain/entity/currency-crypto
       '@ledgerhq/live-countervalues':
         specifier: workspace:*
         version: link:../live-countervalues
@@ -12516,9 +12516,9 @@ importers:
 
   libs/live-wallet:
     dependencies:
-      '@ledgerhq/cryptoassets':
+      '@domain/entity-currency-crypto':
         specifier: workspace:*
-        version: link:../ledgerjs/packages/cryptoassets
+        version: link:../../domain/entity/currency-crypto
       '@ledgerhq/ledger-key-ring-protocol':
         specifier: workspace:*
         version: link:../ledger-key-ring-protocol
@@ -13382,9 +13382,12 @@ importers:
         specifier: workspace:*
         version: link:../ledgerjs/packages/types-live
     devDependencies:
-      '@ledgerhq/cryptoassets':
+      '@domain/entity-currency-crypto':
         specifier: workspace:*
-        version: link:../ledgerjs/packages/cryptoassets
+        version: link:../../domain/entity/currency-crypto
+      '@domain/entity-currency-fiat':
+        specifier: workspace:*
+        version: link:../../domain/entity/currency-fiat
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Replaces `@ledgerhq/cryptoassets` value-lookup imports in three private libs with the new domain packages:

| Lib | Functions moved |
|-----|----------------|
| `@ledgerhq/asset-aggregation` | `findCryptoCurrencyById`, `cryptocurrenciesById` (→ `CRYPTO_CURRENCIES_REGISTRY`) |
| `@ledgerhq/live-wallet` | `getCryptoCurrencyById`, `listCryptoCurrencies` |
| `@ledgerhq/wallet-analytics` | `getCryptoCurrencyById`, `getFiatCurrencyByTicker` |

- Crypto lookups now import from `@domain/entity-currency-crypto`
- Fiat lookups now import from `@domain/entity-currency-fiat`
- `@ledgerhq/cryptoassets` removed from each lib's `package.json`
- `tsconfig.json` `lib` bumped `es2020` → `es2022` in `asset-aggregation` and `live-wallet` to satisfy `Object.hasOwn` used in the domain accessor

These libs are all `"private": true` with no nx boundary tags, so direct `@domain/*` imports are unconstrained.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34647](https://ledgerhq.atlassian.net/browse/LIVE-34647) — blocks [LIVE-31961](https://ledgerhq.atlassian.net/browse/LIVE-31961)
- **ADR** (if any): N/A

[LIVE-34647]: https://ledgerhq.atlassian.net/browse/LIVE-34647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ