### PR TITLE
fix(mobile): correct floatNumberRegex quantifier bug in swap e2e

### DIFF
--- a/.changeset/quiet-zeros-settle.md
+++ b/.changeset/quiet-zeros-settle.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-e2e-shared": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Fix `floatNumberRegex` quantifier bug that rejected well-formed single-digit values (including "0"), which was masking the real cause of intermittent swap e2e timeouts. `clickSwapMax` now explicitly rejects a zero "to" amount instead of relying on the regex to do it.

--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -34,7 +34,7 @@ export const DEFAULT_TIMEOUT = 60000;
 export const VISIBILITY_PROBE_TIMEOUT = 1000;
 export const QUICK_VISIBILITY_PROBE_TIMEOUT = 500;
 
-const DEFAULT_WEB_ELEMENT_INTERVAL = 2000;
+export const DEFAULT_WEB_ELEMENT_INTERVAL = 2000;
 
 export type WaitForElementOptions = {
   errorCheckTimeout?: number;

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -3,7 +3,7 @@ import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { getMinimumSwapAmount } from "@ledgerhq/live-e2e-shared/swap";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
-import { floatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
+import { positiveFloatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
 
 // Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
 // before the sign-permit button (Step 2) appears (the app shows a "1-5 mins" estimate).
@@ -374,7 +374,7 @@ export default class SwapLiveAppPage {
   @Step("Click on swap max")
   async clickSwapMax() {
     await tapWebElementByTestId(this.swapMaxToggle);
-    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex);
+    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, positiveFloatNumberRegex);
   }
 
   @Step("Retrieve send currency amount value")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -375,13 +375,19 @@ export default class SwapLiveAppPage {
   @Step("Click on swap max")
   async clickSwapMax() {
     await tapWebElementByTestId(this.swapMaxToggle);
-    await retryUntilTimeout(async () => {
-      const text = await getWebElementText(this.toAmountInput);
-      if (!floatNumberRegex.test(text) || Number(text) === 0) {
-        throw new Error(`Web Element "${this.toAmountInput}" has no quote yet (amount is "${text}")`);
-      }
-      return text;
-    }, 10000, DEFAULT_WEB_ELEMENT_INTERVAL);
+    await retryUntilTimeout(
+      async () => {
+        const text = await getWebElementText(this.toAmountInput);
+        if (!floatNumberRegex.test(text) || Number(text) === 0) {
+          throw new Error(
+            `Web Element "${this.toAmountInput}" has no quote yet (amount is "${text}")`,
+          );
+        }
+        return text;
+      },
+      10000,
+      DEFAULT_WEB_ELEMENT_INTERVAL,
+    );
   }
 
   @Step("Retrieve send currency amount value")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -3,7 +3,7 @@ import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { getMinimumSwapAmount } from "@ledgerhq/live-e2e-shared/swap";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
-import { positiveFloatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
+import { floatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
 
 // Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
 // before the sign-permit button (Step 2) appears (the app shows a "1-5 mins" estimate).
@@ -374,7 +374,13 @@ export default class SwapLiveAppPage {
   @Step("Click on swap max")
   async clickSwapMax() {
     await tapWebElementByTestId(this.swapMaxToggle);
-    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, positiveFloatNumberRegex);
+    await retryUntilTimeout(async () => {
+      const text = await getWebElementText(this.toAmountInput);
+      if (!floatNumberRegex.test(text) || Number(text) === 0) {
+        throw new Error(`Web Element "${this.toAmountInput}" has no quote yet (amount is "${text}")`);
+      }
+      return text;
+    }, 10000);
   }
 
   @Step("Retrieve send currency amount value")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -4,6 +4,7 @@ import { getMinimumSwapAmount } from "@ledgerhq/live-e2e-shared/swap";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { retryUntilTimeout } from "../../utils/retry";
 import { floatNumberRegex } from "@ledgerhq/live-e2e-shared/data/regexes";
+import { DEFAULT_WEB_ELEMENT_INTERVAL } from "../../helpers/elementHelpers";
 
 // Uniswap's Permit2 "Approve token access" step can take 1-5 min to confirm on-chain
 // before the sign-permit button (Step 2) appears (the app shows a "1-5 mins" estimate).
@@ -380,7 +381,7 @@ export default class SwapLiveAppPage {
         throw new Error(`Web Element "${this.toAmountInput}" has no quote yet (amount is "${text}")`);
       }
       return text;
-    }, 10000);
+    }, 10000, DEFAULT_WEB_ELEMENT_INTERVAL);
   }
 
   @Step("Retrieve send currency amount value")

--- a/libs/live-e2e-shared/src/data/regexes.ts
+++ b/libs/live-e2e-shared/src/data/regexes.ts
@@ -1,1 +1,7 @@
-export const floatNumberRegex = /^\d+\.?\d+$/;
+// Well-formed non-negative number, e.g. "0", "5", "12.34" (fixed decimal digits are not required).
+export const floatNumberRegex = /^\d+(\.\d+)?$/;
+
+// Same, but excludes all-zero values ("0", "0.00") — use where zero can never be a legitimate
+// result (e.g. a computed "max" amount), so the test fails immediately instead of relying on a
+// later, less direct assertion to catch it.
+export const positiveFloatNumberRegex = /^(?!0*\.?0*$)\d+(\.\d+)?$/;

--- a/libs/live-e2e-shared/src/data/regexes.ts
+++ b/libs/live-e2e-shared/src/data/regexes.ts
@@ -1,7 +1,5 @@
-// Well-formed non-negative number, e.g. "0", "5", "12.34" (fixed decimal digits are not required).
+// Well-formed non-negative number, e.g. "0", "5", "12.34".
 export const floatNumberRegex = /^\d+(\.\d+)?$/;
 
-// Same, but excludes all-zero values ("0", "0.00") — use where zero can never be a legitimate
-// result (e.g. a computed "max" amount), so the test fails immediately instead of relying on a
-// later, less direct assertion to catch it.
-export const positiveFloatNumberRegex = /^(?!0*\.?0*$)\d+(\.\d+)?$/;
+// Same, but excludes all-zero values, e.g. "0", "0.00".
+export const positiveFloatNumberRegex = /^(?:[1-9]\d*(\.\d+)?|0+\.\d*[1-9]\d*)$/;

--- a/libs/live-e2e-shared/src/data/regexes.ts
+++ b/libs/live-e2e-shared/src/data/regexes.ts
@@ -1,2 +1,2 @@
 // Well-formed non-negative number, e.g. "0", "5", "12.34".
-export const floatNumberRegex = /^\d+(\.\d+)?$/;
+export const floatNumberRegex = /^\d+(?:\.\d+)?$/;

--- a/libs/live-e2e-shared/src/data/regexes.ts
+++ b/libs/live-e2e-shared/src/data/regexes.ts
@@ -1,5 +1,2 @@
 // Well-formed non-negative number, e.g. "0", "5", "12.34".
 export const floatNumberRegex = /^\d+(\.\d+)?$/;
-
-// Same, but excludes all-zero values, e.g. "0", "0.00".
-export const positiveFloatNumberRegex = /^(?:[1-9]\d*(\.\d+)?|0+\.\d*[1-9]\d*)$/;


### PR DESCRIPTION
## Summary
- `floatNumberRegex` (`/^\d+\.?\d+$/`) required at least 2 digit characters regardless of whether a decimal point was present, so any well-formed single-digit value — including `"0"` — never matched. This was masking the underlying `swapHBAR_XRP.spec.ts` "to-amount stuck at 0" failure behind a misleading "does not contain the expected regex" error, and would equally misfire on a legitimate single-digit quote (e.g. `"5"`).
- Fixed the pattern to `/^\d+(?:\.\d+)?$/` so it correctly matches any well-formed non-negative number, including `"0"` (non-capturing group, since no caller needs the captured decimal part).
- `clickSwapMax` needs the opposite: a stuck-at-zero "max" amount should fail immediately rather than relying on a later, less direct assertion downstream. Expressing "well-formed and not all-zero" as a single regex (tried both a negative-lookahead and a lookahead-free alternation) reliably trips SonarCloud's `S8786` (super-linear backtracking) — the ambiguity is inherent to any regex describing "a digit run contains a nonzero digit somewhere", not specific to lookaheads. So `clickSwapMax` now polls via `retryUntilTimeout` and checks `Number(text) === 0` as a plain comparison instead, keeping `floatNumberRegex` for format validation only. The polling interval is passed explicitly as `DEFAULT_WEB_ELEMENT_INTERVAL` (now exported from `elementHelpers.ts`) to match the cadence of sibling web-element helpers.
- `performSwapUntilQuoteSelectionStep`'s wait keeps the plain `floatNumberRegex`: `"0"` now passes this specific check, but the test still fails downstream via `tapGetQuotesButton`/`waitForQuotes` (60s default timeout) when no real quote is returned — verified these throw when the enabled get-quotes button / quote count never render.

## Test plan
- [ ] Verify `swapHBAR_XRP.spec.ts` still fails (with a different, later error) when the Exodus quote provider has no route for the pair
- [ ] Verify `clickSwapMax`-based swap-max specs still fail fast if the computed max amount is `"0"`
- [ ] Run the mobile swap e2e suite locally / on CI