### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (coin-integration files)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowOperation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendFlowOperation.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -42,7 +41,7 @@ export function useSendFlowOperation({
 
   const onTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       stateActions.dispatchSetError(error);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from "react";
 import { Banner, Button } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { openURL } from "~/renderer/linking";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
 import { urls } from "~/config/urls";
@@ -53,7 +52,7 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (!error) return null;
 
-  if (excludeRecipientRequired && error instanceof RecipientRequired) return null;
+  if (excludeRecipientRequired && error?.name === "RecipientRequired") return null;
 
   if (!translatedError) return null;
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
@@ -139,7 +139,7 @@ export function useAddressValidation({
   });
 
   const hasInvalidBridgeRecipient =
-    bridgeValidation.errors.recipient instanceof InvalidAddress && !ensResolution;
+    bridgeValidation.errors.recipient?.name === "InvalidAddress" && !ensResolution;
   const canMatchValidatedRecipient = Boolean(searchValue) && !hasInvalidBridgeRecipient;
 
   const userAccountsForCurrency = useMemo(() => {
@@ -306,7 +306,7 @@ export function useAddressValidation({
     }));
 
     const filteredBridgeErrors: BridgeValidationErrors = { ...bridgeValidation.errors };
-    if (ensResolution && filteredBridgeErrors.recipient instanceof InvalidAddress) {
+    if (ensResolution && filteredBridgeErrors.recipient?.name === "InvalidAddress") {
       delete filteredBridgeErrors.recipient;
     }
 

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/OptInFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -107,7 +106,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/RestakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aptos/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getDelegationOpMaxAmount } from "@ledgerhq/live-common/families/aptos/staking";
@@ -130,7 +129,7 @@ function Body({
   );
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/Body.tsx
@@ -1,7 +1,6 @@
 import { getOriginalTxFeeRateSatVb } from "@ledgerhq/live-common/families/bitcoin/editTransaction/rbfValidation";
 import { fromTransactionRaw } from "@ledgerhq/coin-bitcoin/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-bitcoin/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -190,7 +189,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+
 import {
   ZCASH_ACTIVATION_DATE,
   ZCASH_ACTIVATION_DATE_STRING,
@@ -62,7 +62,7 @@ const ExportKeyModal = ({ account }: { account: ZcashAccount }) => {
   };
 
   const handleUfvkChanged = (ufvk: string, error?: Error | undefined | null) => {
-    if (error instanceof UserRefusedOnDevice) {
+    if ((error as { name?: string })?.name === "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setUfvkExportError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/OnboardModal/steps/StepOnboard.tsx
@@ -1,5 +1,4 @@
 import { OnboardStatus } from "@ledgerhq/coin-canton/types";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getDefaultAccountNameForCurrencyIndex } from "@ledgerhq/live-wallet/accountName";
 import { isAxiosError } from "axios";
 import React from "react";
@@ -112,8 +111,8 @@ const getStatusMessage = (status?: OnboardStatus): string => {
 };
 
 const getErrorMessage = (error: Error | null) => {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return <Trans i18nKey={error.message} />;
+  if (error?.name === "UserRefusedOnDevice" || error?.name === "LockedDeviceError") {
+    return <Trans i18nKey={error?.message} />;
   }
   return <Trans i18nKey="families.canton.addAccount.onboard.error" />;
 };

--- a/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -12,7 +12,7 @@ import { useCallback, useMemo, useState } from "react";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import { handleTopologyChangeError, TopologyChangeError } from "../hooks/topologyChangeError";
+import { handleTopologyChangeError } from "../hooks/topologyChangeError";
 import PendingTransferProposalsDetails from "./PendingTransferProposalsDetails";
 import type { GroupedProposals, Modal, ProcessedProposal, TransferProposalAction } from "./types";
 import {
@@ -113,7 +113,7 @@ export function usePendingTransferProposalsViewModel(
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           if (device) {
             handleTopologyChangeError(dispatch, {

--- a/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/canton/SendRecipientFields.tsx
@@ -1,4 +1,3 @@
-import { TooManyUtxosCritical, TooManyUtxosWarning } from "@ledgerhq/coin-canton";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import {
   CantonAccount,
@@ -15,7 +14,7 @@ import Alert from "~/renderer/components/Alert";
 import Box from "~/renderer/components/Box";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { modalsStateSelector } from "~/renderer/reducers/modals";
-import { handleTopologyChangeError, TopologyChangeError } from "./hooks/topologyChangeError";
+import { handleTopologyChangeError } from "./hooks/topologyChangeError";
 import CommentField from "./CommentField";
 import ExpiryDurationField from "./ExpiryDurationField";
 
@@ -38,9 +37,9 @@ const Root = (props: {
   const cantonAccount = account as CantonAccount;
   const mainAccount = getMainAccount(account, parentAccount);
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   useEffect(() => {
     if (topologyChangeError) {

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -136,7 +135,7 @@ const Body = ({
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, St, StepId } from "./types";
@@ -122,7 +121,7 @@ const Body = ({
     onChangeStepId("summary");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cardano/UndelegateFlowModal/steps/StepSummary.tsx
@@ -14,7 +14,6 @@ import BigNumber from "bignumber.js";
 import Alert from "~/renderer/components/Alert";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
 
 const FromToWrapper = styled.div``;
@@ -30,7 +29,7 @@ function StepSummary(props: StepProps) {
   const { estimatedFees, errors, warnings } = status;
   const { feeTooHigh } = warnings;
   const displayError = errors.amount?.message ? errors.amount : "";
-  const notEnoughFundsError = error && error instanceof CardanoNotEnoughFunds;
+  const notEnoughFundsError = error && error?.name === "CardanoNotEnoughFunds";
 
   const accountUnit = useMaybeAccountUnit(account);
   if (!account || !transaction || !account.cardanoResources.delegation) return null;

--- a/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/ActivateFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -103,7 +102,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("vote");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/LockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -100,7 +99,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/RevokeFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { NotEnoughBalanceFees } from "@ledgerhq/errors";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import { DefaultStepAmount } from "~/renderer/modals/Send/steps/StepAmount";
 import type { StepProps } from "~/renderer/modals/Send/types";
@@ -9,7 +8,7 @@ export const FEES_BANNER_TESTID = "celo-send-fees-error-banner";
 const SendStepAmount = (props: StepProps) => {
   const { status, error, bridgePending } = props;
   const feesError = status.errors.fees;
-  const showFeesBanner = !error && !bridgePending && feesError instanceof NotEnoughBalanceFees;
+  const showFeesBanner = !error && !bridgePending && feesError?.name === "NotEnoughBalanceFees";
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, openModal, onClose, onChangeStepId, params, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/UnlockFlowModal/steps/StepAmount.tsx
@@ -12,7 +12,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AmountField from "../fields/AmountField";
 import { StepProps } from "../types";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export const StepAmountFooter = ({
   transitionTo,
@@ -58,7 +57,7 @@ const StepAmount = ({
 }: StepProps) => {
   invariant(account && transaction, "account and transaction required");
   const notEnoughFundsError =
-    status.errors.amount && status.errors.amount instanceof NotEnoughBalance;
+    status.errors.amount && status.errors.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/VoteFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -112,7 +111,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/WithdrawFlowModal/steps/StepAmount.tsx
@@ -3,8 +3,6 @@ import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Transaction } from "@ledgerhq/live-common/families/celo/types";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -51,9 +49,8 @@ export const StepAmountFooter = ({
 };
 
 const isTransactionRefuse = (error: unknown) => {
-  return (
-    error && (error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-  );
+  const eName = (error as { name?: string })?.name;
+  return eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice";
 };
 
 const StepAmount = ({

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/OnboardError/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Trans } from "react-i18next";
 import { isAxiosError } from "axios";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import Alert from "~/renderer/components/Alert";
 
 type Props = Readonly<{
@@ -18,8 +17,9 @@ export default function OnboardError({ error, context }: Props) {
 }
 
 function resolveMessageKey(error: Error | null, context: "onboard" | "create"): string {
-  if (error instanceof UserRefusedOnDevice || error instanceof LockedDeviceError) {
-    return error.message;
+  const eName = (error as { name?: string })?.name;
+  if (eName === "UserRefusedOnDevice" || eName === "LockedDeviceError") {
+    return error?.message ?? "";
   }
 
   if (context === "create" && isAxiosError(error) && error.status === 429) {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/pairing.ts
@@ -3,7 +3,6 @@ import {
   ConcordiumPairingProgress,
   ConcordiumPairingStatus,
 } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 
 export const MAX_EXPIRED_RETRIES = 3;
 export const CONFIRMATION_CODE_LENGTH = 4;
@@ -22,7 +21,7 @@ export function shouldRetryPairing(error: unknown, retryCount: number): boolean 
     return false;
   }
 
-  return error instanceof ConcordiumPairingExpiredError;
+  return (error as { name?: string })?.name === "ConcordiumPairingExpiredError";
 }
 
 export type PairingStateUpdate = {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { firstValueFrom } from "rxjs";
 import { Account } from "@ledgerhq/types-live";
-import { ConcordiumTrustedMetadataServiceError, DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -146,7 +146,7 @@ const StepReceiveFunds = ({
     } catch (err) {
       // Trusted-metadata-service failures (network/5xx) are transient — route
       // to the fallback UI instead of the hard error screen.
-      if (err instanceof ConcordiumTrustedMetadataServiceError) {
+      if ((err as { name?: string })?.name === "ConcordiumTrustedMetadataServiceError") {
         onChangeAddressVerified(false, null);
       } else if (err instanceof Error) {
         onChangeAddressVerified(false, err);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -120,7 +119,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -126,7 +125,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/RedelegationFlowModal/Body.tsx
@@ -9,7 +9,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -136,7 +135,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/cosmos/UndelegationFlowModal/steps/Amount.tsx
@@ -19,7 +19,6 @@ import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepAmount({
   account,
@@ -75,7 +74,7 @@ export default function StepAmount({
   );
   const amount = useMemo(() => (validator ? validator.amount : BigNumber(0)), [validator]);
   const crypto = cryptoFactory(account.currency.id);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/ClaimRewardsFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -139,7 +138,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/Body.tsx
@@ -1,6 +1,5 @@
 import { fromTransactionRaw } from "@ledgerhq/live-common/families/evm/transaction";
 import { Transaction, TransactionRaw, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
@@ -172,7 +171,7 @@ const Body = ({
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -28,8 +28,7 @@ describe("EVM TransactionErrorBanner", () => {
   });
 
   it("hides generic description for NotEnoughGas gasPrice errors", () => {
-    const notEnoughGasError = new Error("not enough gas");
-    Object.setPrototypeOf(notEnoughGasError, NotEnoughGas.prototype);
+    const notEnoughGasError = new NotEnoughGas("not enough gas");
 
     render(
       <TransactionErrorBanner

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 
@@ -13,7 +13,7 @@ export const TransactionErrorBanner = ({
     return <ErrorBanner error={new TransactionHasBeenValidatedError()} />;
   }
 
-  if (errors.gasPrice instanceof NotEnoughGas) {
+  if (errors.gasPrice?.name === "NotEnoughGas") {
     return <ErrorBanner error={errors.gasPrice} fallback={{ description: <></> }} />;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/RedelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Transaction as EvmTransaction } from "@ledgerhq/coin-evm/types/index";
@@ -144,7 +143,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("validators");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/UndelegationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -124,7 +123,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/WithdrawFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -129,7 +128,7 @@ const Body = ({ onClose, t, stepId, device, openModal, onChangeStepId, params }:
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -116,7 +115,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/Body.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation } from "@ledgerhq/types-live";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { useHederaValidators } from "@ledgerhq/live-common/families/hedera/react";
@@ -127,7 +126,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/Body.tsx
@@ -11,7 +11,6 @@ import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge"
 import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
 import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
 import { isTokenAssociationRequired } from "@ledgerhq/live-common/families/hedera/utils";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { Account, Operation, TokenAccount } from "@ledgerhq/types-live";
 import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
@@ -242,7 +241,7 @@ const Body = ({
   }, [onChangeAddressVerified, setDisabledSteps, steps, onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import type { Account, Operation } from "@ledgerhq/types-live";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Claim/Body.tsx
@@ -7,7 +7,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -108,7 +107,7 @@ const Body = (props: Props) => {
     onChangeStepId("claimRewards");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Delegate/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -123,7 +122,7 @@ const Body = (props: Props) => {
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Undelegate/Body.tsx
@@ -5,7 +5,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -116,7 +115,7 @@ const Body = (props: Props) => {
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/multiversx/components/Modals/Withdraw/Body.tsx
@@ -6,7 +6,6 @@ import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
@@ -109,7 +108,7 @@ const Body = (props: Props) => {
     onChangeStepId("withdraw");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/StakingFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -104,7 +103,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/UnstakingFlowModal/steps/Amount.tsx
@@ -14,7 +14,6 @@ import Alert from "~/renderer/components/Alert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import AccountFooter from "~/renderer/modals/Send/AccountFooter";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 export default function StepAmount({
   account,
   transaction,
@@ -66,7 +65,7 @@ export default function StepAmount({
     };
   }, [transaction]);
   const amount = useMemo(() => (validator ? validator.amount : new BigNumber(0)), [validator]);
-  const notEnoughFundsError = status.errors?.amount instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.amount?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/near/WithdrawingFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { useDispatch } from "LLD/hooks/redux";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { getMaxAmount } from "@ledgerhq/live-common/families/near/logic";
@@ -120,7 +119,7 @@ function Body({
     [account, dispatch],
   );
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/BondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("castNominations");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/NominationFlowModal/fields/ValidatorsField.tsx
@@ -21,7 +21,6 @@ import {
   PolkadotValidator,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/polkadot/types";
-import { PolkadotValidatorsRequired } from "@ledgerhq/live-common/families/polkadot/errors";
 import { radii } from "~/renderer/styles/theme";
 import { openURL } from "~/renderer/linking";
 import Box from "~/renderer/components/Box";
@@ -189,8 +188,8 @@ const ValidatorField = ({
   if (!status) return null;
   const error = getStatusError(status, "errors");
   const warning = getStatusError(status, "warnings");
-  const maybeChill = error instanceof PolkadotValidatorsRequired;
-  const ignoreError = error instanceof PolkadotValidatorsRequired && !nominations.length; // Do not show error on first nominate
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length; // Do not show error on first nominate
 
   return (
     <>

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/RebondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -96,7 +95,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/SimpleOperationFlowModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St, Mode } from "./types";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, openModal, onChangeStepId, params, onClose, m
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/polkadot/UnbondFlowModal/Body.tsx
@@ -6,7 +6,6 @@ import { Trans, withTranslation } from "react-i18next";
 import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -97,7 +96,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationActivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -113,7 +112,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -111,7 +110,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationDeactivateFlowModal/steps/StepValidator.tsx
@@ -15,7 +15,6 @@ import ValidatorRow from "../../shared/components/ValidatorRow";
 import { StepProps } from "../types";
 import { useMaybeAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import NotEnoughFundsToUnstake from "~/renderer/components/NotEnoughFundsToUnstake";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 
 export default function StepValidator({
   account,
@@ -45,7 +44,7 @@ export default function StepValidator({
   if (validator === undefined) {
     return null;
   }
-  const notEnoughFundsError = status.errors?.fee instanceof NotEnoughBalance;
+  const notEnoughFundsError = status.errors?.fee?.name === "NotEnoughBalance";
 
   return (
     <Box flow={1}>

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationReactivateFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -118,7 +117,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/DelegationWithdrawFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -119,7 +118,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("amount");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/solana/MemoValueField.tsx
@@ -9,7 +9,6 @@ import {
   SolanaAccount,
 } from "@ledgerhq/live-common/families/solana/types";
 import { useFeature } from "@features/platform-feature-flags";
-import { SolanaRecipientMemoIsRequired } from "@ledgerhq/live-common/errors";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
 
 type Props = {
@@ -44,7 +43,7 @@ const MemoValueField = ({ onChange, account, transaction, status, autoFocus }: P
   );
 
   const InputField = lldMemoTag?.enabled ? MemoTagField : Input;
-  const isRecipientMemoRequired = status?.errors?.memo instanceof SolanaRecipientMemoIsRequired;
+  const isRecipientMemoRequired = status?.errors?.memo?.name === "SolanaRecipientMemoIsRequired";
 
   return transaction.model.kind === "transfer" || transaction.model.kind === "token.transfer" ? (
     <InputField

--- a/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/stellar/AddAssetModal/Body.tsx
@@ -8,7 +8,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepProps, StepId, St } from "./types";
@@ -105,7 +104,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("assets");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/DelegationFlowModal/Body.tsx
@@ -7,7 +7,6 @@ import { TFunction } from "i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import Track from "~/renderer/analytics/Track";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { StepId, StepProps, St } from "./types";
@@ -106,7 +105,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("validator");
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/sui/UnstakingFlowModal/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation } from "@ledgerhq/live-common/account/index";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -108,7 +107,7 @@ const Body = ({ t, stepId, device, onClose, openModal, onChangeStepId, params }:
     onChangeStepId("connectDevice" as St["id"]);
   }, [onChangeStepId]);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/DelegateFlowModal/Body.tsx
@@ -11,7 +11,6 @@ import { getMainAccount, addPendingOperation } from "@ledgerhq/live-common/accou
 import { useAccountBridgeOrNull } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import logger from "~/renderer/logger";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import Track from "~/renderer/analytics/Track";
@@ -178,7 +177,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, []);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/Body.tsx
@@ -3,7 +3,6 @@ import { bindActionCreators } from "redux";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Trans, useTranslation } from "react-i18next";
 import invariant from "invariant";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -146,7 +145,7 @@ const Body = ({ stepId, params, onClose, onChangeStepId }: Props) => {
 
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/Body.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from "react";
 import invariant from "invariant";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Operation } from "@ledgerhq/types-live";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
@@ -87,7 +86,7 @@ const Body = ({ stepId, params, onChangeStepId, onClose }: Props) => {
   }, [onChangeStepId]);
 
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/Body.tsx
@@ -6,7 +6,6 @@ import invariant from "invariant";
 import { TFunction } from "i18next";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import {
   addPendingOperation,
   getMainAccount,
@@ -257,7 +256,7 @@ const Body = ({
     setSigned(false);
   }, []);
   const handleTransactionError = useCallback((error: Error) => {
-    if (!(error instanceof UserRefusedOnDevice)) {
+    if (error?.name !== "UserRefusedOnDevice") {
       logger.critical(error);
     }
     setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/DomainErrorHandlers.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { DomainServiceResponseError } from "@ledgerhq/domain-service/hooks/types";
 import Alert from "~/renderer/components/Alert";
 import { useTranslation } from "react-i18next";
@@ -11,7 +10,7 @@ type DomainErrorsProps = {
 };
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
-  if (domainError.error instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <div data-testid="domain-error-invalid-domain">
         <Alert
@@ -28,7 +27,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
   }
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return (
       <div data-testid="domain-error-no-resolution">
         <Alert

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldBase.tsx
@@ -1,5 +1,4 @@
 import React, { memo } from "react";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { TFunction } from "i18next";
@@ -49,7 +48,7 @@ const RecipientFieldBase = ({
         autoFocus={autoFocus}
         withQrCode={!status.recipientIsReadOnly}
         readOnly={status.recipientIsReadOnly}
-        error={hideError || recipientError instanceof RecipientRequired ? null : recipientError}
+        error={hideError || recipientError?.name === "RecipientRequired" ? null : recipientError}
         warning={recipientWarning}
         value={value}
         onChange={onChange}

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientFieldDomainService.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { getRegistriesForDomain } from "@ledgerhq/domain-service/registries/index";
 import { isLoaded, isError } from "@ledgerhq/domain-service/hooks/logic";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
@@ -67,15 +66,15 @@ const RecipientFieldDomainService = <T extends Transaction, TS extends Transacti
 
   const domainErrorHandled = useMemo(() => {
     if (domainError) {
-      if (!isForwardResolution && domainError.error instanceof NoResolution) {
+      if (!isForwardResolution && domainError.error?.name === "NoResolution") {
         return false;
       }
 
       if (
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof NoResolution ||
+        domainError.error?.name === "NoResolution" ||
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        (domainError.error as Error) instanceof InvalidDomain
+        domainError.error?.name === "InvalidDomain"
       ) {
         return true;
       }

--- a/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignRawTransaction/Body.tsx
@@ -1,4 +1,3 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -102,7 +101,7 @@ export default function Body({ onChangeStepId, onClose, setError, params, stepId
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SignTransaction/Body.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { Account, AccountLike, SignedOperation } from "@ledgerhq/types-live";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import Stepper from "~/renderer/components/Stepper";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/bridge/react/index";
 import { isTokenAccount } from "@ledgerhq/live-common/account/index";
@@ -171,7 +170,7 @@ export default function Body({ onChangeStepId, onClose, setError, stepId, params
   }, [setError]);
   const handleTransactionError = useCallback(
     (error: Error) => {
-      if (!(error instanceof UserRefusedOnDevice)) {
+      if (error?.name !== "UserRefusedOnDevice") {
         logger.critical(error);
       }
       setTransactionError(error);

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/components/ErrorSection.tsx
@@ -1,4 +1,3 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import { Alert, Button, Flex, Text } from "@ledgerhq/native-ui";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import React from "react";
@@ -44,7 +43,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof UserRefusedOnDevice) {
+  if (error?.name === "UserRefusedOnDevice") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,
@@ -53,7 +52,7 @@ function getErrorInfo(error: Error | null): ErrorInfo {
     };
   }
 
-  if (error instanceof LockedDeviceError) {
+  if (error?.name === "LockedDeviceError") {
     return {
       titleKey: `errors.${error.name}.title`,
       descriptionKey: `errors.${error.name}.description`,

--- a/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
+++ b/apps/ledger-live-mobile/src/families/canton/PendingTransferProposals/usePendingTransferProposalsViewModel.ts
@@ -1,5 +1,4 @@
 import { isCantonAccount } from "@ledgerhq/coin-canton";
-import { TopologyChangeError } from "@ledgerhq/coin-canton/types/errors";
 import type { Sync } from "@ledgerhq/live-common/bridge/react/types";
 import { useFeature } from "@features/platform-feature-flags";
 import {
@@ -190,7 +189,7 @@ export function usePendingTransferProposalsViewModel({
           reason: "canton-pending-transaction-action",
         });
       } catch (error) {
-        if (error instanceof TopologyChangeError) {
+        if ((error as { name?: string })?.name === "TopologyChangeError") {
           setModal(prev => ({ ...prev, isOpen: false }));
           redirectToReonboarding(action, contractId);
           return;

--- a/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/SendSelectRecipient.tsx
@@ -1,8 +1,3 @@
-import {
-  TooManyUtxosCritical,
-  TooManyUtxosWarning,
-  TopologyChangeError,
-} from "@ledgerhq/coin-canton";
 import { CantonAccount, TransactionStatus } from "@ledgerhq/live-common/families/canton/types";
 import { isCryptoCurrency } from "@ledgerhq/live-common/currencies/index";
 import { useFeature } from "@features/platform-feature-flags";
@@ -35,9 +30,9 @@ function StepRecipientCustomAlert({
   const route = useRoute<ScreenRoute>();
   const llmModularDrawer = useFeature("llmModularDrawer");
 
-  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos instanceof TooManyUtxosCritical;
-  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos instanceof TooManyUtxosWarning;
-  const topologyChangeError = status?.errors?.topologyChange instanceof TopologyChangeError;
+  const tooManyUtxosCritical = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosCritical";
+  const tooManyUtxosWarning = status?.warnings?.tooManyUtxos?.name === "TooManyUtxosWarning";
+  const topologyChangeError = status?.errors?.topologyChange?.name === "TopologyChangeError";
 
   const redirectToReonboarding = useCallback(() => {
     if (!account) return;

--- a/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cardano/UndelegationFlow/01-Summary.tsx
@@ -33,7 +33,6 @@ import GenericErrorBottomModal from "~/components/GenericErrorBottomModal";
 import RetryButton from "~/components/RetryButton";
 import CancelButton from "~/components/CancelButton";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { CardanoNotEnoughFunds } from "@ledgerhq/live-common/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = StackNavigatorProps<
@@ -104,7 +103,7 @@ export default function UndelegationSummary({ navigation, route }: Props) {
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, bridge, transaction]);
 
-  const hasNotEnoughtBalanceError = bridgeError instanceof CardanoNotEnoughFunds;
+  const hasNotEnoughtBalanceError = bridgeError?.name === "CardanoNotEnoughFunds";
 
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/RevokeFlow/VoteAmount.tsx
@@ -22,7 +22,6 @@ import type { BaseComposite, StackNavigatorProps } from "~/components/RootNaviga
 import { CeloRevokeFlowFlowParamList } from "./types";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
 type Props = BaseComposite<
@@ -95,7 +94,7 @@ export default function VoteAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
 
-  const isRevokingWithFeesError = error instanceof NotEnoughBalance;
+  const isRevokingWithFeesError = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/celo/WithdrawFlow/WithdrawAmount.tsx
@@ -30,7 +30,6 @@ import ErrorAndWarning from "../components/ErrorAndWarning";
 import type { BaseComposite, StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import type { CeloWithdrawFlowParamList } from "./types";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -162,7 +161,7 @@ export default function WithdrawAmount({ navigation, route }: Props) {
       <View style={styles.footer}>
         <View style={styles.errors}>
           {!!(error && error instanceof Error) && <ErrorAndWarning error={error} />}
-          {error && error instanceof AddressesSanctionedError && (
+          {error && error?.name === "AddressesSanctionedError" && (
             <SupportLinkError error={error} type="alert" />
           )}
           {!!(warning && warning instanceof Error) && <ErrorAndWarning warning={warning} />}

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/useOnboarding.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import {
-  ConcordiumPairingExpiredError,
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-} from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import type { Account } from "@ledgerhq/types-live";
 import { log } from "@ledgerhq/logs";
@@ -90,11 +85,11 @@ export function useOnboarding(
             message: error instanceof Error ? error.message : String(error),
           });
           unsubscribe();
-          if (error instanceof LockedDeviceError) {
+          if (error?.name === "LockedDeviceError") {
             setCreateStatus(CreateStatus.DEVICE_LOCKED);
           } else if (
-            error instanceof ConcordiumSessionExpiredError ||
-            error instanceof ConcordiumPairingExpiredError
+            error?.name === "ConcordiumSessionExpiredError" ||
+            error?.name === "ConcordiumPairingExpiredError"
           ) {
             onSessionExpired();
           } else {

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/hooks/usePairing.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ConcordiumPairingProgress } from "@ledgerhq/coin-concordium/types";
 import { ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { log } from "@ledgerhq/logs";
 import { Subscription } from "rxjs";
@@ -70,7 +69,7 @@ export function usePairing(currency: CryptoCurrency, onPaired: (sessionTopic: st
         },
         error: (error: unknown) => {
           if (
-            error instanceof ConcordiumPairingExpiredError &&
+            (error as { name?: string })?.name === "ConcordiumPairingExpiredError" &&
             retryCountRef.current < MAX_EXPIRED_RETRIES
           ) {
             retryCountRef.current++;

--- a/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/VerifyAddress.tsx
@@ -4,10 +4,6 @@ import { filter, first, map } from "rxjs/operators";
 import { TouchableOpacity, Linking, LayoutChangeEvent } from "react-native";
 import { useSelector } from "~/context/hooks";
 import { useTranslation, Trans } from "~/context/Locale";
-import {
-  ConcordiumAddressVerificationFailedError,
-  ConcordiumTrustedMetadataServiceError,
-} from "@ledgerhq/errors";
 import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
@@ -122,7 +118,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
           // malformed response). Route to Confirmation with verified: false —
           // the native "skipped verification" path that shows the cached
           // address with the security modal prompt.
-          if (error instanceof ConcordiumTrustedMetadataServiceError) {
+          if (error?.name === "ConcordiumTrustedMetadataServiceError") {
             navigation.navigate(ScreenName.ReceiveConfirmation, {
               ...route.params,
               verified: false,
@@ -178,7 +174,7 @@ export default function ConcordiumReceiveVerifyAddress({ navigation, route }: Pr
 
   // Retrying a terminal address-verification refusal would just hit the same
   // 4xx again — hide the button for that class of error.
-  const canRetry = !(error instanceof ConcordiumAddressVerificationFailedError);
+  const canRetry = error?.name !== "ConcordiumAddressVerificationFailedError";
 
   return (
     <SafeAreaViewFixed isFlex edges={["left", "right", "bottom"]}>

--- a/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/cosmos/DelegationFlow/02-Summary.tsx
@@ -34,7 +34,6 @@ import { CosmosDelegationFlowParamList } from "./types";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -223,7 +222,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
         </View>
       </View>
       <View style={styles.footer}>
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender && status.errors.sender?.name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/EditTransactionSummary.tsx
@@ -6,7 +6,6 @@
 
 import { Transaction as EvmTransaction, TransactionStatus } from "@ledgerhq/coin-evm/types/index";
 import { isCurrencySupported } from "@ledgerhq/live-common/currencies/index";
-import { NotEnoughGas } from "@ledgerhq/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
@@ -106,7 +105,7 @@ function EditTransactionSummaryContent({ navigation, route, transactionToUpdate 
   const firstError = errors[Object.keys(errors)[0]] ?? bridgeError ?? undefined;
 
   let footerAction;
-  if (firstError && firstError instanceof NotEnoughGas) {
+  if (firstError && firstError?.name === "NotEnoughGas") {
     footerAction = isCurrencySupported(currencyOrToken as CryptoCurrency) ? (
       <Button
         event="SummaryBuyEth"

--- a/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/near/shared/02-SelectAmount.tsx
@@ -32,7 +32,6 @@ import { NearWithdrawingFlowParamList } from "../WithdrawingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
     behaviorParam = "padding";
   }
 
-  const errorDuringUnstaking = error instanceof NotEnoughBalance && transaction.mode === "unstake";
+  const errorDuringUnstaking = error?.name === "NotEnoughBalance" && transaction.mode === "unstake";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/NominateFlow/01-Validators.tsx
@@ -26,7 +26,6 @@ import {
   MAX_NOMINATIONS,
   hasMinimumBondBalance,
 } from "@ledgerhq/live-common/families/polkadot/logic";
-import * as PolkadotErrors from "@ledgerhq/live-common/families/polkadot/errors";
 import {
   usePolkadotPreloadData,
   useSortedValidators,
@@ -245,9 +244,8 @@ function NominateSelectValidator({ navigation, route }: Props) {
   const error = getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const maxSelected = validators.length === MAX_NOMINATIONS;
-  const maybeChill = error instanceof PolkadotErrors.PolkadotValidatorsRequired;
-  const ignoreError =
-    error instanceof PolkadotErrors.PolkadotValidatorsRequired && !nominations.length;
+  const maybeChill = error?.name === "PolkadotValidatorsRequired";
+  const ignoreError = error?.name === "PolkadotValidatorsRequired" && !nominations.length;
   // Do not show error on first nominate
   return (
     <SafeAreaView

--- a/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
+++ b/apps/ledger-live-mobile/src/families/polkadot/UnbondFlow/01-Amount.tsx
@@ -24,7 +24,6 @@ import SendRowsFee from "../SendRowsFee";
 import type { StackNavigatorProps } from "~/components/RootNavigator/types/helpers";
 import { PolkadotUnbondFlowParamList } from "./type";
 import { useMaybeAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -105,7 +104,7 @@ export default function PolkadotUnbondAmount({ navigation, route }: Props) {
   const error = amount.eq(0) || bridgePending ? null : getFirstStatusError(status, "errors");
   const warning = getFirstStatusError(status, "warnings");
   const hasErrors = hasStatusError(status);
-  const hasErrorDuringUnbonding = error instanceof NotEnoughBalance;
+  const hasErrorDuringUnbonding = error?.name === "NotEnoughBalance";
 
   return (
     <>

--- a/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/DelegationFlow/Summary.tsx
@@ -36,9 +36,7 @@ import { DelegationAction, SolanaDelegationFlowParamList } from "./types";
 import TranslatedError from "../../../components/TranslatedError";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 
@@ -139,7 +137,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
   const error = Object.values(status.errors)[0];
   const feeError = status.errors.fee;
   const isUndelagating = transaction.model.kind === "stake.undelegate";
-  const hasErrorWhileDesactivating = isUndelagating && feeError instanceof NotEnoughBalance;
+  const hasErrorWhileDesactivating = isUndelagating && feeError?.name === "NotEnoughBalance";
 
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
@@ -206,7 +204,8 @@ export default function DelegationSummary({ navigation, route }: Props) {
       <View style={styles.footer}>
         {hasErrorWhileDesactivating && <NotEnoughFundFeesAlert account={account} />}
 
-        {status.errors.sender && status.errors.sender instanceof AddressesSanctionedError ? (
+        {status.errors.sender &&
+        (status.errors.sender as { name?: string })?.name === "AddressesSanctionedError" ? (
           <>
             <Text color="alert">
               <TranslatedError error={status.errors.sender} />

--- a/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
+++ b/apps/ledger-live-mobile/src/families/sui/shared/02-SelectAmount.tsx
@@ -31,7 +31,6 @@ import { SuiUnstakingFlowParamList } from "../UnstakingFlow/types";
 import { useSettings } from "~/hooks";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
 import NotEnoughFundFeesAlert from "../../shared/StakingErrors/NotEnoughFundFeesAlert";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import AmountInput from "~/screens/SendFunds/AmountInput";
 import Alert from "~/components/Alert";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
@@ -96,7 +95,7 @@ function StakingAmount({ navigation, route }: Props) {
   }
 
   const errorDuringUnstaking =
-    error instanceof NotEnoughBalance && transaction.mode === "undelegate";
+    error?.name === "NotEnoughBalance" && transaction.mode === "undelegate";
 
   return (
     <View

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/SelectValidator.tsx
@@ -13,7 +13,6 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslation, Trans } from "~/context/Locale";
 import { Icons } from "@ledgerhq/native-ui";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import type {
@@ -172,7 +171,7 @@ export default function SelectValidator({ navigation, route }: Props) {
   invariant(transaction, "transaction is undefined");
   let error: Error | null = bridgeError || status.errors.recipient;
 
-  if (error instanceof RecipientRequired) {
+  if (error?.name === "RecipientRequired") {
     error = null;
   }
 

--- a/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
+++ b/apps/ledger-live-mobile/src/families/tezos/DelegationFlow/Summary.tsx
@@ -40,7 +40,6 @@ import type { TezosDelegationFlowParamList } from "./types";
 import { useAccountName } from "~/reducers/wallet";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { useAccountUnit } from "LLM/hooks/useAccountUnit";
-import { NotEnoughBalanceToDelegate } from "@ledgerhq/errors";
 import NotEnoughFundFeesAlert from "~/families/shared/StakingErrors/NotEnoughFundFeesAlert";
 import { useChangeValidatorRotateAnim } from "../../shared/useChangeValidatorRotateAnim";
 import TranslatedError from "~/components/TranslatedError";
@@ -191,7 +190,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
     });
   }, [navigation, route.params, account.id, transaction, status]);
 
-  const notEnoughBalance = status.errors.amount instanceof NotEnoughBalanceToDelegate;
+  const notEnoughBalance = status.errors.amount?.name === "NotEnoughBalanceToDelegate";
   const isUndelagating = route.params?.mode === "undelegate";
   const hasNotEnoughBalanceWhenUndelegating = notEnoughBalance && isUndelagating;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react";
 import { Banner, Button } from "@ledgerhq/lumen-ui-rnative";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { useTranslation } from "~/context/Locale";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
@@ -53,7 +52,7 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (!error) return null;
 
-  if (excludeRecipientRequired && error instanceof RecipientRequired) return null;
+  if (excludeRecipientRequired && error?.name === "RecipientRequired") return null;
 
   if (!translatedError) return null;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import {
   getAccountCurrency,
   getMainAccount,
@@ -285,7 +285,7 @@ export function useAddressValidation({
     }));
 
     const filteredBridgeErrors: BridgeValidationErrors = { ...bridgeValidation.errors };
-    if (ensResolution && filteredBridgeErrors.recipient instanceof InvalidAddress) {
+    if (ensResolution && filteredBridgeErrors.recipient?.name === "InvalidAddress") {
       delete filteredBridgeErrors.recipient;
     }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Signature/components/SignatureDeviceActionView/components/SigningBody.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect } from "react";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import type { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SimplifiedTransactionConfirm } from "../../SimplifiedTransactionConfirm";
 import { SignatureCancelledState } from "./SignatureCancelledState";
@@ -36,7 +34,7 @@ export function SigningBody({ device, action, request, onResult, onClose }: Sign
 
   if (signError) {
     const isUserRefused =
-      signError instanceof UserRefusedOnDevice || signError instanceof TransactionRefusedOnDevice;
+      signError?.name === "UserRefusedOnDevice" || signError?.name === "TransactionRefusedOnDevice";
 
     return isUserRefused ? (
       <SignatureCancelledState onClose={onClose} onRetry={status.onRetry} />

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.tsx
@@ -1,5 +1,4 @@
 import { isConfirmedOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { RecipientRequired } from "@ledgerhq/errors";
 import { Text } from "@ledgerhq/native-ui";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
@@ -51,7 +50,7 @@ import LText from "~/components/LText";
 import SupportLinkError from "~/components/SupportLinkError";
 
 const withoutHiddenError = (error: Error): Error | null =>
-  error instanceof RecipientRequired ? null : error;
+  error?.name === "RecipientRequired" ? null : error;
 
 type Navigation = BaseComposite<
   StackNavigatorProps<SendFundsNavigatorStackParamList, ScreenName.SendSelectRecipient>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.tsx
@@ -153,7 +153,7 @@ function SendSummary({ navigation, route }: Props) {
 
     if (
       senderError?.name === recipientError?.name &&
-      senderError instanceof AddressesSanctionedError
+      senderError?.name === "AddressesSanctionedError"
     ) {
       return new AddressesSanctionedError("AddressesSanctionedError", {
         addresses: [

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainErrorHandlers.tsx
@@ -2,7 +2,6 @@ import React, { memo } from "react";
 import { DomainServiceResponseError } from "@ledgerhq/domain-service/hooks/types";
 import { View, StyleSheet, Platform } from "react-native";
 import { useTranslation } from "~/context/Locale";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import TranslatedError from "~/components/TranslatedError";
 import SupportLinkError from "~/components/SupportLinkError";
 import LText from "~/components/LText";
@@ -31,7 +30,7 @@ export const BasicErrorsView = memo(
     if (!error && !warning) return null;
 
     const hasNoResolutionButIsReverseResolution =
-      domainErrorHandled && domainError?.error instanceof NoResolution && !isForwardResolution;
+      domainErrorHandled && domainError?.error?.name === "NoResolution" && !isForwardResolution;
 
     if (!domainErrorHandled || hasNoResolutionButIsReverseResolution) {
       return (
@@ -69,7 +68,7 @@ type DomainErrorsProps = {
 export const DomainErrorsView = memo(({ domainError, isForwardResolution }: DomainErrorsProps) => {
   const { t } = useTranslation();
 
-  if ((domainError.error as Error) instanceof InvalidDomain) {
+  if (domainError.error?.name === "InvalidDomain") {
     return (
       <Alert
         title={t("send.recipient.domainService.invalidDomain.title")}
@@ -82,7 +81,7 @@ export const DomainErrorsView = memo(({ domainError, isForwardResolution }: Doma
     );
   }
 
-  if ((domainError.error as Error) instanceof NoResolution && isForwardResolution) {
+  if (domainError.error?.name === "NoResolution" && isForwardResolution) {
     return <Alert title={t("send.recipient.domainService.noResolution.title")} type="secondary" />;
   }
 

--- a/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/DomainServiceRecipientRow.tsx
@@ -8,7 +8,6 @@ import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { Platform, StyleSheet, View } from "react-native";
 import { Account, AccountLike } from "@ledgerhq/types-live";
 import Clipboard from "@react-native-clipboard/clipboard";
-import { InvalidDomain, NoResolution } from "@ledgerhq/domain-service/errors/index";
 import { Trans } from "~/context/Locale";
 import { BasicErrorsView, DomainErrorsView } from "./DomainErrorHandlers";
 import RecipientInput from "~/components/RecipientInput";
@@ -16,7 +15,6 @@ import Alert from "~/components/Alert";
 import { urls } from "~/utils/urls";
 import LText from "~/components/LText";
 import TranslatedError from "~/components/TranslatedError";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import SupportLinkError from "~/components/SupportLinkError";
 
 type Props = {
@@ -57,8 +55,7 @@ const DomainServiceRecipientInput = ({
   );
   const domainErrorHandled = useMemo(
     () =>
-      (domainError?.error as Error) instanceof InvalidDomain ||
-      (domainError?.error as Error) instanceof NoResolution,
+      domainError?.error?.name === "InvalidDomain" || domainError?.error?.name === "NoResolution",
     [domainError],
   );
 
@@ -126,9 +123,9 @@ const DomainServiceRecipientInput = ({
         domainError={domainError}
         domainErrorHandled={domainErrorHandled}
         isForwardResolution={isForwardResolution}
-        noLink={error instanceof AddressesSanctionedError}
+        noLink={error?.name === "AddressesSanctionedError"}
       />
-      {error instanceof AddressesSanctionedError ? (
+      {error?.name === "AddressesSanctionedError" ? (
         <>
           <LText
             testID="send-recipient-error-description"

--- a/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/RecipientRow.tsx
@@ -6,7 +6,6 @@ import TranslatedError from "~/components/TranslatedError";
 import SupportLinkError from "~/components/SupportLinkError";
 import LText from "~/components/LText";
 import RecipientInput from "~/components/RecipientInput";
-import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 
 type Props = {
   onChangeText: (value: string) => void;
@@ -48,7 +47,7 @@ const RecipientRow = ({
           >
             <TranslatedError error={error || warning} />
           </LText>
-          {error instanceof AddressesSanctionedError && (
+          {error?.name === "AddressesSanctionedError" && (
             <LText style={[styles.warningBox]} color="alert">
               <TranslatedError error={error} field="description" />
             </LText>

--- a/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignRawTransaction/02-ConnectDevice.tsx
@@ -8,8 +8,6 @@ import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app"
 import { isSwapDisableAppsInstall } from "@ledgerhq/live-common/exchange/swap/utils/isIntegrationTestEnv";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignRawTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignRawTransactionNavigator";
@@ -48,9 +46,8 @@ function ConnectDevice({ navigation, route }: SignRawTransactionConnectDevicePro
 
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 

--- a/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
+++ b/apps/ledger-live-mobile/src/screens/SignTransaction/02-ConnectDevice.tsx
@@ -9,8 +9,6 @@ import type { AppRequest } from "@ledgerhq/live-common/hw/actions/app";
 import { dependenciesToAppRequests } from "@ledgerhq/live-common/hw/actions/app";
 import { useTheme } from "@react-navigation/native";
 import { TransactionResult } from "@ledgerhq/live-common/hw/actions/transaction";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { TransactionRefusedOnDevice } from "@ledgerhq/live-common/errors";
 import DeviceAction from "~/components/DeviceAction";
 import { TrackScreen } from "~/analytics";
 import { SignTransactionNavigatorParamList } from "~/components/RootNavigator/types/SignTransactionNavigator";
@@ -56,9 +54,8 @@ function ConnectDevice({ navigation, route }: SignTransactionConnectDeviceProps)
 
         navigation.getParent<StackNavigatorNavigation<BaseNavigatorStackParamList>>().pop();
       } catch (error) {
-        if (
-          !(error instanceof UserRefusedOnDevice || error instanceof TransactionRefusedOnDevice)
-        ) {
+        const eName = (error as { name?: string })?.name;
+        if (!(eName === "UserRefusedOnDevice" || eName === "TransactionRefusedOnDevice")) {
           logger.critical(error as Error);
         }
 

--- a/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-polkadot/src/bridge/getTransactionStatus.ts
@@ -77,7 +77,7 @@ const getSendTransactionStatus: AccountBridge<
     errors.amount = new AmountRequired();
   }
 
-  if (!(errors.amount instanceof AmountRequired)) {
+  if (errors.amount?.name !== "AmountRequired") {
     if (
       (!transaction.useAllAmount && account.spendableBalance.isZero()) ||
       totalSpent.gt(account.spendableBalance)
@@ -308,7 +308,7 @@ export const getTransactionStatus: AccountBridge<
     errors.amount = new NotEnoughBalance();
   }
 
-  if (!(errors.amount instanceof AmountRequired) && totalSpent.gt(account.spendableBalance)) {
+  if (errors.amount?.name !== "AmountRequired" && totalSpent.gt(account.spendableBalance)) {
     errors.amount = new NotEnoughBalance();
   }
 

--- a/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-solana/src/prepareTransaction.test.ts
@@ -1,7 +1,4 @@
 import { NotEnoughGas } from "@ledgerhq/errors";
-import { Account, VersionedMessage } from "@solana/web3.js";
-import BigNumber from "bignumber.js";
-import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import {
   SolanaMemoIsTooLong,
   SolanaRecipientAccountNotFunded,
@@ -9,6 +6,9 @@ import {
   SolanaStakeAccountNothingToWithdraw,
   SolanaStakeNoWithdrawAuth,
 } from "./errors";
+import { Account, VersionedMessage } from "@solana/web3.js";
+import BigNumber from "bignumber.js";
+import { transaction } from "./__tests__/fixtures/helpers.fixture";
 import { estimateFeeAndSpendable } from "./estimateMaxSpendable";
 import * as logicValidateMemo from "./logic/validateMemo";
 import { ChainAPI } from "./network";

--- a/libs/coin-tester-modules/coin-tester-cardano/src/negativeCases.test.ts
+++ b/libs/coin-tester-modules/coin-tester-cardano/src/negativeCases.test.ts
@@ -1,4 +1,3 @@
-import { CardanoMinAmountError } from "@ledgerhq/coin-cardano/errors";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import type { Account } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
@@ -117,8 +116,8 @@ describe("Cardano negative cases (Yaci devnet)", () => {
 
   it("rejects a below-min-UTXO amount at craft", async () => {
     const tx = build({ recipient, amount: new BigNumber(100), nonce: 0 });
-    await expect(accountBridge.prepareTransaction(account, tx)).rejects.toThrow(
-      CardanoMinAmountError,
-    );
+    await expect(accountBridge.prepareTransaction(account, tx)).rejects.toMatchObject({
+      name: "CardanoMinAmountError",
+    });
   });
 });

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.ts
@@ -1,7 +1,6 @@
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { catchError, concatMap, defer, from, map, of, scan, type Observable } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import type { GetViewKeyOptions } from "@ledgerhq/coin-aleo/signer/getViewKey";
@@ -60,7 +59,7 @@ export const getViewKeyExec = (
           return { accountId: account.id, viewKey };
         }),
         catchError(e => {
-          if (e instanceof UserRefusedOnDevice) {
+          if ((e as { name?: string })?.name === "UserRefusedOnDevice") {
             return of({ accountId: account.id, viewKey: null });
           }
 

--- a/libs/ledger-live-common/src/families/hedera/exchange.ts
+++ b/libs/ledger-live-common/src/families/hedera/exchange.ts
@@ -1,4 +1,4 @@
-import { LatestFirmwareVersionRequired, TransportStatusError } from "@ledgerhq/errors";
+import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 import Exchange from "@ledgerhq/hw-app-exchange";
 import { loadPKI } from "@ledgerhq/hw-bolos";
 import calService from "@ledgerhq/ledger-cal-service";
@@ -7,8 +7,12 @@ import { getEnv } from "@ledgerhq/live-env";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Account } from "@ledgerhq/types-live";
 
-function isPKIUnsupportedError(err: unknown): err is TransportStatusError {
-  return err instanceof TransportStatusError && err.message.includes("0x6a81");
+function isPKIUnsupportedError(err: unknown): boolean {
+  const errName = (err as { name?: string })?.name;
+  return (
+    errName === "TransportStatusError" &&
+    !!(err as { message?: string })?.message?.includes("0x6a81")
+  );
 }
 
 export async function handleHederaTrustedFlow({

--- a/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
@@ -145,7 +145,7 @@ const getTransactionStatus = (a: Account, t: Transaction) => {
     }
   } else {
     // delegation case, we remap NotEnoughBalance to a more precise error
-    if (errors.amount instanceof NotEnoughBalance) {
+    if (errors.amount?.name === "NotEnoughBalance") {
       errors.amount = new NotEnoughBalanceToDelegate();
     }
   }

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/useCoinControlScreenViewModelCore.ts
@@ -1,5 +1,4 @@
 import type { Unit } from "@ledgerhq/types-cryptoassets";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { getAccountCurrency } from "@ledgerhq/ledger-wallet-framework/account/helpers";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import type { SendFlowTransactionActions, SendFlowUiConfig } from "../../types";
@@ -154,7 +153,7 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
       rows != null &&
       rows.length > 0 &&
       utxoData.totalExcludedUTXOS === rows.length;
-    const isInsufficientFundsBridgeError = status.errors?.amount instanceof NotEnoughBalance;
+    const isInsufficientFundsBridgeError = status.errors?.amount?.name === "NotEnoughBalance";
 
     return isInsufficientFundsBridgeError || hasNoSelectedUtxo;
   }, [customStrategyValue, status, transaction, utxoDisplayData]);
@@ -224,7 +223,7 @@ export function useCoinControlScreenViewModelCore<TNetworkFees = unknown>({
     const hasFilledAmount = transaction.useAllAmount || transaction.amount?.gt(0);
     if (isCustomStrategy && !hasFilledAmount) return undefined;
 
-    const isInsufficientFundsBridgeError = status.errors?.amount instanceof NotEnoughBalance;
+    const isInsufficientFundsBridgeError = status.errors?.amount?.name === "NotEnoughBalance";
     // Transaction patches (e.g. toggling custom exclusions) apply before the next bridge sync;
     // status can briefly still reflect the previous pick and show a stale NotEnoughBalance.
     if (isCustomStrategy && hasFilledAmount && bridgePending && isInsufficientFundsBridgeError) {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -1,4 +1,3 @@
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
 import { useMemo } from "react";
 import type { AddressSearchResult } from "../types";
 
@@ -23,9 +22,9 @@ export function useRecipientSearchState({
   const bridgeSenderError = result.bridgeErrors?.sender;
 
   const isSelfTransferError =
-    bridgeRecipientError instanceof InvalidAddressBecauseDestinationIsAlsoSource;
+    bridgeRecipientError?.name === "InvalidAddressBecauseDestinationIsAlsoSource";
   const isBridgeInvalidAddress =
-    bridgeRecipientError instanceof InvalidAddress && !isSelfTransferError;
+    bridgeRecipientError?.name === "InvalidAddress" && !isSelfTransferError;
 
   const hasValidatedAddress =
     result.status === "valid" || result.status === "ens_resolved" || result.status === "sanctioned";

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/job.ts
@@ -1,10 +1,8 @@
-import { TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import type { DeviceConnectionResult, Job } from "@ledgerhq/device-intent";
 import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { getMainAccount } from "../../account/index";
 import { getAccountBridge } from "../../bridge/index";
 import { sendFeatures } from "../../bridge/descriptor/send/features";
-import { TransactionRefusedOnDevice } from "../../errors";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { SignOperationEvent } from "@ledgerhq/types-live";
 import { Observable, type Subscription } from "rxjs";
@@ -25,9 +23,10 @@ function buildSigningDevice(connectionResult: DeviceConnectionResult): SigningDe
 function isUserRefusalError(error: unknown, currency: CryptoOrTokenCurrency | undefined): boolean {
   return (
     sendFeatures.isUserRefusedTransactionError(currency, error) ||
-    error instanceof TransactionRefusedOnDevice ||
-    error instanceof UserRefusedOnDevice ||
-    (error instanceof TransportStatusError && error.statusCode === 0x6985)
+    (error as { name?: string })?.name === "TransactionRefusedOnDevice" ||
+    (error as { name?: string })?.name === "UserRefusedOnDevice" ||
+    ((error as { name?: string; statusCode?: number })?.name === "TransportStatusError" &&
+      (error as { statusCode?: number })?.statusCode === 0x6985)
   );
 }
 

--- a/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
+++ b/libs/ledger-wallet-framework/src/bridge/jsHelpers.ts
@@ -39,7 +39,6 @@ import {
 } from "../account/balanceHistoryCache";
 import { shouldRetainPendingOperation } from "../account/pending";
 import { shouldShowNewAccount } from "../account/support";
-import { UnsupportedDerivation } from "../errors";
 import getAddressWrapper, { GetAddressFn } from "./getAddressWrapper";
 import type { GetAddressResult } from "../derivation";
 import type { CryptoCurrency } from "../types";
@@ -536,7 +535,7 @@ export const makeScanAccounts =
 
                 derivationsCache[seedCacheKey] = result;
               } catch (e) {
-                if (e instanceof UnsupportedDerivation) {
+                if ((e as { name?: string })?.name === "UnsupportedDerivation") {
                   log("scanAccounts", "ignore derivationMode=" + derivationMode);
                   continue;
                 }

--- a/libs/wallet-btc/src/utils.ts
+++ b/libs/wallet-btc/src/utils.ts
@@ -89,7 +89,7 @@ function fixedWeight(currency: ICrypto, derivationMode: string): number {
 function inputWeight(derivationMode: string): number {
   const spec = INPUT_WEIGHT_SPECS[derivationMode];
   if (!spec) {
-    throw UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
+    throw new UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
   }
 
   // base non-witness weight for every input
@@ -115,7 +115,7 @@ function outputWeight(derivationMode: string): number {
   } else if (derivationMode === DerivationModes.LEGACY) {
     outputSize += 25; // DUP + HASH160 + PUSH20 + <20 bytes> + EQUALVERIFY + CHECKSIG
   } else {
-    throw UnsupportedDerivation(derivationMode);
+    throw new UnsupportedDerivation(derivationMode);
   }
 
   return outputSize * 4;


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/coin-integration.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/coin-integration. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35080