### PR TITLE
[LWDM] chore(llc): consume `validateAddress` through `CoinModuleApi` instance

### DIFF
--- a/.changeset/fifty-bananas-float.md
+++ b/.changeset/fifty-bananas-float.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-cardano": patch
+"@ledgerhq/live-common": patch
+"@ledgerhq/wallet-cli": patch
+---
+
+chore(llc): consume `validateAddress` through `CoinModuleApi` instance

--- a/apps/wallet-cli/src/live-common-setup.ts
+++ b/apps/wallet-cli/src/live-common-setup.ts
@@ -64,8 +64,6 @@ const walletCliLoaders: CoinModuleLoader[] = [
       import("@ledgerhq/live-common/families/evm/walletApiAdapter").then(m => m.default),
     loadPlatformAdapter: () =>
       import("@ledgerhq/live-common/families/evm/platformAdapter").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-evm/logic/validateAddress").then(m => m.validateAddress),
     loadSigner: () => import("@ledgerhq/live-common/families/evm/signer").then(m => m.default),
     loadBridgeApi: () =>
       import("@ledgerhq/live-common/families/evm/bridge/api").then(m => m.default),

--- a/libs/coin-modules/coin-cardano/src/api/index.ts
+++ b/libs/coin-modules/coin-cardano/src/api/index.ts
@@ -17,7 +17,6 @@ import type {
   TransactionIntent,
   TransactionValidation,
   Validator,
-  AddressValidationCurrencyParameters,
 } from "@ledgerhq/coin-module-framework/api/index";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
 import { craftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
@@ -32,6 +31,7 @@ import { getStakes } from "../logic/getStakes";
 import { getValidators } from "../logic/getValidators";
 import { lastBlock } from "../logic/lastBlock";
 import { listOperations } from "../logic/listOperations";
+import { validateAddress } from "../logic/validateAddress";
 import { validateIntent } from "../logic/validateIntent";
 
 export function createApi(config: CardanoConfig, currencyId: string): CoinModuleApi<StringMemo> {
@@ -89,12 +89,7 @@ export function createApi(config: CardanoConfig, currencyId: string): CoinModule
     getNextSequence: (_address: string): Promise<bigint> => {
       throw new Error("getNextSequence is not applicable for Cardano");
     },
-    validateAddress: (
-      _address: string,
-      _parameters: Partial<AddressValidationCurrencyParameters>,
-    ): Promise<boolean> => {
-      throw new Error("validateAddress is not supported");
-    },
+    validateAddress,
     craftTransactionData,
   };
 }

--- a/libs/coin-modules/coin-cardano/src/api/validateAddress.test.ts
+++ b/libs/coin-modules/coin-cardano/src/api/validateAddress.test.ts
@@ -1,12 +1,32 @@
 import { createApi } from ".";
 import { type CardanoConfig } from "../config";
+import { validateAddress } from "../logic/validateAddress";
+
+jest.mock("../logic/validateAddress");
+const mockValidateAddress = jest.mocked(validateAddress);
 
 const config: CardanoConfig = { maxFeesWarning: 0, maxFeesError: 0 };
 
 describe("validateAddress", () => {
-  it("throws an unsupported error", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([true, false])("delegates to logic validateAddress and returns %s", async expected => {
+    mockValidateAddress.mockResolvedValue(expected);
+
+    const api = createApi(config, "cardano");
+    const result = await api.validateAddress("addr1...", {});
+
+    expect(result).toBe(expected);
+    expect(mockValidateAddress).toHaveBeenCalledWith("addr1...", {});
+  });
+
+  it("propagates errors from logic validateAddress", async () => {
+    mockValidateAddress.mockRejectedValue(new Error("boom"));
+
     const api = createApi(config, "cardano");
 
-    expect(() => api.validateAddress("address", {})).toThrow("validateAddress is not supported");
+    await expect(api.validateAddress("addr1...", {})).rejects.toThrow("boom");
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
@@ -16,7 +16,7 @@ import { genericBroadcast } from "./broadcast";
 import { genericSignOperation } from "./signOperation";
 import { genericSignRawOperation } from "./signRawOperation";
 import { postSync } from "./postSync";
-import { getValidateAddress } from "./validateAddress";
+import { genericValidateAddress } from "./validateAddress";
 import { getAccountRawAssignHooks } from "./accountRawAssign";
 import type { GenericTransaction, CoinFrameworkSigner } from "./types";
 
@@ -27,7 +27,6 @@ export async function getCoinFrameworkAccountBridge(
 ): Promise<AccountBridge<GenericTransaction>> {
   const signer = customSigner ?? (await getSigner(network));
   const { assignFromAccountRaw, assignToAccountRaw } = await getAccountRawAssignHooks(network);
-  const validateAddress = await getValidateAddress(network);
   return {
     sync: makeSync({ getAccountShape: genericGetAccountShape(network, kind), postSync }),
     receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress)),
@@ -42,6 +41,6 @@ export async function getCoinFrameworkAccountBridge(
     assignFromAccountRaw,
     assignToAccountRaw,
     getSerializedAddressParameters, // NOTE: check whether it should be exposed by coin-module's api instead?
-    validateAddress,
+    validateAddress: genericValidateAddress(network, kind),
   } satisfies Partial<AccountBridge<GenericTransaction>>;
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/validateAddress.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/validateAddress.test.ts
@@ -1,17 +1,48 @@
-import { getValidateAddress } from "./validateAddress";
+import { genericValidateAddress } from "./validateAddress";
 
-describe("validateAddress", () => {
-  it.each(["evm", "stellar", "tezos", "xrp", "ripple"])(
-    "returns address validation for '%s' network",
-    async network => {
-      const fn = await getValidateAddress(network);
-      expect(fn).toBeInstanceOf(Function);
-    },
-  );
+const mockValidateAddress = jest.fn();
+const mockGetCoinModuleApi = jest.fn();
 
-  it("fails on unknown network", async () => {
-    await expect(getValidateAddress("unknown-network")).rejects.toThrow(
-      "No validate address function for network unknown-network",
+jest.mock("./api", () => ({
+  getCoinModuleApi: (...a: any[]) => mockGetCoinModuleApi(...a),
+}));
+
+describe("genericValidateAddress", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCoinModuleApi.mockResolvedValue({
+      validateAddress: (...a: any[]) => mockValidateAddress(...a),
+    });
+  });
+
+  it("returns true for a valid address", async () => {
+    mockValidateAddress.mockResolvedValue(true);
+    const result = await genericValidateAddress("xrp", "local")("rValidAddress", {});
+    expect(result).toBe(true);
+  });
+
+  it("returns false for an invalid address", async () => {
+    mockValidateAddress.mockResolvedValue(false);
+    const result = await genericValidateAddress("xrp", "local")("invalid", {});
+    expect(result).toBe(false);
+  });
+
+  it("resolves the API with parameters.currencyId when provided", async () => {
+    mockValidateAddress.mockResolvedValue(true);
+    await genericValidateAddress("evm", "local")("0xAddress", { currencyId: "ethereum" });
+    expect(mockGetCoinModuleApi).toHaveBeenCalledWith("ethereum", "local");
+  });
+
+  it("falls back to network when parameters.currencyId is absent", async () => {
+    mockValidateAddress.mockResolvedValue(true);
+    await genericValidateAddress("stellar", "local")("GADDRESS", {});
+    expect(mockGetCoinModuleApi).toHaveBeenCalledWith("stellar", "local");
+  });
+
+  it("propagates errors thrown by api.validateAddress", async () => {
+    mockValidateAddress.mockRejectedValue(new Error("validation failed"));
+    await expect(genericValidateAddress("evm", "local")("0xBad", {})).rejects.toThrow(
+      "validation failed",
     );
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/validateAddress.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/validateAddress.ts
@@ -1,12 +1,10 @@
 import type { ValidateAddressFn } from "../../coin-modules/types";
-import { loadValidateAddressForFamily } from "../../coin-modules/registry";
+import { getCoinModuleApi } from "./api";
 
-// coin-framework network names differ from coin family names in a few cases.
-const networkToFamily: Record<string, string> = { ripple: "xrp" };
-
-export async function getValidateAddress(network: string): Promise<ValidateAddressFn> {
-  const family = networkToFamily[network] ?? network;
-  const fn = await loadValidateAddressForFamily(family);
-  if (!fn) throw new Error(`No validate address function for network ${network}`);
-  return fn;
+export function genericValidateAddress(network: string, kind: string): ValidateAddressFn {
+  return async (address, parameters) => {
+    const currencyId = parameters.currencyId ?? network;
+    const api = await getCoinModuleApi(currencyId, kind);
+    return api.validateAddress(address, parameters);
+  };
 }

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -1,4 +1,4 @@
-import type { CoinModuleLoader, FamilySetup, ValidateAddressFn } from "./types";
+import type { CoinModuleLoader, FamilySetup } from "./types";
 
 export const coinModuleLoaders: CoinModuleLoader[] = [
   {
@@ -80,10 +80,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadAccount: () => import("@ledgerhq/coin-cardano/account").then(m => m.default),
     loadMockBridge: () => import("../families/cardano/bridge/mock").then(m => m.default),
     loadBridgeApi: () => import("../families/cardano/bridge/api").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-cardano/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
   },
   {
     family: "casper",
@@ -220,10 +216,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadWalletApiAdapter: () => import("../families/evm/walletApiAdapter").then(m => m.default),
     loadPlatformAdapter: () => import("../families/evm/platformAdapter").then(m => m.default),
     loadMockBridge: () => import("../families/evm/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-evm/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadSigner: () => import("../families/evm/signer").then(m => m.default),
     loadBridgeApi: () => import("../families/evm/bridge/api").then(m => m.default),
     loadAccountRawAssign: () => import("../families/evm/accountRawAssign").then(m => m.default),
@@ -291,10 +283,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-multiversx/deviceTransactionConfig").then(m => m.default),
     loadMockBridge: () => import("../families/multiversx/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-multiversx/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadBridgeApi: () => import("../families/multiversx/bridge/api").then(m => m.default),
   },
   {
@@ -329,10 +317,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
       import("@ledgerhq/coin-solana/deviceTransactionConfig").then(m => m.default),
     loadWalletApiAdapter: () => import("../families/solana/walletApiAdapter").then(m => m.default),
     loadMockBridge: () => import("../families/solana/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-solana/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadSigner: () => import("../families/solana/signer").then(m => m.default),
     loadBridgeApi: () => import("../families/solana/bridge/api").then(m => m.default),
   },
@@ -354,10 +338,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () =>
       import("../families/stellar/deviceTransactionConfig").then(m => m.default),
     loadMockBridge: () => import("../families/stellar/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-stellar/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadSigner: () => import("../families/stellar/signer").then(m => m.default),
     loadBridgeApi: () => import("../families/stellar/bridge/api").then(m => m.default),
     loadBridgeExtensions: () => import("../families/stellar/bridgeExtensions").then(m => m.default),
@@ -378,10 +358,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadDeviceTxConfig: () =>
       import("../families/tezos/deviceTransactionConfig").then(m => m.default),
     loadMockBridge: () => import("../families/tezos/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-tezos/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadSigner: () => import("../families/tezos/signer").then(m => m.default),
     loadBridgeApi: () => import("../families/tezos/bridge/api").then(m => m.default),
     loadAccountRawAssign: () => import("../families/tezos/accountRawAssign").then(m => m.default),
@@ -406,10 +382,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadMockBridge: () => import("../families/tron/bridge/mock").then(m => m.default),
     loadBridgeApi: () => import("../families/tron/bridge/api").then(m => m.default),
     loadBridgeExtensions: () => import("../families/tron/bridgeExtensions").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-tron/logic/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
   },
   {
     family: "vechain",
@@ -432,10 +404,6 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     loadWalletApiAdapter: () => import("../families/xrp/walletApiAdapter").then(m => m.default),
     loadPlatformAdapter: () => import("../families/xrp/platformAdapter").then(m => m.default),
     loadMockBridge: () => import("../families/xrp/bridge/mock").then(m => m.default),
-    loadValidateAddress: () =>
-      import("@ledgerhq/coin-xrp/api/validateAddress").then(
-        ({ validateAddress }): ValidateAddressFn => validateAddress,
-      ),
     loadSigner: () => import("../families/xrp/signer").then(m => m.default),
     loadBridgeExtensions: () => import("../families/xrp/bridgeExtensions").then(m => m.default),
   },

--- a/libs/ledger-live-common/src/coin-modules/non-regression-entry.ts
+++ b/libs/ledger-live-common/src/coin-modules/non-regression-entry.ts
@@ -6,7 +6,7 @@
  * against an explicit allowlist of known eager imports. As files are migrated, that
  * allowlist should shrink — a regression re-adds an entry.
  */
-export { getValidateAddress } from "../bridge/generic-coin-framework/validateAddress";
+export { genericValidateAddress } from "../bridge/generic-coin-framework/validateAddress";
 export { getCurrencyBridge, getAccountBridge } from "../bridge/impl";
 export { sync as mockSync } from "../bridge/mockHelpers";
 export { genAccount } from "../mock/account";

--- a/libs/ledger-live-common/src/coin-modules/registry.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.test.ts
@@ -16,7 +16,6 @@ import {
   loadMockBridgeForFamily,
   loadMockAccountForFamily,
   getLoadedMockAccountForFamily,
-  loadValidateAddressForFamily,
   loadSignerForFamily,
   loadBridgeExtensionsForFamily,
 } from "./registry";
@@ -120,7 +119,6 @@ const allLoaders: LoaderEntry[] = [
   { loaderKey: "loadAccount", fn: loadAccountModuleForFamily },
   { loaderKey: "loadMockBridge", fn: loadMockBridgeForFamily },
   { loaderKey: "loadMockAccount", fn: loadMockAccountForFamily },
-  { loaderKey: "loadValidateAddress", fn: loadValidateAddressForFamily },
   { loaderKey: "loadSigner", fn: loadSignerForFamily },
 ];
 

--- a/libs/ledger-live-common/src/coin-modules/registry.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.ts
@@ -150,10 +150,6 @@ export function getLoadedMockAccountForFamily(family: string): MockAccountModule
   return resolvedMockAccounts.get(family);
 }
 
-export const loadValidateAddressForFamily = makeLoaderCache(family =>
-  loaders.get(family)?.loadValidateAddress?.(),
-);
-
 export const loadSignerForFamily = makeLoaderCache(family => loaders.get(family)?.loadSigner?.());
 
 export const loadBridgeApiForFamily = makeLoaderCache(family =>

--- a/libs/ledger-live-common/src/coin-modules/types.ts
+++ b/libs/ledger-live-common/src/coin-modules/types.ts
@@ -146,7 +146,6 @@ export type CoinModuleLoader<
   loadAccount?: () => Promise<AccountModule<A>>;
   loadMockBridge?: () => Promise<MockBridgeModule<T, A, U, O, R>>;
   loadMockAccount?: () => Promise<MockAccountModule<A>>;
-  loadValidateAddress?: () => Promise<ValidateAddressFn>;
   loadSigner?: () => Promise<CoinFrameworkSigner>;
   loadBridgeExtensions?: () => Promise<AccountBridgeExtensions<T>>;
   loadBridgeApi?: () => Promise<BridgeApi | ((currency: CryptoCurrency) => BridgeApi)>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Internal methods must not be exposed by coin modules. Instead, they must gets called through an instance of `CoinModuleApi`.

`validateAddress` is the only one that gets called directly in production.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34714
- **ADR** (if any): [ADR-049](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7324958730/Coin+modules+-+ADR-049+-+Logic+folder+structure+layer+imports+exports)