### PR TITLE
feat(cryptoassets): mark lib exports @deprecated

### DIFF
--- a/.changeset/deprecate-cryptoassets-value-exports.md
+++ b/.changeset/deprecate-cryptoassets-value-exports.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/cryptoassets": minor
+---
+
+Mark value-accessor exports as deprecated; use the domain/features currency registries instead.

--- a/libs/ledgerjs/packages/cryptoassets/src/api-asset-converter.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-asset-converter.ts
@@ -2,6 +2,7 @@ import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyById } from "./currencies";
 import { convertApiToken, type ApiTokenData } from "./api-token-converter";
 
+/** @deprecated Use @domain/api-currency-token. */
 export interface ApiTokenCurrency {
   type: "token_currency";
   id: string;
@@ -18,6 +19,7 @@ export interface ApiTokenCurrency {
   descriptor?: unknown;
 }
 
+/** @deprecated Use @domain/api-currency-token. */
 export interface ApiCryptoCurrency {
   type: "crypto_currency";
   id: string;
@@ -35,8 +37,10 @@ export interface ApiCryptoCurrency {
   disableCountervalue?: boolean;
 }
 
+/** @deprecated Use @domain/api-currency-token. */
 export type ApiAsset = ApiTokenCurrency | ApiCryptoCurrency;
 
+/** @deprecated Use @domain/api-currency-token. */
 export function convertApiAsset(apiAsset: ApiAsset): CryptoOrTokenCurrency | undefined {
   if (apiAsset.type === "crypto_currency") {
     return convertApiCryptoCurrency(apiAsset);
@@ -97,6 +101,7 @@ function convertApiTokenCurrency(apiToken: ApiTokenCurrency): CryptoOrTokenCurre
   return convertApiToken(apiTokenData);
 }
 
+/** @deprecated Use @domain/api-currency-token. */
 export function convertApiAssets(
   apiAssets: Record<string, ApiAsset>,
 ): Record<string, CryptoOrTokenCurrency> {

--- a/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/api-token-converter.ts
@@ -2,6 +2,7 @@ import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyById } from "./currencies";
 import type { TokenUnit } from "./cal-client/entities";
 
+/** @deprecated Use @domain/api-currency-token. */
 export interface ApiTokenData {
   id: string;
   contractAddress: string;
@@ -16,11 +17,8 @@ export interface ApiTokenData {
 }
 
 /**
- * Converts API token data to Ledger Live TokenCurrency format
- *
- * This function applies client-side transformations to reconcile differences between
- * backend APIs (CAL/DaDa) and Ledger Live's expected token format:
- *
+ * Converts API token data to Ledger Live TokenCurrency format.
+ * @deprecated Use @domain/api-currency-token.
  * @param apiToken - Token data from backend API
  * @returns TokenCurrency object in Ledger Live format, or undefined if parent currency not found
  */

--- a/libs/ledgerjs/packages/cryptoassets/src/cal-client/hooks/useTokensData.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/cal-client/hooks/useTokensData.ts
@@ -7,6 +7,7 @@ const emptyData = () => ({
   pagination: { nextCursor: "" },
 });
 
+/** @deprecated Use @features/platform-currencies. */
 export function useTokensData(params: GetTokensDataParams) {
   const {
     data,

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies-store.ts
@@ -90,6 +90,7 @@ function buildCryptoCurrenciesStore(currencies: CryptoCurrency[]): CryptoCurrenc
  * Uses globalThis to ensure a single shared reference across all module instances,
  * which is critical when coin-modules are lazy-loaded and may resolve to separate
  * module copies.
+ * @deprecated Use @domain/entity-currency-crypto.
  */
 export function setCryptoCurrenciesStore(
   currencies: CryptoCurrency[],

--- a/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/currencies.ts
@@ -99,10 +99,14 @@ const ethereumUnits = (name, code) => [
   },
 ];
 
-// Dual-maintained with `@domain/entity-currency-crypto` (the primary registry); see its README.
-// FIXME: We must be aware that we don't handle correcly currencies that use the same `managerApp`
-// to fix that we should always have the 'main' currency of the managerapp first in this list
-// e.g for Ethereum manager Ethereum is first in the list and other coin are in the bottom of the list
+/**
+ * @deprecated Use @domain/entity-currency-crypto.
+ *
+ * Dual-maintained with `@domain/entity-currency-crypto` (the primary registry); see its README.
+ * FIXME: We must be aware that we don't handle correcly currencies that use the same `managerApp`
+ * to fix that we should always have the 'main' currency of the managerapp first in this list
+ * e.g for Ethereum manager Ethereum is first in the list and other coin are in the bottom of the list
+ */
 export const cryptocurrenciesById: Record<CryptoCurrencyId, CryptoCurrency> = {
   aptos: {
     type: "CryptoCurrency",
@@ -5124,7 +5128,7 @@ function activeCurrenciesStore(): CryptoCurrenciesStore {
 }
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-crypto.
  * @param {*} withDevCrypto
  */
 export function listCryptoCurrencies(withDevCrypto = false): CryptoCurrency[] {
@@ -5133,7 +5137,7 @@ export function listCryptoCurrencies(withDevCrypto = false): CryptoCurrency[] {
 }
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-crypto.
  * @param {*} f
  */
 export function findCryptoCurrency(
@@ -5143,7 +5147,7 @@ export function findCryptoCurrency(
 }
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-crypto.
  * @param {*} scheme
  */
 export function findCryptoCurrencyByScheme(scheme: string): CryptoCurrency | null | undefined {
@@ -5152,13 +5156,14 @@ export function findCryptoCurrencyByScheme(scheme: string): CryptoCurrency | nul
 
 /**
  * @deprecated Tickers are not unique across currencies, so the result is ambiguous and arbitrary.
- * Look up by id with {@link findCryptoCurrencyById} instead.
+ * Use @domain/entity-currency-crypto. Look up by id with {@link findCryptoCurrencyById} instead.
  * @param ticker
  */
 export function findCryptoCurrencyByTicker(ticker: string): CryptoCurrency | null | undefined {
   return activeCurrenciesStore().cryptocurrenciesByTicker[ticker];
 }
 
+/** @deprecated Use @domain/entity-currency-crypto. */
 export function findCryptoCurrencyById(id: string): CryptoCurrency | undefined {
   return activeCurrenciesStore().cryptocurrenciesById[id];
 }
@@ -5175,7 +5180,7 @@ const testsMap = {
 };
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-crypto.
  * @param {*} keyword
  */
 export const findCryptoCurrencyByKeyword = (
@@ -5197,6 +5202,7 @@ export const findCryptoCurrencyByKeyword = (
   }
 };
 
+/** @deprecated Use @domain/entity-currency-crypto. */
 export const findCryptoCurrencyByManagerAppName = (
   managerAppName: string,
 ): CryptoCurrency | null | undefined => {
@@ -5211,12 +5217,13 @@ export const findCryptoCurrencyByManagerAppName = (
 };
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-crypto.
  * @param {*} id
  */
 export const hasCryptoCurrencyId = (id: string): boolean =>
   Object.prototype.hasOwnProperty.call(activeCurrenciesStore().cryptocurrenciesById, id);
 
+/** @deprecated Use @domain/entity-currency-crypto. */
 export function getCryptoCurrencyById(id: string): CryptoCurrency {
   const currency = findCryptoCurrencyById(id);
 

--- a/libs/ledgerjs/packages/cryptoassets/src/fiats-store.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/fiats-store.ts
@@ -46,6 +46,7 @@ export function buildFiatCurrenciesStore(currencies: FiatCurrency[]): FiatCurren
  *
  * Uses globalThis to ensure a single shared reference across all module instances, which is
  * critical when modules are lazy-loaded and may resolve to separate module copies.
+ * @deprecated Use @domain/entity-currency-fiat.
  */
 export function setFiatCurrenciesStore(currencies: FiatCurrency[]): void {
   globalThis.__ledgerFiatCurrenciesStore = buildFiatCurrenciesStore(currencies);

--- a/libs/ledgerjs/packages/cryptoassets/src/fiats.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/fiats.ts
@@ -212,7 +212,7 @@ export function hasFiatCurrencyTicker(ticker: string): boolean {
 }
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-fiat.
  * @param {*} ticker
  */
 export function findFiatCurrencyByTicker(ticker: string): FiatCurrency | null | undefined {
@@ -220,7 +220,7 @@ export function findFiatCurrencyByTicker(ticker: string): FiatCurrency | null | 
 }
 
 /**
- *
+ * @deprecated Use @domain/entity-currency-fiat.
  * @param {*} ticker
  */
 export function getFiatCurrencyByTicker(ticker: string): FiatCurrency {
@@ -233,9 +233,7 @@ export function getFiatCurrencyByTicker(ticker: string): FiatCurrency {
   return cur;
 }
 
-/**
- *
- */
+/** @deprecated Use @domain/entity-currency-fiat. */
 export function listFiatCurrencies(): FiatCurrency[] {
   return activeFiatCurrenciesStore().fiatCurrenciesArray;
 }

--- a/libs/ledgerjs/packages/cryptoassets/src/hooks.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/hooks.ts
@@ -15,7 +15,7 @@ export type CurrencyResult = {
 };
 
 /**
- * Hook to find a token by its ID
+ * @deprecated Use @features/platform-currencies.
  */
 export function useTokenById(id: string, options?: { skip?: boolean }): TokenResult {
   const result = options
@@ -29,7 +29,7 @@ export function useTokenById(id: string, options?: { skip?: boolean }): TokenRes
 }
 
 /**
- * Hook to find a token by its contract address and currency
+ * @deprecated Use @features/platform-currencies.
  */
 export function useTokenByAddressInCurrency(
   address: string,
@@ -48,7 +48,7 @@ export function useTokenByAddressInCurrency(
 }
 
 /**
- * Hook to find a currency (crypto or token) by its ID
+ * @deprecated Use @features/platform-currencies.
  */
 export function useCurrencyById(id: string): CurrencyResult {
   const maybeCryptoCurrency = findCryptoCurrencyById(id);

--- a/libs/ledgerjs/packages/cryptoassets/src/state.ts
+++ b/libs/ledgerjs/packages/cryptoassets/src/state.ts
@@ -13,6 +13,7 @@ declare global {
  * Uses globalThis to ensure a single shared reference across all module instances,
  * which is critical when coin-modules are lazy-loaded and may resolve to separate
  * module copies.
+ * @deprecated Use @domain/api-currency-token.
  */
 export function setCryptoAssetsStore(store: CryptoAssetsStore): void {
   globalThis.__ledgerCryptoAssetsStore = store;
@@ -20,6 +21,7 @@ export function setCryptoAssetsStore(store: CryptoAssetsStore): void {
 
 /**
  * Gets the global CryptoAssetsStore instance.
+ * @deprecated Use @domain/api-currency-token.
  * @throws {Error} If the store has not been set yet.
  */
 export function getCryptoAssetsStore(): CryptoAssetsStore {


### PR DESCRIPTION
### 📝 Description

Adds `@deprecated` JSDoc tags to the entire public value API of `@ledgerhq/cryptoassets` (28 tags across 9 files), pointing consumers to the domain/features replacements:

| Exports | Replacement |
|---|---|
| Currency accessors + `cryptocurrenciesById` map | `@domain/entity-currency-crypto` |
| Fiat accessors | `@domain/entity-currency-fiat` |
| `setCryptoCurrenciesStore` / `setFiatCurrenciesStore` | respective domain packages |
| `setCryptoAssetsStore` / `getCryptoAssetsStore` | `@domain/api-currency-token` |
| Converter functions + interfaces (`api-token-converter`, `api-asset-converter`) | `@domain/api-currency-token` |
| React hooks (`useTokenById`, `useTokenByAddressInCurrency`, `useCurrencyById`, `useTokensData`) | `@features/platform-currencies` |

`@ledgerhq/types-cryptoassets` is intentionally left untouched (separate deprecation track, ~800 consumers).

This is JSDoc-only — no behaviour change. It acts as the regression guard before the drop ticket: the `@deprecated` annotation stops new legacy imports creeping back in from apps/libs that are not covered by the source-import ban.

> ⚠️ **Hold merge** until the last pending repoint PR is merged. Before merging, rebase on `develop` and re-run `pnpm nx run-many -t typecheck` — any deprecation warning outside the two parity test files (`currencies.domain-parity.test.ts`, `fiats.domain-parity.test.ts`) flags a missed repoint and should be fixed, not silenced.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31953 — Deprecate @ledgerhq/cryptoassets value exports](https://ledgerhq.atlassian.net/browse/LIVE-31953)