### PR TITLE
[LWDM] chore(errors): replace instanceof with .name checks (platform files)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useAddMember.ts
@@ -9,10 +9,6 @@ import { Flow, Step, walletSyncOnboardingNewDeviceSelector } from "~/renderer/re
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { TrustchainResult, TrustchainResultType } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  TrustchainAlreadyInitialized,
-  TrustchainAlreadyInitializedWithOtherSeed,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { track } from "~/renderer/analytics/segment";
 import { AnalyticsPage } from "./useLedgerSyncAnalytics";
 import { saveSettings, setLastOnboardedDevice } from "~/renderer/actions/settings";
@@ -104,9 +100,10 @@ export function useAddMember({
 
         transitionToNextScreen(trustchainResult);
       } catch (error) {
-        if (error instanceof TrustchainAlreadyInitialized) {
+        const eName = (error as { name?: string })?.name;
+        if (eName === "TrustchainAlreadyInitialized") {
           dispatch(setFlow({ flow: Flow.Synchronize, step: Step.AlreadySecuredSameSeed }));
-        } else if (error instanceof TrustchainAlreadyInitializedWithOtherSeed) {
+        } else if (eName === "TrustchainAlreadyInitializedWithOtherSeed") {
           dispatch(setFlow({ flow: Flow.Synchronize, step: Step.AlreadySecuredOtherSeed }));
         } else {
           setError(error as Error);

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useOnTrustchainRefreshNeeded.ts
@@ -6,7 +6,6 @@ import {
   TrustchainSDK,
 } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { setTrustchain, resetTrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { log } from "@ledgerhq/logs";
 import { track } from "~/renderer/analytics/segment";
 
@@ -23,7 +22,7 @@ export function useOnTrustchainRefreshNeeded(
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         dispatch(setTrustchain(newTrustchain));
       } catch (e) {
-        if (e instanceof TrustchainEjected) {
+        if ((e as { name?: string })?.name === "TrustchainEjected") {
           dispatch(resetTrustchainStore());
           track("ledgersync_deactivated");
         }

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useQRCode.ts
@@ -1,11 +1,6 @@
 import { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-  QRCodeWSClosed,
-  TrustchainAlreadyInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { setDrawerVisibility, setFlow, setQrCodePinCode } from "~/renderer/actions/walletSync";
@@ -71,17 +66,17 @@ export function useQRCode({ sourcePage }: { sourcePage?: AnalyticsPage }) {
 
     // Don't use retry here because it always uses a delay despite setting it to 0
     onError(e) {
-      if (e instanceof QRCodeWSClosed) {
+      if (e?.name === "QRCodeWSClosed") {
         const { time } = e as unknown as { time: number };
         if (time >= MIN_TIME_TO_REFRESH) startQRCodeProcessing();
       }
-      if (e instanceof InvalidDigitsError) {
+      if (e?.name === "InvalidDigitsError") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.PinCodeError }));
       }
-      if (e instanceof NoTrustchainInitialized) {
+      if (e?.name === "NoTrustchainInitialized") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.UnbackedError }));
       }
-      if (e instanceof TrustchainAlreadyInitialized) {
+      if (e?.name === "TrustchainAlreadyInitialized") {
         dispatch(setFlow({ flow: Flow.Synchronize, step: Step.SynchronizeWithQRCode }));
       }
     },

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useRemoveMember.ts
@@ -9,7 +9,6 @@ import { Flow, Step } from "~/renderer/reducers/walletSync";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 import { TrustchainMember, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 type Props = {
   device: Device | null;
@@ -71,7 +70,7 @@ export function useRemoveMember({ device, member }: Props) {
         transitionToNextScreen(newTrustchain);
       } catch (error) {
         if (error instanceof Error) setError(error);
-        if (error instanceof TrustchainNotAllowed) {
+        if ((error as { name?: string })?.name === "TrustchainNotAllowed") {
           dispatch(setFlow({ flow: Flow.ManageInstances, step: Step.UnsecuredLedger }));
         }
       }

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -38,7 +38,6 @@ import { useOnTrustchainRefreshNeeded } from "./useOnTrustchainRefreshNeeded";
 import { Dispatch } from "redux";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
-import { TrustchainEjected, TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 
 const latestWalletStateSelector = (s: State): WSState => walletSyncStateSelector(walletSelector(s));
 
@@ -146,8 +145,8 @@ export function useWatchWalletSync(): WalletSyncUserState {
 
   useEffect(() => {
     if (walletSyncError) {
-      if (walletSyncError instanceof TrustchainNotAllowed) resetLedgerSync();
-      if (walletSyncError instanceof TrustchainEjected) resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainNotAllowed") resetLedgerSync();
+      if (walletSyncError?.name === "TrustchainEjected") resetLedgerSync();
     }
   }, [dispatch, resetLedgerSync, walletSyncError]);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/walletSync.hooks.ts
@@ -4,11 +4,6 @@ import { useDispatch } from "LLD/hooks/redux";
 import { ErrorType } from "./type.hooks";
 import { setFlow } from "~/renderer/actions/walletSync";
 import { Flow, Step } from "~/renderer/reducers/walletSync";
-import {
-  TrustchainEjected,
-  TrustchainNotAllowed,
-  TrustchainOutdated,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { useRestoreTrustchain } from "./useRestoreTrustchain";
 import { useTrustchainSdk } from "./useTrustchainSdk";
 
@@ -32,10 +27,10 @@ export const useLifeCycle = () => {
   function handleError(error: Error) {
     console.error("GetMember :" + error);
 
-    if (error instanceof TrustchainEjected) reset();
-    if (error instanceof TrustchainNotAllowed) reset();
+    if (error?.name === "TrustchainEjected") reset();
+    if (error?.name === "TrustchainNotAllowed") reset();
 
-    if (error instanceof TrustchainOutdated) restoreTrustchain();
+    if (error?.name === "TrustchainOutdated") restoreTrustchain();
 
     const errorToHandle = Object.entries(includesErrorActions).find(([err, _action]) =>
       error.message.includes(err),

--- a/apps/wallet-cli/src/commands/genuine-check.ts
+++ b/apps/wallet-cli/src/commands/genuine-check.ts
@@ -1,5 +1,4 @@
 import { defineCommand } from "@bunli/core";
-import { DeviceOnDashboardExpected, UserRefusedAllowManager } from "@ledgerhq/errors";
 import { getGenuineCheckFromDeviceId } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
 import type { GetGenuineCheckFromDeviceIdResult } from "@ledgerhq/live-common/hw/getGenuineCheckFromDeviceId";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
@@ -27,10 +26,10 @@ function mapGenuineCheckError(error: unknown): unknown {
   if (isCounterfeitError(error)) {
     return new NonGenuineDeviceError();
   }
-  if (error instanceof UserRefusedAllowManager) {
+  if ((error as { name?: string })?.name === "UserRefusedAllowManager") {
     return new WalletCliDeviceError({ code: "rejected", context: "open_app" }, { cause: error });
   }
-  if (error instanceof DeviceOnDashboardExpected) {
+  if ((error as { name?: string })?.name === "DeviceOnDashboardExpected") {
     return new WalletCliDeviceError(
       { code: "wrong_app", expected: "Ledger dashboard" },
       { cause: error },

--- a/apps/wallet-cli/src/commands/ring/destroy.ts
+++ b/apps/wallet-cli/src/commands/ring/destroy.ts
@@ -1,7 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { createInterface } from "node:readline";
 import type { MemberCredentials } from "@ledgerhq/ledger-key-ring-protocol/types";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import type { Spinner } from "yocto-spinner";
 import { Session, trustchainFromMeta, type TrustchainMeta } from "../../session/session-store";
 import {
@@ -122,7 +121,7 @@ async function performRemoteDestroy(
     destroySpin?.stop();
     return { remoteSucceeded: true, trustchainDestroyed, memberEjected: false };
   } catch (e) {
-    if (e instanceof TrustchainEjected) {
+    if ((e as { name?: string })?.name === "TrustchainEjected") {
       // destroyApplication is idempotent on an already-closed stream (returns without throwing), so
       // TrustchainEjected means this member is no longer on the ring: it was removed by another
       // owner, or the trustchain was destroyed remotely. Either way there's nothing left for us to

--- a/apps/wallet-cli/src/device/classify-device-error.ts
+++ b/apps/wallet-cli/src/device/classify-device-error.ts
@@ -7,12 +7,6 @@
  */
 
 import { SendApduTimeoutError } from "@ledgerhq/device-management-kit";
-import {
-  DisconnectedDevice,
-  DisconnectedDeviceDuringOperation,
-  LockedDeviceError,
-  ManagerDeviceLockedError,
-} from "@ledgerhq/errors";
 import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { EmptyError } from "rxjs";
 import type { DeviceState, RejectedContext } from "./device-state";
@@ -54,17 +48,19 @@ function getErrorCode(error: unknown): string | undefined {
 }
 
 function isDisconnectedError(error: unknown): boolean {
+  const eName = (error as { name?: string })?.name;
   return (
     error instanceof EmptyError ||
-    error instanceof DisconnectedDevice ||
-    error instanceof DisconnectedDeviceDuringOperation
+    eName === "DisconnectedDevice" ||
+    eName === "DisconnectedDeviceDuringOperation"
   );
 }
 
 function isLockedError(error: unknown): boolean {
+  const eName = (error as { name?: string })?.name;
   return (
-    error instanceof ManagerDeviceLockedError ||
-    error instanceof LockedDeviceError ||
+    eName === "ManagerDeviceLocked" ||
+    eName === "LockedDeviceError" ||
     hasTag(error, "DeviceLockedError")
   );
 }
@@ -96,6 +92,9 @@ function classifyTransportStatusError(
 }
 
 export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): DeviceState {
+  // Null/undefined can't be classified by name; fall through to unknown.
+  if (error == null) return { code: "unknown", cause: error };
+
   // Device-not-detected: rxjs EmptyError is thrown when lastValueFrom sees no emission,
   // @ledgerhq/errors Disconnected* covers USB unplug / transport close.
   if (isDisconnectedError(error)) {
@@ -108,8 +107,8 @@ export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): 
   }
 
   // User-rejection / wrong-app / locked via legacy SW codes.
-  if (error instanceof TransportStatusError) {
-    const state = classifyTransportStatusError(error, ctx);
+  if ((error as { name?: string })?.name === "TransportStatusError") {
+    const state = classifyTransportStatusError(error as TransportStatusError, ctx);
     if (state) {
       return state;
     }

--- a/apps/wallet-cli/src/key-ring/load-key-ring.ts
+++ b/apps/wallet-cli/src/key-ring/load-key-ring.ts
@@ -1,5 +1,4 @@
 import type { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Session, type TrustchainMeta, trustchainFromMeta } from "../session/session-store";
 import { loadMemberCredentials } from "./keychain";
 import { createLkrpSdk } from "./lkrp-sdk";
@@ -57,7 +56,7 @@ export async function loadDomainKey(
     // The wallet-cli application stream was closed (deactivated from another device, or this member
     // was removed): restoreTrustchain rejects a closed stream with TrustchainEjected. Point the user
     // at the recovery path rather than surfacing the raw protocol error.
-    if (e instanceof TrustchainEjected) {
+    if ((e as { name?: string })?.name === "TrustchainEjected") {
       throw new Error(
         "The wallet-cli application is no longer active on this Ledger Key Ring (deactivated " +
           "elsewhere, or this member was removed). Run `wallet-cli ring destroy` then " +

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -33,7 +33,6 @@ import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/f
 import { listCryptoCurrencies, getCurrencyColor } from "@ledgerhq/live-common/currencies/index";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { Loading } from "./Loading";
-import { TrustchainEjected } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Tick } from "./Tick";
 import { State } from "./types";
 import { Actionable } from "./Actionable";
@@ -149,7 +148,7 @@ export default function AppAccountsSync({
         const newTrustchain = await trustchainSdk.restoreTrustchain(trustchain, memberCredentials);
         setTrustchain(newTrustchain);
       } catch (e) {
-        if (e instanceof TrustchainEjected) {
+        if ((e as { name?: string })?.name === "TrustchainEjected") {
           setTrustchain(null);
         }
       }

--- a/apps/web-tools/src/trustchain/components/AppQRCodeCandidate.tsx
+++ b/apps/web-tools/src/trustchain/components/AppQRCodeCandidate.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeCandidateInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { TextInput } from "@ledgerhq/lumen-ui-react";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { Actionable } from "./Actionable";
@@ -56,7 +53,7 @@ export function AppQRCodeCandidate({
           return true;
         })
         .catch(e => {
-          if (e instanceof InvalidDigitsError) {
+          if (e?.name === "InvalidDigitsError") {
             alert("Invalid digits");
             return;
           }

--- a/apps/web-tools/src/trustchain/components/AppQRCodeHost.tsx
+++ b/apps/web-tools/src/trustchain/components/AppQRCodeHost.tsx
@@ -1,9 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { createQRCodeHostInstance } from "@ledgerhq/ledger-key-ring-protocol/qrcode/index";
-import {
-  InvalidDigitsError,
-  NoTrustchainInitialized,
-} from "@ledgerhq/ledger-key-ring-protocol/errors";
+import { NoTrustchainInitialized } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { RenderActionable } from "./Actionable";
 import QRCode from "./QRCode";
@@ -44,7 +41,7 @@ export function AppQRCodeHost({
       initialTrustchainId: trustchain.rootId,
     })
       .catch(e => {
-        if (e instanceof InvalidDigitsError) {
+        if (e?.name === "InvalidDigitsError") {
           return;
         }
         setError(e);

--- a/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
@@ -1,7 +1,7 @@
 import { from, lastValueFrom } from "rxjs";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { ApduDevice } from "@ledgerhq/hw-ledger-key-ring-protocol/ApduDevice";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
+import { StatusCodes } from "@ledgerhq/hw-transport";
 import { crypto, device } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import getApi from "./api";
 import { genericWithJWT } from "./auth";
@@ -57,10 +57,10 @@ export class HWDeviceProvider {
     try {
       return await lastValueFrom(runWithDevice(transport => from(job(device.apdu(transport)))));
     } catch (error) {
-      if (!(error instanceof TransportStatusError)) {
+      if ((error as { name?: string })?.name !== "TransportStatusError") {
         throw error;
       }
-      switch (error.statusCode) {
+      switch ((error as { statusCode?: number })?.statusCode) {
         case StatusCodes.USER_REFUSED_ON_DEVICE:
         case StatusCodes.CONDITIONS_OF_USE_NOT_SATISFIED:
           throw new UserRefusedOnDevice();

--- a/libs/ledger-key-ring-protocol/src/auth.ts
+++ b/libs/ledger-key-ring-protocol/src/auth.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { AuthCachePolicy, JWT } from "./types";
 import { TrustchainNotAllowed, TrustchainOutdated } from "./errors";
@@ -81,13 +80,14 @@ function networkCheckJwtExpiration(error: unknown): JwtExpirationCheck {
   let isTrustchainOutdated = false;
   let isUncaughtClientError = false;
   // this assume live-network is used and we adapt to its error's format
-  if (error instanceof LedgerAPI4xx) {
-    if (error.message.includes("JWT is expired")) {
+  if ((error as { name?: string })?.name === "LedgerAPI4xx") {
+    const message = (error as Error)?.message ?? "";
+    if (message.includes("JWT is expired")) {
       hasExpired = true;
-      canBeRefreshed = error.message.includes("/refresh");
-    } else if (error.message.includes("JWT contains no permission")) {
+      canBeRefreshed = message.includes("/refresh");
+    } else if (message.includes("JWT contains no permission")) {
       isNotPermitted = true;
-    } else if (error.message.includes("path does not match")) {
+    } else if (message.includes("path does not match")) {
       isTrustchainOutdated = true;
     } else {
       isUncaughtClientError = true;

--- a/libs/ledger-key-ring-protocol/src/sdk.ts
+++ b/libs/ledger-key-ring-protocol/src/sdk.ts
@@ -25,7 +25,6 @@ import {
 import getApi from "./api";
 import { KeyPair as CryptoKeyPair } from "@ledgerhq/hw-ledger-key-ring-protocol/Crypto";
 import { log } from "@ledgerhq/logs";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import {
   TrustchainAlreadyInitialized,
   TrustchainAlreadyInitializedWithOtherSeed,
@@ -450,11 +449,11 @@ export class SDK implements TrustchainSDK {
       })
       .catch(e => {
         if (
-          e instanceof LedgerAPI4xx &&
-          (e.message.includes("Not a member of trustchain") ||
-            e.message.includes("You are not member"))
+          (e as { name?: string })?.name === "LedgerAPI4xx" &&
+          ((e as Error)?.message.includes("Not a member of trustchain") ||
+            (e as Error)?.message.includes("You are not member"))
         ) {
-          throw new TrustchainEjected(e.message);
+          throw new TrustchainEjected((e as Error)?.message);
         }
         throw e;
       });

--- a/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/destroyApplicationKeepsOtherApps.ts
@@ -1,4 +1,4 @@
-import { TrustchainEjected, TrustchainNotAllowed } from "../../src/errors";
+import { TrustchainEjected } from "../../src/errors";
 import { ScenarioOptions } from "../test-helpers/types";
 
 // Deactivating one application (Ledger Sync, app 16) must close only that
@@ -58,10 +58,8 @@ export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions
       () => null,
       (e: unknown) => e,
     );
-  expect(
-    sync2RestoreError instanceof TrustchainNotAllowed ||
-      sync2RestoreError instanceof TrustchainEjected,
-  ).toBe(true);
+  const eName = (sync2RestoreError as { name?: string })?.name;
+  expect(eName === "TrustchainNotAllowed" || eName === "TrustchainEjected").toBe(true);
 
   // cleanup
   await sdkSync1.destroyTrustchain(reactivated.trustchain, sync1creds);

--- a/libs/ledger-live-common/src/device-action/utils.ts
+++ b/libs/ledger-live-common/src/device-action/utils.ts
@@ -1,5 +1,3 @@
-import { TransportStatusError } from "@ledgerhq/errors";
-import { DeviceNotOnboarded } from "../errors";
 import { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account } from "@ledgerhq/types-live";
 
@@ -46,11 +44,12 @@ export function getFlowNameFromMapping<TLocation extends string | number | symbo
 
 // remap transport status 6d06/6d07 as DeviceNotOnboarded for UX handling consistency.
 export function isDeviceNotOnboardedError(e: unknown) {
+  const eName = (e as { name?: string })?.name;
   const maybeMessage = (e as { message?: string })?.message;
 
   return (
-    e instanceof DeviceNotOnboarded ||
-    (e instanceof TransportStatusError &&
+    eName === "DeviceNotOnboarded" ||
+    (eName === "TransportStatusError" &&
       (maybeMessage?.includes("0x6d06") || maybeMessage?.includes("0x6d07")))
   );
 }

--- a/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
+++ b/libs/live-wallet/src/walletsync/createWalletSyncWatchLoop.ts
@@ -3,7 +3,6 @@ import { CloudSyncSDKInterface } from "../cloudsync";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { WalletSyncDataManager } from "./types";
 import { log } from "@ledgerhq/logs";
-import { TrustchainEjected, TrustchainOutdated } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { Subscription } from "rxjs";
 
 export type WatchConfig = {
@@ -152,7 +151,8 @@ export function createWalletSyncWatchLoop<UserState, LocalState, Update, Schema 
         await walletSyncSdk.push(trustchain, memberCredentials, diff.nextState);
       }
     } catch (e) {
-      const shouldRefresh = e instanceof TrustchainEjected || e instanceof TrustchainOutdated;
+      const eName = (e as { name?: string })?.name;
+      const shouldRefresh = eName === "TrustchainEjected" || eName === "TrustchainOutdated";
       if (shouldRefresh) {
         await onTrustchainRefreshNeeded(trustchain);
         return;


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check across files owned by @ledgerhq/platform.

**Before:**
```ts
if (e instanceof UserRefusedOnDevice) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "UserRefusedOnDevice") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

> [!NOTE]
> This is a split of #19761 scoped to files owned by @ledgerhq/platform. See that PR for full context.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35082