### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (wallet-xp files)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -91,7 +91,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "open success", data: { descriptor } });
       return new IPCTransport(descriptor, requestId);
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;
@@ -133,7 +133,7 @@ export default class IPCTransport extends Transport {
       trace({ type: LOG_TYPE, message: "exchange success", data: { apdu: apduHex } });
       return Buffer.from(result.data, "hex");
     } catch (error) {
-      if (error instanceof TransportError) {
+      if ((error as { name?: string })?.name === "TransportError") {
         throw error;
       }
       const err = error as Error;

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorDisplay.tsx
@@ -1,9 +1,3 @@
-import {
-  ManagerNotEnoughSpaceError,
-  UpdateYourApp,
-  LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
-import { OutdatedApp } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { renderError } from "~/renderer/components/DeviceAction/rendering";
 import { DmkError } from "@ledgerhq/live-dmk-desktop";
@@ -29,10 +23,9 @@ const ErrorDisplay = ({
 }: ErrorDisplayProps) => {
   const { t } = useTranslation();
 
+  const eName = (error as { name?: string })?.name;
   const managerAppName =
-    error instanceof ManagerNotEnoughSpaceError ||
-    (error as unknown) instanceof OutdatedApp ||
-    (error as unknown) instanceof UpdateYourApp
+    eName === "ManagerNotEnoughSpace" || eName === "OutdatedApp" || eName === "UpdateYourApp"
       ? (error as unknown as { managerAppName: string }).managerAppName
       : undefined;
 
@@ -41,7 +34,7 @@ const ErrorDisplay = ({
     error,
     onRetry,
     managerAppName,
-    requireFirmwareUpdate: error instanceof LatestFirmwareVersionRequired,
+    requireFirmwareUpdate: eName === "LatestFirmwareVersionRequired",
     withExportLogs,
     list,
     supportLink,

--- a/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ErrorIcon.tsx
@@ -3,22 +3,6 @@ import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import Lock from "~/renderer/icons/LockCircle";
-import {
-  UserRefusedAllowManager,
-  UserRefusedFirmwareUpdate,
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  ManagerDeviceLockedError,
-  UserRefusedDeviceNameChange,
-} from "@ledgerhq/errors";
-import {
-  SwapGenericAPIError,
-  DeviceNotOnboarded,
-  NoSuchAppOnProvider,
-  LanguageInstallRefusedOnDevice,
-  ImageDoesNotExistOnDevice,
-  ImageLoadRefusedOnDevice,
-} from "@ledgerhq/live-common/errors";
 import { IconsLegacy } from "@ledgerhq/react-ui";
 
 export type ErrorIconProps = {
@@ -28,29 +12,30 @@ export type ErrorIconProps = {
 
 const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
   if (!error) return null;
+  const errorName = (error as { name?: string })?.name;
 
-  if (error instanceof DeviceNotOnboarded) {
+  if (errorName === "DeviceNotOnboarded") {
     return <InfoCircle size={size} />;
   }
 
   if (
-    error instanceof UserRefusedFirmwareUpdate ||
-    error instanceof UserRefusedAllowManager ||
-    error instanceof UserRefusedOnDevice ||
-    error instanceof UserRefusedAddress ||
-    error instanceof LanguageInstallRefusedOnDevice ||
-    error instanceof ImageDoesNotExistOnDevice ||
-    error instanceof ImageLoadRefusedOnDevice ||
-    error instanceof UserRefusedDeviceNameChange
+    errorName === "UserRefusedFirmwareUpdate" ||
+    errorName === "UserRefusedAllowManager" ||
+    errorName === "UserRefusedOnDevice" ||
+    errorName === "UserRefusedAddress" ||
+    errorName === "LanguageInstallRefusedOnDevice" ||
+    errorName === "ImageDoesNotExistOnDevice" ||
+    errorName === "ImageLoadRefusedOnDevice" ||
+    errorName === "UserRefusedDeviceNameChange"
   ) {
     return <IconsLegacy.InfoMedium size={size} color="primary.c80" />;
   }
 
-  if (error instanceof SwapGenericAPIError || error instanceof NoSuchAppOnProvider) {
+  if (errorName === "SwapGenericAPIError" || errorName === "NoSuchAppOnProvider") {
     return <CrossCircle size={size} />;
   }
 
-  if (error instanceof ManagerDeviceLockedError) {
+  if (errorName === "ManagerDeviceLocked") {
     return <Lock size={size} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/components/Input.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Input.tsx
@@ -16,7 +16,6 @@ import Box from "~/renderer/components/Box";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import BigSpinner from "~/renderer/components/BigSpinner";
 import { BoxProps } from "./Box/Box";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 export type InputError = Error | boolean | null | undefined;
 
@@ -302,7 +301,7 @@ const Input = function Input(
               <ErrorDisplay id="input-error" data-testid="input-error">
                 <TranslatedError
                   error={error}
-                  field={error instanceof AddressesSanctionedError ? "description" : undefined}
+                  field={error?.name === "AddressesSanctionedError" ? "description" : undefined}
                 />
               </ErrorDisplay>
             )

--- a/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/RepairModal/index.tsx
@@ -2,7 +2,6 @@ import React, { useState, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { repairChoices } from "@ledgerhq/live-common/hw/firmwareUpdate-repair";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
 import Button from "~/renderer/components/Button";
@@ -169,7 +168,7 @@ const RepairModal = ({
 
   const onClose = !cancellable && isLoading ? undefined : onReject;
   const disableRepair =
-    isLoading || !selectedOption || !!(error && error instanceof MCUNotGenuineToDashboard);
+    isLoading || !selectedOption || !!(error && error?.name === "MCUNotGenuineToDashboard");
 
   return (
     <Modal

--- a/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
+++ b/apps/ledger-live-mobile/src/components/CustomLockScreenDeviceAction/index.tsx
@@ -5,7 +5,6 @@ import { Flex, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "~/context/Locale";
 import withRemountableWrapper from "@ledgerhq/live-common/hoc/withRemountableWrapper";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { setLastSeenCustomImage, clearLastSeenCustomImage } from "~/actions/settings";
 import { DeviceActionDefaultRendering } from "../DeviceAction";
 import { ImageSourceContext } from "../CustomImage/FramedPicture";
@@ -117,12 +116,11 @@ const CustomImageDeviceAction: React.FC<Props & { remountMe: () => void }> = ({
   }, [CLSError]);
   const isError = !!error;
   const refusedOnDevice =
-    (error as unknown) instanceof ImageLoadRefusedOnDevice ||
-    (error as unknown) instanceof ImageCommitRefusedOnDevice;
+    error?.name === "ImageLoadRefusedOnDevice" || error?.name === "ImageCommitRefusedOnDevice";
 
   useEffect(() => {
     // Once transferred the old image is wiped, we need to clear it from the data.
-    if (error instanceof ImageCommitRefusedOnDevice) {
+    if (error?.name === "ImageCommitRefusedOnDevice") {
       dispatch(clearLastSeenCustomImage());
     }
   }, [dispatch, error]);

--- a/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceActionModal.tsx
@@ -8,7 +8,6 @@ import { PartialNullable } from "~/types/helpers";
 import QueuedDrawer from "./QueuedDrawer";
 import DeviceAction from "./DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 
 const DeviceActionContainer = styled(Flex).attrs({
@@ -74,7 +73,7 @@ export default function DeviceActionModal<Req, Stt, Res>({
 
   const onDeviceActionError = useCallback(
     (e: Error) => {
-      if (e instanceof PeerRemovedPairing || isCounterfeitError(e)) {
+      if (e?.name === "PeerRemovedPairing" || isCounterfeitError(e)) {
         setShowInfo(false);
       }
       onError?.(e);

--- a/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
+++ b/apps/ledger-live-mobile/src/components/GenericErrorView.tsx
@@ -2,7 +2,6 @@ import React, { memo } from "react";
 import { useTranslation } from "~/context/Locale";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy, Link } from "@ledgerhq/native-ui";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { NewIconType } from "@ledgerhq/native-ui/components/Icon/type";
 import useExportLogs from "./useExportLogs";
 import TranslatedError from "./TranslatedError";
@@ -53,7 +52,7 @@ const GenericErrorView = ({
   const subtitleError = outerError ? error : null;
 
   // In case bluetooth was necessary but the `RequiresBle` component could not be used directly
-  if (error instanceof BluetoothRequired) {
+  if ((error as { name?: string })?.name === "BluetoothRequired") {
     return (
       <>
         <BluetoothDisabled />

--- a/apps/ledger-live-mobile/src/components/ValidateError.tsx
+++ b/apps/ledger-live-mobile/src/components/ValidateError.tsx
@@ -8,7 +8,6 @@ import NeedHelp from "./NeedHelp";
 import { BaseNavigation } from "./RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { MANAGER_TABS } from "~/const/manager";
-import { UpdateYourApp, LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 import { RequiredFirmwareUpdate } from "./DeviceAction/rendering";
 import { useSelector } from "~/context/hooks";
 import { lastConnectedDeviceSelector } from "~/reducers/settings";
@@ -25,7 +24,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
   const { t } = useTranslation();
   const { colors } = useTheme();
 
-  const managerAppName = error instanceof UpdateYourApp ? error.managerAppName : undefined;
+  const managerAppName = error?.name === "UpdateYourApp" ? error.managerAppName : undefined;
 
   const lastConnectedDevice = useSelector(lastConnectedDeviceSelector);
 
@@ -60,7 +59,7 @@ function ValidateError({ error, onClose, onRetry }: Props) {
       ]}
     >
       <View style={styles.container}>
-        {error instanceof LatestFirmwareVersionRequired && lastConnectedDevice ? (
+        {error?.name === "LatestFirmwareVersionRequired" && lastConnectedDevice ? (
           <RequiredFirmwareUpdate navigation={navigation} device={lastConnectedDevice} />
         ) : (
           <>

--- a/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
+++ b/apps/ledger-live-mobile/src/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling.tsx
@@ -1,5 +1,5 @@
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import Transport, { StatusCodes, type TransportStatusError } from "@ledgerhq/hw-transport";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import getAppAndVersion from "@ledgerhq/live-common/hw/getAppAndVersion";
 import { useCallback, useEffect, useState } from "react";
@@ -32,12 +32,12 @@ export function isLockedDevicePolling(
       map<unknown, IsDeviceLockedResult>(() => ({ type: IsDeviceLockedResultType.unlocked })),
       catchError((error: Error) => {
         if (
-          error instanceof TransportStatusError &&
+          error?.name === "TransportStatusError" &&
           [
             StatusCodes.CLA_NOT_SUPPORTED,
             StatusCodes.CLA_NOT_SUPPORTED_BOOTLOADER,
             StatusCodes.INS_NOT_SUPPORTED,
-          ].includes(error.statusCode)
+          ].includes((error as TransportStatusError).statusCode)
         ) {
           return of<IsDeviceLockedResult>({
             type: IsDeviceLockedResultType.lockedStateCannotBeDetermined,
@@ -49,8 +49,9 @@ export function isLockedDevicePolling(
         }
 
         if (
-          error instanceof TransportStatusError &&
-          error.statusCode === StatusCodes.LOCKED_DEVICE
+          error?.name === "LockedDeviceError" ||
+          (error?.name === "TransportStatusError" &&
+            (error as TransportStatusError).statusCode === StatusCodes.LOCKED_DEVICE)
         ) {
           return of<IsDeviceLockedResult>({ type: IsDeviceLockedResultType.locked });
         }

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -20,10 +20,7 @@ import {
   formatOperation,
   formatAccount,
 } from "@ledgerhq/live-common/account/index";
-import {
-  createTransactionBroadcastError,
-  TransactionBroadcastError,
-} from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
+import { createTransactionBroadcastError } from "@ledgerhq/live-common/errors/transactionBroadcastErrors";
 import { formatTransaction } from "@ledgerhq/live-common/transaction/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -32,7 +29,6 @@ import { useBroadcast } from "@ledgerhq/live-common/hooks/useBroadcast";
 import { broadcastLogger } from "~/datadog";
 import { getEnv } from "@ledgerhq/live-env";
 import { useSelector, useDispatch } from "~/context/hooks";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { updateAccountWithUpdater } from "../actions/accounts";
 import logger from "../logger";
@@ -368,16 +364,12 @@ export function useSignedTxHandler({
           dispatch,
         });
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 
-        if (
-          error instanceof TransactionBroadcastError &&
-          route.name === ScreenName.SendConnectDevice
-        ) {
+        if (eName === "TransactionBroadcastError" && route.name === ScreenName.SendConnectDevice) {
           return (navigation as NativeStackNavigationProp<{ [key: string]: object }>).replace(
             ScreenName.SendBroadcastError,
             { ...route.params, error },

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/useDeviceSectionViewModel.ts
@@ -4,7 +4,6 @@ import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { Linking } from "react-native";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { findMatchingNewDevice, useBleDevicesScanning } from "@ledgerhq/live-dmk-mobile";
@@ -137,7 +136,7 @@ export const useDeviceSectionViewModel = (): DeviceSectionViewModel => {
   }, []);
 
   const onDeviceActionError = useCallback((error: Error) => {
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setSelectedDevice(null);
     }
   }, []);

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/MyLedgerSection.tsx
@@ -4,7 +4,6 @@ import { useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { RouteProp } from "@react-navigation/native";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Result } from "@ledgerhq/live-common/hw/actions/manager";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
@@ -86,7 +85,7 @@ function MyLedgerSectionContent({ onPairingStateChanged }: MyLedgerSectionProps)
   };
 
   const onError = (error: Error) => {
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       setDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -5,12 +5,7 @@ import {
 } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTrustchainSdk } from "./useTrustchainSdk";
-import {
-  NoTrustchainInitialized,
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-  TrustchainNotAllowed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TrustchainResult, TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useRef } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -23,7 +18,6 @@ import { ScreenName } from "~/const";
 import { hasCompletedOnboardingSelector, onboardingTypeSelector } from "~/reducers/settings";
 import { DrawerProps, SceneKind, useFollowInstructionDrawer } from "./useFollowInstructionDrawer";
 import { OnboardingType } from "~/reducers/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { CONNECTION_TYPES } from "~/analytics/hooks/variables";
 
 export function useAddMember({ device }: { device: Device | null }): DrawerProps {
@@ -79,16 +73,17 @@ export function useAddMember({ device }: { device: Device | null }): DrawerProps
           transitionToNextScreen(trustchainResult);
         }
       } catch (error) {
-        if (error instanceof TrustchainNotAllowed) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "TrustchainNotAllowed") {
           setScene({ kind: SceneKind.KeyError });
-        } else if (error instanceof TrustchainAlreadyInitialized) {
+        } else if (eName === "TrustchainAlreadyInitialized") {
           setScene({ kind: SceneKind.AlreadySecuredSameSeed });
-        } else if (error instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           setScene({ kind: SceneKind.AlreadySecuredOtherSeed });
-        } else if (error instanceof NoTrustchainInitialized) {
+        } else if (eName === "NoTrustchainInitialized") {
           setScene({ kind: SceneKind.UnbackedError });
         } else if (error instanceof Error) {
-          if (error instanceof UserRefusedOnDevice) {
+          if (eName === "UserRefusedOnDevice") {
             track(AnalyticsEvents.LedgerSyncRejectedOnDevice, {
               page: "Ledger Sync",
               modelId: device?.modelId,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLifeCycle.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useLifeCycle.ts
@@ -1,10 +1,5 @@
 import { resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useDispatch } from "~/context/hooks";
-import {
-  TrustchainEjected,
-  TrustchainNotAllowed,
-  TrustchainOutdated,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { ErrorType } from "./type.hooks";
 import { StackActions, useNavigation } from "@react-navigation/native";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
@@ -34,10 +29,10 @@ export const useLifeCycle = () => {
   };
 
   function handleError(error: Error) {
-    if (error instanceof TrustchainEjected) reset();
-    if (error instanceof TrustchainNotAllowed) reset();
+    if (error?.name === "TrustchainEjected") reset();
+    if (error?.name === "TrustchainNotAllowed") reset();
 
-    if (error instanceof TrustchainOutdated) restoreTrustchain();
+    if (error?.name === "TrustchainOutdated") restoreTrustchain();
 
     const errorToHandle = Object.entries(includesErrorActions).find(([err, _action]) =>
       error.message.includes(err),

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
@@ -6,7 +6,6 @@ import {
   TrustchainSDK,
 } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { setTrustchain, resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { log } from "@ledgerhq/logs";
 import { AnalyticsEvents } from "LLM/features/WalletSync/Analytics/enums";
 import { track } from "~/analytics";
@@ -24,7 +23,8 @@ export function useOnTrustchainRefreshNeeded(
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         dispatch(setTrustchain(newTrustchain));
       } catch (e) {
-        if (e instanceof TrustchainEjected || e instanceof TrustchainNotAllowed) {
+        const eName = (e as { name?: string })?.name;
+        if (eName === "TrustchainEjected" || eName === "TrustchainNotAllowed") {
           dispatch(resetTrustchainStore());
           track(AnalyticsEvents.LedgerSyncDeactivated);
         }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useQRCodeHost.ts
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  QRCodeWSClosed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useSelector, useDispatch } from "~/context/hooks";
 import {
@@ -92,14 +88,14 @@ export function useQRCodeHost({ currentOption }: Props) {
 
     // Don't use retry here because it always uses a delay despite setting it to 0
     onError: e => {
-      if (e instanceof QRCodeWSClosed) {
+      if (e?.name === "QRCodeWSClosed") {
         const { time } = e as unknown as { time: number };
         if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
       }
-      if (e instanceof InvalidDigitsError) {
+      if (e?.name === "InvalidDigitsError") {
         setCurrentStep(Steps.SyncError);
       }
-      if (e instanceof NoTrustchainInitialized) {
+      if (e?.name === "NoTrustchainInitialized") {
         setCurrentStep(Steps.UnbackedError);
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
@@ -5,7 +5,7 @@ import {
 } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useTrustchainSdk } from "./useTrustchainSdk";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TrustchainMember, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback } from "react";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -60,7 +60,7 @@ export function useRemoveMember({ device, member }: Props): DrawerProps {
 
         transitionToNextScreen(newTrustchain);
       } catch (error) {
-        if (error instanceof TrustchainNotAllowed) {
+        if ((error as { name?: string })?.name === "TrustchainNotAllowed") {
           setScene({ kind: SceneKind.KeyError });
         } else if (error instanceof Error) {
           setScene({ kind: SceneKind.GenericError, error });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useSyncWithQrCode.ts
@@ -1,14 +1,7 @@
 import { useCallback, useState, useRef } from "react";
 import { MemberCredentials, TrustchainMember } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { createQRCodeCandidateInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  ScannedOldImportQrCode,
-  ScannedInvalidQrCode,
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { setTrustchain, trustchainSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { useNavigation } from "@react-navigation/native";
@@ -77,26 +70,27 @@ export const useSyncWithQrCode = () => {
         onSyncFinished();
         return true;
       } catch (e) {
-        if (e instanceof ScannedOldImportQrCode) {
+        const eName = (e as { name?: string })?.name;
+        if (eName === "ScannedOldImportQrCode") {
           setCurrentStep(Steps.ScannedOldImportQrCode);
           return;
-        } else if (e instanceof ScannedInvalidQrCode) {
+        } else if (eName === "ScannedInvalidQrCode") {
           setCurrentStep(Steps.ScannedInvalidQrCode);
           return;
-        } else if (e instanceof InvalidDigitsError) {
+        } else if (eName === "InvalidDigitsError") {
           setCurrentStep(Steps.SyncError);
           return;
-        } else if (e instanceof NoTrustchainInitialized) {
+        } else if (eName === "NoTrustchainInitialized") {
           setCurrentStep(Steps.UnbackedError);
           return;
-        } else if (e instanceof TrustchainAlreadyInitialized) {
-          if (e.message === trustchain?.rootId) {
+        } else if (eName === "TrustchainAlreadyInitialized") {
+          if ((e as Error)?.message === trustchain?.rootId) {
             setCurrentStep(Steps.AlreadyBacked);
           } else {
             setCurrentStep(Steps.BackedWithDifferentSeeds);
           }
           return;
-        } else if (e instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           setCurrentStep(Steps.BackedWithDifferentSeeds);
           return;
         }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -38,7 +38,6 @@ import { bridgeCache } from "~/bridge/cache";
 import { replaceAccounts } from "~/actions/accounts";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { TrustchainNotAllowed, TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(walletSelector(s));
 
@@ -146,8 +145,8 @@ export function useWatchWalletSync(): WalletSyncUserState {
 
   useEffect(() => {
     if (walletSyncError) {
-      if (walletSyncError instanceof TrustchainNotAllowed) resetLedgerSync();
-      if (walletSyncError instanceof TrustchainEjected) resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainNotAllowed") resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainEjected") resetLedgerSync();
     }
   }, [dispatch, resetLedgerSync, walletSyncError]);
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/DeviceSelection/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState, memo } from "react";
 import { useIsFocused, useNavigation } from "@react-navigation/native";
 import { Trans } from "~/context/Locale";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
-import { BluetoothRequired } from "@ledgerhq/errors";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { ScreenName } from "~/const";
 import SelectDevice2, { SetHeaderOptionsRequest } from "~/components/SelectDevice2";
@@ -75,7 +74,7 @@ const WalletSyncActivationDeviceSelection: React.FC<ChooseDeviceProps> = ({
     // By setting back the device to `undefined` it gives back the responsibilities to those select components to check for the bluetooth requirements
     // and avoids a duplicated error drawers/messages.
     // The only drawback: the user has to select again their device once the bluetooth requirements are respected.
-    if (error instanceof BluetoothRequired) {
+    if (error?.name === "BluetoothRequired") {
       selectDevice(undefined);
     }
   };

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Manage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/screens/Manage/index.tsx
@@ -19,7 +19,6 @@ import { Steps } from "../../types/Activation";
 import { TrackScreen } from "~/analytics";
 import { AlertLedgerSyncDown } from "../../components/AlertLedgerSyncDown";
 import { useLedgerSyncStatus } from "../../hooks/useLedgerSyncStatus";
-import { TrustchainNotFound } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { useCustomTimeOut } from "../../hooks/useCustomTimeOut";
 import { useDispatch } from "~/context/hooks";
 import { blockPasswordLock } from "~/actions/appstate";
@@ -141,9 +140,7 @@ const WalletSyncManage = () => {
               key={index}
               disabled={
                 props.id === "manageKey"
-                  ? hasError && error instanceof TrustchainNotFound
-                    ? false
-                    : hasError
+                  ? hasError && error?.name !== "TrustchainNotFound"
                   : hasError
               }
             />

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -3,7 +3,6 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Trans, useTranslation } from "~/context/Locale";
 import { connect } from "react-redux";
 import { TextInput as NativeTextInput } from "react-native";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
 import { Button, Text, IconsLegacy, Flex } from "@ledgerhq/native-ui";
 import getDeviceNameMaxLength from "@ledgerhq/live-common/hw/getDeviceNameMaxLength";
 import { TrackScreen } from "~/analytics";
@@ -22,6 +21,7 @@ import { BleSaveDeviceNamePayload } from "~/actions/types";
 import { useRenameDeviceAction } from "~/hooks/deviceActions";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useToastsActions } from "~/actions/toast";
+import { DeviceNameInvalid } from "@ledgerhq/errors";
 
 const mapDispatchToProps = {
   saveBleDeviceName,


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/wallet-xp.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/wallet-xp. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ