### PR TITLE
chore(sonar): cpd-exclude @ledgerhq/cryptoassets

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -86,7 +86,8 @@ devtools/registry/**,\
 features/platform/jest-config/**,\
 features/flow/**/jest.native.ts
 sonar.cpd.exclusions=libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts,\
-libs/ledger-live-common/src/families/tron/bridge/api.ts
+libs/ledger-live-common/src/families/tron/bridge/api.ts,\
+libs/ledgerjs/packages/cryptoassets/**
 sonar.javascript.lcov.reportPaths=lcov.info
 sonar.testExecutionReportPaths=sonar-executionTests-report.xml
 sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json,shared/**/tsconfig.json,domain/**/tsconfig.json,devtools/**/tsconfig.json


### PR DESCRIPTION
### 📝 Description

Adds `libs/ledgerjs/packages/cryptoassets/**` to `sonar.cpd.exclusions` in `sonar-project.properties`.

`@ledgerhq/cryptoassets` is being sunset as part of the crypto-assets data-layer initiative. Its currency registry has been seeded into `@domain/entity-currency-{crypto,fiat,token}`, so Sonar reports high duplication between the two. The duplication is intentional and temporary — excluding the legacy lib silences the noise without hiding real issues in the new domain code.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34649](https://ledgerhq.atlassian.net/browse/LIVE-34649)

[LIVE-34649]: https://ledgerhq.atlassian.net/browse/LIVE-34649