### PR TITLE
feat(web-tools): add PRD/STG env switcher to /sync page

### DIFF
--- a/apps/web-tools/src/pages/sync.tsx
+++ b/apps/web-tools/src/pages/sync.tsx
@@ -4,17 +4,16 @@ import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account } from "@ledgerhq/types-live";
 import { Button, Spinner, TextInput } from "@ledgerhq/lumen-ui-react";
-import { setEnv, getEnv, getEnvDefault } from "@ledgerhq/live-env";
+import { setEnvUnsafe, getEnv, getEnvDefault } from "@ledgerhq/live-env";
 import type { EnvName } from "@ledgerhq/live-env";
 import { ToolPage } from "../components/ToolPage";
 import { syncAccount } from "../logic/syncAccount";
 
 // Coin endpoint env vars that can be switched between PRD (ledger.com) and STG (ledger-test.com).
-// Note: Cosmos-family chains (cosmos, osmosis, axelar, coreum, dydx, injective, …) use
-// live-config with hardcoded LCD URLs — they are NOT covered by this switcher.
+// Note: Some chains use hardcoded URLs outside live-env (Cosmos-family via live-config,
+// Polkadot asset hub/westend in config.ts…) — they are NOT covered by this switcher.
 const COIN_ENDPOINT_VARS = [
   "EXPLORER",
-  "LEDGER_REST_API_BASE",
   "API_ALGORAND_BLOCKCHAIN_EXPLORER_API_ENDPOINT",
   "API_CELO_INDEXER",
   "API_CELO_NODE",
@@ -48,16 +47,17 @@ const COIN_ENDPOINT_VARS = [
 
 type CoinEnv = "prd" | "stg";
 
-// setEnv typed narrowly: all entries in COIN_ENDPOINT_VARS are string-valued env vars,
-// so the string→string transform is safe. The cast is necessary because TypeScript cannot
-// distribute EnvValue<K> over a union K when iterating.
 function setCoinEnvVar(name: (typeof COIN_ENDPOINT_VARS)[number], value: string) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setEnv(name, value as any);
+  setEnvUnsafe(name, value);
 }
 
 function detectCoinEnv(): CoinEnv {
-  return (getEnv("EXPLORER") as string).includes("ledger-test.com") ? "stg" : "prd";
+  try {
+    const { hostname } = new URL(getEnv("EXPLORER") as string);
+    return hostname === "ledger-test.com" || hostname.endsWith(".ledger-test.com") ? "stg" : "prd";
+  } catch {
+    return "prd";
+  }
 }
 
 function SyncEnvSwitcher({ onEnvChange }: { onEnvChange: () => void }) {
@@ -65,7 +65,7 @@ function SyncEnvSwitcher({ onEnvChange }: { onEnvChange: () => void }) {
 
   const applyPrd = useCallback(() => {
     for (const name of COIN_ENDPOINT_VARS) {
-      setCoinEnvVar(name, getEnvDefault(name) as string);
+      setCoinEnvVar(name, String(getEnvDefault(name)));
     }
     setCoinEnv("prd");
     onEnvChange();
@@ -73,10 +73,7 @@ function SyncEnvSwitcher({ onEnvChange }: { onEnvChange: () => void }) {
 
   const applyStg = useCallback(() => {
     for (const name of COIN_ENDPOINT_VARS) {
-      setCoinEnvVar(
-        name,
-        (getEnvDefault(name) as string).replace(/ledger\.com/g, "ledger-test.com"),
-      );
+      setCoinEnvVar(name, String(getEnvDefault(name)).replace(/ledger\.com/g, "ledger-test.com"));
     }
     setCoinEnv("stg");
     onEnvChange();
@@ -103,7 +100,8 @@ function SyncEnvSwitcher({ onEnvChange }: { onEnvChange: () => void }) {
       </Button>
       {coinEnv === "stg" && (
         <span className="body-3 text-warning">
-          ⚠ Cosmos-family chains (cosmos, osmosis, axelar…) use hardcoded URLs — not switched.
+          ⚠ Some chains use hardcoded URLs outside live-env (Cosmos-family, Polkadot asset
+          hub/westend…) — not switched.
         </span>
       )}
     </div>
@@ -145,7 +143,7 @@ function App() {
           if (!cancelled) setAccount(acc);
         },
         err => {
-          if (!cancelled) setAccountError(err);
+          if (!cancelled) setAccountError(err instanceof Error ? err.message : String(err));
         },
       );
     } catch (e) {

--- a/apps/web-tools/src/pages/sync.tsx
+++ b/apps/web-tools/src/pages/sync.tsx
@@ -1,11 +1,114 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { encodeAccountId, decodeAccountId } from "@ledgerhq/live-common/account/index";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { asDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account } from "@ledgerhq/types-live";
-import { Spinner, TextInput } from "@ledgerhq/lumen-ui-react";
+import { Button, Spinner, TextInput } from "@ledgerhq/lumen-ui-react";
+import { setEnv, getEnv, getEnvDefault } from "@ledgerhq/live-env";
+import type { EnvName } from "@ledgerhq/live-env";
 import { ToolPage } from "../components/ToolPage";
 import { syncAccount } from "../logic/syncAccount";
+
+// Coin endpoint env vars that can be switched between PRD (ledger.com) and STG (ledger-test.com).
+// Note: Cosmos-family chains (cosmos, osmosis, axelar, coreum, dydx, injective, …) use
+// live-config with hardcoded LCD URLs — they are NOT covered by this switcher.
+const COIN_ENDPOINT_VARS = [
+  "EXPLORER",
+  "LEDGER_REST_API_BASE",
+  "API_ALGORAND_BLOCKCHAIN_EXPLORER_API_ENDPOINT",
+  "API_CELO_INDEXER",
+  "API_CELO_NODE",
+  "API_FILECOIN_ENDPOINT",
+  "API_HEDERA_HGRAPH",
+  "API_HEDERA_MIRROR",
+  "API_KASPA_ENDPOINT",
+  "API_POLKADOT_INDEXER",
+  "API_POLKADOT_NODE",
+  "API_POLKADOT_SIDECAR",
+  "API_SOLANA_PROXY",
+  "API_STACKS_ENDPOINT",
+  "API_STELLAR_HORIZON",
+  "API_SUI_GRAPHQL_PROXY",
+  "API_SUI_NODE_PROXY",
+  "API_TEZOS_BAKER",
+  "API_TEZOS_BLOCKCHAIN_EXPLORER_API_ENDPOINT",
+  "API_TEZOS_NODE",
+  "API_TEZOS_TZKT_API",
+  "API_TRONGRID_PROXY",
+  "API_VECHAIN_THOREST",
+  "APTOS_API_ENDPOINT",
+  "APTOS_INDEXER_ENDPOINT",
+  "CARDANO_API_ENDPOINT",
+  "CARDANO_EPOCH_PARAMS_ENDPOINT",
+  "CRYPTO_ORG_INDEXER",
+  "CRYPTO_ORG_RPC_URL",
+  "MULTIVERSX_API_ENDPOINT",
+  "MULTIVERSX_DELEGATION_API_ENDPOINT",
+] as const satisfies EnvName[];
+
+type CoinEnv = "prd" | "stg";
+
+// setEnv typed narrowly: all entries in COIN_ENDPOINT_VARS are string-valued env vars,
+// so the string→string transform is safe. The cast is necessary because TypeScript cannot
+// distribute EnvValue<K> over a union K when iterating.
+function setCoinEnvVar(name: (typeof COIN_ENDPOINT_VARS)[number], value: string) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setEnv(name, value as any);
+}
+
+function detectCoinEnv(): CoinEnv {
+  return (getEnv("EXPLORER") as string).includes("ledger-test.com") ? "stg" : "prd";
+}
+
+function SyncEnvSwitcher({ onEnvChange }: { onEnvChange: () => void }) {
+  const [coinEnv, setCoinEnv] = useState<CoinEnv>(detectCoinEnv);
+
+  const applyPrd = useCallback(() => {
+    for (const name of COIN_ENDPOINT_VARS) {
+      setCoinEnvVar(name, getEnvDefault(name) as string);
+    }
+    setCoinEnv("prd");
+    onEnvChange();
+  }, [onEnvChange]);
+
+  const applyStg = useCallback(() => {
+    for (const name of COIN_ENDPOINT_VARS) {
+      setCoinEnvVar(
+        name,
+        (getEnvDefault(name) as string).replace(/ledger\.com/g, "ledger-test.com"),
+      );
+    }
+    setCoinEnv("stg");
+    onEnvChange();
+  }, [onEnvChange]);
+
+  return (
+    <div className="flex items-center gap-8 text-sm text-muted">
+      <span className="body-3">Coin endpoints:</span>
+      <Button
+        type="button"
+        size="sm"
+        appearance={coinEnv === "prd" ? "base" : "transparent"}
+        onClick={applyPrd}
+      >
+        PRD
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        appearance={coinEnv === "stg" ? "accent" : "transparent"}
+        onClick={applyStg}
+      >
+        STG
+      </Button>
+      {coinEnv === "stg" && (
+        <span className="body-3 text-warning">
+          ⚠ Cosmos-family chains (cosmos, osmosis, axelar…) use hardcoded URLs — not switched.
+        </span>
+      )}
+    </div>
+  );
+}
 
 function App() {
   // synchronise account with an id that is input in a input text field
@@ -14,6 +117,9 @@ function App() {
 
   const [account, setAccount] = useState<Account | undefined | null>(null);
   const [accountError, setAccountError] = useState("");
+
+  // bumped each time the env switcher changes, to re-trigger sync
+  const [syncRevision, setSyncRevision] = useState(0);
 
   useEffect(() => {
     // if we have an accountId, we try to infer it
@@ -28,19 +134,28 @@ function App() {
   }, [accountId]);
 
   useEffect(() => {
-    // if we have an accountId, we try to synchronise it
-    if (accountId) {
-      try {
-        decodeAccountId(accountId);
-        setAccountError("");
-        setAccount(undefined);
-        syncAccount(accountId).then(setAccount, setAccountError);
-      } catch (e) {
-        setAccount(null);
-        console.error(e);
-      }
+    if (!accountId) return;
+    let cancelled = false;
+    try {
+      decodeAccountId(accountId);
+      setAccountError("");
+      setAccount(undefined);
+      syncAccount(accountId).then(
+        acc => {
+          if (!cancelled) setAccount(acc);
+        },
+        err => {
+          if (!cancelled) setAccountError(err);
+        },
+      );
+    } catch (e) {
+      setAccount(null);
+      console.error(e);
     }
-  }, [accountId]);
+    return () => {
+      cancelled = true;
+    };
+  }, [accountId, syncRevision]);
 
   const isLoading = account === undefined && !accountError;
 
@@ -49,6 +164,8 @@ function App() {
       title="Synchronisation"
       description="Synchronise an account from its id (or a currency:xpub/address shorthand)."
     >
+      <SyncEnvSwitcher onEnvChange={() => setSyncRevision(r => r + 1)} />
+
       <TextInput
         label="Account id"
         placeholder="ethereum:0x… or js:2:ethereum:0x…:"

--- a/libs/wallet-btc/src/wallet.ts
+++ b/libs/wallet-btc/src/wallet.ts
@@ -29,12 +29,13 @@ class BitcoinLikeWallet {
   constructor() {}
 
   getExplorer(currency: WalletBtcCurrency) {
-    if (!this.explorers[currency.id]) {
-      this.explorers[currency.id] = new BitcoinLikeExplorer({
+    const explorerURI = blockchainBaseURL(currency);
+    if (!this.explorers[explorerURI]) {
+      this.explorers[explorerURI] = new BitcoinLikeExplorer({
         cryptoCurrency: currency,
       });
     }
-    return this.explorers[currency.id];
+    return this.explorers[explorerURI];
   }
 
   async generateAccount(
@@ -53,7 +54,7 @@ class BitcoinLikeWallet {
     const explorerURI = blockchainBaseURL(cryptoCurrency);
     this.explorers[explorerURI] = this.getExplorer(cryptoCurrency);
     const crypto = cryptoFactory(params.currency);
-    const storageId = params.xpub + cryptoCurrency.id;
+    const storageId = params.xpub + cryptoCurrency.id + cryptoCurrency.explorerEndpoint;
     if (!this.storages[storageId]) {
       this.storages[storageId] = new BitcoinLikeStorage();
     }


### PR DESCRIPTION
### 📝 Description

Adds a **PRD / STG** toggle to the `/sync` page in live.ledger.tools.

Clicking STG bulk-replaces `ledger.com` → `ledger-test.com` across all 31 live-env coin endpoint variables at runtime, routing syncs to the Cloudflare-managed STG zone without redeploying. Clicking PRD restores all defaults.

> [!NOTE]
> Cosmos-family chains (cosmos, osmosis, axelar, coreum, dydx, injective…) use hardcoded LCD URLs in `coin-cosmos/src/config.ts` via live-config, not live-env — they are not affected by the toggle. A warning is shown in the UI when STG is active.

### 🔗 Context

- **JIRA / GitHub issue**: CORS validation of infra STG fix (ledger-test.com Cloudflare snippet)
- **ADR** (if any): N/A