### PR TITLE
[LWM] fix(mobile): make device selection drawer scrollable

### DIFF
--- a/.changeset/calm-devices-scroll.md
+++ b/.changeset/calm-devices-scroll.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix device selection drawer layout and scrolling for long device lists

--- a/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -3,9 +3,10 @@ import {
   type DeviceIntentExecutorProps,
   type ExecutorPlatformConfiguration,
 } from "@ledgerhq/device-intent";
-import { BottomSheetHeader, BottomSheetView } from "@ledgerhq/lumen-ui-rnative";
+import { BottomSheetHeader, BottomSheetScrollView } from "@ledgerhq/lumen-ui-rnative";
 import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
 import React from "react";
+import { Platform, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { DeviceDisconnected } from "./components/DeviceDisconnected";
 import { IntentError } from "./components/IntentError";
@@ -55,7 +56,10 @@ const platformConfig: ExecutorPlatformConfiguration<InitializationInput, Initial
 export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): React.ReactElement {
-  const { bottom: bottomInset } = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+  const { top: topInset, bottom: bottomInset } = useSafeAreaInsets();
+  // Lumen's static preset can force Android dynamic sheets full height, so use the live window cap.
+  const maxDynamicContentSize = Platform.OS === "ios" ? "fullWithOffset" : windowHeight - topInset;
   const {
     sourceFlow,
     wrappedProps,
@@ -73,17 +77,21 @@ export function DeviceIntentExecutorLWM<JobState, Input, ExtraProps>(
       onBackdropPress={onBackdropPress}
       hideHandle
       enableDynamicSizing
+      maxDynamicContentSize={maxDynamicContentSize}
     >
       <SourceFlowProvider value={sourceFlow}>
         <DeviceIntentExecutorHeaderContext.Provider value={headerContextValue}>
-          <BottomSheetView style={{ paddingBottom: bottomInset + 16 }}>
+          <BottomSheetScrollView
+            contentContainerStyle={{ paddingBottom: bottomInset + 16 }}
+            showsVerticalScrollIndicator={false}
+          >
             {!hasHeaderOverride && <BottomSheetHeader density="expanded" />}
             <DeviceIntentExecutor
               {...wrappedProps}
               platformConfig={platformConfig}
               initializerConfig={wrappedProps.initializerConfig}
             />
-          </BottomSheetView>
+          </BottomSheetScrollView>
         </DeviceIntentExecutorHeaderContext.Provider>
       </SourceFlowProvider>
     </QueuedDrawerBottomSheet>


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The existing Device Intent Executor suite passes; bottom-sheet sizing and scrolling require manual validation._
- [x] **Impact of the changes:**
  - Long device lists remain fully reachable by scrolling.
  - Short device lists keep their content-sized drawer layout.
  - Header controls and safe-area spacing remain correct on Android and iOS.

### 📝 Description

The Device Information Experience drawer could exceed the usable screen height when many devices were available, breaking its layout and preventing users from reaching every device.

This change caps the dynamically sized drawer for each platform and replaces its static Lumen bottom-sheet view with the gesture-integrated `BottomSheetScrollView`. The header remains part of the measured content, and the body becomes scrollable when it reaches the maximum height.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34581](https://ledgerhq.atlassian.net/browse/LIVE-34581)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34581]: https://ledgerhq.atlassian.net/browse/LIVE-34581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ