### PR TITLE
[LWM] fix: aleo testnet support in add account + token accounts in assets view

### DIFF
--- a/.changeset/pink-crabs-vanish.md
+++ b/.changeset/pink-crabs-vanish.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+---
+
+fix: unique account key in aleo add account flow
+fix: missing getParentCurrencyId in quick actions

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -54,6 +54,7 @@ const withTwoAccounts = (state: State): State => ({
 
 describe("useAssetActions - custom send flow", () => {
   beforeEach(() => {
+    mockGetCustomSendFlow.mockClear();
     mockGetCustomSendFlow.mockReturnValue(null);
   });
 

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.test.ts
@@ -5,6 +5,7 @@ import type { State } from "~/reducers/types";
 import { ScreenName } from "~/const";
 import useAssetActions from "./useAssetActions";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+import { aleoTokenCurrency } from "~/families/aleo/__mocks__/currency.mock";
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
@@ -103,6 +104,14 @@ describe("useAssetActions - custom send flow", () => {
       screen: ScreenName.SendCoin,
       params: expect.objectContaining({ selectedCurrency: currencyAleo }),
     });
+  });
+
+  it("resolves family from the parent currency when currency is a token", () => {
+    renderHook(() => useAssetActions({ currency: aleoTokenCurrency, accounts: [ALEO_ACCOUNT_1] }), {
+      overrideInitialState: withSingleAccount,
+    });
+
+    expect(mockGetCustomSendFlow).toHaveBeenCalledWith("aleo");
   });
 
   it("includes additional family actions from getAdditionalAssetActions", () => {

--- a/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
+++ b/apps/ledger-live-mobile/src/components/FabActions/hooks/useAssetActions.tsx
@@ -35,6 +35,11 @@ type useAssetActionsProps = {
   accounts?: AccountLikeArray;
 };
 
+function getParentCurrencyId(currency?: CryptoCurrency | TokenCurrency): string | undefined {
+  if (!currency) return undefined;
+  return currency.type === "TokenCurrency" ? currency.parentCurrencyId : currency.id;
+}
+
 const iconBuy = IconsLegacy.PlusMedium;
 const iconSell = IconsLegacy.MinusMedium;
 const iconSwap = IconsLegacy.BuyCryptoMedium;
@@ -85,7 +90,8 @@ export default function useAssetActions({ currency, accounts }: useAssetActionsP
 
   const { getCanStakeCurrency } = useStake();
   const accountCurrency = !defaultAccount ? null : getAccountCurrency(defaultAccount);
-  const family = currency ? getFamilyByCurrencyId(currency.id) : undefined;
+  const parentCurrencyId = getParentCurrencyId(currency);
+  const family = parentCurrencyId ? getFamilyByCurrencyId(parentCurrencyId) : undefined;
   const assetId = !currency ? accountCurrency?.id : currency.id;
   const canStakeCurrency = !assetId ? false : getCanStakeCurrency(assetId);
 

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/ViewKeyApproveScreen.tsx
@@ -75,8 +75,9 @@ export default function ViewKeyApproveScreen() {
   // transport subscription off selectedAccounts by reference, not content — recomputing it
   // mid-approval would tear down the subscription without restarting it.
   const [accountsToAdd] = useState(() => {
-    const existingAddresses = new Set(existingAccounts.map(a => a.freshAddress));
-    return allAccountsToAdd.filter(a => !existingAddresses.has(a.freshAddress));
+    const accountKey = (a: Account) => `${a.currency.id}:${a.freshAddress}`;
+    const existingKeys = new Set(existingAccounts.map(accountKey));
+    return allAccountsToAdd.filter(a => !existingKeys.has(accountKey(a)));
   });
 
   const hasAccountsToAdd = accountsToAdd.length > 0;

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@ledgerhq/live-common/families/aleo/react";
 import ViewKeyApproveScreen from "../ViewKeyApproveScreen";
 import { ScreenName } from "~/const";
+import { aleoCurrency, aleoTestnetCurrency } from "../../__mocks__/currency.mock";
 
 type MockViewKeyApprovalReturn = {
   hookState: {
@@ -137,8 +138,13 @@ jest.mock("@ledgerhq/live-wallet/addAccounts", () => ({
   addAccountsAction: jest.fn(() => ({ type: "ADD_ACCOUNTS" })),
 }));
 
-const ACCOUNT_1 = { id: "account1", freshAddress: "addr1" } as Account;
-const ACCOUNT_2 = { id: "account2", freshAddress: "addr2" } as Account;
+const ACCOUNT_1 = { id: "account1", freshAddress: "addr1", currency: aleoCurrency } as Account;
+const ACCOUNT_2 = { id: "account2", freshAddress: "addr2", currency: aleoCurrency } as Account;
+const ACCOUNT_TESTNET_1 = {
+  id: "accountTestnet1",
+  freshAddress: ACCOUNT_1.freshAddress,
+  currency: aleoTestnetCurrency,
+} as Account;
 
 const mockParentNavigate = jest.fn();
 const mockNavigation = {
@@ -259,7 +265,9 @@ describe("ViewKeyApproveScreen", () => {
 
     it("shows only accounts whose freshAddress is not already in the wallet", () => {
       const { useSelector } = jest.requireMock("~/context/hooks");
-      useSelector.mockReturnValue([{ id: "existing", freshAddress: "addr1" }]);
+      useSelector.mockReturnValue([
+        { id: "existing", freshAddress: "addr1", currency: aleoCurrency },
+      ]);
 
       renderScreen({
         hookState: { sharePending: true, shareProgress: { completed: 0, total: 1 } },
@@ -267,6 +275,20 @@ describe("ViewKeyApproveScreen", () => {
 
       expect(screen.getByText("account2")).toBeTruthy();
       expect(screen.queryByText("account1")).toBeNull();
+    });
+
+    it("does not filter out a testnet account sharing the same freshAddress as an existing mainnet account", () => {
+      const { useSelector } = jest.requireMock("~/context/hooks");
+      useSelector.mockReturnValue([
+        { id: "existing", freshAddress: "addr1", currency: aleoCurrency },
+      ]);
+
+      renderScreen(
+        { hookState: { sharePending: true, shareProgress: { completed: 0, total: 1 } } },
+        { accountsToAdd: [ACCOUNT_TESTNET_1] },
+      );
+
+      expect(screen.getByText("accountTestnet1")).toBeTruthy();
     });
   });
 
@@ -279,8 +301,8 @@ describe("ViewKeyApproveScreen", () => {
     it("does not start the device action and closes the flow", () => {
       const { useSelector } = jest.requireMock("~/context/hooks");
       useSelector.mockReturnValue([
-        { id: "existing1", freshAddress: "addr1" },
-        { id: "existing2", freshAddress: "addr2" },
+        { id: "existing1", freshAddress: "addr1", currency: aleoCurrency },
+        { id: "existing2", freshAddress: "addr2", currency: aleoCurrency },
       ]);
       const mockOnClose = jest.fn();
 

--- a/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AddAccountFlow/__tests__/ViewKeyApproveScreen.test.tsx
@@ -138,13 +138,23 @@ jest.mock("@ledgerhq/live-wallet/addAccounts", () => ({
   addAccountsAction: jest.fn(() => ({ type: "ADD_ACCOUNTS" })),
 }));
 
-const ACCOUNT_1 = { id: "account1", freshAddress: "addr1", currency: aleoCurrency } as Account;
-const ACCOUNT_2 = { id: "account2", freshAddress: "addr2", currency: aleoCurrency } as Account;
+const ACCOUNT_1 = {
+  id: "account1",
+  freshAddress: "addr1",
+  currency: aleoCurrency,
+} as unknown as Account;
+
+const ACCOUNT_2 = {
+  id: "account2",
+  freshAddress: "addr2",
+  currency: aleoCurrency,
+} as unknown as Account;
+
 const ACCOUNT_TESTNET_1 = {
   id: "accountTestnet1",
   freshAddress: ACCOUNT_1.freshAddress,
   currency: aleoTestnetCurrency,
-} as Account;
+} as unknown as Account;
 
 const mockParentNavigate = jest.fn();
 const mockNavigation = {
@@ -285,7 +295,10 @@ describe("ViewKeyApproveScreen", () => {
 
       renderScreen(
         { hookState: { sharePending: true, shareProgress: { completed: 0, total: 1 } } },
-        { accountsToAdd: [ACCOUNT_TESTNET_1] },
+        {
+          accountsToAdd: [ACCOUNT_TESTNET_1],
+          currency: { type: "CryptoCurrency" as const, id: aleoTestnetCurrency.id },
+        },
       );
 
       expect(screen.getByText("accountTestnet1")).toBeTruthy();

--- a/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/__mocks__/currency.mock.ts
@@ -2,6 +2,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/cryptoassets/index";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 
 export const aleoCurrency = getCryptoCurrencyById("aleo");
+export const aleoTestnetCurrency = getCryptoCurrencyById("aleo_testnet");
 
 export const aleoTokenCurrency: TokenCurrency = {
   type: "TokenCurrency",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR fixes two independent Aleo bugs in mobile:
- quick actions (buy/sell/swap/stake) resolved the wrong family for token currencies because getFamilyByCurrencyId was called with the token's own id instead of its parent currency id 
- the Aleo add-account flow deduped new accounts against existing ones using freshAddress alone, which could incorrectly filter out accounts that share an address across different currencies - the key now combines currency.id:freshAddress.

Impact of changes

- Quick actions on token accounts — verify the correct actions show up and route to the correct family flow
- Aleo add-account flow (ViewKeyApproveScreen) — verify accounts aren't wrongly excluded as "existing" when they share a freshAddress with an account of another currency, and that true duplicates are still filtered out

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34677
- https://ledgerhq.atlassian.net/browse/LIVE-34672