### PR TITLE
ci: enable JFrog npm auth on ledger-live-linux-8CPU-32RAM jobs

### DIFF
--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -81,6 +81,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - uses: LedgerHQ/ledger-live/tools/actions/composites/setup-test-desktop@develop
         id: setup-test-desktop
         with:

--- a/.github/workflows/test-devtools-reusable.yml
+++ b/.github/workflows/test-devtools-reusable.yml
@@ -49,6 +49,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Install dependencies
         run: pnpm i --filter="@devtools/*..."
 

--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -49,6 +49,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Install dependencies
         run: pnpm i --filter="./domain/**" --filter="./shared/**"
 

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -49,6 +49,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Install dependencies
         run: pnpm i --filter="./features/**" --filter="./shared/**" --filter="./domain/**"
 

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -53,6 +53,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Install dependencies
         run: pnpm i --filter="{./libs/**}..."
 

--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -115,6 +115,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: setup JDK 17
         uses: actions/setup-java@v5
         with:
@@ -195,6 +200,11 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
 
       - uses: nick-fields/retry@v4
         name: install dependencies

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -226,6 +226,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - uses: nick-fields/retry@v4
         name: install dependencies
         id: install-dependencies

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -382,6 +382,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Download Native Build
         uses: LedgerHQ/ledger-live/tools/actions/composites/cache/download@develop
         with:

--- a/.github/workflows/test-shared-reusable.yml
+++ b/.github/workflows/test-shared-reusable.yml
@@ -49,6 +49,11 @@ jobs:
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: Install dependencies
         run: pnpm i --filter="./shared/**"
 


### PR DESCRIPTION
### 📝 Description

Wires the `jfrog-npm-auth` composite into every CI job that runs on the self-hosted `ledger-live-linux-8CPU-32RAM` runner, so npm is authenticated against the Artifactory registry before dependencies are installed — mirroring what #19687 did for the self-hosted macOS jobs.

The step is inserted right after `setup caches` / before the dependency install in each job, passing `registry: ${{ vars.ARTIFACTORY_URL }}`:

| Workflow | Job |
|---|---|
| `test-features-reusable.yml` | `test-features` |
| `test-domain-reusable.yml` | `test-domain` |
| `test-devtools-reusable.yml` | `test-devtools` |
| `test-shared-reusable.yml` | `test-shared` |
| `test-libs-reusable.yml` | `test-libs` |
| `generate-screenshots.yml` | screenshots (before `setup-test-desktop`) |
| `test-mobile-build-ios-reusable.yml` | `build-ios-js` |
| `test-mobile-build-android-reusable.yml` | `build-android-native` **and** `build-android-js` |
| `test-mobile-mock-reusable.yml` | `detox-ui-e2e-android` |

**10 jobs across 9 workflows.**

```yaml
- name: JFrog npm auth
  uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
  with:
    registry: ${{ vars.ARTIFACTORY_URL }}
```

Scope notes:
- Only jobs tagged `ledger-live-linux-8CPU-32RAM` are targeted here.
- The composite guards on an empty `registry`, so if `vars.ARTIFACTORY_URL` isn't set it is a **no-op** rather than a failure.
- The macOS jobs in `test-mobile-build-ios-reusable.yml` / `test-mobile-mock-reusable.yml` already got the composite in #19687 — only the Linux jobs are touched here, no duplicates.
- `release-final-nightly.yml` (the other job on this runner) is intentionally out of scope — it's handled by #19844.

### 🔗 Context

- **Precedent**: #19687 (same composite wired into the self-hosted macOS jobs)
- **Composite**: `tools/actions/composites/jfrog-npm-auth` — OIDC `jfrog-login@1.4.0` + `jfrog-npm@0.3.0`
Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/29829942263
