### PR TITLE
chore(wallet-pnl): mark package as private

### DIFF
--- a/libs/wallet-pnl/package.json
+++ b/libs/wallet-pnl/package.json
@@ -13,9 +13,7 @@
     "url": "https://github.com/LedgerHQ/ledger-live/issues"
   },
   "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/wallet-pnl",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "main": "lib/index.js",
   "module": "lib-es/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
### 📝 Description

Adds `"private": true` to `@ledgerhq/wallet-pnl/package.json` so the package can never be accidentally published to npm. The library is an internal computation module consumed only within the monorepo (LLD, LLM, and internal libs); it has no external npm consumers.

Removes the now-redundant `publishConfig` block.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34684](https://ledgerhq.atlassian.net/browse/LIVE-34684) 

[LIVE-34684]: https://ledgerhq.atlassian.net/browse/LIVE-34684