### PR TITLE
[LWD] Redelegate / Undelegate modal — percentage buttons (25/50/75/100) apply amount only on second tap

### DIFF
--- a/.changeset/amber-foxes-wander.md
+++ b/.changeset/amber-foxes-wander.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix InputCurrency not applying external value updates (e.g. amount presets) when focused after typing

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
@@ -1,10 +1,36 @@
-import React from "react";
+import React, { useState } from "react";
 import { BigNumber } from "bignumber.js";
 import { render, screen } from "tests/testSetup";
 import InputCurrency from "./InputCurrency";
 
 // Ethereum's "Gwei" fee unit — magnitude 9, i.e. at most 9 decimals.
 const gweiUnit = { name: "Gwei", code: "Gwei", magnitude: 9 };
+
+// Babylon-like unit (magnitude 6) for the percentage-preset scenarios.
+const babyUnit = { name: "Baby", code: "BABY", magnitude: 6 };
+
+// Mirrors the cosmos Amount field: presets live in renderRight and drive the
+// value through onChange, which flows back down as the value prop.
+function PresetHarness({ delegated }: { delegated: BigNumber }) {
+  const [value, setValue] = useState<BigNumber>(delegated);
+  const presets = [
+    { label: "25%", value: delegated.multipliedBy(0.25).integerValue() },
+    { label: "50%", value: delegated.multipliedBy(0.5).integerValue() },
+    { label: "100%", value: delegated },
+  ];
+  return (
+    <InputCurrency
+      unit={babyUnit}
+      value={value}
+      onChange={setValue}
+      renderRight={presets.map(p => (
+        <button key={p.label} type="button" onClick={() => setValue(p.value)}>
+          {p.label}
+        </button>
+      ))}
+    />
+  );
+}
 
 describe("InputCurrency — caret preservation", () => {
   // Regression: the EVM advanced-fee inputs (Max Priority Fee / Max Fee) are
@@ -106,5 +132,43 @@ describe("InputCurrency — caret preservation", () => {
 
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
     expect(ref.current).toBe(screen.getByRole("textbox"));
+  });
+});
+
+describe("InputCurrency — percentage presets (LIVE-34511)", () => {
+  it("applies a preset on the first tap, with no typing", async () => {
+    const { user } = render(<PresetHarness delegated={new BigNumber("4500000")} />); // 4.5 BABY
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("4.5");
+
+    await user.click(screen.getByText("25%"));
+
+    // 25% of 4.5 = 1.125, applied immediately — not only on a second tap.
+    expect(input.value).toBe("1.125");
+  });
+
+  it("lets a preset override a value the user has already typed", async () => {
+    const { user } = render(<PresetHarness delegated={new BigNumber("4500000")} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    await user.clear(input);
+    await user.type(input, "2");
+    expect(input.value).toBe("2");
+
+    await user.click(screen.getByText("50%"));
+
+    // 50% of 4.5 = 2.25 must replace the typed "2".
+    expect(input.value).toBe("2.25");
+  });
+
+  it("preserves the in-progress edit when the value prop is only the echo of typing", async () => {
+    const { user } = render(<PresetHarness delegated={new BigNumber("4500000")} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    await user.clear(input);
+    await user.type(input, "1.2");
+
+    // No external change happened — the field must show exactly what was typed.
+    expect(input.value).toBe("1.2");
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.test.tsx
@@ -9,8 +9,8 @@ const gweiUnit = { name: "Gwei", code: "Gwei", magnitude: 9 };
 // Babylon-like unit (magnitude 6) for the percentage-preset scenarios.
 const babyUnit = { name: "Baby", code: "BABY", magnitude: 6 };
 
-// Mirrors the cosmos Amount field: presets live in renderRight and drive the
-// value through onChange, which flows back down as the value prop.
+// Mirrors the cosmos Amount field: presets live in renderRight and set the
+// amount directly (an external change), which flows back in as the value prop.
 function PresetHarness({ delegated }: { delegated: BigNumber }) {
   const [value, setValue] = useState<BigNumber>(delegated);
   const presets = [

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -143,7 +143,7 @@ function InputCurrency(props: Props) {
     [unit, locale, showAllDigits, subMagnitude, allowZero, value],
   );
 
-  // Synchronously reformat display when value/unit change while not focused
+  // Reformat the display when the value/unit prop changes.
   useLayoutEffect(() => {
     setState(prev => {
       // An external value change (ratio preset, "send max") must win even while

--- a/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/InputCurrency.tsx
@@ -119,6 +119,7 @@ function InputCurrency(props: Props) {
   // ref exposing `.current`) keeps working, and expose it to any forwarded ref.
   const innerRef = useRef<HTMLInputElement | null>(null);
   const caretRef = useRef<number | null>(null);
+  const lastTypedRef = useRef<BigNumber | null>(null);
   useImperativeHandle(forwardedRef, () => innerRef.current as HTMLInputElement, []);
 
   const syncInput = useCallback(
@@ -145,7 +146,16 @@ function InputCurrency(props: Props) {
   // Synchronously reformat display when value/unit change while not focused
   useLayoutEffect(() => {
     setState(prev => {
-      if (prev.isFocused && prev.rawValue && !disabled) return prev;
+      // An external value change (ratio preset, "send max") must win even while
+      // focused; only an echo of what the user just typed preserves their edit.
+      if (prev.isFocused && prev.rawValue && !disabled) {
+        const isEcho =
+          lastTypedRef.current != null &&
+          value != null &&
+          !value.isNaN() &&
+          lastTypedRef.current.isEqualTo(value);
+        if (isEcho) return prev;
+      }
       const displayValue =
         !value || value.isNaN() || value.isZero()
           ? ""
@@ -178,6 +188,7 @@ function InputCurrency(props: Props) {
       }
 
       const satoshiValue = BigNumber(r.value);
+      lastTypedRef.current = satoshiValue;
       if (!value || !value.isEqualTo(satoshiValue)) {
         onChange(satoshiValue, unit);
       }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**Previous behaviour**: Amount presets (25/50/75/100%) and "send max" live in the input's renderRight; clicking one focuses the field. InputCurrency (the shared desktop amount input) syncs its display from the value prop in a useLayoutEffect that bailed out while the field was focused and held a typed value — so a preset was ignored once the user had edited the field. LIVE-34610 fixed the no-typing case; this closes the post-edit gap.

**Fix**: Track the last typed value (lastTypedRef) and keep the in-progress edit only when the incoming value is an echo of it; any external change now wins. Desktop only.

**Regression check**: InputCurrency.test.tsx: preset applies on first tap, preset overrides a typed value, and a typing echo is still preserved.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34511](https://ledgerhq.atlassian.net/browse/LIVE-34511?atlOrigin=eyJpIjoiMDcxMWU5ZGI4MGM2NDY5MWJkMWI5NzY0YjE2MDZiZmEiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34511]: https://ledgerhq.atlassian.net/browse/LIVE-34511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ