### PR TITLE
fix(e2e-mobile): truncate swap amount in different-seed device verification

### DIFF
--- a/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swap.other.ts
@@ -97,10 +97,11 @@ export function runSwapWithDifferentSeedTest(
         swap.accountToDebit,
         swap.accountToCredit,
       );
+      const swapAmount = minAmount ? truncateSwapAmount(minAmount) : minAmount;
       await performSwapUntilQuoteSelectionStep(
         swap.accountToDebit,
         swap.accountToCredit,
-        minAmount,
+        swapAmount,
       );
       const provider = await app.swapLiveApp.selectExchange();
       await app.swapLiveApp.checkExchangeButtonHasProviderName(provider.uiName);
@@ -109,7 +110,7 @@ export function runSwapWithDifferentSeedTest(
       if (errorMessage) {
         await app.swapLiveApp.checkErrorMessage(errorMessage);
       } else {
-        await app.swap.verifyAmountsAndAcceptSwapForDifferentSeed(swap, minAmount, errorMessage);
+        await app.swap.verifyAmountsAndAcceptSwapForDifferentSeed(swap, swapAmount, errorMessage);
         await app.swap.waitForSuccessAndContinue();
       }
     });


### PR DESCRIPTION
## Summary
- `runSwapWithDifferentSeedTest` (used by e.g. "Swap using a different seed - Bitcoin to Ethereum") compared the raw, untruncated `minAmount` from `getMinimumSwapAmount()` against the Speculos device screen, which truncates BTC to 8 decimal places.
- When the live quote API returned a minimum amount with more than 8 decimal digits, the device-screen assertion threw before hold-to-sign, failing the test intermittently depending on live market/quote data.
- The sibling `runUserRefusesTransactionTest` (and the main swap flow in `swap.ts`) already got this exact fix via `truncateSwapAmount()` on 2026-07-02/03 — this test function was missed.
- This applies the same fix: truncate `minAmount` to 8 decimals before filling the swap form and before the device-screen assertion.

## Test plan
- [x] `pnpm --filter ledger-live-mobile-e2e-tests typecheck`
- [ ] CI mobile E2E run for the swap different-seed specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)