### PR TITLE
[LWM] fix(android): sync AndroidManifest targetSdkVersion to 36

### DIFF
--- a/apps/ledger-live-mobile/android/app/src/debug/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/debug/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk
         android:minSdkVersion="25"
-        android:targetSdkVersion="35"
+        android:targetSdkVersion="36"
         tools:overrideLibrary="com.ledger.reactnative, ca.jaysoo.extradimensions" />
 
     <application

--- a/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" /> <!-- Required for the webview camera/audio media -->
     <uses-sdk
         android:minSdkVersion="25"
-        android:targetSdkVersion="35"
+        android:targetSdkVersion="36"
         tools:overrideLibrary="com.ledger.reactnative, ca.jaysoo.extradimensions" />
 
     <uses-feature


### PR DESCRIPTION
## Summary

- `build.gradle` already sets `targetSdkVersion = 36` (required by Google Play API 36 deadline, August 31st)
- Both `AndroidManifest.xml` files still declared `targetSdkVersion="35"` — stale and misleading
- AGP overrides the manifest value at build time, so the shipped AAB was already correct; this is a consistency fix only

## Impact

No runtime, permission, or behaviour changes. No QA sign-off needed.

## Files changed

- `apps/ledger-live-mobile/android/app/src/main/AndroidManifest.xml`
- `apps/ledger-live-mobile/android/app/src/debug/AndroidManifest.xml`

## References

[LIVE-34758](https://ledgerhq.atlassian.net/browse/LIVE-34758)

[LIVE-34758]: https://ledgerhq.atlassian.net/browse/LIVE-34758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ