### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (partner-blockydevs files)

### DIFF
--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -1,7 +1,6 @@
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { log } from "@ledgerhq/logs";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import {
@@ -250,7 +249,10 @@ export async function accessProvableApi({
   try {
     status = await apiClient.getRecordScannerStatus(currency, uuid);
   } catch (error) {
-    if (error instanceof LedgerAPI4xx && error.status === 422) {
+    if (
+      (error as { name?: string; status?: number }).name === "LedgerAPI4xx" &&
+      (error as { status?: number }).status === 422
+    ) {
       throw new AleoApiConfigurationResetError();
     }
     throw error;

--- a/libs/coin-modules/coin-aleo/src/network/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.ts
@@ -249,10 +249,8 @@ export async function accessProvableApi({
   try {
     status = await apiClient.getRecordScannerStatus(currency, uuid);
   } catch (error) {
-    if (
-      (error as { name?: string; status?: number }).name === "LedgerAPI4xx" &&
-      (error as { status?: number }).status === 422
-    ) {
+    const err = error as { name?: string; status?: number } | null | undefined;
+    if (err?.name === "LedgerAPI4xx" && err?.status === 422) {
       throw new AleoApiConfigurationResetError();
     }
     throw error;

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -12,13 +12,13 @@ import { HEDERA_TRANSACTION_MODES } from "../constants";
 import {
   HederaInsufficientFundsForAssociation,
   HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
   HederaNoStakingRewardsError,
   HederaRecipientEvmAddressVerificationRequired,
   HederaRecipientInvalidChecksum,
   HederaRecipientTokenAssociationRequired,
   HederaRecipientTokenAssociationUnverified,
   HederaRedundantStakingNodeIdError,
-  HederaMemoExceededSizeError,
 } from "../errors";
 import * as estimateFees from "../logic/estimateFees";
 import * as logicUtils from "../logic/utils";


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/ledger-partner-blockydevs.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/ledger-partner-blockydevs. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35077