### PR TITLE
feat: contacts feature intro

### DIFF
--- a/.changeset/flow-contacts-feature-introduction-state.md
+++ b/.changeset/flow-contacts-feature-introduction-state.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared Contacts feature introduction state, preference port, and Ledger Sync priority resolvers

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -9,7 +9,7 @@ Shared Contacts flow package for Desktop and Mobile.
 
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
-- `useAddContactViewModel` hook (this package; app wiring injects `ContactCreationPort`)
+- `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 
@@ -37,6 +37,7 @@ src/
 ├── components/
 │   └── ContactsButton/   # My Wallet entry
 ├── add/                  # Shared add-contact scenario state
+├── featureIntroduction/  # One-time feature intro preference + Ledger Sync priority
 ├── hooks/
 ├── list/                 # Shared list view models and page shells
 │   ├── components/

--- a/features/flow/contacts/src/featureIntroduction/index.ts
+++ b/features/flow/contacts/src/featureIntroduction/index.ts
@@ -1,0 +1,10 @@
+export {
+  CONTACTS_FEATURE_INTRODUCTION_DISMISSED_PREFERENCE,
+  type ContactsFeatureIntroductionPreferencePort,
+} from "./ports";
+export {
+  resolveContactsFeatureIntroductionRequested,
+  resolveContactsLedgerSyncIntroductionOpen,
+  type ContactsFeatureIntroductionRequestInput,
+  type ContactsLedgerSyncIntroductionOpenInput,
+} from "./resolver";

--- a/features/flow/contacts/src/featureIntroduction/ports.ts
+++ b/features/flow/contacts/src/featureIntroduction/ports.ts
@@ -1,0 +1,8 @@
+export const CONTACTS_FEATURE_INTRODUCTION_DISMISSED_PREFERENCE =
+  "hasDismissedContactsFeatureIntroduction" as const;
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactsFeatureIntroductionPreferencePort = Readonly<{
+  isDismissed: boolean;
+  markDismissed: () => void;
+}>;

--- a/features/flow/contacts/src/featureIntroduction/preference.mock.ts
+++ b/features/flow/contacts/src/featureIntroduction/preference.mock.ts
@@ -1,0 +1,25 @@
+import type { ContactsFeatureIntroductionPreferencePort } from "./ports";
+
+export type ContactsFeatureIntroductionPreferenceMock =
+  ContactsFeatureIntroductionPreferencePort &
+    Readonly<{
+      reset: () => void;
+    }>;
+
+export function createContactsFeatureIntroductionPreferenceMock(
+  initialDismissed = false,
+): ContactsFeatureIntroductionPreferenceMock {
+  let isDismissed = initialDismissed;
+
+  return {
+    get isDismissed() {
+      return isDismissed;
+    },
+    markDismissed: () => {
+      isDismissed = true;
+    },
+    reset: () => {
+      isDismissed = initialDismissed;
+    },
+  };
+}

--- a/features/flow/contacts/src/featureIntroduction/resolver.test.ts
+++ b/features/flow/contacts/src/featureIntroduction/resolver.test.ts
@@ -1,0 +1,75 @@
+import {
+  resolveContactsFeatureIntroductionRequested,
+  resolveContactsLedgerSyncIntroductionOpen,
+} from "./resolver";
+
+describe("resolveContactsFeatureIntroductionRequested", () => {
+  it("requests the introduction on a first visit when the entry is available", () => {
+    expect(
+      resolveContactsFeatureIntroductionRequested({
+        isContactsEntryAvailable: true,
+        isDismissed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not request the introduction after dismissal", () => {
+    expect(
+      resolveContactsFeatureIntroductionRequested({
+        isContactsEntryAvailable: true,
+        isDismissed: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not request the introduction when the entry is unavailable", () => {
+    expect(
+      resolveContactsFeatureIntroductionRequested({
+        isContactsEntryAvailable: false,
+        isDismissed: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("resolveContactsLedgerSyncIntroductionOpen", () => {
+  it("defers the Ledger Sync introduction while the feature introduction is requested", () => {
+    expect(
+      resolveContactsLedgerSyncIntroductionOpen({
+        isFeatureIntroductionRequested: true,
+        ledgerSyncStatus: "inactive",
+        isLedgerSyncIntroductionDismissed: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("opens the Ledger Sync introduction once the feature introduction is no longer requested", () => {
+    expect(
+      resolveContactsLedgerSyncIntroductionOpen({
+        isFeatureIntroductionRequested: false,
+        ledgerSyncStatus: "inactive",
+        isLedgerSyncIntroductionDismissed: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not open the Ledger Sync introduction while sync status is not inactive", () => {
+    expect(
+      resolveContactsLedgerSyncIntroductionOpen({
+        isFeatureIntroductionRequested: false,
+        ledgerSyncStatus: "checking",
+        isLedgerSyncIntroductionDismissed: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reopen the Ledger Sync introduction after session dismissal", () => {
+    expect(
+      resolveContactsLedgerSyncIntroductionOpen({
+        isFeatureIntroductionRequested: false,
+        ledgerSyncStatus: "inactive",
+        isLedgerSyncIntroductionDismissed: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/features/flow/contacts/src/featureIntroduction/resolver.ts
+++ b/features/flow/contacts/src/featureIntroduction/resolver.ts
@@ -1,0 +1,28 @@
+import type { ContactsLedgerSyncStatus } from "../list/types";
+
+export type ContactsFeatureIntroductionRequestInput = Readonly<{
+  isContactsEntryAvailable: boolean;
+  isDismissed: boolean;
+}>;
+
+export type ContactsLedgerSyncIntroductionOpenInput = Readonly<{
+  isFeatureIntroductionRequested: boolean;
+  ledgerSyncStatus: ContactsLedgerSyncStatus;
+  isLedgerSyncIntroductionDismissed: boolean;
+}>;
+
+export function resolveContactsFeatureIntroductionRequested(
+  input: ContactsFeatureIntroductionRequestInput,
+): boolean {
+  return input.isContactsEntryAvailable && !input.isDismissed;
+}
+
+export function resolveContactsLedgerSyncIntroductionOpen(
+  input: ContactsLedgerSyncIntroductionOpenInput,
+): boolean {
+  if (input.isFeatureIntroductionRequested) {
+    return false;
+  }
+
+  return input.ledgerSyncStatus === "inactive" && !input.isLedgerSyncIntroductionDismissed;
+}

--- a/features/flow/contacts/src/hooks/index.ts
+++ b/features/flow/contacts/src/hooks/index.ts
@@ -4,3 +4,8 @@ export type { UseAddContactViewModelResult } from "./useAddContactViewModel";
 export { useContactsListViewModel } from "./useContactsListViewModel";
 export { useContactsMeContact } from "./useContactsMeContact";
 export { useContactsSearchViewModel } from "./useContactsSearchViewModel";
+export { useContactsFeatureIntroductionState } from "./useContactsFeatureIntroductionState";
+export type {
+  ContactsFeatureIntroductionState,
+  UseContactsFeatureIntroductionStateInput,
+} from "./useContactsFeatureIntroductionState";

--- a/features/flow/contacts/src/hooks/useContactsFeatureIntroductionState.test.ts
+++ b/features/flow/contacts/src/hooks/useContactsFeatureIntroductionState.test.ts
@@ -1,0 +1,60 @@
+import { act, renderHook } from "@testing-library/react";
+import { createContactsFeatureIntroductionPreferenceMock } from "../featureIntroduction/preference.mock";
+import { useContactsFeatureIntroductionState } from "./useContactsFeatureIntroductionState";
+
+describe("useContactsFeatureIntroductionState", () => {
+  it("requests the introduction on a first visit when the entry is available", () => {
+    const preference = createContactsFeatureIntroductionPreferenceMock(false);
+
+    const { result } = renderHook(() =>
+      useContactsFeatureIntroductionState({
+        isContactsEntryAvailable: true,
+        preference,
+      }),
+    );
+
+    expect(result.current.isRequested).toBe(true);
+  });
+
+  it("stops requesting the introduction after dismissal", () => {
+    const preference = createContactsFeatureIntroductionPreferenceMock(false);
+
+    const { result, rerender } = renderHook(() =>
+      useContactsFeatureIntroductionState({
+        isContactsEntryAvailable: true,
+        preference,
+      }),
+    );
+
+    act(() => {
+      result.current.dismiss();
+    });
+    rerender();
+
+    expect(result.current.isRequested).toBe(false);
+  });
+
+  it("can reset the mocked preference to make the introduction eligible again", () => {
+    const preference = createContactsFeatureIntroductionPreferenceMock(false);
+
+    const { result, rerender } = renderHook(() =>
+      useContactsFeatureIntroductionState({
+        isContactsEntryAvailable: true,
+        preference,
+      }),
+    );
+
+    act(() => {
+      result.current.dismiss();
+    });
+    rerender();
+    expect(result.current.isRequested).toBe(false);
+
+    act(() => {
+      preference.reset();
+    });
+    rerender();
+
+    expect(result.current.isRequested).toBe(true);
+  });
+});

--- a/features/flow/contacts/src/hooks/useContactsFeatureIntroductionState.ts
+++ b/features/flow/contacts/src/hooks/useContactsFeatureIntroductionState.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import type { ContactsFeatureIntroductionPreferencePort } from "../featureIntroduction/ports";
+import { resolveContactsFeatureIntroductionRequested } from "../featureIntroduction/resolver";
+
+export type UseContactsFeatureIntroductionStateInput = Readonly<{
+  isContactsEntryAvailable: boolean;
+  preference: ContactsFeatureIntroductionPreferencePort;
+}>;
+
+export type ContactsFeatureIntroductionState = Readonly<{
+  isRequested: boolean;
+  dismiss: () => void;
+}>;
+
+export function useContactsFeatureIntroductionState(
+  input: UseContactsFeatureIntroductionStateInput,
+): ContactsFeatureIntroductionState {
+  const isRequested = resolveContactsFeatureIntroductionRequested({
+    isContactsEntryAvailable: input.isContactsEntryAvailable,
+    isDismissed: input.preference.isDismissed,
+  });
+  const dismiss = useCallback(() => {
+    input.preference.markDismissed();
+  }, [input.preference]);
+
+  return {
+    isRequested,
+    dismiss,
+  };
+}

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -1,4 +1,5 @@
 export * from "./add";
+export * from "./featureIntroduction";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./add";
+export * from "./featureIntroduction";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";

--- a/features/flow/contacts/src/jest.native.ts
+++ b/features/flow/contacts/src/jest.native.ts
@@ -1,4 +1,5 @@
 export * from "./add";
+export * from "./featureIntroduction";
 export * from "./featureFlags";
 export * from "./hooks";
 export * from "./list";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces a shared "Contacts" feature introduction state, including a user preference port and Ledger Sync priority resolvers, for use across both Desktop and Mobile. The changes add new state management hooks, preference handling, and logic to control when the feature introduction and Ledger Sync dialogs are shown, along with comprehensive tests and documentation updates.

**Feature Introduction State and Preference Handling**
* Added a new `featureIntroduction` module with:
  - A constant and type for the feature introduction dismissed preference (`CONTACTS_FEATURE_INTRODUCTION_DISMISSED_PREFERENCE`, `ContactsFeatureIntroductionPreferencePort`) to track if the user has seen/dismissed the introduction.
  - A mock utility for the preference port to facilitate testing.
* Exported the new module from the package entry points for both web and native. 

**Introduction State Management Hook**
* Introduced the `useContactsFeatureIntroductionState` hook to determine if the introduction should be shown and to handle dismissal, along with its types and tests. 

**Feature Introduction and Ledger Sync Resolvers**
* Added resolver functions to control when the feature introduction and Ledger Sync dialogs are requested/opened, with corresponding types and unit tests. 

**Documentation Updates**
* Updated the package `README.md` to describe the new shared feature introduction state, preference port, and Ledger Sync priority logic, and documented the new module structure. 

**Changelog**
* Added a changeset documenting the introduction of the shared Contacts feature introduction state, preference port, and Ledger Sync priority resolvers.

### 🔗 Context

[LIVE-34640](https://ledgerhq.atlassian.net/browse/LIVE-34640)


[LIVE-34640]: https://ledgerhq.atlassian.net/browse/LIVE-34640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ