### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (ptx files)

### DIFF
--- a/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
+++ b/apps/wallet-cli/src/commands/swap/cli-swap-pipeline.ts
@@ -460,9 +460,9 @@ export async function runFullSwapPipeline(
     const causeSuffix = rawErrorCause ? `, ${JSON.stringify(rawErrorCause)}` : "";
     const errorMessageWithCause = rawErrorMessage + causeSuffix;
 
-    const completeExchangeError =
-      error instanceof CompleteExchangeError
-        ? error
+    const completeExchangeError: CompleteExchangeError =
+      (error as { name?: string })?.name === "CompleteExchangeError"
+        ? (error as CompleteExchangeError)
         : new CompleteExchangeError("INIT", rawErrorName, errorMessageWithCause);
 
     if (swapId) {

--- a/libs/ledger-live-common/src/exchange/error.ts
+++ b/libs/ledger-live-common/src/exchange/error.ts
@@ -1,4 +1,3 @@
-import { TransportStatusError } from "@ledgerhq/errors";
 import { getExchangeErrorMessage } from "@ledgerhq/hw-app-exchange";
 import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
 import get from "lodash/get";
@@ -41,12 +40,16 @@ export function convertTransportError(
   step: CompleteExchangeStep,
   err: unknown,
 ): CompleteExchangeError | unknown {
-  if (err instanceof TransportStatusError) {
-    const errorCode =
-      step === "CHECK_REFUND_ADDRESS" && err.statusCode == null
-        ? ErrorStatus.INVALID_ADDRESS
-        : err.statusCode;
-
+  if ((err as { name?: string })?.name === "TransportStatusError") {
+    const tse = err as { statusCode?: number | null };
+    let errorCode: number;
+    if (typeof tse.statusCode === "number") {
+      errorCode = tse.statusCode;
+    } else if (step === "CHECK_REFUND_ADDRESS") {
+      errorCode = ErrorStatus.INVALID_ADDRESS;
+    } else {
+      return err;
+    }
     const { errorName, errorMessage } = getExchangeErrorMessage(errorCode, step);
     return new CompleteExchangeError(step, errorName, errorMessage);
   }

--- a/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { firstValueFrom, from, Observable } from "rxjs";
-import { TransportStatusError, WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
 
 import { delay } from "../../../promise";
 import {
@@ -149,7 +149,11 @@ const completeExchange = (
             payoutAddressParameters,
           );
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const transportErr = e as { name?: string; statusCode?: number };
+          if (
+            transportErr?.name === "TransportStatusError" &&
+            transportErr?.statusCode === 0x6a83
+          ) {
             throw new WrongDeviceForAccount();
           }
 
@@ -163,16 +167,18 @@ const completeExchange = (
       }).catch(e => {
         if (ignoreTransportError) return;
 
+        const transportErr = e as { name?: string; statusCode?: number };
         if (
-          e instanceof TransportStatusError &&
-          (e.statusCode === 0x6a84 || e.statusCode === 0x5501)
+          transportErr?.name === "TransportStatusError" &&
+          (transportErr?.statusCode === 0x6a84 || transportErr?.statusCode === 0x5501)
         ) {
           throw new TransactionRefusedOnDevice();
         }
 
-        // Preserve known error types checked by instanceof downstream
-        if (e instanceof CompleteExchangeError) throw e;
-        if (e instanceof WrongDeviceForAccount || e instanceof TransactionRefusedOnDevice) throw e;
+        // Preserve known error types checked by .name downstream
+        const eName = (e as { name?: string })?.name;
+        if (eName === "CompleteExchangeError") throw e;
+        if (eName === "WrongDeviceForAccount" || eName === "TransactionRefusedOnDevice") throw e;
         // Wrap any remaining unknown errors with the current step context
         throw new CompleteExchangeError(
           currentStep,

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
@@ -1,7 +1,6 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { fetchCurrencyAllMock } from "./__mocks__/fetchCurrencyAll.mocks";
 import { ResponseData as ResponseDataTo } from "./fetchCurrencyTo";
 import { ResponseData as ResponseDataFrom } from "./fetchCurrencyFrom";
@@ -47,7 +46,7 @@ export async function fetchCurrencyAll({
         // TODO: LIVE-8901 (handle request timeout)
       }
     }
-    if (e instanceof LedgerAPI4xx) {
+    if ((e as { name?: string })?.name === "LedgerAPI4xx") {
       // TODO: LIVE-8901 (handle 4xx)
     }
     throw e;

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyTo.ts
@@ -3,7 +3,6 @@ import { fetchCurrencyToMock } from "./__mocks__/fetchCurrencyTo.mocks";
 import { isIntegrationTestEnv } from "../../utils/isIntegrationTestEnv";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { flattenV5CurrenciesToAndFrom } from "../../utils/flattenV5CurrenciesToAndFrom";
 import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
 
@@ -52,7 +51,7 @@ export async function fetchCurrencyTo({
         // TODO: LIVE-8901 (handle request timeout)
       }
     }
-    if (e instanceof LedgerAPI4xx) {
+    if ((e as { name?: string })?.name === "LedgerAPI4xx") {
       // TODO: LIVE-8901 (handle 4xx)
     }
     throw e;

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchRates.ts
@@ -1,7 +1,6 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import axios from "axios";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { ExchangeRate, ExchangeRateErrorDefault, ExchangeRateResponseRaw } from "../../types";
 import { Unit } from "@ledgerhq/live-app-sdk";
 import { SwapGenericAPIError } from "../../../../errors";
@@ -126,7 +125,7 @@ export async function fetchRates({
         // TODO: LIVE-8901 (handle request timeout)
       }
     }
-    if (e instanceof LedgerAPI4xx) {
+    if ((e as { name?: string })?.name === "LedgerAPI4xx") {
       // TODO: LIVE-8901 (handle 4xx)
     }
     throw e;

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -1,7 +1,6 @@
 import type { Account } from "@ledgerhq/types-live";
 import {
   DisconnectedDeviceDuringOperation,
-  TransportStatusError,
   WrongDeviceForAccountPayout,
   WrongDeviceForAccountRefund,
 } from "@ledgerhq/errors";
@@ -252,9 +251,13 @@ const completeExchange = (
             payoutAddressParameters,
           );
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const transportErr = e as { name?: string; statusCode?: number } | null | undefined;
+          if (
+            transportErr?.name === "TransportStatusError" &&
+            transportErr?.statusCode === 0x6a83
+          ) {
             throw new WrongDeviceForAccountPayout(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(transportErr.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(payoutAccount),
               },
@@ -293,10 +296,14 @@ const completeExchange = (
           );
           log(COMPLETE_EXCHANGE_LOG, "checkrefund address");
         } catch (e) {
-          if (e instanceof TransportStatusError && e.statusCode === 0x6a83) {
+          const transportErr = e as { name?: string; statusCode?: number } | null | undefined;
+          if (
+            transportErr?.name === "TransportStatusError" &&
+            transportErr?.statusCode === 0x6a83
+          ) {
             log(COMPLETE_EXCHANGE_LOG, "transport error");
             throw new WrongDeviceForAccountRefund(
-              getExchangeErrorMessage(e.statusCode, currentStep).errorMessage,
+              getExchangeErrorMessage(transportErr.statusCode, currentStep).errorMessage,
               {
                 accountName: getDefaultAccountName(refundAccount),
               },
@@ -316,9 +323,10 @@ const completeExchange = (
         // During signature delegation, Exchange does not remap refusal errors from the coin app/OS.
         // 0x6a84: user refused the proposal for an owned destination address.
         // 0x5501: BOLOS/OS-level refusal (not an Exchange app error code).
+        const transportErr = e as { name?: string; statusCode?: number } | null | undefined;
         if (
-          e instanceof TransportStatusError &&
-          (e.statusCode === 0x6a84 || e.statusCode === 0x5501)
+          transportErr?.name === "TransportStatusError" &&
+          (transportErr?.statusCode === 0x6a84 || transportErr?.statusCode === 0x5501)
         ) {
           throw new TransactionRefusedOnDevice();
         }

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -1,12 +1,6 @@
 import { getAccountCurrency, getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
-import {
-  AmountRequired,
-  FeeNotLoaded,
-  NotEnoughBalanceSwap,
-  NotEnoughGas,
-  NotEnoughGasSwap,
-} from "@ledgerhq/errors";
+import { NotEnoughBalanceSwap, NotEnoughGasSwap } from "@ledgerhq/errors";
 import { Account } from "@ledgerhq/types-live";
 import { useEffect, useMemo, useState } from "react";
 import useBridgeTransaction, { Result } from "../../../bridge/useBridgeTransaction";
@@ -62,10 +56,11 @@ export const useFromAmountStatusMessage = (
     // don't return an error/warning if we have no transaction or if transaction.amount <= 0
     if (transaction?.amount.lte(0)) return undefined;
 
-    const [relevantStatus] = statusEntries
+    const relevantStatus = statusEntries
       .filter(maybeError => maybeError instanceof Error)
-      .filter(errorOrWarning => !(errorOrWarning instanceof AmountRequired));
-    const isRelevantStatus = (relevantStatus as Error) instanceof NotEnoughGas;
+      .find(errorOrWarning => (errorOrWarning as { name?: string })?.name !== "AmountRequired");
+    const relevantStatusName = (relevantStatus as { name?: string })?.name;
+    const isRelevantStatus = relevantStatusName === "NotEnoughGas";
 
     // Skip gas validation for sponsored transactions since gas fees are covered by sponsor
 
@@ -85,7 +80,7 @@ export const useFromAmountStatusMessage = (
     }
 
     // convert to swap variation of error to display correct message to frontend.
-    if (relevantStatus instanceof FeeNotLoaded) {
+    if (relevantStatusName === "FeeNotLoaded") {
       return new NotEnoughBalanceSwap();
     }
 


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/ptx.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/ptx. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35081