### PR TITLE
[LWM] feat(mobile): add contacts debug samples

### DIFF
--- a/.changeset/swift-contacts-seed.md
+++ b/.changeset/swift-contacts-seed.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Add Contacts sample data controls to Mobile Debug settings.

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
@@ -1,0 +1,12 @@
+import { createContactsDebugSamples } from "../mockContacts";
+
+describe("createContactsDebugSamples", () => {
+  it("creates 25 saved contacts across the section index", () => {
+    const contacts = createContactsDebugSamples();
+
+    expect(contacts).toHaveLength(25);
+    expect(contacts.every(contact => !contact.isMe)).toBe(true);
+    expect(contacts.map(contact => contact.name)).toContain("\u042f\u043d\u0430");
+    expect(contacts.find(contact => contact.name === "David")?.addresses).toHaveLength(3);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/useContactsDevToolViewModel.test.ts
@@ -70,4 +70,31 @@ describe("useContactsDevToolViewModel", () => {
 
     expect(store.getState().featureFlags.overrides[CONTACTS_FLAG]).toBeUndefined();
   });
+
+  it("should replace saved contacts with 25 sample contacts", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleLoadSamples();
+    });
+
+    const contacts = store.getState().contacts.contacts;
+
+    expect(contacts).toHaveLength(26);
+    expect(contacts[0]).toMatchObject({ id: "contact-me", isMe: true, name: "Me" });
+    expect(contacts.filter(contact => !contact.isMe)).toHaveLength(25);
+  });
+
+  it("should preserve Me when clearing saved contacts", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel());
+
+    act(() => {
+      result.current.handleLoadSamples();
+      result.current.handleClearContacts();
+    });
+
+    expect(store.getState().contacts.contacts).toEqual([
+      expect.objectContaining({ id: "contact-me", isMe: true, name: "Me" }),
+    ]);
+  });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsSampleDataSection.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/ContactsSampleDataSection.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsSampleDataSectionProps } from "../types";
+import { SectionHeader } from "./SectionHeader";
+
+export function ContactsSampleDataSection({
+  onLoadSamples,
+  onClearContacts,
+}: ContactsSampleDataSectionProps): React.JSX.Element {
+  return (
+    <>
+      <SectionHeader title="CONTACTS DATA" />
+      <Box
+        lx={{
+          backgroundColor: "surface",
+          borderRadius: "md",
+          padding: "s16",
+          marginBottom: "s24",
+        }}
+      >
+        <Text typography="body3" lx={{ color: "muted", marginBottom: "s16" }}>
+          Replace saved contacts with 25 sample contacts for list and section index testing.
+        </Text>
+        <Button appearance="accent" size="sm" onPress={onLoadSamples} lx={{ marginBottom: "s12" }}>
+          Load 25 sample contacts
+        </Button>
+        <Button appearance="base" size="sm" onPress={onClearContacts}>
+          Clear saved contacts
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/components/index.ts
@@ -1,5 +1,6 @@
 export { ContactsDevToolHeader } from "./ContactsDevToolHeader";
 export { ContactsEnabledToggle } from "./ContactsEnabledToggle";
+export { ContactsSampleDataSection } from "./ContactsSampleDataSection";
 export { EligibleAddressFamiliesSection } from "./EligibleAddressFamiliesSection";
 export { FeatureFlagPreview } from "./FeatureFlagPreview";
 export { FeatureParamRow } from "./FeatureParamRow";

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/index.tsx
@@ -5,6 +5,7 @@ import { useContactsDevToolViewModel } from "./useContactsDevToolViewModel";
 import {
   ContactsDevToolHeader,
   ContactsEnabledToggle,
+  ContactsSampleDataSection,
   EligibleAddressFamiliesSection,
   FeatureFlagPreview,
   FeatureParamRow,
@@ -21,6 +22,8 @@ export default function DebugContacts() {
     handleToggleNewBadge,
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
+    handleLoadSamples,
+    handleClearContacts,
   } = useContactsDevToolViewModel();
 
   const featureFlagSummary = useMemo(
@@ -41,6 +44,11 @@ export default function DebugContacts() {
       <Box lx={{ paddingHorizontal: "s24", paddingVertical: "s16" }}>
         <ContactsDevToolHeader onRestoreDefaults={handleRestoreDefaults} />
         <ContactsEnabledToggle isEnabled={isEnabled} onToggle={handleToggleEnabled} />
+
+        <ContactsSampleDataSection
+          onLoadSamples={handleLoadSamples}
+          onClearContacts={handleClearContacts}
+        />
 
         <SectionHeader title="FEATURE PARAMETERS" />
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
@@ -1,0 +1,57 @@
+import { contact, contactAddress, type Contact } from "@domain/entity-contact";
+
+type SampleContact = Readonly<{
+  id: string;
+  name: string;
+  addressCount: number;
+}>;
+
+const SAMPLE_CONTACTS: readonly SampleContact[] = [
+  { id: "contact-ada", name: "Ada", addressCount: 0 },
+  { id: "contact-ben", name: "Ben", addressCount: 1 },
+  { id: "contact-clara", name: "Clara", addressCount: 2 },
+  { id: "contact-david", name: "David", addressCount: 3 },
+  { id: "contact-elena", name: "Elena", addressCount: 1 },
+  { id: "contact-felix", name: "Felix", addressCount: 2 },
+  { id: "contact-gabriel", name: "Gabriel", addressCount: 0 },
+  { id: "contact-hana", name: "Hana", addressCount: 1 },
+  { id: "contact-iris", name: "Iris", addressCount: 2 },
+  { id: "contact-jonas", name: "Jonas", addressCount: 3 },
+  { id: "contact-kiara", name: "Kiara", addressCount: 1 },
+  { id: "contact-liam", name: "Liam", addressCount: 2 },
+  { id: "contact-maya", name: "Maya", addressCount: 0 },
+  { id: "contact-nora", name: "Nora", addressCount: 1 },
+  { id: "contact-olive", name: "Olive", addressCount: 2 },
+  { id: "contact-pablo", name: "Pablo", addressCount: 3 },
+  { id: "contact-quinn", name: "Quinn", addressCount: 1 },
+  { id: "contact-rosa", name: "Rosa", addressCount: 2 },
+  { id: "contact-sofia", name: "Sofia", addressCount: 0 },
+  { id: "contact-theo", name: "Theo", addressCount: 1 },
+  { id: "contact-uma", name: "Uma", addressCount: 2 },
+  { id: "contact-victor", name: "Victor", addressCount: 3 },
+  { id: "contact-xanna", name: "Xanna", addressCount: 1 },
+  { id: "contact-yara", name: "Yara", addressCount: 2 },
+  { id: "contact-yana", name: "\u042f\u043d\u0430", addressCount: 1 },
+];
+
+function createSampleAddresses(contactId: string, count: number) {
+  return Array.from({ length: count }, (_, index) =>
+    contactAddress({
+      id: `${contactId}-address-${index + 1}`,
+      currencyId: "ethereum",
+      label: "Ethereum",
+      address: `0x${String(index + 1).padStart(40, "0")}`,
+    }),
+  );
+}
+
+export function createContactsDebugSamples(): Contact[] {
+  return SAMPLE_CONTACTS.map(sample =>
+    contact({
+      id: sample.id,
+      isMe: false,
+      name: sample.name,
+      addresses: createSampleAddresses(sample.id, sample.addressCount),
+    }),
+  );
+}

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
@@ -1,38 +1,32 @@
 import { contact, contactAddress, type Contact } from "@domain/entity-contact";
 
-type SampleContact = Readonly<{
-  id: string;
-  name: string;
-  addressCount: number;
-}>;
-
-const SAMPLE_CONTACTS: readonly SampleContact[] = [
-  { id: "contact-ada", name: "Ada", addressCount: 0 },
-  { id: "contact-ben", name: "Ben", addressCount: 1 },
-  { id: "contact-clara", name: "Clara", addressCount: 2 },
-  { id: "contact-david", name: "David", addressCount: 3 },
-  { id: "contact-elena", name: "Elena", addressCount: 1 },
-  { id: "contact-felix", name: "Felix", addressCount: 2 },
-  { id: "contact-gabriel", name: "Gabriel", addressCount: 0 },
-  { id: "contact-hana", name: "Hana", addressCount: 1 },
-  { id: "contact-iris", name: "Iris", addressCount: 2 },
-  { id: "contact-jonas", name: "Jonas", addressCount: 3 },
-  { id: "contact-kiara", name: "Kiara", addressCount: 1 },
-  { id: "contact-liam", name: "Liam", addressCount: 2 },
-  { id: "contact-maya", name: "Maya", addressCount: 0 },
-  { id: "contact-nora", name: "Nora", addressCount: 1 },
-  { id: "contact-olive", name: "Olive", addressCount: 2 },
-  { id: "contact-pablo", name: "Pablo", addressCount: 3 },
-  { id: "contact-quinn", name: "Quinn", addressCount: 1 },
-  { id: "contact-rosa", name: "Rosa", addressCount: 2 },
-  { id: "contact-sofia", name: "Sofia", addressCount: 0 },
-  { id: "contact-theo", name: "Theo", addressCount: 1 },
-  { id: "contact-uma", name: "Uma", addressCount: 2 },
-  { id: "contact-victor", name: "Victor", addressCount: 3 },
-  { id: "contact-xanna", name: "Xanna", addressCount: 1 },
-  { id: "contact-yara", name: "Yara", addressCount: 2 },
-  { id: "contact-yana", name: "\u042f\u043d\u0430", addressCount: 1 },
-];
+const SAMPLE_CONTACT_NAMES = [
+  "Ada",
+  "Ben",
+  "Clara",
+  "David",
+  "Elena",
+  "Felix",
+  "Gabriel",
+  "Hana",
+  "Iris",
+  "Jonas",
+  "Kiara",
+  "Liam",
+  "Maya",
+  "Nora",
+  "Olive",
+  "Pablo",
+  "Quinn",
+  "Rosa",
+  "Sofia",
+  "Theo",
+  "Uma",
+  "Victor",
+  "Xanna",
+  "Yara",
+  "\u042f\u043d\u0430",
+] as const;
 
 function createSampleAddresses(contactId: string, count: number) {
   return Array.from({ length: count }, (_, index) =>
@@ -46,12 +40,14 @@ function createSampleAddresses(contactId: string, count: number) {
 }
 
 export function createContactsDebugSamples(): Contact[] {
-  return SAMPLE_CONTACTS.map(sample =>
-    contact({
-      id: sample.id,
+  return SAMPLE_CONTACT_NAMES.map((name, index) => {
+    const id = `contact-sample-${index + 1}`;
+
+    return contact({
+      id,
       isMe: false,
-      name: sample.name,
-      addresses: createSampleAddresses(sample.id, sample.addressCount),
-    }),
-  );
+      name,
+      addresses: createSampleAddresses(id, index % 4),
+    });
+  });
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/types.ts
@@ -11,6 +11,11 @@ export type ContactsEnabledToggleProps = {
   readonly onToggle: () => void;
 };
 
+export type ContactsSampleDataSectionProps = {
+  readonly onLoadSamples: () => void;
+  readonly onClearContacts: () => void;
+};
+
 export type FeatureParamRowProps = {
   readonly label: string;
   readonly isFeatureEnabled: boolean;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/useContactsDevToolViewModel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
+import { setContacts } from "@domain/entity-contact";
 import { useFeature } from "@features/platform-feature-flags";
 import {
   resolveContactsFeatureParams,
@@ -8,6 +9,7 @@ import {
 } from "@features/flow-contacts";
 import { setOverride } from "@shared/feature-flags";
 import { CONTACTS_FLAG } from "./constants";
+import { createContactsDebugSamples } from "./mockContacts";
 
 export function useContactsDevToolViewModel() {
   const dispatch = useDispatch();
@@ -49,6 +51,14 @@ export function useContactsDevToolViewModel() {
     dispatch(setOverride({ key: CONTACTS_FLAG, value: undefined }));
   }, [dispatch]);
 
+  const handleLoadSamples = useCallback(() => {
+    dispatch(setContacts(createContactsDebugSamples()));
+  }, [dispatch]);
+
+  const handleClearContacts = useCallback(() => {
+    dispatch(setContacts([]));
+  }, [dispatch]);
+
   return {
     featureFlag,
     isEnabled,
@@ -58,5 +68,7 @@ export function useContactsDevToolViewModel() {
     handleToggleNewBadge,
     handleSetEligibleAddressFamilies,
     handleRestoreDefaults,
+    handleLoadSamples,
+    handleClearContacts,
   };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Settings > Debug > Contacts sample-data controls
  - Loading samples preserves the Me contact and clearing removes saved contacts only

### 📝 Description

This PR splits the Contacts Debug sample-data tooling out of #19781 so it can be merged independently before the interactive index.

It adds Debug-only controls to load 25 sample Contacts and clear saved Contacts, together with focused tests. No production Contacts flow is changed.

<img width="333" height="224" alt="image" src="https://github.com/user-attachments/assets/4822485c-369a-4f8e-a776-b4312a4c9bf2" />

### ❓ Context

- **JIRA or GitHub link**: [#19781](https://github.com/LedgerHQ/ledger-live/pull/19781)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)