### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (engagement files)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Onboarding/screens/SyncOnboardingCompanion/useSyncOnboardingCompanionViewModel.ts
@@ -19,7 +19,6 @@ import { trackPage } from "~/renderer/analytics/segment";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import LockedDeviceDrawer from "~/renderer/components/SyncOnboarding/Manual/LockedDeviceDrawer";
-import { LockedDeviceError } from "@ledgerhq/errors";
 import { useRecoverRestoreOnboarding } from "~/renderer/hooks/useRecoverRestoreOnboarding";
 import { useTrackOnboardingFlow } from "~/renderer/analytics/hooks/useTrackOnboardingFlow";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
@@ -413,7 +412,7 @@ const useSyncOnboardingCompanionViewModel = ({
   useEffect(() => {
     let desyncTimer: NodeJS.Timeout | null = null;
 
-    if (allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (allowedError && allowedError?.name !== "LockedDeviceError") {
       setIsDesyncOverlayOpen(true);
       desyncTimer = setTimeout(handleDesyncTimerRunsOut, desyncTimeout);
     } else {

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackAddAccountModal.ts
@@ -1,13 +1,6 @@
 import { useRef, useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -67,22 +60,22 @@ export const useTrackAddAccountModal = ({
       page: "Add account modal",
     };
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during account creation
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition during account creation
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during account creation
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested.current && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app during account creation
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
@@ -92,7 +85,7 @@ export const useTrackAddAccountModal = ({
       track("Device connection lost", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during account creation
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackExchangeFlow.ts
@@ -1,12 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerError } from "~/renderer/components/DeviceAction";
@@ -71,30 +63,30 @@ export const useTrackExchangeFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open exchange app
       track("Open app denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedAllowManager) {
+    } else if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackGenericDAppTransactionSend.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -83,7 +76,7 @@ export const useTrackGenericDAppTransactionSend = ({
       track("Secure Channel approved", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
@@ -100,22 +93,22 @@ export const useTrackGenericDAppTransactionSend = ({
       previousOpenAppRequested.current.clear();
     }
 
-    if (previousOpenAppRequested.current.size && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested.current.size && error?.name === "UserRefusedOnDevice") {
       // user refused to open add during generic DApp transaction flow (send)
       track("User refused to open app", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during generic DApp transaction flow (send)
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during generic DApp transaction flow (send)
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during generic DApp transaction flow (send)
       track("Device locked", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackManagerSectionEvents.ts
@@ -1,9 +1,4 @@
 import { useRef, useEffect } from "react";
-import {
-  UserRefusedAllowManager,
-  UserRefusedDeviceNameChange,
-  UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
@@ -69,13 +64,13 @@ export const useTrackManagerSectionEvents = ({
       track("Deleted Custom Lock Screen", defaultPayload, isTrackingEnabled);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", defaultPayload, isTrackingEnabled);
-    } else if ((error as unknown) instanceof UserRefusedFirmwareUpdate) {
+    } else if (error?.name === "UserRefusedFirmwareUpdate") {
       // user refused OS update
       track("User refused OS update via LL", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackReceiveFlow.ts
@@ -1,14 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  UserRefusedAddress,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
@@ -69,32 +61,32 @@ export const useTrackReceiveFlow = ({
       page: "Receive",
     };
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if ((verifyAddressError as unknown) instanceof UserRefusedAddress) {
+    if (verifyAddressError?.name === "UserRefusedAddress") {
       // user refused to confirm address
       track("Address confirmation rejected", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSendFlow.ts
@@ -1,13 +1,6 @@
 import { useEffect } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { LedgerError } from "~/renderer/components/DeviceAction";
 
@@ -65,27 +58,27 @@ export const useTrackSendFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedOnDevice) {
+    if (error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/hooks/useTrackSyncFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
 import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-import {
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 
 type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
@@ -87,27 +80,27 @@ export const useTrackSyncFlow = ({
       track("Wrong device association", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel refused", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload, isTrackingEnabled);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload, isTrackingEnabled);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload, isTrackingEnabled);
     }
 
-    if (previousOpenAppRequested && error instanceof UserRefusedOnDevice) {
+    if (previousOpenAppRequested && error?.name === "UserRefusedOnDevice") {
       // user refused to open Ledger Sync app
       track("User refused to open Ledger Sync app", defaultPayload, isTrackingEnabled);
     }

--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/index.tsx
@@ -21,7 +21,6 @@ import { useChangeLanguagePrompt } from "./EarlySecurityChecks/useChangeLanguage
 import DeviceAction from "../../DeviceAction";
 import TroubleshootingDrawer from "./TroubleshootingDrawer";
 import LockedDeviceDrawer from "./LockedDeviceDrawer";
-import { LockedDeviceError, UnexpectedBootloader } from "@ledgerhq/errors";
 import { FinalFirmware } from "@ledgerhq/types-live";
 import { useConnectManagerAction } from "~/renderer/hooks/useConnectAppAction";
 
@@ -201,7 +200,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
 
   // A fatal error during polling triggers directly an error message
   useEffect(() => {
-    if ((fatalError as unknown) instanceof UnexpectedBootloader) {
+    if (fatalError?.name === "UnexpectedBootloader") {
       setIsBootloader(true);
     } else if (fatalError) {
       setIsPollingOn(false);
@@ -213,7 +212,7 @@ const SyncOnboardingScreen: React.FC<SyncOnboardingScreenProps> = ({
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
 
-    if (allowedError && !(allowedError instanceof LockedDeviceError)) {
+    if (allowedError && allowedError?.name !== "LockedDeviceError") {
       timeout = setTimeout(() => {
         setIsPollingOn(false);
         setTroubleshootingDrawerOpen(true);

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackAddAccountFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackAddAccountFlow = {
@@ -52,17 +45,21 @@ export const useTrackAddAccountFlow = ({
       page: "Add account",
     };
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during add account flow
       track("Transport error", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
@@ -70,23 +67,23 @@ export const useTrackAddAccountFlow = ({
     if (
       previousAllowOpeningGranted.current &&
       !allowOpeningGranted &&
-      error instanceof CantOpenDevice
+      error?.name === "CantOpenDevice"
     ) {
       // user lost connection after opening app
       track("Device connection lost", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (previousAllowOpeningGranted.current && error instanceof LockedDeviceError) {
+    if (previousAllowOpeningGranted.current && error?.name === "LockedDeviceError") {
       // device is locked while scanning for new accounts
       track("Device locked", defaultPayload);
       previousAllowOpeningGranted.current = undefined;
     }
 
-    if (isScanningForNewAccounts && error instanceof CantOpenDevice) {
+    if (isScanningForNewAccounts && error?.name === "CantOpenDevice") {
       // user lost connection while scanning for new accounts
       track("Device connection lost", defaultPayload);
-    } else if (error instanceof CantOpenDevice) {
+    } else if (error?.name === "CantOpenDevice") {
       // device is detected but connection failed
       track("Connection failed", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackLedgerSyncFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackLedgerSyncFlow = {
@@ -74,7 +67,7 @@ export const useTrackLedgerSyncFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && error instanceof UserRefusedOnDevice) {
+    if (previousRequestOpenApp.current && error?.name === "UserRefusedOnDevice") {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -82,22 +75,22 @@ export const useTrackLedgerSyncFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during ledger synch
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during ledger synch
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during ledger synch
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackMyLedgerEvents.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import { UserRefusedAllowManager, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackMyLedgerSectionEvents = {
@@ -70,10 +69,10 @@ export const useTrackMyLedgerSectionEvents = ({
       track("Custom Lock Screen Image removed", defaultPayload);
     }
 
-    if ((error as unknown) instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secure channel
       track("Secure Channel denied", defaultPayload);
-    } else if ((error as unknown) instanceof UserRefusedDeviceNameChange) {
+    } else if (error?.name === "UserRefusedDeviceNameChange") {
       // user refused device name change
       track("Renamed Device cancelled", { ...defaultPayload, page: "Manager RenamedDevice" });
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackReceiveFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedAddress,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackReceiveFlow = {
@@ -58,32 +50,36 @@ export const useTrackReceiveFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAddress) {
+    if (error?.name === "UserRefusedAddress") {
       // user refused to verify address
       track("Address confirmation rejected", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during receive flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during receive flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during receive flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSendFlow.ts
@@ -2,13 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-  LockedDeviceError,
-  CantOpenDevice,
-  TransportError,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSendFlow = {
@@ -49,7 +42,11 @@ export const useTrackSendFlow = ({
       page: "Send",
     };
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {
@@ -57,22 +54,22 @@ export const useTrackSendFlow = ({
       track("Open app accepted", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during send flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during send flow
       track("Transport error", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during send flow
       track("Device locked", defaultPayload);
     }

--- a/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
+++ b/apps/ledger-live-mobile/src/analytics/hooks/useTrackSwapFlow.ts
@@ -2,14 +2,6 @@ import { useEffect, useRef } from "react";
 import { CONNECTION_TYPES, HOOKS_TRACKING_LOCATIONS } from "./variables";
 import { track } from "../segment";
 import { Device } from "@ledgerhq/types-devices";
-import {
-  CantOpenDevice,
-  LockedDeviceError,
-  TransportError,
-  UserRefusedAllowManager,
-  UserRefusedOnDevice,
-  TransportRaceCondition,
-} from "@ledgerhq/errors";
 import { LedgerError } from "~/types/error";
 
 export type UseTrackSwapFlow = {
@@ -62,32 +54,36 @@ export const useTrackSwapFlow = ({
       track("Wrong device association", defaultPayload);
     }
 
-    if (error instanceof UserRefusedAllowManager) {
+    if (error?.name === "UserRefusedAllowManager") {
       // user refused secured channel
       track("Secure Channel refused", defaultPayload);
     }
 
-    if (error instanceof CantOpenDevice) {
+    if (error?.name === "CantOpenDevice") {
       // device disconnected during swap flow
       track("Connection failed", defaultPayload);
     }
 
-    if (error instanceof TransportError) {
+    if (error?.name === "TransportError") {
       // transport error during swap flow
       track("Transport error", defaultPayload);
     }
 
-    if (error instanceof TransportRaceCondition) {
+    if (error?.name === "TransportRaceCondition") {
       // transport race condition
       track("Transport race condition", defaultPayload);
     }
 
-    if (isLocked || error instanceof LockedDeviceError) {
+    if (isLocked || error?.name === "LockedDeviceError") {
       // device locked during swap flow
       track("Device locked", defaultPayload);
     }
 
-    if (previousRequestOpenApp.current && !requestOpenApp && error instanceof UserRefusedOnDevice) {
+    if (
+      previousRequestOpenApp.current &&
+      !requestOpenApp &&
+      error?.name === "UserRefusedOnDevice"
+    ) {
       // user refused to open app
       track("Open app denied", defaultPayload);
     } else if (previousRequestOpenApp.current && !requestOpenApp && !error) {


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/engagement.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/engagement. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35076