### PR TITLE
[LWDM] chore(errors): port remaining instanceof guards missed in per-team PRs

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ErrorDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SyncOnboarding/Manual/EarlySecurityChecks/ErrorDrawer.tsx
@@ -11,7 +11,6 @@ import { setDrawer } from "~/renderer/drawers/Provider";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { track } from "~/renderer/analytics/segment";
 import { ErrorBody } from "~/renderer/components/ErrorBody";
-import { FirmwareNotRecognized } from "@ledgerhq/errors";
 import { DmkError } from "@ledgerhq/live-dmk-desktop";
 
 export type Props = {
@@ -28,7 +27,8 @@ const ErrorDrawer: React.FC<Props> = ({ error, onClickRetry, closeable = false }
   const { t } = useTranslation();
   const navigate = useNavigate();
   const isNotFoundEntityError =
-    error.message === "not found entity" || error instanceof FirmwareNotRecognized;
+    error.message === "not found entity" ||
+    (error as { name?: string })?.name === "FirmwareNotRecognized";
   const providerNumber = useEnv("FORCE_PROVIDER");
 
   const drawerAnalyticsName = `Error: ${

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/utils/errors.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/utils/errors.ts
@@ -1,10 +1,9 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { ErrorType } from "../hooks/type.hooks";
 
 export const isNoTrustchainError = (error: Error) =>
   error.message.includes(ErrorType.NO_TRUSTCHAIN);
 
 export const isUnauthorizedMemberError = (error: Error) =>
-  error instanceof LedgerAPI4xx &&
+  error.name === "LedgerAPI4xx" &&
   (error.message.includes("Not a member of trustchain") ||
     error.message.includes("You are not member"));

--- a/libs/coin-modules/coin-aleo/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/sync.ts
@@ -272,7 +272,7 @@ export async function performPrivateSync({
     });
 
     // this error means that the current provableApi configuration is invalid and needs to be reset
-    if (err instanceof AleoApiConfigurationResetError) {
+    if ((err as { name?: string })?.name === "AleoApiConfigurationResetError") {
       throw err;
     }
 
@@ -602,7 +602,10 @@ export function createPrivateSyncObservable(
       .catch(err => {
         releaseLock();
 
-        if (err instanceof AleoApiConfigurationResetError && initialAccount?.aleoResources) {
+        if (
+          (err as { name?: string })?.name === "AleoApiConfigurationResetError" &&
+          initialAccount?.aleoResources
+        ) {
           // set `provableApi` to null before surfacing the error so the next sync cycle starts fresh re-registration
           subscriber.next({
             operations: initialAccount.operations,

--- a/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
@@ -101,7 +101,7 @@ export const createNewTransaction = async (
   log("debug", `Creating new Transaction: ${sender}, ${recipient}, ${network}`);
 
   if (recipient && !isAddressValid(recipient)) {
-    throw InvalidAddress(`Invalid recipient Address ${recipient}`);
+    throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
   const client = getCasperNodeRpcClient();

--- a/libs/coin-modules/coin-evm/src/logic/getBlock.ts
+++ b/libs/coin-modules/coin-evm/src/logic/getBlock.ts
@@ -10,7 +10,6 @@ import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { rpcTransactionToBlockOperations } from "../adapters/blockOperations";
 import { DEFAULT_INTERNAL_TX_SOURCES, getCoinConfig } from "../config";
-import { UnsupportedRpcMethodError } from "../errors";
 import { getNodeApi } from "../network/node";
 import { BlockReceiptInfo, PrefetchedBlockTransaction } from "../network/node/types";
 import { createInternalTransactionsFetcher } from "./internalTransactionsFetcher";
@@ -158,13 +157,14 @@ async function getTransactionsFromPrefetchedData(
 
     return transactions;
   } catch (error) {
-    if (!(error instanceof UnsupportedRpcMethodError) || error.method !== "eth_getBlockReceipts")
+    const err = error as { name?: string; method?: string; rawError?: unknown } | null | undefined;
+    if (err?.name !== "UnsupportedRpcMethodError" || err?.method !== "eth_getBlockReceipts")
       throw error;
 
     log("warn", "EVM getBlock fallback: eth_getBlockReceipts unsupported", {
       currencyId: currency.id,
       blockHeight,
-      error: error.rawError,
+      error: err?.rawError,
     });
     return null;
   }

--- a/libs/coin-modules/coin-evm/src/logic/internalTransactionsFetcher.ts
+++ b/libs/coin-modules/coin-evm/src/logic/internalTransactionsFetcher.ts
@@ -40,7 +40,7 @@ async function runInternalTxSources(
     try {
       return await fetchers[source](height);
     } catch (error) {
-      if (error instanceof SourceUnavailableError) {
+      if ((error as { name?: string })?.name === "SourceUnavailableError") {
         hadUnavailableSource = true;
         continue;
       }

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.ts
@@ -1,8 +1,6 @@
 import type { Balance } from "@ledgerhq/coin-module-framework/api/types";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import BigNumber from "bignumber.js";
 import { type HederaCoinConfig } from "../config";
-import { HederaAddAccountError } from "../errors";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2 } from "../network/utils";
 import type { HederaERC20TokenBalance, HederaMirrorToken } from "../types";
@@ -87,8 +85,10 @@ export async function getBalance({
 
     return [nativeBalance, ...tokenBalances];
   } catch (err) {
+    const errNamed = err as { name?: string; status?: number } | null | undefined;
     const isNonExistentAccount =
-      err instanceof HederaAddAccountError || (err instanceof LedgerAPI4xx && err.status === 404);
+      errNamed?.name === "HederaAddAccountError" ||
+      (errNamed?.name === "LedgerAPI4xx" && errNamed?.status === 404);
 
     if (isNonExistentAccount) {
       return [];

--- a/libs/coin-modules/coin-hedera/src/network/api.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import type { LiveNetworkResponse } from "@ledgerhq/live-network/network";
 import BigNumber from "bignumber.js";
@@ -45,7 +44,7 @@ async function getAccountsForPublicKey({
       url: `${config.apiUrls.mirrorNode}/api/v1/accounts?account.publicKey=${publicKey}&balance=true&limit=100`,
     });
   } catch (e: unknown) {
-    if (e instanceof LedgerAPI4xx) return [];
+    if ((e as { name?: string })?.name === "LedgerAPI4xx") return [];
     throw e;
   }
 
@@ -92,7 +91,10 @@ async function getAccount({
 
     return account;
   } catch (error) {
-    if (error instanceof LedgerAPI4xx && "status" in error && error.status === 404) {
+    if (
+      (error as { name?: string; status?: number })?.name === "LedgerAPI4xx" &&
+      (error as { status?: number })?.status === 404
+    ) {
       throw new HederaAddAccountError();
     }
 

--- a/libs/coin-modules/coin-mina/src/network/index.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI5xx } from "@ledgerhq/errors";
 import network from "@ledgerhq/live-network";
 import { log } from "@ledgerhq/logs";
 
@@ -53,14 +52,13 @@ const isAbortOrTimeoutError = (error: unknown): error is Error & { code?: string
 
 const RETRYABLE_HTTP_STATUS_CODES = new Set([502, 503, 504]);
 
-type LedgerAPI5xxInstance = InstanceType<typeof LedgerAPI5xx>;
-
 const isRetryableServerError = (
   error: unknown,
-): error is LedgerAPI5xxInstance & { status: number } =>
-  error instanceof LedgerAPI5xx &&
-  typeof (error as LedgerAPI5xxInstance & { status?: number }).status === "number" &&
-  RETRYABLE_HTTP_STATUS_CODES.has((error as LedgerAPI5xxInstance & { status: number }).status);
+): error is { name: string; message: string; status: number } =>
+  (error as { name?: string })?.name === "LedgerAPI5xx" &&
+  typeof (error as { message?: string }).message === "string" &&
+  typeof (error as { status?: number }).status === "number" &&
+  RETRYABLE_HTTP_STATUS_CODES.has((error as { status: number }).status);
 
 const backoffDelay = (attempt: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, attempt)));

--- a/libs/coin-modules/coin-solana/src/hw-signMessage.ts
+++ b/libs/coin-modules/coin-solana/src/hw-signMessage.ts
@@ -1,6 +1,5 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { Account, AnyMessage, DeviceId } from "@ledgerhq/types-live";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import bs58 from "bs58";
 import invariant from "invariant";
 import semver from "semver";
@@ -14,8 +13,8 @@ import { SolanaSigner } from "./signer";
 // Handles both DmkSignerSol (maps to typed errors) and LegacySignerSolana
 // (propagates raw TransportStatusError with a numeric statusCode).
 function isFormatRejection(err: unknown): boolean {
-  if (err instanceof UserRefusedOnDevice) return false;
-  if (err instanceof LockedDeviceError) return false;
+  if ((err as { name?: string })?.name === "UserRefusedOnDevice") return false;
+  if ((err as { name?: string })?.name === "LockedDeviceError") return false;
   // TransportStatusError duck-type: 0x6985 = user refused, 0x5515 = device locked
   if (err && typeof err === "object" && "statusCode" in err) {
     const { statusCode } = err as { statusCode: number };

--- a/libs/coin-modules/coin-solana/src/network/chain/index.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/index.ts
@@ -123,7 +123,7 @@ export type ChainAPI = Readonly<{
 
 // Naive mode, allow us to filter in sentry all this error coming from Sol RPC node
 const remapErrors = (e: unknown) => {
-  if (e instanceof NetworkError) {
+  if ((e as { name?: string })?.name === "NetworkError") {
     throw e;
   }
 

--- a/libs/ledger-live-common/src/families/evm/editTransaction/isTransactionConfirmed.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/isTransactionConfirmed.ts
@@ -1,4 +1,3 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
 import { getNodeApi } from "@ledgerhq/coin-evm/network/node/index";
 import type { AccountLike } from "@ledgerhq/types-live";
 
@@ -27,7 +26,8 @@ export const isTransactionConfirmed = async ({
     const { blockHeight = null } = await nodeApi.getTransaction(account.currency, hash);
     return blockHeight !== null;
   } catch (e: unknown) {
-    if (e instanceof LedgerAPI4xx && e.status === 404) {
+    const err = e as { name?: string; status?: number } | null | undefined;
+    if (err?.name === "LedgerAPI4xx" && err?.status === 404) {
       return false;
     }
     throw e;

--- a/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/onboarding/hooks/useOnboardingStatePolling.ts
@@ -144,6 +144,6 @@ const getNewAllowedErrorIfChanged = (
   prevError: Error | null,
   newError: Error | null,
 ): Error | null => {
-  // Only interested if the errors are instances of the same Error class
-  return prevError?.constructor === newError?.constructor ? prevError : newError;
+  // Only interested if the errors are of the same named class
+  return prevError?.name === newError?.name ? prevError : newError;
 };

--- a/libs/ledger-live-common/src/wallet-api/Exchange/handleSwapErrors.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/handleSwapErrors.ts
@@ -77,10 +77,6 @@ function extractErrorDetails(value: unknown): {
   message: string;
   cause?: SwapErrorCauseDetails;
 } {
-  if (value instanceof SwapError) {
-    return { message: value.message, cause: value.cause };
-  }
-
   if (value instanceof Error) {
     return {
       message: value.message,
@@ -131,12 +127,9 @@ export function handleErrors(error: unknown, options: ErrorHandlerOptions = {}):
     throw markErrorAsHandled(error);
   }
 
-  // Display error to user if handler provided
-  if (error instanceof SwapError && onDisplayError) {
-    // Skip displaying "swap003Ignored" errors
-    if (cause?.swapCode !== "swap003Ignored") {
-      void onDisplayError(error);
-    }
+  // Display error to user if handler provided (matches all SwapError subclasses via cause.swapCode)
+  if (onDisplayError && typeof cause?.swapCode === "string") {
+    void onDisplayError(error as SwapError);
   }
 
   // Always throw the error so caller can handle it
@@ -154,8 +147,7 @@ export function isHandledError(error: unknown): boolean {
  * Extracts swap code from error if available
  */
 export function getSwapCode(error: unknown): string | undefined {
-  if (error instanceof SwapError) {
-    return error.cause.swapCode;
-  }
-  return undefined;
+  if (!isRecord(error)) return undefined;
+  const cause = toCauseDetails((error as { cause?: unknown }).cause);
+  return cause?.swapCode;
 }

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -24,7 +24,6 @@ import {
   setWalletApiIdForAccountId,
   resolveWalletApiSpendableBalance,
 } from "./converters";
-import { AccountPublicKeyUnavailable } from "../errors";
 import { isWalletAPISupportedCurrency } from "./helpers";
 import {
   WalletAPICurrency,
@@ -1257,14 +1256,10 @@ export function useWalletAPIServer({
       try {
         return await accountGetPublicKeyLogic({ manifest, accounts, tracking }, accountId);
       } catch (error) {
-        // Surface a native message, then let the RPC reject as before. Match by name (not just
-        // instanceof, per createCustomErrorClass) so it holds even if the error loses its
-        // prototype (e.g. serialized to a plain object across a transport).
+        // Surface a native message, then let the RPC reject as before. Match by name so it holds
+        // even if the error loses its prototype (e.g. serialized across a transport).
         const isPublicKeyUnavailable =
-          error instanceof AccountPublicKeyUnavailable ||
-          (typeof error === "object" &&
-            error !== null &&
-            (error as { name?: unknown }).name === "AccountPublicKeyUnavailable");
+          (error as { name?: string } | null | undefined)?.name === "AccountPublicKeyUnavailable";
         if (isPublicKeyUnavailable && uiAccountPublicKeyUnavailable) {
           try {
             const localAccountId = getAccountIdFromWalletAccountId(accountId);


### PR DESCRIPTION
### 📝 Description

Replace every `instanceof SomeError` guard with an equivalent `.name` string check, covering gaps and files not owned by any specific team.

**Before:**
```ts
if (e instanceof NetworkError) { ... }
```

**After:**
```ts
if ((e as { name?: string }).name === "NetworkError") { ... }
```

**Why?** Decouples error identity from class reference — makes errors matchable across serialization/deserialization boundaries and paves the way for dropping `@ledgerhq/errors`.

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **Big picture**: #19761

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35083