### PR TITLE
[LWDM] feat(coin-evm): support eth_call read API on Ledger nodes

### DIFF
--- a/.changeset/evm-call-ledger-node.md
+++ b/.changeset/evm-call-ledger-node.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/coin-celo": patch
+---
+
+Support the read-only smart-contract `call` (ADR-044) on EVM Ledger nodes, in addition to external RPC nodes. Ledger nodes serve it through the explorer `contract/read` endpoint (the same one already used for allowances and L1 fee oracles), so `call` no longer throws "call is not supported" on Ledger-node chains.

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.test.ts
@@ -36,15 +36,77 @@ const ledgerConfig = { type: "ledger" as const, explorerId: "eth" as const, retr
 
 describe("EVM Family", () => {
   describe("network/node/ledger.ts", () => {
-    it("does not expose contract calls through ledger nodes", async () => {
-      const api = createLedgerNodeApi(ledgerConfig);
+    describe("call", () => {
+      // USDC on Ethereum, EIP-55 checksummed — asserts we normalize (lowercase) the `to` address.
+      const USDC = "0xA0b86991c6218b36c1D19D4a2e9Eb0cE3606eB48";
+      const DECIMALS_SELECTOR = "0x313ce567"; // decimals()
+      const DECIMALS_RESPONSE =
+        "0x0000000000000000000000000000000000000000000000000000000000000006";
 
-      await expect(
-        api.call(currency, {
-          to: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
-          data: "0x1234",
-        }),
-      ).rejects.toThrow("call is not supported");
+      // Clear the shared axios mock's call history after each case so counts don't leak into sibling
+      // tests (e.g. the retry test below asserts an exact number of axios.request calls).
+      afterEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it("reads a contract through the explorer contract/read endpoint", async () => {
+        const api = createLedgerNodeApi(ledgerConfig);
+        const spy = jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+          data: [
+            {
+              info: { contract: USDC.toLowerCase(), data: DECIMALS_SELECTOR, blockNumber: null },
+              response: DECIMALS_RESPONSE,
+            },
+          ],
+        }));
+
+        const result = await api.call(currency, { to: USDC, data: DECIMALS_SELECTOR });
+
+        expect(result).toEqual(DECIMALS_RESPONSE);
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: "POST",
+            url: expect.stringContaining("/blockchain/v4/eth/contract/read"),
+            data: [{ contract: USDC.toLowerCase(), data: DECIMALS_SELECTOR }],
+          }),
+        );
+      });
+
+      it("forwards the requested block", async () => {
+        const api = createLedgerNodeApi(ledgerConfig);
+        const spy = jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+          data: [
+            {
+              info: { contract: USDC.toLowerCase(), data: DECIMALS_SELECTOR, blockNumber: 123 },
+              response: DECIMALS_RESPONSE,
+            },
+          ],
+        }));
+
+        await api.call(currency, { to: USDC, data: DECIMALS_SELECTOR, block: 123 });
+
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: [{ contract: USDC.toLowerCase(), data: DECIMALS_SELECTOR, blockNumber: 123 }],
+          }),
+        );
+      });
+
+      it("throws when the node reports a failure (e.g. revert)", async () => {
+        const api = createLedgerNodeApi(ledgerConfig);
+        jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+          data: [
+            {
+              info: { contract: USDC.toLowerCase(), data: DECIMALS_SELECTOR, blockNumber: null },
+              error: { code: "REVERTED", message: "execution reverted" },
+            },
+          ],
+        }));
+
+        await expect(api.call(currency, { to: USDC, data: DECIMALS_SELECTOR })).rejects.toThrow(
+          "EVM call failed",
+        );
+      });
     });
 
     describe("createLedgerNodeApi / retries", () => {

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.ts
@@ -11,10 +11,10 @@ import OptimismGasPriceOracleAbi from "../../abis/optimismGasPriceOracle.abi.jso
 import { BlockFinalizationTag, LedgerNodeConfig } from "../../config";
 import { GasEstimationError } from "../../errors";
 import { LedgerExplorerOperation } from "../../types";
-import { padHexString, safeEncodeEIP55 } from "../../utils";
+import { normalizeAddress, padHexString, safeEncodeEIP55 } from "../../utils";
 import { getGasOptions } from "../gasTracker/ledger";
 import { withRetries } from "../withRetries";
-import { BlockByHeightResult, NodeApi, TransactionInfo } from "./types";
+import { BlockByHeightResult, EvmCallParams, NodeApi, TransactionInfo } from "./types";
 
 const LEDGER_TIMEOUT = 10_000; // 10s for network call timeout
 const LEDGER_TIME_BETWEEN_TRIES = 200; // 200ms between 2 calls
@@ -306,6 +306,54 @@ async function getOptimismAdditionalFees(
   return new BigNumber(result.response);
 }
 
+/**
+ * A single entry of the Ledger explorer `contract/read` batch response. On success the node returns
+ * the raw `response` (hex-encoded call output); on a revert/failure it returns `error` instead.
+ */
+type ContractReadResult = {
+  response?: string;
+  error?: unknown;
+};
+
+/**
+ * Read-only contract call (ADR-044) over a Ledger node. Unlike external nodes (which use the RPC
+ * `eth_call`), Ledger nodes expose the same capability through the explorer `contract/read` endpoint,
+ * so the returned `response` is the hex-encoded call output, kept opaque here.
+ */
+async function call(
+  fetch: LedgerFetch,
+  config: LedgerNodeConfig,
+  _currency: CryptoCurrency,
+  params: EvmCallParams,
+): Promise<string> {
+  // `contract/read` accepts a decimal block height or a tag ("latest"/"earliest"/"pending"); it
+  // defaults to latest when omitted. We forward `block` as-is (unlike the RPC path, no hex quantity).
+  const [result] = await fetch<ContractReadResult[]>({
+    method: "POST",
+    url: `${getEnv("EXPLORER")}/blockchain/v4/${config.explorerId}/contract/read`,
+    data: [
+      {
+        contract: normalizeAddress(params.to),
+        data: params.data,
+        ...(params.block !== undefined ? { blockNumber: params.block } : {}),
+      },
+    ],
+  });
+  if (result?.response === undefined) {
+    // `error` comes straight from the JSON response (a string or a `{ code, message }`-like object),
+    // so there are no cycles/Error instances to worry about. Keep plain strings verbatim to avoid the
+    // extra quotes JSON.stringify would wrap them in.
+    const reason =
+      result?.error === undefined
+        ? "empty response"
+        : typeof result.error === "string"
+          ? result.error
+          : JSON.stringify(result.error);
+    throw new Error(`EVM call failed on ${config.explorerId}: ${reason}`);
+  }
+  return result.response;
+}
+
 function makeGetTokenAllowance(
   config: LedgerNodeConfig,
   fetch: LedgerFetch,
@@ -369,9 +417,7 @@ export function createLedgerNodeApi(config: LedgerNodeConfig): NodeApi {
     Batcher<{ address: string; contract: string }, BigNumber>
   >();
   return {
-    async call() {
-      throw new Error("call is not supported");
-    },
+    call: make(call, config, fetch),
     getBlockByHeight: make(getBlockByHeight, config, fetch),
     getCoinBalance: make(getCoinBalance, config, fetch),
     getTokenBalance: makeGetTokenBalance(config, fetch, tokenBalancesBatchersMap),


### PR DESCRIPTION
## What

Implements the read-only smart-contract `call` API (ADR-044) for EVM **Ledger nodes**. Until now `call` was only supported on external RPC nodes (`eth_call`); Ledger-node chains (e.g. `ethereum`) threw `"call is not supported"`.

Ledger nodes expose the same capability through the explorer **`POST /blockchain/v4/{explorerId}/contract/read`** endpoint — the same one already used for token allowances and the Optimism/Scroll L1-fee oracles (Atlas v2's `ContractReadView`). This wires `NodeApi.call` to it for the Ledger node.

## Changes

- `network/node/ledger.ts`: implement `call` via `contract/read`
  - normalize the `to` address (consistent with the RPC path)
  - forward an optional `block` (decimal height or `latest`/`earliest`/`pending`; defaults to latest)
  - surface node-reported failures (e.g. reverts) as thrown errors, matching the RPC path's throw-on-revert behavior
- `network/node/ledger.test.ts`: replace the "not supported" test with happy-path, block-forwarding and failure unit tests
- changeset: `coin-evm` minor, `coin-celo` patch (celo spreads `evmApi`)

## Notes

- Standalone PR off `develop` (no longer stacked on #19743). The integration test for the read API lives in #19743.
- The RPC path encodes numeric blocks as hex quantities; the Ledger path forwards decimal height / tag as `contract/read` expects. Block tags beyond `latest`/`earliest`/`pending` (e.g. `safe`/`finalized`) are not supported by `contract/read`.
- Downstream: coin-service's `call is rejected on a Ledger-node chain` test (in alpaca-coin-module) will need updating once this ships and the nightly is bumped there, since Ledger-node chains will start succeeding.