### PR TITLE
[LWM] fix(LIVE-34674): prevent manual go back from view key approve screen

### DIFF
--- a/.changeset/popular-geckos-bow.md
+++ b/.changeset/popular-geckos-bow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+prevent go back from view key approve screen for Aleo

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { ScrollView, StyleSheet } from "react-native";
-import { useNavigation, useRoute } from "@react-navigation/native";
+import { BackHandler, ScrollView, StyleSheet } from "react-native";
+import { useFocusEffect, useNavigation, useRoute } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import SafeAreaView from "~/components/SafeAreaView";
 import { Box, Spinner, Text } from "@ledgerhq/lumen-ui-rnative";
@@ -95,6 +95,13 @@ export default function ViewKeyApproveScreen() {
       onCloseNavigation?.();
     }
   }, [hasAccountsToAdd, onCloseNavigation]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const subscription = BackHandler.addEventListener("hardwareBackPress", () => true);
+      return () => subscription.remove();
+    }, []),
+  );
 
   const quitConfirmation = useQuitConfirmation({
     onCloseNavigation,

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, Text, TouchableOpacity, Pressable } from "react-native";
+import { View, Text, TouchableOpacity, Pressable, BackHandler } from "react-native";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { render, screen } from "@tests/test-renderer";
 import type { Account } from "@ledgerhq/types-live";
@@ -35,6 +35,10 @@ jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: jest.fn(),
   useRoute: jest.fn(),
+  useFocusEffect: jest.fn((callback: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => callback(), [callback]);
+  }),
 }));
 
 jest.mock("@ledgerhq/live-common/families/aleo/react", () => ({
@@ -361,6 +365,37 @@ describe("ViewKeyApproveScreen", () => {
       // Not aborted: onResult still proceeds normally.
       capturedOnResult?.();
       expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("hardware back button (Android)", () => {
+    let mockSubscriptionRemove: jest.Mock;
+
+    beforeEach(() => {
+      mockSubscriptionRemove = jest.fn();
+      jest
+        .spyOn(BackHandler, "addEventListener")
+        .mockReturnValue({ remove: mockSubscriptionRemove });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("registers a handler that prevents default back navigation", () => {
+      renderScreen();
+      expect(BackHandler.addEventListener).toHaveBeenCalledWith(
+        "hardwareBackPress",
+        expect.any(Function),
+      );
+      const [[, handler]] = (BackHandler.addEventListener as jest.Mock).mock.calls;
+      expect(handler()).toBe(true);
+    });
+
+    it("removes the handler when the screen unmounts", () => {
+      const { unmount } = renderScreen();
+      unmount();
+      expect(mockSubscriptionRemove).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Blocks the Android hardware back button on ViewKeyApproveScreen via BackHandler + useFocusEffect, preventing users from navigating away mid-approval (which could cause loop or state issues)
- iOS was already covered by the navigator options (gestureEnabled: false, headerLeft: () => null)
- Adds useFocusEffect to the test mock and two new test cases: handler returns true (consumes the event), and the subscription is cleaned up on unmount

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34674](https://ledgerhq.atlassian.net/browse/LIVE-34674)
