### PR TITLE
[LWDM] feat(large-screen-upsell): gate modal by selected variant

### DIFF
--- a/.changeset/quiet-screens-toggle.md
+++ b/.changeset/quiet-screens-toggle.md
@@ -1,0 +1,8 @@
+---
+"@features/flow-large-screen-upsell": patch
+"@shared/feature-flags": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Gate the large-screen upsell modal by the enabled state of the selected opt-in variant

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -56,7 +56,15 @@ const NOW = new Date("2026-07-15T12:00:00.000Z");
 function eligibleState(settingsOverrides: Partial<State["settings"]> = {}): DeepPartial<State> {
   return {
     ...withFlagOverrides({
-      largeScreenUpsell: { enabled: true },
+      largeScreenUpsell: {
+        enabled: true,
+        params: {
+          opted_out: {
+            enabled: true,
+            link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+          },
+        },
+      },
       lwdWallet40: { enabled: true, params: { tour: false } },
     }),
     settings: {
@@ -223,8 +231,14 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         largeScreenUpsell: {
           enabled: true,
           params: {
-            opted_in: { link: "https://shop.ledger.com/pages/opted-in-offer" },
-            opted_out: { link: "https://shop.ledger.com/pages/opted-out-offer" },
+            opted_in: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/opted-in-offer",
+            },
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/opted-out-offer",
+            },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },
@@ -268,8 +282,14 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         largeScreenUpsell: {
           enabled: true,
           params: {
-            opted_in: { link: "https://shop.ledger.com/pages/opted-in-offer" },
-            opted_out: { link: "https://shop.ledger.com/pages/opted-out-offer" },
+            opted_in: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/opted-in-offer",
+            },
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/opted-out-offer",
+            },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },
@@ -356,7 +376,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
         largeScreenUpsell: {
           enabled: true,
           params: {
-            opted_out: { link: "   " },
+            opted_out: { enabled: true, link: "   " },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },
@@ -404,6 +424,10 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
           enabled: true,
           params: {
             modal: { enabled: true, killThreshold: 3, cadenceDays: 30 },
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },
@@ -511,6 +535,52 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await expectModalNotOpen();
   });
 
+  it("should not open when the opted-out variant is disabled", async () => {
+    const { store } = renderMount({
+      ...eligibleState(),
+      ...withFlagOverrides({
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: false,
+              link: "https://shop.ledger.com/pages/opted-out-offer",
+            },
+          },
+        },
+        lwdWallet40: { enabled: true, params: { tour: false } },
+      }),
+    });
+
+    await expectModalNotOpen();
+
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(trackPage).not.toHaveBeenCalled();
+  });
+
+  it("should not open when the opted-in variant is disabled", async () => {
+    const { store } = renderMount({
+      ...eligibleState({ sharePersonalizedRecommandations: true }),
+      ...withFlagOverrides({
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_in: {
+              enabled: false,
+              link: "https://shop.ledger.com/pages/opted-in-offer",
+            },
+          },
+        },
+        lwdWallet40: { enabled: true, params: { tour: false } },
+      }),
+    });
+
+    await expectModalNotOpen();
+
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(trackPage).not.toHaveBeenCalled();
+  });
+
   it("should not open when the seen nano model is disabled for the audience", async () => {
     renderMount({
       ...eligibleState(),
@@ -562,6 +632,10 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
           enabled: true,
           params: {
             modal: { enabled: true, killThreshold: 3, cadenceDays: 30 },
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },
@@ -584,6 +658,10 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
           enabled: true,
           params: {
             modal: { enabled: true, killThreshold: 3, cadenceDays: 30 },
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
           },
         },
         lwdWallet40: { enabled: true, params: { tour: false } },

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -110,7 +110,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should auto-open the upsell modal when eligible and unblocked", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -131,7 +139,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should track the modal view with shared analytics properties when it auto-opens", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -156,7 +172,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should track opted-in offer properties when personalized recommendations are enabled", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_in: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -180,10 +204,76 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
     });
   });
 
+  it("should not open when the opted-out variant is disabled", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: false,
+              link: "https://shop.ledger.com/pages/opted-out-offer",
+            },
+          },
+        },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS]),
+    );
+
+    const { store } = render(<IntegrationNavigator />, { overrideInitialState });
+
+    expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
+    act(() => jest.runOnlyPendingTimers());
+    expect(screen.queryByTestId("large-screen-upsell-modal-drawer")).toBeNull();
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(jest.mocked(analyticsScreen)).not.toHaveBeenCalled();
+  });
+
+  it("should not open when the opted-in variant is disabled", async () => {
+    const overrideInitialState = withFlagOverrides(
+      {
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_in: {
+              enabled: false,
+              link: "https://shop.ledger.com/pages/opted-in-offer",
+            },
+          },
+        },
+        lwmProductTour: { enabled: false },
+        lwmGenericAwarenessModal: { enabled: false },
+        analyticsOptIn: { enabled: false },
+      },
+      withKnownDeviceModels([DeviceModelId.nanoS], {
+        personalizedRecommendationsEnabled: true,
+      }),
+    );
+
+    const { store } = render(<IntegrationNavigator />, { overrideInitialState });
+
+    expect(await screen.findByTestId("large-screen-upsell-integration-portfolio")).toBeVisible();
+    act(() => jest.runOnlyPendingTimers());
+    expect(screen.queryByTestId("large-screen-upsell-modal-drawer")).toBeNull();
+    expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
+    expect(jest.mocked(analyticsScreen)).not.toHaveBeenCalled();
+  });
+
   it("should track button_clicked with shared analytics properties when the CTA is pressed", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -210,7 +300,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should track modal_dismissed with dismissMethod close button exactly once when the header close button is pressed", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -243,7 +341,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should auto-open the upsell modal when product tour is enabled but onboarding is not completed", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: true },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },
@@ -267,7 +373,15 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
   it("should not auto-open the upsell modal when a competing app-start modal opens after mount", async () => {
     const overrideInitialState = withFlagOverrides(
       {
-        largeScreenUpsell: { enabled: true },
+        largeScreenUpsell: {
+          enabled: true,
+          params: {
+            opted_out: {
+              enabled: true,
+              link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+            },
+          },
+        },
         lwmProductTour: { enabled: false },
         lwmGenericAwarenessModal: { enabled: false },
         analyticsOptIn: { enabled: false },

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/components/LargeScreenUpsellModalPortfolioMount/useLargeScreenUpsellModalPortfolioMountViewModel.ts
@@ -65,8 +65,12 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
     hasSeenCompetingAppStartModalRef.current = true;
   }
 
+  const variant: LargeScreenUpsellVariant = personalizedRecommendationsEnabled
+    ? "opted_in"
+    : "opted_out";
+
   const params = feature?.params;
-  const hasEnabledFeature = Boolean(feature?.enabled && params);
+  const hasEnabledFeature = Boolean(feature?.enabled && params?.[variant].enabled);
   const lastSeenAtDate = typeof lastSeenAt === "number" ? new Date(lastSeenAt) : null;
 
   const isThrottled =
@@ -87,10 +91,6 @@ export function useLargeScreenUpsellModalPortfolioMountViewModel(): LargeScreenU
   );
   const shouldAttemptAutoOpen =
     isEligible && !hasSeenCompetingAppStartModalRef.current && !hasAutoOpenedThisSession;
-
-  const variant: LargeScreenUpsellVariant = personalizedRecommendationsEnabled
-    ? "opted_in"
-    : "opted_out";
 
   const sharedAnalyticsProps: LargeScreenUpsellSharedAnalyticsProps | null = useMemo(() => {
     if (!("deviceModelId" in eligibility)) {

--- a/features/flow/large-screen-upsell/src/hooks/useLargeScreenUpsellDecision.ts
+++ b/features/flow/large-screen-upsell/src/hooks/useLargeScreenUpsellDecision.ts
@@ -5,12 +5,14 @@ import {
   retriesUpsellModalSelector,
 } from "@domain/entity-large-screen-upsell-modal";
 import { getLargeScreenUpsellDecision } from "../decision/getLargeScreenUpsellDecision";
+import type { LargeScreenUpsellVariant } from "../utils/upsellContent";
 import type { LargeScreenUpsellDecision, NanoDeviceModelId } from "../types";
 
 export type UseLargeScreenUpsellDecisionInput = {
   seenNanoModelIds: NanoDeviceModelId[];
   hasSeenTouchscreenDevice: boolean;
   onboardingDate: Date | null;
+  variant: LargeScreenUpsellVariant;
   now?: Date;
 };
 
@@ -30,7 +32,7 @@ export function useLargeScreenUpsellDecision(
       frequency: { retries, lastSeenAt },
     },
     {
-      isFeatureEnabled: Boolean(feature?.enabled) && params !== undefined,
+      isFeatureEnabled: Boolean(feature?.enabled && params?.[input.variant].enabled),
       isModalEnabled: Boolean(params?.modal.enabled),
       audienceModels: params?.audience.models ?? { nanoS: false, nanoSP: false, nanoX: false },
       cooldownDays: params?.cooldownDays ?? { default: Infinity },

--- a/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
+++ b/features/flow/large-screen-upsell/src/screens/LargeScreenUpsellModal/useLargeScreenUpsellModalViewModel.ts
@@ -51,6 +51,7 @@ export function useLargeScreenUpsellModalViewModel({
     seenNanoModelIds,
     hasSeenTouchscreenDevice,
     onboardingDate,
+    variant,
     now,
   });
   const [isOpen, setIsOpen] = useState(false);

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
@@ -1,0 +1,23 @@
+import { largeScreenUpsell } from "./largeScreenUpsell";
+
+describe("largeScreenUpsell", () => {
+  it("should default variant enabled states to false when they are missing", () => {
+    const defaults = largeScreenUpsell.parse(undefined);
+
+    if (!defaults.params) {
+      throw new Error("Expected large-screen upsell default params");
+    }
+
+    const result = largeScreenUpsell.parse({
+      enabled: true,
+      params: {
+        ...defaults.params,
+        opted_in: { link: defaults.params.opted_in.link },
+        opted_out: { link: defaults.params.opted_out.link },
+      },
+    });
+
+    expect(result.params?.opted_in.enabled).toBe(false);
+    expect(result.params?.opted_out.enabled).toBe(false);
+  });
+});

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
@@ -23,6 +23,7 @@ const modalSchema = z.object({
 });
 
 const ctaSchema = z.object({
+  enabled: z.boolean().default(false),
   link: z.string(),
 });
 
@@ -42,8 +43,12 @@ export const largeScreenUpsell = flagWith(
       cooldownDays: { default: 30, nanoS: 0 },
       discount: 0.2,
       modal: { enabled: true, killThreshold: 3, cadenceDays: 30 },
-      opted_in: { link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program" },
+      opted_in: {
+        enabled: true,
+        link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
+      },
       opted_out: {
+        enabled: false,
         link: "https://shop.ledger.com/pages/ledger-nano-upgrade-program",
       },
     },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Large-screen upsell modal visibility for opted-in and opted-out users on Desktop and Mobile
  - Feature-flag configurations where a variant-level `enabled` value is missing
  - Existing audience, cooldown, cadence, and global modal gates

### 📝 Description

The large-screen upsell modal was controlled only by the global feature flag and modal eligibility. The feature configuration now exposes independent `enabled` values for the `opted_in` and `opted_out` variants, so each audience needs to be gated separately.

This PR defaults missing variant enablement to `false`, resolves the active variant from the personalized-recommendations preference, and folds that value into the existing visibility decision on Desktop and Mobile. Desktop centralizes the check in `useLargeScreenUpsellDecision`; Mobile adds it to the existing feature gate.

```ts
isFeatureEnabled: Boolean(feature?.enabled && params?.[input.variant].enabled)
```

Automatic coverage includes enabled and disabled opted-in/opted-out paths on both platforms, plus the missing-`enabled` schema fallback. The shared packages pass typecheck. Full app typechecks remain blocked by pre-existing React 18/19 type conflicts; the modified files do not appear in those errors.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34745

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)