### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (blockchain-support files)

### DIFF
--- a/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
@@ -101,7 +101,7 @@ export const createNewTransaction = async (
   log("debug", `Creating new Transaction: ${sender}, ${recipient}, ${network}`);
 
   if (recipient && !isAddressValid(recipient)) {
-    throw InvalidAddress(`Invalid recipient Address ${recipient}`);
+    throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
   const client = getCasperNodeRpcClient();

--- a/libs/coin-modules/coin-mina/src/network/index.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI5xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 
@@ -53,14 +52,12 @@ const isAbortOrTimeoutError = (error: unknown): error is Error & { code?: string
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([502, 503, 504]);
 
-type LedgerAPI5xxInstance = InstanceType<typeof LedgerAPI5xx>;
-
 const isRetryableServerError = (
   error: unknown,
-): error is LedgerAPI5xxInstance & { status: number } =>
-  error instanceof LedgerAPI5xx &&
-  typeof (error as LedgerAPI5xxInstance & { status?: number }).status === "number" &&
-  RETRYABLE_HTTP_STATUS_CODES.has((error as LedgerAPI5xxInstance & { status: number }).status);
+): error is { name: string; status: number; message: string } =>
+  (error as { name?: string })?.name === "LedgerAPI5xx" &&
+  typeof (error as { status?: number }).status === "number" &&
+  RETRYABLE_HTTP_STATUS_CODES.has((error as { status: number }).status);
 
 const backoffDelay = (attempt: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt)));


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/blockchain-support.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/blockchain-support. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ