### PR TITLE
[LWM] refactor(mobile): migrate coin-integration screens to custom SafeAreaView (LIVE-34625)

### DIFF
--- a/.changeset/tidy-lizards-attack.md
+++ b/.changeset/tidy-lizards-attack.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Migrate coin-integration screens to the custom `~/components/SafeAreaView`, which handles the experimental header and avoids double safe-area insets.

--- a/apps/ledger-live-mobile/src/components/EditTransaction/EditTransactionSummaryView.tsx
+++ b/apps/ledger-live-mobile/src/components/EditTransaction/EditTransactionSummaryView.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "styled-components/native";
 import BigNumber from "bignumber.js";
 import React, { type ComponentProps, type ReactNode } from "react";
 import { StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import type { Account } from "@ledgerhq/types-live";
 import { TrackScreen } from "~/analytics";
 import Alert from "~/components/Alert";

--- a/apps/ledger-live-mobile/src/components/NetworkFeeInfo.tsx
+++ b/apps/ledger-live-mobile/src/components/NetworkFeeInfo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Icons } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import LText from "./LText";

--- a/apps/ledger-live-mobile/src/families/algorand/OptInFlow/03-Validation.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/OptInFlow/03-Validation.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { View, StyleSheet, ActivityIndicator } from "react-native";
 import { useDispatch } from "~/context/hooks";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/algorand/OptInFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/OptInFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Info.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/01-Info.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { View, StyleSheet, Linking } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import { useTheme } from "@react-navigation/native";
 import { Flex } from "@ledgerhq/native-ui";

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/03-Validation.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/03-Validation.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { View, StyleSheet, ActivityIndicator } from "react-native";
 import { useDispatch } from "~/context/hooks";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/Rewards/ClaimRewardsFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/algorand/ScreenEditMemoValue.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/ScreenEditMemo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/EditMemo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
+++ b/apps/ledger-live-mobile/src/families/casper/ScreenEditTransferId.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/02-SelectMethod.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import type {
   CosmosAccount,

--- a/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/ClaimRewardsFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/EditMemo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/01-SelectValidator.tsx
@@ -8,7 +8,7 @@ import {
   SectionListRenderItemInfo,
 } from "react-native";
 import BigNumber from "bignumber.js";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import type {
   CosmosAccount,

--- a/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/RedelegationFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/UndelegationFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/01-SelectValidator.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useMemo } from "react";
 import { FlatList, ListRenderItem, StyleSheet, TouchableOpacity, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import BigNumber from "bignumber.js";
 import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.tsx
@@ -2,7 +2,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { useTheme } from "@react-navigation/native";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/03-ValidationError.tsx
@@ -2,7 +2,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";
 import type {

--- a/apps/ledger-live-mobile/src/families/evm/DelegationFlow/06-RedelegationValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/DelegationFlow/06-RedelegationValidationError.tsx
@@ -2,7 +2,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";
 import type {

--- a/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ScreenEditGasLimit.tsx
@@ -3,7 +3,7 @@ import React, { useState, useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { Keyboard, StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import Button from "~/components/Button";
 import KeyboardView from "~/components/KeyboardView";

--- a/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/UndelegationFlow/03-ValidationError.tsx
@@ -2,7 +2,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";
 import type {

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/01-Withdraw.tsx
@@ -2,7 +2,7 @@
 import invariant from "invariant";
 import React, { useCallback } from "react";
 import { StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { Alert, Flex, Text } from "@ledgerhq/native-ui";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";

--- a/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/WithdrawFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useNavigation, useRoute, useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 
 import type { HederaAssociateTokenFlowParamList } from "./types";

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/Claim.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { Trans } from "~/context/Locale";
 import invariant from "invariant";
 import { StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/SelectReward.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/SelectReward.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { View, StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { HederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/types";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/ValidationError.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type {

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/SelectValidator.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { FlatList, StyleSheet, View } from "react-native";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/Summary.tsx
@@ -16,7 +16,7 @@ import { useTheme } from "@react-navigation/native";
 import invariant from "invariant";
 import { Trans, useTranslation } from "~/context/Locale";
 import { Animated, StyleSheet, View, TextStyle, StyleProp } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
 import Circle from "~/components/Circle";

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/ValidationError.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { TrackScreen } from "~/analytics";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";

--- a/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/EditMemo.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/Amount.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import invariant from "invariant";
 import { StyleSheet, View } from "react-native";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { Text } from "@ledgerhq/native-ui";
 import type { AccountBridge } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/SelectValidator.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { FlatList, StyleSheet } from "react-native";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/ValidationError.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { TrackScreen } from "~/analytics";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/Amount.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import invariant from "invariant";
 import { StyleSheet, View } from "react-native";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { Text } from "@ledgerhq/native-ui";
 import type { AccountBridge } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/ValidationError.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import { TrackScreen } from "~/analytics";
 import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";

--- a/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/internet_computer/ScreenEditMemo.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/mina/ScreenEditMemo.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
+++ b/apps/ledger-live-mobile/src/families/multiversx/components/Flows/Delegate/components/SetDelegation/SetDelegation.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useEffect, useCallback } from "react";
 import { Image, View, Animated } from "react-native";
 import { useChangeValidatorRotateAnim } from "~/families/shared/useChangeValidatorRotateAnim";
 import { useTheme } from "@react-navigation/native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import {
   handleTransactionStatus,
   denominate,

--- a/apps/ledger-live-mobile/src/families/near/StakingFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/near/StakingFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/near/UnstakingFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/near/UnstakingFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/near/WithdrawingFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import { ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -9,7 +9,7 @@ import {
   Linking,
   SectionListRenderItem,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans, useTranslation } from "~/context/Locale";
 import { useTheme } from "styled-components/native";
 import type {

--- a/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/RebondFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/SimpleOperationFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectAmount.tsx
@@ -16,7 +16,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Flex, Link, Text } from "@ledgerhq/native-ui";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/SelectValidator.tsx
@@ -7,7 +7,7 @@ import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { Trans } from "~/context/Locale";
 import { FlatList, StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import Touchable from "~/components/Touchable";

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Started.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Started.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { Trans } from "~/context/Locale";
 import { Linking, StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import BulletList, { BulletGreenCheck } from "~/components/BulletList";
 import Button from "~/components/Button";

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -20,7 +20,7 @@ import { capitalize } from "lodash/fp";
 import React, { ReactNode, useCallback, useEffect, useMemo } from "react";
 import { Trans } from "~/context/Locale";
 import { Animated, StyleSheet, View, TextStyle, StyleProp } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import { rgba } from "../../../colors";
 import Button from "~/components/Button";

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/ValidationError.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
 import type {

--- a/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/ScreenEditMemo.tsx
@@ -6,7 +6,7 @@ import i18next from "i18next";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "~/context/Locale";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import Button from "~/components/Button";
 import TextInput from "~/components/FocusedTextInput";
 import KeyboardView from "~/components/KeyboardView";

--- a/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
+++ b/apps/ledger-live-mobile/src/families/stacks/ScreenEditMemo.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-Validation.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-Validation.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { View, StyleSheet, ActivityIndicator } from "react-native";
 import { useDispatch } from "~/context/hooks";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import invariant from "invariant";
 import { useTheme } from "@react-navigation/native";
 import { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/AddAssetFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
+++ b/apps/ledger-live-mobile/src/families/stellar/ScreenEditMemoValue.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/sui/StakingFlow/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/StakingFlow/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/UnstakingFlow/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -10,7 +10,7 @@ import {
   KeyboardEventListener,
   ListRenderItem,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
 import { RecipientRequired } from "@ledgerhq/errors";

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from "react";
 import { View, StyleSheet, Animated, TextStyle, StyleProp } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import ValidateError from "~/components/ValidateError";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/tezos/StakeFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/StakeFlow/01-Amount.tsx
@@ -15,7 +15,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { Trans, useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/tezos/UnstakeFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/UnstakeFlow/01-Amount.tsx
@@ -7,7 +7,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import React, { useCallback, useEffect, useState } from "react";
 import { Keyboard, StyleSheet, Switch, TouchableWithoutFeedback, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Text } from "@ledgerhq/native-ui";
 import { Trans, useTranslation } from "~/context/Locale";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
+++ b/apps/ledger-live-mobile/src/families/ton/ScreenEditComment.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import i18next from "i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
+++ b/apps/ledger-live-mobile/src/families/xrp/ScreenEditTag.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useState } from "react";
 import { View, StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation, i18n } from "~/context/Locale";
 import { BigNumber } from "bignumber.js";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationStatusLayout/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Confirmation/components/ConfirmationStatusLayout/index.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from "react";
 import { View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { StatusGradient, type StatusGradientTone } from "LLM/components/StatusGradient";

--- a/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubApp/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubApp/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Box, Spinner } from "@ledgerhq/lumen-ui-rnative";
 import type { AppProps } from "LLM/features/Web3Hub/types";
 import WebPlatformPlayer from "./components/Web3Player";

--- a/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubMain/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubMain/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useTranslation } from "~/context/Locale";
 import { View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import type { MainProps } from "LLM/features/Web3Hub/types";
 import useScrollHandler from "LLM/features/Web3Hub/hooks/useScrollHandler";
 import ManifestsList from "LLM/features/Web3Hub/components/ManifestsList";

--- a/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubSearch/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Web3Hub/screens/Web3HubSearch/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useTheme } from "@react-navigation/native";
 import { View } from "react-native";
 import { useTranslation } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import type { SearchProps } from "LLM/features/Web3Hub/types";
 import useScrollHandler from "LLM/features/Web3Hub/hooks/useScrollHandler";
 import ManifestsList from "LLM/features/Web3Hub/components/ManifestsList";

--- a/apps/ledger-live-mobile/src/screens/Account/TokenContractAddress.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/TokenContractAddress.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react";
 import { StyleSheet, Linking, View } from "react-native";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Icons } from "@ledgerhq/native-ui";
 import type { TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";

--- a/apps/ledger-live-mobile/src/screens/ClaimRewards/02-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/ClaimRewards/02-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import { ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/01-Info.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/01-Info.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet, ScrollView, View, Linking } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { ScreenName } from "~/const";

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/02-Amount.tsx
@@ -8,7 +8,7 @@ import {
   Keyboard,
   TouchableOpacity,
 } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans, useTranslation } from "~/context/Locale";
 import invariant from "invariant";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/screens/FreezeFunds/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/FreezeFunds/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/screens/OperationDetails/Modal.tsx
+++ b/apps/ledger-live-mobile/src/screens/OperationDetails/Modal.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from "react";
 import { StyleSheet, View, Linking } from "react-native";
 import { Trans } from "~/context/Locale";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "@react-navigation/native";
 import { Currency } from "@ledgerhq/types-cryptoassets";
 import QueuedDrawer from "~/components/QueuedDrawer";

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/CompleteExchange.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
 import { useSelector } from "~/context/hooks";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { broadcastLogger } from "~/datadog";

--- a/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
+++ b/apps/ledger-live-mobile/src/screens/Platform/exchange/StartExchange.tsx
@@ -2,7 +2,7 @@ import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { Flex } from "@ledgerhq/native-ui";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import DeviceActionModal from "~/components/DeviceActionModal";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import {

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-SendBroadcastError.tsx
@@ -2,7 +2,7 @@ import { CompositeScreenProps } from "@react-navigation/native";
 import React, { useCallback } from "react";
 import { useTranslation } from "~/context/Locale";
 import { Linking, ScrollView } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import styled from "styled-components/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { Button, Flex, Icons, Text } from "@ledgerhq/native-ui";

--- a/apps/ledger-live-mobile/src/screens/SendFunds/07-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/07-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/01-Summary.tsx
@@ -5,7 +5,7 @@ import invariant from "invariant";
 import React, { memo, useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "~/context/Locale";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { TrackScreen } from "~/analytics";
 import Button from "~/components/Button";
 import LText from "~/components/LText";

--- a/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/03-ConnectDevice.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useMemo } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignMessage/04-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { memo, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";

--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { memo, useCallback, useMemo } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";

--- a/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/screens/UnfreezeFunds/01-Amount.tsx
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import React, { useCallback, useMemo, useEffect, useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Trans } from "~/context/Locale";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import type { Account } from "@ledgerhq/types-live";

--- a/apps/ledger-live-mobile/src/screens/UnfreezeFunds/03-ValidationError.tsx
+++ b/apps/ledger-live-mobile/src/screens/UnfreezeFunds/03-ValidationError.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { CompositeScreenProps, useTheme } from "@react-navigation/native";
 import { TrackScreen } from "~/analytics";
 import ValidateError from "~/components/ValidateError";


### PR DESCRIPTION
### 📝 Description

Migrate all raw `SafeAreaView` imports from `react-native-safe-area-context` to the custom `~/components/SafeAreaView` (`SafeAreaViewFixed`) for the **coin-integration** scope (90 files).

The custom component handles the experimental header (skips top padding when it is enabled, since the header owns top positioning) and avoids double safe-area insets.

```diff
- import { SafeAreaView } from "react-native-safe-area-context";
+ import SafeAreaView from "~/components/SafeAreaView";
```

**Scope & behaviour**
- Exactly the coin-integration file list from the ticket; each diff is only the import line.
- No prop changes were needed: RNSAC `SafeAreaView` (v5.6.1) forwards props to the native view and does **not** force `flex: 1`, matching the custom component's `flex: 0` default. So no `isFlex` was added anywhere, and layout behaviour is preserved.
- Out of scope (sibling tickets): ~39 remaining files outside coin-integration (onboarding/device, custom image, swap, wallet sync, settings/debug), including 5 mixed imports.

**Checks**
- ✅ No `import { SafeAreaView } from "react-native-safe-area-context"` remains in scope
- ✅ `oxlint` clean on changed files (pre-existing i18next warnings unrelated)
- ✅ Mobile `typecheck` passes
- ⬜ Visual smoke-test with experimental header on/off (to validate on device)

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34625](https://ledgerhq.atlassian.net/browse/LIVE-34625)


[LIVE-34625]: https://ledgerhq.atlassian.net/browse/LIVE-34625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ