### PR TITLE
test(desktop): remove redundant Tezos Delegation e2e test (QAA-1409)

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -275,49 +275,6 @@ test.describe("Delegate without Broadcasting", () => {
   );
 });
 
-test.describe("e2e delegation - Tezos", () => {
-  // XTZ_1 (index 0) is the funded + UNDELEGATED account: with lldTezosStaking off (the default) this
-  // routes to the delegate starter ("delegate to earn rewards"). The delegated + staked account lives
-  // on XTZ_2 (index 1), used by the staking specs.
-  const account = new Delegate(Account.XTZ_1, "N/A", "Ledger by Kiln");
-  setupEnv(true);
-  test.use({
-    teamOwner: Team.EARN,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: account.account.currency.speculosApp,
-    cliCommands: [liveDataCommand(account.account)],
-  });
-
-  test(
-    "Tezos Delegation",
-    {
-      tag: buildTags({ currencyId: account.account.currency.id }),
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-3041",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.mainNavigation.openTargetFromMainNavigation("accounts");
-      await app.accounts.navigateToAccountByName(account.account.accountName);
-      await app.account.startStakingFlowFromMainStakeButton();
-      await app.delegate.clickDelegateToEarnRewardsButton();
-      await app.delegate.verifyTezosDelegateInfos(account.provider);
-      await app.delegate.continue();
-      await app.speculos.signDelegationTransaction(account);
-      await app.delegate.verifySuccessMessage();
-      await app.delegate.clickViewDetailsButton();
-      await app.drawer.waitForDrawerToBeVisible();
-      await app.delegateDrawer.verifyTxTypeIsVisible();
-      await app.delegateDrawer.verifyTxTypeIs("Delegated");
-      await app.delegateDrawer.providerIsVisible(account);
-      await app.delegateDrawer.operationTypeIsCorrect("Delegated");
-      await app.drawer.closeDrawer();
-    },
-  );
-});
-
 test.describe("e2e delegation - Celo", () => {
   const account = new Delegate(Account.CELO_1, "0.001", "N/A");
   test.use({


### PR DESCRIPTION
### ✅ Checklist

- [x] **No changeset needed** — this PR only touches files under `e2e/`.
- [ ] **Covered by automatic tests.** _This PR removes an automated test that is no longer valid. The Tezos staking e2e suite (B2CQA-5915 / B2CQA-5917 / B2CQA-5918) already exercises this area. `pnpm --filter ledger-live-desktop-e2e-tests typecheck` passes._
- [x] **Impact of the changes:**
      - Desktop E2E suite only — removes one obsolete Playwright spec block.
      - No app/runtime code touched; no user-facing impact.

### 📝 Description

The desktop **Tezos Delegation** E2E test (`B2CQA-3041`) started failing on the scheduled *[Desktop] E2E Only* run after the `lldTezosStaking` feature flag was enabled.

**Problem**: With staking on, starting a delegation now opens the earning-choice chooser (Delegate vs Stake) *before* the delegation starter screen. The test expects to land straight on the starter, so its `delegation-starter-infos` step times out.

**Solution**: `lldTezosStaking` is permanent and the Tezos **staking** E2E suite already covers this area, so this removes the now-redundant `e2e delegation - Tezos › Tezos Delegation` block from `delegate.spec.ts`. **Desktop only** — mobile's `llmTezosStaking` is still off, so the mobile delegation test still guards a live flow and stays in place for now.

**Residual coverage note**: The staking suite intentionally does not sign a delegation (delegation is one-time per account, so signing would break re-runs). As a result, the delegation *success screen* and the *"Delegated" operation in history* are no longer checked end-to-end. This was reviewed and accepted by QA; if we want it back, it fits better as an integration test than an E2E test.

### ❓ Context

- **JIRA link**: [QAA-1409](https://ledgerhq.atlassian.net/browse/QAA-1409)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA issue.
- **The PR description clearly documents the changes** and the residual-coverage trade-off.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been validated** (typecheck passes; staking suite covers the area).

[QAA-1409]: https://ledgerhq.atlassian.net/browse/QAA-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ