### PR TITLE
ci: publish nightly to jFrog

### DIFF
--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           ruby-version: 3.3.0
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: install dependencies
         run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli"
 
@@ -69,15 +74,33 @@ jobs:
         with:
           path: ${{ github.workspace }}/apps/wallet-cli
 
+        #JFrog publishing - if statements to be removed when all is migrated
+
+      - name: JFrog npm auth (publish registry)
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_PUBLISH_URL }}
+
+      - name: publish nightly (JFrog)
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
+        run: npm_config_registry="https://${{ vars.ARTIFACTORY_PUBLISH_URL }}/" pnpm changeset publish --tag nightly --no-git-tag
+
+        #NPM publishing - to be removed when all is migrated
+
       - name: authenticate with npm
         uses: actions/setup-node@v4
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL == '' }}
         with:
           registry-url: "https://registry.npmjs.org"
 
       - name: publish nightly
         run: pnpm changeset publish --tag nightly --no-git-tag
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL == '' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+
+      #NPM publishing - end removal
 
       - uses: LedgerHQ/ledger-live/tools/actions/get-package-infos@develop
         id: post-desktop-version

--- a/.github/workflows/release-final-nightly.yml
+++ b/.github/workflows/release-final-nightly.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   nightly-release:
     name: Nightly Release
-    runs-on: ubuntu-24.04
+    runs-on: ledger-live-linux-8CPU-32RAM
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
     steps:


### PR DESCRIPTION
### 📝 Description

Migrates the scheduled nightly release (`release-final-nightly.yml`) onto JFrog Artifactory for both **consuming** and **publishing** npm packages, while keeping the existing npmjs.org path as a gated fallback for a safe, reversible rollout.

**1. Consume from JFrog** (aligned with #19687)

Adds the `jfrog-npm-auth` composite before `install dependencies`, so the job authenticates against the Artifactory registry before resolving packages:

```yaml
- name: JFrog npm auth
  uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
  with:
    registry: ${{ vars.ARTIFACTORY_URL }}
```

The composite self-guards on an empty `registry`, so it is a no-op if `vars.ARTIFACTORY_URL` is unset.

**2. Publish to JFrog** (gated on `vars.ARTIFACTORY_PUBLISH_URL`)

Reuses the *same* composite for the publish-registry login/`.npmrc` setup (no hand-rolled `jfrog-login` + `jfrog-npm` duplication), then publishes via changesets:

```yaml
- name: JFrog npm auth (publish registry)
  if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
  uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
  with:
    registry: ${{ vars.ARTIFACTORY_PUBLISH_URL }}

- name: publish nightly (JFrog)
  if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
  run: npm_config_registry="https://${{ vars.ARTIFACTORY_PUBLISH_URL }}/" pnpm changeset publish --tag nightly --no-git-tag
```

The legacy npmjs.org steps are kept but gated on `${{ vars.ARTIFACTORY_PUBLISH_URL == '' }}`, so unsetting the var instantly reverts to the old behaviour. All migration steps are marked for later cleanup.

**3. Update to custom runner**

jFrog requires a custom runner to allow connection through the whitelist

### ⚠️ Why `npm_config_registry` is still required

The `.npmrc` written by the composite is **not** enough to redirect the publish. `@changesets/cli@2.27.7`'s `getCorrectRegistry()` resolves the publish target from only two sources — a package's `publishConfig.registry`, then the `npm_config_registry` **env var** — before defaulting to `registry.npmjs.org`. It never reads the `registry=` line from `.npmrc` (that only drives auth + install resolution). Since no ledger-live lib sets `publishConfig.registry`, the explicit `npm_config_registry=` prefix on the publish command is what actually routes packages to Artifactory.

### 🔏 On attestation

The reworked [`attest-for-npmsjs-com`](https://github.com/LedgerHQ/actions-security/tree/main/actions/attest-for-npmsjs-com) action is intentionally **not** wired into the nightly. It attests a single tarball by exact bytes and requires publishing those same bytes — which is incompatible with the nightly's bulk `pnpm changeset publish` (multi-package, re-packed from each dir). npmjs.com provenance attestation belongs in the final-release flow where a per-package pack → attest → `publish ${tarball-path}` loop can guarantee byte-identity.

### 🔗 Context

- **Consume-side precedent**: #19687 (wires `jfrog-npm-auth` into the self-hosted macOS jobs)
- **Composite**: `tools/actions/composites/jfrog-npm-auth` — OIDC `jfrog-login@1.4.0` + `jfrog-npm@0.3.0`, writes `$HOME/.npmrc`
Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/29828864664/job/88628480361
