### PR TITLE
[LWDM] chore(live-network): decouple from @ledgerhq/live-env via local state singleton

### DIFF
--- a/.changeset/live-network-decouple-live-env.md
+++ b/.changeset/live-network-decouple-live-env.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-network": minor
+---
+
+Decouple from `@ledgerhq/live-env` via local state singleton. Network configuration (timeouts, log flags, client version) is now managed via `setNetworkState()` and defaults to the previous env var values. Consumers in the monorepo call `bridgeEnvToNetworkState()` from `@ledgerhq/live-common/network/setup` at boot. External consumers get sensible defaults with no setup required.

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -1,4 +1,5 @@
 import { EnvName, setEnv, setEnvUnsafe, getEnv } from "@ledgerhq/live-env";
+import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { listen } from "@ledgerhq/logs";
 import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
@@ -66,5 +67,6 @@ if (process.env.VERBOSE) {
 
 const value = "cli/0.0.0";
 setEnv("LEDGER_CLIENT_VERSION", value);
+bridgeEnvToNetworkState();
 
 BigNumber.set({ DECIMAL_PLACES: getEnv("BIG_NUMBER_DECIMAL_PLACES") });

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -1,5 +1,6 @@
 import os from "os";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
+import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
 import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
@@ -35,6 +36,7 @@ if (process.env.NODE_ENV !== "production") {
 setEnv("LEDGER_CLIENT_VERSION", ledgerClientVersion);
 
 process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
+bridgeEnvToNetworkState();
 
 liveBlindSigningReporter.setContext({
   platform: "desktop",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -2,6 +2,7 @@ import Config from "react-native-config";
 import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-coins";
 import { listen } from "@ledgerhq/logs";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
+import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { setDeviceMode } from "@ledgerhq/live-common/hw/actions/app";
@@ -68,6 +69,7 @@ if (process.env.NODE_ENV !== "production") {
 
 setEnv("LEDGER_CLIENT_VERSION", ledgerClientVersion);
 process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
+bridgeEnvToNetworkState();
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 setSecp256k1Instance(require("./logic/secp256k1"));

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -6,6 +6,7 @@ import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { setEnv, getEnv } from "@ledgerhq/live-env";
+import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { registerWalletCliDmkTransport } from "./device/register-dmk-transport";
 import {
   getCryptoCurrencyById,
@@ -29,6 +30,7 @@ if (!process.env.USER_ID) {
 const ledgerClientVersion = `wallet-cli/${pkg.version}`;
 setEnv("LEDGER_CLIENT_VERSION", ledgerClientVersion);
 process.env.LEDGER_CLIENT_VERSION = ledgerClientVersion;
+bridgeEnvToNetworkState();
 
 /**
  * Wallet-cli-specific coin-module loaders (bitcoin, evm, solana only).

--- a/apps/web-tools/src/live-common-setup-network.ts
+++ b/apps/web-tools/src/live-common-setup-network.ts
@@ -1,3 +1,5 @@
 import { setEnv } from "@ledgerhq/live-env";
+import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 
 setEnv("LEDGER_CLIENT_VERSION", "ll-web-tools/0.0.0");
+bridgeEnvToNetworkState();

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
@@ -6,11 +6,13 @@ import { createSpeculosDevice, releaseSpeculosDevice } from "@ledgerhq/speculos-
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { crypto, TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { setNetworkState } from "@ledgerhq/live-network";
 import { RecorderConfig, ScenarioOptions, genSeed, recorderConfigDefaults } from "./types";
 import { getSdk } from "../../src";
 import { WithDevice } from "../../src/types";
 
 setEnv("GET_CALLS_RETRY", 0);
+setNetworkState({ getCallsRetry: 0 });
 
 export async function recordTestTrustchainSdk(
   file: string | null,

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
@@ -3,11 +3,13 @@ import { setupServer } from "msw/node";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
 import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { setNetworkState } from "@ledgerhq/live-network";
 import { ScenarioOptions } from "./types";
 import { getSdk } from "../../src";
 import { WithDevice } from "../../src/types";
 
 setEnv("GET_CALLS_RETRY", 0);
+setNetworkState({ getCallsRetry: 0 });
 
 /**
  * Volatile headers added by Node.js or MSW that vary between versions.

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -263,6 +263,7 @@
     "src/mock/account.ts",
     "src/mock/helpers.ts",
     "src/network-troubleshooting/index.ts",
+    "src/network/setup.ts",
     "src/notifications/ServiceStatusProvider/index.tsx",
     "src/notifications/ServiceStatusProvider/types.ts",
     "src/notifications/ToastProvider/index.tsx",

--- a/libs/ledger-live-common/src/network/setup.test.ts
+++ b/libs/ledger-live-common/src/network/setup.test.ts
@@ -1,0 +1,92 @@
+import { getEnv, changes } from "@ledgerhq/live-env";
+import { setNetworkState } from "@ledgerhq/live-network";
+import { bridgeEnvToNetworkState } from "./setup";
+
+const mockUnsubscribe = jest.fn();
+const mockSubscribe = jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe });
+
+jest.mock("@ledgerhq/live-env", () => ({
+  getEnv: jest.fn().mockImplementation((name: string) => {
+    const envValues: Record<string, unknown> = {
+      ENABLE_NETWORK_LOGS: false,
+      DEBUG_HTTP_RESPONSE: true,
+      LEDGER_CLIENT_VERSION: "desktop/1.0",
+      GET_CALLS_TIMEOUT: 30000,
+      GET_CALLS_RETRY: 1,
+    };
+    return envValues[name];
+  }),
+  changes: { subscribe: (...args: unknown[]) => mockSubscribe(...args) },
+}));
+
+jest.mock("@ledgerhq/live-network", () => ({
+  setNetworkState: jest.fn(),
+}));
+
+const mockedSetNetworkState = jest.mocked(setNetworkState);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("bridgeEnvToNetworkState", () => {
+  test("should bridge initial env state to network state", () => {
+    bridgeEnvToNetworkState();
+
+    expect(mockedSetNetworkState).toHaveBeenCalledWith({
+      enableNetworkLogs: getEnv("ENABLE_NETWORK_LOGS"),
+      debugHttpResponse: getEnv("DEBUG_HTTP_RESPONSE"),
+      ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+      getCallsTimeout: getEnv("GET_CALLS_TIMEOUT"),
+      getCallsRetry: getEnv("GET_CALLS_RETRY"),
+    });
+  });
+
+  test("should subscribe to env changes", () => {
+    bridgeEnvToNetworkState();
+    expect(mockSubscribe).toHaveBeenCalled();
+  });
+
+  test("should update network state on ENABLE_NETWORK_LOGS change", () => {
+    bridgeEnvToNetworkState();
+    const [subscriber] = mockSubscribe.mock.calls[0];
+    subscriber({ name: "ENABLE_NETWORK_LOGS", value: true });
+    expect(mockedSetNetworkState).toHaveBeenLastCalledWith({ enableNetworkLogs: true });
+  });
+
+  test("should update network state on DEBUG_HTTP_RESPONSE change", () => {
+    bridgeEnvToNetworkState();
+    const [subscriber] = mockSubscribe.mock.calls[0];
+    subscriber({ name: "DEBUG_HTTP_RESPONSE", value: false });
+    expect(mockedSetNetworkState).toHaveBeenLastCalledWith({ debugHttpResponse: false });
+  });
+
+  test("should update network state on LEDGER_CLIENT_VERSION change", () => {
+    bridgeEnvToNetworkState();
+    const [subscriber] = mockSubscribe.mock.calls[0];
+    subscriber({ name: "LEDGER_CLIENT_VERSION", value: "wallet-cli/2.0" });
+    expect(mockedSetNetworkState).toHaveBeenLastCalledWith({
+      ledgerClientVersion: "wallet-cli/2.0",
+    });
+  });
+
+  test("should update network state on GET_CALLS_TIMEOUT change", () => {
+    bridgeEnvToNetworkState();
+    const [subscriber] = mockSubscribe.mock.calls[0];
+    subscriber({ name: "GET_CALLS_TIMEOUT", value: 90000 });
+    expect(mockedSetNetworkState).toHaveBeenLastCalledWith({ getCallsTimeout: 90000 });
+  });
+
+  test("should update network state on GET_CALLS_RETRY change", () => {
+    bridgeEnvToNetworkState();
+    const [subscriber] = mockSubscribe.mock.calls[0];
+    subscriber({ name: "GET_CALLS_RETRY", value: 3 });
+    expect(mockedSetNetworkState).toHaveBeenLastCalledWith({ getCallsRetry: 3 });
+  });
+
+  test("should return a function that unsubscribes from env changes", () => {
+    const unsubscribe = bridgeEnvToNetworkState();
+    unsubscribe();
+    expect(mockUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-live-common/src/network/setup.ts
+++ b/libs/ledger-live-common/src/network/setup.ts
@@ -1,0 +1,39 @@
+import { getEnv, changes } from "@ledgerhq/live-env";
+import { setNetworkState } from "@ledgerhq/live-network";
+
+/**
+ * Bridges live-env configuration into live-network's local state.
+ * Call once at app boot, after LEDGER_CLIENT_VERSION is set.
+ * Returns an unsubscribe function.
+ */
+export function bridgeEnvToNetworkState(): () => void {
+  setNetworkState({
+    enableNetworkLogs: getEnv("ENABLE_NETWORK_LOGS"),
+    debugHttpResponse: getEnv("DEBUG_HTTP_RESPONSE"),
+    ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
+    getCallsTimeout: getEnv("GET_CALLS_TIMEOUT"),
+    getCallsRetry: getEnv("GET_CALLS_RETRY"),
+  });
+
+  const subscription = changes.subscribe(({ name, value }) => {
+    switch (name) {
+      case "ENABLE_NETWORK_LOGS":
+        setNetworkState({ enableNetworkLogs: value as boolean });
+        break;
+      case "DEBUG_HTTP_RESPONSE":
+        setNetworkState({ debugHttpResponse: value as boolean });
+        break;
+      case "LEDGER_CLIENT_VERSION":
+        setNetworkState({ ledgerClientVersion: value as string });
+        break;
+      case "GET_CALLS_TIMEOUT":
+        setNetworkState({ getCallsTimeout: value as number });
+        break;
+      case "GET_CALLS_RETRY":
+        setNetworkState({ getCallsRetry: value as number });
+        break;
+    }
+  });
+
+  return () => subscription.unsubscribe();
+}

--- a/libs/live-network/package.json
+++ b/libs/live-network/package.json
@@ -68,16 +68,18 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/errors": "workspace:^",
-    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-promise": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
-    "axios": "catalog:",
     "lru-cache": "^7.14.1"
+  },
+  "peerDependencies": {
+    "axios": "catalog:"
   },
   "devDependencies": {
     "@types/invariant": "^2.2.35",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "axios": "catalog:",
     "jest": "catalog:",
     "@swc/jest": "catalog:",
     "@swc/core": "catalog:"

--- a/libs/live-network/src/index.ts
+++ b/libs/live-network/src/index.ts
@@ -1,2 +1,5 @@
 import { newImplementation } from "./network";
+export { setNetworkState } from "./network";
+export { getNetworkState } from "./state";
+export type { NetworkState } from "./network";
 export default newImplementation;

--- a/libs/live-network/src/network.test.ts
+++ b/libs/live-network/src/network.test.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosHeaders } from "axios";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
-import network, { requestInterceptor, responseInterceptor } from "./network";
+import { getNetworkState } from "./state";
+import network, { requestInterceptor, responseInterceptor, setNetworkState } from "./network";
 import * as logs from "@ledgerhq/logs";
 
 jest.mock("axios");
@@ -8,22 +8,21 @@ jest.mock("axios");
 const mockedAxios = jest.mocked(axios);
 
 describe("network", () => {
-  const DEFAULT_ENABLE_NETWORK_LOGS = getEnv("ENABLE_NETWORK_LOGS");
-  const DEFAULT_GET_CALLS_RETRY = getEnv("GET_CALLS_RETRY");
-  const DEFAULT_LEDGER_CLIENT_VERSION = getEnv("LEDGER_CLIENT_VERSION");
+  const DEFAULT_STATE = {
+    enableNetworkLogs: getNetworkState().enableNetworkLogs,
+    debugHttpResponse: getNetworkState().debugHttpResponse,
+    ledgerClientVersion: getNetworkState().ledgerClientVersion,
+    getCallsTimeout: getNetworkState().getCallsTimeout,
+    getCallsRetry: getNetworkState().getCallsRetry,
+  };
 
   afterEach(() => {
-    // restore the spy created with spyOn
-    jest.restoreAllMocks();
     jest.clearAllMocks();
-
-    // Restore DEFAULT_ENABLE_NETWORK_LOGS
-    setEnv("ENABLE_NETWORK_LOGS", DEFAULT_ENABLE_NETWORK_LOGS);
-    setEnv("LEDGER_CLIENT_VERSION", DEFAULT_LEDGER_CLIENT_VERSION);
+    setNetworkState(DEFAULT_STATE);
   });
 
   describe("requestInterceptor", () => {
-    test("should return provided request when ENABLE_NETWORK_LOGS is false", () => {
+    test("should return provided request unchanged when network logs are disabled", () => {
       const request = {
         baseURL: "baseURL",
         url: "url",
@@ -34,8 +33,8 @@ describe("network", () => {
       expect(req).toEqual(request);
     });
 
-    test("should return provided request with metadata when ENABLE_NETWORK_LOGS is true", () => {
-      setEnv("ENABLE_NETWORK_LOGS", true);
+    test("should attach request metadata when network logs are enabled", () => {
+      setNetworkState({ enableNetworkLogs: true });
 
       const request = {
         baseURL: "baseURL",
@@ -50,10 +49,10 @@ describe("network", () => {
       });
     });
 
-    test("should call log when ENABLE_NETWORK_LOGS is true", () => {
+    test("should call log when network logs are enabled", () => {
       const spy = jest.spyOn(logs, "log");
 
-      setEnv("ENABLE_NETWORK_LOGS", true);
+      setNetworkState({ enableNetworkLogs: true });
 
       const request = {
         baseURL: "baseURL",
@@ -68,7 +67,7 @@ describe("network", () => {
   });
 
   describe("responseInterceptor", () => {
-    test("should return provided response when ENABLE_NETWORK_LOGS is false", () => {
+    test("should return provided response unchanged when network logs are disabled", () => {
       const response = {
         config: {
           baseURL: "baseURL",
@@ -85,8 +84,8 @@ describe("network", () => {
       expect(res).toEqual(response);
     });
 
-    test("should return provided response when ENABLE_NETWORK_LOGS is true", () => {
-      setEnv("ENABLE_NETWORK_LOGS", true);
+    test("should return provided response when network logs are enabled", () => {
+      setNetworkState({ enableNetworkLogs: true });
 
       const response = {
         config: {
@@ -104,10 +103,10 @@ describe("network", () => {
       expect(res).toEqual(response);
     });
 
-    test("should call log when ENABLE_NETWORK_LOGS is true", () => {
+    test("should call log when network logs are enabled", () => {
       const spy = jest.spyOn(logs, "log");
 
-      setEnv("ENABLE_NETWORK_LOGS", true);
+      setNetworkState({ enableNetworkLogs: true });
 
       const response = {
         config: {
@@ -148,7 +147,7 @@ describe("network", () => {
         });
         // eslint-disable-next-line no-empty
       } catch {}
-      expect(mockedAxios).toHaveBeenCalledTimes(DEFAULT_GET_CALLS_RETRY + 1);
+      expect(mockedAxios).toHaveBeenCalledTimes(DEFAULT_STATE.getCallsRetry + 1);
     });
 
     test("should not retry request when response status is 422", async () => {
@@ -178,15 +177,15 @@ describe("network", () => {
 
   describe("ledger client version headers", () => {
     test("should set ledger client version as axios client headers", () => {
-      setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.1");
+      setNetworkState({ ledgerClientVersion: "wallet-cli/0.1.1" });
 
       expect(axios.defaults.headers.common["X-Ledger-Client-Version"]).toBe("wallet-cli/0.1.1");
       expect(axios.defaults.headers.common["User-Agent"]).toBe("wallet-cli/0.1.1");
     });
 
-    test("should clear ledger client version headers when env is empty", () => {
-      setEnv("LEDGER_CLIENT_VERSION", "wallet-cli/0.1.1");
-      setEnv("LEDGER_CLIENT_VERSION", "");
+    test("should clear ledger client version headers when ledgerClientVersion is empty", () => {
+      setNetworkState({ ledgerClientVersion: "wallet-cli/0.1.1" });
+      setNetworkState({ ledgerClientVersion: "" });
 
       expect(axios.defaults.headers.common["X-Ledger-Client-Version"]).toBeUndefined();
       expect(axios.defaults.headers.common["User-Agent"]).toBeUndefined();

--- a/libs/live-network/src/network.ts
+++ b/libs/live-network/src/network.ts
@@ -6,7 +6,8 @@ import axios, {
   type AxiosRequestConfig,
 } from "axios";
 import { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "@ledgerhq/errors";
-import { changes, getEnv } from "@ledgerhq/live-env";
+import { getNetworkState } from "./state";
+import type { NetworkState } from "./state";
 import { retry } from "@ledgerhq/live-promise";
 import { log } from "@ledgerhq/logs";
 
@@ -16,7 +17,7 @@ type ExtendedAxiosRequestConfig = InternalAxiosRequestConfig & { metadata?: Meta
 export const requestInterceptor = (
   request: ExtendedAxiosRequestConfig,
 ): ExtendedAxiosRequestConfig => {
-  if (!getEnv("ENABLE_NETWORK_LOGS")) {
+  if (!getNetworkState().enableNetworkLogs) {
     return request;
   }
 
@@ -33,7 +34,7 @@ export const requestInterceptor = (
 type ExtendedAxiosResponse = AxiosResponse & { config: { metadata?: Metadata } };
 
 export const responseInterceptor = (response: ExtendedAxiosResponse): ExtendedAxiosResponse => {
-  if (!getEnv("ENABLE_NETWORK_LOGS")) {
+  if (!getNetworkState().enableNetworkLogs) {
     return response;
   }
 
@@ -91,7 +92,7 @@ export const errorInterceptor = (error: InterceptedError): InterceptedError => {
     log(
       "network-error",
       `${status} ${method} ${baseURL || ""}${url} (${duration}): ${errorToThrow.message}`,
-      getEnv("DEBUG_HTTP_RESPONSE") ? { data: data } : {},
+      getNetworkState().debugHttpResponse ? { data: data } : {},
     );
     throw errorToThrow;
   } else if (error.request) {
@@ -105,10 +106,13 @@ axios.interceptors.request.use(requestInterceptor);
 axios.interceptors.response.use(responseInterceptor, errorInterceptor);
 
 /**
- * We only allow HTTPS agent on platforms other than LLM because
- * https library is not compatible with react native
+ * Only enable HTTPS keepAlive on Node.js (excludes React Native / browser) and
+ * for non-LLM builds (llm- prefix = Ledger Live Mobile client version).
  */
-const NETWORK_USE_HTTPS_KEEP_ALIVE = !getEnv("LEDGER_CLIENT_VERSION")?.startsWith("llm-");
+const NETWORK_USE_HTTPS_KEEP_ALIVE =
+  typeof process !== "undefined" &&
+  process.release?.name === "node" &&
+  !getNetworkState().ledgerClientVersion?.startsWith("llm-");
 if (NETWORK_USE_HTTPS_KEEP_ALIVE) {
   // the keepAlive is necessary when we make a lot of request in in parallel, especially for bitcoin sync. Otherwise, it may raise "connect ETIMEDOUT" error
   // this should only be needed in Windows as UNIX systems reuse TCP packets by default
@@ -197,11 +201,11 @@ export const newImplementation = async <T = unknown, U = unknown>(
 
   if (request.method === "GET") {
     if (!("timeout" in request)) {
-      request.timeout = getEnv("GET_CALLS_TIMEOUT");
+      request.timeout = getNetworkState().getCallsTimeout;
     }
 
     response = await retry(() => axios(request), {
-      maxRetry: getEnv("GET_CALLS_RETRY"),
+      maxRetry: getNetworkState().getCallsRetry,
       retryCondition: error => {
         if (error && error.status) {
           // not all status codes are retryable
@@ -230,11 +234,11 @@ const implementation = <T = any>(arg: AxiosRequestConfig): AxiosPromise<T> => {
 
   if (arg.method === "GET") {
     if (!("timeout" in arg)) {
-      arg.timeout = getEnv("GET_CALLS_TIMEOUT");
+      arg.timeout = getNetworkState().getCallsTimeout;
     }
 
     promise = retry(() => axios(arg), {
-      maxRetry: getEnv("GET_CALLS_RETRY"),
+      maxRetry: getNetworkState().getCallsRetry,
       retryCondition: error => {
         if (error && error.status) {
           // A 422 shouldn't be retried without change as explained in this documentation
@@ -270,11 +274,20 @@ function setAxiosLedgerClientVersionHeader(value: string) {
     }
   }
 }
-setAxiosLedgerClientVersionHeader(getEnv("LEDGER_CLIENT_VERSION"));
-changes.subscribe(e => {
-  if (e.name === "LEDGER_CLIENT_VERSION") {
-    setAxiosLedgerClientVersionHeader(e.value);
+setAxiosLedgerClientVersionHeader(getNetworkState().ledgerClientVersion);
+
+export function setNetworkState(partial: Partial<NetworkState>): void {
+  const state = getNetworkState() as NetworkState;
+  if (partial.enableNetworkLogs !== undefined) state.enableNetworkLogs = partial.enableNetworkLogs;
+  if (partial.debugHttpResponse !== undefined) state.debugHttpResponse = partial.debugHttpResponse;
+  if (partial.ledgerClientVersion !== undefined) {
+    state.ledgerClientVersion = partial.ledgerClientVersion;
+    setAxiosLedgerClientVersionHeader(partial.ledgerClientVersion);
   }
-});
+  if (partial.getCallsTimeout !== undefined) state.getCallsTimeout = partial.getCallsTimeout;
+  if (partial.getCallsRetry !== undefined) state.getCallsRetry = partial.getCallsRetry;
+}
+
+export type { NetworkState };
 
 export default implementation;

--- a/libs/live-network/src/state.ts
+++ b/libs/live-network/src/state.ts
@@ -1,0 +1,28 @@
+type NetworkState = {
+  enableNetworkLogs: boolean;
+  debugHttpResponse: boolean;
+  ledgerClientVersion: string;
+  getCallsTimeout: number;
+  getCallsRetry: number;
+};
+
+declare global {
+  interface GlobalThis {
+    __ledgerLiveNetworkState?: NetworkState;
+  }
+}
+
+const defaults: NetworkState = {
+  enableNetworkLogs: false,
+  debugHttpResponse: false,
+  ledgerClientVersion: "",
+  getCallsTimeout: 60 * 1000,
+  getCallsRetry: 2,
+};
+
+export function getNetworkState(): Readonly<NetworkState> {
+  globalThis.__ledgerLiveNetworkState ??= { ...defaults };
+  return globalThis.__ledgerLiveNetworkState;
+}
+
+export type { NetworkState };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4371,12 +4371,12 @@ importers:
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-test-renderer:
-        specifier: 'catalog:'
-        version: 19.1.4(react@19.1.4)
       react-redux:
         specifier: 'catalog:'
         version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.4.0
@@ -12045,18 +12045,12 @@ importers:
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       '@ledgerhq/live-promise':
         specifier: workspace:^
         version: link:../promise
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../ledgerjs/packages/logs
-      axios:
-        specifier: 'catalog:'
-        version: 1.13.5
       lru-cache:
         specifier: ^7.14.1
         version: 7.18.3
@@ -12076,6 +12070,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      axios:
+        specifier: 'catalog:'
+        version: 1.13.5
       jest:
         specifier: 'catalog:'
         version: 30.2.0(@types/node@24.12.0)


### PR DESCRIPTION

### 📝 Description

`@ledgerhq/live-network` previously imported `getEnv` and `changes` from `@ledgerhq/live-env` at both module-load and per-request time. This prevents external consumers of `live-network` from using it without first calling `injectDefinitions()` (introduced in the companion PR that decouples definitions from the `live-env` framework).

**Changes:**

- **`libs/live-network/src/state.ts`** (new) — `globalThis.__ledgerLiveNetworkState` singleton, same pattern as `libs/env/src/state.ts`. Exposes `getNetworkState()` / `setNetworkState()` with defaults matching the previous `envDefinitions` values.
- **`libs/live-network/src/network.ts`** — all `getEnv(...)` calls replaced with `getNetworkState().x`; `changes.subscribe(...)` removed; `setNetworkState()` is wrapped here to also re-apply the axios `X-Ledger-Client-Version` header side-effect.
- **`libs/live-network/package.json`** — `@ledgerhq/live-env` removed from `dependencies`; `axios` moved from `dependencies` → `peerDependencies` (+ `devDependencies`) to avoid duplicate instances that would break interceptor sharing across the monorepo.
- **`libs/ledger-live-common/src/network/setup.ts`** (new) — `bridgeNetworkStateToEnv()` function: reads the current env values, applies them to network state, then subscribes to `changes` to keep them in sync for the lifetime of the process. **in Future, this will be moved in `features/platform/env/` in #19747**
- **App setup files** (desktop, mobile, CLI, wallet-cli, web-tools) — each calls `bridgeNetworkStateToEnv()` after `setEnv("LEDGER_CLIENT_VERSION", ...)`.

**Consumer API:**
```ts
// External consumers — zero setup, sensible defaults apply:
import network from "@ledgerhq/live-network";
await network({ url: "https://..." });

// Or override specific values:
import { setNetworkState } from "@ledgerhq/live-network";
setNetworkState({ ledgerClientVersion: "my-app/1.0.0" });
```


### Future note

- Once [#19747](https://github.com/LedgerHQ/ledger-live/pull/19747) lands, move `libs/ledger-live-common/src/network/setup.ts` into `features/platform/env/` (the platform env bridge layer introduced by that PR is the natural home for this wiring).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32919](https://ledgerhq.atlassian.net/browse/LIVE-32919)

[LIVE-32919]: https://ledgerhq.atlassian.net/browse/LIVE-32919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ