### PR TITLE
[LWDM] refactor(LIVE-28042): resolve node config from AleoCoinConfig instead of CryptoCu…

### DIFF
--- a/.changeset/cool-moose-pretend.md
+++ b/.changeset/cool-moose-pretend.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+Refactor Aleo network apiClient and sdkClient to receive coin config directly instead of resolving it via currency lookup, removing redundant currency plumbing throughout the sync/signing paths

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -220,7 +220,7 @@ describe("createApi", () => {
       expect(mockedListOperations).toHaveBeenCalledTimes(1);
       expect(mockedListOperations).toHaveBeenCalledWith({
         config: { ...mockConfig, status: { type: "active" } },
-        currency: expect.any(Object),
+        currencyId: "aleo",
         address: "aleo1test",
         options,
         mode: "coin-framework",

--- a/libs/coin-modules/coin-aleo/src/api/index.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.ts
@@ -17,7 +17,6 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import coinConfig from "../config";
 import { estimateFees, getBalance, lastBlock, listOperations, validateAddress } from "../logic";
 import { getTransactionType } from "../logic/utils";
@@ -29,7 +28,6 @@ export function createApi(
 ): CoinModuleApi<MemoNotSupported, AleoTransactionIntentData> {
   const aleoCoinConfig: AleoCoinConfig = { ...config, status: { type: "active" } };
   coinConfig.setCoinConfig(() => aleoCoinConfig);
-  const currency = getCryptoCurrencyById(currencyId);
 
   return {
     async call() {
@@ -60,15 +58,15 @@ export function createApi(
       return estimateFees({ configOrCurrencyId: aleoCoinConfig, transactionType });
     },
     getBalance: (address: string, options?: BalanceOptions): Promise<Balance[]> => {
-      return rejectBalanceOptions(() => getBalance(currency, address), options);
+      return rejectBalanceOptions(() => getBalance(aleoCoinConfig, address), options);
     },
     lastBlock: async (): Promise<BlockInfo> => {
-      return lastBlock(currency);
+      return lastBlock(aleoCoinConfig);
     },
     listOperations: async (address, options) => {
       const { operations, nextCursor } = await listOperations({
         config: aleoCoinConfig,
-        currency,
+        currencyId,
         address,
         options,
         mode: "coin-framework",

--- a/libs/coin-modules/coin-aleo/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/broadcast.test.ts
@@ -55,7 +55,6 @@ describe("bridge broadcast", () => {
     expect(mockLogicBroadcast).toHaveBeenCalledTimes(1);
     expect(mockLogicBroadcast).toHaveBeenCalledWith({
       configOrCurrencyId: mockConfig,
-      account,
       signedTx: signature,
     });
     expect(mockPatchOperationWithHash).toHaveBeenCalledTimes(1);

--- a/libs/coin-modules/coin-aleo/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/broadcast.ts
@@ -12,7 +12,6 @@ export const broadcast: AccountBridge<AleoTransaction, AleoAccount>["broadcast"]
 
   const hash = await logicBroadcast({
     configOrCurrencyId: config,
-    account,
     signedTx: signedOperation.signature,
   });
 

--- a/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/signOperation.ts
@@ -124,7 +124,7 @@ async function buildFeeAuthorization({
   const { account, transaction, config, baseFee, priorityFee, viewKey } = params;
 
   const craftedFeeRequest = await craftTransaction({
-    currency: account.currency,
+    config,
     viewKey,
     feeConfiguration: null,
     txIntent: createFeeTransactionIntent({
@@ -144,7 +144,7 @@ async function buildFeeAuthorization({
   onDeviceSigned();
 
   const result = await sdkClient.createAuthorization({
-    currency: account.currency,
+    config,
     request: feeRequest,
     signatures: config.recordPickingStrategy === "manual" ? signature : [signature],
     viewKey,
@@ -196,7 +196,7 @@ async function executeSigningFlow({
 
   // create authorization for main transaction
   const authorization = await sdkClient.createAuthorization({
-    currency: account.currency,
+    config,
     request,
     signatures,
     viewKey,
@@ -257,7 +257,7 @@ export const buildSignOperation =
             if (o.closed) return;
 
             const craftedRequest = await craftTransaction({
-              currency: account.currency,
+              config,
               viewKey,
               feeConfiguration,
               txIntent,

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.test.ts
@@ -249,7 +249,7 @@ describe("sync.ts", () => {
       expect(mockListOperations).toHaveBeenCalledTimes(1);
       expect(mockListOperations).toHaveBeenCalledWith({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAccount.freshAddress,
         ledgerAccountId: expect.any(String),
         mode: "bridge",
@@ -290,7 +290,7 @@ describe("sync.ts", () => {
       expect(mockListOperations).toHaveBeenCalledTimes(1);
       expect(mockListOperations).toHaveBeenCalledWith({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAccount.freshAddress,
         ledgerAccountId: mockInitialAccount.id,
         mode: "bridge",
@@ -799,7 +799,7 @@ describe("sync.ts", () => {
 
       expect(mockAccessProvableApi).toHaveBeenCalledTimes(1);
       expect(mockAccessProvableApi).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: "AViewKey123",
         provableApi: accountWithProvableApi.aleoResources?.provableApi,
       });
@@ -994,18 +994,18 @@ describe("sync.ts", () => {
 
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledTimes(2);
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: configuredProvableApi.uuid,
         start: 0,
       });
       expect(mockFetchAllOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: configuredProvableApi.uuid,
         unspent: true,
       });
       expect(mockListPrivateOperations).toHaveBeenCalledTimes(1);
       expect(mockListPrivateOperations).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: "AViewKey123",
         address: mockAccount.freshAddress,
         ledgerAccountId: expect.any(String),
@@ -1013,7 +1013,7 @@ describe("sync.ts", () => {
       });
       expect(mockGetPrivateBalance).toHaveBeenCalledTimes(1);
       expect(mockGetPrivateBalance).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: "AViewKey123",
         privateRecords: mockUnspentRecords,
         oldUnspentRecords: [],
@@ -1347,7 +1347,7 @@ describe("sync.ts", () => {
 
       expect(mockPatchPublicOperations).toHaveBeenCalledTimes(1);
       expect(mockPatchPublicOperations).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: expect.any(Array),
         privateRecords: [privateRecord],
         address: mockAccount.freshAddress,
@@ -1408,7 +1408,7 @@ describe("sync.ts", () => {
 
       expect(mockGetPrivateBalance).toHaveBeenCalledTimes(1);
       expect(mockGetPrivateBalance).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: "AViewKey123",
         privateRecords: [unspentRecord],
         oldUnspentRecords: [],

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -76,8 +76,8 @@ export async function performPublicSync(
   const config = resolveConfig(currency.id);
 
   const [balances, latestBlock] = await Promise.all([
-    getBalance(currency, address),
-    lastBlock(currency),
+    getBalance(config, address),
+    lastBlock(config),
   ]);
 
   const blockHeight = latestBlock?.height ?? initialAccount?.blockHeight ?? 0;
@@ -107,7 +107,7 @@ export async function performPublicSync(
 
   const latestAccountPublicOperations = await listOperations({
     config,
-    currency,
+    currencyId: currency.id,
     address,
     ledgerAccountId,
     mode: "bridge",
@@ -164,7 +164,7 @@ export async function performPublicSync(
   const { updatedCoinOperations: updatedPublicOperations, subAccounts } =
     await resolveTokenSubAccounts({
       enableTokens: config.enableTokens,
-      currency,
+      config,
       address,
       ledgerAccountId,
       publicOperations,
@@ -261,7 +261,7 @@ export async function performPrivateSync({
   const config = resolveConfig(currency.id);
 
   const provableApi = await accessProvableApi({
-    currency,
+    config,
     viewKey,
     provableApi: initialAccount.aleoResources?.provableApi ?? null,
   }).catch(err => {
@@ -310,7 +310,7 @@ export async function performPrivateSync({
     customData: viewKey,
   });
 
-  const latestBlock = await lastBlock(currency);
+  const latestBlock = await lastBlock(config);
   const blockHeight = latestBlock?.height ?? initialAccount?.blockHeight ?? 0;
 
   // When the public sync ran from scratch (e.g. CAL change), reset private cursor to 0
@@ -336,20 +336,20 @@ export async function performPrivateSync({
     rawUnspentTokenRecords,
   ] = await Promise.all([
     fetchAllOwnedRecords({
-      currency,
+      config,
       uuid: provableApi.uuid,
       start: lastPrivateBlockHeight,
       ...(signal && { signal }),
     }),
     fetchAllOwnedRecords({
-      currency,
+      config,
       uuid: provableApi.uuid,
       unspent: true,
       ...(signal && { signal }),
     }),
     config.enableTokens
       ? fetchAllOwnedRecords({
-          currency,
+          config,
           uuid: provableApi.uuid,
           start: tokenSyncStartHeight,
           // empty arrays opt out of the credits.aleo-only filter, returning records for all programs
@@ -360,7 +360,7 @@ export async function performPrivateSync({
       : Promise.resolve([]),
     config.enableTokens
       ? fetchAllOwnedRecords({
-          currency,
+          config,
           uuid: provableApi.uuid,
           unspent: true,
           // empty arrays opt out of the credits.aleo-only filter, returning records for all programs
@@ -397,7 +397,7 @@ export async function performPrivateSync({
 
   const [latestAccountPrivateOperations, patchedPublicOperations] = await Promise.all([
     listPrivateOperations({
-      currency,
+      config,
       viewKey,
       address,
       ledgerAccountId,
@@ -417,7 +417,7 @@ export async function performPrivateSync({
       ...(signal && { signal }),
     }),
     patchPublicOperations({
-      currency,
+      config,
       publicOperations: currentPublicOps,
       privateRecords: rawNewNativePrivateRecords,
       address,
@@ -443,7 +443,7 @@ export async function performPrivateSync({
   signal?.throwIfAborted();
 
   const privateBalanceResult = await getPrivateBalance({
-    currency,
+    config,
     viewKey,
     privateRecords: filteredUnspentRecords,
     oldUnspentRecords: initialAccount.aleoResources?.unspentPrivateRecords ?? [],
@@ -488,7 +488,7 @@ export async function performPrivateSync({
 
     const { subAccounts: tokenSubAccounts, privateTokenOpsByAccountId } =
       await buildSubAccountsFromPrivateRecords({
-        currency,
+        config,
         ledgerAccountId,
         allPrivateRecords: calTokenRecords,
         unspentPrivateRecords: filteredUnspentTokenRecords,

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.test.ts
@@ -15,6 +15,7 @@ import {
   getMockedTokenCurrency,
   MOCK_TOKEN_PROGRAM_ID,
 } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import type { AleoOperation, AleoTokenAccount, AleoPrivateTokenBalance } from "../types";
 import { getMockedRecord, MOCK_ALEO_ADDRESS } from "../__tests__/fixtures/api.fixture";
@@ -47,6 +48,7 @@ const mockDecryptRecord = jest.mocked(sdkClient.decryptRecord);
 const mockGetTransactionById = jest.mocked(apiClient.getTransactionById);
 
 const mockCurrency = getMockedCurrency();
+const mockConfig = getMockedConfig("mainnet");
 const mockTokenCurrency = getMockedTokenCurrency();
 const mockLedgerAccountId = encodeAccountId({
   type: "js",
@@ -353,7 +355,7 @@ describe("tokens utils", () => {
 
       const { updatedCoinOperations, subAccounts } = await resolveTokenSubAccounts({
         enableTokens: true,
-        currency: mockCurrency,
+        config: mockConfig,
         address,
         ledgerAccountId,
         publicOperations: [],
@@ -373,7 +375,7 @@ describe("tokens utils", () => {
         operationsCount: 1,
       });
       expect(mockGetTokenBalance).toHaveBeenCalledWith(
-        mockCurrency,
+        mockConfig,
         MOCK_TOKEN_PROGRAM_ID,
         MOCK_ALEO_ADDRESS,
       );
@@ -381,11 +383,7 @@ describe("tokens utils", () => {
         type: "IN",
         accountId: tokenAccountId,
       });
-      expect(mockGetTokenBalance).toHaveBeenCalledWith(
-        mockCurrency,
-        MOCK_TOKEN_PROGRAM_ID,
-        address,
-      );
+      expect(mockGetTokenBalance).toHaveBeenCalledWith(mockConfig, MOCK_TOKEN_PROGRAM_ID, address);
     });
 
     it("should fetch transparent balances for pre-existing sub-accounts after merge", async () => {
@@ -400,7 +398,7 @@ describe("tokens utils", () => {
 
       const { subAccounts } = await resolveTokenSubAccounts({
         enableTokens: true,
-        currency: mockCurrency,
+        config: mockConfig,
         address,
         ledgerAccountId,
         publicOperations: [],
@@ -410,11 +408,7 @@ describe("tokens utils", () => {
         initialAccount: getMockedAccount({ subAccounts: [existingSubAccount] }),
       });
 
-      expect(mockGetTokenBalance).toHaveBeenCalledWith(
-        mockCurrency,
-        MOCK_TOKEN_PROGRAM_ID,
-        address,
-      );
+      expect(mockGetTokenBalance).toHaveBeenCalledWith(mockConfig, MOCK_TOKEN_PROGRAM_ID, address);
       expect(subAccounts).toHaveLength(1);
       const aleoSubAccount = subAccounts[0];
       assertAleoTokenAccount(aleoSubAccount);
@@ -431,7 +425,7 @@ describe("tokens utils", () => {
 
       const { subAccounts } = await resolveTokenSubAccounts({
         enableTokens: true,
-        currency: mockCurrency,
+        config: mockConfig,
         address,
         ledgerAccountId,
         publicOperations: [],
@@ -461,7 +455,7 @@ describe("tokens utils", () => {
 
       const { subAccounts } = await resolveTokenSubAccounts({
         enableTokens: true,
-        currency: mockCurrency,
+        config: mockConfig,
         address,
         ledgerAccountId,
         publicOperations: [],
@@ -493,7 +487,7 @@ describe("tokens utils", () => {
 
       const { updatedCoinOperations, subAccounts } = await resolveTokenSubAccounts({
         enableTokens: false,
-        currency: mockCurrency,
+        config: mockConfig,
         address,
         ledgerAccountId,
         publicOperations: [parentOp],
@@ -798,7 +792,7 @@ describe("tokens utils", () => {
       const calTokens = new Map([[MOCK_TOKEN_PROGRAM_ID, mockTokenCurrency]]);
 
       const { subAccounts } = await buildSubAccountsFromPrivateRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         ledgerAccountId,
         allPrivateRecords: [],
         unspentPrivateRecords: [unspentRecord],
@@ -822,7 +816,7 @@ describe("tokens utils", () => {
       const calTokens = new Map([[MOCK_TOKEN_PROGRAM_ID, mockTokenCurrency]]);
 
       const { subAccounts, privateTokenOpsByAccountId } = await buildSubAccountsFromPrivateRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         ledgerAccountId,
         allPrivateRecords: [incomingRecord],
         unspentPrivateRecords: [],
@@ -866,7 +860,7 @@ describe("tokens utils", () => {
       const calTokens = new Map([[MOCK_TOKEN_PROGRAM_ID, mockTokenCurrency]]);
 
       const { subAccounts } = await buildSubAccountsFromPrivateRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         ledgerAccountId,
         allPrivateRecords: [],
         unspentPrivateRecords: [unspentRecord],

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Account, OperationType, TokenAccount } from "@ledgerhq/types-live";
 import { encodeTokenAccountId, emptyHistoryCache } from "@ledgerhq/ledger-wallet-framework/account";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
@@ -21,6 +21,7 @@ import type {
   AleoPrivateRecord,
   AleoPrivateTokenBalance,
   AleoDecryptedRecordResponse,
+  AleoCoinConfig,
 } from "../types";
 
 interface TxOpEntry {
@@ -322,7 +323,7 @@ export function applyTransparentBalance(
  */
 export async function resolveTokenSubAccounts({
   enableTokens,
-  currency,
+  config,
   address,
   ledgerAccountId,
   publicOperations,
@@ -332,7 +333,7 @@ export async function resolveTokenSubAccounts({
   initialAccount,
 }: {
   enableTokens: boolean;
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   address: string;
   ledgerAccountId: string;
   publicOperations: AleoOperation[];
@@ -376,7 +377,7 @@ export async function resolveTokenSubAccounts({
       freshTransparentById.set(
         subAccount.id,
         parseAmount(
-          await apiClient.getTokenBalance(currency, subAccount.token.contractAddress, address),
+          await apiClient.getTokenBalance(config, subAccount.token.contractAddress, address),
         ),
       );
     } catch (e) {
@@ -684,7 +685,7 @@ function upsertTxEntry({
 }
 
 export async function buildSubAccountsFromPrivateRecords({
-  currency,
+  config,
   ledgerAccountId,
   allPrivateRecords,
   unspentPrivateRecords,
@@ -693,7 +694,7 @@ export async function buildSubAccountsFromPrivateRecords({
   address,
   calTokens,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   ledgerAccountId: string;
   allPrivateRecords: AleoPrivateRecord[];
   unspentPrivateRecords: AleoPrivateRecord[];
@@ -724,7 +725,7 @@ export async function buildSubAccountsFromPrivateRecords({
       if (!tokenCurrency) return;
 
       const decrypted = await sdkClient.decryptRecord({
-        currency,
+        config,
         ciphertext: record.record_ciphertext,
         viewKey,
       });
@@ -780,7 +781,7 @@ export async function buildSubAccountsFromPrivateRecords({
 
     if (isOutgoingRecord) {
       // OUT: read the actual sent amount and recipient address from the transition inputs.
-      const outDetails = await getTokenOutDetails({ currency, record, viewKey });
+      const outDetails = await getTokenOutDetails({ config, record, viewKey });
       if (outDetails.amount === null) {
         log(
           "aleo/buildSubAccountsFromPrivateRecords",
@@ -793,7 +794,7 @@ export async function buildSubAccountsFromPrivateRecords({
     } else {
       // IN (or Private self-transfer): the record itself contains the correct received amount.
       const decrypted = await sdkClient.decryptRecord({
-        currency,
+        config,
         ciphertext: record.record_ciphertext,
         viewKey,
       });

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.test.ts
@@ -1,4 +1,3 @@
-import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
 import { apiClient } from "../network/api";
 import { sdkClient } from "../network/sdk";
 import {
@@ -20,7 +19,6 @@ jest.mock("./utils", () => ({
 const mockFromHex = jest.mocked(fromHex);
 
 describe("broadcast", () => {
-  const mockAccount = getMockedAccount();
   const mockSignedTx = "abcdef1234567890";
   const mockAuthorization = getMockedAuthorization();
   const mockFeeAuthorization = getMockedFeeAuthorization();
@@ -39,7 +37,6 @@ describe("broadcast", () => {
   it("should broadcast transaction and return the transaction id when useEncryptedProve is false", async () => {
     const result = await broadcast({
       configOrCurrencyId: mockConfig,
-      account: mockAccount,
       signedTx: mockSignedTx,
     });
 
@@ -47,7 +44,7 @@ describe("broadcast", () => {
     expect(mockFromHex).toHaveBeenCalledWith(mockSignedTx);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledTimes(1);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      config: mockConfig,
       authorization: mockAuthorization,
       feeAuthorization: mockFeeAuthorization,
       broadcast: true,
@@ -62,13 +59,12 @@ describe("broadcast", () => {
 
     await broadcast({
       configOrCurrencyId: mockConfig,
-      account: mockAccount,
       signedTx: mockSignedTx,
     });
 
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledTimes(1);
     expect(apiClient.submitDelegatedProvingRequest).toHaveBeenCalledWith({
-      currency: mockAccount.currency,
+      config: mockConfig,
       authorization: mockAuthorization,
       broadcast: true,
     });
@@ -80,7 +76,7 @@ describe("broadcast", () => {
       .mockRejectedValue(new Error("Network error: Connection refused"));
 
     await expect(
-      broadcast({ configOrCurrencyId: mockConfig, account: mockAccount, signedTx: mockSignedTx }),
+      broadcast({ configOrCurrencyId: mockConfig, signedTx: mockSignedTx }),
     ).rejects.toThrow("Network error: Connection refused");
   });
 
@@ -104,25 +100,24 @@ describe("broadcast", () => {
     it("should broadcast transaction using encrypted prove and return the transaction id", async () => {
       const result = await broadcast({
         configOrCurrencyId: encryptedConfig,
-        account: mockAccount,
         signedTx: mockSignedTx,
       });
 
       expect(apiClient.getProvePublicKey).toHaveBeenCalledTimes(1);
       expect(apiClient.getProvePublicKey).toHaveBeenCalledWith({
-        currency: mockAccount.currency,
+        config: encryptedConfig,
       });
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledTimes(1);
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.data.public_key,
-        currency: mockAccount.currency,
+        config: encryptedConfig,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
       });
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledTimes(1);
       expect(apiClient.submitEncryptedDelegatedProvingRequest).toHaveBeenCalledWith({
-        currency: mockAccount.currency,
+        config: encryptedConfig,
         keyId: mockPublicKeyResponse.data.key_id,
         encryptedData: mockEncryptedData,
         stickySessionCookie: mockPublicKeyResponse.stickySessionCookie,
@@ -137,13 +132,12 @@ describe("broadcast", () => {
 
       await broadcast({
         configOrCurrencyId: encryptedConfig,
-        account: mockAccount,
         signedTx: mockSignedTx,
       });
 
       expect(sdkClient.encryptProvingRequest).toHaveBeenCalledWith({
         publicKey: mockPublicKeyResponse.data.public_key,
-        currency: mockAccount.currency,
+        config: encryptedConfig,
         authorization: mockAuthorization,
         broadcast: true,
       });
@@ -152,7 +146,6 @@ describe("broadcast", () => {
     it("should not call submitDelegatedProvingRequest", async () => {
       await broadcast({
         configOrCurrencyId: encryptedConfig,
-        account: mockAccount,
         signedTx: mockSignedTx,
       });
 
@@ -172,7 +165,6 @@ describe("broadcast", () => {
       await expect(
         broadcast({
           configOrCurrencyId: encryptedConfig,
-          account: mockAccount,
           signedTx: mockSignedTx,
         }),
       ).rejects.toThrow("aleo: broadcast failed with status: Rejected (Transaction rejected)");
@@ -189,7 +181,6 @@ describe("broadcast", () => {
       await expect(
         broadcast({
           configOrCurrencyId: encryptedConfig,
-          account: mockAccount,
           signedTx: mockSignedTx,
         }),
       ).rejects.toThrow("aleo: broadcast failed with status: Skipped (Unknown error)");

--- a/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/broadcast.ts
@@ -1,15 +1,13 @@
 import { apiClient } from "../network/api";
 import { sdkClient } from "../network/sdk";
-import type { AleoAccount, AleoCoinConfig } from "../types";
+import type { AleoCoinConfig } from "../types";
 import { fromHex, resolveConfig } from "./utils";
 
 export async function broadcast({
   configOrCurrencyId,
-  account,
   signedTx,
 }: {
   configOrCurrencyId: AleoCoinConfig | string;
-  account: AleoAccount;
   signedTx: string;
 }): Promise<string> {
   const config = resolveConfig(configOrCurrencyId);
@@ -23,7 +21,7 @@ export async function broadcast({
   // TODO: not used anymore, remove with https://ledgerhq.atlassian.net/browse/LIVE-29982
   if (!config.useEncryptedProve) {
     const res = await apiClient.submitDelegatedProvingRequest({
-      currency: account.currency,
+      config,
       authorization,
       ...(feeAuthorization && { feeAuthorization }),
       broadcast: true,
@@ -33,19 +31,19 @@ export async function broadcast({
   }
 
   const publicKeyResponse = await apiClient.getProvePublicKey({
-    currency: account.currency,
+    config,
   });
 
   const encryptedData = await sdkClient.encryptProvingRequest({
     publicKey: publicKeyResponse.data.public_key,
-    currency: account.currency,
+    config,
     authorization,
     ...(feeAuthorization && { feeAuthorization }),
     broadcast: true,
   });
 
   const res = await apiClient.submitEncryptedDelegatedProvingRequest({
-    currency: account.currency,
+    config,
     keyId: publicKeyResponse.data.key_id,
     encryptedData,
     stickySessionCookie: publicKeyResponse.stickySessionCookie,

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -1,6 +1,4 @@
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { getEnv } from "@ledgerhq/live-env";
-import aleoConfig from "../config";
 import { testnetViewKey } from "../__tests__/fixtures/api.fixture";
 import {
   mockTxIntentFeePrivate,
@@ -11,12 +9,25 @@ import {
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
 import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
-import type { FeeConfiguration, PreparedRequestResponse } from "../types";
+import type { AleoCoinConfig, FeeConfiguration, PreparedRequestResponse } from "../types";
 import { craftTransaction } from "./craftTransaction";
 import { fromHex } from "./utils";
 
 describe("craftTransaction", () => {
-  const currency = getCryptoCurrencyById("aleo");
+  const config: AleoCoinConfig = {
+    status: { type: "active" },
+    networkType: "testnet",
+    apiUrls: {
+      node: getEnv("ALEO_NODE_ENDPOINT"),
+      sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
+    },
+    feeByTransactionType: mockFeeByTransactionType,
+    feeSafetyMultiplier: 1,
+    isFeeSponsored: true,
+    enableTokens: false,
+    useEncryptedProve: false,
+    recordPickingStrategy: "manual",
+  };
   const publicFeeConfiguration: FeeConfiguration = {
     function_name: "fee_public",
     max_base_fee: "34060",
@@ -27,23 +38,6 @@ describe("craftTransaction", () => {
     max_base_fee: "2308",
     max_priority_fee: "0",
   };
-
-  beforeAll(() => {
-    aleoConfig.setCoinConfig(() => ({
-      status: { type: "active" },
-      networkType: "testnet",
-      apiUrls: {
-        node: getEnv("ALEO_NODE_ENDPOINT"),
-        sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
-      },
-      feeByTransactionType: mockFeeByTransactionType,
-      feeSafetyMultiplier: 1,
-      isFeeSponsored: true,
-      enableTokens: false,
-      useEncryptedProve: false,
-      recordPickingStrategy: "manual",
-    }));
-  });
 
   it.each([
     {
@@ -89,7 +83,7 @@ describe("craftTransaction", () => {
     "should craft a prepared request for $name",
     async ({ txIntent, expectedFunctionName, feeConfiguration, viewKey }) => {
       const result = await craftTransaction({
-        currency,
+        config,
         txIntent,
         feeConfiguration,
         ...(typeof viewKey === "string" && { viewKey }),

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.test.ts
@@ -1,5 +1,5 @@
 import { sdkClient } from "../network/sdk";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import {
   mockTxIntentFeePrivate,
@@ -14,7 +14,7 @@ import { mapTransactionIntentToSdkIntent, toHex } from "./utils";
 jest.mock("../network/sdk");
 jest.mock("./utils");
 
-const mockCurrency = getMockedCurrency();
+const mockConfig = getMockedConfig("mainnet");
 const mockViewKey = "AViewKey1mockviewkey";
 const mockSdkIntent: Intent = {
   type: "transfer_public",
@@ -50,7 +50,7 @@ describe("craftTransaction", () => {
 
   it("should craft transaction by mapping intent, calling SDK and serializing response", async () => {
     const result = await craftTransaction({
-      currency: mockCurrency,
+      config: mockConfig,
       txIntent: mockTxIntentTransferPublic,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
@@ -61,7 +61,7 @@ describe("craftTransaction", () => {
     expect(mapTransactionIntentToSdkIntent).toHaveBeenCalledWith(mockTxIntentTransferPublic);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       intent: mockSdkIntent,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
@@ -72,14 +72,14 @@ describe("craftTransaction", () => {
 
   it("should omit viewKey from request when not provided", async () => {
     await craftTransaction({
-      currency: mockCurrency,
+      config: mockConfig,
       txIntent: mockTxIntentTransferPublic,
       feeConfiguration: null,
     });
 
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       intent: mockSdkIntent,
       feeConfiguration: null,
     });
@@ -90,7 +90,7 @@ describe("craftTransaction", () => {
 
     await expect(
       craftTransaction({
-        currency: mockCurrency,
+        config: mockConfig,
         txIntent: mockTxIntentTransferPublic,
         feeConfiguration: mockFeeConfiguration,
         viewKey: mockViewKey,
@@ -100,7 +100,7 @@ describe("craftTransaction", () => {
 
   it("should craft fee_private intent and call SDK", async () => {
     await craftTransaction({
-      currency: mockCurrency,
+      config: mockConfig,
       txIntent: mockTxIntentFeePrivate,
       feeConfiguration: mockFeeConfiguration,
     });
@@ -116,7 +116,7 @@ describe("craftTransaction", () => {
     jest.mocked(mapTransactionIntentToSdkIntent).mockReturnValue(mockMultiRecordSdkIntent);
 
     await craftTransaction({
-      currency: mockCurrency,
+      config: mockConfig,
       txIntent: mockTxIntentTransferPrivate2,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
@@ -125,7 +125,7 @@ describe("craftTransaction", () => {
 
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledTimes(1);
     expect(sdkClient.createRequestFromIntent).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       intent: mockMultiRecordSdkIntent,
       feeConfiguration: mockFeeConfiguration,
       viewKey: mockViewKey,
@@ -138,7 +138,7 @@ describe("craftTransaction", () => {
 
     await expect(
       craftTransaction({
-        currency: mockCurrency,
+        config: mockConfig,
         txIntent: mockTxIntentTransferPrivate2,
         feeConfiguration: mockFeeConfiguration,
         viewKey: mockViewKey,

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.ts
@@ -4,19 +4,18 @@ import type {
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { sdkClient } from "../network/sdk";
-import type { AleoTransactionIntentData, FeeConfiguration } from "../types";
+import type { AleoCoinConfig, AleoTransactionIntentData, FeeConfiguration } from "../types";
 import { mapTransactionIntentToSdkIntent, toHex } from "./utils";
 
 export async function craftTransaction({
-  currency,
+  config,
   txIntent,
   feeConfiguration,
   viewKey,
   tvks,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   txIntent: TransactionIntent<MemoNotSupported, AleoTransactionIntentData>;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
@@ -29,7 +28,7 @@ export async function craftTransaction({
   }
 
   const response = await sdkClient.createRequestFromIntent({
-    currency,
+    config,
     intent,
     feeConfiguration,
     ...(viewKey !== undefined && { viewKey }),

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.test.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../network/api";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
 import { getBalance } from "./getBalance";
 
@@ -8,7 +8,7 @@ jest.mock("../network/api");
 const mockGetAccountBalance = jest.mocked(apiClient.getAccountBalance);
 
 describe("getBalance", () => {
-  const mockCurrency = getMockedCurrency();
+  const mockConfig = getMockedConfig("mainnet");
   const mockAccount = getMockedAccount();
 
   beforeEach(() => {
@@ -18,7 +18,7 @@ describe("getBalance", () => {
   it("should return balance when account has funds", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -27,13 +27,13 @@ describe("getBalance", () => {
       },
     ]);
     expect(mockGetAccountBalance).toHaveBeenCalledTimes(1);
-    expect(mockGetAccountBalance).toHaveBeenCalledWith(mockCurrency, mockAccount.freshAddress);
+    expect(mockGetAccountBalance).toHaveBeenCalledWith(mockConfig, mockAccount.freshAddress);
   });
 
   it("should handle zero balance", async () => {
     mockGetAccountBalance.mockResolvedValue("0u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -46,7 +46,7 @@ describe("getBalance", () => {
   it("should handle large balance values", async () => {
     mockGetAccountBalance.mockResolvedValue("999999999999999999u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -59,7 +59,7 @@ describe("getBalance", () => {
   it("should parse balance correctly by removing last 3 characters (u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("123456789u64");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -72,7 +72,7 @@ describe("getBalance", () => {
   it("should return empty array when API returns null", async () => {
     mockGetAccountBalance.mockResolvedValue(null);
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([]);
   });
@@ -80,13 +80,13 @@ describe("getBalance", () => {
   it("should throw error when balance format is invalid (missing u64)", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should parse balance with u32 suffix", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u32");
 
-    const result = await getBalance(mockCurrency, mockAccount.freshAddress);
+    const result = await getBalance(mockConfig, mockAccount.freshAddress);
 
     expect(result).toEqual([
       {
@@ -99,12 +99,12 @@ describe("getBalance", () => {
   it("should throw error when balance format has incomplete unit suffix", async () => {
     mockGetAccountBalance.mockResolvedValue("1000000u");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 
   it("should throw error when balance format is completely invalid", async () => {
     mockGetAccountBalance.mockResolvedValue("invalid");
 
-    await expect(getBalance(mockCurrency, mockAccount.freshAddress)).rejects.toThrow();
+    await expect(getBalance(mockConfig, mockAccount.freshAddress)).rejects.toThrow();
   });
 });

--- a/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getBalance.ts
@@ -1,10 +1,10 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { AleoCoinConfig } from "../types";
 import { apiClient } from "../network/api";
 import { parseMicrocredits } from "./utils";
 
-export async function getBalance(currency: CryptoCurrency, address: string): Promise<Balance[]> {
-  const microcreditsU64 = await apiClient.getAccountBalance(currency, address);
+export async function getBalance(config: AleoCoinConfig, address: string): Promise<Balance[]> {
+  const microcreditsU64 = await apiClient.getAccountBalance(config, address);
 
   if (!microcreditsU64) {
     return [];

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -5,10 +5,9 @@ import {
   setCryptoAssetsStore,
   type FrameworkCryptoAssetsStore,
 } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import aleoConfig from "../config";
 import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
 import { testnetViewKey, testnetPrivateRecord } from "../__tests__/fixtures/api.fixture";
+import type { AleoCoinConfig } from "../types";
 import { getPrivateBalance } from "./getPrivateBalance";
 
 setCryptoAssetsStore(
@@ -19,28 +18,24 @@ setCryptoAssetsStore(
 );
 
 describe("getPrivateBalance", () => {
-  const currency = getCryptoCurrencyById("aleo");
-
-  beforeAll(() => {
-    aleoConfig.setCoinConfig(() => ({
-      status: { type: "active" },
-      networkType: "testnet",
-      apiUrls: {
-        node: getEnv("ALEO_NODE_ENDPOINT"),
-        sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
-      },
-      feeByTransactionType: mockFeeByTransactionType,
-      feeSafetyMultiplier: 1,
-      isFeeSponsored: true,
-      enableTokens: false,
-      useEncryptedProve: false,
-      recordPickingStrategy: "manual",
-    }));
-  });
+  const config: AleoCoinConfig = {
+    status: { type: "active" },
+    networkType: "testnet",
+    apiUrls: {
+      node: getEnv("ALEO_NODE_ENDPOINT"),
+      sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
+    },
+    feeByTransactionType: mockFeeByTransactionType,
+    feeSafetyMultiplier: 1,
+    isFeeSponsored: true,
+    enableTokens: false,
+    useEncryptedProve: false,
+    recordPickingStrategy: "manual",
+  };
 
   it("should sum microcredits across all unspent credits records", async () => {
     const { balance } = await getPrivateBalance({
-      currency,
+      config,
       viewKey: testnetViewKey,
       privateRecords: [testnetPrivateRecord, testnetPrivateRecord],
       oldUnspentRecords: [],
@@ -51,7 +46,7 @@ describe("getPrivateBalance", () => {
 
   it("should return all decrypted records as unspentRecords", async () => {
     const { unspentRecords } = await getPrivateBalance({
-      currency,
+      config,
       viewKey: testnetViewKey,
       privateRecords: [testnetPrivateRecord],
       oldUnspentRecords: [],
@@ -71,7 +66,7 @@ describe("getPrivateBalance", () => {
 
   it("should return zero balance and empty records when given no records", async () => {
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency,
+      config,
       viewKey: testnetViewKey,
       privateRecords: [],
       oldUnspentRecords: [],
@@ -83,7 +78,7 @@ describe("getPrivateBalance", () => {
 
   it("should skip records marked as spent", async () => {
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency,
+      config,
       viewKey: testnetViewKey,
       privateRecords: [{ ...testnetPrivateRecord, spent: true }],
       oldUnspentRecords: [],
@@ -100,7 +95,7 @@ describe("getPrivateBalance", () => {
     ];
 
     const { unspentRecords } = await getPrivateBalance({
-      currency,
+      config,
       viewKey: testnetViewKey,
       privateRecords: mixedRecords,
       oldUnspentRecords: [],

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.test.ts
@@ -2,14 +2,14 @@ import BigNumber from "bignumber.js";
 import { sdkClient } from "../network/sdk";
 import { PROGRAM_ID } from "../constants";
 import { testnetPrivateRecord } from "../__tests__/fixtures/api.fixture";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import type { AleoUnspentRecord } from "../types";
 import { getPrivateBalance } from "./getPrivateBalance";
 
 jest.mock("../network/sdk");
 
 describe("getPrivateBalance", () => {
-  const mockCurrency = getMockedCurrency();
+  const mockConfig = getMockedConfig("mainnet");
   const mockViewKey = "AViewKey1mock";
 
   const mockDecryptedRecord = {
@@ -26,7 +26,7 @@ describe("getPrivateBalance", () => {
 
   it("should return zero balance and empty unspentRecords when no records are provided", async () => {
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [],
       oldUnspentRecords: [],
@@ -41,7 +41,7 @@ describe("getPrivateBalance", () => {
     const record = { ...testnetPrivateRecord, spent: false };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [record],
       oldUnspentRecords: [],
@@ -49,7 +49,7 @@ describe("getPrivateBalance", () => {
 
     expect(sdkClient.decryptRecord).toHaveBeenCalledTimes(1);
     expect(sdkClient.decryptRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       ciphertext: record.record_ciphertext,
     });
@@ -78,7 +78,7 @@ describe("getPrivateBalance", () => {
       });
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [record1, record2],
       oldUnspentRecords: [],
@@ -93,7 +93,7 @@ describe("getPrivateBalance", () => {
     const spentRecord = { ...testnetPrivateRecord, spent: true };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [spentRecord],
       oldUnspentRecords: [],
@@ -108,7 +108,7 @@ describe("getPrivateBalance", () => {
     const nonCreditsRecord = { ...testnetPrivateRecord, program_name: "other_program.aleo" };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [nonCreditsRecord],
       oldUnspentRecords: [],
@@ -128,7 +128,7 @@ describe("getPrivateBalance", () => {
     const otherRecord = { ...testnetPrivateRecord, program_name: "staking.aleo", spent: false };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [creditsRecord, otherRecord],
       oldUnspentRecords: [],
@@ -144,7 +144,7 @@ describe("getPrivateBalance", () => {
     const unspentRecord = { ...testnetPrivateRecord, commitment: "unspent1", spent: false };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [spentRecord, unspentRecord],
       oldUnspentRecords: [],
@@ -161,7 +161,7 @@ describe("getPrivateBalance", () => {
 
     await expect(
       getPrivateBalance({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: mockViewKey,
         privateRecords: [testnetPrivateRecord],
         oldUnspentRecords: [],
@@ -178,7 +178,7 @@ describe("getPrivateBalance", () => {
     };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [record],
       oldUnspentRecords: [cachedUnspentRecord],
@@ -208,7 +208,7 @@ describe("getPrivateBalance", () => {
     });
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [cachedRecord, newRecord],
       oldUnspentRecords: [cachedUnspentRecord],
@@ -230,7 +230,7 @@ describe("getPrivateBalance", () => {
     };
 
     const { balance, unspentRecords } = await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [],
       oldUnspentRecords: [spentCachedRecord],
@@ -259,7 +259,7 @@ describe("getPrivateBalance", () => {
     const onProgress = jest.fn();
 
     await getPrivateBalance({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       privateRecords: [record1, record2],
       oldUnspentRecords: [],
@@ -277,7 +277,7 @@ describe("getPrivateBalance", () => {
 
     await expect(
       getPrivateBalance({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: mockViewKey,
         privateRecords: [testnetPrivateRecord],
         oldUnspentRecords: [],

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.ts
@@ -1,20 +1,19 @@
 import BigNumber from "bignumber.js";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { PROGRAM_ID } from "../constants";
 import { sdkClient } from "../network/sdk";
-import type { AleoPrivateRecord, AleoUnspentRecord } from "../types";
+import type { AleoCoinConfig, AleoPrivateRecord, AleoUnspentRecord } from "../types";
 import { parseMicrocredits } from "./utils";
 
 export async function getPrivateBalance({
-  currency,
+  config,
   viewKey,
   privateRecords,
   oldUnspentRecords,
   onProgress,
   signal,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   viewKey: string;
   privateRecords: AleoPrivateRecord[];
   oldUnspentRecords: AleoUnspentRecord[];
@@ -42,7 +41,7 @@ export async function getPrivateBalance({
       };
     } else {
       const decryptedRecord = await sdkClient.decryptRecord({
-        currency,
+        config,
         viewKey,
         ciphertext: record.record_ciphertext,
       });

--- a/libs/coin-modules/coin-aleo/src/logic/lastBlock.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/lastBlock.test.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "../network/api";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { lastBlock } from "./lastBlock";
 
 jest.mock("../network/api");
@@ -7,7 +7,7 @@ jest.mock("../network/api");
 const mockGetLatestBlock = jest.mocked(apiClient.getLatestBlock);
 
 describe("lastBlock", () => {
-  const mockCurrency = getMockedCurrency();
+  const mockConfig = getMockedConfig("mainnet");
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,10 +27,10 @@ describe("lastBlock", () => {
 
     mockGetLatestBlock.mockResolvedValue(mockBlockResponse);
 
-    const result = await lastBlock(mockCurrency);
+    const result = await lastBlock(mockConfig);
 
     expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
-    expect(mockGetLatestBlock).toHaveBeenCalledWith(mockCurrency);
+    expect(mockGetLatestBlock).toHaveBeenCalledWith(mockConfig);
     expect(result).toEqual({
       height: 1234567,
       hash: "ab1234567890",

--- a/libs/coin-modules/coin-aleo/src/logic/lastBlock.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/lastBlock.ts
@@ -1,9 +1,9 @@
 import type { BlockInfo } from "@ledgerhq/coin-module-framework/api/index";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { AleoCoinConfig } from "../types";
 import { apiClient } from "../network/api";
 
-export async function lastBlock(currency: CryptoCurrency): Promise<BlockInfo> {
-  const lastBlock = await apiClient.getLatestBlock(currency);
+export async function lastBlock(config: AleoCoinConfig): Promise<BlockInfo> {
+  const lastBlock = await apiClient.getLatestBlock(config);
 
   return {
     height: lastBlock.header.metadata.height,

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.test.ts
@@ -50,7 +50,7 @@ describe("listOperations", () => {
 
       const result = await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -59,7 +59,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         address: mockAddress,
         fetchAllPages: true,
         minBlockHeight: 0,
@@ -86,7 +86,7 @@ describe("listOperations", () => {
 
       await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -111,7 +111,7 @@ describe("listOperations", () => {
 
       const result = await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,
         mode: "bridge",
@@ -161,7 +161,7 @@ describe("listOperations", () => {
 
         const result = await listOperations({
           config: mockConfigWithTokens,
-          currency: mockCurrency,
+          currencyId: mockCurrency.id,
           address: mockAddress,
           ledgerAccountId: mockLedgerAccountId,
           mode: "bridge",
@@ -193,7 +193,7 @@ describe("listOperations", () => {
 
         const result = await listOperations({
           config: mockConfigWithTokens,
-          currency: mockCurrency,
+          currencyId: mockCurrency.id,
           address: mockAddress,
           ledgerAccountId: mockLedgerAccountId,
           mode: "bridge",
@@ -238,7 +238,7 @@ describe("listOperations", () => {
 
         const result = await listOperations({
           config: mockConfigWithTokens,
-          currency: mockCurrency,
+          currencyId: mockCurrency.id,
           address: mockAddress,
           ledgerAccountId: mockLedgerAccountId,
           mode: "bridge",
@@ -277,7 +277,7 @@ describe("listOperations", () => {
 
       const result = await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         mode: "coin-framework",
         options: { minHeight: 0, order: "asc" },
@@ -285,7 +285,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         address: mockAddress,
         fetchAllPages: false,
         minBlockHeight: 0,
@@ -309,7 +309,7 @@ describe("listOperations", () => {
 
       const result = await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         mode: "coin-framework",
         options: { minHeight: 0 },
@@ -329,7 +329,7 @@ describe("listOperations", () => {
 
       await listOperations({
         config: mockConfigWithTokens,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         mode: "coin-framework",
         options: { minHeight: 0 },
@@ -348,7 +348,7 @@ describe("listOperations", () => {
 
       await listOperations({
         config: mockConfig,
-        currency: mockCurrency,
+        currencyId: mockCurrency.id,
         address: mockAddress,
         mode: "coin-framework",
         options: {
@@ -361,7 +361,7 @@ describe("listOperations", () => {
 
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledTimes(1);
       expect(mockFetchAccountTransactionsFromHeight).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         address: mockAddress,
         fetchAllPages: false,
         minBlockHeight: 1000,

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.ts
@@ -1,4 +1,4 @@
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Operation, ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/types";
 import type { AleoOperation } from "../types/bridge";
 import { fetchAccountTransactionsFromHeight } from "../network/utils";
@@ -6,7 +6,7 @@ import { getCalTokens, toCoinFrameworkOperation, toBridgeOperation } from "./uti
 import type { AleoCoinConfig } from "../types";
 
 interface Params {
-  currency: CryptoCurrency;
+  currencyId: string;
   address: string;
   options: ListOperationsOptions;
   config: AleoCoinConfig;
@@ -33,13 +33,13 @@ export async function listOperations(params: CoinFrameworkParams): Promise<Resul
 export async function listOperations(
   params: BridgeParams | CoinFrameworkParams,
 ): Promise<Result<AleoOperation | Operation>> {
-  const { mode, currency, address, options, config } = params;
+  const { mode, currencyId, address, options, config } = params;
   const operations: Array<AleoOperation | Operation> = [];
   const tokenOperations: Array<AleoOperation | Operation> = [];
   const fetchAllPages = mode === "bridge";
 
   const result = await fetchAccountTransactionsFromHeight({
-    currency,
+    config,
     address,
     fetchAllPages,
     minBlockHeight: options.minHeight,
@@ -52,7 +52,7 @@ export async function listOperations(
 
   if (config.enableTokens && mode === "bridge") {
     calTokens = await getCalTokens({
-      currencyId: currency.id,
+      currencyId,
       programNames: result.transactions.map(rawTx => rawTx.program_id),
     });
   }

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.test.ts
@@ -1,4 +1,4 @@
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedEnrichedPrivateRecord, getMockedRecord } from "../__tests__/fixtures/api.fixture";
 import { getMockedOperation } from "../__tests__/fixtures/operation.fixture";
 import { EXPLORER_TRANSFER_TYPES, PROGRAM_ID } from "../constants";
@@ -14,7 +14,7 @@ const mockToPrivateBridgeOperation = jest.mocked(toPrivateBridgeOperation);
 
 describe("listPrivateOperations", () => {
   const mockOp = getMockedOperation();
-  const mockCurrency = getMockedCurrency();
+  const mockConfig = getMockedConfig("mainnet");
   const mockViewKey = "AViewKey1mockviewkey";
   const mockAddress = "aleo1test123address456";
   const mockLedgerAccountId = "js:2:aleo:aleo1test123address456:";
@@ -25,7 +25,7 @@ describe("listPrivateOperations", () => {
 
   it("should return an empty operations array and empty set when no private records are provided", async () => {
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -46,7 +46,7 @@ describe("listPrivateOperations", () => {
     mockEnrichPrivateRecord.mockResolvedValue(null);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -55,7 +55,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -75,7 +75,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -84,7 +84,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -103,7 +103,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -112,7 +112,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -131,7 +131,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -140,7 +140,7 @@ describe("listPrivateOperations", () => {
 
     expect(mockEnrichPrivateRecord).toHaveBeenCalledTimes(1);
     expect(mockEnrichPrivateRecord).toHaveBeenCalledWith({
-      currency: mockCurrency,
+      config: mockConfig,
       rawRecord: record,
       viewKey: mockViewKey,
       address: mockAddress,
@@ -157,7 +157,7 @@ describe("listPrivateOperations", () => {
     mockEnrichPrivateRecord.mockResolvedValue(null);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -180,7 +180,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -212,7 +212,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -258,7 +258,7 @@ describe("listPrivateOperations", () => {
       .mockReturnValueOnce(ops[2]);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -288,7 +288,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -324,7 +324,7 @@ describe("listPrivateOperations", () => {
     mockEnrichPrivateRecord.mockResolvedValue(null);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -369,7 +369,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -410,7 +410,7 @@ describe("listPrivateOperations", () => {
     mockToPrivateBridgeOperation.mockReturnValue(mockOp);
 
     const result = await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -442,7 +442,7 @@ describe("listPrivateOperations", () => {
     const onProgress = jest.fn();
 
     await listPrivateOperations({
-      currency: mockCurrency,
+      config: mockConfig,
       viewKey: mockViewKey,
       address: mockAddress,
       ledgerAccountId: mockLedgerAccountId,
@@ -466,7 +466,7 @@ describe("listPrivateOperations", () => {
 
     await expect(
       listPrivateOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         viewKey: mockViewKey,
         address: mockAddress,
         ledgerAccountId: mockLedgerAccountId,

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.ts
@@ -1,10 +1,10 @@
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import type {
   AleoOperation,
   AleoPrivateRecord,
   EnrichedPrivateRecord,
   AleoTransitionValue,
+  AleoCoinConfig,
 } from "../types";
 import { enrichPrivateRecord } from "../network/utils";
 import { toPrivateBridgeOperation } from "./utils";
@@ -42,7 +42,7 @@ export function buildConsumedRecordTags(
 }
 
 export async function listPrivateOperations({
-  currency,
+  config,
   viewKey,
   address,
   ledgerAccountId,
@@ -51,7 +51,7 @@ export async function listPrivateOperations({
   signal,
   tokenRecords,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   viewKey: string;
   address: string;
   ledgerAccountId: string;
@@ -69,7 +69,7 @@ export async function listPrivateOperations({
   let completed = 0;
   const enrichedRecords = await promiseAllBatched(2, recordsToEnrich, async rawRecord => {
     signal?.throwIfAborted();
-    const result = await enrichPrivateRecord({ currency, rawRecord, address, viewKey });
+    const result = await enrichPrivateRecord({ config, rawRecord, address, viewKey });
     onProgress?.(++completed, recordsToEnrich.length);
     return result;
   });

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -50,7 +50,6 @@ import {
 } from "../__tests__/fixtures/transaction.fixture";
 import type { AleoOperationExtra, ProvableApi } from "../types";
 import {
-  getNetworkConfig,
   parseMicrocredits,
   parseAmount,
   normalizeAleoPlaintext,
@@ -119,33 +118,6 @@ const supportedPrivateTransactionModes = [
   TRANSACTION_TYPE.TRANSFER_PRIVATE,
   TRANSACTION_TYPE.CONVERT_PRIVATE_TO_PUBLIC,
 ] as const;
-
-describe("getNetworkConfig", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it("should return network config with correct structure", () => {
-    mockedAleoConfig.getCoinConfig.mockReturnValue(mockConfig);
-
-    const result = getNetworkConfig(mockCurrency);
-
-    expect(result).toEqual({
-      nodeUrl: "https://node.example.com",
-      sdkUrl: "https://sdk.example.com",
-      networkType: "mainnet",
-    });
-  });
-
-  it("should call getCoinConfig with correct currency", () => {
-    mockedAleoConfig.getCoinConfig.mockReturnValue(mockConfig);
-
-    getNetworkConfig(mockCurrency);
-
-    expect(aleoConfig.getCoinConfig).toHaveBeenCalledTimes(1);
-    expect(aleoConfig.getCoinConfig).toHaveBeenCalledWith(mockCurrency.id);
-  });
-});
 
 describe("parseMicrocredits", () => {
   it.each([

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { log } from "@ledgerhq/logs";
 import { findCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type {
   Account,
   AccountLike,
@@ -78,16 +78,6 @@ export function parseMicrocredits(microcredits: string): string {
 export function parseAmount(raw: string | null): BigNumber {
   if (!raw) return new BigNumber(0);
   return new BigNumber(matchAleoPlaintextAmount(raw) ?? 0);
-}
-
-export function getNetworkConfig(currency: CryptoCurrency) {
-  const config = aleoConfig.getCoinConfig(currency.id);
-
-  return {
-    nodeUrl: config.apiUrls.node,
-    sdkUrl: config.apiUrls.sdk,
-    networkType: config.networkType,
-  };
 }
 
 export function patchAccountWithViewKey(account: Account, viewKey: string): Account {

--- a/libs/coin-modules/coin-aleo/src/network/api.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.test.ts
@@ -1,5 +1,4 @@
 import network from "@ledgerhq/live-network";
-import { getNetworkConfig } from "../logic/utils";
 import type { AleoLatestBlockResponse } from "../types/api";
 import { EXPLORER_TRANSFER_TYPES } from "../constants";
 import {
@@ -12,28 +11,17 @@ import {
   getMockedFeeAuthorization,
   getMockedDelegatedProvingResponse,
 } from "../__tests__/fixtures/api.fixture";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { apiClient } from "./api";
 
 jest.mock("@ledgerhq/live-network");
-jest.mock("../logic/utils");
 
 describe("apiClient", () => {
-  const mockCurrency = getMockedCurrency();
-  const mockNetworkConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://api.aleo.network",
-    sdkUrl: "https://sdk.aleo.network",
-    networkType: "mainnet",
-  };
-  const testnetConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://api.testnet.aleo.network",
-    sdkUrl: "https://sdk.testnet.aleo.network",
-    networkType: "testnet",
-  };
+  const mockConfig = getMockedConfig("mainnet");
+  const testnetConfig = getMockedConfig("testnet");
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(getNetworkConfig).mockReturnValue(mockNetworkConfig);
   });
 
   describe("getLatestBlock", () => {
@@ -51,14 +39,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getLatestBlock(mockCurrency);
+      const result = await apiClient.getLatestBlock(mockConfig);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/blocks/latest`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/blocks/latest`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -66,12 +52,10 @@ describe("apiClient", () => {
     it("should throw an error when network request fails", async () => {
       jest.mocked(network).mockRejectedValue(new Error("Network error"));
 
-      await expect(apiClient.getLatestBlock(mockCurrency)).rejects.toThrow("Network error");
+      await expect(apiClient.getLatestBlock(mockConfig)).rejects.toThrow("Network error");
     });
 
     it("should use correct network configuration", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
-
       const mockResponse: AleoLatestBlockResponse = {
         block_hash: "test123",
         previous_hash: "test456",
@@ -85,13 +69,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      await apiClient.getLatestBlock(mockCurrency);
+      await apiClient.getLatestBlock(testnetConfig);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/blocks/latest`,
+        url: `${testnetConfig.apiUrls.node}/v2/${testnetConfig.networkType}/blocks/latest`,
       });
     });
   });
@@ -103,14 +86,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getTransactionById(mockCurrency, mockTransactionId);
+      const result = await apiClient.getTransactionById(mockConfig, mockTransactionId);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/${mockTransactionId}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/${mockTransactionId}`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -118,14 +99,12 @@ describe("apiClient", () => {
     it("should throw an error when transaction is not found", async () => {
       jest.mocked(network).mockRejectedValue(new Error("Transaction not found"));
 
-      await expect(apiClient.getTransactionById(mockCurrency, "at1nonexistent")).rejects.toThrow(
+      await expect(apiClient.getTransactionById(mockConfig, "at1nonexistent")).rejects.toThrow(
         "Transaction not found",
       );
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
-
       const mockTransactionId = "at1testnet123";
       const mockResponse = getMockedSimpleTransactionDetails(mockTransactionId, {
         block_height: 100,
@@ -134,13 +113,12 @@ describe("apiClient", () => {
 
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      await apiClient.getTransactionById(mockCurrency, mockTransactionId);
+      await apiClient.getTransactionById(testnetConfig, mockTransactionId);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/transactions/${mockTransactionId}`,
+        url: `${testnetConfig.apiUrls.node}/v2/${testnetConfig.networkType}/transactions/${mockTransactionId}`,
       });
     });
   });
@@ -152,16 +130,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true`,
       });
       expect(result).toEqual(mockResponse);
       expect(result.transactions).toHaveLength(2);
@@ -176,16 +152,15 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
         limit: customLimit,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=10&sort=asc&direction=next&token_info=true`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=10&sort=asc&direction=next&token_info=true`,
       });
     });
 
@@ -197,16 +172,15 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
         order: "desc",
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=desc&direction=next&token_info=true`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=desc&direction=next&token_info=true`,
       });
     });
 
@@ -227,16 +201,15 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
         cursor,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true&cursor_block_number=${cursor}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true&cursor_block_number=${cursor}`,
       });
     });
 
@@ -248,16 +221,15 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
         direction: "prev",
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=prev&token_info=true`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=prev&token_info=true`,
       });
     });
 
@@ -285,7 +257,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
         cursor,
         limit: 20,
@@ -293,11 +265,10 @@ describe("apiClient", () => {
         direction: "prev",
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=20&sort=desc&direction=prev&token_info=true&cursor_block_number=${cursor}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=20&sort=desc&direction=prev&token_info=true&cursor_block_number=${cursor}`,
       });
       expect(result).toEqual(mockResponse);
     });
@@ -307,7 +278,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.getAccountPublicTransactions({
-          currency: mockCurrency,
+          config: mockConfig,
           address: MOCK_ALEO_ADDRESS,
         }),
       ).rejects.toThrow("Network error");
@@ -321,7 +292,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: mockConfig,
         address: MOCK_ALEO_ADDRESS,
       });
 
@@ -329,8 +300,6 @@ describe("apiClient", () => {
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
-
       const mockResponse = getMockedAccountPublicTransactions(MOCK_ALEO_ADDRESS, {
         transactions: [],
       });
@@ -338,15 +307,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await apiClient.getAccountPublicTransactions({
-        currency: mockCurrency,
+        config: testnetConfig,
         address: MOCK_ALEO_ADDRESS,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true`,
+        url: `${testnetConfig.apiUrls.node}/v2/${testnetConfig.networkType}/transactions/address/${MOCK_ALEO_ADDRESS}?metadata=true&limit=50&sort=asc&direction=next&token_info=true`,
       });
     });
   });
@@ -356,14 +324,12 @@ describe("apiClient", () => {
       const mockBalance = "1000000u64";
       jest.mocked(network).mockResolvedValue({ data: mockBalance, status: 200 });
 
-      const result = await apiClient.getAccountBalance(mockCurrency, MOCK_ALEO_ADDRESS);
+      const result = await apiClient.getAccountBalance(mockConfig, MOCK_ALEO_ADDRESS);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/v2/${mockNetworkConfig.networkType}/program/credits.aleo/mapping/account/${MOCK_ALEO_ADDRESS}`,
+        url: `${mockConfig.apiUrls.node}/v2/${mockConfig.networkType}/program/credits.aleo/mapping/account/${MOCK_ALEO_ADDRESS}`,
       });
       expect(result).toEqual(mockBalance);
     });
@@ -371,7 +337,7 @@ describe("apiClient", () => {
     it("should return null when account has no balance", async () => {
       jest.mocked(network).mockResolvedValue({ data: null, status: 200 });
 
-      const result = await apiClient.getAccountBalance(mockCurrency, MOCK_ALEO_ADDRESS);
+      const result = await apiClient.getAccountBalance(mockConfig, MOCK_ALEO_ADDRESS);
 
       expect(result).toBeNull();
     });
@@ -380,21 +346,20 @@ describe("apiClient", () => {
       const mockError = new Error("Network error");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getAccountBalance(mockCurrency, MOCK_ALEO_ADDRESS)).rejects.toThrow(
+      await expect(apiClient.getAccountBalance(mockConfig, MOCK_ALEO_ADDRESS)).rejects.toThrow(
         "Network error",
       );
     });
 
     it("should use correct network configuration for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest.mocked(network).mockResolvedValue({ data: "500000u64", status: 200 });
 
-      await apiClient.getAccountBalance(mockCurrency, MOCK_ALEO_ADDRESS);
+      await apiClient.getAccountBalance(testnetConfig, MOCK_ALEO_ADDRESS);
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/v2/${testnetConfig.networkType}/program/credits.aleo/mapping/account/${MOCK_ALEO_ADDRESS}`,
+        url: `${testnetConfig.apiUrls.node}/v2/${testnetConfig.networkType}/program/credits.aleo/mapping/account/${MOCK_ALEO_ADDRESS}`,
       });
     });
   });
@@ -407,29 +372,26 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getScannerPublicKey(mockCurrency);
+      const result = await apiClient.getScannerPublicKey(mockConfig);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/pubkey`,
+        url: `${mockConfig.apiUrls.node}/scanner/${mockConfig.networkType}/pubkey`,
       });
       expect(result).toEqual(mockResponse);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getScannerPublicKey(mockCurrency);
+      await apiClient.getScannerPublicKey(testnetConfig);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/scanner/testnet/pubkey`,
+        url: `${testnetConfig.apiUrls.node}/scanner/testnet/pubkey`,
       });
     });
 
@@ -437,7 +399,7 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getScannerPublicKey(mockCurrency)).rejects.toThrow("Forbidden");
+      await expect(apiClient.getScannerPublicKey(mockConfig)).rejects.toThrow("Forbidden");
     });
   });
 
@@ -450,28 +412,25 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.registerForScanningAccountRecordsEncrypted({
-        currency: mockCurrency,
+        config: mockConfig,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/register/encrypted`,
+        url: `${mockConfig.apiUrls.node}/scanner/${mockConfig.networkType}/register/encrypted`,
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
       expect(result).toEqual(mockResponse);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest.mocked(network).mockResolvedValue({ data: { uuid: "scan-uuid-testnet" }, status: 200 });
 
       await apiClient.registerForScanningAccountRecordsEncrypted({
-        currency: mockCurrency,
+        config: testnetConfig,
         encryptedData: mockEncryptedData,
         keyId: mockKeyId,
       });
@@ -479,7 +438,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/register/encrypted`,
+        url: `${testnetConfig.apiUrls.node}/scanner/${testnetConfig.networkType}/register/encrypted`,
         data: { key_id: mockKeyId, ciphertext: mockEncryptedData },
       });
     });
@@ -490,7 +449,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.registerForScanningAccountRecordsEncrypted({
-          currency: mockCurrency,
+          config: mockConfig,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         }),
@@ -505,14 +464,12 @@ describe("apiClient", () => {
       const mockResponse = { synced: true, percentage: 100 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      const result = await apiClient.getRecordScannerStatus(mockConfig, mockUuid);
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/status`,
+        url: `${mockConfig.apiUrls.node}/scanner/${mockConfig.networkType}/status`,
         headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
@@ -523,24 +480,23 @@ describe("apiClient", () => {
       const mockResponse = { synced: false, percentage: 42 };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      const result = await apiClient.getRecordScannerStatus(mockConfig, mockUuid);
 
       expect(result.synced).toBe(false);
       expect(result.percentage).toBe(42);
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { synced: true, percentage: 100 }, status: 200 });
 
-      await apiClient.getRecordScannerStatus(mockCurrency, mockUuid);
+      await apiClient.getRecordScannerStatus(testnetConfig, mockUuid);
 
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/status`,
+        url: `${testnetConfig.apiUrls.node}/scanner/${testnetConfig.networkType}/status`,
         headers: { "Content-Type": "application/json" },
         data: `"${mockUuid}"`,
       });
@@ -550,7 +506,7 @@ describe("apiClient", () => {
       const mockError = new Error("Status fetch failed");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getRecordScannerStatus(mockCurrency, mockUuid)).rejects.toThrow(
+      await expect(apiClient.getRecordScannerStatus(mockConfig, mockUuid)).rejects.toThrow(
         "Status fetch failed",
       );
     });
@@ -564,16 +520,14 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/scanner/${mockNetworkConfig.networkType}/records/owned`,
+        url: `${mockConfig.apiUrls.node}/scanner/${mockConfig.networkType}/records/owned`,
         data: { uuid: mockUuid },
       });
       expect(result).toEqual(mockResponse);
@@ -583,7 +537,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: true,
       });
@@ -600,7 +554,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: false,
       });
@@ -617,7 +571,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
@@ -630,7 +584,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         start: mockStart,
       });
@@ -647,7 +601,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
@@ -660,7 +614,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: true,
         start: mockStart,
@@ -678,7 +632,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       const result = await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
@@ -691,18 +645,17 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.getAccountOwnedRecords({
-          currency: mockCurrency,
+          config: mockConfig,
           uuid: mockUuid,
         }),
       ).rejects.toThrow("Unauthorized");
     });
 
     it("should use the correct network type in the URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: testnetConfig,
         uuid: mockUuid,
       });
 
@@ -710,7 +663,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "POST",
-          url: `${testnetConfig.nodeUrl}/scanner/${testnetConfig.networkType}/records/owned`,
+          url: `${testnetConfig.apiUrls.node}/scanner/${testnetConfig.networkType}/records/owned`,
         }),
       );
     });
@@ -719,7 +672,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         resultsPerPage: 100,
       });
@@ -736,7 +689,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         page: 2,
       });
@@ -754,7 +707,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         start: mockStart,
         resultsPerPage: 500,
@@ -776,7 +729,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: true,
         resultsPerPage: 200,
@@ -799,7 +752,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         page: 0,
       });
@@ -817,7 +770,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         programs,
       });
@@ -834,7 +787,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         programs: [],
       });
@@ -847,7 +800,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
@@ -861,7 +814,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: true,
         start: mockStart,
@@ -890,7 +843,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         functions,
       });
@@ -907,7 +860,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         functions: [],
       });
@@ -920,7 +873,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
       });
 
@@ -939,7 +892,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: [testnetPrivateRecord], status: 200 });
 
       await apiClient.getAccountOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUuid,
         unspent: true,
         start: mockStart,
@@ -970,14 +923,12 @@ describe("apiClient", () => {
       };
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
-      const result = await apiClient.getProvePublicKey({ currency: mockCurrency });
+      const result = await apiClient.getProvePublicKey({ config: mockConfig });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/pubkey`,
+        url: `${mockConfig.apiUrls.node}/prove/${mockConfig.networkType}/pubkey`,
       });
       expect(result).toEqual({
         data: mockResponse,
@@ -986,16 +937,15 @@ describe("apiClient", () => {
     });
 
     it("should use the correct network type in the URL", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest
         .mocked(network)
         .mockResolvedValue({ data: { key_id: "k1", public_key: "pk1" }, status: 200 });
 
-      await apiClient.getProvePublicKey({ currency: mockCurrency });
+      await apiClient.getProvePublicKey({ config: testnetConfig });
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "GET",
-        url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/pubkey`,
+        url: `${testnetConfig.apiUrls.node}/prove/${testnetConfig.networkType}/pubkey`,
       });
     });
 
@@ -1009,7 +959,7 @@ describe("apiClient", () => {
         headers: { "set-cookie": setCookieValue },
       });
 
-      const result = await apiClient.getProvePublicKey({ currency: mockCurrency });
+      const result = await apiClient.getProvePublicKey({ config: mockConfig });
 
       expect(result).toEqual({
         data: mockResponse,
@@ -1021,7 +971,7 @@ describe("apiClient", () => {
       const mockError = new Error("Forbidden");
       jest.mocked(network).mockRejectedValue(mockError);
 
-      await expect(apiClient.getProvePublicKey({ currency: mockCurrency })).rejects.toThrow(
+      await expect(apiClient.getProvePublicKey({ config: mockConfig })).rejects.toThrow(
         "Forbidden",
       );
     });
@@ -1036,18 +986,16 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       const result = await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove`,
+        url: `${mockConfig.apiUrls.node}/prove/${mockConfig.networkType}/prove`,
         data: {
           authorization: mockAuthorization,
           fee_authorization: mockFeeAuthorization,
@@ -1058,11 +1006,10 @@ describe("apiClient", () => {
     });
 
     it("should use correct network URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: testnetConfig,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: true,
@@ -1071,7 +1018,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/prove`,
+          url: `${testnetConfig.apiUrls.node}/prove/${testnetConfig.networkType}/prove`,
         }),
       );
     });
@@ -1082,7 +1029,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.submitDelegatedProvingRequest({
-          currency: mockCurrency,
+          config: mockConfig,
           authorization: mockAuthorization,
           feeAuthorization: mockFeeAuthorization,
           broadcast: true,
@@ -1094,7 +1041,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         authorization: mockAuthorization,
         feeAuthorization: mockFeeAuthorization,
         broadcast: false,
@@ -1114,7 +1061,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         authorization: mockAuthorization,
         broadcast: true,
       });
@@ -1140,18 +1087,16 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       const result = await apiClient.submitEncryptedDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
         stickySessionCookie: null,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.nodeUrl}/prove/${mockNetworkConfig.networkType}/prove/encrypted`,
+        url: `${mockConfig.apiUrls.node}/prove/${mockConfig.networkType}/prove/encrypted`,
         data: {
           key_id: mockKeyId,
           ciphertext: mockEncryptedData,
@@ -1161,11 +1106,10 @@ describe("apiClient", () => {
     });
 
     it("should use correct network URL for testnet", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitEncryptedDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: testnetConfig,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
         stickySessionCookie: null,
@@ -1174,7 +1118,7 @@ describe("apiClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.nodeUrl}/prove/${testnetConfig.networkType}/prove/encrypted`,
+          url: `${testnetConfig.apiUrls.node}/prove/${testnetConfig.networkType}/prove/encrypted`,
         }),
       );
     });
@@ -1185,7 +1129,7 @@ describe("apiClient", () => {
 
       await expect(
         apiClient.submitEncryptedDelegatedProvingRequest({
-          currency: mockCurrency,
+          config: mockConfig,
           keyId: mockKeyId,
           encryptedData: mockEncryptedData,
           stickySessionCookie: null,
@@ -1199,7 +1143,7 @@ describe("apiClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDelegatedProvingResponse, status: 200 });
 
       await apiClient.submitEncryptedDelegatedProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         keyId: mockKeyId,
         encryptedData: mockEncryptedData,
         stickySessionCookie: setCookieValue,

--- a/libs/coin-modules/coin-aleo/src/network/api.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.ts
@@ -1,5 +1,4 @@
 import network from "@ledgerhq/live-network";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
 import type {
   AleoLatestBlockResponse,
@@ -12,29 +11,26 @@ import type {
   AleoPrivateRecord,
   DelegatedProvingResponse,
 } from "../types/api";
-import { getNetworkConfig } from "../logic/utils";
+import type { AleoCoinConfig } from "../types";
 import { PROGRAM_ID } from "../constants";
 
-async function getLatestBlock(currency: CryptoCurrency): Promise<AleoLatestBlockResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+async function getLatestBlock(config: AleoCoinConfig): Promise<AleoLatestBlockResponse> {
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoLatestBlockResponse>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/blocks/latest`,
+    url: `${apiUrls.node}/v2/${networkType}/blocks/latest`,
   });
 
   return res.data;
 }
 
-async function getAccountBalance(
-  currency: CryptoCurrency,
-  address: string,
-): Promise<string | null> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+async function getAccountBalance(config: AleoCoinConfig, address: string): Promise<string | null> {
+  const { apiUrls, networkType } = config;
 
   const res = await network<string | null>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/account/${address}`,
+    url: `${apiUrls.node}/v2/${networkType}/program/${PROGRAM_ID.CREDITS}/mapping/account/${address}`,
   });
 
   return res.data;
@@ -44,56 +40,56 @@ async function getAccountBalance(
  * Fetches the public balance of an address-mapped token program
  * (e.g. usdcx_stablecoin.aleo, usad_stablecoin.aleo) for a given address.
  *
- * @param currency - The Aleo currency
+ * @param config - The Aleo coin config
  * @param programId - The token program id
  * @param address - The owner's Aleo address
  * @returns The balance in raw units (u128) or null if no balance exists
  */
 async function getTokenBalance(
-  currency: CryptoCurrency,
+  config: AleoCoinConfig,
   programId: string,
   address: string,
 ): Promise<string | null> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<string | null>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/program/${programId}/mapping/balances/${address}`,
+    url: `${apiUrls.node}/v2/${networkType}/program/${programId}/mapping/balances/${address}`,
   });
 
   return res.data;
 }
 
 async function getTransactionById(
-  currency: CryptoCurrency,
+  config: AleoCoinConfig,
   transactionId: string,
 ): Promise<AleoPublicTransactionDetailsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoPublicTransactionDetailsResponse>({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/transactions/${transactionId}`,
+    url: `${apiUrls.node}/v2/${networkType}/transactions/${transactionId}`,
   });
 
   return res.data;
 }
 
 async function getAccountPublicTransactions({
-  currency,
+  config,
   address,
   cursor,
   limit = 50,
   order = "asc",
   direction = "next",
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   address: string;
   cursor?: string;
   limit?: number;
   order?: "asc" | "desc";
   direction?: "prev" | "next";
 }): Promise<AleoPublicTransactionsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
   const params = new URLSearchParams({
     metadata: "true",
     limit: limit.toString(),
@@ -105,39 +101,39 @@ async function getAccountPublicTransactions({
 
   const res: LiveNetworkResponse<AleoPublicTransactionsResponse> = await network({
     method: "GET",
-    url: `${nodeUrl}/v2/${networkType}/transactions/address/${address}?${params.toString()}`,
+    url: `${apiUrls.node}/v2/${networkType}/transactions/address/${address}?${params.toString()}`,
   });
 
   return res.data;
 }
 
 async function getScannerPublicKey(
-  currency: CryptoCurrency,
+  config: AleoCoinConfig,
 ): Promise<AleoGetScannerPublicKeyResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoGetScannerPublicKeyResponse>({
     method: "GET",
-    url: `${nodeUrl}/scanner/${networkType}/pubkey`,
+    url: `${apiUrls.node}/scanner/${networkType}/pubkey`,
   });
 
   return res.data;
 }
 
 async function registerForScanningAccountRecordsEncrypted({
-  currency,
+  config,
   encryptedData,
   keyId,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   encryptedData: string;
   keyId: string;
 }): Promise<AleoRegisterForRecordsResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoRegisterForRecordsResponse>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/register/encrypted`,
+    url: `${apiUrls.node}/scanner/${networkType}/register/encrypted`,
     data: {
       key_id: keyId,
       ciphertext: encryptedData,
@@ -148,14 +144,14 @@ async function registerForScanningAccountRecordsEncrypted({
 }
 
 const getRecordScannerStatus = async (
-  currency: CryptoCurrency,
+  config: AleoCoinConfig,
   uuid: string,
 ): Promise<AleoRecordScannerStatusResponse> => {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoRecordScannerStatusResponse>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/status`,
+    url: `${apiUrls.node}/scanner/${networkType}/status`,
     headers: {
       "Content-Type": "application/json",
     },
@@ -166,7 +162,7 @@ const getRecordScannerStatus = async (
 };
 
 async function getAccountOwnedRecords({
-  currency,
+  config,
   uuid,
   unspent,
   start,
@@ -175,7 +171,7 @@ async function getAccountOwnedRecords({
   programs,
   functions,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   uuid: string;
   unspent?: boolean;
   start?: number;
@@ -184,7 +180,7 @@ async function getAccountOwnedRecords({
   programs?: string[];
   functions?: string[];
 }): Promise<AleoPrivateRecord[]> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const filter = {
     ...(typeof start === "number" && { start }),
@@ -196,7 +192,7 @@ async function getAccountOwnedRecords({
 
   const res = await network<AleoPrivateRecord[]>({
     method: "POST",
-    url: `${nodeUrl}/scanner/${networkType}/records/owned`,
+    url: `${apiUrls.node}/scanner/${networkType}/records/owned`,
     data: {
       ...(typeof unspent === "boolean" && { unspent }),
       ...(Object.keys(filter).length > 0 && { filter }),
@@ -208,20 +204,20 @@ async function getAccountOwnedRecords({
 }
 
 async function submitDelegatedProvingRequest({
-  currency,
+  config,
   authorization,
   feeAuthorization,
   broadcast,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
 }): Promise<DelegatedProvingResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
-    url: `${nodeUrl}/prove/${networkType}/prove`,
+    url: `${apiUrls.node}/prove/${networkType}/prove`,
     data: {
       authorization,
       ...(feeAuthorization ? { fee_authorization: feeAuthorization } : {}),
@@ -237,15 +233,15 @@ async function submitDelegatedProvingRequest({
  * Browsers handle the cookie automatically (Electron renderer side),
  * but Node.js does not - so it needs to be captured and forwarded manually.
  */
-async function getProvePublicKey({ currency }: { currency: CryptoCurrency }): Promise<{
+async function getProvePublicKey({ config }: { config: AleoCoinConfig }): Promise<{
   data: AleoGetProvePublicKeyResponse;
   stickySessionCookie: string[] | null;
 }> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
 
   const res = await network<AleoGetProvePublicKeyResponse>({
     method: "GET",
-    url: `${nodeUrl}/prove/${networkType}/pubkey`,
+    url: `${apiUrls.node}/prove/${networkType}/pubkey`,
   });
 
   const stickySessionCookie = res.headers?.["set-cookie"] ?? null;
@@ -257,20 +253,20 @@ async function getProvePublicKey({ currency }: { currency: CryptoCurrency }): Pr
 }
 
 async function submitEncryptedDelegatedProvingRequest({
-  currency,
+  config,
   keyId,
   encryptedData,
   stickySessionCookie,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   keyId: string;
   encryptedData: string;
   stickySessionCookie: string[] | null;
 }): Promise<DelegatedProvingResponse> {
-  const { nodeUrl, networkType } = getNetworkConfig(currency);
+  const { apiUrls, networkType } = config;
   const res = await network<DelegatedProvingResponse>({
     method: "POST",
-    url: `${nodeUrl}/prove/${networkType}/prove/encrypted`,
+    url: `${apiUrls.node}/prove/${networkType}/prove/encrypted`,
     ...(stickySessionCookie && {
       headers: { Cookie: stickySessionCookie.join("; ") },
     }),

--- a/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.test.ts
@@ -1,29 +1,17 @@
 import network from "@ledgerhq/live-network";
-import { getNetworkConfig } from "../logic/utils";
 import type { AleoEncryptedRegistrationResponse, FeeConfiguration, Intent } from "../types/sdk";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedPreparedRequestResponse } from "../__tests__/fixtures/sdk.fixture";
 import { sdkClient } from "./sdk";
 
 jest.mock("@ledgerhq/live-network");
-jest.mock("../logic/utils");
 
 describe("sdkClient", () => {
-  const mockCurrency = getMockedCurrency();
-  const mockNetworkConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://node.aleo.network",
-    sdkUrl: "https://sdk.aleo.network",
-    networkType: "mainnet",
-  };
-  const testnetConfig: ReturnType<typeof getNetworkConfig> = {
-    nodeUrl: "https://node.testnet.aleo.network",
-    sdkUrl: "https://sdk.testnet.aleo.network",
-    networkType: "testnet",
-  };
+  const mockConfig = getMockedConfig("mainnet");
+  const testnetConfig = getMockedConfig("testnet");
 
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.mocked(getNetworkConfig).mockReturnValue(mockNetworkConfig);
   });
 
   describe("encryptRegistrationPayload", () => {
@@ -31,25 +19,11 @@ describe("sdkClient", () => {
       encrypted: "mock_encrypted_data",
     };
 
-    it("should call getNetworkConfig with the provided currency", async () => {
-      jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
-
-      await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
-        publicKey: "aleo1publickey",
-        viewKey: "AViewKey1viewkey",
-        start: 0,
-      });
-
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
-    });
-
     it("should call network with correct method, url and data", async () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        config: mockConfig,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -58,7 +32,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/encrypt_registration`,
+        url: `${mockConfig.apiUrls.sdk}/encrypt_registration`,
         data: {
           public_key: "aleo1publickey",
           view_key: "AViewKey1viewkey",
@@ -71,7 +45,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       const result = await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        config: mockConfig,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -80,12 +54,11 @@ describe("sdkClient", () => {
       expect(result).toEqual(mockResponse);
     });
 
-    it("should construct the URL using sdkUrl from getNetworkConfig", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+    it("should construct the URL using sdkUrl from config", async () => {
       jest.mocked(network).mockResolvedValue({ data: mockResponse, status: 200 });
 
       await sdkClient.encryptRegistrationPayload({
-        currency: mockCurrency,
+        config: testnetConfig,
         publicKey: "aleo1publickey",
         viewKey: "AViewKey1viewkey",
         start: 0,
@@ -94,7 +67,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/encrypt_registration`,
+          url: `${testnetConfig.apiUrls.sdk}/encrypt_registration`,
         }),
       );
     });
@@ -105,7 +78,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.encryptRegistrationPayload({
-          currency: mockCurrency,
+          config: mockConfig,
           publicKey: "aleo1publickey",
           viewKey: "AViewKey1viewkey",
           start: 0,
@@ -128,7 +101,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockDecryptedData, status: 200 });
 
       const result = await sdkClient.decryptRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: mockCiphertext,
         viewKey: mockViewKey,
       });
@@ -136,7 +109,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/decrypt`,
+        url: `${mockConfig.apiUrls.sdk}/decrypt`,
         data: {
           ciphertext: mockCiphertext,
           view_key: mockViewKey,
@@ -151,7 +124,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.decryptRecord({
-          currency: mockCurrency,
+          config: mockConfig,
           ciphertext: mockCiphertext,
           viewKey: mockViewKey,
         }),
@@ -161,7 +134,7 @@ describe("sdkClient", () => {
 
   describe("decryptCiphertext", () => {
     const mockParams = {
-      currency: mockCurrency,
+      config: mockConfig,
       ciphertext: "ct1mock_ciphertext_data",
       tpk: "tpk1mock_transition_public_key",
       viewKey: "AViewKey1mock_view_key_data",
@@ -181,7 +154,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/symmetric_decrypt`,
+        url: `${mockConfig.apiUrls.sdk}/symmetric_decrypt`,
         headers: {
           "Content-Type": "application/json",
         },
@@ -234,18 +207,16 @@ describe("sdkClient", () => {
 
     it("should create a transaction request from intent", async () => {
       const result = await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: mockConfig,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
       });
 
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: null,
@@ -255,11 +226,9 @@ describe("sdkClient", () => {
       expect(result).toEqual(mockPreparedRequestResponse);
     });
 
-    it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
-
+    it("should use correct SDK URL from config", async () => {
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: testnetConfig,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -267,7 +236,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/transactions/request`,
+          url: `${testnetConfig.apiUrls.sdk}/transactions/request`,
         }),
       );
       expect(network).toHaveBeenCalledTimes(1);
@@ -281,7 +250,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: mockConfig,
         intent: largeAmountIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -289,7 +258,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: largeAmountIntent,
           fee: null,
@@ -305,7 +274,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createRequestFromIntent({
-          currency: mockCurrency,
+          config: mockConfig,
           intent: mockIntent,
           feeConfiguration: null,
           viewKey: mockViewKey,
@@ -319,7 +288,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createRequestFromIntent({
-          currency: mockCurrency,
+          config: mockConfig,
           intent: mockIntent,
           feeConfiguration: null,
           viewKey: mockViewKey,
@@ -334,7 +303,7 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: responseWithMetadata, status: 200 });
 
       const result = await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: mockConfig,
         intent: mockIntent,
         feeConfiguration: null,
         viewKey: mockViewKey,
@@ -351,7 +320,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: mockConfig,
         intent: mockIntent,
         feeConfiguration,
         viewKey: mockViewKey,
@@ -360,7 +329,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: feeConfiguration,
@@ -377,7 +346,7 @@ describe("sdkClient", () => {
       };
 
       await sdkClient.createRequestFromIntent({
-        currency: mockCurrency,
+        config: mockConfig,
         intent: mockIntent,
         feeConfiguration,
       });
@@ -385,7 +354,7 @@ describe("sdkClient", () => {
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/request`,
+        url: `${mockConfig.apiUrls.sdk}/transactions/request`,
         data: {
           intent: mockIntent,
           fee: feeConfiguration,
@@ -407,19 +376,17 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockAuthorizationResponse, status: 200 });
 
       const result = await sdkClient.createAuthorization({
-        currency: mockCurrency,
+        config: mockConfig,
         request: mockRequest,
         signatures: mockSignatures,
         viewKey: mockViewKey,
       });
 
       expect(result).toEqual(mockAuthorizationResponse);
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/transactions/authorization`,
+        url: `${mockConfig.apiUrls.sdk}/transactions/authorization`,
         data: {
           request: mockRequest,
           signatures: mockSignatures,
@@ -428,12 +395,11 @@ describe("sdkClient", () => {
       });
     });
 
-    it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+    it("should use correct SDK URL from config", async () => {
       jest.mocked(network).mockResolvedValue({ data: mockAuthorizationResponse, status: 200 });
 
       await sdkClient.createAuthorization({
-        currency: mockCurrency,
+        config: testnetConfig,
         request: mockRequest,
         signatures: mockSignatures,
         viewKey: mockViewKey,
@@ -441,7 +407,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/transactions/authorization`,
+          url: `${testnetConfig.apiUrls.sdk}/transactions/authorization`,
         }),
       );
     });
@@ -452,7 +418,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.createAuthorization({
-          currency: mockCurrency,
+          config: mockConfig,
           request: mockRequest,
           signatures: mockSignatures,
           viewKey: mockViewKey,
@@ -470,19 +436,17 @@ describe("sdkClient", () => {
       jest.mocked(network).mockResolvedValue({ data: mockEncryptedResponse, status: 200 });
 
       const result = await sdkClient.encryptProvingRequest({
-        currency: mockCurrency,
+        config: mockConfig,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
       });
 
       expect(result).toBe(mockEncryptedResponse.encrypted);
-      expect(getNetworkConfig).toHaveBeenCalledTimes(1);
-      expect(getNetworkConfig).toHaveBeenCalledWith(mockCurrency);
       expect(network).toHaveBeenCalledTimes(1);
       expect(network).toHaveBeenCalledWith({
         method: "POST",
-        url: `${mockNetworkConfig.sdkUrl}/encrypt_proving_request`,
+        url: `${mockConfig.apiUrls.sdk}/encrypt_proving_request`,
         data: {
           public_key: mockPublicKey,
           proving_request: {
@@ -494,12 +458,11 @@ describe("sdkClient", () => {
       });
     });
 
-    it("should use correct SDK URL from network config", async () => {
-      jest.mocked(getNetworkConfig).mockReturnValue(testnetConfig);
+    it("should use correct SDK URL from config", async () => {
       jest.mocked(network).mockResolvedValue({ data: mockEncryptedResponse, status: 200 });
 
       await sdkClient.encryptProvingRequest({
-        currency: mockCurrency,
+        config: testnetConfig,
         publicKey: mockPublicKey,
         authorization: mockAuthorization,
         broadcast: true,
@@ -507,7 +470,7 @@ describe("sdkClient", () => {
 
       expect(network).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${testnetConfig.sdkUrl}/encrypt_proving_request`,
+          url: `${testnetConfig.apiUrls.sdk}/encrypt_proving_request`,
         }),
       );
     });
@@ -518,7 +481,7 @@ describe("sdkClient", () => {
 
       await expect(
         sdkClient.encryptProvingRequest({
-          currency: mockCurrency,
+          config: mockConfig,
           publicKey: mockPublicKey,
           authorization: mockAuthorization,
           broadcast: true,

--- a/libs/coin-modules/coin-aleo/src/network/sdk.ts
+++ b/libs/coin-modules/coin-aleo/src/network/sdk.ts
@@ -1,7 +1,5 @@
 import network from "@ledgerhq/live-network";
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
-import { getNetworkConfig } from "../logic/utils";
-import type { AleoDecryptedCiphertextResponse } from "../types";
+import type { AleoCoinConfig, AleoDecryptedCiphertextResponse } from "../types";
 import type {
   AleoDecryptedRecordResponse,
   AleoEncryptedRegistrationResponse,
@@ -13,21 +11,21 @@ import type {
 } from "../types/sdk";
 
 async function encryptRegistrationPayload({
-  currency,
+  config,
   publicKey,
   viewKey,
   start,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   publicKey: string;
   viewKey: string;
   start: number;
 }): Promise<AleoEncryptedRegistrationResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<AleoEncryptedRegistrationResponse>({
     method: "POST",
-    url: `${sdkUrl}/encrypt_registration`,
+    url: `${apiUrls.sdk}/encrypt_registration`,
     data: {
       public_key: publicKey,
       view_key: viewKey,
@@ -39,19 +37,19 @@ async function encryptRegistrationPayload({
 }
 
 async function decryptRecord({
-  currency,
+  config,
   ciphertext,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   ciphertext: string;
   viewKey: string;
 }): Promise<AleoDecryptedRecordResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<AleoDecryptedRecordResponse>({
     method: "POST",
-    url: `${sdkUrl}/decrypt`,
+    url: `${apiUrls.sdk}/decrypt`,
     data: {
       ciphertext,
       view_key: viewKey,
@@ -62,7 +60,7 @@ async function decryptRecord({
 }
 
 async function decryptCiphertext({
-  currency,
+  config,
   ciphertext,
   tpk,
   viewKey,
@@ -70,7 +68,7 @@ async function decryptCiphertext({
   functionName,
   outputIndex,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   ciphertext: string;
   tpk: string;
   viewKey: string;
@@ -78,11 +76,11 @@ async function decryptCiphertext({
   functionName: string;
   outputIndex: number;
 }): Promise<AleoDecryptedCiphertextResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<AleoDecryptedCiphertextResponse>({
     method: "POST",
-    url: `${sdkUrl}/symmetric_decrypt`,
+    url: `${apiUrls.sdk}/symmetric_decrypt`,
     headers: {
       "Content-Type": "application/json",
     },
@@ -100,23 +98,23 @@ async function decryptCiphertext({
 }
 
 async function createRequestFromIntent({
-  currency,
+  config,
   intent,
   feeConfiguration,
   viewKey,
   tvks,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   intent: Intent;
   feeConfiguration: FeeConfiguration | null;
   viewKey?: string;
   tvks?: string[];
 }): Promise<PreparedRequestResponse> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<PreparedRequestResponse>({
     method: "POST",
-    url: `${sdkUrl}/transactions/request`,
+    url: `${apiUrls.sdk}/transactions/request`,
     data: {
       intent,
       fee: feeConfiguration,
@@ -129,21 +127,21 @@ async function createRequestFromIntent({
 }
 
 async function createAuthorization({
-  currency,
+  config,
   request,
   signatures,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   request: PreparedRequestResponse;
   signatures: string | string[];
   viewKey: string;
 }) {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<AuthorizationResponse>({
     method: "POST",
-    url: `${sdkUrl}/transactions/authorization`,
+    url: `${apiUrls.sdk}/transactions/authorization`,
     data: {
       request,
       signatures,
@@ -155,23 +153,23 @@ async function createAuthorization({
 }
 
 async function encryptProvingRequest({
-  currency,
+  config,
   publicKey,
   authorization,
   feeAuthorization,
   broadcast,
 }: {
   publicKey: string;
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   authorization: Record<string, unknown>;
   feeAuthorization?: Record<string, unknown>;
   broadcast: boolean;
 }): Promise<string> {
-  const { sdkUrl } = getNetworkConfig(currency);
+  const { apiUrls } = config;
 
   const res = await network<EncryptProvingRequestResponse>({
     method: "POST",
-    url: `${sdkUrl}/encrypt_proving_request`,
+    url: `${apiUrls.sdk}/encrypt_proving_request`,
     data: {
       public_key: publicKey,
       proving_request: {

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -9,7 +9,7 @@ import {
   RECIPIENT_ARG_INDEX,
   AMOUNT_ARG_INDEX,
 } from "../constants";
-import { getMockedCurrency } from "../__tests__/fixtures/currency.fixture";
+import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { sdkClient } from "../network/sdk";
 import type { ProvableApi } from "../types";
 import {
@@ -46,7 +46,7 @@ const mockDecryptCiphertext = jest.mocked(sdkClient.decryptCiphertext);
 const mockDecryptRecord = jest.mocked(sdkClient.decryptRecord);
 
 describe("network/utils", () => {
-  const mockCurrency = getMockedCurrency();
+  const mockConfig = getMockedConfig("mainnet");
   const mockAddress = "aleo1test123address456";
 
   beforeEach(() => {
@@ -79,7 +79,7 @@ describe("network/utils", () => {
           });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -87,13 +87,13 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(2);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenNthCalledWith(1, {
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "asc",
         });
         expect(apiClient.getAccountPublicTransactions).toHaveBeenNthCalledWith(2, {
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -118,7 +118,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -126,7 +126,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -152,7 +152,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -161,7 +161,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "desc",
@@ -188,7 +188,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -197,7 +197,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit,
           order: "asc",
@@ -220,7 +220,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -229,7 +229,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit,
           order: "asc",
@@ -249,7 +249,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: false,
           minBlockHeight,
@@ -258,7 +258,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "asc",
@@ -277,7 +277,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -298,7 +298,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -307,7 +307,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: customLimit,
           order: "asc",
@@ -324,7 +324,7 @@ describe("network/utils", () => {
         });
 
         await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -333,7 +333,7 @@ describe("network/utils", () => {
 
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledTimes(1);
         expect(apiClient.getAccountPublicTransactions).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           limit: 50,
           order: "desc",
@@ -381,7 +381,7 @@ describe("network/utils", () => {
         });
 
         const result = await fetchAccountTransactionsFromHeight({
-          currency: mockCurrency,
+          config: mockConfig,
           address: mockAddress,
           fetchAllPages: true,
           minBlockHeight,
@@ -418,23 +418,23 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 5 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          config: mockConfig,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
 
         expect(mockGetScannerPublicKey).toHaveBeenCalledTimes(1);
-        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockCurrency);
+        expect(mockGetScannerPublicKey).toHaveBeenCalledWith(mockConfig);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledTimes(1);
         expect(mockEncryptRegistrationPayload).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           publicKey: mockPublicKey,
           viewKey: mockViewKey,
           start: 0,
         });
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledTimes(1);
         expect(mockRegisterForScanningAccountRecords).toHaveBeenCalledWith({
-          currency: mockCurrency,
+          config: mockConfig,
           encryptedData: mockEncryptedData,
           keyId: mockKeyId,
         });
@@ -450,7 +450,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 60 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          config: mockConfig,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -470,7 +470,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: true, percentage: 100 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          config: mockConfig,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -493,7 +493,7 @@ describe("network/utils", () => {
 
         await expect(
           accessProvableApi({
-            currency: mockCurrency,
+            config: mockConfig,
             viewKey: mockViewKey,
             provableApi: existingProvableApi,
           }),
@@ -513,7 +513,7 @@ describe("network/utils", () => {
 
         await expect(
           accessProvableApi({
-            currency: mockCurrency,
+            config: mockConfig,
             viewKey: mockViewKey,
             provableApi: existingProvableApi,
           }),
@@ -529,7 +529,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue(null as any);
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          config: mockConfig,
           viewKey: mockViewKey,
           provableApi: existingProvableApi,
         });
@@ -542,7 +542,7 @@ describe("network/utils", () => {
         mockGetRecordScannerStatus.mockResolvedValue({ synced: false, percentage: 0 });
 
         const result = await accessProvableApi({
-          currency: mockCurrency,
+          config: mockConfig,
           viewKey: mockViewKey,
           provableApi: null,
         });
@@ -563,7 +563,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -600,7 +600,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -608,7 +608,7 @@ describe("network/utils", () => {
 
       expect(result).toBeNull();
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_pub_to_priv");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, "tx_pub_to_priv");
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
       expect(mockDecryptRecord).not.toHaveBeenCalled();
     });
@@ -625,7 +625,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -663,7 +663,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -705,7 +705,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -747,7 +747,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -789,7 +789,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -840,7 +840,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce({ plaintext: "750000u64" });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -854,7 +854,7 @@ describe("network/utils", () => {
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
       expect(mockDecryptRecord).not.toHaveBeenCalled();
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_recipient",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -863,7 +863,7 @@ describe("network/utils", () => {
         outputIndex: RECIPIENT_ARG_INDEX,
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_amount",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -907,7 +907,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -952,7 +952,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -965,7 +965,7 @@ describe("network/utils", () => {
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
       expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
       expect(mockDecryptRecord).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_output_record",
         viewKey: mockViewKey,
       });
@@ -1006,7 +1006,7 @@ describe("network/utils", () => {
       });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -1047,14 +1047,14 @@ describe("network/utils", () => {
       });
 
       await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
       });
 
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_with_spaces");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, "tx_with_spaces");
       expect(mockDecryptRecord).toHaveBeenCalledTimes(1);
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
@@ -1090,7 +1090,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -1136,7 +1136,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce({ plaintext: "800000u64" });
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -1147,7 +1147,7 @@ describe("network/utils", () => {
       expect(result?.value).toEqual(new BigNumber(800000));
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_recipient",
         tpk: "tpk_token",
         viewKey: mockViewKey,
@@ -1156,7 +1156,7 @@ describe("network/utils", () => {
         outputIndex: RECIPIENT_ARG_INDEX - 1,
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_amount",
         tpk: "tpk_token",
         viewKey: mockViewKey,
@@ -1196,7 +1196,7 @@ describe("network/utils", () => {
       );
 
       const result = await enrichPrivateRecord({
-        currency: mockCurrency,
+        config: mockConfig,
         rawRecord,
         address: mockEnrichAddress,
         viewKey: mockViewKey,
@@ -1220,7 +1220,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1251,7 +1251,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1297,7 +1297,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1339,7 +1339,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1385,7 +1385,7 @@ describe("network/utils", () => {
       mockDecryptCiphertext.mockResolvedValueOnce({ plaintext: "aleo1decrypted_recipient" });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [feeRecord],
         address: patchAddress,
@@ -1432,7 +1432,7 @@ describe("network/utils", () => {
 
       // no private records -> latestScannedBlockHeight = 0, which is less than tx block 100
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1447,7 +1447,7 @@ describe("network/utils", () => {
         }),
       ]);
       expect(mockGetTransactionById).toHaveBeenCalledTimes(1);
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, txHash);
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, txHash);
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(1);
       expect(mockDecryptCiphertext).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1496,7 +1496,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [scannerWatermarkRecord],
         address: patchAddress,
@@ -1525,7 +1525,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [patchedOp],
         privateRecords: [],
         address: patchAddress,
@@ -1566,7 +1566,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1608,7 +1608,7 @@ describe("network/utils", () => {
       mockGetTransactionById.mockResolvedValueOnce(mockDetails);
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [],
         address: patchAddress,
@@ -1648,7 +1648,7 @@ describe("network/utils", () => {
 
       await expect(
         patchPublicOperations({
-          currency: mockCurrency,
+          config: mockConfig,
           publicOperations: [publicOp],
           privateRecords: [],
           address: patchAddress,
@@ -1672,7 +1672,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [publicOp],
         privateRecords: [recordWithSpaces],
         address: patchAddress,
@@ -1705,7 +1705,7 @@ describe("network/utils", () => {
       });
 
       const result = await patchPublicOperations({
-        currency: mockCurrency,
+        config: mockConfig,
         publicOperations: [fullyPublicOp, semiPublicOp],
         privateRecords: [matchingRecord],
         address: patchAddress,
@@ -1734,13 +1734,13 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
       });
 
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(1);
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: DEFAULT_RECORDS_PAGE_SIZE,
         page: 0,
@@ -1762,14 +1762,14 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
 
       expect(mockGetAccountOwnedRecords).toHaveBeenCalledTimes(2);
       expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(1, {
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 0,
@@ -1782,7 +1782,7 @@ describe("network/utils", () => {
         ],
       });
       expect(mockGetAccountOwnedRecords).toHaveBeenNthCalledWith(2, {
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
         page: 1,
@@ -1801,7 +1801,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
       });
 
@@ -1814,7 +1814,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         unspent: true,
       });
@@ -1830,7 +1830,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(records);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         start: 5000,
       });
@@ -1845,7 +1845,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
       });
 
@@ -1859,7 +1859,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce([]);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
       });
 
@@ -1880,7 +1880,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce(page2);
 
       const result = await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
@@ -1897,7 +1897,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
@@ -1920,7 +1920,7 @@ describe("network/utils", () => {
       mockGetAccountOwnedRecords.mockResolvedValueOnce(page0).mockResolvedValueOnce(page1);
 
       await fetchAllOwnedRecords({
-        currency: mockCurrency,
+        config: mockConfig,
         uuid: mockUUID,
         resultsPerPage: pageSize,
       });
@@ -1947,7 +1947,7 @@ describe("network/utils", () => {
 
       await expect(
         fetchAllOwnedRecords({
-          currency: mockCurrency,
+          config: mockConfig,
           uuid: mockUUID,
         }),
       ).rejects.toThrow("Scanner unavailable");
@@ -1959,7 +1959,7 @@ describe("network/utils", () => {
 
       await expect(
         fetchAllOwnedRecords({
-          currency: mockCurrency,
+          config: mockConfig,
           uuid: mockUUID,
           signal: controller.signal,
         }),
@@ -1985,7 +1985,7 @@ describe("network/utils", () => {
       );
 
       const result = await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
@@ -1995,7 +1995,7 @@ describe("network/utils", () => {
         recipient: null,
         fee: new BigNumber(12345),
       });
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_missing_transition");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, "tx_missing_transition");
       expect(mockDecryptCiphertext).not.toHaveBeenCalled();
     });
 
@@ -2032,7 +2032,7 @@ describe("network/utils", () => {
       );
 
       const result = await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
@@ -2080,7 +2080,7 @@ describe("network/utils", () => {
         .mockResolvedValueOnce({ plaintext: "300000u64" });
 
       const result = await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
@@ -2092,7 +2092,7 @@ describe("network/utils", () => {
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledTimes(2);
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_recipient",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -2101,7 +2101,7 @@ describe("network/utils", () => {
         outputIndex: RECIPIENT_ARG_INDEX - 1,
       });
       expect(mockDecryptCiphertext).toHaveBeenCalledWith({
-        currency: mockCurrency,
+        config: mockConfig,
         ciphertext: "ciphertext_amount",
         tpk: "tpk_private",
         viewKey: mockViewKey,
@@ -2139,7 +2139,7 @@ describe("network/utils", () => {
       );
 
       const result = await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
@@ -2184,7 +2184,7 @@ describe("network/utils", () => {
       mockDecryptCiphertext.mockRejectedValue(new Error("decrypt failed"));
 
       const result = await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
@@ -2225,12 +2225,12 @@ describe("network/utils", () => {
       );
 
       await getTokenOutDetails({
-        currency: mockCurrency,
+        config: mockConfig,
         record,
         viewKey: mockViewKey,
       });
 
-      expect(mockGetTransactionById).toHaveBeenCalledWith(mockCurrency, "tx_with_spaces");
+      expect(mockGetTransactionById).toHaveBeenCalledWith(mockConfig, "tx_with_spaces");
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,4 +1,3 @@
-import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
 import { AleoApiConfigurationResetError } from "../errors";
@@ -19,6 +18,7 @@ import type {
   AleoPrivateRecord,
   AleoOperation,
   AleoTransition,
+  AleoCoinConfig,
 } from "../types";
 import {
   isAleoAddressPlaintext,
@@ -48,7 +48,7 @@ function hasReachedMinHeight(
 }
 
 export async function fetchAccountTransactionsFromHeight({
-  currency,
+  config,
   address,
   fetchAllPages,
   minBlockHeight,
@@ -56,7 +56,7 @@ export async function fetchAccountTransactionsFromHeight({
   limit = 50,
   order = "asc",
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   address: string;
   fetchAllPages: boolean;
   minBlockHeight: number;
@@ -73,7 +73,7 @@ export async function fetchAccountTransactionsFromHeight({
 
   while (hasMorePages) {
     const page = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address,
       limit,
       order,
@@ -139,7 +139,7 @@ export async function fetchAccountTransactionsFromHeight({
 /**
  * Fetches all pages of owned records from the scanner
  *
- * @param params.currency - The cryptocurrency being accessed
+ * @param params.config - The Aleo coin config
  * @param params.uuid - The scanner UUID for the account
  * @param params.unspent - When true, fetch only unspent records
  * @param params.start - Optional block height to start scanning from
@@ -147,7 +147,7 @@ export async function fetchAccountTransactionsFromHeight({
  * @returns A flat array of all matching records across all pages
  */
 export async function fetchAllOwnedRecords({
-  currency,
+  config,
   uuid,
   unspent,
   start,
@@ -161,7 +161,7 @@ export async function fetchAllOwnedRecords({
     EXPLORER_TRANSFER_TYPES.FEE_PRIVATE,
   ],
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   uuid: string;
   unspent?: boolean;
   start?: number;
@@ -177,7 +177,7 @@ export async function fetchAllOwnedRecords({
   while (hasMore) {
     signal?.throwIfAborted();
     const records = await apiClient.getAccountOwnedRecords({
-      currency,
+      config,
       uuid,
       ...(typeof unspent === "boolean" && { unspent }),
       ...(typeof start === "number" && { start }),
@@ -203,7 +203,7 @@ export async function fetchAllOwnedRecords({
  * - Account registration for scanning records if UUID is not set
  * - Retrieval of current scanner status
  *
- * @param currency - The cryptocurrency being accessed
+ * @param config - The Aleo coin config
  * @param viewKey - The view key for the account
  * @param provableApi - Existing Provable API credentials and state, or null for initial setup
  *
@@ -214,11 +214,11 @@ export async function fetchAllOwnedRecords({
  */
 
 export async function accessProvableApi({
-  currency,
+  config,
   viewKey,
   provableApi,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   viewKey: string;
   provableApi: ProvableApi | null;
 }): Promise<ProvableApi> {
@@ -228,17 +228,17 @@ export async function accessProvableApi({
   let status;
 
   if (!uuid) {
-    const { public_key, key_id } = await apiClient.getScannerPublicKey(currency);
+    const { public_key, key_id } = await apiClient.getScannerPublicKey(config);
 
     const { encrypted: encryptedData } = await sdkClient.encryptRegistrationPayload({
-      currency,
+      config,
       publicKey: public_key,
       viewKey,
       start: 0,
     });
 
     const { uuid: accountUuid } = await apiClient.registerForScanningAccountRecordsEncrypted({
-      currency,
+      config,
       encryptedData,
       keyId: key_id,
     });
@@ -247,7 +247,7 @@ export async function accessProvableApi({
   }
 
   try {
-    status = await apiClient.getRecordScannerStatus(currency, uuid);
+    status = await apiClient.getRecordScannerStatus(config, uuid);
   } catch (error) {
     const err = error as { name?: string; status?: number } | null | undefined;
     if (err?.name === "LedgerAPI4xx" && err?.status === 422) {
@@ -343,14 +343,14 @@ function getTransferArguments(
 }
 
 async function enrichOutgoingRecord({
-  currency,
+  config,
   rawRecord,
   recordTransition,
   transactionId,
   viewKey,
   address,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   rawRecord: AleoPrivateRecord;
   recordTransition: AleoTransition;
   transactionId: string;
@@ -382,7 +382,7 @@ async function enrichOutgoingRecord({
 
   const [recipientData, amountData] = await Promise.all([
     sdkClient.decryptCiphertext({
-      currency,
+      config,
       ciphertext: recipientArgument.value,
       tpk: recordTransition.tpk,
       viewKey,
@@ -391,7 +391,7 @@ async function enrichOutgoingRecord({
       outputIndex: recipientOutputIndex,
     }),
     sdkClient.decryptCiphertext({
-      currency,
+      config,
       ciphertext: amountArgument.value,
       tpk: recordTransition.tpk,
       viewKey,
@@ -409,20 +409,20 @@ async function enrichOutgoingRecord({
 }
 
 async function enrichIncomingRecord({
-  currency,
+  config,
   rawRecord,
   transactionId,
   viewKey,
   address,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   rawRecord: AleoPrivateRecord;
   transactionId: string;
   viewKey: string;
   address: string;
 }): Promise<EnrichedRecordData | null> {
   const outputRecord = await sdkClient.decryptRecord({
-    currency,
+    config,
     ciphertext: rawRecord.record_ciphertext,
     viewKey,
   });
@@ -444,12 +444,12 @@ async function enrichIncomingRecord({
 }
 
 export async function enrichPrivateRecord({
-  currency,
+  config,
   rawRecord,
   address,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   rawRecord: AleoPrivateRecord;
   address: string;
   viewKey: string;
@@ -464,7 +464,7 @@ export async function enrichPrivateRecord({
     return null;
   }
 
-  const details = await apiClient.getTransactionById(currency, transactionId);
+  const details = await apiClient.getTransactionById(config, transactionId);
 
   if (shouldSkipPublicToPrivateRecord(rawRecord, address)) {
     return null;
@@ -478,7 +478,7 @@ export async function enrichPrivateRecord({
   const enrichedRecordData =
     rawRecord.sender === address
       ? await enrichOutgoingRecord({
-          currency,
+          config,
           rawRecord,
           recordTransition,
           transactionId,
@@ -486,7 +486,7 @@ export async function enrichPrivateRecord({
           address,
         })
       : await enrichIncomingRecord({
-          currency,
+          config,
           rawRecord,
           transactionId,
           viewKey,
@@ -529,14 +529,14 @@ function splitPublicAndSemiPublicOperations(
  * @returns Array of patched operations including additional operations for semi transparent transfers
  */
 export const patchPublicOperations = async ({
-  currency,
+  config,
   publicOperations,
   privateRecords,
   address,
   ledgerAccountId,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   publicOperations: AleoOperation[];
   privateRecords: AleoPrivateRecord[];
   address: string;
@@ -610,7 +610,7 @@ export const patchPublicOperations = async ({
     // - semi-transparent transfer from another account to another account
     // - semi-transparent transfer from our own account to another account
     else {
-      const txDetails = await apiClient.getTransactionById(currency, operation.hash);
+      const txDetails = await apiClient.getTransactionById(config, operation.hash);
       const recordTransition = txDetails.execution.transitions[0] ?? null;
       const recipientInput = recordTransition?.inputs[0] ?? {};
       const recipientArgument = "value" in recipientInput ? recipientInput : null;
@@ -626,7 +626,7 @@ export const patchPublicOperations = async ({
           operation.extra.programId ?? recordTransition.program ?? PROGRAM_ID.CREDITS;
 
         const recipientData = await sdkClient.decryptCiphertext({
-          currency,
+          config,
           ciphertext: recipientArgument.value,
           tpk: recordTransition.tpk,
           viewKey,
@@ -667,15 +667,15 @@ export const patchPublicOperations = async ({
  * callers should fall back to 0 for amount and omit the recipient.
  */
 export async function getTokenOutDetails({
-  currency,
+  config,
   record,
   viewKey,
 }: {
-  currency: CryptoCurrency;
+  config: AleoCoinConfig;
   record: AleoPrivateRecord;
   viewKey: string;
 }): Promise<{ amount: BigNumber | null; recipient: string | null; fee: BigNumber }> {
-  const txDetails = await apiClient.getTransactionById(currency, record.transaction_id.trim());
+  const txDetails = await apiClient.getTransactionById(config, record.transaction_id.trim());
   const fee = new BigNumber(txDetails.fee_value);
   const transition = txDetails.execution?.transitions[record.transition_index];
 
@@ -715,7 +715,7 @@ export async function getTokenOutDetails({
 
     try {
       const dec = await sdkClient.decryptCiphertext({
-        currency,
+        config,
         ciphertext: input.value,
         tpk: transition.tpk,
         viewKey,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Refactor Aleo network apiClient and sdkClient to receive coin config directly instead of resolving it via currency lookup, removing redundant currency plumbing throughout the sync/signing paths.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-28042