### PR TITLE
[LWDM] fix: cannot read property length of undefined error when selling usdt…

### DIFF
--- a/.changeset/clever-coats-report.md
+++ b/.changeset/clever-coats-report.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+Fix: check if votes existe before checking the length

--- a/libs/coin-modules/coin-tron/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/prepareTransaction.test.ts
@@ -111,4 +111,16 @@ describe("prepareTransaction", () => {
 
     expect(mockAccountNamesCache).not.toHaveBeenCalled();
   });
+
+  it("should not crash when votes is undefined (e.g. wallet-api sell flow)", async () => {
+    const account = createAccount();
+    const transaction = createTransaction({
+      networkInfo: baseNetworkInfo,
+      votes: undefined as unknown as Transaction["votes"],
+    });
+
+    const result = await prepareTransaction(account, transaction);
+    expect(result.votes).toEqual(undefined);
+    expect(mockAccountNamesCache).not.toHaveBeenCalled();
+  });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/prepareTransaction.ts
@@ -9,7 +9,7 @@ export const prepareTransaction: AccountBridge<
   const networkInfo =
     transaction.networkInfo || (await getTronAccountNetwork(account.freshAddress));
 
-  if (transaction.votes.length) {
+  if (transaction.votes?.length) {
     transaction.votes = await Promise.all(
       transaction.votes.map(async vote => ({
         ...vote,


### PR DESCRIPTION
… on tron

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

in prepareTransaction we have an if statement which is doing `if (transaction.votes.length)` but moonpay return votes as `undefined`.
The simple change is to change that if statement into `if(transaction.votes?.length)`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31312](https://ledgerhq.atlassian.net/browse/LIVE-31312)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-31312]: https://ledgerhq.atlassian.net/browse/LIVE-31312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ