### PR TITLE
[LWD] chore(lwd): show currency-specific disabled tooltip message

### DIFF
--- a/.changeset/kind-waves-burn.md
+++ b/.changeset/kind-waves-burn.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show a currency-specific disabled tooltip on the EVM Undelegate button: 0G explains the 1 Gwei minimum shares threshold; SEI explains the 7-validator limit.

--- a/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Row.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/Delegation/Row.tsx
@@ -187,7 +187,7 @@ export function Row({
             i18nKey={
               status === "activating"
                 ? "ethereum.evmStaking.delegation.undelegateActivatingTooltip"
-                : "ethereum.evmStaking.delegation.undelegateDisabledTooltip"
+                : `ethereum.evmStaking.delegation.undelegateDisabledTooltip.${account.currency.id}`
             }
           >
             <b></b>
@@ -210,6 +210,7 @@ export function Row({
       _canUndelegate,
       redelegateDisabledTooltip,
       status,
+      account.currency.id,
     ],
   );
   const name = validator?.name ?? validatorName ?? validatorAddress;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -4364,7 +4364,10 @@
         "redelegate": "Redelegate",
         "redelegateDisabledTooltip": "You can redelegate again <0>{{days}}</0>",
         "redelegateMaxDisabledTooltip": "You cannot redelegate more than <0>7</0> validators at a time",
-        "undelegateDisabledTooltip": "You cannot undelegate more than <0>7</0> validators at a time",
+        "undelegateDisabledTooltip": {
+          "sei_evm": "You cannot undelegate more than <0>7</0> validators at a time",
+          "zero_gravity": "You need at least 1 Gwei of shares delegated to undelegate"
+        },
         "undelegateActivatingTooltip": "You cannot undelegate a stake that is still activating",
         "reward": "Claim rewards",
         "activeTooltip": "Delegated amounts generate rewards",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Show a currency-specific tooltip when the EVM Undelegate button is disabled. `ethereum.evmStaking.delegation.undelegateDisabledTooltip` becomes a nested object keyed by currency id.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34712
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
