### PR TITLE
[LWDM] Feat(LIVE-34467): aleo integ tests part 1

### DIFF
--- a/.changeset/popular-eels-notice.md
+++ b/.changeset/popular-eels-notice.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/coin-aleo": patch
+"@ledgerhq/coin-aleo": minor
 ---
 
 test: improve aleo integration tests coverage

--- a/.changeset/popular-eels-notice.md
+++ b/.changeset/popular-eels-notice.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": patch
+---
+
+test: improve aleo integration tests coverage

--- a/libs/coin-modules/coin-aleo/.unimportedrc.json
+++ b/libs/coin-modules/coin-aleo/.unimportedrc.json
@@ -11,6 +11,7 @@
   ],
   "ignorePatterns": [
     "**/node_modules/**",
+    "**/__tests__/**",
     "**/*.fixture.ts",
     "**/*.mock.ts",
     "**/*.test.{js,jsx,ts,tsx}"

--- a/libs/coin-modules/coin-aleo/jest.config.js
+++ b/libs/coin-modules/coin-aleo/jest.config.js
@@ -19,7 +19,13 @@ module.exports = {
       },
     ],
   },
-  testPathIgnorePatterns: ["lib/", "lib-es/", ".integration.test.ts", ".integ.test.ts"],
+  testPathIgnorePatterns: [
+    "lib/",
+    "lib-es/",
+    ".integration.test.ts",
+    ".integ.test.ts",
+    "__tests__/",
+  ],
   modulePathIgnorePatterns: ["__tests__/fixtures"],
   reporters: [
     "default",

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/api.fixture.ts
@@ -200,25 +200,232 @@ export function getMockedEnrichedPrivateRecord(
   };
 }
 
-export const testnetViewKey = "AViewKey1tTb4WYnMFnDWjSgTSA5VkiyLKNZH1szDcMyEuzSu1zbk";
+export const testnetViewKey = "AViewKey1jyaKC65RhaGN3b6h79hLdwTBk3YAMbRL1MMeCArLDJ6E";
 
-// this record has `microcredits: "800000u64.private"` in the decrypted data
-export const testnetPrivateRecord: AleoPrivateRecord = {
-  block_height: 14192647,
-  block_timestamp: 1770127220,
-  commitment: "5577911026701224136131721605774668283349812508334064746703596134075753528694field",
-  function_name: "transfer_public_to_private",
+// Integration tests fixtures
+//
+// testnetAddress/testnetViewKey point at the team's dedicated Aleo testnet seed account
+// (small, controlled tx history — keeps `pnpm coin:aleo test-integ` fast and deterministic).
+// All values below (tx ids, amounts, fees, block heights/hashes, decrypted recipients) are
+// real chain data pulled from that account, not fabricated.
+//
+// Record scanner responses pad transaction_id/transition_id to a fixed width, so those fields
+// keep their trailing spaces here verbatim — call sites .trim() them.
+
+export const testnetAddress = "aleo1uhf67fhy46jvv5hadf586pkdarax6ppuzq8xtpk7jdk9hhujku8sfa39ml";
+export const testnetLedgerAccountId = `js:2:aleo_testnet:${testnetAddress}:`;
+
+// Inbound native transfer_public from a third party.
+export const referenceTransferPublicTx = {
+  id: "at1tywkrphxmm47ry8zrr30h27ae9st4lnza295mkgu0tgals2qlqpsy797ng",
+  blockHash: "ab1t7s68spdt4qzrh2lrcv87za9ga8hhckxwrgnrhaxd025hmznr5rqdkn0f4",
+  blockHeight: 18140205,
+  sender: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+  recipient: testnetAddress,
+  value: 1000000,
+  fee: 2725,
+};
+
+// Rejected self-transfer (sender === recipient === testnetAddress on credits.aleo, so it
+// classifies as type "IN" — this account's only 2 Rejected txs are both self-transfers).
+export const referenceFailedTransferPublicTx = {
+  id: "at1v6ltk8nl59xygf47jkfzkky20jqcune2a8e9e7juw5ge4ksegg9sl92e4n",
+  blockHash: "ab1ylkge4yau4n7apn3qn4cfnuxssc4um77tx60np8p37van80whcpsed6tny",
+  blockHeight: 18140530,
+  sender: testnetAddress,
+  recipient: testnetAddress,
+  value: 100977275,
+  fee: 2725,
+};
+
+// Incoming private transfer_private (USAD token) from a third party.
+export const testnetIncomingPrivateRecord1: AleoPrivateRecord = {
+  block_height: 18140237,
+  block_timestamp: 1784723374,
+  commitment: "617000749956434394410612068854231617966302744000835069812024420526288185879field",
+  function_name: "transfer_private",
+  output_index: 2,
+  owner: "4376890048891554766371961235062563625708746456629390535882860164705933280131field",
+  program_name: "test_usad_stablecoin.aleo",
+  record_ciphertext:
+    "record1qvqspsaa5lnv4hzngdp3j9nupr99edtedhehexl9877dunqs4773t0cqqyrxzmt0w4h8ggcqqgqsq7u2z5zn49wg7dsfcmzrxgmyt9n7t28d89rzwr26v4n82vrk0vs8p53rnus9z2x0pdur4nqx933cwcg0laj72p0ycxvg4knd2hxldq9s03hs97",
+  record_name: "Token",
+  sender: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+  spent: true,
+  tag: "6536029625204622934622029539749775399091767334234898271579078276003642217007field",
+  transaction_id: "at1tpm2ara52q2udq9adaga348wxsrvf8tukgg4mpk7hwm4rnm8l5yql3w8z9    ",
+  transition_id: "au1p559t583kffcactwhpqzpsvur7x7fuh6eysvfft9jy5xcu4cpurqqcfu73    ",
+  transaction_index: 0,
+  transition_index: 0,
+};
+
+// Incoming private transfer_private (credits) from a third party.
+export const testnetIncomingPrivateRecord2: AleoPrivateRecord = {
+  block_height: 18140198,
+  block_timestamp: 1784723235,
+  commitment: "5393587348407548654408434195241212354951323226624605903120980321138262732639field",
+  function_name: "transfer_private",
   output_index: 0,
-  owner: "4061324383530370528773115724536366126386700749943799382889243452721616108297field",
+  owner: "4376890048891554766371961235062563625708746456629390535882860164705933280131field",
   program_name: "credits.aleo",
   record_ciphertext:
-    "record1qvqsps6wqrka73247spvsvdlgwr8qhmn5f4uze4t8zutp4k8mwm3zdgtqyxx66trwfhkxun9v35hguerqqpqzqrpdge64jwzyz32aknuxc800uugfwv52pqse4dk4p32datlzpd8z95td5t0dhdm4dfhtq9w285uj2arltzky4u6hmdv2xpdnkv365l3qg9hn0g",
+    "record1qvqspfx56gdd3xpypzyjjy0cq3e6z6qsl567vnnvlfxasumdc2sdmsssqyxx66trwfhkxun9v35hguerqqpqzq93cul35wv4jdns30ge9kffdj4m8m7ns7wt3vkmd8dq65t6lapnp8psy84n4uzs5l9p3ljquqn2mxx58tcd4l6w7xducgkj33m00nkqsedw0n8",
   record_name: "credits",
-  sender: "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f",
+  sender: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+  spent: true,
+  tag: "887468612124957275709993390220003380630741693066953074610446212632873805452field",
+  transaction_id: "at14zv9mxgvv78w5r7v9mm9hpyjvj6hczq8g44fxvfmjhdvg5sp2q8s6ry6n9    ",
+  transition_id: "au1kdmrtwa99w8fj94d23f8yhusezmwusjk83420pxpc63y5cvcusrsa3dsv9    ",
+  transaction_index: 0,
+  transition_index: 0,
+};
+
+// Change record from an outgoing transfer_private (credits) — testnetAddress sent 1
+// microcredit out, kept 69999 back. Real decrypted recipient is a third party.
+export const testnetOutgoingChangeRecord: AleoPrivateRecord = {
+  block_height: 18140913,
+  block_timestamp: 1784725777,
+  commitment: "972283894715646643445412145796667731505755537305166732912653860904895591858field",
+  function_name: "transfer_private",
+  output_index: 1,
+  owner: "4376890048891554766371961235062563625708746456629390535882860164705933280131field",
+  program_name: "credits.aleo",
+  record_ciphertext:
+    "record1qvqsq58cqccdcscegwr0uwyztmfvd8x9c66wqzakly9dskmr2hes5wgwqyxx66trwfhkxun9v35hguerqqpqzq9ylrsar0xkdyz6hu5c6hnlwet8lkm2uqf88may3pv2qvz78fd3zqalyqrrtr27j5kgz6h3xxatpn20x3z8zcp9kkhxjwhh6e2a5pkpq9y6weg",
+  record_name: "credits",
+  sender: testnetAddress,
   spent: false,
-  tag: "4138557248634429596246575371443174357174703200753459213664031563822892655489field",
-  transaction_id: "at144lgzzq73r38hx4jvtecxteg8v32creg2pxpazs9n4xcduu5jsfqv43lx9    ",
-  transition_id: "au1mxddgfe8yl0yadjrm6qaz6wqljtlqth885muwxvrzvpd9852cyqqxhxr76    ",
+  tag: "7049880475565599900269739447529902813115071775806317707080891849101393223250field",
+  transaction_id: "at19p0dlt05nv06dnvk2wymd2denkke8kgzc7k5w8x6tzjk9rsamvysglmznk    ",
+  transition_id: "au12wnhyuhhncshtsrdfw2nf0q0r3acx4hdtqsr0svsqzqn4hs54qzsdm9av3    ",
+  transaction_index: 0,
+  transition_index: 0,
+};
+
+// tag of the record consumed as the input to testnetOutgoingChangeRecord's transaction
+export const testnetConsumedRecordTag =
+  "2804102848750158300015081071011994354147556116878781998669735218310444038662field";
+
+export const testnetPrivateRecord: AleoPrivateRecord = testnetOutgoingChangeRecord;
+
+export const testnetSelfConversionTx: AleoPublicTransaction = {
+  transaction_id: "at195ql6qgnjez6cmshd08axspr4wze8w3k93pydpml2qeqtrtf3ursn7aest",
+  transition_id: "au1yty0yhkepee4h5vwunlrq34nxftw9m3q6kgyk822q79avh3ntqqs2zh6ay",
+  transaction_status: "Accepted",
+  block_number: 18140241,
+  block_timestamp: "1784723386",
+  function_id: "transfer_public_to_private",
+  amount: 40000,
+  sender_address: testnetAddress,
+  recipient_address: "",
+  program_id: "credits.aleo",
+  fee: 2304,
+  block_hash: "ab1rwtek42atm8f684w4rthcwhsvxen967gh0y9n49g3aqjcjfhyc9q047m2w",
+};
+
+export const testnetMatchingPrivateRecord: AleoPrivateRecord = {
+  transaction_id: testnetSelfConversionTx.transaction_id,
+  block_height: testnetSelfConversionTx.block_number,
+  transition_index: 0,
+  function_name: "transfer_public_to_private",
+  sender: testnetAddress,
+  record_ciphertext:
+    "record1qvqsps7vj52rzarp5086axl2s9fd8aegt5xk9lzzc6hleul0j87a42s9qyxx66trwfhkxun9v35hguerqqpqzqql2ndz7nz7dph04pj2mzpecf6fnqlthzc02ds9kf4f4a4pq6q4pr78a7g8gvkwmm8h3kk0n77un9yll7xkluhdfvhtr24chwh0yg4pq3qfntn",
+  program_name: "credits.aleo",
+  block_timestamp: 1784723386,
+  commitment: "5149004594992751980906412565011737332363200190257547267783655949005464254071field",
+  output_index: 0,
+  owner: testnetAddress,
+  record_name: "credits",
+  spent: true,
+  tag: "7476707562559171997214599869656425013100816241248032462223077391492620471705field",
+  transition_id: "au1yty0yhkepee4h5vwunlrq34nxftw9m3q6kgyk822q79avh3ntqqs2zh6ay",
+  transaction_index: 0,
+};
+
+// sender_address is blank on-chain here (private input, not omitted data)
+export const testnetInboundPrivateToPublicTx: AleoPublicTransaction = {
+  transaction_id: "at1ru0pnp4djgdd4cxpmjsaqkzke9gcmx20ensxfk4pev6gylz4xs8spszpn6",
+  transition_id: "au1h42kmls4srk6xdm4ze6dk7gmjca5z6ws4y0h9v48z2gs5h8zlypq27lyn2",
+  transaction_status: "Accepted",
+  block_number: 18140248,
+  block_timestamp: "1784723415",
+  function_id: "transfer_private_to_public",
+  amount: 20000,
+  sender_address: "",
+  recipient_address: testnetAddress,
+  program_id: "credits.aleo",
+  fee: 2826,
+  block_hash: "ab1mq5uh3m55asxehmp0p4w2d6tpjgckau0ne5rwercdkj2dzemrvzq4ezk0x",
+};
+
+export const TEST_TOKEN_PROGRAM_ID = "test_usad_stablecoin.aleo";
+
+// Outgoing transfer_private_to_public (credits) — testnetAddress converts a private record to
+// a THIRD PARTY's public balance (not itself). Exercises getTokenOutDetails's PRIVATE_TO_PUBLIC
+// branch, which is program-agnostic (reads plaintext public inputs, no token-argument offset).
+export const testnetOutgoingPrivateToPublicRecord: AleoPrivateRecord = {
+  block_height: 18140930,
+  block_timestamp: 1784725835,
+  commitment: "3370831306241866899435465229889427783819801082442994275880252318917098679540field",
+  function_name: "transfer_private_to_public",
+  output_index: 0,
+  owner: "4376890048891554766371961235062563625708746456629390535882860164705933280131field",
+  program_name: "credits.aleo",
+  record_ciphertext:
+    "record1qvqsqhljy6pthjdz59jvvtaylhfe7gwqx8s58r5ezj9erxax3259grg0qyxx66trwfhkxun9v35hguerqqpqzqzh820wtusnaq579x4j2dt8ylcsr4vxd68xxq9ekaczmeg27yxkqj2f92ze7jr9pueenmuw046mrku0kp8rdntpq6ccqvk6pvkyzj2s7wzdzlt",
+  record_name: "credits",
+  sender: testnetAddress,
+  spent: false,
+  tag: "5193253143771075521166756894688973688732317086718207582571507084795422235795field",
+  transaction_id: "at10jt4v3glr9pkrpndqclgasqa8ed4hu0gj7r3qujmqhmaekrv05qq5a6tsx    ",
+  transition_id: "au1w9sl4j5g3fkajdz0s4c23qpl4tj055l9j47cxemuzlhfu588nsxstgafae    ",
+  transaction_index: 0,
+  transition_index: 0,
+};
+
+// Outgoing transfer_public_to_private (credits) where testnetAddress is the PUBLIC SENDER but
+// the resulting private record is owned by a THIRD PARTY (no matching record in our own private
+// history — decrypted via the sender's own view key). Exercises patchPublicOperations's
+// "private record not found" branch.
+export const testnetThirdPartyConversionTx: AleoPublicTransaction = {
+  transaction_id: "at1jxfrgfn094jsj7qsqnn7acnzss0kj8avqa49uxwtkaexvj44cqxsnzrtfh",
+  transition_id: "au16tnzsz3u5xtzxd0zmwdvx0j9mqw6vc3k93hg6gl9aqsyc8ges5xqfh4qn9",
+  transaction_status: "Accepted",
+  block_number: 18142836,
+  block_timestamp: "1784732700",
+  function_id: "transfer_public_to_private",
+  amount: 1,
+  sender_address: testnetAddress,
+  recipient_address: "",
+  program_id: "credits.aleo",
+  fee: 2304,
+  block_hash: "ab16ddsrma8tkgrhy070mr07ll2wx48tg5v6kj8vaqhgjftpkf7ev9sknjn0c",
+};
+// Real decrypted recipient (via testnetViewKey as the sender's own view key).
+export const testnetThirdPartyRealRecipient =
+  "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs";
+
+// Change record from an outgoing fully-private (transfer_private, not private-to-public) TOKEN
+// transfer — testnetAddress sends its whole 1u128 test_usad balance to a third party, keeping 0
+// back. Exercises getTokenOutDetails's fully-private branch, which reads token-program argument
+// offsets — a credits.aleo record cannot substitute here.
+export const testnetOutgoingPrivateTokenRecord: AleoPrivateRecord = {
+  block_height: 18142903,
+  block_timestamp: 1784732952,
+  commitment: "7697418092607833431542672676731397551535700112850932363436936462037048292936field",
+  function_name: "transfer_private",
+  output_index: 1,
+  owner: "4376890048891554766371961235062563625708746456629390535882860164705933280131field",
+  program_name: "test_usad_stablecoin.aleo",
+  record_ciphertext:
+    "record1qvqsqdn9cdhqrd2e742s59zyxyqljzj90yylsq82hlexw7n789dejqcxqyrxzmt0w4h8ggcqqgqspll4m395r8arplc3u8tfe27f74zyxfjaads7cf98apzwymrxnuc2066smls02l8csutd00mxayg95e2h5hstkk3k9r50jkh8jmqh7ygsgxksk0",
+  record_name: "Token",
+  sender: testnetAddress,
+  spent: false,
+  tag: "4392512920219901218231725864729520973094519988822818816129624829367585023809field",
+  transaction_id: "at1dj2hj6pufrcrqfzuuetg26h2sntpecn7jfc3lddqkkr8n5w9nqfqpwj874    ",
+  transition_id: "au1l7gtqkk8knrwhfml5zq9pql3w9ajgcns8hjkh7merq8tuh9xqcxq8c4906    ",
   transaction_index: 0,
   transition_index: 0,
 };

--- a/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/fixtures/config.fixture.ts
@@ -1,3 +1,4 @@
+import { getEnv } from "@ledgerhq/live-env";
 import { TRANSACTION_TYPE } from "../../constants";
 import type { AleoCoinConfig, TransactionType } from "../../types";
 
@@ -28,3 +29,23 @@ export const getMockedConfig = (networkType: "mainnet" | "testnet"): AleoCoinCon
     status: { type: "active" },
   };
 };
+
+/**
+ * Real testnet config for *.integ.test.ts files, pointed at the live Aleo testnet node
+ * and SDK endpoints. Pass `overrides` for scenario-specific flags (e.g. `enableTokens`).
+ */
+export const getTestnetIntegConfig = (overrides?: Partial<AleoCoinConfig>): AleoCoinConfig => ({
+  status: { type: "active" },
+  networkType: "testnet",
+  apiUrls: {
+    node: getEnv("ALEO_NODE_ENDPOINT"),
+    sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
+  },
+  feeByTransactionType: mockFeeByTransactionType,
+  feeSafetyMultiplier: 1,
+  isFeeSponsored: true,
+  enableTokens: false,
+  useEncryptedProve: false,
+  recordPickingStrategy: "manual",
+  ...overrides,
+});

--- a/libs/coin-modules/coin-aleo/src/__tests__/helpers/account.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/helpers/account.ts
@@ -1,0 +1,12 @@
+export async function getPristineAccount(): Promise<{ address: string; viewKey: string }> {
+  const { Account } = await import("@provablehq/sdk/testnet.js");
+  const account = new Account();
+  try {
+    return {
+      address: account.address().toString(),
+      viewKey: account.viewKey().toString(),
+    };
+  } finally {
+    account.destroy();
+  }
+}

--- a/libs/coin-modules/coin-aleo/src/__tests__/helpers/cal.ts
+++ b/libs/coin-modules/coin-aleo/src/__tests__/helpers/cal.ts
@@ -1,0 +1,19 @@
+import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies/legacy";
+import {
+  setCryptoAssetsStore,
+  type FrameworkCryptoAssetsStore,
+} from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+
+/**
+ * Registers a standalone CAL (Crypto Assets List) store for *.integ.test.ts files that
+ * exercise code paths depending on it (currency/token lookups). Points at the real CAL
+ * service by default; override via CAL_SERVICE_URL / LEDGER_CLIENT_VERSION env vars.
+ */
+export const setupCalStore = (): void => {
+  setCryptoAssetsStore(
+    buildStandaloneCryptoAssetsStore({
+      calServiceUrl: process.env.CAL_SERVICE_URL ?? "https://global.api.prd.ledger.com/cal",
+      ledgerClientVersion: process.env.LEDGER_CLIENT_VERSION || "coin-aleo-integration-test",
+    }) as unknown as FrameworkCryptoAssetsStore,
+  );
+};

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -183,11 +183,11 @@ describe("createApi", () => {
   describe("getBalance", () => {
     it("returns the balance for a valid address", async () => {
       // not an exact value: testnetAddress's public balance shifts as the team runs more
-      // transactions against it, so only shape + positivity are checked here.
+      // transactions against it, so only shape + non-negativity are checked here.
       const balance = await api.getBalance(testnetAddress);
 
       expect(balance).toEqual([expect.objectContaining({ asset: { type: "native" } })]);
-      expect(balance[0].value).toBeGreaterThan(0n);
+      expect(balance[0].value).toBeGreaterThanOrEqual(0n);
     });
 
     it("returns an empty array for a non-existing valid address", async () => {

--- a/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.integ.test.ts
@@ -1,37 +1,23 @@
 import invariant from "invariant";
-import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies/legacy";
-import {
-  setCryptoAssetsStore,
-  type FrameworkCryptoAssetsStore,
-} from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { getEnv } from "@ledgerhq/live-env";
 import { createApi } from "../api";
 import { TRANSACTION_TYPE } from "../constants";
-import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  referenceFailedTransferPublicTx,
+  referenceTransferPublicTx,
+  testnetAddress,
+} from "../__tests__/fixtures/api.fixture";
+import { setupCalStore } from "../__tests__/helpers/cal";
+import { getPristineAccount } from "../__tests__/helpers/account";
 
 describe("createApi", () => {
-  const emptyAccountAddress = "aleo172yejeypnffsdft3nrlpwnu964sn83p7ga6dm5zj7ucmqfqjk5rq3pmx6f";
-  const testAccountAddress = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px";
-  const mockConfig = getMockedConfig("testnet");
+  const api = createApi(getTestnetIntegConfig(), "aleo_testnet");
+  let emptyAddress: string;
 
-  const api = createApi(
-    {
-      ...mockConfig,
-      apiUrls: {
-        node: getEnv("ALEO_NODE_ENDPOINT"),
-        sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
-      },
-    },
-    "aleo",
-  );
-
-  beforeAll(() => {
-    setCryptoAssetsStore(
-      buildStandaloneCryptoAssetsStore({
-        calServiceUrl: process.env.CAL_SERVICE_URL ?? "https://global.api.prd.ledger.com/cal",
-        ledgerClientVersion: process.env.LEDGER_CLIENT_VERSION || "coin-aleo-integration-test",
-      }) as unknown as FrameworkCryptoAssetsStore,
-    );
+  beforeAll(async () => {
+    setupCalStore();
+    const pristineAccount = await getPristineAccount();
+    emptyAddress = pristineAccount.address;
   });
 
   describe("estimateFees", () => {
@@ -41,8 +27,8 @@ describe("createApi", () => {
         asset: { type: "native" },
         type: TRANSACTION_TYPE.TRANSFER_PUBLIC,
         amount: 100n,
-        sender: testAccountAddress,
-        recipient: emptyAccountAddress,
+        sender: testnetAddress,
+        recipient: emptyAddress,
       });
 
       expect(fees.value).toBeGreaterThanOrEqual(0n);
@@ -51,7 +37,7 @@ describe("createApi", () => {
 
   describe("listOperations", () => {
     it("returns empty array for pristine account", async () => {
-      const { items: operations } = await api.listOperations(emptyAccountAddress, {
+      const { items: operations } = await api.listOperations(emptyAddress, {
         minHeight: 0,
         order: "desc",
       });
@@ -60,42 +46,72 @@ describe("createApi", () => {
     });
 
     it("returns operations with correct metadata", async () => {
-      const testTxId = "at1qe8ml060qvvqp5caxejnc2r4sj3yjx83nfe9mykyx0zyhv5h5yzsfa85j0";
-      const testBlockHashOfTx = "ab1ae88smgn0cr80yzzd84kvupawre67j69xcpthcegmcutqew8wgrs6hrxh8";
-      const { items: page } = await api.listOperations(testAccountAddress, {
+      const { items: page } = await api.listOperations(testnetAddress, {
         minHeight: 0,
         limit: 10,
         order: "asc",
       });
 
-      const operation = page.find(op => op.tx.hash === testTxId);
+      const operation = page.find(op => op.tx.hash === referenceTransferPublicTx.id);
 
       expect(operation).toMatchObject({
-        value: 20n,
+        type: "IN",
+        value: BigInt(referenceTransferPublicTx.value),
         asset: { type: "native" },
+        senders: [referenceTransferPublicTx.sender],
+        recipients: [referenceTransferPublicTx.recipient],
         tx: {
-          hash: testTxId,
-          fees: 51060n,
+          hash: referenceTransferPublicTx.id,
+          fees: BigInt(referenceTransferPublicTx.fee),
           failed: false,
           block: {
-            hash: testBlockHashOfTx,
-            height: 168835,
+            hash: referenceTransferPublicTx.blockHash,
+            height: referenceTransferPublicTx.blockHeight,
+          },
+        },
+      });
+    });
+
+    it("returns a failed operation for a known rejected transaction", async () => {
+      const { items: page } = await api.listOperations(testnetAddress, {
+        minHeight: referenceFailedTransferPublicTx.blockHeight,
+        limit: 10,
+        order: "asc",
+      });
+
+      const operation = page.find(op => op.tx.hash === referenceFailedTransferPublicTx.id);
+
+      // this account's only Rejected txs are self-transfers (sender === recipient), which
+      // classify as type "IN" (see referenceFailedTransferPublicTx in api.fixture.ts)
+      expect(operation).toMatchObject({
+        type: "IN",
+        value: BigInt(referenceFailedTransferPublicTx.value),
+        asset: { type: "native" },
+        senders: [referenceFailedTransferPublicTx.sender],
+        recipients: [referenceFailedTransferPublicTx.recipient],
+        tx: {
+          hash: referenceFailedTransferPublicTx.id,
+          fees: BigInt(referenceFailedTransferPublicTx.fee),
+          failed: true,
+          block: {
+            hash: referenceFailedTransferPublicTx.blockHash,
+            height: referenceFailedTransferPublicTx.blockHeight,
           },
         },
       });
     });
     it.each(["desc", "asc"] as const)(
-      "returns paginated operations for account with high activity (%s)",
+      "returns 2 non-overlapping, correctly ordered pages (%s)",
       async order => {
-        const limit = 10;
-        const { items: page1, next: cursor1 } = await api.listOperations(testAccountAddress, {
+        const limit = 3;
+        const { items: page1, next: cursor1 } = await api.listOperations(testnetAddress, {
           minHeight: 0,
           limit,
           order,
         });
 
         const { items: page2, next: cursor2 } = await api.listOperations(
-          testAccountAddress,
+          testnetAddress,
           cursor1
             ? {
                 minHeight: 0,
@@ -140,8 +156,8 @@ describe("createApi", () => {
     it.each(["desc", "asc"] as const)(
       "returns operations with min height filter (%s)",
       async order => {
-        const minHeight = order === "asc" ? 200_000 : 13_940_000;
-        const { items: page } = await api.listOperations(testAccountAddress, {
+        const minHeight = referenceFailedTransferPublicTx.blockHeight;
+        const { items: page } = await api.listOperations(testnetAddress, {
           minHeight,
           limit: 10,
           order,
@@ -149,6 +165,7 @@ describe("createApi", () => {
 
         expect(page.length).toBeGreaterThan(0);
         expect(page.every(op => op.tx.block.height >= minHeight)).toBe(true);
+        expect(page.some(op => op.tx.hash === referenceTransferPublicTx.id)).toBe(false);
       },
     );
   });
@@ -165,19 +182,16 @@ describe("createApi", () => {
 
   describe("getBalance", () => {
     it("returns the balance for a valid address", async () => {
-      const address = "aleo1zcwqycj02lccfuu57dzjhva7w5dpzc7pngl0sxjhp58t6vlnnqxs6lnp6f";
-      const balance = await api.getBalance(address);
+      // not an exact value: testnetAddress's public balance shifts as the team runs more
+      // transactions against it, so only shape + positivity are checked here.
+      const balance = await api.getBalance(testnetAddress);
 
-      expect(balance).toBeInstanceOf(Array);
-      expect(balance.length).toBeGreaterThanOrEqual(0);
-      balance.forEach(b => {
-        expect(b.value).toBeGreaterThan(0n);
-      });
+      expect(balance).toEqual([expect.objectContaining({ asset: { type: "native" } })]);
+      expect(balance[0].value).toBeGreaterThan(0n);
     });
 
     it("returns an empty array for a non-existing valid address", async () => {
-      const address = "aleo1g82wnc9um2f50a64a8xnsfz6meqkl3e7rk3q327vc47kykxway8qphwg9p";
-      const balance = await api.getBalance(address);
+      const balance = await api.getBalance(emptyAddress);
 
       expect(balance).toEqual([]);
     });
@@ -185,7 +199,10 @@ describe("createApi", () => {
     it("throws an error for an invalid address", async () => {
       const invalidAddress = "invalid_address";
 
-      await expect(api.getBalance(invalidAddress)).rejects.toThrow();
+      await expect(api.getBalance(invalidAddress)).rejects.toMatchObject({
+        name: "LedgerAPI4xx",
+        status: 404,
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.integ.test.ts
@@ -1,0 +1,197 @@
+import BigNumber from "bignumber.js";
+import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import { SYNC_TYPE_TRANSPARENT } from "@ledgerhq/types-live";
+import type { SyncConfig } from "@ledgerhq/types-live";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import { testnetAddress, testnetViewKey } from "../__tests__/fixtures/api.fixture";
+import { getMockedAccount } from "../__tests__/fixtures/account.fixture";
+import { setupCalStore } from "../__tests__/helpers/cal";
+import { getPristineAccount } from "../__tests__/helpers/account";
+import { AleoApiConfigurationResetError } from "../errors";
+import { performPublicSync, performPrivateSync } from "./sync";
+import type { AleoAccount, AleoResources } from "../types";
+
+const currency = getCryptoCurrencyById("aleo_testnet");
+const syncConfig: SyncConfig = { paginationConfig: {}, syncType: SYNC_TYPE_TRANSPARENT };
+
+// performPrivateSync reads the view key back out of the account id, so it has to be encoded in
+const ledgerAccountId = encodeAccountId({
+  type: "js",
+  version: "2",
+  currencyId: currency.id,
+  xpubOrAddress: testnetAddress,
+  derivationMode: "",
+  customData: testnetViewKey,
+});
+
+function makeShapeInfo(address: string, initialAccount?: AleoAccount) {
+  return {
+    currency,
+    address,
+    index: 0,
+    derivationPath: "",
+    derivationMode: "" as const,
+    ...(initialAccount && { initialAccount }),
+  };
+}
+
+// null provableApi forces a fresh scanner registration; accessProvableApi is idempotent per view key
+function makePrivateSyncArgs(provableApi: AleoResources["provableApi"] = null) {
+  const initialAccount = getMockedAccount({
+    id: ledgerAccountId,
+    freshAddress: testnetAddress,
+    currency,
+    aleoResources: {
+      transparentBalance: new BigNumber(0),
+      provableApi,
+      privateBalance: null,
+      unspentPrivateRecords: null,
+      lastPrivateSyncDate: null,
+    },
+  });
+
+  return {
+    info: makeShapeInfo(testnetAddress, initialAccount),
+    syncConfig,
+    currentPublicOps: [],
+  };
+}
+
+beforeAll(() => {
+  aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  setupCalStore();
+});
+
+describe("performPublicSync — fresh sync of active account", () => {
+  let result: Partial<AleoAccount>;
+
+  beforeAll(async () => {
+    result = await performPublicSync(makeShapeInfo(testnetAddress), syncConfig);
+  });
+
+  it("returns positive balance and block height", () => {
+    expect(result.balance?.toNumber()).toBeGreaterThan(0);
+    expect(result.spendableBalance?.toNumber()).toBeGreaterThan(0);
+    expect(result.blockHeight).toBeGreaterThan(0);
+  });
+
+  it("returns operations sorted newest first", () => {
+    const ops = result.operations ?? [];
+
+    expect(ops.length).toBeGreaterThan(0);
+    for (let i = 0; i < ops.length - 1; i++) {
+      expect(ops[i].date.getTime()).toBeGreaterThanOrEqual(ops[i + 1].date.getTime());
+    }
+  });
+
+  it("returns operations with correct shape", () => {
+    expect(result.operations?.length).toBeGreaterThan(0);
+    const op = result.operations![0];
+
+    expect(op.id.length).toBeGreaterThan(0);
+    expect(op.hash.length).toBeGreaterThan(0);
+    expect(op.blockHeight).toBeGreaterThan(0);
+    expect(op.date).toBeInstanceOf(Date);
+    expect(op.value.toNumber()).toBeGreaterThanOrEqual(0);
+  });
+
+  it("populates aleoResources with transparent balance and null private balance", () => {
+    expect(result.aleoResources?.transparentBalance?.toNumber()).toBeGreaterThan(0);
+    expect(result.aleoResources?.privateBalance).toBeNull();
+    expect(result.lastSyncDate).toBeInstanceOf(Date);
+  });
+});
+
+describe("performPublicSync — fresh sync of empty account", () => {
+  let result: Partial<AleoAccount>;
+
+  beforeAll(async () => {
+    const pristineAccount = await getPristineAccount();
+    result = await performPublicSync(makeShapeInfo(pristineAccount.address), syncConfig);
+  });
+
+  it("returns zero balance and empty operations list", () => {
+    expect(result.balance?.toNumber()).toBe(0);
+    expect(result.operations).toEqual([]);
+    expect(result.operationsCount).toBe(0);
+  });
+
+  it("still returns a valid block height", () => {
+    expect(result.blockHeight).toBeGreaterThan(0);
+  });
+});
+
+describe("performPrivateSync — account with private history", () => {
+  let result: Partial<AleoAccount> | null;
+  const progress: number[] = [];
+
+  beforeAll(async () => {
+    result = await performPrivateSync({
+      ...makePrivateSyncArgs(),
+      onProgress: pct => progress.push(pct),
+    });
+  });
+
+  // performPrivateSync resolves to null while the record scanner is still catching up, which it
+  // is for a while after any new transaction on this account. Asserted on its own so that case
+  // fails once, clearly, instead of surfacing as four confusing undefined mismatches below.
+  it("completes instead of bailing out on a scanner that is still catching up", () => {
+    expect(result).not.toBeNull();
+  });
+
+  // deliberately not asserting a fixed amount: this reads the account's live records, so any
+  // private transaction the team makes would change it. The sum invariant holds regardless.
+  it("returns a private balance equal to the sum of its unspent records", () => {
+    const records = result?.aleoResources?.unspentPrivateRecords ?? [];
+    const total = records.reduce((acc, r) => acc.plus(r.microcredits), new BigNumber(0));
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(result?.aleoResources?.privateBalance).toEqual(total);
+  });
+
+  it("returns a scanner uuid and a private sync date", () => {
+    expect(result?.aleoResources?.provableApi?.uuid).toEqual(expect.any(String));
+    expect(result?.aleoResources?.lastPrivateSyncDate).toBeInstanceOf(Date);
+  });
+
+  it("totals balance as transparent + private", () => {
+    const transparent = result?.aleoResources?.transparentBalance ?? new BigNumber(0);
+    const priv = result?.aleoResources?.privateBalance ?? new BigNumber(0);
+
+    expect(result?.balance).toEqual(transparent.plus(priv));
+    expect(result?.spendableBalance).toEqual(result?.balance);
+  });
+
+  it("returns private operations sorted newest first", () => {
+    const ops = result?.operations ?? [];
+
+    expect(ops).toEqual(
+      expect.arrayContaining([expect.objectContaining({ accountId: ledgerAccountId })]),
+    );
+
+    for (let i = 0; i < ops.length - 1; i++) {
+      expect(ops[i].date.getTime()).toBeGreaterThanOrEqual(ops[i + 1].date.getTime());
+    }
+  });
+
+  it("reports monotonic progress ending at 100", () => {
+    expect(progress.at(-1)).toBe(100);
+    expect([...progress].sort((a, b) => a - b)).toEqual(progress);
+  });
+});
+
+describe("performPrivateSync — failure paths", () => {
+  it("throws AleoApiConfigurationResetError for an unknown stored scanner uuid", async () => {
+    await expect(
+      performPrivateSync(makePrivateSyncArgs({ uuid: "00000000-0000-0000-0000-000000000000" })),
+    ).rejects.toBeInstanceOf(AleoApiConfigurationResetError);
+  });
+
+  it("aborts when the signal is already aborted", async () => {
+    await expect(
+      performPrivateSync({ ...makePrivateSyncArgs(), signal: AbortSignal.abort() }),
+    ).rejects.toThrow(/abort/i);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.integ.test.ts
@@ -42,7 +42,7 @@ describe("resolveTokenSubAccounts", () => {
   beforeAll(async () => {
     listOperationsResult = await listOperations({
       config,
-      currency,
+      currencyId: currency.id,
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,
       mode: "bridge",
@@ -53,7 +53,7 @@ describe("resolveTokenSubAccounts", () => {
   const resolve = (enableTokens: boolean) =>
     resolveTokenSubAccounts({
       enableTokens,
-      currency,
+      config,
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,
       publicOperations: listOperationsResult.operations,
@@ -91,7 +91,7 @@ describe("resolveTokenSubAccounts", () => {
 describe("buildSubAccountsFromPrivateRecords", () => {
   const build = (calTokensOverride?: Map<string, TokenCurrency>) =>
     buildSubAccountsFromPrivateRecords({
-      currency,
+      config,
       ledgerAccountId: testnetLedgerAccountId,
       allPrivateRecords: [testnetIncomingPrivateRecord1, testnetOutgoingPrivateTokenRecord],
       unspentPrivateRecords: [testnetOutgoingPrivateTokenRecord],

--- a/libs/coin-modules/coin-aleo/src/bridge/tokens.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/tokens.integ.test.ts
@@ -1,0 +1,131 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  TEST_TOKEN_PROGRAM_ID,
+  testnetAddress,
+  testnetIncomingPrivateRecord1,
+  testnetLedgerAccountId,
+  testnetOutgoingPrivateTokenRecord,
+  testnetViewKey,
+} from "../__tests__/fixtures/api.fixture";
+import { setupCalStore } from "../__tests__/helpers/cal";
+import { listOperations } from "../logic/listOperations";
+import { getCalTokens } from "../logic/utils";
+import { buildSubAccountsFromPrivateRecords, resolveTokenSubAccounts } from "./tokens";
+import type { AleoOperation } from "../types";
+
+const currency = getCryptoCurrencyById("aleo_testnet");
+const config = { ...getTestnetIntegConfig(), enableTokens: true };
+const TEST_USAD_TOKEN_ID = "aleo_testnet/arc22/test_usad";
+
+let calTokens: Map<string, TokenCurrency>;
+
+beforeAll(async () => {
+  setupCalStore();
+  aleoConfig.setCoinConfig(() => config);
+  calTokens = await getCalTokens({
+    currencyId: currency.id,
+    programNames: [TEST_TOKEN_PROGRAM_ID],
+  });
+});
+
+describe("resolveTokenSubAccounts", () => {
+  let listOperationsResult: {
+    operations: AleoOperation[];
+    tokenOperations: AleoOperation[];
+    calTokens: Map<string, TokenCurrency>;
+  };
+
+  beforeAll(async () => {
+    listOperationsResult = await listOperations({
+      config,
+      currency,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      mode: "bridge",
+      options: { minHeight: 0, limit: 50, order: "asc" },
+    });
+  });
+
+  const resolve = (enableTokens: boolean) =>
+    resolveTokenSubAccounts({
+      enableTokens,
+      currency,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      publicOperations: listOperationsResult.operations,
+      tokenOperations: listOperationsResult.tokenOperations,
+      calTokens: listOperationsResult.calTokens,
+      shouldSyncFromScratch: true,
+      initialAccount: undefined,
+    });
+
+  it("builds a token sub-account carrying its public balance and operations", async () => {
+    const { subAccounts } = await resolve(true);
+
+    expect(subAccounts).toEqual([
+      expect.objectContaining({
+        token: expect.objectContaining({ id: TEST_USAD_TOKEN_ID }),
+        operations: expect.arrayContaining([
+          expect.objectContaining({
+            extra: expect.objectContaining({ programId: TEST_TOKEN_PROGRAM_ID }),
+          }),
+        ]),
+      }),
+    ]);
+    // live on-chain token balance, so only its presence and sign are stable
+    expect(subAccounts[0].balance.isGreaterThanOrEqualTo(0)).toBe(true);
+  });
+
+  it("drops token sub-accounts and token-bearing operations when tokens are disabled", async () => {
+    const { subAccounts, updatedCoinOperations } = await resolve(false);
+
+    expect(subAccounts).toEqual([]);
+    expect(updatedCoinOperations.every(op => (op.subOperations ?? []).length === 0)).toBe(true);
+  });
+});
+
+describe("buildSubAccountsFromPrivateRecords", () => {
+  const build = (calTokensOverride?: Map<string, TokenCurrency>) =>
+    buildSubAccountsFromPrivateRecords({
+      currency,
+      ledgerAccountId: testnetLedgerAccountId,
+      allPrivateRecords: [testnetIncomingPrivateRecord1, testnetOutgoingPrivateTokenRecord],
+      unspentPrivateRecords: [testnetOutgoingPrivateTokenRecord],
+      baseSubAccounts: [],
+      viewKey: testnetViewKey,
+      address: testnetAddress,
+      calTokens: calTokensOverride ?? calTokens,
+    });
+
+  it("decrypts private token records into a sub-account with its private balance", async () => {
+    const { subAccounts } = await build();
+
+    expect(subAccounts).toEqual([
+      expect.objectContaining({
+        token: expect.objectContaining({ id: TEST_USAD_TOKEN_ID }),
+        // the sole unspent record is the 0-value change left by a fully drained transfer
+        balance: new BigNumber(0),
+      }),
+    ]);
+  });
+
+  it("derives IN and OUT operations from the record history, newest first", async () => {
+    const { subAccounts, privateTokenOpsByAccountId } = await build();
+
+    expect(privateTokenOpsByAccountId.get(subAccounts[0].id)).toEqual([
+      expect.objectContaining({ type: "OUT", value: new BigNumber(1) }),
+      expect.objectContaining({ type: "IN", value: new BigNumber(1) }),
+    ]);
+  });
+
+  it("ignores records whose program is not a known CAL token", async () => {
+    const { subAccounts, privateTokenOpsByAccountId } = await build(new Map());
+
+    expect(subAccounts).toEqual([]);
+    expect(privateTokenOpsByAccountId.size).toBe(0);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -1,4 +1,5 @@
 import { getEnv } from "@ledgerhq/live-env";
+import aleoConfig from "../config";
 import { testnetViewKey } from "../__tests__/fixtures/api.fixture";
 import {
   mockTxIntentFeePrivate,
@@ -10,6 +11,7 @@ import {
 } from "../__tests__/fixtures/transaction.fixture";
 import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
 import type { AleoCoinConfig, FeeConfiguration, PreparedRequestResponse } from "../types";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import { craftTransaction } from "./craftTransaction";
 import { fromHex } from "./utils";
 
@@ -38,6 +40,10 @@ describe("craftTransaction", () => {
     max_base_fee: "2308",
     max_priority_fee: "0",
   };
+
+  beforeAll(() => {
+    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  });
 
   it.each([
     {

--- a/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/craftTransaction.integ.test.ts
@@ -1,4 +1,3 @@
-import { getEnv } from "@ledgerhq/live-env";
 import aleoConfig from "../config";
 import { testnetViewKey } from "../__tests__/fixtures/api.fixture";
 import {
@@ -9,27 +8,14 @@ import {
   mockTxIntentTransferPrivate,
   mockTxIntentTransferPublic,
 } from "../__tests__/fixtures/transaction.fixture";
-import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
-import type { AleoCoinConfig, FeeConfiguration, PreparedRequestResponse } from "../types";
+import type { FeeConfiguration, PreparedRequestResponse } from "../types";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import { craftTransaction } from "./craftTransaction";
 import { fromHex } from "./utils";
 
 describe("craftTransaction", () => {
-  const config: AleoCoinConfig = {
-    status: { type: "active" },
-    networkType: "testnet",
-    apiUrls: {
-      node: getEnv("ALEO_NODE_ENDPOINT"),
-      sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
-    },
-    feeByTransactionType: mockFeeByTransactionType,
-    feeSafetyMultiplier: 1,
-    isFeeSponsored: true,
-    enableTokens: false,
-    useEncryptedProve: false,
-    recordPickingStrategy: "manual",
-  };
+  const config = getTestnetIntegConfig();
+
   const publicFeeConfiguration: FeeConfiguration = {
     function_name: "fee_public",
     max_base_fee: "34060",
@@ -42,7 +28,7 @@ describe("craftTransaction", () => {
   };
 
   beforeAll(() => {
-    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+    aleoConfig.setCoinConfig(() => config);
   });
 
   it.each([

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -1,23 +1,23 @@
 import BigNumber from "bignumber.js";
 import { getEnv } from "@ledgerhq/live-env";
-import { buildStandaloneCryptoAssetsStore } from "@features/platform-currencies/legacy";
-import {
-  setCryptoAssetsStore,
-  type FrameworkCryptoAssetsStore,
-} from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
-import { testnetViewKey, testnetPrivateRecord } from "../__tests__/fixtures/api.fixture";
 import type { AleoCoinConfig } from "../types";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  testnetViewKey,
+  testnetPrivateRecord,
+  testnetOutgoingPrivateToPublicRecord,
+} from "../__tests__/fixtures/api.fixture";
+import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPrivateBalance } from "./getPrivateBalance";
 
-setCryptoAssetsStore(
-  buildStandaloneCryptoAssetsStore({
-    calServiceUrl: process.env.CAL_SERVICE_URL ?? "https://global.api.prd.ledger.com/cal",
-    ledgerClientVersion: process.env.LEDGER_CLIENT_VERSION || "coin-aleo-integration-test",
-  }) as unknown as FrameworkCryptoAssetsStore,
-);
-
 describe("getPrivateBalance", () => {
+  beforeAll(() => {
+    setupCalStore();
+    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  });
+
   const config: AleoCoinConfig = {
     status: { type: "active" },
     networkType: "testnet",
@@ -34,14 +34,15 @@ describe("getPrivateBalance", () => {
   };
 
   it("should sum microcredits across all unspent credits records", async () => {
-    const { balance } = await getPrivateBalance({
+    const { balance, unspentRecords } = await getPrivateBalance({
       config,
       viewKey: testnetViewKey,
-      privateRecords: [testnetPrivateRecord, testnetPrivateRecord],
+      privateRecords: [testnetPrivateRecord, testnetOutgoingPrivateToPublicRecord],
       oldUnspentRecords: [],
     });
 
-    expect(balance).toEqual(new BigNumber(800000 + 800000));
+    expect(unspentRecords.map(r => r.microcredits)).toEqual(["69999", "0"]);
+    expect(balance).toEqual(new BigNumber(69999));
   });
 
   it("should return all decrypted records as unspentRecords", async () => {
@@ -54,10 +55,10 @@ describe("getPrivateBalance", () => {
 
     expect(unspentRecords).toEqual([
       expect.objectContaining({
-        microcredits: "800000",
+        microcredits: "69999",
         decryptedData: expect.objectContaining({
           data: {
-            microcredits: "800000u64.private",
+            microcredits: "69999u64.private",
           },
         }),
       }),

--- a/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/getPrivateBalance.integ.test.ts
@@ -1,7 +1,4 @@
 import BigNumber from "bignumber.js";
-import { getEnv } from "@ledgerhq/live-env";
-import { mockFeeByTransactionType } from "../__tests__/fixtures/config.fixture";
-import type { AleoCoinConfig } from "../types";
 import aleoConfig from "../config";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -13,25 +10,12 @@ import { setupCalStore } from "../__tests__/helpers/cal";
 import { getPrivateBalance } from "./getPrivateBalance";
 
 describe("getPrivateBalance", () => {
+  const config = getTestnetIntegConfig();
+
   beforeAll(() => {
     setupCalStore();
-    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+    aleoConfig.setCoinConfig(() => config);
   });
-
-  const config: AleoCoinConfig = {
-    status: { type: "active" },
-    networkType: "testnet",
-    apiUrls: {
-      node: getEnv("ALEO_NODE_ENDPOINT"),
-      sdk: getEnv("ALEO_TESTNET_SDK_ENDPOINT"),
-    },
-    feeByTransactionType: mockFeeByTransactionType,
-    feeSafetyMultiplier: 1,
-    isFeeSponsored: true,
-    enableTokens: false,
-    useEncryptedProve: false,
-    recordPickingStrategy: "manual",
-  };
 
   it("should sum microcredits across all unspent credits records", async () => {
     const { balance, unspentRecords } = await getPrivateBalance({

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.integ.test.ts
@@ -1,0 +1,101 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  referenceTransferPublicTx,
+  TEST_TOKEN_PROGRAM_ID,
+  testnetAddress,
+  testnetLedgerAccountId,
+} from "../__tests__/fixtures/api.fixture";
+import { setupCalStore } from "../__tests__/helpers/cal";
+import { listOperations } from "./listOperations";
+
+describe("listOperations (bridge mode)", () => {
+  const currency = getCryptoCurrencyById("aleo_testnet");
+  const config = getTestnetIntegConfig();
+
+  beforeAll(() => {
+    setupCalStore();
+    aleoConfig.setCoinConfig(() => config);
+  });
+
+  it("returns AleoOperation-shaped results with correct metadata for a known transaction", async () => {
+    const result = await listOperations({
+      config,
+      currency,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      mode: "bridge",
+      options: { minHeight: 0, limit: 10, order: "asc" },
+    });
+
+    const operation = result.operations.find(op => op.hash === referenceTransferPublicTx.id);
+
+    expect(operation).toMatchObject({
+      type: "IN",
+      value: new BigNumber(referenceTransferPublicTx.value),
+      senders: [referenceTransferPublicTx.sender],
+      recipients: [referenceTransferPublicTx.recipient],
+      hash: referenceTransferPublicTx.id,
+      fee: new BigNumber(referenceTransferPublicTx.fee),
+      blockHeight: referenceTransferPublicTx.blockHeight,
+      blockHash: referenceTransferPublicTx.blockHash,
+      accountId: testnetLedgerAccountId,
+    });
+  });
+
+  it("ignores the limit option and paginates through every page up to the tip", async () => {
+    const options = { minHeight: 15_500_000, order: "asc" as const };
+
+    const [smallPageSize, largePageSize] = await Promise.all([
+      listOperations({
+        config,
+        currency,
+        address: testnetAddress,
+        ledgerAccountId: testnetLedgerAccountId,
+        mode: "bridge",
+        options: { ...options, limit: 5 },
+      }),
+      listOperations({
+        config,
+        currency,
+        address: testnetAddress,
+        ledgerAccountId: testnetLedgerAccountId,
+        mode: "bridge",
+        options: { ...options, limit: 50 },
+      }),
+    ]);
+
+    // guards that this window actually spans more than a single page at the smallest size
+    expect(smallPageSize.operations.length).toBeGreaterThan(5);
+    expect(smallPageSize.operations.length).toBe(largePageSize.operations.length);
+    expect(smallPageSize.nextCursor).toBeNull();
+    expect(largePageSize.nextCursor).toBeNull();
+
+    const smallIds = smallPageSize.operations.map(op => op.id).sort();
+    const largeIds = largePageSize.operations.map(op => op.id).sort();
+    expect(smallIds).toEqual(largeIds);
+  });
+
+  it("resolves CAL tokens and token operations for a testnet token program", async () => {
+    const result = await listOperations({
+      config: { ...config, enableTokens: true },
+      currency,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      mode: "bridge",
+      options: { minHeight: 0, limit: 50, order: "asc" },
+    });
+
+    expect(result.calTokens.get(TEST_TOKEN_PROGRAM_ID)?.id).toBe("aleo_testnet/arc22/test_usad");
+    expect(result.tokenOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: testnetLedgerAccountId,
+          extra: expect.objectContaining({ programId: TEST_TOKEN_PROGRAM_ID }),
+        }),
+      ]),
+    );
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listOperations.integ.test.ts
@@ -1,5 +1,4 @@
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import aleoConfig from "../config";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -12,7 +11,6 @@ import { setupCalStore } from "../__tests__/helpers/cal";
 import { listOperations } from "./listOperations";
 
 describe("listOperations (bridge mode)", () => {
-  const currency = getCryptoCurrencyById("aleo_testnet");
   const config = getTestnetIntegConfig();
 
   beforeAll(() => {
@@ -23,7 +21,7 @@ describe("listOperations (bridge mode)", () => {
   it("returns AleoOperation-shaped results with correct metadata for a known transaction", async () => {
     const result = await listOperations({
       config,
-      currency,
+      currencyId: "aleo_testnet",
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,
       mode: "bridge",
@@ -51,7 +49,7 @@ describe("listOperations (bridge mode)", () => {
     const [smallPageSize, largePageSize] = await Promise.all([
       listOperations({
         config,
-        currency,
+        currencyId: "aleo_testnet",
         address: testnetAddress,
         ledgerAccountId: testnetLedgerAccountId,
         mode: "bridge",
@@ -59,7 +57,7 @@ describe("listOperations (bridge mode)", () => {
       }),
       listOperations({
         config,
-        currency,
+        currencyId: "aleo_testnet",
         address: testnetAddress,
         ledgerAccountId: testnetLedgerAccountId,
         mode: "bridge",
@@ -81,7 +79,7 @@ describe("listOperations (bridge mode)", () => {
   it("resolves CAL tokens and token operations for a testnet token program", async () => {
     const result = await listOperations({
       config: { ...config, enableTokens: true },
-      currency,
+      currencyId: "aleo_testnet",
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,
       mode: "bridge",

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.integ.test.ts
@@ -1,0 +1,90 @@
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  testnetAddress,
+  testnetConsumedRecordTag,
+  testnetIncomingPrivateRecord1,
+  testnetIncomingPrivateRecord2,
+  testnetLedgerAccountId,
+  testnetOutgoingChangeRecord,
+  testnetViewKey,
+} from "../__tests__/fixtures/api.fixture";
+import { getPristineAccount } from "../__tests__/helpers/account";
+import { listPrivateOperations } from "./listPrivateOperations";
+
+describe("listPrivateOperations", () => {
+  const currency = getCryptoCurrencyById("aleo_testnet");
+  let emptyAddress: string;
+
+  beforeAll(async () => {
+    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+    const pristineAccount = await getPristineAccount();
+    emptyAddress = pristineAccount.address;
+  });
+
+  it("returns private operations for a known testnet account with private records", async () => {
+    const { operations } = await listPrivateOperations({
+      currency,
+      viewKey: testnetViewKey,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      privateRecords: [testnetIncomingPrivateRecord1, testnetIncomingPrivateRecord2],
+    });
+
+    expect(operations).toHaveLength(2);
+    expect(operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "IN",
+          hash: testnetIncomingPrivateRecord1.transaction_id.trim(),
+          value: new BigNumber(1),
+          date: new Date(testnetIncomingPrivateRecord1.block_timestamp * 1000),
+          senders: [testnetIncomingPrivateRecord1.sender],
+          recipients: [testnetAddress],
+        }),
+        expect.objectContaining({
+          type: "IN",
+          hash: testnetIncomingPrivateRecord2.transaction_id.trim(),
+          value: new BigNumber(50000),
+          date: new Date(testnetIncomingPrivateRecord2.block_timestamp * 1000),
+          senders: [testnetIncomingPrivateRecord2.sender],
+          recipients: [testnetAddress],
+        }),
+      ]),
+    );
+  });
+
+  it("returns an empty result for an account with no private records", async () => {
+    const result = await listPrivateOperations({
+      currency,
+      viewKey: testnetViewKey,
+      address: emptyAddress,
+      ledgerAccountId: `js:2:aleo_testnet:${emptyAddress}:`,
+      privateRecords: [],
+    });
+
+    expect(result.operations).toEqual([]);
+    expect(result.consumedRecordTags).toEqual(new Set());
+  });
+
+  it("marks a record consumed as input in an outgoing transaction as a consumed record tag", async () => {
+    const { operations, consumedRecordTags } = await listPrivateOperations({
+      currency,
+      viewKey: testnetViewKey,
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      privateRecords: [testnetOutgoingChangeRecord],
+    });
+
+    expect(consumedRecordTags.has(testnetConsumedRecordTag)).toBe(true);
+    expect(operations).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        hash: testnetOutgoingChangeRecord.transaction_id.trim(),
+        senders: [testnetAddress],
+      }),
+    ]);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/listPrivateOperations.integ.test.ts
@@ -1,5 +1,4 @@
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import aleoConfig from "../config";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -15,18 +14,18 @@ import { getPristineAccount } from "../__tests__/helpers/account";
 import { listPrivateOperations } from "./listPrivateOperations";
 
 describe("listPrivateOperations", () => {
-  const currency = getCryptoCurrencyById("aleo_testnet");
+  const config = getTestnetIntegConfig();
   let emptyAddress: string;
 
   beforeAll(async () => {
-    aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+    aleoConfig.setCoinConfig(() => config);
     const pristineAccount = await getPristineAccount();
     emptyAddress = pristineAccount.address;
   });
 
   it("returns private operations for a known testnet account with private records", async () => {
     const { operations } = await listPrivateOperations({
-      currency,
+      config,
       viewKey: testnetViewKey,
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,
@@ -58,7 +57,7 @@ describe("listPrivateOperations", () => {
 
   it("returns an empty result for an account with no private records", async () => {
     const result = await listPrivateOperations({
-      currency,
+      config,
       viewKey: testnetViewKey,
       address: emptyAddress,
       ledgerAccountId: `js:2:aleo_testnet:${emptyAddress}:`,
@@ -71,7 +70,7 @@ describe("listPrivateOperations", () => {
 
   it("marks a record consumed as input in an outgoing transaction as a consumed record tag", async () => {
     const { operations, consumedRecordTags } = await listPrivateOperations({
-      currency,
+      config,
       viewKey: testnetViewKey,
       address: testnetAddress,
       ledgerAccountId: testnetLedgerAccountId,

--- a/libs/coin-modules/coin-aleo/src/network/api.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.integ.test.ts
@@ -1,4 +1,3 @@
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import aleoConfig from "../config";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -9,18 +8,18 @@ import {
 import { getPristineAccount } from "../__tests__/helpers/account";
 import { apiClient } from "./api";
 
-const currency = getCryptoCurrencyById("aleo_testnet");
+const config = getTestnetIntegConfig();
 let emptyAddress: string;
 
 beforeAll(async () => {
-  aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  aleoConfig.setCoinConfig(() => config);
   const pristineAccount = await getPristineAccount();
   emptyAddress = pristineAccount.address;
 });
 
 describe("getLatestBlock", () => {
   it("returns a block with a positive height and valid hashes", async () => {
-    const block = await apiClient.getLatestBlock(currency);
+    const block = await apiClient.getLatestBlock(config);
 
     expect(block.header.metadata.height).toBeGreaterThan(0);
     expect(typeof block.header.metadata.timestamp).toBe("number");
@@ -31,14 +30,14 @@ describe("getLatestBlock", () => {
 
 describe("getAccountBalance", () => {
   it("returns a u64 balance string for an account with public funds", async () => {
-    const balance = await apiClient.getAccountBalance(currency, testnetAddress);
+    const balance = await apiClient.getAccountBalance(config, testnetAddress);
 
     expect(typeof balance).toBe("string");
     expect(balance).toMatch(/^\d+u64$/);
   });
 
   it("returns null for an account with no public credits balance", async () => {
-    const balance = await apiClient.getAccountBalance(currency, emptyAddress);
+    const balance = await apiClient.getAccountBalance(config, emptyAddress);
 
     expect(balance).toBeNull();
   });
@@ -46,25 +45,21 @@ describe("getAccountBalance", () => {
 
 describe("getTokenBalance", () => {
   it("returns the raw balance string for a known account holding the token", async () => {
-    const balance = await apiClient.getTokenBalance(
-      currency,
-      TEST_TOKEN_PROGRAM_ID,
-      testnetAddress,
-    );
+    const balance = await apiClient.getTokenBalance(config, TEST_TOKEN_PROGRAM_ID, testnetAddress);
 
     expect(typeof balance).toBe("string");
     expect(balance).toMatch(/^\d+u128$/);
   });
 
   it("returns null for an account with no balance for that token", async () => {
-    const balance = await apiClient.getTokenBalance(currency, TEST_TOKEN_PROGRAM_ID, emptyAddress);
+    const balance = await apiClient.getTokenBalance(config, TEST_TOKEN_PROGRAM_ID, emptyAddress);
 
     expect(balance).toBeNull();
   });
 
   it("returns null for a program that doesn't exist", async () => {
     const balance = await apiClient.getTokenBalance(
-      currency,
+      config,
       "totally_unknown_program_xyz.aleo",
       testnetAddress,
     );
@@ -74,14 +69,14 @@ describe("getTokenBalance", () => {
 
   it("throws for a malformed address", async () => {
     await expect(
-      apiClient.getTokenBalance(currency, TEST_TOKEN_PROGRAM_ID, "invalid_address"),
+      apiClient.getTokenBalance(config, TEST_TOKEN_PROGRAM_ID, "invalid_address"),
     ).rejects.toMatchObject({ name: "LedgerAPI4xx", status: 404 });
   });
 });
 
 describe("getTransactionById", () => {
   it("returns full details for a known accepted transaction", async () => {
-    const tx = await apiClient.getTransactionById(currency, referenceTransferPublicTx.id);
+    const tx = await apiClient.getTransactionById(config, referenceTransferPublicTx.id);
 
     expect(tx.id).toBe(referenceTransferPublicTx.id);
     expect(tx.status).toBe("Accepted");
@@ -95,7 +90,7 @@ describe("getTransactionById", () => {
   it("throws for an unknown transaction id", async () => {
     await expect(
       apiClient.getTransactionById(
-        currency,
+        config,
         "at1unknowntransactionidthatdoesnotexistonthechain0000000000000000",
       ),
     ).rejects.toMatchObject({ name: "LedgerAPI4xx", status: 404 });
@@ -105,7 +100,7 @@ describe("getTransactionById", () => {
 describe("getAccountPublicTransactions", () => {
   it("returns transactions list and address for an active account", async () => {
     const result = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address: testnetAddress,
     });
 
@@ -122,7 +117,7 @@ describe("getAccountPublicTransactions", () => {
 
   it("returns transactions in descending block order when order=desc", async () => {
     const result = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address: testnetAddress,
       order: "desc",
       limit: 10,
@@ -138,7 +133,7 @@ describe("getAccountPublicTransactions", () => {
 
   it("respects the limit parameter", async () => {
     const result = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address: testnetAddress,
       limit: 3,
     });
@@ -148,7 +143,7 @@ describe("getAccountPublicTransactions", () => {
 
   it("returns a next_cursor for pagination when limit is smaller than total", async () => {
     const result = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address: testnetAddress,
       limit: 3,
       order: "asc",
@@ -160,7 +155,7 @@ describe("getAccountPublicTransactions", () => {
 
   it("returns empty transactions list for an account with no activity", async () => {
     const result = await apiClient.getAccountPublicTransactions({
-      currency,
+      config,
       address: emptyAddress,
     });
 
@@ -171,7 +166,7 @@ describe("getAccountPublicTransactions", () => {
 
 describe("getScannerPublicKey", () => {
   it("returns a non-empty key_id and public_key", async () => {
-    const result = await apiClient.getScannerPublicKey(currency);
+    const result = await apiClient.getScannerPublicKey(config);
 
     expect(typeof result.key_id).toBe("string");
     expect(result.key_id.length).toBeGreaterThan(0);
@@ -182,7 +177,7 @@ describe("getScannerPublicKey", () => {
 
 describe("getProvePublicKey", () => {
   it("returns a non-empty key_id and public_key", async () => {
-    const { data } = await apiClient.getProvePublicKey({ currency });
+    const { data } = await apiClient.getProvePublicKey({ config });
 
     expect(typeof data.key_id).toBe("string");
     expect(data.key_id.length).toBeGreaterThan(0);
@@ -191,7 +186,7 @@ describe("getProvePublicKey", () => {
   });
 
   it("returns stickySessionCookie as an array or null", async () => {
-    const { stickySessionCookie } = await apiClient.getProvePublicKey({ currency });
+    const { stickySessionCookie } = await apiClient.getProvePublicKey({ config });
 
     expect(stickySessionCookie === null || Array.isArray(stickySessionCookie)).toBe(true);
   });

--- a/libs/coin-modules/coin-aleo/src/network/api.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/api.integ.test.ts
@@ -1,0 +1,198 @@
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  referenceTransferPublicTx,
+  TEST_TOKEN_PROGRAM_ID,
+  testnetAddress,
+} from "../__tests__/fixtures/api.fixture";
+import { getPristineAccount } from "../__tests__/helpers/account";
+import { apiClient } from "./api";
+
+const currency = getCryptoCurrencyById("aleo_testnet");
+let emptyAddress: string;
+
+beforeAll(async () => {
+  aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  const pristineAccount = await getPristineAccount();
+  emptyAddress = pristineAccount.address;
+});
+
+describe("getLatestBlock", () => {
+  it("returns a block with a positive height and valid hashes", async () => {
+    const block = await apiClient.getLatestBlock(currency);
+
+    expect(block.header.metadata.height).toBeGreaterThan(0);
+    expect(typeof block.header.metadata.timestamp).toBe("number");
+    expect(block.block_hash).toMatch(/^ab1[a-z0-9]+$/);
+    expect(block.previous_hash).toMatch(/^ab1[a-z0-9]+$/);
+  });
+});
+
+describe("getAccountBalance", () => {
+  it("returns a u64 balance string for an account with public funds", async () => {
+    const balance = await apiClient.getAccountBalance(currency, testnetAddress);
+
+    expect(typeof balance).toBe("string");
+    expect(balance).toMatch(/^\d+u64$/);
+  });
+
+  it("returns null for an account with no public credits balance", async () => {
+    const balance = await apiClient.getAccountBalance(currency, emptyAddress);
+
+    expect(balance).toBeNull();
+  });
+});
+
+describe("getTokenBalance", () => {
+  it("returns the raw balance string for a known account holding the token", async () => {
+    const balance = await apiClient.getTokenBalance(
+      currency,
+      TEST_TOKEN_PROGRAM_ID,
+      testnetAddress,
+    );
+
+    expect(typeof balance).toBe("string");
+    expect(balance).toMatch(/^\d+u128$/);
+  });
+
+  it("returns null for an account with no balance for that token", async () => {
+    const balance = await apiClient.getTokenBalance(currency, TEST_TOKEN_PROGRAM_ID, emptyAddress);
+
+    expect(balance).toBeNull();
+  });
+
+  it("returns null for a program that doesn't exist", async () => {
+    const balance = await apiClient.getTokenBalance(
+      currency,
+      "totally_unknown_program_xyz.aleo",
+      testnetAddress,
+    );
+
+    expect(balance).toBeNull();
+  });
+
+  it("throws for a malformed address", async () => {
+    await expect(
+      apiClient.getTokenBalance(currency, TEST_TOKEN_PROGRAM_ID, "invalid_address"),
+    ).rejects.toMatchObject({ name: "LedgerAPI4xx", status: 404 });
+  });
+});
+
+describe("getTransactionById", () => {
+  it("returns full details for a known accepted transaction", async () => {
+    const tx = await apiClient.getTransactionById(currency, referenceTransferPublicTx.id);
+
+    expect(tx.id).toBe(referenceTransferPublicTx.id);
+    expect(tx.status).toBe("Accepted");
+    expect(tx.block_height).toBe(referenceTransferPublicTx.blockHeight);
+    expect(tx.block_hash).toBe(referenceTransferPublicTx.blockHash);
+    expect(tx.type).toBe("execute");
+    expect(typeof tx.fee_value).toBe("number");
+    expect(tx.fee_value).toBeGreaterThan(0);
+  });
+
+  it("throws for an unknown transaction id", async () => {
+    await expect(
+      apiClient.getTransactionById(
+        currency,
+        "at1unknowntransactionidthatdoesnotexistonthechain0000000000000000",
+      ),
+    ).rejects.toMatchObject({ name: "LedgerAPI4xx", status: 404 });
+  });
+});
+
+describe("getAccountPublicTransactions", () => {
+  it("returns transactions list and address for an active account", async () => {
+    const result = await apiClient.getAccountPublicTransactions({
+      currency,
+      address: testnetAddress,
+    });
+
+    expect(result.address).toBe(testnetAddress);
+    expect(Array.isArray(result.transactions)).toBe(true);
+    expect(result.transactions.length).toBeGreaterThan(0);
+
+    const tx = result.transactions[0];
+    expect(tx.transaction_id).toMatch(/^at1[a-z0-9]+$/);
+    expect(typeof tx.block_number).toBe("number");
+    expect(tx.block_number).toBeGreaterThan(0);
+    expect(["Accepted", "Rejected"]).toContain(tx.transaction_status);
+  });
+
+  it("returns transactions in descending block order when order=desc", async () => {
+    const result = await apiClient.getAccountPublicTransactions({
+      currency,
+      address: testnetAddress,
+      order: "desc",
+      limit: 10,
+    });
+
+    expect(result.transactions.length).toBeGreaterThan(1);
+
+    const heights = result.transactions.map(tx => tx.block_number);
+    for (let i = 0; i < heights.length - 1; i++) {
+      expect(heights[i]).toBeGreaterThanOrEqual(heights[i + 1]);
+    }
+  });
+
+  it("respects the limit parameter", async () => {
+    const result = await apiClient.getAccountPublicTransactions({
+      currency,
+      address: testnetAddress,
+      limit: 3,
+    });
+
+    expect(result.transactions.length).toBeLessThanOrEqual(3);
+  });
+
+  it("returns a next_cursor for pagination when limit is smaller than total", async () => {
+    const result = await apiClient.getAccountPublicTransactions({
+      currency,
+      address: testnetAddress,
+      limit: 3,
+      order: "asc",
+    });
+
+    expect(typeof result.next_cursor?.block_number).toBe("number");
+    expect(typeof result.next_cursor?.transition_id).toBe("string");
+  });
+
+  it("returns empty transactions list for an account with no activity", async () => {
+    const result = await apiClient.getAccountPublicTransactions({
+      currency,
+      address: emptyAddress,
+    });
+
+    expect(result.address).toBe(emptyAddress);
+    expect(result.transactions).toHaveLength(0);
+  });
+});
+
+describe("getScannerPublicKey", () => {
+  it("returns a non-empty key_id and public_key", async () => {
+    const result = await apiClient.getScannerPublicKey(currency);
+
+    expect(typeof result.key_id).toBe("string");
+    expect(result.key_id.length).toBeGreaterThan(0);
+    expect(typeof result.public_key).toBe("string");
+    expect(result.public_key.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getProvePublicKey", () => {
+  it("returns a non-empty key_id and public_key", async () => {
+    const { data } = await apiClient.getProvePublicKey({ currency });
+
+    expect(typeof data.key_id).toBe("string");
+    expect(data.key_id.length).toBeGreaterThan(0);
+    expect(typeof data.public_key).toBe("string");
+    expect(data.public_key.length).toBeGreaterThan(0);
+  });
+
+  it("returns stickySessionCookie as an array or null", async () => {
+    const { stickySessionCookie } = await apiClient.getProvePublicKey({ currency });
+
+    expect(stickySessionCookie === null || Array.isArray(stickySessionCookie)).toBe(true);
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
@@ -1,6 +1,5 @@
 import invariant from "invariant";
 import BigNumber from "bignumber.js";
-import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import aleoConfig from "../config";
 import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
 import {
@@ -26,16 +25,16 @@ import {
   patchPublicOperations,
 } from "./utils";
 
-const currency = getCryptoCurrencyById("aleo_testnet");
+const config = getTestnetIntegConfig();
 
 beforeAll(() => {
-  aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+  aleoConfig.setCoinConfig(() => config);
 });
 
 describe("accessProvableApi", () => {
   it("registers a new scanner account when no uuid is known and returns its status", async () => {
     const result = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: null,
     });
@@ -48,12 +47,12 @@ describe("accessProvableApi", () => {
 
   it("registering the same view key twice returns the same scanner uuid", async () => {
     const first = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: null,
     });
     const second = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: null,
     });
@@ -63,14 +62,14 @@ describe("accessProvableApi", () => {
 
   it("reuses a known uuid without re-registering and refreshes its scanner status", async () => {
     const { uuid } = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: null,
     });
     invariant(uuid, "guard: missing uuid");
 
     const result = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: { uuid, scannerStatus: { synced: false, percentage: 0 } },
     });
@@ -85,7 +84,7 @@ describe("accessProvableApi", () => {
   it("throws AleoApiConfigurationResetError for an unknown scanner uuid", async () => {
     await expect(
       accessProvableApi({
-        currency,
+        config,
         viewKey: testnetViewKey,
         provableApi: { uuid: "00000000-0000-0000-0000-000000000000" },
       }),
@@ -98,7 +97,7 @@ describe("fetchAllOwnedRecords", () => {
 
   beforeAll(async () => {
     const provableApi = await accessProvableApi({
-      currency,
+      config,
       viewKey: testnetViewKey,
       provableApi: null,
     });
@@ -110,14 +109,14 @@ describe("fetchAllOwnedRecords", () => {
     const pristineAccount = await getPristineAccount();
 
     const freshProvableApi = await accessProvableApi({
-      currency,
+      config,
       viewKey: pristineAccount.viewKey,
       provableApi: null,
     });
     invariant(freshProvableApi.uuid, "guard: missing uuid");
 
     const records = await fetchAllOwnedRecords({
-      currency,
+      config,
       uuid: freshProvableApi.uuid,
     });
 
@@ -125,9 +124,9 @@ describe("fetchAllOwnedRecords", () => {
   });
 
   it("paginates across multiple pages without gaps or duplicates", async () => {
-    const fullFetch = await fetchAllOwnedRecords({ currency, uuid });
+    const fullFetch = await fetchAllOwnedRecords({ config, uuid });
     const pagedFetch = await fetchAllOwnedRecords({
-      currency,
+      config,
       uuid,
       resultsPerPage: 2,
     });
@@ -142,8 +141,8 @@ describe("fetchAllOwnedRecords", () => {
 
   it("returns only unspent records when unspent is true", async () => {
     const [fullFetch, unspentFetch] = await Promise.all([
-      fetchAllOwnedRecords({ currency, uuid }),
-      fetchAllOwnedRecords({ currency, uuid, unspent: true }),
+      fetchAllOwnedRecords({ config, uuid }),
+      fetchAllOwnedRecords({ config, uuid, unspent: true }),
     ]);
 
     expect(unspentFetch.length).toBeGreaterThan(0);
@@ -153,7 +152,7 @@ describe("fetchAllOwnedRecords", () => {
 
   it("filters records by function name", async () => {
     const records = await fetchAllOwnedRecords({
-      currency,
+      config,
       uuid,
       functions: ["transfer_private"],
     });
@@ -168,7 +167,7 @@ describe("patchPublicOperations", () => {
     const op = toBridgeOperation(testnetLedgerAccountId, testnetSelfConversionTx, testnetAddress);
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [op],
       privateRecords: [testnetMatchingPrivateRecord],
       address: testnetAddress,
@@ -213,7 +212,7 @@ describe("patchPublicOperations", () => {
     };
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [op],
       privateRecords: [caughtUpPrivateRecord],
       address: testnetAddress,
@@ -239,7 +238,7 @@ describe("patchPublicOperations", () => {
     );
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [op],
       privateRecords: [],
       address: testnetAddress,
@@ -264,7 +263,7 @@ describe("patchPublicOperations", () => {
     );
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [op],
       privateRecords: [],
       address: testnetAddress,
@@ -280,7 +279,7 @@ describe("patchPublicOperations", () => {
     const alreadyPatched = { ...op, extra: { ...op.extra, patched: true } };
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [alreadyPatched],
       privateRecords: [],
       address: testnetAddress,
@@ -311,7 +310,7 @@ describe("patchPublicOperations", () => {
     const op = toBridgeOperation(testnetLedgerAccountId, fullyPublicTx, testnetAddress);
 
     const result = await patchPublicOperations({
-      currency,
+      config,
       publicOperations: [op],
       privateRecords: [],
       address: testnetAddress,
@@ -326,7 +325,7 @@ describe("patchPublicOperations", () => {
 describe("getTokenOutDetails", () => {
   it("decrypts amount and recipient for a fully private outgoing token transfer", async () => {
     const result = await getTokenOutDetails({
-      currency,
+      config,
       record: testnetOutgoingPrivateTokenRecord,
       viewKey: testnetViewKey,
     });
@@ -340,7 +339,7 @@ describe("getTokenOutDetails", () => {
 
   it("reads amount and recipient directly for a private-to-public conversion sent to a third party", async () => {
     const result = await getTokenOutDetails({
-      currency,
+      config,
       record: testnetOutgoingPrivateToPublicRecord,
       viewKey: testnetViewKey,
     });
@@ -354,7 +353,7 @@ describe("getTokenOutDetails", () => {
 
   it("falls back to null amount and recipient when the transition index is out of range", async () => {
     const result = await getTokenOutDetails({
-      currency,
+      config,
       record: {
         ...testnetOutgoingPrivateToPublicRecord,
         transition_index: 999,

--- a/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
@@ -1,0 +1,372 @@
+import invariant from "invariant";
+import BigNumber from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import aleoConfig from "../config";
+import { getTestnetIntegConfig } from "../__tests__/fixtures/config.fixture";
+import {
+  testnetAddress,
+  testnetInboundPrivateToPublicTx,
+  testnetLedgerAccountId,
+  testnetMatchingPrivateRecord,
+  testnetOutgoingPrivateToPublicRecord,
+  testnetOutgoingPrivateTokenRecord,
+  testnetSelfConversionTx,
+  testnetThirdPartyConversionTx,
+  testnetThirdPartyRealRecipient,
+  testnetViewKey,
+} from "../__tests__/fixtures/api.fixture";
+import { getPristineAccount } from "../__tests__/helpers/account";
+import { AleoApiConfigurationResetError } from "../errors";
+import { toBridgeOperation } from "../logic/utils";
+import type { AleoPrivateRecord, AleoPublicTransaction } from "../types";
+import {
+  accessProvableApi,
+  fetchAllOwnedRecords,
+  getTokenOutDetails,
+  patchPublicOperations,
+} from "./utils";
+
+const currency = getCryptoCurrencyById("aleo_testnet");
+
+beforeAll(() => {
+  aleoConfig.setCoinConfig(() => getTestnetIntegConfig());
+});
+
+describe("accessProvableApi", () => {
+  it("registers a new scanner account when no uuid is known and returns its status", async () => {
+    const result = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: null,
+    });
+
+    expect(typeof result.uuid).toBe("string");
+    expect(result.uuid?.length).toBeGreaterThan(0);
+    expect(typeof result.scannerStatus?.synced).toBe("boolean");
+    expect(typeof result.scannerStatus?.percentage).toBe("number");
+  });
+
+  it("registering the same view key twice returns the same scanner uuid", async () => {
+    const first = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: null,
+    });
+    const second = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: null,
+    });
+
+    expect(second.uuid).toBe(first.uuid);
+  });
+
+  it("reuses a known uuid without re-registering and refreshes its scanner status", async () => {
+    const { uuid } = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: null,
+    });
+    invariant(uuid, "guard: missing uuid");
+
+    const result = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: { uuid, scannerStatus: { synced: false, percentage: 0 } },
+    });
+
+    // this fixture account has been fully scanned in the past, so its real status is synced
+    expect(result).toEqual({
+      uuid,
+      scannerStatus: { synced: true, percentage: 100 },
+    });
+  });
+
+  it("throws AleoApiConfigurationResetError for an unknown scanner uuid", async () => {
+    await expect(
+      accessProvableApi({
+        currency,
+        viewKey: testnetViewKey,
+        provableApi: { uuid: "00000000-0000-0000-0000-000000000000" },
+      }),
+    ).rejects.toBeInstanceOf(AleoApiConfigurationResetError);
+  });
+});
+
+describe("fetchAllOwnedRecords", () => {
+  let uuid: string;
+
+  beforeAll(async () => {
+    const provableApi = await accessProvableApi({
+      currency,
+      viewKey: testnetViewKey,
+      provableApi: null,
+    });
+    invariant(provableApi.uuid, "guard: missing uuid");
+    uuid = provableApi.uuid;
+  });
+
+  it("returns an empty array for a fresh, never-used account", async () => {
+    const pristineAccount = await getPristineAccount();
+
+    const freshProvableApi = await accessProvableApi({
+      currency,
+      viewKey: pristineAccount.viewKey,
+      provableApi: null,
+    });
+    invariant(freshProvableApi.uuid, "guard: missing uuid");
+
+    const records = await fetchAllOwnedRecords({
+      currency,
+      uuid: freshProvableApi.uuid,
+    });
+
+    expect(records).toEqual([]);
+  });
+
+  it("paginates across multiple pages without gaps or duplicates", async () => {
+    const fullFetch = await fetchAllOwnedRecords({ currency, uuid });
+    const pagedFetch = await fetchAllOwnedRecords({
+      currency,
+      uuid,
+      resultsPerPage: 2,
+    });
+
+    // guards that this fixture account has enough history to actually span multiple pages
+    expect(pagedFetch.length).toBeGreaterThan(2);
+    expect(pagedFetch.length).toBe(fullFetch.length);
+
+    const uniqueCommitments = new Set(pagedFetch.map(r => r.commitment));
+    expect(uniqueCommitments.size).toBe(pagedFetch.length);
+  });
+
+  it("returns only unspent records when unspent is true", async () => {
+    const [fullFetch, unspentFetch] = await Promise.all([
+      fetchAllOwnedRecords({ currency, uuid }),
+      fetchAllOwnedRecords({ currency, uuid, unspent: true }),
+    ]);
+
+    expect(unspentFetch.length).toBeGreaterThan(0);
+    expect(unspentFetch.every(record => !record.spent)).toBe(true);
+    expect(unspentFetch.length).toBe(fullFetch.filter(record => !record.spent).length);
+  });
+
+  it("filters records by function name", async () => {
+    const records = await fetchAllOwnedRecords({
+      currency,
+      uuid,
+      functions: ["transfer_private"],
+    });
+
+    expect(records.length).toBeGreaterThan(0);
+    expect(records.every(record => record.function_name === "transfer_private")).toBe(true);
+  });
+});
+
+describe("patchPublicOperations", () => {
+  it("splits a self conversion into a patched pair of IN/OUT operations", async () => {
+    const op = toBridgeOperation(testnetLedgerAccountId, testnetSelfConversionTx, testnetAddress);
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [op],
+      privateRecords: [testnetMatchingPrivateRecord],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        hash: testnetSelfConversionTx.transaction_id,
+        senders: [testnetAddress],
+        recipients: [testnetAddress],
+        extra: expect.objectContaining({
+          patched: true,
+          transactionType: "public",
+        }),
+      }),
+      expect.objectContaining({
+        type: "IN",
+        hash: testnetSelfConversionTx.transaction_id,
+        senders: [testnetAddress],
+        recipients: [testnetAddress],
+        extra: expect.objectContaining({
+          patched: true,
+          transactionType: "private",
+        }),
+      }),
+    ]);
+  });
+
+  it("decrypts the real recipient for a transfer to a different private account and marks it patched once private sync has caught up", async () => {
+    const op = toBridgeOperation(
+      testnetLedgerAccountId,
+      testnetThirdPartyConversionTx,
+      testnetAddress,
+    );
+    const caughtUpPrivateRecord: AleoPrivateRecord = {
+      ...testnetMatchingPrivateRecord,
+      transaction_id: "unrelated-tx",
+      block_height: testnetThirdPartyConversionTx.block_number + 100,
+    };
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [op],
+      privateRecords: [caughtUpPrivateRecord],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        type: "OUT",
+        hash: testnetThirdPartyConversionTx.transaction_id,
+        recipients: [testnetThirdPartyRealRecipient],
+        extra: expect.objectContaining({ patched: true }),
+      }),
+    ]);
+  });
+
+  it("decrypts the real recipient but leaves it unpatched when private sync hasn't caught up", async () => {
+    const op = toBridgeOperation(
+      testnetLedgerAccountId,
+      testnetThirdPartyConversionTx,
+      testnetAddress,
+    );
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [op],
+      privateRecords: [],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        hash: testnetThirdPartyConversionTx.transaction_id,
+        recipients: [testnetThirdPartyRealRecipient],
+        extra: expect.not.objectContaining({ patched: true }),
+      }),
+    ]);
+  });
+
+  it("passes an inbound private-to-public operation through unchanged", async () => {
+    const op = toBridgeOperation(
+      testnetLedgerAccountId,
+      testnetInboundPrivateToPublicTx,
+      testnetAddress,
+    );
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [op],
+      privateRecords: [],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([op]);
+  });
+
+  it("passes an already patched operation through unchanged without reprocessing", async () => {
+    const op = toBridgeOperation(testnetLedgerAccountId, testnetSelfConversionTx, testnetAddress);
+    const alreadyPatched = { ...op, extra: { ...op.extra, patched: true } };
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [alreadyPatched],
+      privateRecords: [],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([alreadyPatched]);
+  });
+
+  it("passes fully public operations through without any patching", async () => {
+    // synthetic transaction: this branch never touches the network, so no real chain
+    // data is needed here.
+    const fullyPublicTx: AleoPublicTransaction = {
+      transaction_id: "at1fullypublictx",
+      transition_id: "au1fullypublictx",
+      transaction_status: "Accepted",
+      block_number: 1,
+      block_timestamp: "1700000000",
+      function_id: "transfer_public",
+      amount: 42,
+      sender_address: testnetAddress,
+      recipient_address: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+      program_id: "credits.aleo",
+      fee: 100,
+      block_hash: "ab1fullypublictx",
+    };
+    const op = toBridgeOperation(testnetLedgerAccountId, fullyPublicTx, testnetAddress);
+
+    const result = await patchPublicOperations({
+      currency,
+      publicOperations: [op],
+      privateRecords: [],
+      address: testnetAddress,
+      ledgerAccountId: testnetLedgerAccountId,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual([op]);
+  });
+});
+
+describe("getTokenOutDetails", () => {
+  it("decrypts amount and recipient for a fully private outgoing token transfer", async () => {
+    const result = await getTokenOutDetails({
+      currency,
+      record: testnetOutgoingPrivateTokenRecord,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual({
+      amount: new BigNumber(1),
+      recipient: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+      fee: new BigNumber(4609),
+    });
+  });
+
+  it("reads amount and recipient directly for a private-to-public conversion sent to a third party", async () => {
+    const result = await getTokenOutDetails({
+      currency,
+      record: testnetOutgoingPrivateToPublicRecord,
+      viewKey: testnetViewKey,
+    });
+
+    expect(result).toEqual({
+      amount: new BigNumber(1),
+      recipient: "aleo1dtadcxqsjp4fvvafv4ynlq9mp5vgwsap7djlzell8ngag7pj3uysdlhxjs",
+      fee: new BigNumber(2826),
+    });
+  });
+
+  it("falls back to null amount and recipient when the transition index is out of range", async () => {
+    const result = await getTokenOutDetails({
+      currency,
+      record: {
+        ...testnetOutgoingPrivateToPublicRecord,
+        transition_index: 999,
+      },
+      viewKey: testnetViewKey,
+    });
+
+    // fee is still read from the transaction root, independent of the transition lookup
+    expect(result).toEqual({
+      amount: null,
+      recipient: null,
+      fee: new BigNumber(2826),
+    });
+  });
+});

--- a/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.integ.test.ts
@@ -75,11 +75,11 @@ describe("accessProvableApi", () => {
       provableApi: { uuid, scannerStatus: { synced: false, percentage: 0 } },
     });
 
-    // this fixture account has been fully scanned in the past, so its real status is synced
-    expect(result).toEqual({
-      uuid,
-      scannerStatus: { synced: true, percentage: 100 },
-    });
+    expect(result.uuid).toBe(uuid);
+    expect(result.scannerStatus).toEqual(
+      expect.objectContaining({ synced: expect.any(Boolean), percentage: expect.any(Number) }),
+    );
+    expect(result.scannerStatus).not.toEqual({ synced: false, percentage: 0 });
   });
 
   it("throws AleoApiConfigurationResetError for an unknown scanner uuid", async () => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds a comprehensive integration test suite for coin-aleo (part 1 without mobile & desktop tests)

New integration test files

- src/api/index.integ.test.ts — reworked; covers getBalance, getTransactionByHash, public transaction listing
- src/bridge/sync.integ.test.ts — new; covers the bridge sync function end-to-end
- src/bridge/tokens.integ.test.ts — new; covers token bridge syncing
- src/network/api.integ.test.ts — new; covers the raw API client responses
- src/network/utils.integ.test.ts — new; covers accessProvableApi, fetchAllOwnedRecords, patchPublicOperations, getTokenOutDetails

Test infrastructure:

- src/__tests__/helpers/account.ts — helper to generate a fresh Aleo account via @provablehq/sdk (used to assert empty-account behaviour)
- src/__tests__/helpers/cal.ts — helper to register a standalone CAL store before integration tests run
- src/__tests__/fixtures/api.fixture.ts — replaced fabricated mock fixtures with real chain data from the team's dedicated testnet seed account; all tx ids, amounts, fees and block heights are live chain values
- src/__tests__/fixtures/config.fixture.ts — added getTestnetIntegConfig() pointing at the live testnet endpoints via getEnv

Config fixes:

- jest.config.js — added __tests__/ to testPathIgnorePatterns so helper files are not picked up as test suites
- .unimportedrc.json — added **/__tests__/** to ignorePatterns to fix the unimported CI check which was flagging the new helper files

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34467](https://ledgerhq.atlassian.net/browse/LIVE-34467)
