### PR TITLE
[LWM] feat(mobile): render contact name validation errors (LIVE-33903)

### DIFF
--- a/.changeset/clear-contacts-name-validation.md
+++ b/.changeset/clear-contacts-name-validation.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Render validation errors in the add contact form.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10230,7 +10230,8 @@
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
-      "confirmName": "Confirm name"
+      "confirmName": "Confirm name",
+      "invalidNameError": "Special characters are not allowed."
     },
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
@@ -43,7 +43,20 @@ describe("Contacts add contact drawer integration", () => {
     });
 
     await user.press(screen.getByTestId("contacts-add-contact-row"));
-    await user.type(screen.getByTestId("contacts-add-contact-name-input"), "Ada");
+    const input = screen.getByTestId("contacts-add-contact-name-input");
+
+    await user.type(input, "Ada1");
+
+    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
+
+    fireEvent.changeText(input, "Ada");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Special characters are not allowed.")).toBeNull();
+      expect(screen.getByRole("button", { name: "Confirm name" })).toBeEnabled();
+    });
+
     await user.press(screen.getByRole("button", { name: "Confirm name" }));
 
     await waitFor(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -22,12 +22,16 @@ function createViewModel(
     isConfirmEnabled: false,
     isSaving: false,
     draftName: "",
+    invalidNameError: null,
     labels: {
       title: "Add contact",
       namePlaceholder: "Contact name",
       namingDisclaimer:
         "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
       confirmName: "Confirm name",
+      nameValidationErrors: {
+        InvalidContactNameError: "Special characters are not allowed.",
+      },
     },
     onOpen: jest.fn(),
     onClose: jest.fn(),
@@ -83,6 +87,27 @@ describe("ContactsAddContactDrawerSheet", () => {
       "a".repeat(32),
     );
     expect(screen.getByText("32/32")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-name-count")).toHaveProp(
+      "accessibilityLiveRegion",
+      "polite",
+    );
+    expect(screen.getByRole("button", { name: "Confirm name" })).toBeEnabled();
+  });
+
+  it("should render the shared validation error and disable confirmation", () => {
+    render(
+      <ContactsAddContactDrawerSheet
+        {...createViewModel({ draftName: "Ada1", invalidNameError: "InvalidContactNameError" })}
+      />,
+    );
+
+    expect(screen.getByText("Contact name")).toBeVisible();
+    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-name-error")).toHaveProp(
+      "accessibilityLiveRegion",
+      "polite",
+    );
+    expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
   });
 
   it("should expose the edited name, enable confirmation, and close the drawer", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -101,7 +101,7 @@ describe("ContactsAddContactDrawerSheet", () => {
       />,
     );
 
-    expect(screen.getByText("Contact name")).toBeVisible();
+    expect(screen.getByPlaceholderText("Contact name")).toBeVisible();
     expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
     expect(screen.getByTestId("contacts-add-contact-name-error")).toHaveProp(
       "accessibilityLiveRegion",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -55,11 +55,15 @@ function createViewModel({
       isConfirmEnabled: false,
       isSaving: false,
       draftName: "",
+      invalidNameError: null,
       labels: {
         title: "Add contact",
         namePlaceholder: "Contact name",
         namingDisclaimer: "Use a nickname.",
         confirmName: "Confirm name",
+        nameValidationErrors: {
+          InvalidContactNameError: "Special characters are not allowed.",
+        },
       },
       onOpen: jest.fn(),
       onClose: jest.fn(),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { v4 as uuid } from "uuid";
-import { addContact, contact } from "@domain/entity-contact";
+import { addContact, contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
 import {
   type ContactCreationPort,
   type ContactsAddContactDrawerLabels,
@@ -32,13 +32,19 @@ export function useContactsAddContactDrawerAdapter(
     }),
     [dispatch],
   );
-  const drawerViewModel = useAddContactDrawerViewModel({ contactCreation, onSaveSuccess });
+  const drawerViewModel = useAddContactDrawerViewModel({
+    contactCreation,
+    onSaveSuccess,
+  });
   const labels = useMemo<ContactsAddContactDrawerLabels>(
     () => ({
       title: t("contacts.addContact"),
       namePlaceholder: t("contacts.addContactDrawer.namePlaceholder"),
       namingDisclaimer: t("contacts.addContactDrawer.namingDisclaimer"),
       confirmName: t("contacts.addContactDrawer.confirmName"),
+      nameValidationErrors: {
+        [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
+      },
     }),
     [t],
   );

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/ContactNameInput.native.tsx
@@ -33,7 +33,7 @@ export function ContactNameInput({
         lx={{
           alignItems: "center",
           flexDirection: "row",
-          justifyContent: "space-between",
+          justifyContent: errorMessage ? "space-between" : "flex-end",
         }}
       >
         {errorMessage ? (
@@ -55,9 +55,7 @@ export function ContactNameInput({
               {errorMessage}
             </Text>
           </Box>
-        ) : (
-          <Box lx={{ flex: 1 }} />
-        )}
+        ) : null}
         <Text
           testID="contacts-add-contact-name-count"
           typography="body3"

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/ContactNameInput.native.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { Box, Text, TextInput } from "@ledgerhq/lumen-ui-rnative";
+import { DeleteCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { CONTACT_NAME_MAX_LENGTH } from "../../../add/model/constants";
+
+type ContactNameInputProps = Readonly<{
+  value: string;
+  placeholder: string;
+  errorMessage?: string;
+  onChangeText: (name: string) => void;
+}>;
+
+export function ContactNameInput({
+  value,
+  placeholder,
+  errorMessage,
+  onChangeText,
+}: ContactNameInputProps): React.JSX.Element {
+  const isAtNameLengthLimit = value.length === CONTACT_NAME_MAX_LENGTH;
+
+  return (
+    <Box lx={{ gap: "s8" }}>
+      <TextInput
+        testID="contacts-add-contact-name-input"
+        autoFocus
+        placeholder={placeholder}
+        value={value}
+        onChangeText={onChangeText}
+        maxLength={CONTACT_NAME_MAX_LENGTH}
+        status={errorMessage ? "error" : undefined}
+      />
+      <Box
+        lx={{
+          alignItems: "center",
+          flexDirection: "row",
+          justifyContent: "space-between",
+        }}
+      >
+        {errorMessage ? (
+          <Box
+            lx={{
+              alignItems: "center",
+              flex: 1,
+              flexDirection: "row",
+              gap: "s4",
+            }}
+          >
+            <DeleteCircleFill color="error" size={16} />
+            <Text
+              testID="contacts-add-contact-name-error"
+              typography="body3"
+              accessibilityLiveRegion="polite"
+              lx={{ color: "error" }}
+            >
+              {errorMessage}
+            </Text>
+          </Box>
+        ) : (
+          <Box lx={{ flex: 1 }} />
+        )}
+        <Text
+          testID="contacts-add-contact-name-count"
+          typography="body3"
+          accessibilityLiveRegion="polite"
+          lx={{ color: isAtNameLengthLimit ? "error" : "muted" }}
+        >
+          {`${value.length}/${CONTACT_NAME_MAX_LENGTH}`}
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/index.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactNameInput/index.ts
@@ -1,0 +1,1 @@
+export { ContactNameInput } from "./ContactNameInput.native";

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
@@ -6,10 +6,8 @@ import {
   Box,
   Button,
   Text,
-  TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
-import { DeleteCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_NAME_MAX_LENGTH } from "../../add/model/constants";
+import { ContactNameInput } from "./ContactNameInput";
 import type { ContactsAddContactDrawerProps } from "./types";
 
 export function ContactsAddContactDrawer({
@@ -26,8 +24,6 @@ export function ContactsAddContactDrawer({
 }: ContactsAddContactDrawerProps): React.JSX.Element {
   const nameValidationError =
     invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
-  const isAtNameLengthLimit = draftName.length === CONTACT_NAME_MAX_LENGTH;
-
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
@@ -37,55 +33,12 @@ export function ContactsAddContactDrawer({
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>
-            <Box lx={{ gap: "s8" }}>
-              <TextInput
-                testID="contacts-add-contact-name-input"
-                autoFocus
-                placeholder={labels.namePlaceholder}
-                value={draftName}
-                onChangeText={onDraftNameChange}
-                maxLength={CONTACT_NAME_MAX_LENGTH}
-                status={invalidNameError === null ? undefined : "error"}
-              />
-              <Box
-                lx={{
-                  alignItems: "center",
-                  flexDirection: "row",
-                  justifyContent: "space-between",
-                }}
-              >
-                {nameValidationError ? (
-                  <Box
-                    lx={{
-                      alignItems: "center",
-                      flex: 1,
-                      flexDirection: "row",
-                      gap: "s4",
-                    }}
-                  >
-                    <DeleteCircleFill color="error" size={16} />
-                    <Text
-                      testID="contacts-add-contact-name-error"
-                      typography="body3"
-                      accessibilityLiveRegion="polite"
-                      lx={{ color: "error" }}
-                    >
-                      {nameValidationError}
-                    </Text>
-                  </Box>
-                ) : (
-                  <Box lx={{ flex: 1 }} />
-                )}
-                <Text
-                  testID="contacts-add-contact-name-count"
-                  typography="body3"
-                  accessibilityLiveRegion="polite"
-                  lx={{ color: isAtNameLengthLimit ? "error" : "muted" }}
-                >
-                  {`${draftName.length}/${CONTACT_NAME_MAX_LENGTH}`}
-                </Text>
-              </Box>
-            </Box>
+            <ContactNameInput
+              value={draftName}
+              placeholder={labels.namePlaceholder}
+              errorMessage={nameValidationError}
+              onChangeText={onDraftNameChange}
+            />
             <Banner appearance="info" description={labels.namingDisclaimer} />
           </Box>
           <Button

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
+import { DeleteCircleFill } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { CONTACT_NAME_MAX_LENGTH } from "../../add/model/constants";
 import type { ContactsAddContactDrawerProps } from "./types";
 
@@ -16,12 +17,17 @@ export function ContactsAddContactDrawer({
   isConfirmEnabled,
   isSaving,
   draftName,
+  invalidNameError,
   bottomInset = 0,
   keyboardInset = 0,
   labels,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactDrawerProps): React.JSX.Element {
+  const nameValidationError =
+    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+  const isAtNameLengthLimit = draftName.length === CONTACT_NAME_MAX_LENGTH;
+
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 + keyboardInset }}>
       {isOpen ? (
@@ -31,15 +37,55 @@ export function ContactsAddContactDrawer({
             <Text typography="heading3SemiBold" lx={{ color: "base" }}>
               {labels.title}
             </Text>
-            <TextInput
-              testID="contacts-add-contact-name-input"
-              autoFocus
-              placeholder={labels.namePlaceholder}
-              value={draftName}
-              onChangeText={onDraftNameChange}
-              maxLength={CONTACT_NAME_MAX_LENGTH}
-              maxCount={CONTACT_NAME_MAX_LENGTH}
-            />
+            <Box lx={{ gap: "s8" }}>
+              <TextInput
+                testID="contacts-add-contact-name-input"
+                autoFocus
+                label={labels.namePlaceholder}
+                value={draftName}
+                onChangeText={onDraftNameChange}
+                maxLength={CONTACT_NAME_MAX_LENGTH}
+                status={invalidNameError === null ? undefined : "error"}
+              />
+              <Box
+                lx={{
+                  alignItems: "center",
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                }}
+              >
+                {nameValidationError ? (
+                  <Box
+                    lx={{
+                      alignItems: "center",
+                      flex: 1,
+                      flexDirection: "row",
+                      gap: "s4",
+                    }}
+                  >
+                    <DeleteCircleFill color="error" size={16} />
+                    <Text
+                      testID="contacts-add-contact-name-error"
+                      typography="body3"
+                      accessibilityLiveRegion="polite"
+                      lx={{ color: "error" }}
+                    >
+                      {nameValidationError}
+                    </Text>
+                  </Box>
+                ) : (
+                  <Box lx={{ flex: 1 }} />
+                )}
+                <Text
+                  testID="contacts-add-contact-name-count"
+                  typography="body3"
+                  accessibilityLiveRegion="polite"
+                  lx={{ color: isAtNameLengthLimit ? "error" : "muted" }}
+                >
+                  {`${draftName.length}/${CONTACT_NAME_MAX_LENGTH}`}
+                </Text>
+              </Box>
+            </Box>
             <Banner appearance="info" description={labels.namingDisclaimer} />
           </Box>
           <Button

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDrawer.native.tsx
@@ -41,7 +41,7 @@ export function ContactsAddContactDrawer({
               <TextInput
                 testID="contacts-add-contact-name-input"
                 autoFocus
-                label={labels.namePlaceholder}
+                placeholder={labels.namePlaceholder}
                 value={draftName}
                 onChangeText={onDraftNameChange}
                 maxLength={CONTACT_NAME_MAX_LENGTH}

--- a/features/flow/contacts/src/components/AddContactDrawer/types.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/types.ts
@@ -1,3 +1,4 @@
+import type { ContactNameValidationErrorName } from "@domain/entity-contact";
 import type { ContactCreationPort } from "../../add/model/ports";
 
 export type AddContactDrawerViewModel = Readonly<{
@@ -5,6 +6,7 @@ export type AddContactDrawerViewModel = Readonly<{
   isConfirmEnabled: boolean;
   isSaving: boolean;
   draftName: string;
+  invalidNameError: ContactNameValidationErrorName | null;
   onOpen: () => void;
   onClose: () => void;
   onDraftNameChange: (name: string) => void;
@@ -21,6 +23,7 @@ export type ContactsAddContactDrawerLabels = Readonly<{
   namePlaceholder: string;
   namingDisclaimer: string;
   confirmName: string;
+  nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
 }>;
 
 export type ContactsAddContactDrawerProps = AddContactDrawerViewModel &

--- a/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.ts
@@ -9,7 +9,8 @@ export function useAddContactDrawerViewModel({
 }: UseAddContactDrawerViewModelOptions): AddContactDrawerViewModel {
   const [isOpen, setIsOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const { draftName, isSaveEnabled, save, setDraftName } = useAddContactViewModel(contactCreation);
+  const { draftName, invalidNameError, isSaveEnabled, save, setDraftName } =
+    useAddContactViewModel(contactCreation);
   const onOpen = useCallback(() => setIsOpen(true), []);
   const onClose = useCallback(() => {
     setIsOpen(false);
@@ -42,6 +43,7 @@ export function useAddContactDrawerViewModel({
     isConfirmEnabled: isSaveEnabled && !isSaving,
     isSaving,
     draftName,
+    invalidNameError,
     onOpen,
     onClose,
     onDraftNameChange,

--- a/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.web.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { contact } from "@domain/entity-contact";
+import { contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
 import type { ContactCreationPort } from "../../add/model/ports";
 import { useAddContactDrawerViewModel } from "./useAddContactDrawerViewModel";
 
@@ -22,6 +22,15 @@ describe("useAddContactDrawerViewModel", () => {
 
     act(() => {
       result.current.onOpen();
+      result.current.onDraftNameChange("Ada1");
+    });
+
+    expect(result.current).toMatchObject({
+      invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+      isConfirmEnabled: false,
+    });
+
+    act(() => {
       result.current.onDraftNameChange("Ada");
     });
 
@@ -35,6 +44,7 @@ describe("useAddContactDrawerViewModel", () => {
       isOpen: false,
       draftName: "",
       isConfirmEnabled: false,
+      invalidNameError: null,
     });
   });
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Add contact name validation and disabled confirmation state
  - Character-limit warning and accessibility announcements

### 📝 Description

This PR renders shared add-contact name validation errors in Ledger Wallet Mobile.

The Flow drawer now exposes the Domain validation code, while the Mobile adapter maps it to the English copy. The native drawer renders the Figma error state, keeps confirmation disabled for invalid names, and shows `32/32` in red as a visual warning without invalidating a 32-character valid name. No image/avatar step is included.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-07-22 at 16 30 43" src="https://github.com/user-attachments/assets/050863ba-0d8c-4514-a02c-ff6d0c16cffe" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33903](https://ledgerhq.atlassian.net/browse/LIVE-33903)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33903]: https://ledgerhq.atlassian.net/browse/LIVE-33903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ