### PR TITLE
chore(skills): add resolve-codeowners.js to codeownership skill

### DIFF
--- a/.agents/skills/codeownership/SKILL.md
+++ b/.agents/skills/codeownership/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codeownership
-description: Maintain CODEOWNERS file and team specific directories. Use when working with "**/team-*/**" file structure or to split an old file into team-specific parts
+description: Maintain CODEOWNERS file and team directories. Provides resolve-codeowners.js to annotate files with their owner team — useful to split a large PR by team. Use when working with "**/team-*/**" or splitting monolithic files.
 ---
 
 # Codeownership
@@ -15,6 +15,31 @@ description: Maintain CODEOWNERS file and team specific directories. Use when wo
 - Organise some directories into team-specific sub-directories
 - Maintain CODEOWNERS files when team specific directories are added or removed
 - Split monolithic files or folders that have been identified as being touched by too many teams
+
+## Resolving ownership for a list of files
+
+Use `resolve-codeowners.js` to annotate any list of files with their CODEOWNERS team — handy when splitting a large PR by team owner. The script finds `ignore` in the pnpm virtual store automatically (no extra install).
+
+```bash
+# From a git diff
+git diff --name-only HEAD~1 | node .agents/skills/codeownership/resolve-codeowners.js
+
+# Explicit file list
+node .agents/skills/codeownership/resolve-codeowners.js apps/ledger-live-desktop/src/foo.ts libs/env/src/bar.ts
+
+# Override CODEOWNERS location
+node .agents/skills/codeownership/resolve-codeowners.js --codeowners /path/to/CODEOWNERS <files...>
+```
+
+Output format (same columns as CODEOWNERS, but resolved to actual files):
+```
+apps/ledger-live-desktop/src/main/index.ts  @ledgerhq/platform
+apps/ledger-live-desktop/src/renderer/foo.ts  @ledgerhq/wallet-xp
+.github/workflows/e2e.yml  @ledgerhq/wallet-ci @ledgerhq/qaa
+random/unknown/file.xyz  (no owner)
+```
+
+Semantics: last-rule-wins; ownerless entries appear as `(no owner)`.
 
 ## Target
 

--- a/.agents/skills/codeownership/resolve-codeowners.js
+++ b/.agents/skills/codeownership/resolve-codeowners.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Resolve CODEOWNERS for a list of files (last-rule-wins, gitignore semantics)
+//
+// Usage:
+//   git diff --name-only HEAD~1 | node .agents/skills/codeownership/resolve-codeowners.js
+//   node .agents/skills/codeownership/resolve-codeowners.js apps/ledger-live-desktop/src/foo.ts
+//   node .agents/skills/codeownership/resolve-codeowners.js --codeowners /path/to/CODEOWNERS <files...>
+//
+// Output: space-aligned columns (CODEOWNERS style) — "file    @owner1 @owner2" or "file    (no owner)"
+// Deps: uses the `ignore` package from the monorepo pnpm store — no extra dep to add (requires pnpm install)
+
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+// ── Resolve `ignore` from pnpm store or fallback ──────────────────────────────
+function semverDesc(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pb[i] || 0) - (pa[i] || 0);
+    if (diff !== 0) return diff; // descending: highest first
+  }
+  return 0;
+}
+
+function loadIgnore(gitRoot) {
+  // 1. Try monorepo pnpm virtual store (populated by pnpm install)
+  const pnpmDir = path.join(gitRoot, "node_modules", ".pnpm");
+  if (fs.existsSync(pnpmDir)) {
+    const versionOf = d => d.slice("ignore@".length).replace(/[_+].*$/, "");
+    const dirs = fs
+      .readdirSync(pnpmDir)
+      .filter(d => /^ignore@/.test(d))
+      .sort((a, b) => semverDesc(versionOf(a), versionOf(b))); // highest first
+    const v5 = dirs.find(d => /^ignore@5\./.test(d));
+    const chosen = v5 ?? dirs[0];
+    if (chosen) {
+      return require(path.join(pnpmDir, chosen, "node_modules", "ignore"));
+    }
+  }
+  // 2. Try standard node_modules resolution from repo root or script directory
+  for (const searchPath of [gitRoot, __dirname]) {
+    try {
+      return require(require.resolve("ignore", { paths: [searchPath] }));
+    } catch (_) {}
+  }
+  // 3. Give up with a clear message
+  console.error(
+    "Error: `ignore` package not found. Install it locally:\n" +
+      `  npm install --prefix "${__dirname}" --no-save --no-package-lock ignore@5\n` +
+      "Then re-run the script.",
+  );
+  process.exit(1);
+}
+
+// ── Git root detection ────────────────────────────────────────────────────────
+function getGitRoot() {
+  try {
+    return execSync("git rev-parse --show-toplevel", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// ── CODEOWNERS file location ──────────────────────────────────────────────────
+function findCodeowners(gitRoot) {
+  for (const rel of ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]) {
+    const p = path.join(gitRoot, rel);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+// ── Parse CODEOWNERS → [{pattern, owners}] ───────────────────────────────────
+function parseCodeowners(content) {
+  return content
+    .split("\n")
+    .map(l => l.trim())
+    .filter(l => l && !l.startsWith("#"))
+    .map(l => {
+      const parts = l.split(/\s+/);
+      return { pattern: parts[0], owners: parts.slice(1) };
+    });
+}
+
+// ── Compile rules: one ignore instance per pattern ───────────────────────────
+function compileRules(rules, ignore) {
+  return rules.map(({ pattern, owners }) => {
+    try {
+      const ig = ignore().add(pattern);
+      return { test: p => ig.ignores(p), owners };
+    } catch (err) {
+      process.stderr.write(
+        `[resolve-codeowners] Warning: skipping invalid pattern "${pattern}": ${err.message}\n`,
+      );
+      return { test: () => false, owners };
+    }
+  });
+}
+
+// ── Resolve owners for a file (last-rule-wins) ───────────────────────────────
+function resolveOwners(filePath, compiledRules) {
+  const normalized = filePath.replace(/^\.\//, "").replace(/^\//, "").replace(/\\/g, "/");
+  if (!normalized) return [];
+  let owners = [];
+  for (const { test, owners: ruleOwners } of compiledRules) {
+    if (test(normalized)) owners = ruleOwners;
+  }
+  return owners;
+}
+
+// ── Align output columns ──────────────────────────────────────────────────────
+function formatOutput(rows) {
+  const maxLen = Math.max(...rows.map(([f]) => f.length));
+  return rows
+    .map(([file, owners]) => {
+      const pad = " ".repeat(Math.max(1, maxLen - file.length + 2));
+      return `${file}${pad}${owners}`;
+    })
+    .join("\n");
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+function main() {
+  const args = process.argv.slice(2);
+
+  const gitRoot = getGitRoot();
+  const ignore = loadIgnore(gitRoot);
+
+  // --codeowners <path> override — resolved against git root for consistency
+  let codeownersPath = null;
+  const flagIdx = args.indexOf("--codeowners");
+  if (flagIdx !== -1) {
+    const next = args[flagIdx + 1];
+    if (!next || next.startsWith("--")) {
+      console.error("Error: --codeowners requires a file path argument.");
+      process.exit(1);
+    }
+    codeownersPath = path.resolve(gitRoot, next);
+    args.splice(flagIdx, 2);
+  }
+
+  codeownersPath ??= findCodeowners(gitRoot);
+  if (!codeownersPath) {
+    console.error(
+      "Error: CODEOWNERS file not found (tried CODEOWNERS, .github/CODEOWNERS, docs/CODEOWNERS)",
+    );
+    process.exit(1);
+  }
+
+  const rules = parseCodeowners(fs.readFileSync(codeownersPath, "utf8"));
+  const compiledRules = compileRules(rules, ignore);
+
+  // File list: args or stdin
+  let files = args;
+  if (files.length === 0) {
+    const stdin = fs.readFileSync(0, "utf8"); // fd 0 = stdin, portable
+    files = stdin.split(/\r?\n/).filter(Boolean); // handle CRLF and LF
+  }
+
+  if (files.length === 0) {
+    console.error("No files provided. Pass paths as arguments or pipe via stdin.");
+    process.exit(1);
+  }
+
+  const rows = files.map(file => {
+    const rel = path.isAbsolute(file) ? path.relative(gitRoot, file) : file;
+    const owners = resolveOwners(rel, compiledRules);
+    return [rel, owners.length ? owners.join(" ") : "(no owner)"];
+  });
+
+  console.log(formatOutput(rows));
+}
+
+main();


### PR DESCRIPTION
> [!NOTE]
> Claude cannot reliably infer team ownership from CODEOWNERS — the last-rule-wins override system trips it up quickly. A common pattern is splitting a large PR by team; this script makes that reliable.

### 📝 Description

Adds `resolve-codeowners.js` to the `codeownership` skill. The script takes a file list (e.g. from `git diff --name-only`) and annotates each file with its resolved CODEOWNERS team, applying correct **last-rule-wins** semantics via the [`ignore`](https://www.npmjs.com/package/ignore) package (gitignore-compatible, already in the pnpm store — no extra deps).

```bash
# Usage
git diff --name-only HEAD~1 | node .agents/skills/codeownership/resolve-codeowners.js
# Output
apps/ledger-live-desktop/src/main/index.ts       @ledgerhq/platform
apps/ledger-live-desktop/src/renderer/foo.ts     @ledgerhq/wallet-xp
.github/workflows/e2e.yml                        @ledgerhq/wallet-ci @ledgerhq/qaa
```

#### Demo

```
❯ list the files changed by commit bddb7629cab70ce19851ca1617bc21c8e63e612e and give me their   
  ownership with /codeownership
```


<img width="1160" height="391" alt="Screenshot 2026-07-21 at 11 50 41" src="https://github.com/user-attachments/assets/20b57f44-4f3d-4bf2-ad46-0d4621995bcc" />

<img width="1230" height="705" alt="Screenshot 2026-07-21 at 11 50 34" src="https://github.com/user-attachments/assets/cac200b3-9205-4776-a63b-52076c118329" />


### 🔗 Context

- **JIRA / GitHub issue**: N/A (internal tooling)