### PR TITLE
fix(e2e-desktop): stabilize Entry Point - Asset Allocation swap test

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -464,16 +464,30 @@ export class SwapPage extends WebViewAppPage {
   }
 
   @step("Wait for the to-account coin selector to be populated")
-  async waitForToAssetSelectorReady() {
-    const webview = await this.getWebView();
-    await webview.waitForFunction(
-      selectorTestId => {
-        const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-        return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
-      },
-      this.toAccountCoinSelector,
-      { timeout: 5_000 },
-    );
+  async waitForToAssetSelectorReady(timeout = 40_000) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const webview = await this.getWebView();
+      try {
+        await webview.waitForFunction(
+          selectorTestId => {
+            const el = document.querySelector(`[data-testid='${selectorTestId}']`);
+            return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
+          },
+          this.toAccountCoinSelector,
+          { timeout },
+        );
+        return;
+      } catch (error) {
+        // The embedded swap widget can remount (new webview instance) once its default
+        // currency resolves; if that happens mid-poll, retry once against the fresh webview
+        // instead of failing on the now-stale reference.
+        if (attempt === 0 && webview.isClosed()) {
+          this._webviewPage = undefined;
+          continue;
+        }
+        throw error;
+      }
+    }
   }
 
   @step("Check currency to swap to contains $0")

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -1,6 +1,6 @@
 import { WebViewAppPage } from "./webViewApp.page";
 import { step } from "tests/misc/reporters/step";
-import { expect } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { ChooseAssetDrawer } from "./drawer/choose.asset.drawer";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
@@ -368,49 +368,44 @@ export class SwapPage extends WebViewAppPage {
     await expect(webview.getByTestId(this.fromAccountCoinSelector)).toContainText(asset);
   }
 
+  private async waitForSelectorPopulated(webview: Page, testId: string, timeout: number) {
+    await webview.waitForFunction(
+      selectorTestId => {
+        const el = document.querySelector(`[data-testid='${selectorTestId}']`);
+        return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
+      },
+      testId,
+      { timeout },
+    );
+  }
+
   @step("Check if $0 asset is already selected")
   async checkIfFromAssetIsAlreadySelected(asset: string): Promise<boolean> {
     const webview = await this.getWebView();
-    const selector = webview.getByTestId(this.fromAccountCoinSelector);
 
     try {
-      await webview.waitForFunction(
-        selectorTestId => {
-          const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-          return el && el.textContent && el.textContent !== "Choose asset";
-        },
-        this.fromAccountCoinSelector,
-        { timeout: 5_000 },
-      );
+      await this.waitForSelectorPopulated(webview, this.fromAccountCoinSelector, 5_000);
     } catch {
       // Page context closed or from-selector not yet pre-populated; caller will proceed to manual selection
       return false;
     }
 
-    const text = await selector.textContent();
+    const text = await webview.getByTestId(this.fromAccountCoinSelector).textContent();
     return text?.includes(asset) ?? false;
   }
 
   @step("Check if $0 asset is already selected")
   async checkIfToAssetIsAlreadySelected(asset: string): Promise<boolean> {
     const webview = await this.getWebView();
-    const selector = webview.getByTestId(this.toAccountCoinSelector);
 
     try {
-      await webview.waitForFunction(
-        selectorTestId => {
-          const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-          return el && el.textContent && el.textContent !== "Choose asset";
-        },
-        this.toAccountCoinSelector,
-        { timeout: 5_000 },
-      );
+      await this.waitForSelectorPopulated(webview, this.toAccountCoinSelector, 5_000);
     } catch {
       // to-selector was not pre-populated; caller will proceed to manual selection
       return false;
     }
 
-    const text = await selector.textContent();
+    const text = await webview.getByTestId(this.toAccountCoinSelector).textContent();
     return text?.includes(asset) ?? false;
   }
 
@@ -465,28 +460,22 @@ export class SwapPage extends WebViewAppPage {
 
   @step("Wait for the to-account coin selector to be populated")
   async waitForToAssetSelectorReady(timeout = 40_000) {
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const webview = await this.getWebView();
-      try {
-        await webview.waitForFunction(
-          selectorTestId => {
-            const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-            return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
-          },
-          this.toAccountCoinSelector,
-          { timeout },
-        );
-        return;
-      } catch (error) {
-        // The embedded swap widget can remount (new webview instance) once its default
-        // currency resolves; if that happens mid-poll, retry once against the fresh webview
-        // instead of failing on the now-stale reference.
-        if (attempt === 0 && webview.isClosed()) {
-          this._webviewPage = undefined;
-          continue;
-        }
+    const webview = await this.getWebView();
+    try {
+      await this.waitForSelectorPopulated(webview, this.toAccountCoinSelector, timeout);
+    } catch (error) {
+      // The embedded swap widget can remount (new webview instance) once its default currency
+      // resolves; if that happens mid-poll, retry once against the fresh webview instead of
+      // failing on the now-stale reference.
+      if (!webview.isClosed()) {
         throw error;
       }
+      this._webviewPage = undefined;
+      await this.waitForSelectorPopulated(
+        await this.getWebView(),
+        this.toAccountCoinSelector,
+        timeout,
+      );
     }
   }
 

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -466,10 +466,14 @@ export class SwapPage extends WebViewAppPage {
   @step("Wait for the to-account coin selector to be populated")
   async waitForToAssetSelectorReady() {
     const webview = await this.getWebView();
-    await webview.waitForFunction(selectorTestId => {
-      const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-      return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
-    }, this.toAccountCoinSelector);
+    await webview.waitForFunction(
+      selectorTestId => {
+        const el = document.querySelector(`[data-testid='${selectorTestId}']`);
+        return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
+      },
+      this.toAccountCoinSelector,
+      { timeout: 5_000 },
+    );
   }
 
   @step("Check currency to swap to contains $0")

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -478,7 +478,9 @@ export class SwapPage extends WebViewAppPage {
 
   @step("Check currency to swap to contains $0")
   async checkAssetToContains(expected: string) {
-    await this.waitForToAssetSelectorReady();
+    if (expected !== "Choose asset") {
+      await this.waitForToAssetSelectorReady();
+    }
     const webview = await this.getWebView();
     await expect(webview.getByTestId(this.toAccountCoinSelector)).toContainText(expected);
   }

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -89,6 +89,17 @@ export class SwapPage extends WebViewAppPage {
     this.page.getByTestId(`swap-history-to-amount-${swapId}`);
   private chooseAssetDrawer = new ChooseAssetDrawer(this.page);
 
+  private async waitForSelectorPopulated(webview: Page, testId: string, timeout: number) {
+    await webview.waitForFunction(
+      selectorTestId => {
+        const el = document.querySelector(`[data-testid='${selectorTestId}']`);
+        return Boolean(el?.textContent && el.textContent.trim().toLowerCase() !== "choose asset");
+      },
+      testId,
+      { timeout },
+    );
+  }
+
   async sendMax() {
     await this.maxSpendableToggle.click();
   }
@@ -368,17 +379,6 @@ export class SwapPage extends WebViewAppPage {
     await expect(webview.getByTestId(this.fromAccountCoinSelector)).toContainText(asset);
   }
 
-  private async waitForSelectorPopulated(webview: Page, testId: string, timeout: number) {
-    await webview.waitForFunction(
-      selectorTestId => {
-        const el = document.querySelector(`[data-testid='${selectorTestId}']`);
-        return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
-      },
-      testId,
-      { timeout },
-    );
-  }
-
   @step("Check if $0 asset is already selected")
   async checkIfFromAssetIsAlreadySelected(asset: string): Promise<boolean> {
     const webview = await this.getWebView();
@@ -481,7 +481,7 @@ export class SwapPage extends WebViewAppPage {
 
   @step("Check currency to swap to contains $0")
   async checkAssetToContains(expected: string) {
-    if (expected !== "Choose asset") {
+    if (expected.toLowerCase() !== "choose asset") {
       await this.waitForToAssetSelectorReady();
     }
     const webview = await this.getWebView();

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -463,8 +463,18 @@ export class SwapPage extends WebViewAppPage {
     await webview.getByTestId(this.fromAccountCoinSelector).click();
   }
 
+  @step("Wait for the to-account coin selector to be populated")
+  async waitForToAssetSelectorReady() {
+    const webview = await this.getWebView();
+    await webview.waitForFunction(selectorTestId => {
+      const el = document.querySelector(`[data-testid='${selectorTestId}']`);
+      return Boolean(el?.textContent && el.textContent.trim() !== "Choose asset");
+    }, this.toAccountCoinSelector);
+  }
+
   @step("Check currency to swap to contains $0")
   async checkAssetToContains(expected: string) {
+    await this.waitForToAssetSelectorReady();
     const webview = await this.getWebView();
     await expect(webview.getByTestId(this.toAccountCoinSelector)).toContainText(expected);
   }


### PR DESCRIPTION
## Summary
- Fixes flaky failure of `Entry Point - Asset Allocation` in `entrypoint.swap.spec.ts` seen in [this CI run](https://github.com/LedgerHQ/ledger-live/actions/runs/29803004686), where the assertion expected `BTC` in the `to-account-coin-selector` but got the placeholder `"Choose asset"`.
- Root cause: the embedded swap rail resolves its default "to" currency asynchronously and can remount the widget after `checkAssetToContains` has already started asserting, so the check can catch the placeholder before the real value lands.
- Adds `waitForToAssetSelectorReady()` (mirrors the existing `checkIfToAssetIsAlreadySelected` pattern already in `swap.page.ts`) and calls it before the assertion in `checkAssetToContains`.

## Test plan
- [ ] `pnpm format` clean on the changed file
- [ ] `tsc --noEmit` shows no new errors introduced by this change
- [ ] Re-run the Desktop E2E workflow (or just `entrypoint.swap.spec.ts`) to confirm `Entry Point - Asset Allocation` passes reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)