### PR TITLE
[LWDM] chore(coin-evm): add config driven operation amount resolver

### DIFF
--- a/.changeset/tricky-carpets-lick.md
+++ b/.changeset/tricky-carpets-lick.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Add a mandatory `resolveOperationAmount` to `StakingContractConfig`, following the same config-driven pattern as `resolveValidatorAddress`. Each chain owns its amount derivation; 0G calls `convertToTokens(shares)` on the validator contract so the undelegate drawer shows the real OG token amount instead of the raw vault-share value.

--- a/libs/coin-modules/coin-evm/src/staking/contracts.ts
+++ b/libs/coin-modules/coin-evm/src/staking/contracts.ts
@@ -1,6 +1,10 @@
+import { BigNumber } from "bignumber.js";
 import { ethers } from "ethers";
 import type { StakingContractConfig, StakingOperation } from "../types/staking";
 import { USEI_TO_EVM_SCALE } from "../utils";
+import { getCoinConfig } from "../config";
+import { withApi } from "../network/node/rpc.common";
+import { isExternalNodeConfig } from "../network/node/types";
 import { getValidatorAddressById } from "./validators/monadResolver";
 
 export function getStakingContractAddress(
@@ -87,6 +91,18 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     resolveValidatorAddress: async d => {
       return typeof d[0] === "string" ? d[0] : null;
     },
+    resolveOperationAmount: async (decoded, operationType) => {
+      switch (operationType) {
+        case "undelegate": {
+          const raw = decoded[1];
+          return typeof raw === "bigint"
+            ? new BigNumber((raw * USEI_TO_EVM_SCALE).toString())
+            : null;
+        }
+        default:
+          return null;
+      }
+    },
   },
 
   // Celo staking
@@ -102,6 +118,16 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     },
     resolveValidatorAddress: async d => {
       return typeof d[0] === "string" ? d[0] : null;
+    },
+    resolveOperationAmount: async (decoded, operationType) => {
+      switch (operationType) {
+        case "undelegate": {
+          const raw = decoded[1];
+          return typeof raw === "bigint" ? new BigNumber(raw.toString()) : null;
+        }
+        default:
+          return null;
+      }
     },
   },
 
@@ -161,6 +187,16 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
         ? getValidatorAddressById("monad", d[0])
         : Promise.resolve(null);
     },
+    resolveOperationAmount: async (decoded, operationType) => {
+      switch (operationType) {
+        case "undelegate": {
+          const raw = decoded[1];
+          return typeof raw === "bigint" ? new BigNumber(raw.toString()) : null;
+        }
+        default:
+          return null;
+      }
+    },
   },
 
   // 0G staking - factory-per-validator model.
@@ -194,6 +230,36 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     resolveValidatorAddress: async (_, contractAddress) => {
       return contractAddress ? ethers.getAddress(contractAddress) : null;
     },
+    resolveOperationAmount: async (decoded, operationType, currency, contractAddress) => {
+      switch (operationType) {
+        case "undelegate": {
+          const shares = decoded[1];
+          if (typeof shares !== "bigint") return null;
+          const node = getCoinConfig(currency.id).info.node;
+          if (!isExternalNodeConfig(node)) return null;
+          try {
+            return await withApi(
+              currency,
+              async provider => {
+                const iface = new ethers.Interface([
+                  "function convertToTokens(uint256 shares) view returns (uint256)",
+                ]);
+                const data = iface.encodeFunctionData("convertToTokens", [shares]);
+                const raw = await provider.call({ to: contractAddress, data });
+                const result = iface.decodeFunctionResult("convertToTokens", raw);
+                if (!Array.isArray(result) || typeof result[0] !== "bigint") return null;
+                return new BigNumber(result[0].toString());
+              },
+              node,
+            );
+          } catch {
+            return null;
+          }
+        }
+        default:
+          return null;
+      }
+    },
     canUndelegate: delegation => {
       return delegation.shares?.gt(0) ?? true;
     },
@@ -215,6 +281,16 @@ export const STAKING_CONTRACTS: Record<string, StakingContractConfig> = {
     value: ({ mode, amount }) => (mode === "delegate" ? amount : 0n),
     resolveValidatorAddress: async parameters => {
       return typeof parameters[0] === "string" ? parameters[0] : null;
+    },
+    resolveOperationAmount: async (decoded, operationType) => {
+      switch (operationType) {
+        case "undelegate": {
+          const raw = decoded[1];
+          return typeof raw === "bigint" ? new BigNumber(raw.toString()) : null;
+        }
+        default:
+          return null;
+      }
     },
   },
 };

--- a/libs/coin-modules/coin-evm/src/staking/redelegations.test.ts
+++ b/libs/coin-modules/coin-evm/src/staking/redelegations.test.ts
@@ -354,6 +354,46 @@ describe("redelegations", () => {
       });
     });
 
+    describe("undelegate (0G, convertToTokens)", () => {
+      it("calls convertToTokens on the validator contract to resolve the display amount", async () => {
+        const zgIface = new ethers.Interface(getStakingABI("zero_gravity")!);
+        const convertIface = new ethers.Interface([
+          "function convertToTokens(uint256 shares) view returns (uint256)",
+        ]);
+        const op = makeOperation({
+          type: "UNDELEGATE",
+          recipients: ["0x3333333333333333333333333333333333333333"],
+          extra: {
+            contractPayload: zgIface.encodeFunctionData("undelegate", [
+              "0x4444444444444444444444444444444444444444",
+              1_284_193_000_000_000n,
+            ]),
+          },
+        });
+
+        const mockNode = { type: "external", uri: "https://0g.rpc" };
+        mockGetCoinConfig.mockReturnValue({ info: { node: mockNode } });
+        mockIsExternalNodeConfig.mockImplementation((node: unknown) => node === mockNode);
+        mockWithApi.mockImplementation((_currency: unknown, fn: (p: unknown) => unknown) =>
+          fn({
+            call: async () =>
+              convertIface.encodeFunctionResult("convertToTokens", [13_000_000_000_000_000n]),
+          }),
+        );
+
+        const result = await resolveStakingValidator(
+          { id: "zero_gravity" } as CryptoCurrency,
+          op,
+          "undelegate",
+        );
+
+        expect(result).toEqual({
+          validatorAddress: "0x3333333333333333333333333333333333333333",
+          amount: new BigNumber("13000000000000000"),
+        });
+      });
+    });
+
     describe("delegate", () => {
       it("should decode validator from cached contractPayload", async () => {
         const op = makeOperation({

--- a/libs/coin-modules/coin-evm/src/staking/redelegations.ts
+++ b/libs/coin-modules/coin-evm/src/staking/redelegations.ts
@@ -288,20 +288,12 @@ export async function resolveStakingValidator(
   try {
     const iface = new ethers.Interface(abi);
     const d = iface.decodeFunctionData(functionName, payload);
-    const [, rawAmount] = d;
 
     const validatorAddress = await config.resolveValidatorAddress(d, operation.recipients[0]);
     if (!validatorAddress) return null;
 
-    const scale = config.calldataAmountScale ?? 1n;
-    const amount =
-      rawAmount !== undefined
-        ? new BigNumber(
-            (
-              (typeof rawAmount === "bigint" ? rawAmount : BigInt(String(rawAmount))) * scale
-            ).toString(),
-          )
-        : null;
+    const contractAddress = operation.recipients[0] ?? validatorAddress;
+    const amount = await config.resolveOperationAmount(d, operationType, currency, contractAddress);
     return { validatorAddress, amount };
   } catch {
     return null;

--- a/libs/coin-modules/coin-evm/src/types/staking.ts
+++ b/libs/coin-modules/coin-evm/src/types/staking.ts
@@ -1,3 +1,4 @@
+import type { BigNumber } from "bignumber.js";
 import type { Stake } from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { StakingDelegation } from "@ledgerhq/types-live";
@@ -157,6 +158,13 @@ export type StakingContractConfig = {
     decoded: readonly unknown[],
     contractAddress: string | undefined,
   ) => Promise<string | null>;
+  /** Derive the display amount from the decoded calldata args. Return `null` when the amount is not representable from calldata alone (e.g. msg.value-based delegates, vault-share undelegates). */
+  resolveOperationAmount: (
+    decoded: readonly unknown[],
+    operationType: "delegate" | "undelegate" | "withdraw",
+    currency: CryptoCurrency,
+    contractAddress: string,
+  ) => Promise<BigNumber | null>;
   /** Chain-specific guard called after cross-cutting checks. Returns true when the delegation can be undelegated. */
   canUndelegate?: (delegation: StakingDelegation) => boolean;
 };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add chain specific `resolveOperationAmount` to compute the amount of the operation base on the type.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34644
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
