### PR TITLE
[LWDM] feat(live-signer-evm): wire CAL_SERVICE_URL into DMK ContextModule

### DIFF
--- a/.changeset/silver-lamps-wire.md
+++ b/.changeset/silver-lamps-wire.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-evm": minor
+---
+
+Wire CAL_SERVICE_URL into DMK ContextModule for the EVM signer

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -28,6 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/context-module": "catalog:",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/errors": "workspace:^",

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -18,6 +18,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
 import { EIP712Message } from "@ledgerhq/types-live";
+import { getEnv } from "@ledgerhq/live-env";
 import {
   EthAppPleaseEnableContractData,
   LockedDeviceError,
@@ -56,10 +57,13 @@ export class DmkSignerEth implements EvmSigner {
       ),
     );
     liveBlindSigningReporter.setContext({ sessionId });
+    const calUrl = getEnv("CAL_SERVICE_URL");
+    const calMode = calUrl.includes("ledger-test") || calUrl.includes(".stg.") ? "test" : "prod";
     const contextModule = new ContextModuleBuilder({ originToken })
       .setAppSource("ledger-wallet")
       .setBlindSigningReporter(liveBlindSigningReporter)
       .setChain(ContextModuleChainID.Ethereum)
+      .setCalConfig({ url: calUrl, mode: calMode, branch: "main" })
       .build();
     this.signer = new SignerEthBuilder({
       dmk,

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -63,7 +63,7 @@ export class DmkSignerEth implements EvmSigner {
       .setAppSource("ledger-wallet")
       .setBlindSigningReporter(liveBlindSigningReporter)
       .setChain(ContextModuleChainID.Ethereum)
-      .setCalConfig({ url: calUrl, mode: calMode, branch: "main" })
+      .setCalConfig({ url: `${calUrl}/v1`, mode: calMode, branch: "main" })
       .build();
     this.signer = new SignerEthBuilder({
       dmk,

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -3,6 +3,12 @@ import { EIP712Message } from "@ledgerhq/types-live";
 import { lastValueFrom, of } from "rxjs";
 import { DmkSignerEth } from "../src/DmkSignerEth";
 import { SignTransactionDAStep } from "@ledgerhq/device-signer-kit-ethereum";
+import { getEnv } from "@ledgerhq/live-env";
+import { ContextModuleBuilder } from "@ledgerhq/context-module";
+
+jest.mock("@ledgerhq/live-env", () => ({
+  getEnv: jest.fn(),
+}));
 
 describe("DmkSignerEth", () => {
   const dmkMock = {
@@ -19,6 +25,7 @@ describe("DmkSignerEth", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getEnv).mockReturnValue("https://global.api.prd.ledger.com/cal" as never);
 
     signer = new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
   });
@@ -616,6 +623,45 @@ describe("DmkSignerEth", () => {
         // THEN
         expect(error).toEqual(new Error("Method not implemented."));
       }
+    });
+  });
+
+  describe("CAL config wiring", () => {
+    let setCalConfigSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      setCalConfigSpy = jest.spyOn(ContextModuleBuilder.prototype, "setCalConfig");
+    });
+
+    afterEach(() => {
+      setCalConfigSpy.mockRestore();
+    });
+
+    it("passes prod mode and the env URL for a prod endpoint", () => {
+      const url = "https://global.api.prd.ledger.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "prod", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains 'ledger-test'", () => {
+      const url = "https://global.api.stg.ledger-test.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "test", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains '.stg.' but not 'ledger-test'", () => {
+      const url = "https://global.api.stg.example.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "test", branch: "main" });
     });
   });
 });

--- a/libs/live-signer-evm/tests/DmkSignerEth.test.ts
+++ b/libs/live-signer-evm/tests/DmkSignerEth.test.ts
@@ -637,13 +637,13 @@ describe("DmkSignerEth", () => {
       setCalConfigSpy.mockRestore();
     });
 
-    it("passes prod mode and the env URL for a prod endpoint", () => {
+    it("passes prod mode and the env URL with /v1 for a prod endpoint", () => {
       const url = "https://global.api.prd.ledger.com/cal";
       jest.mocked(getEnv).mockReturnValue(url as never);
 
       new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
 
-      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "prod", branch: "main" });
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "prod", branch: "main" });
     });
 
     it("passes test mode when CAL_SERVICE_URL contains 'ledger-test'", () => {
@@ -652,7 +652,7 @@ describe("DmkSignerEth", () => {
 
       new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
 
-      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "test", branch: "main" });
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
     });
 
     it("passes test mode when CAL_SERVICE_URL contains '.stg.' but not 'ledger-test'", () => {
@@ -661,7 +661,7 @@ describe("DmkSignerEth", () => {
 
       new DmkSignerEth(dmkMock as unknown as DeviceManagementKit, "sessionId");
 
-      expect(setCalConfigSpy).toHaveBeenCalledWith({ url, mode: "test", branch: "main" });
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12342,6 +12342,9 @@ importers:
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -22882,7 +22885,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25147,7 +25150,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -66147,7 +66150,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66271,54 +66274,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
## Summary

- Passes `CAL_SERVICE_URL` (+ `/v1` version path) into `ContextModuleBuilder.setCalConfig()` in `DmkSignerEth`, replacing the context module's hardcoded default URL
- Mode is derived from the URL at runtime (`"test"` for staging URLs, `"prod"` otherwise) — no new env var needed
- Adds `@ledgerhq/live-env` dep to `@ledgerhq/live-signer-evm`

Closes LIVE-33579

## Test plan

- [ ] `pnpm --filter @ledgerhq/live-signer-evm test` — all tests pass
- [ ] Verify in a running app that ETH signing enrichment calls hit the URL set in `CAL_SERVICE_URL` with the `/v1` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)