### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (partner-hoodies files)

### DIFF
--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -239,16 +239,14 @@ export const buildAuthorizePreapproval =
 /**
  * Check if an error is a LockedDeviceError or UserRefusedOnDevice and create user-friendly error messages
  */
-const handleDeviceErrors = (error: Error): Error | null => {
-  if (error.name === "TransportStatusError") {
-    const statusCode = (error as { statusCode?: number }).statusCode;
-    if (statusCode === 0x6985) {
-      const userRefusedError = new UserRefusedOnDevice("errors.UserRefusedOnDevice.description");
-      return userRefusedError;
+const handleDeviceErrors = (error: unknown): Error | null => {
+  const err = error as { name?: string; statusCode?: number } | null | undefined;
+  if (err?.name === "TransportStatusError") {
+    if (err.statusCode === 0x6985) {
+      return new UserRefusedOnDevice("errors.UserRefusedOnDevice.description");
     }
-    if (statusCode === 0x5515) {
-      const lockedDeviceError = new LockedDeviceError("errors.LockedDeviceError.description");
-      return lockedDeviceError;
+    if (err.statusCode === 0x5515) {
+      return new LockedDeviceError("errors.LockedDeviceError.description");
     }
   }
 

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -1,4 +1,4 @@
-import { TransportStatusError, UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
@@ -240,12 +240,13 @@ export const buildAuthorizePreapproval =
  * Check if an error is a LockedDeviceError or UserRefusedOnDevice and create user-friendly error messages
  */
 const handleDeviceErrors = (error: Error): Error | null => {
-  if (error instanceof TransportStatusError) {
-    if (error.statusCode === 0x6985) {
+  if (error.name === "TransportStatusError") {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    if (statusCode === 0x6985) {
       const userRefusedError = new UserRefusedOnDevice("errors.UserRefusedOnDevice.description");
       return userRefusedError;
     }
-    if (error.statusCode === 0x5515) {
+    if (statusCode === 0x5515) {
       const lockedDeviceError = new LockedDeviceError("errors.LockedDeviceError.description");
       return lockedDeviceError;
     }

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -1,5 +1,6 @@
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 import coinConfig from "../config";
 import {
   createMockCantonCurrency,
@@ -8,7 +9,6 @@ import {
   createMockPendingTransferProposal,
   setupMockCoinConfig,
 } from "../test/fixtures";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { TopologyChangeError } from "../types/errors";
 import type { GetBalanceResponse } from "../types/gateway";
 import { TransactionType } from "../types/gateway";

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import coinConfig from "../config";
@@ -9,6 +8,7 @@ import {
   createMockPendingTransferProposal,
   setupMockCoinConfig,
 } from "../test/fixtures";
+import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { TopologyChangeError } from "../types/errors";
 import type { GetBalanceResponse } from "../types/gateway";
 import { TransactionType } from "../types/gateway";

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -3,7 +3,6 @@ import {
   ConcordiumPairingExpiredError,
   ConcordiumSessionExpiredError,
   LockedDeviceError,
-  TransportStatusError,
   UserRefusedOnDevice,
 } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
@@ -158,13 +157,14 @@ export const buildOnboardAccount =
       main().then(
         () => o.complete(),
         error => {
-          if (error instanceof TransportStatusError) {
-            if (error.statusCode === 0x6985) {
+          if ((error as { name?: string })?.name === "TransportStatusError") {
+            const statusCode = (error as { statusCode?: number }).statusCode;
+            if (statusCode === 0x6985) {
               o.error(new UserRefusedOnDevice("errors.UserRefusedOnDevice.description"));
               return;
             }
 
-            if (error.statusCode === 0x5515) {
+            if (statusCode === 0x5515) {
               o.error(new LockedDeviceError("errors.LockedDeviceError.description"));
               return;
             }


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/ledger-partner-hoodies.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/ledger-partner-hoodies. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35078