### PR TITLE
chore(wallet-framework): break cyclic devDependency on wallet-framework-test-setup

### DIFF
--- a/libs/ledger-wallet-framework/jest.config.js
+++ b/libs/ledger-wallet-framework/jest.config.js
@@ -15,7 +15,13 @@ module.exports = {
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],
-  setupFilesAfterEnv: ["<rootDir>/src/setup.ts", "@ledgerhq/wallet-framework-test-setup"],
+  // wallet-framework-test-setup wires domain data into the framework's ports at test time.
+  // Loaded by relative path (not as a package dep) so the public framework carries no
+  // package.json edge back to it — that edge is what nx flags as a cyclic dependency.
+  setupFilesAfterEnv: [
+    "<rootDir>/src/setup.ts",
+    "<rootDir>/../wallet-framework-test-setup/src/index.js",
+  ],
   testEnvironment: "node",
   moduleNameMapper: {
     "^@ledgerhq/ledger-wallet-framework/(.*)$": "<rootDir>/src/$1",

--- a/libs/ledger-wallet-framework/package.json
+++ b/libs/ledger-wallet-framework/package.json
@@ -111,7 +111,6 @@
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:^",
-    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@ledgerhq/hw-transport-node-speculos": "workspace:^",
     "@types/imurmurhash": "^0.1.4",
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9687,9 +9687,6 @@ importers:
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:^
         version: link:../live-dmk-speculos
-      '@ledgerhq/wallet-framework-test-setup':
-        specifier: workspace:^
-        version: link:../wallet-framework-test-setup
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
## What

Breaks the cyclic dependency nx flags between `@ledgerhq/ledger-wallet-framework` and `@ledgerhq/wallet-framework-test-setup`.

## Why

`wallet-framework-test-setup` is the private, test-time composition root that wires `@domain/entity-currency-crypto` data into the framework's injectable ports (`setCurrenciesResolver` / `setCryptoAssetsStore`) — necessary because the **public** framework cannot depend on `@domain/*` itself. It therefore depends on the framework to call those setters.

The framework consumed it back only through jest `setupFilesAfterEnv`, which forced a `devDependency` and closed the loop. The test-setup → framework edge is a real import that must stay, so the cycle is broken on the framework side.

## How

- Drop the `@ledgerhq/wallet-framework-test-setup` devDependency from `libs/ledger-wallet-framework/package.json` (the package.json edge nx flags).
- Load the bootstrap by relative path in `jest.config.js`: `"<rootDir>/../wallet-framework-test-setup/src/index.js"`.

Same bootstrap runs; no package edge → no cycle. `wallet-framework-test-setup` is unchanged and its other consumers (coin-modules, apps) are unaffected.

## Verification

- `@ledgerhq/ledger-wallet-framework` unit tests green (260/260, including the derivation/account/nft-fixture suites that use the injected resolver — proves the relative-path bootstrap resolves).
- `pnpm install --frozen-lockfile` passes; lockfile diff is 3 lines (only the framework's importer entry).

## Changeset

None — devDependency + jest config only; no change to the published package artifact.