### PR TITLE
[LWM] fix(LIVE-34675): summary step padding updated

### DIFF
--- a/.changeset/forty-rats-watch.md
+++ b/.changeset/forty-rats-watch.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+updated bottom spacing for summary step

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -229,7 +229,7 @@ function SendSummary({ navigation, route }: Props) {
       ]}
     >
       <TrackScreen category="SendFunds" name="Summary" currencyName={currencyOrToken?.name} />
-      <NavigationScrollView style={styles.body}>
+      <NavigationScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
         {transaction.useAllAmount && hasNonEmptySubAccounts ? (
           <View style={styles.infoBox}>
             <Alert type="primary">
@@ -406,8 +406,11 @@ const styles = StyleSheet.create({
   body: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingVertical: 16,
+    paddingTop: 16,
     backgroundColor: "transparent",
+  },
+  bodyContent: {
+    paddingBottom: 24,
   },
   footer: {
     flexDirection: "column",


### PR DESCRIPTION
### 📝 Description

- Fixed bottom padding on the Send flow summary step (mobile) — content was clipped/tight at the bottom of the scroll view
- Moved bottom padding from the scroll view's style to contentContainerStyle so it scrolls correctly, and increased it from 16 to 24px for better spacing

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34675](https://ledgerhq.atlassian.net/browse/LIVE-34675)

Preview after fix: 
<img width="1080" height="2400" alt="Screenshot_2026-07-21-08-44-34-542_com ledger live debug" src="https://github.com/user-attachments/assets/cee00ea2-f0d8-4f8f-8b5f-18b04837ff9e" />
