### PR TITLE
[LWM] fix(mobile): reset navigation for token deeplinks

### DIFF
--- a/.changeset/calm-tokens-reset.md
+++ b/.changeset/calm-tokens-reset.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Reset mobile navigation state for sequential token deeplinks and redirect invalid asset deeplinks to Market

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,18 +1,24 @@
 import React from "react";
-import { View } from "react-native";
-import type { CurrencyResult } from "@ledgerhq/cryptoassets/hooks";
+import type { CurrencyResult } from "@features/platform-currencies";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { render, screen, waitFor, within, withFlagOverrides } from "@tests/test-renderer";
+import {
+  render,
+  renderWithReactQuery,
+  screen,
+  waitFor,
+  within,
+  withFlagOverrides,
+} from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import {
   findCryptoCurrencyById,
   getCryptoCurrencyById,
 } from "@ledgerhq/live-common/currencies/index";
-import { createFixtureTokenAccount } from "@ledgerhq/live-common/mock/fixtures/cryptoCurrencies";
 import type { Account } from "@ledgerhq/types-live";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
+import MarketList from "LLM/features/Market/screens/MarketList";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
 import { QUICK_ACTIONS_TEST_IDS } from "LLM/features/QuickActions/testIds";
@@ -25,6 +31,7 @@ import {
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
 const mockUseCurrencyById = jest.fn<CurrencyResult, [string]>();
+type TokenCurrency = Extract<NonNullable<CurrencyResult["currency"]>, { type: "TokenCurrency" }>;
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
   useRampCatalog: () => ({ isCurrencyAvailable: mockIsCurrencyAvailable }),
@@ -32,10 +39,6 @@ jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampC
 
 jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
   useAcceptedCurrency: () => mockIsAcceptedCurrency,
-}));
-
-jest.mock("@ledgerhq/cryptoassets/hooks", () => ({
-  useCurrencyById: (id: string) => mockUseCurrencyById(id),
 }));
 
 jest.mock("@features/platform-currencies", () => ({
@@ -72,11 +75,6 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
 }));
 
 const Stack = createNativeStackNavigator<BaseNavigatorStackParamList, typeof BASE_NAVIGATOR_ID>();
-const MARKET_LIST_TEST_ID = "market-list-screen";
-
-function MarketListScreen() {
-  return <View testID={MARKET_LIST_TEST_ID} />;
-}
 
 type NavigatorParams = {
   currencyId: string;
@@ -100,7 +98,7 @@ function AssetDetailTestNavigator({
         }}
         options={{ headerShown: false }}
       />
-      <Stack.Screen name={ScreenName.MarketList} component={MarketListScreen} />
+      <Stack.Screen name={ScreenName.MarketList} component={MarketList} />
     </Stack.Navigator>
   );
 }
@@ -527,7 +525,7 @@ describe("AssetDetail screen layout", () => {
           error: undefined,
         });
 
-        render(
+        renderWithReactQuery(
           <AssetDetailTestNavigator
             params={{
               currencyId: tokenId,
@@ -537,13 +535,22 @@ describe("AssetDetail screen layout", () => {
           />,
         );
 
-        await waitFor(() => expect(screen.getByTestId(MARKET_LIST_TEST_ID)).toBeVisible());
+        await waitFor(() => expect(screen.getByTestId("market-list")).toBeVisible());
         expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeNull();
       },
     );
 
     it("keeps a valid token deeplink on Asset Detail", () => {
-      const token = createFixtureTokenAccount().token;
+      const token = {
+        type: "TokenCurrency",
+        id: "ethereum/erc20/usd-tether" as TokenCurrency["id"],
+        parentCurrencyId: "ethereum" as TokenCurrency["parentCurrencyId"],
+        contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        tokenType: "erc20",
+        name: "Tether USD",
+        ticker: "USDT",
+        units: [{ name: "Tether USD", code: "USDT", magnitude: 6 }],
+      } satisfies TokenCurrency;
       mockUseCurrencyById.mockReturnValue({
         currency: token,
         loading: false,
@@ -561,7 +568,7 @@ describe("AssetDetail screen layout", () => {
       );
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
-      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId("market-list")).toBeNull();
     });
 
     it("keeps Asset Detail visible while the token lookup is loading", () => {
@@ -583,7 +590,7 @@ describe("AssetDetail screen layout", () => {
       );
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
-      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId("market-list")).toBeNull();
     });
 
     it("keeps the Asset Detail screen on token lookup errors", () => {
@@ -605,7 +612,7 @@ describe("AssetDetail screen layout", () => {
       );
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
-      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId("market-list")).toBeNull();
     });
 
     it("keeps market-only assets on Asset Detail outside deeplinks", () => {
@@ -626,7 +633,7 @@ describe("AssetDetail screen layout", () => {
       );
 
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
-      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+      expect(screen.queryByTestId("market-list")).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/__integrations__/assetDetail.integration.test.tsx
@@ -1,10 +1,17 @@
 import React from "react";
+import { View } from "react-native";
+import type { CurrencyResult } from "@ledgerhq/cryptoassets/hooks";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { render, screen, waitFor, within, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import {
+  findCryptoCurrencyById,
+  getCryptoCurrencyById,
+} from "@ledgerhq/live-common/currencies/index";
+import { createFixtureTokenAccount } from "@ledgerhq/live-common/mock/fixtures/cryptoCurrencies";
 import type { Account } from "@ledgerhq/types-live";
-import { NavigatorName, ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
 import type { State } from "~/reducers/types";
 import AssetDetailNavigator from "../Navigator";
 import { ASSET_DETAIL_TEST_IDS } from "../testIds";
@@ -17,6 +24,7 @@ import {
 
 const mockIsCurrencyAvailable = jest.fn().mockReturnValue(false);
 const mockIsAcceptedCurrency = jest.fn().mockReturnValue(false);
+const mockUseCurrencyById = jest.fn<CurrencyResult, [string]>();
 
 jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampCatalog", () => ({
   useRampCatalog: () => ({ isCurrencyAvailable: mockIsCurrencyAvailable }),
@@ -24,6 +32,15 @@ jest.mock("@ledgerhq/live-common/platform/providers/RampCatalogProvider/useRampC
 
 jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
   useAcceptedCurrency: () => mockIsAcceptedCurrency,
+}));
+
+jest.mock("@ledgerhq/cryptoassets/hooks", () => ({
+  useCurrencyById: (id: string) => mockUseCurrencyById(id),
+}));
+
+jest.mock("@features/platform-currencies", () => ({
+  ...jest.requireActual("@features/platform-currencies"),
+  useCurrencyById: (id: string) => mockUseCurrencyById(id),
 }));
 
 jest.mock("@ledgerhq/asset-detail", () => ({
@@ -54,7 +71,12 @@ jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
   ),
 }));
 
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<BaseNavigatorStackParamList, typeof BASE_NAVIGATOR_ID>();
+const MARKET_LIST_TEST_ID = "market-list-screen";
+
+function MarketListScreen() {
+  return <View testID={MARKET_LIST_TEST_ID} />;
+}
 
 type NavigatorParams = {
   currencyId: string;
@@ -68,7 +90,7 @@ function AssetDetailTestNavigator({
   params?: NavigatorParams;
 } = {}) {
   return (
-    <Stack.Navigator>
+    <Stack.Navigator id={BASE_NAVIGATOR_ID}>
       <Stack.Screen
         name={NavigatorName.AssetDetail}
         component={AssetDetailNavigator}
@@ -78,6 +100,7 @@ function AssetDetailTestNavigator({
         }}
         options={{ headerShown: false }}
       />
+      <Stack.Screen name={ScreenName.MarketList} component={MarketListScreen} />
     </Stack.Navigator>
   );
 }
@@ -125,6 +148,12 @@ function withBlacklistedTokens(tokenIds: string[]) {
 
 describe("AssetDetail screen layout", () => {
   beforeEach(() => {
+    mockUseCurrencyById.mockReset();
+    mockUseCurrencyById.mockImplementation((id: string) => ({
+      currency: findCryptoCurrencyById(id),
+      loading: false,
+      error: undefined,
+    }));
     mockIsCurrencyAvailable.mockReturnValue(false);
     mockIsAcceptedCurrency.mockReturnValue(false);
     setAvailability();
@@ -486,6 +515,118 @@ describe("AssetDetail screen layout", () => {
         expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
       });
       expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.balanceGraph)).toBeVisible();
+    });
+
+    it.each(["deeplink_asset", "deeplink_market"])(
+      "redirects a missing token %s deeplink to Market",
+      async source => {
+        const tokenId = "ethereum/erc20/does_not_exist";
+        mockUseCurrencyById.mockReturnValue({
+          currency: undefined,
+          loading: false,
+          error: undefined,
+        });
+
+        render(
+          <AssetDetailTestNavigator
+            params={{
+              currencyId: tokenId,
+              source,
+              marketState: { id: tokenId, ledgerIds: [tokenId] },
+            }}
+          />,
+        );
+
+        await waitFor(() => expect(screen.getByTestId(MARKET_LIST_TEST_ID)).toBeVisible());
+        expect(screen.queryByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeNull();
+      },
+    );
+
+    it("keeps a valid token deeplink on Asset Detail", () => {
+      const token = createFixtureTokenAccount().token;
+      mockUseCurrencyById.mockReturnValue({
+        currency: token,
+        loading: false,
+        error: undefined,
+      });
+
+      render(
+        <AssetDetailTestNavigator
+          params={{
+            currencyId: token.id,
+            source: "deeplink_asset",
+            marketState: { id: token.id, ledgerIds: [token.id] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+    });
+
+    it("keeps Asset Detail visible while the token lookup is loading", () => {
+      const tokenId = "ethereum/erc20/loading";
+      mockUseCurrencyById.mockReturnValue({
+        currency: undefined,
+        loading: true,
+        error: undefined,
+      });
+
+      render(
+        <AssetDetailTestNavigator
+          params={{
+            currencyId: tokenId,
+            source: "deeplink_asset",
+            marketState: { id: tokenId, ledgerIds: [tokenId] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+    });
+
+    it("keeps the Asset Detail screen on token lookup errors", () => {
+      const tokenId = "ethereum/erc20/unavailable";
+      mockUseCurrencyById.mockReturnValue({
+        currency: undefined,
+        loading: false,
+        error: new Error("CAL unavailable"),
+      });
+
+      render(
+        <AssetDetailTestNavigator
+          params={{
+            currencyId: tokenId,
+            source: "deeplink_market",
+            marketState: { id: tokenId, ledgerIds: [tokenId] },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
+    });
+
+    it("keeps market-only assets on Asset Detail outside deeplinks", () => {
+      mockUseCurrencyById.mockReturnValue({
+        currency: undefined,
+        loading: false,
+        error: undefined,
+      });
+
+      render(
+        <AssetDetailTestNavigator
+          params={{
+            currencyId: "market-only-asset",
+            source: "market_banner",
+            marketState: { id: "market-only-asset" },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId(ASSET_DETAIL_TEST_IDS.screen)).toBeVisible();
+      expect(screen.queryByTestId(MARKET_LIST_TEST_ID)).toBeNull();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
@@ -1,25 +1,45 @@
-import React, { useLayoutEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import type { NativeStackHeaderRightProps } from "@react-navigation/native-stack";
 import { useNavigation } from "@react-navigation/native";
+import type { CompositeNavigationProp } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
-import { ScreenName } from "~/const";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
 import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
 import { useAssetDetailViewModel } from "./useAssetDetailViewModel";
 import { AssetDetailView } from "./AssetDetailView";
 import { AssetCoinOptionsTrailing } from "./components/CoinOptions/AssetCoinOptionsTrailing";
 
-type NavigationProps = NativeStackNavigationProp<
-  AssetDetailNavigatorParamsList,
-  ScreenName.AssetDetail
+type BaseNavigatorNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
+type NavigationProps = CompositeNavigationProp<
+  NativeStackNavigationProp<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>,
+  BaseNavigatorNavigation
 >;
 
 export default function AssetDetail() {
   const viewModel = useAssetDetailViewModel();
-  const { currency, coinOptions } = viewModel;
+  const { currency, coinOptions, shouldRedirectToMarket } = viewModel;
   const navigation = useNavigation<NavigationProps>();
+
+  useEffect(() => {
+    if (!shouldRedirectToMarket) return;
+
+    const baseNavigation = navigation.getParent<BaseNavigatorNavigation>(BASE_NAVIGATOR_ID);
+    if (baseNavigation) {
+      baseNavigation.replace(ScreenName.MarketList);
+      return;
+    }
+
+    navigation.navigate(ScreenName.MarketList);
+  }, [navigation, shouldRedirectToMarket]);
 
   useLayoutEffect(() => {
     if (!currency) return;
@@ -56,6 +76,8 @@ export default function AssetDetail() {
     };
     navigation.setOptions(opts);
   }, [navigation, currency, coinOptions.openCoinOptions, coinOptions.trailingAccessibilityLabel]);
+
+  if (shouldRedirectToMarket) return null;
 
   return <AssetDetailView {...viewModel} />;
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/index.tsx
@@ -1,45 +1,25 @@
-import React, { useEffect, useLayoutEffect } from "react";
+import React, { useLayoutEffect } from "react";
 import type { NativeStackHeaderRightProps } from "@react-navigation/native-stack";
 import { useNavigation } from "@react-navigation/native";
-import type { CompositeNavigationProp } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import CurrencyIcon from "~/components/CurrencyIcon";
 import type { LumenNativeStackNavigationOptions } from "LLM/components/Navigation";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
-import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
-import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
+import { ScreenName } from "~/const";
 import { ASSET_DETAIL_TEST_IDS } from "../../testIds";
 import { useAssetDetailViewModel } from "./useAssetDetailViewModel";
 import { AssetDetailView } from "./AssetDetailView";
 import { AssetCoinOptionsTrailing } from "./components/CoinOptions/AssetCoinOptionsTrailing";
 
-type BaseNavigatorNavigation = NativeStackNavigationProp<
-  BaseNavigatorStackParamList,
-  keyof BaseNavigatorStackParamList,
-  typeof BASE_NAVIGATOR_ID
->;
-
-type NavigationProps = CompositeNavigationProp<
-  NativeStackNavigationProp<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>,
-  BaseNavigatorNavigation
+type NavigationProps = NativeStackNavigationProp<
+  AssetDetailNavigatorParamsList,
+  ScreenName.AssetDetail
 >;
 
 export default function AssetDetail() {
   const viewModel = useAssetDetailViewModel();
   const { currency, coinOptions, shouldRedirectToMarket } = viewModel;
   const navigation = useNavigation<NavigationProps>();
-
-  useEffect(() => {
-    if (!shouldRedirectToMarket) return;
-
-    const baseNavigation = navigation.getParent<BaseNavigatorNavigation>(BASE_NAVIGATOR_ID);
-    if (baseNavigation) {
-      baseNavigation.replace(ScreenName.MarketList);
-      return;
-    }
-
-    navigation.navigate(ScreenName.MarketList);
-  }, [navigation, shouldRedirectToMarket]);
 
   useLayoutEffect(() => {
     if (!currency) return;

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -1,10 +1,13 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCurrencyById } from "@features/platform-currencies";
 import useEnv from "@ledgerhq/live-common/hooks/useEnv";
 import { useFeature } from "@features/platform-feature-flags";
-import { useRoute } from "@react-navigation/native";
+import { useNavigation, useRoute } from "@react-navigation/native";
+import type { CompositeNavigationProp } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
-import { ScreenName } from "~/const";
+import { BASE_NAVIGATOR_ID, ScreenName } from "~/const";
 import { useDistribution } from "~/actions/general";
 import {
   resolveAssetMarketInputs,
@@ -19,9 +22,21 @@ import { isRobinhoodExclusiveAsset } from "./utils/isRobinhoodExclusiveAsset";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
+type BaseNavigatorNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
+type Navigation = CompositeNavigationProp<
+  NativeStackNavigationProp<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>,
+  BaseNavigatorNavigation
+>;
+
 const ASSET_DETAIL_DEEPLINK_SOURCES = new Set(["deeplink_asset", "deeplink_market"]);
 
 export function useAssetDetailViewModel() {
+  const navigation = useNavigation<Navigation>();
   const route = useRoute<Route>();
   const { currencyId, source, marketState } = route.params;
 
@@ -49,6 +64,18 @@ export function useAssetDetailViewModel() {
     !isCurrencyLoading &&
     !currencyError &&
     !currency;
+
+  useEffect(() => {
+    if (!shouldRedirectToMarket) return;
+
+    const baseNavigation = navigation.getParent<BaseNavigatorNavigation>(BASE_NAVIGATOR_ID);
+    if (baseNavigation) {
+      baseNavigation.replace(ScreenName.MarketList);
+      return;
+    }
+
+    navigation.navigate(ScreenName.MarketList);
+  }, [navigation, shouldRedirectToMarket]);
 
   const { marketApiId, knownLedgerIds, knownMarketId } = useMemo(
     () =>

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/screens/AssetDetail/useAssetDetailViewModel.ts
@@ -19,6 +19,8 @@ import { isRobinhoodExclusiveAsset } from "./utils/isRobinhoodExclusiveAsset";
 
 type Route = StackNavigatorProps<AssetDetailNavigatorParamsList, ScreenName.AssetDetail>["route"];
 
+const ASSET_DETAIL_DEEPLINK_SOURCES = new Set(["deeplink_asset", "deeplink_market"]);
+
 export function useAssetDetailViewModel() {
   const route = useRoute<Route>();
   const { currencyId, source, marketState } = route.params;
@@ -35,8 +37,18 @@ export function useAssetDetailViewModel() {
   );
 
   const ledgerIdFallback = marketState?.ledgerIds?.[0] ?? currencyId;
-  const { currency: ledgerCurrencyById } = useCurrencyById(ledgerIdFallback);
+  const {
+    currency: ledgerCurrencyById,
+    loading: isCurrencyLoading,
+    error: currencyError,
+  } = useCurrencyById(ledgerIdFallback);
   const currency = distributionItem?.currency ?? ledgerCurrencyById;
+  const shouldRedirectToMarket =
+    ASSET_DETAIL_DEEPLINK_SOURCES.has(source ?? "") &&
+    !distribution.isLoading &&
+    !isCurrencyLoading &&
+    !currencyError &&
+    !currency;
 
   const { marketApiId, knownLedgerIds, knownMarketId } = useMemo(
     () =>
@@ -107,5 +119,6 @@ export function useAssetDetailViewModel() {
     coinOptions,
     isLoading,
     ledgerIds: receiveLedgerIds,
+    shouldRedirectToMarket,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/utils/__tests__/getActionFromAssetDetailDeeplinkState.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/utils/__tests__/getActionFromAssetDetailDeeplinkState.test.ts
@@ -1,0 +1,65 @@
+import { getStateFromPath } from "@react-navigation/native";
+import { ScreenName } from "~/const";
+import { handleAssetDetailDeeplink } from "~/navigation/deeplinks/handleAssetDetailDeeplink";
+import { getActionFromAssetDetailDeeplinkState } from "../getActionFromAssetDetailDeeplinkState";
+
+function createAssetDetailState(params: Parameters<typeof handleAssetDetailDeeplink>[0]) {
+  const state = handleAssetDetailDeeplink(params);
+
+  if (!state) {
+    throw new Error("Expected an Asset Detail navigation state");
+  }
+
+  return state;
+}
+
+describe("getActionFromAssetDetailDeeplinkState", () => {
+  it("should reset navigation for each sequential token Asset Detail deeplink", () => {
+    const firstState = createAssetDetailState({
+      currencyId: "ethereum/erc20/usd_tether__erc20_",
+      source: "deeplink_asset",
+      marketState: {
+        id: "ethereum/erc20/usd_tether__erc20_",
+        ledgerIds: ["ethereum/erc20/usd_tether__erc20_"],
+      },
+    });
+    const secondState = createAssetDetailState({
+      currencyId: "ethereum/erc20/usd__coin",
+      source: "deeplink_asset",
+      marketState: {
+        id: "ethereum/erc20/usd__coin",
+        ledgerIds: ["ethereum/erc20/usd__coin"],
+      },
+    });
+
+    expect(getActionFromAssetDetailDeeplinkState(firstState)).toEqual({
+      type: "RESET",
+      payload: firstState,
+    });
+    expect(getActionFromAssetDetailDeeplinkState(secondState)).toEqual({
+      type: "RESET",
+      payload: secondState,
+    });
+  });
+
+  it("should keep the default navigation action for coin Asset Detail deeplinks", () => {
+    const state = createAssetDetailState({
+      currencyId: "bitcoin",
+      source: "deeplink_asset",
+    });
+
+    expect(getActionFromAssetDetailDeeplinkState(state)?.type).toBe("NAVIGATE");
+  });
+
+  it("should keep the default navigation action for Stake deeplinks", () => {
+    const state = getStateFromPath("earn?action=stake", {
+      screens: { [ScreenName.Earn]: "earn" },
+    });
+
+    if (!state) {
+      throw new Error("Expected a Stake navigation state");
+    }
+
+    expect(getActionFromAssetDetailDeeplinkState(state)?.type).toBe("NAVIGATE");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/utils/getActionFromAssetDetailDeeplinkState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/AssetDetail/utils/getActionFromAssetDetailDeeplinkState.ts
@@ -1,0 +1,46 @@
+import {
+  CommonActions,
+  getActionFromState,
+  type NavigationState,
+  type PartialState,
+} from "@react-navigation/native";
+import { ScreenName } from "~/const";
+
+type DeeplinkState = NavigationState | PartialState<NavigationState>;
+
+function hasMarketStateParam(params: unknown): params is { marketState: unknown } {
+  if (typeof params !== "object" || params === null) {
+    return false;
+  }
+
+  return (params as { marketState?: unknown }).marketState !== undefined;
+}
+
+function isAssetDetailTokenState(state: DeeplinkState): boolean {
+  const route = state.routes[state.index ?? state.routes.length - 1];
+
+  if (!route) {
+    return false;
+  }
+
+  if (route.state && isAssetDetailTokenState(route.state)) {
+    return true;
+  }
+
+  return (
+    route.name === ScreenName.AssetDetail &&
+    route.params !== undefined &&
+    hasMarketStateParam(route.params)
+  );
+}
+
+export function getActionFromAssetDetailDeeplinkState(
+  state: DeeplinkState,
+  options?: Parameters<typeof getActionFromState>[1],
+) {
+  if (isAssetDetailTokenState(state)) {
+    return CommonActions.reset(state as PartialState<NavigationState>);
+  }
+
+  return getActionFromState(state as PartialState<NavigationState>, options);
+}

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -54,6 +54,7 @@ import { handleProductTourDeeplink } from "./deeplinks/handleProductTourDeeplink
 import { handleBackupHubDeeplink } from "./deeplinks/handleBackupHubDeeplink";
 import { SplashScreenHandle } from "LLM/features/LaunchScreen/SplashScreenHandle";
 import { useDeeplinkDrawerCleanup } from "./deeplinks/useDeeplinkDrawerCleanup";
+import { getActionFromAssetDetailDeeplinkState } from "LLM/features/AssetDetail/utils/getActionFromAssetDetailDeeplinkState";
 
 const themes: {
   [key: string]: Theme;
@@ -609,6 +610,7 @@ export const DeeplinksProvider = ({
             sub.remove();
           };
         },
+        getActionFromState: getActionFromAssetDetailDeeplinkState,
         getStateFromPath: (path, config) => {
           const url = new URL(`ledgerwallet://${path}`);
           const { hostname, searchParams, pathname } = url;

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/resolveMarketOrAssetDeeplinkIntent.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/resolveMarketOrAssetDeeplinkIntent.test.ts
@@ -49,10 +49,10 @@ describe("resolveMarketOrAssetDeeplinkIntent", () => {
       ).toEqual({ type: "market-banner" });
     });
 
-    it("falls back to portfolio for a token on legacy asset", () => {
+    it("falls back to the market banner for a token on legacy asset", () => {
       expect(
         resolveMarketOrAssetDeeplinkIntent({ ...off, hostname: "asset", pathname: tokenPath }),
-      ).toEqual({ type: "portfolio" });
+      ).toEqual({ type: "market-banner" });
     });
   });
 
@@ -90,10 +90,10 @@ describe("resolveMarketOrAssetDeeplinkIntent", () => {
       ).toEqual({ type: "market-banner", category: undefined });
     });
 
-    it("routes a non-empty asset path to portfolio", () => {
+    it("routes an unknown crypto asset id to the market banner", () => {
       expect(
         resolveMarketOrAssetDeeplinkIntent({ ...base, hostname: "asset", pathname: "/not-a-coin" }),
-      ).toEqual({ type: "portfolio" });
+      ).toEqual({ type: "market-banner" });
     });
 
     it("routes an empty asset path to portfolio when Wallet 4.0 is on", () => {

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/resolveMarketOrAssetDeeplinkIntent.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/resolveMarketOrAssetDeeplinkIntent.ts
@@ -59,8 +59,7 @@ export function resolveMarketOrAssetDeeplinkIntent({
       return { type: "legacy-path", currencyId: action.currencyId };
     }
 
-    // Token id on legacy screens is unsupported.
-    return hostname === "market" ? { type: "market-banner" } : { type: "portfolio" };
+    return { type: "market-banner" };
   }
 
   const hasPath = pathname.trim().split("/").some(Boolean);
@@ -74,7 +73,11 @@ export function resolveMarketOrAssetDeeplinkIntent({
     return { type: "market-banner", category };
   }
 
-  if (hasPath || shouldDisplayAggregatedAssets) {
+  if (hasPath) {
+    return { type: "market-banner" };
+  }
+
+  if (shouldDisplayAggregatedAssets) {
     return { type: "portfolio" };
   }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Unit tests cover token, coin, and Stake navigation actions. The original native crash still requires validation on the affected physical iPhone/build._
- [x] **Impact of the changes:**
  - Open a token deeplink followed by another token deeplink, both immediately and after a delay.
  - Verify each token opens the expected Asset Detail screen without crashing.
  - Verify coin Asset Detail and `earn?action=stake` deeplinks keep their existing navigation behavior.
  - Verify Back returns to the main screen after opening a token deeplink.

### 📝 Description

Opening a token Asset Detail deeplink followed by another token deeplink can crash Ledger Wallet Mobile on iOS. The available crash report shows a secondary React Native/Hermes failure while converting a native exception, but it does not expose the original native module, method, or exception reason.

**Before:** Token Asset Detail deeplinks used React Navigation's default action generation, allowing the existing Asset Detail route to be reused for the next token.

**After:** Token Asset Detail states are dispatched as reset actions so every token deeplink creates a fresh navigation state and remounts the screen. Coin Asset Detail, Stake, and all other deeplinks continue using React Navigation's default action generation. This is independent of how quickly the links are opened.

This is a targeted mitigation for route reuse. Confirming the native root cause still requires reproducing the original exception on the affected physical iPhone/build.

Automatic validation:
- Targeted Jest suite: 1 passed, 3 tests passed.
- Formatting: passed.
- Lint: passed with 0 warnings and 0 errors.
- Mobile typecheck: blocked by 180 existing errors across 119 files on `develop`, primarily React 18/19 type conflicts and locally unbuilt domain package exports. No typecheck error is reported in the new utility or test.

### 🎥 Demo

The video demonstrates the following deeplink scenarios:

1. A valid token deeplink opens the USDT Asset Detail page:
   `ledgerlive://asset/ethereum/erc20/usd_tether__erc20_`

2. An invalid token deeplink redirects to the Market page:
   `ledgerlive://asset/ethereum/erc20/does_not_exist`

3. A cryptocurrency deeplink opens the Ethereum Asset Detail page:
   `ledgerlive://asset/ethereum`

https://github.com/user-attachments/assets/c640cbbc-dccb-4323-8cd4-a212573c4f33



### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34539

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)