### PR TITLE
feat: save name validation

### DIFF
--- a/.changeset/flow-contacts-add-contact-validation-errors.md
+++ b/.changeset/flow-contacts-add-contact-validation-errors.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"@domain/entity-contact": minor
+---
+
+Expose shared add-contact invalid name validation state

--- a/domain/entity/contact/src/errors.test.ts
+++ b/domain/entity/contact/src/errors.test.ts
@@ -1,0 +1,10 @@
+import { InvalidContactNameError, INVALID_CONTACT_NAME_ERROR_NAME } from "./errors";
+
+describe("errors", () => {
+  it("InvalidContactNameError extends Error and keeps the stable name", () => {
+    const error = new InvalidContactNameError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+  });
+});

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -1,0 +1,16 @@
+export class ContactError extends Error {
+  override name = "ContactError";
+}
+
+export class InvalidContactNameError extends ContactError {
+  override name = "InvalidContactNameError";
+
+  constructor() {
+    super("Expected letters, spaces, apostrophes, or hyphens");
+  }
+}
+
+export type ContactNameValidationErrorName = "InvalidContactNameError";
+
+export const INVALID_CONTACT_NAME_ERROR_NAME =
+  "InvalidContactNameError" satisfies ContactNameValidationErrorName;

--- a/domain/entity/contact/src/index.ts
+++ b/domain/entity/contact/src/index.ts
@@ -3,3 +3,5 @@ export * from "./types";
 export * from "./define";
 export * from "./slice";
 export * from "./selectors";
+export * from "./errors";
+export * from "./validation";

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,0 +1,31 @@
+import { InvalidContactNameError, INVALID_CONTACT_NAME_ERROR_NAME } from "./errors";
+import { getContactNameValidationError, isValidContactName, parseContactName } from "./validation";
+
+describe("contact name validation", () => {
+  it("does not report an error for an empty draft name", () => {
+    expect(getContactNameValidationError("")).toBeNull();
+    expect(getContactNameValidationError("   ")).toBeNull();
+  });
+
+  it("does not report an error for a valid draft name", () => {
+    expect(getContactNameValidationError("Ben")).toBeNull();
+  });
+
+  it("reports the stable InvalidContactNameError name for a non-empty invalid draft name", () => {
+    expect(getContactNameValidationError("Olive2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+  });
+
+  it("validates trimmed names consistently", () => {
+    expect(isValidContactName("  Ben  ")).toBe(true);
+    expect(isValidContactName("Olive2")).toBe(false);
+    expect(isValidContactName("")).toBe(false);
+  });
+
+  it("parseContactName throws InvalidContactNameError for an invalid draft name", () => {
+    expect(() => parseContactName("Olive2")).toThrow(InvalidContactNameError);
+  });
+
+  it("parseContactName returns a parsed name for a valid draft name", () => {
+    expect(parseContactName("  Ben  ")).toBe("Ben");
+  });
+});

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,0 +1,35 @@
+import {
+  INVALID_CONTACT_NAME_ERROR_NAME,
+  InvalidContactNameError,
+  type ContactNameValidationErrorName,
+} from "./errors";
+import { ContactNameSchema } from "./schema";
+import type { ContactName } from "./types";
+
+export function getContactNameValidationError(
+  draftName: string,
+): ContactNameValidationErrorName | null {
+  const trimmedDraftName = draftName.trim();
+
+  if (trimmedDraftName.length === 0) {
+    return null;
+  }
+
+  return ContactNameSchema.safeParse(trimmedDraftName).success
+    ? null
+    : INVALID_CONTACT_NAME_ERROR_NAME;
+}
+
+export function isValidContactName(draftName: string): boolean {
+  return draftName.trim().length > 0 && getContactNameValidationError(draftName) === null;
+}
+
+export function parseContactName(draftName: string): ContactName {
+  const parsed = ContactNameSchema.safeParse(draftName.trim());
+
+  if (!parsed.success) {
+    throw new InvalidContactNameError();
+  }
+
+  return parsed.data;
+}

--- a/features/flow/contacts/src/add/controller.test.ts
+++ b/features/flow/contacts/src/add/controller.test.ts
@@ -18,6 +18,15 @@ describe("createAddContactController", () => {
     expect(controller.getViewModel("Ben").isSaveEnabled).toBe(true);
   });
 
+  it("exposes the stable invalid name error while the draft name is invalid", () => {
+    const controller = createAddContactController(createContactCreationPort(jest.fn()));
+
+    expect(controller.getViewModel("Olive2")).toMatchObject({
+      invalidNameError: "InvalidContactNameError",
+      isSaveEnabled: false,
+    });
+  });
+
   it("rejects save when the draft name is empty", async () => {
     const controller = createAddContactController(createContactCreationPort(jest.fn()));
 

--- a/features/flow/contacts/src/add/controller.ts
+++ b/features/flow/contacts/src/add/controller.ts
@@ -1,4 +1,4 @@
-import { ContactNameSchema, type Contact } from "@domain/entity-contact";
+import { parseContactName, type Contact } from "@domain/entity-contact";
 import type { ContactCreationPort } from "./ports";
 import { createAddContactViewModel } from "./viewModel";
 import type { AddContactViewModel } from "./types";
@@ -14,9 +14,9 @@ export function createAddContactController(
   return {
     getViewModel: draftName => createAddContactViewModel(draftName),
     save: async draftName => {
-      const parsedName = ContactNameSchema.parse(draftName.trim());
+      const name = parseContactName(draftName);
 
-      return contactCreation.createContact({ name: parsedName });
+      return contactCreation.createContact({ name });
     },
   };
 }

--- a/features/flow/contacts/src/add/types.ts
+++ b/features/flow/contacts/src/add/types.ts
@@ -1,5 +1,8 @@
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
+
 export type AddContactViewModel = Readonly<{
   draftName: string;
   avatarInitial: string;
+  invalidNameError: ContactNameValidationErrorName | null;
   isSaveEnabled: boolean;
 }>;

--- a/features/flow/contacts/src/add/viewModel.test.ts
+++ b/features/flow/contacts/src/add/viewModel.test.ts
@@ -1,3 +1,4 @@
+import { INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
 import { createAddContactViewModel } from "./viewModel";
 
 describe("createAddContactViewModel", () => {
@@ -5,6 +6,7 @@ describe("createAddContactViewModel", () => {
     expect(createAddContactViewModel("")).toEqual({
       draftName: "",
       avatarInitial: "",
+      invalidNameError: null,
       isSaveEnabled: false,
     });
   });
@@ -13,13 +15,16 @@ describe("createAddContactViewModel", () => {
     expect(createAddContactViewModel("Ben")).toEqual({
       draftName: "Ben",
       avatarInitial: "B",
+      invalidNameError: null,
       isSaveEnabled: true,
     });
   });
 
-  it("disables save for an invalid draft name", () => {
-    expect(createAddContactViewModel("Olive2")).toMatchObject({
+  it("exposes the stable invalid name error for an invalid draft name", () => {
+    expect(createAddContactViewModel("Olive2")).toEqual({
       draftName: "Olive2",
+      avatarInitial: "O",
+      invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
       isSaveEnabled: false,
     });
   });

--- a/features/flow/contacts/src/add/viewModel.ts
+++ b/features/flow/contacts/src/add/viewModel.ts
@@ -1,13 +1,15 @@
-import { ContactNameSchema } from "@domain/entity-contact";
+import { getContactNameValidationError } from "@domain/entity-contact";
 import { getContactInitial } from "../list/internals";
 import type { AddContactViewModel } from "./types";
 
 export function createAddContactViewModel(draftName: string): AddContactViewModel {
   const trimmedDraftName = draftName.trim();
+  const invalidNameError = getContactNameValidationError(draftName);
 
   return {
     draftName,
     avatarInitial: getContactInitial(trimmedDraftName),
-    isSaveEnabled: ContactNameSchema.safeParse(trimmedDraftName).success,
+    invalidNameError,
+    isSaveEnabled: trimmedDraftName.length > 0 && invalidNameError === null,
   };
 }

--- a/features/flow/contacts/src/hooks/useAddContactViewModel.test.ts
+++ b/features/flow/contacts/src/hooks/useAddContactViewModel.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { contact } from "@domain/entity-contact";
+import { INVALID_CONTACT_NAME_ERROR_NAME, contact } from "@domain/entity-contact";
 import type { ContactCreationPort } from "../add/ports";
 import { useAddContactViewModel } from "./useAddContactViewModel";
 
@@ -20,8 +20,23 @@ describe("useAddContactViewModel", () => {
     expect(result.current).toMatchObject({
       draftName: "Ben",
       avatarInitial: "B",
+      invalidNameError: null,
       isSaveEnabled: true,
     });
+  });
+
+  it("exposes the stable invalid name error when the draft name is invalid", () => {
+    const contactCreation: ContactCreationPort = {
+      createContact: jest.fn(),
+    };
+    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+
+    act(() => {
+      result.current.setDraftName("Olive2");
+    });
+
+    expect(result.current.invalidNameError).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(result.current.isSaveEnabled).toBe(false);
   });
 
   it("delegates save to the injected creation port", async () => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces a shared validation mechanism for contact names and updates the add-contact flow to expose and handle invalid name errors. The changes ensure that invalid contact names are consistently validated and that the UI can display relevant validation errors. Tests have been added and updated to verify the new validation logic.

**Contact Name Validation Logic:**

* Added a shared validation module (`validation.ts`) in `@domain/entity-contact` that provides `getContactNameValidationError` and `isValidContactName` functions, along with the `CONTACT_NAME_VALIDATION_ERROR` constant and type.
* Exported the new validation utilities from the contact entity index for use in other modules.

**Add-Contact Flow Integration:**

* Updated the add-contact view model (`createAddContactViewModel` in `viewModel.ts` and related types) to use the shared validation logic and expose an `invalidNameError` field for invalid names. 
* Modified tests and controller logic to check for and assert on the presence of `invalidNameError` when the draft name is invalid, ensuring the UI can react accordingly. 

**Testing and Documentation:**

* Added comprehensive unit tests for the contact name validation logic and updated existing tests in the add-contact flow to cover the new validation error exposure. 
* Documented the feature addition in a changeset.

### 🔗 Context

[LIVE-33901](https://ledgerhq.atlassian.net/browse/LIVE-33901)


[LIVE-33901]: https://ledgerhq.atlassian.net/browse/LIVE-33901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ