### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (live-devices files)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CustomImage/CustomLockScreenDeviceAction/index.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { setLastSeenCustomImage } from "~/renderer/actions/settings";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { createAction } from "@ledgerhq/live-common/hw/actions/customLockScreenLoad";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { getEnv } from "@ledgerhq/live-env";
 import { useTranslation } from "react-i18next";
@@ -43,7 +42,8 @@ const action = createAction(getEnv("MOCK") ? mockedEventEmitter : customLockScre
 const mockedDevice = { deviceId: "", modelId: DeviceModelId.stax, wired: true };
 
 function checkIfIsRefusedOnStaxError(e: unknown): boolean {
-  return e instanceof ImageLoadRefusedOnDevice || e instanceof ImageCommitRefusedOnDevice;
+  const eName = (e as { name?: string })?.name;
+  return eName === "ImageLoadRefusedOnDevice" || eName === "ImageCommitRefusedOnDevice";
 }
 
 const CustomImageDeviceAction: React.FC<Props> = withRemountableWrapper(props => {

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -4,25 +4,8 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Action } from "@ledgerhq/live-common/hw/actions/types";
 import type { Theme } from "@ledgerhq/react-ui";
-import {
-  EConnResetError,
-  ImageDoesNotExistOnDevice,
-  LanguageInstallRefusedOnDevice,
-  NoSuchAppOnProvider,
-  OutdatedApp,
-} from "@ledgerhq/live-common/errors";
-import {
-  LatestFirmwareVersionRequired,
-  ManagerNotEnoughSpaceError,
-  TransportRaceCondition,
-  UnresponsiveDeviceError,
-  UpdateYourApp,
-  UserRefusedAddress,
-  UserRefusedAllowManager,
-  UserRefusedDeviceNameChange,
-  UserRefusedFirmwareUpdate,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { EConnResetError } from "@ledgerhq/live-common/errors";
+import { UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import {
   addNewDeviceModel,
@@ -509,8 +492,8 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     return renderAllowLanguageInstallation({ modelId, type, t });
   }
   if (imageRemoveRequested) {
-    const refused = error instanceof UserRefusedOnDevice;
-    const noImage = error instanceof ImageDoesNotExistOnDevice;
+    const refused = error?.name === "UserRefusedOnDevice";
+    const noImage = error?.name === "ImageDoesNotExistOnDevice";
     if (error) {
       if (refused || noImage) {
         return renderError({
@@ -600,7 +583,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     return renderInWrongAppForAccount({ t, onRetry });
   }
 
-  if (unresponsive || error instanceof TransportRaceCondition) {
+  if (unresponsive || error?.name === "TransportRaceCondition") {
     return renderError({
       t,
       error: new UnresponsiveDeviceError(),
@@ -610,11 +593,11 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
   }
 
   if (!isLoading && error) {
-    const e = error as unknown;
+    const e = error as { name?: string };
     if (
-      e instanceof ManagerNotEnoughSpaceError ||
-      e instanceof OutdatedApp ||
-      e instanceof UpdateYourApp
+      e.name === "ManagerNotEnoughSpace" ||
+      e.name === "OutdatedApp" ||
+      e.name === "UpdateYourApp"
     ) {
       return renderError({
         t,
@@ -623,7 +606,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       });
     }
 
-    if (e instanceof LatestFirmwareVersionRequired) {
+    if (e.name === "LatestFirmwareVersionRequired") {
       return renderError({
         t,
         error,
@@ -637,7 +620,7 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
       return <DeviceNotOnboardedErrorComponent t={t} device={device} location={location} />;
     }
 
-    if (e instanceof NoSuchAppOnProvider) {
+    if (e.name === "NoSuchAppOnProvider") {
       return renderError({
         t,
         error,
@@ -665,18 +648,18 @@ export const DeviceActionDefaultRendering = <R, H extends States, P>({
     // All the error rendering needs to be unified, the same way we do for ErrorIcon
     // not handled here.
     if (
-      (error as unknown) instanceof UserRefusedFirmwareUpdate ||
-      (error as unknown) instanceof UserRefusedAllowManager ||
-      (error as unknown) instanceof UserRefusedOnDevice ||
-      (error as unknown) instanceof UserRefusedAddress ||
-      (error as unknown) instanceof UserRefusedDeviceNameChange ||
-      (error as unknown) instanceof LanguageInstallRefusedOnDevice
+      error?.name === "UserRefusedFirmwareUpdate" ||
+      error?.name === "UserRefusedAllowManager" ||
+      error?.name === "UserRefusedOnDevice" ||
+      error?.name === "UserRefusedAddress" ||
+      error?.name === "UserRefusedDeviceNameChange" ||
+      error?.name === "LanguageInstallRefusedOnDevice"
     ) {
       withExportLogs = false;
       warning = true;
     }
 
-    if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    if (error?.name === "UserRefusedDeviceNameChange") {
       withDescription = false;
     }
     return renderError({

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -20,25 +20,13 @@ import {
   Text,
   Theme,
 } from "@ledgerhq/react-ui";
-import {
-  FirmwareNotRecognized,
-  LockedDeviceError,
-  UpdateYourApp,
-  LatestFirmwareVersionRequired,
-  WrongDeviceForAccount,
-  DisconnectedDevice,
-  UnsupportedFeatureError,
-} from "@ledgerhq/errors";
+import { WrongDeviceForAccount, DisconnectedDevice } from "@ledgerhq/errors";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { getNoticeType, getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
 import { CompleteExchangeError } from "@ledgerhq/live-common/exchange/error";
 import { useFeature } from "@features/platform-feature-flags";
-import {
-  DeviceNotOnboarded,
-  NoSuchAppOnProvider,
-  TransactionRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
+import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
@@ -926,6 +914,7 @@ export const renderError = ({
   currencyName?: string;
 }) => {
   let tmpError = error;
+  const eName = (error as { name?: string })?.name;
   // Redirects from renderError and not from DeviceActionDefaultRendering because renderError
   // can be used directly by other component
   if (
@@ -933,9 +922,9 @@ export const renderError = ({
     ("name" in error && error.name === "AlreadySendingApduError")
   ) {
     return renderAlreadySendingApduError({ t, onRetry, inlineRetry });
-  } else if (tmpError instanceof LockedDeviceError) {
+  } else if (eName === "LockedDeviceError") {
     return renderLockedDeviceError({ t, onRetry, device, inlineRetry });
-  } else if (tmpError instanceof DeviceNotOnboarded) {
+  } else if (eName === "DeviceNotOnboarded") {
     return <DeviceNotOnboardedErrorComponent t={t} device={device} />;
   } else if (isCounterfeitError(tmpError)) {
     return (
@@ -944,12 +933,12 @@ export const renderError = ({
       />
     );
   } else if (
-    tmpError instanceof FirmwareNotRecognized ||
+    eName === "FirmwareNotRecognized" ||
     isInvalidGetFirmwareMetadataResponseError(tmpError)
   ) {
     return <FirmwareNotRecognizedErrorComponent onRetry={onRetry} />;
-  } else if (tmpError instanceof CompleteExchangeError) {
-    if (tmpError.title === "userRefused") {
+  } else if (eName === "CompleteExchangeError") {
+    if ((tmpError as CompleteExchangeError).title === "userRefused") {
       tmpError = new TransactionRefusedOnDevice();
     }
   } else if (isDmkError(error) && error._tag === "DeviceDeprecationError") {
@@ -960,16 +949,16 @@ export const renderError = ({
         coinName={currencyName}
       />
     );
-  } else if (tmpError instanceof NoSuchAppOnProvider) {
+  } else if (eName === "NoSuchAppOnProvider") {
     return (
       <NoSuchAppOnProviderErrorComponent
-        error={tmpError}
+        error={tmpError as Error}
         productName={getDeviceModel(device?.modelId as DeviceModelId)?.productName}
         learnMoreLink={learnMoreLink}
         learnMoreTextKey={learnMoreTextKey}
       />
     );
-  } else if (tmpError instanceof UnsupportedFeatureError) {
+  } else if (eName === "UnsupportedFeatureError") {
     return <UnsupportedFeatureErrorComponent />;
   } else if (isDisconnectedWhileSendingApduError(tmpError)) {
     tmpError = new DisconnectedDevice();
@@ -1014,8 +1003,8 @@ export const renderError = ({
         {managerAppName || requireFirmwareUpdate ? (
           <OpenManagerButton
             appName={managerAppName}
-            updateApp={tmpError instanceof UpdateYourApp}
-            firmwareUpdate={tmpError instanceof LatestFirmwareVersionRequired}
+            updateApp={eName === "UpdateYourApp"}
+            firmwareUpdate={eName === "LatestFirmwareVersionRequired"}
           />
         ) : (
           <>

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.tsx
@@ -5,7 +5,6 @@ import type { Action, Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SkipReason } from "@ledgerhq/live-common/apps/types";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useTranslation } from "react-i18next";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
 import AppInstallItem, { ItemState } from "./AppInstallItem";
 import AllowManagerModal from "./AllowManagerModal";
 import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";
@@ -59,7 +58,7 @@ const InstallSetOfApps = ({
   } = status;
 
   useEffect(() => {
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       onCancel();
     } else if (onError && error) {
       onError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/errors/DeviceError.tsx
@@ -5,12 +5,6 @@ import { useNavigate } from "react-router";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import { context } from "~/renderer/drawers/Provider";
 import UpdateFirmwareError from ".";
-import { LockedDeviceError, UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
-import {
-  ImageCommitRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  LanguageInstallRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 type Props = {
   error: Error;
@@ -33,18 +27,18 @@ const DeviceCancel = ({
   const onCloseReload = useCallback(() => {
     onDrawerClose();
 
-    if (error instanceof UserRefusedFirmwareUpdate && shouldReloadManagerOnCloseIfUpdateRefused) {
+    if (error?.name === "UserRefusedFirmwareUpdate" && shouldReloadManagerOnCloseIfUpdateRefused) {
       navigate("/manager/reload");
       setDrawer();
     }
   }, [error, navigate, onDrawerClose, setDrawer, shouldReloadManagerOnCloseIfUpdateRefused]);
 
-  const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
-  const isDeviceLockedError = error instanceof LockedDeviceError;
+  const isUserRefusedFirmwareUpdate = error?.name === "UserRefusedFirmwareUpdate";
+  const isDeviceLockedError = error?.name === "LockedDeviceError";
   const isRestoreStepRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof ImageCommitRefusedOnDevice ||
-    error instanceof LanguageInstallRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" ||
+    error?.name === "ImageCommitRefusedOnDevice" ||
+    error?.name === "LanguageInstallRefusedOnDevice";
   const isRetryableError =
     isUserRefusedFirmwareUpdate || isDeviceLockedError || isRestoreStepRefusedOnDevice;
 

--- a/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/UpdateFirmwareModal/index.tsx
@@ -10,7 +10,6 @@ import { Flex, FlowStepper, Text } from "@ledgerhq/react-ui";
 import Disclaimer from "./Disclaimer";
 import Cancel from "./errors/Cancel";
 import DeviceCancel from "./errors/DeviceError";
-import { DisconnectedDevice, DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
 import SideDrawerHeader from "~/renderer/components/SideDrawerHeader";
 import { createFirmwareUpdateSteps } from "./helpers/createFirmwareUpdateSteps";
 import { StepId, STEPS } from "./types";
@@ -59,8 +58,9 @@ const UpdateModal = ({
   const withFinal = useMemo(() => hasFinalFirmware(firmware.final), [firmware]);
   const [cancel, setCancel] = useState<boolean>(false);
 
-  const isDisconnectedDeviceError = err instanceof DisconnectedDevice;
-  const isDisconnectedDeviceDuringOperationError = err instanceof DisconnectedDeviceDuringOperation;
+  const isDisconnectedDeviceError = err?.name === "DisconnectedDevice";
+  const isDisconnectedDeviceDuringOperationError =
+    err?.name === "DisconnectedDeviceDuringOperation";
   const isDeviceDisconnected =
     isDisconnectedDeviceError ||
     isDisconnectedDeviceDuringOperationError ||

--- a/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/customImage/Step4Transfer.tsx
@@ -3,7 +3,6 @@ import { ProcessorResult } from "~/renderer/components/CustomImage/dithering/typ
 import { Step, StepProps } from "./types";
 import { useTranslation } from "react-i18next";
 import { Flex } from "@ledgerhq/react-ui";
-import { ImageCommitRefusedOnDevice, ImageLoadRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/live-common/device/use-cases/isCustomLockScreenSupported";
 import StepFooter from "./StepFooter";
 import StepContainer from "./StepContainer";
@@ -50,9 +49,9 @@ const StepTransfer: React.FC<Props> = props => {
 
   // User refused loading the image OR committing the image
   const userRefusedOnDevice =
-    error instanceof ImageLoadRefusedOnDevice ||
+    error?.name === "ImageLoadRefusedOnDevice" ||
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageCommitRefusedOnDevice";
 
   return (
     <StepContainer

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/RemoveCustomImage.tsx
@@ -7,7 +7,6 @@ import removeImage from "@ledgerhq/live-common/hw/customLockScreenRemove";
 import { withV3StyleProvider } from "~/renderer/styles/StyleProviderV3";
 import { useTranslation } from "react-i18next";
 import { clearLastSeenCustomImage } from "~/renderer/actions/settings";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 
 const action = createAction(removeImage);
@@ -40,14 +39,14 @@ const RemoveCustomImage: React.FC<Props> = ({ onClose, onRemoved }) => {
   const onError = useCallback(
     (error: Error) => {
       setError(error);
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         dispatch(clearLastSeenCustomImage());
       }
     },
     [dispatch],
   );
 
-  const showRetry = error && !(error instanceof ImageDoesNotExistOnDevice);
+  const showRetry = error && error?.name !== "ImageDoesNotExistOnDevice";
 
   return (
     <Flex

--- a/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
+++ b/apps/ledger-live-mobile/src/components/BleDevicePairingFlow/DmkBleDevicePairing.tsx
@@ -4,7 +4,6 @@ import { Flex } from "@ledgerhq/native-ui";
 import { useBleDevicePairing } from "@ledgerhq/live-dmk-mobile";
 import { Device } from "@ledgerhq/types-devices";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleFailedPairing } from "~/components/BleDevicePairingFlow/BleDevicePairingContent/BleFailedPairing";
 import { BleDevicePairingProgress } from "./BleDevicePairingContent/BleDevicePairingProgress";
 import { BleDevicePaired } from "./BleDevicePairingContent/BleDevicePaired";
@@ -37,7 +36,7 @@ export const DmkBleDevicePairing = ({
   let content;
 
   const needsToForgetDevice = useMemo(() => {
-    return pairingError instanceof PeerRemovedPairing;
+    return (pairingError as { name?: string })?.name === "PeerRemovedPairing";
   }, [pairingError]);
 
   useEffect(() => {
@@ -46,9 +45,10 @@ export const DmkBleDevicePairing = ({
     }
   }, [isPaired, device, onPaired]);
 
+  const pairingErrorName = (pairingError as { name?: string })?.name;
   if (isPaired) {
     content = <BleDevicePaired device={device} productName={productName} />;
-  } else if (pairingError instanceof PeerRemovedPairing) {
+  } else if (pairingErrorName === "PeerRemovedPairing") {
     content = (
       <BleForgetDeviceDrawer
         isOpen={needsToForgetDevice}
@@ -56,7 +56,7 @@ export const DmkBleDevicePairing = ({
         onRetry={onRetry}
       />
     );
-  } else if (pairingError && !(pairingError instanceof LockedDeviceError)) {
+  } else if (pairingError && pairingErrorName !== "LockedDeviceError") {
     content = (
       <BleFailedPairing productName={productName} onRetry={onRetry} onOpenHelp={onOpenHelp} />
     );

--- a/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/InstallSetOfApps/index.tsx
@@ -18,7 +18,6 @@ import Confirmation from "./Confirmation";
 import Restore from "./Restore";
 import { lastSeenDeviceSelector } from "~/reducers/settings";
 import { useAppDeviceAction } from "~/hooks/deviceActions";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
 
 type Props = {
   restore?: boolean;
@@ -179,7 +178,7 @@ const InstallSetOfApps = ({
         onClose={onWrappedError}
         onModalHide={onWrappedError}
       >
-        {error instanceof UserRefusedAllowManager ? (
+        {error?.name === "UserRefusedAllowManager" ? (
           <TrackScreen
             category="App restoration cancelled on device"
             refreshSource={false}

--- a/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/index.tsx
@@ -1,15 +1,3 @@
-import {
-  TransportStatusError,
-  UserRefusedDeviceNameChange,
-  UserRefusedOnDevice,
-  LatestFirmwareVersionRequired,
-  UnsupportedFeatureError,
-} from "@ledgerhq/errors";
-import {
-  DeviceNotOnboarded,
-  ImageDoesNotExistOnDevice,
-  NoSuchAppOnProvider,
-} from "@ledgerhq/live-common/errors";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
@@ -533,8 +521,8 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
   // level instead of being an exception here.
   if (imageRemoveRequested) {
     if (error) {
-      const refused = (error as Status["error"]) instanceof UserRefusedOnDevice;
-      const noImage = (error as Status["error"]) instanceof ImageDoesNotExistOnDevice;
+      const refused = error?.name === "UserRefusedOnDevice";
+      const noImage = error?.name === "ImageDoesNotExistOnDevice";
       if (refused || noImage) {
         return renderError({
           t,
@@ -652,30 +640,30 @@ export function DeviceActionDefaultRendering<R, H extends Status, P>({
     // into another handled case.
     if (
       device &&
-      (error instanceof DeviceNotOnboarded ||
-        ((error as unknown) instanceof TransportStatusError &&
+      (error?.name === "DeviceNotOnboarded" ||
+        (error?.name === "TransportStatusError" &&
           ((error as Error).message.includes("0x6d06") ||
             (error as Error).message.includes("0x6d07"))))
     ) {
       return renderDeviceNotOnboarded({ t, device, navigation });
     }
 
-    if (error instanceof LatestFirmwareVersionRequired) {
+    if (error?.name === "LatestFirmwareVersionRequired") {
       return <RequiredFirmwareUpdate navigation={navigation} device={selectedDevice} />;
     }
 
-    if (error instanceof UnsupportedFeatureError) {
+    if (error?.name === "UnsupportedFeatureError") {
       return <UnsupportedFeatureComponent error={error} />;
     }
 
-    if (error instanceof NoSuchAppOnProvider && device?.modelId === DeviceModelId.nanoS) {
+    if (error?.name === "NoSuchAppOnProvider" && device?.modelId === DeviceModelId.nanoS) {
       // This should be only happening for Nano S devices, but in order to make sure we don't miss any
       // use case for other devices we keep the check and will consider to remove it later after complete
       // checks.
       return <NanoSNotSupportedComponent />;
     }
 
-    if ((error as Status["error"]) instanceof UserRefusedDeviceNameChange) {
+    if (error?.name === "UserRefusedDeviceNameChange") {
       return renderError({
         t,
         navigation,

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -9,15 +9,7 @@ import { ParamListBase, T } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import { getDeviceModel } from "@ledgerhq/devices";
-import {
-  BluetoothRequired,
-  LockedDeviceError,
-  PeerRemovedPairing,
-  WrongDeviceForAccount,
-  FirmwareNotRecognized,
-  UnsupportedFeatureError,
-  NanoSNotSupported,
-} from "@ledgerhq/errors";
+import { WrongDeviceForAccount, NanoSNotSupported } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
@@ -603,9 +595,9 @@ export function renderError({
   currencyName?: string;
   hasExportLogButton?: boolean;
 }) {
-  if (error instanceof LockedDeviceError) {
+  if (error?.name === "LockedDeviceError") {
     return renderLockedDeviceError({ t, onRetry, device });
-  } else if (error instanceof PeerRemovedPairing) {
+  } else if (error?.name === "PeerRemovedPairing") {
     // User needs to forget the device on their phone settings
     const productName = device ? getDeviceModel(device?.modelId).productName : "Ledger Device";
     return (
@@ -629,10 +621,10 @@ export function renderError({
       const getCTA = (error: Error, hasRetry: boolean): CTA => {
         if (
           isInvalidGetFirmwareMetadataResponseError(error) ||
-          error instanceof FirmwareNotRecognized
+          error?.name === "FirmwareNotRecognized"
         ) {
           return "OpenExperimentalSettings";
-        } else if (!(error instanceof PeerRemovedPairing) && hasRetry) {
+        } else if (error?.name !== "PeerRemovedPairing" && hasRetry) {
           return "Retry";
         }
         return "None";
@@ -688,7 +680,7 @@ export function renderError({
             }
           };
           return (
-            <Flex alignSelf="stretch" mb={0} mt={error instanceof BluetoothRequired ? 0 : 8}>
+            <Flex alignSelf="stretch" mb={0} mt={error?.name === "BluetoothRequired" ? 0 : 8}>
               <StyledButton
                 event="DeviceActionErrorRetry"
                 type="main"
@@ -706,7 +698,7 @@ export function renderError({
     };
     return (
       <Wrapper>
-        {error instanceof UnsupportedFeatureError ? (
+        {error?.name === "UnsupportedFeatureError" ? (
           <TrackScreen category="Unsupported Feature" name="Error: App Unavailable" />
         ) : null}
         <GenericErrorView

--- a/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
+++ b/apps/ledger-live-mobile/src/components/SelectDevice2/DeviceLockedCheckDrawer.tsx
@@ -10,10 +10,8 @@ import { useStuckDeviceActionHint } from "../StuckDeviceActionHint/useStuckDevic
 import QueuedDrawer from "../QueuedDrawer";
 import { useIsDeviceLockedPolling } from "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling";
 import { IsDeviceLockedResultType } from "~/hooks/useIsDeviceLockedPolling/types";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { BleForgetDeviceIllustration } from "../BleDevicePairingFlow/BleDevicePairingContent/BleForgetDeviceIllustration";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { AlreadySendingApduError } from "@ledgerhq/device-management-kit";
 
 type Props = {
   isOpen: boolean;
@@ -29,9 +27,9 @@ export const DeviceLockedCheckDrawer = ({ isOpen, device, onDeviceUnlocked, onCl
   const isLocked = isLockedResult.type === IsDeviceLockedResultType.locked;
   const isUnlocked = isLockedResult.type === IsDeviceLockedResultType.unlocked;
   const isError = isLockedResult.type === IsDeviceLockedResultType.error;
-  const isPeerRemovedPairingError = isError && isLockedResult.error instanceof PeerRemovedPairing;
+  const isPeerRemovedPairingError = isError && isLockedResult.error?.name === "PeerRemovedPairing";
   const isAlreadySendingApduError =
-    isError && isLockedResult.error instanceof AlreadySendingApduError;
+    isError && isLockedResult.error?.name === "AlreadySendingApduError";
   const isOtherError = isError && !isPeerRemovedPairingError && !isAlreadySendingApduError;
   const isLockedStateCannotBeDetermined =
     isLockedResult.type === IsDeviceLockedResultType.lockedStateCannotBeDetermined;

--- a/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
+++ b/apps/ledger-live-mobile/src/screens/CustomImage/CustomImageRemoval.tsx
@@ -3,7 +3,6 @@ import { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/t
 import { CustomImageNavigatorParamList } from "~/components/RootNavigator/types/CustomImageNavigator";
 import { ScreenName } from "~/const";
 import { useRemoveImageDeviceAction } from "~/hooks/deviceActions";
-import { ImageDoesNotExistOnDevice } from "@ledgerhq/live-common/errors";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useTranslation } from "~/context/Locale";
 import DeviceAction from "~/components/DeviceAction";
@@ -47,7 +46,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
 
   const onError = useCallback(
     (error: Error) => {
-      if (error instanceof ImageDoesNotExistOnDevice) {
+      if (error?.name === "ImageDoesNotExistOnDevice") {
         setDeviceHasImage?.(false);
       }
       setError(error);
@@ -76,7 +75,7 @@ export function CustomImageRemoval({ route }: NavigationProps) {
             <Flex flex={1} justifyContent="center">
               <GenericErrorView error={error} hasExportLogButton={false} />
             </Flex>
-            {!(error instanceof ImageDoesNotExistOnDevice) && (
+            {error?.name !== "ImageDoesNotExistOnDevice" && (
               <Button type="main" size="large" onPress={handleTryAgain} my={4}>
                 {t("common.tryAgain")}
               </Button>

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/RestoreStepDenied.tsx
@@ -6,12 +6,6 @@ import { getDeviceModel } from "@ledgerhq/devices";
 import Button from "~/components/wrappedUi/Button";
 import Link from "~/components/wrappedUi/Link";
 import { TrackScreen } from "~/analytics";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
-import {
-  LanguageInstallRefusedOnDevice,
-  ImageLoadRefusedOnDevice,
-  ImageCommitRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 
 export const RestoreStepDenied = ({
   t,
@@ -26,15 +20,20 @@ export const RestoreStepDenied = ({
   onPressSkip: () => void;
   stepDeniedError: Error;
 }) => {
-  const analyticsDrawerName =
-    stepDeniedError instanceof LanguageInstallRefusedOnDevice
-      ? `Error: the language change was cancelled on the device`
-      : (stepDeniedError as Error) instanceof ImageLoadRefusedOnDevice ||
-          (stepDeniedError as Error) instanceof ImageCommitRefusedOnDevice
-        ? `Error: the restoration of lock screen picture was cancelled on the device`
-        : (stepDeniedError as Error) instanceof UserRefusedAllowManager
-          ? `Error: the restoration of apps was cancelled on the device`
-          : `Error: ${(stepDeniedError as Error).name}`;
+  const errorName = stepDeniedError?.name;
+  let analyticsDrawerName: string;
+  if (errorName === "LanguageInstallRefusedOnDevice") {
+    analyticsDrawerName = `Error: the language change was cancelled on the device`;
+  } else if (
+    errorName === "ImageLoadRefusedOnDevice" ||
+    errorName === "ImageCommitRefusedOnDevice"
+  ) {
+    analyticsDrawerName = `Error: the restoration of lock screen picture was cancelled on the device`;
+  } else if (errorName === "UserRefusedAllowManager") {
+    analyticsDrawerName = `Error: the restoration of apps was cancelled on the device`;
+  } else {
+    analyticsDrawerName = `Error: ${errorName}`;
+  }
   return (
     <Flex alignItems="center" justifyContent="center" px={1}>
       <TrackScreen category={analyticsDrawerName} refreshSource={false} />

--- a/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
+++ b/apps/ledger-live-mobile/src/screens/FirmwareUpdate/useUpdateFirmwareAndRestoreSettings.ts
@@ -17,8 +17,6 @@ import {
   UserRefusedAllowManager,
   WebsocketConnectionError,
   WebsocketConnectionFailed,
-  CustomErrorClassType,
-  TransportStatusErrorClassType,
 } from "@ledgerhq/errors";
 import {
   ConnectManagerTimeout,
@@ -36,9 +34,7 @@ import {
 import { isCustomLockScreenSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 
 // Errors related to the device connection
-export const reconnectDeviceErrorClasses: Array<
-  CustomErrorClassType | TransportStatusErrorClassType
-> = [
+export const reconnectDeviceErrorClasses: Array<new (...args: never) => Error> = [
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
@@ -48,17 +44,16 @@ export const reconnectDeviceErrorClasses: Array<
 ];
 
 // Errors that could be solved by the user: either on their phone or on their device
-export const userSolvableErrorClasses: Array<CustomErrorClassType | TransportStatusErrorClassType> =
-  [
-    ...reconnectDeviceErrorClasses,
-    WebsocketConnectionError,
-    UserRefusedAllowManager,
-    LanguageInstallRefusedOnDevice,
-    ImageCommitRefusedOnDevice,
-    ImageLoadRefusedOnDevice,
-    WebsocketConnectionFailed,
-    DisconnectedDeviceDuringOperation,
-  ];
+export const userSolvableErrorClasses: Array<new (...args: never) => Error> = [
+  ...reconnectDeviceErrorClasses,
+  WebsocketConnectionError,
+  UserRefusedAllowManager,
+  LanguageInstallRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+  ImageLoadRefusedOnDevice,
+  WebsocketConnectionFailed,
+  DisconnectedDeviceDuringOperation,
+];
 
 export type FirmwareUpdateParams = {
   device: Device;
@@ -413,7 +408,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "languageRestore" &&
       installLanguageState.error &&
-      installLanguageState.error instanceof LanguageInstallRefusedOnDevice
+      installLanguageState.error?.name === "LanguageInstallRefusedOnDevice"
     ) {
       return installLanguageState.error;
     }
@@ -421,8 +416,8 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "imageRestore" &&
       loadImageState.error &&
-      (loadImageState.error instanceof ImageLoadRefusedOnDevice ||
-        (loadImageState.error as unknown) instanceof ImageCommitRefusedOnDevice)
+      (loadImageState.error?.name === "ImageLoadRefusedOnDevice" ||
+        loadImageState.error?.name === "ImageCommitRefusedOnDevice")
     ) {
       return loadImageState.error;
     }
@@ -430,7 +425,7 @@ export const useUpdateFirmwareAndRestoreSettings = ({
     if (
       updateStep === "appsRestore" &&
       restoreAppsState.error &&
-      restoreAppsState.error instanceof UserRefusedAllowManager
+      restoreAppsState.error?.name === "UserRefusedAllowManager"
     ) {
       return restoreAppsState.error;
     }

--- a/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/MyLedgerChooseDevice/index.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { Flex } from "@ledgerhq/native-ui";
 import { ScreenName } from "~/const";
@@ -88,7 +87,7 @@ const ChooseDevice: React.FC<ChooseDeviceProps> = ({ isFocused }) => {
     // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
     // and avoids a duplicated error drawers/messages.
     // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/GenuineCheckErrorDrawer.tsx
@@ -5,7 +5,6 @@ import QueuedDrawer from "~/components/QueuedDrawer";
 import { TrackScreen, track } from "~/analytics";
 import GenericErrorView from "~/components/GenericErrorView";
 import { GenericInformationBody } from "~/components/GenericInformationBody";
-import { BluetoothRequired, FirmwareNotRecognized } from "@ledgerhq/errors";
 import { useNavigation } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 import type { SyncOnboardingScreenProps } from "LLM/features/Onboarding/screens/SyncOnboardingCompanion/types";
@@ -60,11 +59,12 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const navigation = useNavigation<SyncOnboardingScreenProps["navigation"]>();
+  const eName = (error as { name?: string })?.name;
 
   // Depending from where the device was not recognized we can a FirmwareNotRecognized or a simple Error
   const isNotFoundEntity =
     error &&
-    (error instanceof FirmwareNotRecognized ||
+    (eName === "FirmwareNotRecognized" ||
       (error instanceof Error && error.message === "not found entity"));
 
   const onGoToSettings = useCallback(() => {
@@ -85,7 +85,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
   const screenName = isNotFoundEntity
     ? "Error: Device OS version not recognized"
     : error
-      ? `Error: ${isDmkError(error) ? error._tag : (error as Error).name}`
+      ? `Error: ${isDmkError(error) ? error._tag : eName}`
       : "Error: unknown error";
 
   const handleRetry = () => {
@@ -140,7 +140,7 @@ const GenuineCheckErrorDrawer: React.FC<Props> = ({
         />
         <Button
           type="main"
-          mt={(error as unknown as Error) instanceof BluetoothRequired ? 6 : 8}
+          mt={eName === "BluetoothRequired" ? 6 : 8}
           mb={7}
           size={"large"}
           onPress={handleRetry}

--- a/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/SyncOnboarding/index.tsx
@@ -6,7 +6,6 @@ import { OnboardingStep } from "@ledgerhq/live-common/hw/extractOnboardingState"
 import { useToggleOnboardingEarlyCheck } from "@ledgerhq/live-common/deviceSDK/hooks/useToggleOnboardingEarlyChecks";
 import { log } from "@ledgerhq/logs";
 import { getDeviceModel } from "@ledgerhq/devices";
-import { LockedDeviceError, UnexpectedBootloader } from "@ledgerhq/errors";
 import { NORMAL_DESYNC_OVERLAY_DISPLAY_DELAY_MS } from "./constants";
 import { EarlySecurityCheck } from "./EarlySecurityCheck";
 import DesyncDrawer from "./DesyncDrawer";
@@ -232,7 +231,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   // A fatal error during polling triggers directly an error message (or the auto repair)
   useEffect(() => {
     if (isFocused && fatalError) {
-      if (fatalError instanceof UnexpectedBootloader) {
+      if (fatalError?.name === "UnexpectedBootloader") {
         log("SyncOnboardingIndex", "Device in bootloader mode. Trying to auto repair", {
           fatalError,
         });
@@ -250,7 +249,7 @@ export const SyncOnboarding = ({ navigation, route }: SyncOnboardingScreenProps)
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
 
-    if (isFocused && allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (isFocused && allowedError && allowedError?.name !== "LockedDeviceError") {
       log("SyncOnboardingIndex", "Polling allowed error", { allowedError });
 
       timeout = setTimeout(() => {

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -155,7 +155,7 @@ export const reducer = (state: State, action: Action): State => {
 
         /*
           const error = event.error;
-          if (error instanceof ManagerDeviceLockedError) {
+          if ((error as { name?: string })?.name === "ManagerDeviceLocked") {
             return {
               ...state,
               currentError: {

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/restoreAppData.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/restoreAppData.ts
@@ -1,6 +1,5 @@
 import {
   AppNotFound,
-  UserRefusedOnDevice,
   restoreAppStorage,
   restoreAppStorageCommit,
   restoreAppStorageInit,
@@ -67,7 +66,7 @@ export function restoreAppData(
           }
 
           // User refused on device
-          if (e instanceof UserRefusedOnDevice) {
+          if ((e as { name?: string })?.name === "UserRefusedOnDevice") {
             // NOTE: Display a message to the user to retry the restore process
             // If he does not, we should delete the app data (in another flow)
             subscriber.next({

--- a/libs/ledger-live-common/src/deviceSDK/actions/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/core.ts
@@ -1,4 +1,3 @@
-import { LockedDeviceError, UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { SharedTaskEvent } from "../tasks/core";
 
 // Represents the state that is shared with any action
@@ -41,10 +40,7 @@ export function sharedReducer({ event }: { event: SharedTaskEvent }): Partial<Sh
       const { error, retrying } = event;
       const { name, message } = error;
 
-      if (
-        error instanceof LockedDeviceError ||
-        (error as unknown) instanceof UnresponsiveDeviceError
-      ) {
+      if (name === "LockedDeviceError" || name === "UnresponsiveDeviceError") {
         // Propagates the error so the consumer can distinguish locked (from error response) and unresponsive error.
         return { lockedDevice: true, error: { type: "SharedError", name, message, retrying } };
       }

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
@@ -1,6 +1,6 @@
 import { Observable, of, throwError } from "rxjs";
 import URL from "url";
-import Transport, { TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 import type { FinalFirmware, OsuFirmware, DeviceInfo, SocketEvent } from "@ledgerhq/types-live";
 import { version as livecommonversion } from "../../../../package.json";
 import { getEnv } from "@ledgerhq/live-env";
@@ -11,7 +11,6 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   UserRefusedFirmwareUpdate,
   DeviceOnDashboardExpected,
-  ManagerDeviceLockedError,
 } from "@ledgerhq/errors";
 import { LOG_TYPE, UnresponsiveCmdEvent } from "../core";
 
@@ -122,7 +121,7 @@ export function installFirmwareCommand(
 const remapSocketUnresponsiveError: (
   e: Error,
 ) => Observable<InstallFirmwareCommandEvent> | Observable<never> = (e: Error) => {
-  if (e instanceof ManagerDeviceLockedError) {
+  if ((e as { name?: string })?.name === "ManagerDeviceLocked") {
     return of({ type: "unresponsive" });
   }
 
@@ -137,10 +136,11 @@ const remapSocketFirmwareError: (e: Error) => Observable<never> = (e: Error) => 
     return throwError(() => new DeviceOnDashboardExpected());
   }
 
+  const statusCode = (e as { statusCode?: number }).statusCode;
   const status =
-    e instanceof TransportStatusError
-      ? e.statusCode.toString(16)
-      : (e as Error).message.slice((e as Error).message.length - 4);
+    (e as { name?: string })?.name === "TransportStatusError" && statusCode !== undefined
+      ? statusCode.toString(16)
+      : (e as { message?: string })?.message?.slice(-4);
 
   switch (status) {
     case "6a84":

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.ts
@@ -1,12 +1,4 @@
-import {
-  CantOpenDevice,
-  DisconnectedDevice,
-  LockedDeviceError,
-  TransportRaceCondition,
-  UnresponsiveDeviceError,
-  TransportStatusErrorClassType,
-  CustomErrorClassType,
-} from "@ledgerhq/errors";
+import { TransportStatusErrorClassType, CustomErrorClassType } from "@ledgerhq/errors";
 import { Observable, from, of, throwError, timer } from "rxjs";
 import { catchError, concatMap, retry, switchMap, timeout } from "rxjs/operators";
 import { Transport, TransportRef } from "../transports/core";
@@ -44,12 +36,13 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
               // - LockedDeviceError and UnresponsiveDeviceError: on every transport if there is a device but it is locked
               // - CantOpenDevice: it can come from a transport when no device is found
               // - DisconnectedDevice: it can come from a transport while switching app
+              const eName = (error as { name?: string })?.name;
               if (
-                error instanceof LockedDeviceError ||
-                error instanceof UnresponsiveDeviceError ||
-                error instanceof CantOpenDevice ||
-                error instanceof DisconnectedDevice ||
-                error instanceof TransportRaceCondition
+                eName === "LockedDeviceError" ||
+                eName === "UnresponsiveDeviceError" ||
+                eName === "CantOpenDevice" ||
+                eName === "DisconnectedDevice" ||
+                eName === "TransportRaceCondition"
               ) {
                 // Emits to the action an error event so it is aware of it (for ex locked device) before retrying
                 const event: SharedTaskEvent = {
@@ -73,7 +66,10 @@ export function sharedLogicTaskWrapper<TaskArgsType, TaskEventsType>(
   };
 }
 
-type ErrorClass = CustomErrorClassType | TransportStatusErrorClassType;
+type ErrorClass =
+  | (new (...args: any[]) => Error)
+  | CustomErrorClassType
+  | TransportStatusErrorClassType;
 
 // To be able to retry a command, the command needs to take an object containing a transport as its argument
 type CommandTransportArgs = { transport: Transport };

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -1,4 +1,4 @@
-import { DisconnectedDevice, StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { DisconnectedDevice, StatusCodes } from "@ledgerhq/errors";
 import type { DeviceId } from "@ledgerhq/types-live";
 
 import { Observable, concat, of, throwError } from "rxjs";
@@ -67,7 +67,10 @@ function internalGetBatteryStatusesTask({
           return { type: "data" as const, batteryStatus };
         }),
         catchError((err: Error) => {
-          if (err instanceof TransportStatusError && err.statusCode === StatusCodes.UNKNOWN_APDU)
+          if (
+            (err as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+            (err as { statusCode?: number }).statusCode === StatusCodes.UNKNOWN_APDU
+          )
             return of<GetBatteryStatusesTaskEvent>({ type: "taskError", error: "UnknownApdu" });
 
           return throwError(() => err);

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
@@ -7,7 +7,7 @@ import {
   toggleOnboardingEarlyCheckCmd,
   ToggleTypeP2,
 } from "../commands/toggleOnboardingEarlyCheck";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/errors";
 
 export type ToggleOnboardingEarlyCheckTaskError =
   | "DeviceInInvalidState"
@@ -55,16 +55,17 @@ function internalToggleOnboardingEarlyCheckTask({
     ).subscribe({
       next: _ => subscriber.next({ type: "success" }),
       error: (error: unknown) => {
-        if (error instanceof TransportStatusError) {
+        if ((error as { name?: string })?.name === "TransportStatusError") {
           tracer.trace("A TransportStatusError error occurred", { error });
+          const statusCode = (error as { statusCode?: number }).statusCode;
 
-          if (error.statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED) {
+          if (statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED) {
             subscriber.next({
               type: "taskError",
               error: "DeviceInInvalidState",
             });
             return;
-          } else if (error.statusCode === StatusCodes.INCORRECT_LENGTH) {
+          } else if (statusCode === StatusCodes.INCORRECT_LENGTH) {
             subscriber.next({
               type: "taskError",
               error: "InternalError",

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -3,8 +3,6 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   UnresponsiveDeviceError,
-  UserRefusedAllowManager,
-  UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 import type {
@@ -167,9 +165,10 @@ function internalUpdateFirmwareTask({
       error: error => {
         tracer.trace(`Error: ${error}`, { error });
 
-        if (error instanceof UserRefusedFirmwareUpdate) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "UserRefusedFirmwareUpdate") {
           subscriber.next({ type: "installOsuDevicePermissionDenied" });
-        } else if (error instanceof UserRefusedAllowManager) {
+        } else if (eName === "UserRefusedAllowManager") {
           subscriber.next({ type: "allowSecureChannelDenied" });
         } else {
           subscriber.next({ type: "error", error, retrying: false });

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -2,17 +2,7 @@ import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  BluetoothRequired,
-  CantOpenDevice,
-  DeviceHalted,
-  FirmwareOrAppUpdateRequired,
-  PairingFailed,
-  PeerRemovedPairing,
-  TransportInterfaceNotAvailable,
-  TransportStatusError,
-  TransportWebUSBGestureRequired,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, DeviceHalted, FirmwareOrAppUpdateRequired } from "@ledgerhq/errors";
 import { open, close } from "../../hw/index";
 
 export { Transport };
@@ -105,11 +95,12 @@ export const withTransport = (
       // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
       const onErrorDuringTransportSetup = (error: unknown) => {
         tracer.trace("Error while setting up a transport: ", { error });
-        if (error instanceof BluetoothRequired) throw error;
-        if (error instanceof TransportWebUSBGestureRequired) throw error;
-        if (error instanceof TransportInterfaceNotAvailable) throw error;
-        if (error instanceof PeerRemovedPairing) throw error;
-        if (error instanceof PairingFailed) throw error;
+        const errorName = (error as { name?: string })?.name;
+        if (errorName === "BluetoothRequired") throw error;
+        if (errorName === "TransportWebUSBGestureRequired") throw error;
+        if (errorName === "TransportInterfaceNotAvailable") throw error;
+        if (errorName === "PeerRemovedPairing") throw error;
+        if (errorName === "PairingFailed") throw error;
         if (error instanceof Error) throw new CantOpenDevice(error.message);
         else throw new CantOpenDevice("Unknown error");
       };
@@ -230,11 +221,12 @@ const transportFinally =
 const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
   let mappedError = error;
 
-  if (error && error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6faa) {
-      mappedError = new DeviceHalted(error.message);
-    } else if (error.statusCode === 0x6b00) {
-      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+  if ((error as { name?: string })?.name === "TransportStatusError") {
+    const tse = error as { statusCode?: number; message?: string };
+    if (tse.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(tse.message);
+    } else if (tse.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(tse.message);
     }
   }
 

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -59,13 +59,11 @@ type PollingImplementationParams<Request, EmittedEvents> = {
   config?: PollingImplementationConfig;
   // retryableWithDelayDisconnectedErrors has default value of [DisconnectedDevice, DisconnectedDeviceDuringOperation]
   // used to filter which error(s) retry polling after a delay, reconnectWaitTime
-  retryableWithDelayDisconnectedErrors?: ReadonlyArray<ErrorConstructor>;
+  retryableWithDelayDisconnectedErrors?: ReadonlyArray<new (message?: string) => Error>;
 };
 
-const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<ErrorConstructor> = [
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-];
+const defaultRetryableWithDelayDisconnectedErrors: ReadonlyArray<new (message?: string) => Error> =
+  [DisconnectedDevice, DisconnectedDeviceDuringOperation];
 
 export const defaultImplementationConfig: PollingImplementationConfig = {
   pollingFrequency: 2000,

--- a/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/rawTransaction.ts
@@ -2,7 +2,6 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
@@ -91,7 +90,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -129,7 +129,7 @@ export const createAction = (
             if (
               productName &&
               e.type === "error" &&
-              e.error instanceof UserRefusedDeviceNameChange
+              (e.error as { name?: string })?.name === "UserRefusedDeviceNameChange"
             ) {
               e.error = new UserRefusedDeviceNameChange(undefined, {
                 productName,

--- a/libs/ledger-live-common/src/hw/actions/transaction.ts
+++ b/libs/ledger-live-common/src/hw/actions/transaction.ts
@@ -2,7 +2,6 @@ import { of, Observable } from "rxjs";
 import { scan, catchError, tap } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
 import type { Transaction, TransactionStatus } from "../../coin-modules/transaction-types";
 import { TransactionRefusedOnDevice } from "../../errors";
 import { getMainAccount } from "../../account";
@@ -92,7 +91,8 @@ const reducer = (state: State, e: Event): State => {
     case "error": {
       const { error } = e;
       const transactionSignError =
-        error instanceof TransportStatusError && error.statusCode === 0x6985
+        (error as { name?: string; statusCode?: number }).name === "TransportStatusError" &&
+        (error as { statusCode?: number }).statusCode === 0x6985
           ? new TransactionRefusedOnDevice()
           : error;
       return { ...initialState, transactionSignError };

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -2,15 +2,10 @@ import semver from "semver";
 import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
 import {
-  TransportStatusError,
   FirmwareOrAppUpdateRequired,
   UserRefusedOnDevice,
-  BtcUnmatchedApp,
   UpdateYourApp,
-  DisconnectedDeviceDuringOperation,
-  DisconnectedDevice,
   StatusCodes,
-  LockedDeviceError,
   LatestFirmwareVersionRequired,
 } from "@ledgerhq/errors";
 import type Transport from "@ledgerhq/hw-transport";
@@ -212,8 +207,9 @@ export const openAppFromDashboard = (
               }),
             ),
             catchError(e => {
-              if (e && e instanceof TransportStatusError) {
-                switch (e.statusCode) {
+              const tse = e as { name?: string; statusCode?: number };
+              if (tse.name === "TransportStatusError") {
+                switch (tse.statusCode) {
                   case 0x6984: // No StatusCodes definition
                   case 0x6807: // No StatusCodes definition
                     return inlineAppInstall({
@@ -225,7 +221,7 @@ export const openAppFromDashboard = (
                   case 0x5501: // No StatusCodes definition
                     return throwError(() => new UserRefusedOnDevice());
                 }
-              } else if (e instanceof LockedDeviceError) {
+              } else if (tse.name === "LockedDeviceError") {
                 // openAppFromDashboard is exported, so LockedDeviceError should be handled here too
                 return of({
                   type: "lockedDevice",
@@ -285,20 +281,21 @@ const derivationLogic = (
     catchError(e => {
       if (!e) return throwError(() => e);
 
-      if (e instanceof BtcUnmatchedApp) {
+      const tse = e as { name?: string; statusCode?: number };
+      if (tse.name === "BtcUnmatchedApp") {
         return of<ConnectAppEvent>({
           type: "ask-open-app",
           appName,
         });
       }
 
-      if (e instanceof TransportStatusError) {
-        const { statusCode } = e;
+      if (tse.name === "TransportStatusError") {
+        const statusCode = tse.statusCode;
 
         if (
           statusCode === StatusCodes.SECURITY_STATUS_NOT_SATISFIED ||
           statusCode === StatusCodes.INCORRECT_LENGTH ||
-          (0x6600 <= statusCode && statusCode <= 0x67ff)
+          (statusCode !== undefined && 0x6600 <= statusCode && statusCode <= 0x67ff)
         ) {
           return of<ConnectAppEvent>({
             type: "ask-open-app",
@@ -313,7 +310,7 @@ const derivationLogic = (
             // this is likely because it's the wrong app (LNS 1.3.1)
             return attemptToQuitApp(transport, appAndVersion);
         }
-      } else if (e instanceof LockedDeviceError) {
+      } else if (tse.name === "LockedDeviceError") {
         // derivationLogic is also called inside the catchError of cmd below
         // so it needs to handle LockedDeviceError too
         return of({
@@ -479,21 +476,23 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
           }
         }),
         catchError((e: unknown) => {
+          const eName = (e as { name?: string })?.name;
           if (
             (typeof e === "object" &&
               e !== null &&
               "_tag" in e &&
               e._tag === "DeviceDisconnectedWhileSendingError") ||
-            e instanceof DisconnectedDeviceDuringOperation ||
-            e instanceof DisconnectedDevice
+            eName === "DisconnectedDeviceDuringOperation" ||
+            eName === "DisconnectedDevice"
           ) {
             return of(<ConnectAppEvent>{
               type: "disconnected",
             });
           }
 
-          if (e && e instanceof TransportStatusError) {
-            switch (e.statusCode) {
+          const tse2 = e as { name?: string; statusCode?: number };
+          if (tse2.name === "TransportStatusError") {
+            switch (tse2.statusCode) {
               case StatusCodes.CLA_NOT_SUPPORTED: // in 1.3.1 dashboard
               case StatusCodes.INS_NOT_SUPPORTED: // in 1.3.1 and bitcoin app
                 // fallback on "old way" because device does not support getAppAndVersion
@@ -507,7 +506,7 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectAppEve
                   appName,
                 });
             }
-          } else if (e instanceof LockedDeviceError) {
+          } else if (eName === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectAppEvent);

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -1,11 +1,6 @@
 import { Observable, concat, concatWith, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import {
-  TransportStatusError,
-  DeviceOnDashboardExpected,
-  StatusCodes,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/errors";
 import { isCharonSupported } from "@ledgerhq/device-core";
 import { identifyTargetId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";
@@ -103,21 +98,21 @@ const cmd = (transport: Transport, { request }: Input): Observable<ConnectManage
           );
         }),
         catchError((e: unknown) => {
-          if (e instanceof LockedDeviceError) {
+          const eName = (e as { name?: string })?.name;
+          if (eName === "LockedDeviceError") {
             return of({
               type: "lockedDevice",
             } as ConnectManagerEvent);
           } else if (
-            e instanceof DeviceOnDashboardExpected ||
-            (e &&
-              e instanceof TransportStatusError &&
+            eName === "DeviceOnDashboardExpected" ||
+            (eName === "TransportStatusError" &&
               [
                 StatusCodes.CLA_NOT_SUPPORTED,
                 StatusCodes.INS_NOT_SUPPORTED,
                 StatusCodes.UNKNOWN_APDU,
                 0x6e01, // No StatusCodes definition
                 0x6d01, // No StatusCodes definition
-              ].includes(e.statusCode))
+              ].includes((e as { statusCode: number }).statusCode))
           ) {
             return from(getAppAndVersion(transport)).pipe(
               concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
@@ -1,11 +1,6 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import {
-  DeviceOnDashboardExpected,
-  TransportError,
-  TransportStatusError,
-  StatusCodes,
-} from "@ledgerhq/errors";
+import { TransportError, StatusCodes } from "@ledgerhq/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 
@@ -162,11 +157,14 @@ export default function fetchImage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
@@ -1,11 +1,9 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 import {
-  DeviceOnDashboardExpected,
   ManagerNotEnoughSpaceError,
   StatusCodes,
   TransportError,
-  TransportStatusError,
   DisconnectedDevice,
 } from "@ledgerhq/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
@@ -200,11 +198,14 @@ export default function loadImage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode: number }).statusCode,
+                  ))
               ) {
                 return from(getAppAndVersion(transportRef.current)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -2,18 +2,10 @@ import { firstValueFrom, from, Observable, throwError, timer } from "rxjs";
 import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
 import {
-  WrongDeviceForAccount,
-  WrongAppForCurrency,
   CantOpenDevice,
-  UpdateYourApp,
-  BluetoothRequired,
-  TransportWebUSBGestureRequired,
-  TransportInterfaceNotAvailable,
   FirmwareOrAppUpdateRequired,
   TransportStatusError,
   DeviceHalted,
-  PeerRemovedPairing,
-  PairingFailed,
 } from "@ledgerhq/errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@ledgerhq/live-env";
@@ -24,11 +16,12 @@ const LOG_TYPE = "hw";
 const initialErrorRemapping = (error: unknown, context?: TraceContext) => {
   let mappedError = error;
 
-  if (error && error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6faa) {
-      mappedError = new DeviceHalted(error.message);
-    } else if (error.statusCode === 0x6b00) {
-      mappedError = new FirmwareOrAppUpdateRequired(error.message);
+  const tse = error as { name?: string; statusCode?: number; message?: string };
+  if (tse.name === "TransportStatusError") {
+    if (tse.statusCode === 0x6faa) {
+      mappedError = new DeviceHalted(tse.message);
+    } else if (tse.statusCode === 0x6b00) {
+      mappedError = new FirmwareOrAppUpdateRequired(tse.message);
     }
   }
 
@@ -153,13 +146,14 @@ export const withDevice =
         // This catch is here only for errors that might happen at open or at clean up of the transport before doing the job
         .catch(e => {
           tracer.trace(`Error while opening Transport: ${e}`, { error: e });
-          if (e instanceof BluetoothRequired) throw e;
-          if (e instanceof TransportWebUSBGestureRequired) throw e;
-          if (e instanceof TransportInterfaceNotAvailable) throw e;
-          if (e instanceof PeerRemovedPairing) throw e;
-          if (e instanceof PairingFailed) throw e;
+          const eName = (e as { name?: string })?.name;
+          if (eName === "BluetoothRequired") throw e;
+          if (eName === "TransportWebUSBGestureRequired") throw e;
+          if (eName === "TransportInterfaceNotAvailable") throw e;
+          if (eName === "PeerRemovedPairing") throw e;
+          if (eName === "PairingFailed") throw e;
           console.error(e);
-          throw new CantOpenDevice(e.message);
+          throw new CantOpenDevice((e as { message?: string })?.message);
         })
         // Executes the job
         .then(transport => {
@@ -222,15 +216,16 @@ export const withDevicePromise = <T>(deviceId: string, fn: (Transport) => Promis
   firstValueFrom(withDevice(deviceId)(transport => from(fn(transport))));
 
 export const genericCanRetryOnError = (err: unknown): boolean => {
-  if (err instanceof WrongAppForCurrency) return false;
-  if (err instanceof WrongDeviceForAccount) return false;
-  if (err instanceof CantOpenDevice) return false;
-  if (err instanceof BluetoothRequired) return false;
-  if (err instanceof UpdateYourApp) return false;
-  if (err instanceof FirmwareOrAppUpdateRequired) return false;
-  if (err instanceof DeviceHalted) return false;
-  if (err instanceof TransportWebUSBGestureRequired) return false;
-  if (err instanceof TransportInterfaceNotAvailable) return false;
+  const errName = (err as { name?: string })?.name;
+  if (errName === "WrongAppForCurrency") return false;
+  if (errName === "WrongDeviceForAccount") return false;
+  if (errName === "CantOpenDevice") return false;
+  if (errName === "BluetoothRequired") return false;
+  if (errName === "UpdateYourApp") return false;
+  if (errName === "FirmwareOrAppUpdateRequired") return false;
+  if (errName === "DeviceHalted") return false;
+  if (errName === "TransportWebUSBGestureRequired") return false;
+  if (errName === "TransportInterfaceNotAvailable") return false;
   return true;
 };
 

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
@@ -1,7 +1,7 @@
 import { log } from "@ledgerhq/logs";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import { concatMap, delay, scan, distinctUntilChanged, throttleTime } from "rxjs/operators";
-import { CantOpenDevice, DeviceInOSUExpected } from "@ledgerhq/errors";
+import { DeviceInOSUExpected } from "@ledgerhq/errors";
 import { withDevicePolling, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
 import flash from "./flash";
@@ -30,7 +30,7 @@ const main = (
   const withDeviceInstall = install =>
     withDevicePolling(deviceId)(
       install,
-      e => e instanceof CantOpenDevice, // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
+      e => (e as { name?: string })?.name === "CantOpenDevice", // this can happen if withDevicePolling was still seeing the device but it was then interrupted by a device reboot
     );
 
   const waitForBootloader = withDeviceInfo.pipe(

--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import { DeviceOnDashboardExpected, StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { DeviceOnDashboardExpected, StatusCodes } from "@ledgerhq/errors";
 import { LocalTracer, log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
@@ -24,15 +24,16 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
     .then(({ name }) => isDashboardName(name))
     .catch(e => {
       tracer.trace(`Error from getAppAndVersion: ${e}`, { error: e });
-      if (e instanceof TransportStatusError) {
+      if ((e as { name?: string })?.name === "TransportStatusError") {
+        const statusCode = (e as { statusCode?: number }).statusCode;
         if (
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
-          e.statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED ||
+          statusCode === StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER
         ) {
           return true;
         }
 
-        if (e.statusCode === StatusCodes.INS_NOT_SUPPORTED) {
+        if (statusCode === StatusCodes.INS_NOT_SUPPORTED) {
           return false;
         }
       }
@@ -47,8 +48,9 @@ export default async function (transport: Transport): Promise<DeviceInfo> {
 
   const res = await getVersion(transport).catch(e => {
     tracer.trace(`Error from getVersion: ${e}`, { error: e });
-    if (e instanceof TransportStatusError) {
-      if (e.statusCode === 0x6d06 || e.statusCode === 0x6d07) {
+    if ((e as { name?: string })?.name === "TransportStatusError") {
+      const statusCode = (e as { statusCode?: number }).statusCode;
+      if (statusCode === 0x6d06 || statusCode === 0x6d07) {
         throw new DeviceNotOnboarded();
       }
     }

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.ts
@@ -1,6 +1,5 @@
-import { CantOpenDevice, LockedDeviceError } from "@ledgerhq/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
-import { from, Observable, TimeoutError } from "rxjs";
+import { from, Observable } from "rxjs";
 import { retryWhen, timeout } from "rxjs/operators";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -61,7 +60,7 @@ export const getDeviceRunningMode = ({
               return false;
             }
 
-            if (e instanceof CantOpenDevice) {
+            if ((e as { name?: string })?.name === "CantOpenDevice") {
               if (cantOpenDeviceRetryCount < cantOpenDeviceRetryLimit) {
                 cantOpenDeviceRetryCount++;
                 return true;
@@ -88,7 +87,7 @@ export const getDeviceRunningMode = ({
           if (isLockedDeviceError(e)) {
             o.next({ type: "lockedDevice" });
             o.complete();
-          } else if (e instanceof CantOpenDevice) {
+          } else if ((e as { name?: string })?.name === "CantOpenDevice") {
             o.next({ type: "disconnectedOrlockedDevice" });
             o.complete();
           } else {
@@ -100,5 +99,6 @@ export const getDeviceRunningMode = ({
   });
 
 const isLockedDeviceError = (e: Error) => {
-  return e && (e instanceof TimeoutError || e instanceof LockedDeviceError);
+  const eName = (e as { name?: string })?.name;
+  return e && (eName === "TimeoutError" || eName === "LockedDeviceError");
 };

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.ts
@@ -1,7 +1,6 @@
 import type { SocketEvent } from "@ledgerhq/types-live";
 import { from, Observable } from "rxjs";
 import { mergeMap, retryWhen } from "rxjs/operators";
-import { LockedDeviceError } from "@ledgerhq/errors";
 import getDeviceInfo from "./getDeviceInfo";
 import { retryWhileErrors, withDevice } from "./deviceAccess";
 import genuineCheck from "./genuineCheck";
@@ -63,7 +62,7 @@ export const getGenuineCheckFromDeviceId = ({
               // Cancels the locked-device unresponsive/timeout strategy if received any response/error
               clearTimeout(lockedDeviceTimeout);
 
-              if (e instanceof LockedDeviceError) {
+              if ((e as { name?: string })?.name === "LockedDeviceError") {
                 subscriber.next({ socketEvent: null, lockedDevice: true });
                 return true;
               }

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -1,19 +1,11 @@
-import { defer, from, of, throwError, Observable, TimeoutError, timer } from "rxjs";
+import { defer, from, of, throwError, Observable, timer } from "rxjs";
 import { map, catchError, first, timeout, repeat, switchMap } from "rxjs/operators";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { withDevice } from "./deviceAccess";
 import {
-  TransportStatusError,
   StatusCodes,
   DeviceOnboardingStatePollingError,
-  DeviceExtractOnboardingStateError,
-  DisconnectedDevice,
-  CantOpenDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
   UnexpectedBootloader,
-  TransportExchangeTimeoutError,
-  DisconnectedDeviceDuringOperation,
 } from "@ledgerhq/errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
@@ -74,9 +66,9 @@ export const getOnboardingStatePolling = ({
       return getVersionObs.pipe(
         catchError((error: unknown) => {
           const isApduNotSupported =
-            error instanceof TransportStatusError &&
+            (error as { name?: string })?.name === "TransportStatusError" &&
             [StatusCodes.CLA_NOT_SUPPORTED, StatusCodes.INS_NOT_SUPPORTED].includes(
-              (error as TransportStatusError).statusCode,
+              (error as { statusCode: number }).statusCode,
             );
 
           if (isApduNotSupported && !hasQuitAppAlreadyRun) {
@@ -113,10 +105,10 @@ export const getOnboardingStatePolling = ({
           try {
             onboardingState = extractOnboardingState(firmwareInfo.flags, firmwareInfo.charonState);
           } catch (error: unknown) {
-            if (error instanceof DeviceExtractOnboardingStateError) {
+            if ((error as { name?: string })?.name === "DeviceExtractOnboardingStateError") {
               return {
                 onboardingState: null,
-                allowedError: error,
+                allowedError: error as Error,
                 lockedDevice: false,
               };
             } else {
@@ -149,7 +141,7 @@ export const getOnboardingStatePolling = ({
           return {
             onboardingState: null,
             allowedError: allowedError,
-            lockedDevice: allowedError instanceof LockedDeviceError,
+            lockedDevice: (allowedError as { name?: string })?.name === "LockedDeviceError",
           };
         }
       }),
@@ -164,19 +156,20 @@ export const getOnboardingStatePolling = ({
 };
 
 export const isAllowedOnboardingStatePollingError = (error: unknown): boolean => {
+  const eName = (error as { name?: string })?.name;
   if (
     error &&
     // Timeout error is thrown by rxjs's timeout
-    (error instanceof TimeoutError ||
-      error instanceof TransportExchangeTimeoutError ||
-      error instanceof DisconnectedDevice ||
-      error instanceof DisconnectedDeviceDuringOperation ||
+    (eName === "TimeoutError" ||
+      eName === "TransportExchangeTimeoutError" ||
+      eName === "DisconnectedDevice" ||
+      eName === "DisconnectedDeviceDuringOperation" ||
       error instanceof DeviceDisconnectedWhileSendingError ||
-      error instanceof CantOpenDevice ||
-      error instanceof TransportRaceCondition ||
-      error instanceof TransportStatusError ||
+      eName === "CantOpenDevice" ||
+      eName === "TransportRaceCondition" ||
+      eName === "TransportStatusError" ||
       // A locked device is handled as an allowed error
-      error instanceof LockedDeviceError)
+      eName === "LockedDeviceError")
   ) {
     return true;
   }

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { UnresponsiveDeviceError, UserRefusedAllowManager } from "@ledgerhq/errors";
+import { UnresponsiveDeviceError } from "@ledgerhq/errors";
 import { isCounterfeitError } from "../isCounterfeitError";
 import type { DeviceId } from "@ledgerhq/types-live";
 import { getGenuineCheckFromDeviceId as defaultGetGenuineCheckFromDeviceId } from "../getGenuineCheckFromDeviceId";
@@ -133,7 +133,7 @@ export const useGenuineCheck = ({
       },
       error: (e: any) => {
         clearTimeoutRef(timeoutRef);
-        if (e instanceof UserRefusedAllowManager) {
+        if ((e as { name?: string })?.name === "UserRefusedAllowManager") {
           setDevicePermissionState("refused");
         } else if (isCounterfeitError(e)) {
           setGenuineState("non-genuine");

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -1,11 +1,6 @@
 import { Observable, throwError, timer } from "rxjs";
 import { throttleTime, filter, map, catchError, retry, switchMap } from "rxjs/operators";
-import {
-  LockedDeviceError,
-  ManagerAppDepInstallRequired,
-  ManagerDeviceLockedError,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";
@@ -68,11 +63,12 @@ export default function installApp(
         retry({
           count: retryLimit,
           delay: (error: unknown, retryCount: number) => {
+            const eName = (error as { name?: string })?.name;
             // Not retrying on locked device errors
             if (
-              error instanceof LockedDeviceError ||
-              error instanceof ManagerDeviceLockedError ||
-              error instanceof UnresponsiveDeviceError
+              eName === "LockedDeviceError" ||
+              eName === "ManagerDeviceLocked" ||
+              eName === "UnresponsiveDeviceError"
             ) {
               tracer.trace(`Not retrying on error: ${error}`, {
                 error,

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -1,10 +1,8 @@
 import {
-  DeviceOnDashboardExpected,
   LanguageNotFound,
   ManagerNotEnoughSpaceError,
   StatusCodes,
   TransportError,
-  TransportStatusError,
 } from "@ledgerhq/errors";
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
@@ -131,11 +129,14 @@ export default function installLanguage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode?: number })?.statusCode ?? -1,
+                  ))
               ) {
                 return from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/hw/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/renameDevice.ts
@@ -1,6 +1,5 @@
 import { concat, defer, from, Observable, of, throwError } from "rxjs";
 import { catchError, concatMap } from "rxjs/operators";
-import { DisconnectedDevice } from "@ledgerhq/errors";
 import { withDevice } from "./deviceAccess";
 import editDeviceName from "./editDeviceName";
 import getAppAndVersion from "./getAppAndVersion";
@@ -92,7 +91,7 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
             /**
              * If the error is that the device is not on the dashboard, we retry the innerSub
              */
-            if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+            if (error.message === "not on dashboard" || error.name === "DisconnectedDevice") {
               return innerSub;
             }
 
@@ -117,7 +116,7 @@ export default function renameDevice({ deviceId, request }: Input): Observable<R
        * We do have a global timeout so that we are not in a infinite loop
        *
        */
-      if (error.message === "not on dashboard" || error instanceof DisconnectedDevice) {
+      if (error.message === "not on dashboard" || error.name === "DisconnectedDevice") {
         return of<RenameDeviceEvent>({
           type: "disconnected",
           expected: true,

--- a/libs/ledger-live-common/src/hw/uninstallLanguage.ts
+++ b/libs/ledger-live-common/src/hw/uninstallLanguage.ts
@@ -1,6 +1,5 @@
 import { Observable, from, of, throwError, EMPTY } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import { DeviceOnDashboardExpected, TransportStatusError } from "@ledgerhq/errors";
 
 import { withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
@@ -80,11 +79,14 @@ export default function unistallLanguage({
               subscriber.complete();
             }),
             catchError((e: unknown) => {
+              const eName = (e as { name?: string })?.name;
               if (
-                e instanceof DeviceOnDashboardExpected ||
+                eName === "DeviceOnDashboardExpected" ||
                 (e &&
-                  e instanceof TransportStatusError &&
-                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
+                  eName === "TransportStatusError" &&
+                  [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(
+                    (e as { statusCode?: number })?.statusCode ?? -1,
+                  ))
               ) {
                 const quitAppObservable = from(getAppAndVersion(transport)).pipe(
                   concatMap(appAndVersion => {

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -7,7 +7,6 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   ManagerNotEnoughSpaceError,
   NetworkDown,
-  TransportStatusError,
   UserRefusedFirmwareUpdate,
 } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
@@ -60,10 +59,11 @@ const remapSocketError = (context?: string) =>
       return throwError(() => new DeviceOnDashboardExpected());
     }
 
+    const statusCode = (e as { statusCode?: number }).statusCode;
     const status =
-      e instanceof TransportStatusError
-        ? e.statusCode.toString(16)
-        : (e as Error).message.slice((e as Error).message.length - 4);
+      (e as { name?: string })?.name === "TransportStatusError" && statusCode !== undefined
+        ? statusCode.toString(16)
+        : (e as { message?: string })?.message?.slice(-4);
 
     // TODO use StatusCode instead of this.
     switch (status) {

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
-import { DisconnectedDevice } from "@ledgerhq/errors";
 import Transport from "@ledgerhq/hw-transport";
+import { DisconnectedDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { Subject } from "rxjs";
 

--- a/libs/live-dmk-mobile/src/connectDevice/utils.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/utils.ts
@@ -10,7 +10,6 @@ import {
   type MatchedDevice,
 } from "@ledgerhq/live-dmk-shared";
 import { isPeerRemovedPairingError } from "../errors";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { BaseConnectionErrorTypes, ConnectionErrorTypes, MobileConnectionError } from "./types";
 import { findMatchingNewDevice } from "../utils/matchDevicesByNameOrId";
 import { buildUsbCompatDeviceId } from "../transport/usbCompatDeviceId";
@@ -66,7 +65,10 @@ export const createConnectionError = (error: unknown): MobileConnectionError => 
     };
   }
 
-  if (error instanceof PeerRemovedPairing || isPeerRemovedPairingError(error)) {
+  if (
+    (error as { name?: string })?.name === "PeerRemovedPairing" ||
+    isPeerRemovedPairingError(error)
+  ) {
     return {
       type: ConnectionErrorTypes.BlePairingPeerRemovedPairing,
     };

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -5,12 +5,8 @@ import {
   type DeviceSessionState,
   DeviceStatus,
   DiscoveredDevice,
-  OpeningConnectionError,
 } from "@ledgerhq/device-management-kit";
-import {
-  PairingRefusedError,
-  rnBleTransportIdentifier,
-} from "@ledgerhq/device-transport-kit-react-native-ble";
+import { rnBleTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-ble";
 import { activeDeviceSessionSubject, dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer, TraceContext } from "@ledgerhq/logs";
 import {
@@ -230,13 +226,11 @@ export class DeviceManagementKitBLETransport extends Transport {
             getDeviceManagementKit().stopDiscovering();
 
             tracer.trace("[DMKTransport] [open2] error", error);
-            if (error instanceof PairingRefusedError) {
+            const eName = (error as { name?: string })?.name;
+            if (eName === "PairingRefusedError") {
               // NB: in LLM, we don't have a specific error for pairing refused, so we remap it to PairingFailed
               return throwError(() => new PairingFailed());
-            } else if (
-              error instanceof PeerRemovedPairing ||
-              error instanceof OpeningConnectionError
-            ) {
+            } else if (eName === "PeerRemovedPairing" || eName === "OpeningConnectionError") {
               return throwError(() => error);
             }
 

--- a/libs/live-signer-solana/src/LegacySignerSolana.ts
+++ b/libs/live-signer-solana/src/LegacySignerSolana.ts
@@ -7,7 +7,7 @@ import {
   SolanaSigner,
 } from "@ledgerhq/coin-solana/signer";
 import Solana from "@ledgerhq/hw-app-solana";
-import Transport, { TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId } from "@ledgerhq/devices";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";
@@ -25,8 +25,12 @@ import { LatestFirmwareVersionRequired, UpdateYourApp } from "@ledgerhq/errors";
 const MIN_VERSION = "1.9.2";
 const MANAGER_APP_NAME = "Solana";
 
-function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+function isPKIUnsupportedError(err: unknown): boolean {
+  const errName = (err as { name?: string })?.name;
+  return (
+    errName === "TransportStatusError" &&
+    !!(err as { message?: string })?.message?.includes("0x6a81")
+  );
 }
 
 async function tryLoadPKI(...args: Parameters<typeof loadPKI>) {


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/live-devices.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/live-devices. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ