### PR TITLE
[LWDM] fix(BACK-11952): fix hedera getBlock with paginated ERC20 transfers

### DIFF
--- a/.changeset/calm-blocks-paginate.md
+++ b/.changeset/calm-blocks-paginate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+fix(BACK-11952): fix hedera getBlock with paginated ERC20 transfers

--- a/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.integ.test.ts
@@ -467,6 +467,16 @@ describe("createApi", () => {
   });
 
   describe("getBlock", () => {
+    it("returns block when ERC20 transfers require pagination", async () => {
+      const blockHeight = 178347043;
+
+      const block = await api.getBlock(blockHeight);
+
+      expect(block.info.height).toBe(blockHeight);
+      expect(block.info.hash?.length).toBe(64);
+      expect(block.transactions.length).toBeGreaterThan(0);
+    });
+
     it("returns block with proper multi-transfer data", async () => {
       const blockHeight = 176051087;
       const multiTransferTxHash =

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
@@ -477,7 +477,9 @@ describe("hgraphClient", () => {
       expect(firstCall.data.variables).not.toHaveProperty("cursor");
       // Second call should use _gt with cursor
       expect(secondCall.data.query).toContain("_gt: $cursor");
+      expect(secondCall.data.query).not.toContain("$startTimestamp");
       expect(secondCall.data.variables.cursor).toBe("1100000000000000000");
+      expect(secondCall.data.variables).not.toHaveProperty("startTimestamp");
     });
 
     it("should support custom order parameter", async () => {

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.ts
@@ -225,7 +225,7 @@ async function getERC20TransfersByTimestampRange({
       method: "POST",
       data: {
         query: `
-          query GetAccountTransfers($startTimestamp: bigint!, $endTimestamp: bigint!, $cursor: bigint, $limit: Int!) {
+          query GetAccountTransfers(${cursor ? "$cursor: bigint!" : "$startTimestamp: bigint!"}, $endTimestamp: bigint!, $limit: Int!) {
             erc_token_transfer(
                 where: {
                     transfer_type: { _in: ["transfer", "mint", "burn"] }
@@ -253,10 +253,9 @@ async function getERC20TransfersByTimestampRange({
           }
         `,
         variables: {
-          startTimestamp: normalizedStartTimestamp,
           endTimestamp: normalizedEndTimestamp,
           limit,
-          ...(cursor && { cursor }),
+          ...(cursor ? { cursor } : { startTimestamp: normalizedStartTimestamp }),
         },
       },
     });

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -9,7 +9,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "freshAddressPath": "44/3030",
     "hederaResources": {
       "delegation": {
-        "delegated": "851513",
+        "delegated": "92300851514",
         "nodeId": 20,
       },
       "isAutoTokenAssociationEnabled": false,
@@ -17,7 +17,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     },
     "id": "js:2:hedera:0.0.1040977:hederaBip44",
     "index": 0,
-    "operationsCount": 92,
+    "operationsCount": 94,
     "pendingOperations": [],
     "seedIdentifier": "9e92a312233d5fd6b5a723875aeea2cea81a8e48ffc00341cff6dffcfd3ab7f2",
     "subAccounts": [],
@@ -261,6 +261,29 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
 exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
 [
   [
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "consensusTimestamp": "1783600346.045490061",
+        "feesPayer": "0.0.10096335",
+        "pagingToken": "1783600346.045490061",
+        "transactionId": "0.0.10096335-1783600331-553098000",
+      },
+      "fee": "141844",
+      "hasFailed": false,
+      "hash": "_rztbS9s1RPJ-GYcJpKWd7HuXgcIjpJKgJ8iUpHzyFraoajpdqs2s4h9LMiVfaTy",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-_rztbS9s1RPJ-GYcJpKWd7HuXgcIjpJKgJ8iUpHzyFraoajpdqs2s4h9LMiVfaTy-IN",
+      "recipients": [
+        "0.0.1040977",
+      ],
+      "senders": [
+        "0.0.10096335",
+      ],
+      "type": "IN",
+      "value": "92300000000",
+    },
     {
       "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
@@ -538,6 +561,29 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "type": "OUT",
       "value": "103687",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "consensusTimestamp": "1783600355.641401441",
+        "feesPayer": "0.0.10231006",
+        "pagingToken": "1783600355.641401441",
+        "transactionId": "0.0.10231006-1783600346-697279177",
+      },
+      "fee": "141844",
+      "hasFailed": false,
+      "hash": "8nAcKRZPzXChxdDe6PrwbYbL-R7TP3t62K2Du9w-V6Gij_PDQchi0-5rCk5Vqe7_",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-8nAcKRZPzXChxdDe6PrwbYbL-R7TP3t62K2Du9w-V6Gij_PDQchi0-5rCk5Vqe7_-IN",
+      "recipients": [
+        "0.0.1040977",
+      ],
+      "senders": [
+        "0.0.10231006",
+      ],
+      "type": "IN",
+      "value": "1",
     },
     {
       "accountId": "js:2:hedera:0.0.1040977:hederaBip44",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Hgraph API rejects the `startTimestamp` parameter on second page, only `cursor` must be used to iterate pages:
```
failed to fetch ERC20 transfers by timestamp range from Hgraph: unexpected variables in variableValues: startTimestamp
```

Reproducer: https://coin-service.api.ledger.com/v1/hedera/block/178347043

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/BACK-11952
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
