### PR TITLE
ci(mobile): use noop build-lib-deps for jest unit tests (LIVE-31963)

### DIFF
--- a/.github/workflows/test-mobile-reusable.yml
+++ b/.github/workflows/test-mobile-reusable.yml
@@ -108,10 +108,10 @@ jobs:
           region: ${{ secrets.AWS_CACHE_REGION }}
 
       - name: Install dependencies
-        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --filter="./libs/**" --no-frozen-lockfile --unsafe-perm
+        run: pnpm i --filter="live-mobile..." --filter="ledger-live" --unsafe-perm
 
       - name: Build dependencies
-        run: pnpm exec nx run-many -t build --projects=tag:scope:libs
+        run: pnpm exec nx run live-mobile:build-lib-deps
 
       - name: Run unit tests
         shell: bash


### PR DESCRIPTION
### 📝 Description

Switches the **Mobile Unit Tests** job in `test-mobile-reusable.yml` back to the nx noop `build-lib-deps` target and simplifies the install step:

- **Build dependencies:** `nx run-many -t build --projects=tag:scope:libs` → `nx run live-mobile:build-lib-deps` (the `nx:noop` target with `dependsOn: ["^build"]`, mirroring desktop).
- **Install dependencies:** dropped `--filter="./libs/**"` (and `--no-frozen-lockfile`), leaving `pnpm i --filter="live-mobile..." --filter="ledger-live" --unsafe-perm`.

**Why:** PR #18124 introduced the mobile `build-lib-deps` noop target but did **not** wire the jest job onto it. Instead it shipped a deliberate interim — a real `nx run-many` libs build plus the `./libs/**` install filter — to avoid breaking **hotfix cherry-picks**, since the noop target didn't yet exist on release branches and relying on it immediately would have broken those flows.

LIVE-31963 tracked doing the swap "2 releases post-merge", once the target is present in release branches and needs no cherry-picking. That window has passed, so this PR adopts the noop path: nx now resolves lib deps via `^build` (with cache) rather than an explicit run-many + broad install filter.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-31963](https://ledgerhq.atlassian.net/browse/LIVE-31963) · follow-up to #18124
- **PR run**: https://github.com/LedgerHQ/ledger-live/actions/runs/29836242371


[LIVE-31963]: https://ledgerhq.atlassian.net/browse/LIVE-31963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ