### PR TITLE
test(e2e): hardcode HBAR to XRP swap amount to 500

### DIFF
--- a/.changeset/quick-hbars-swap.md
+++ b/.changeset/quick-hbars-swap.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+test(e2e): hardcode the HBAR to XRP swap amount to 500 as a temporary workaround for LIVE-33611; revert once the swap "min amount for quotes" bug is fixed.

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -145,6 +145,9 @@ const swaps = [
     toAccount: Account.XRP_1,
     xrayTicket: "B2CQA-3753",
     tag: [...deviceTagsWithoutLNS(), "@hedera", "@ripple", "@family-xrp", "@family-hedera"],
+    // TODO(LIVE-33611): remove hardcoded amount once the swap "min amount for quotes" bug is fixed
+    // https://ledgerhq.atlassian.net/browse/LIVE-33611
+    amount: "500",
   },
   {
     fromAccount: TokenAccount.SUI_USDC_1,
@@ -171,7 +174,7 @@ const swaps = [
   // },
 ];
 
-for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {
+for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
   test.describe("Swap - Accepted (without tx broadcast)", () => {
     setupEnv(true);
 
@@ -219,7 +222,7 @@ for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {
       async ({ app, speculos }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
+        const minAmount = amount ?? (await app.swap.getMinimumAmount(fromAccount, toAccount));
         const swap = new Swap(fromAccount, toAccount, minAmount);
 
         await performSwapUntilQuoteSelectionStep(app, swap, minAmount);

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -32,6 +32,7 @@ export function runSwapTest(
   tmsLinks: string[],
   tags: string[],
   fee: Fee = Fee.MEDIUM,
+  hardcodedAmount?: string,
 ) {
   // The amount is resolved at runtime from the provider minimum and set on `swap` inside the test.
   const swap = new Swap(accountToDebit, accountToCredit, "", undefined, fee);
@@ -45,8 +46,13 @@ export function runSwapTest(
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
-      const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
-      const swapAmount = minAmount ? truncateSwapAmount(minAmount) : minAmount;
+      let swapAmount: string;
+      if (hardcodedAmount) {
+        swapAmount = hardcodedAmount;
+      } else {
+        const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
+        swapAmount = minAmount ? truncateSwapAmount(minAmount) : minAmount;
+      }
       swap.amount = swapAmount;
 
       await performSwapUntilQuoteSelectionStep(accountToDebit, accountToCredit, swapAmount);

--- a/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
+++ b/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
@@ -1,4 +1,5 @@
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { Fee } from "@ledgerhq/live-e2e-shared/enum/Fee";
 import { runSwapTest } from "./swap";
 
 runSwapTest(
@@ -17,4 +18,8 @@ runSwapTest(
     "@ripple",
     "@family-xrp",
   ],
+  Fee.MEDIUM,
+  // TODO(LIVE-33611): remove hardcoded amount once the swap "min amount for quotes" bug is fixed
+  // https://ledgerhq.atlassian.net/browse/LIVE-33611
+  "500",
 );


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This change is to the HBAR→XRP swap E2E specs themselves (LWD `send.swap.spec.ts`, LWM `swapHBAR_XRP.spec.ts`)._
- [x] **Impact of the changes:**
  - HBAR → XRP swap E2E flow on Desktop (LWD) and Mobile (LWM)
  - The swap must proceed using the fixed **500 HBAR** amount instead of the fetched provider minimum
  - All other swap pairs must be unaffected (still resolve the amount dynamically from the provider minimum)

### 📝 Description

The swap "minimum amount for quotes" fetch has a failing edge case (**LIVE-33611**): the returned minimum is sometimes rejected by the provider as too low, which makes the HBAR → XRP swap E2E test fail at the amount-entry step.

As a temporary workaround, the HBAR → XRP swap amount is now hardcoded to **500 HBAR** on both Desktop and Mobile, short-circuiting `getMinimumAmount` for this pair only. A `TODO(LIVE-33611)` is left at each hardcoded value so it can be reverted once the underlying bug is fixed.

- **Desktop** — `e2e/desktop/tests/specs/send.swap.spec.ts`: added `amount: "500"` to the `HEDERA_1 → XRP_1` config entry; the test uses `amount ?? (await app.swap.getMinimumAmount(...))`.
- **Mobile** — `e2e/mobile/specs/swap/swap.ts`: `runSwapTest(...)` gained an optional trailing `hardcodedAmount?` param that bypasses `getMinimumAmount`/`truncateSwapAmount` when set; `swapHBAR_XRP.spec.ts` passes `"500"`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33611](https://ledgerhq.atlassian.net/browse/LIVE-33611)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33611]: https://ledgerhq.atlassian.net/browse/LIVE-33611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ