### PR TITLE
[LWM] fix(LIVE-34754): show all digits in aleo send flow

### DIFF
--- a/.changeset/gold-gorillas-explode.md
+++ b/.changeset/gold-gorillas-explode.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: show all digits in aleo send flow

--- a/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/QuickAmountSelector.tsx
@@ -206,7 +206,7 @@ export function QuickAmountSelector({
                       numberOfLines={1}
                       adjustsFontSizeToFit
                     >
-                      <CurrencyUnitValue unit={unit} value={tile.rangeSum} showCode />
+                      <CurrencyUnitValue unit={unit} value={tile.rangeSum} showCode showAllDigits />
                     </Text>
                   )}
 
@@ -250,7 +250,7 @@ export function QuickAmountSelector({
                 numberOfLines={1}
                 adjustsFontSizeToFit
               >
-                <CurrencyUnitValue unit={unit} value={spendableBalance} showCode />
+                <CurrencyUnitValue unit={unit} value={spendableBalance} showCode showAllDigits />
               </Text>
             </Box>
             <Box

--- a/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/Send/__tests__/QuickAmountSelector.test.tsx
@@ -8,6 +8,7 @@ import { render, screen } from "@tests/test-renderer";
 import { QuickAmountSelector } from "../QuickAmountSelector";
 import { ALEO_ACCOUNT_1 } from "../../__mocks__/account.mock";
 import { urls } from "~/utils/urls";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 
 const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
 
@@ -21,8 +22,10 @@ jest.mock("LLM/hooks/useLocalizedUrls", () => ({
 
 jest.mock("~/components/CurrencyUnitValue", () => ({
   __esModule: true,
-  default: ({ value }: { value: BigNumber }) => <Text>{value.toString()}</Text>,
+  default: jest.fn(),
 }));
+
+const mockCurrencyUnitValue = jest.mocked(CurrencyUnitValue);
 
 const mockUseKeyboardVisible = jest.fn(() => ({ isKeyboardVisible: false, keyboardHeight: 0 }));
 jest.mock("~/logic/keyboardVisible", () => ({
@@ -81,6 +84,9 @@ describe("QuickAmountSelector", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseKeyboardVisible.mockReturnValue({ isKeyboardVisible: false, keyboardHeight: 0 });
+    mockCurrencyUnitValue.mockImplementation(({ value }: { value?: BigNumber | number | null }) => (
+      <Text>{value?.toString()}</Text>
+    ));
   });
 
   afterAll(() => {
@@ -217,6 +223,17 @@ describe("QuickAmountSelector", () => {
       const updater = mockUpdateTransaction.mock.calls[0][0];
       const result = updater(transaction);
       expect(result.useAllAmount).toBe(true);
+    });
+
+    it("shows full amount instead of rounding it down", () => {
+      mockCurrencyUnitValue.mockImplementation(
+        jest.requireActual("~/components/CurrencyUnitValue").default,
+      );
+
+      renderSelector(account, transaction, new BigNumber("1000001"));
+
+      expect(screen.getByText("1.000001 ALEO")).toBeOnTheScreen();
+      expect(screen.queryByText("1 ALEO")).not.toBeOnTheScreen();
     });
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/families/aleo/customSendFlow.ts
@@ -31,6 +31,7 @@ const aleoSendFlow = {
   SummaryToSection,
   AfterAmountInput: QuickAmountSelector,
   hideSummaryTotalSection: true,
+  showAllDigits: true,
   buildSendEntrypoint: ({ account, parentAccount }) => ({
     screen: ScreenName.AleoSendBalanceSelection,
     params: { account, parentAccount, isSelfTransfer: false },

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
@@ -1,24 +1,32 @@
 import React from "react";
 import { View } from "react-native";
 import { BigNumber } from "bignumber.js";
-import { render, screen } from "@tests/test-renderer";
+import { render, screen, waitFor } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import { ALEO_ACCOUNT_1, ALEO_TOKEN_ACCOUNT_1 } from "~/families/aleo/__mocks__/account.mock";
+import CurrencyUnitValue from "~/components/CurrencyUnitValue";
 import SendAmountCoin from "./03a-AmountCoin";
 
 jest.mock("LLM/hooks/useAccountScreen", () => ({
   useAccountScreen: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
-  useAccountBridge: jest.fn(() => ({
+jest.mock("~/components/CurrencyUnitValue", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => {
+  const bridge = {
     estimateMaxSpendable: jest.fn(() => Promise.resolve(new BigNumber(0))),
     updateTransaction: jest.fn((t: object, patch: object) => ({ ...t, ...patch })),
-  })),
-}));
+  };
+
+  return { useAccountBridge: jest.fn(() => bridge) };
+});
 
 jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
   __esModule: true,
@@ -32,6 +40,7 @@ jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
 const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
 const mockUseAccountScreen = jest.mocked(useAccountScreen);
 const mockUseBridgeTransaction = jest.mocked(useBridgeTransaction);
+const mockCurrencyUnitValue = jest.mocked(CurrencyUnitValue);
 const mockTransaction = {
   family: "aleo",
   recipient: "",
@@ -70,6 +79,7 @@ describe("SendAmountCoin — custom send flow", () => {
     } as never);
 
     mockNavigation.navigate.mockClear();
+    mockCurrencyUnitValue.mockClear();
   });
 
   it("renders without AfterAmountInput when no custom flow", () => {
@@ -103,5 +113,29 @@ describe("SendAmountCoin — custom send flow", () => {
 
     expect(mockGetCustomSendFlow).toHaveBeenCalledWith("aleo");
     expect(screen.getByTestId("after-amount-input")).toBeOnTheScreen();
+  });
+
+  it("passes the custom send flow's showAllDigits to the available balance", async () => {
+    mockGetCustomSendFlow.mockReturnValue({ screens: [], showAllDigits: true });
+
+    render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    await waitFor(() => {
+      expect(mockCurrencyUnitValue).toHaveBeenCalledWith(
+        expect.objectContaining({ showAllDigits: true }),
+        undefined,
+      );
+    });
+  });
+
+  it("does not force showAllDigits without a custom send flow", async () => {
+    render(<SendAmountCoin navigation={mockNavigation as never} route={mockRoute as never} />);
+
+    await waitFor(() => {
+      expect(mockCurrencyUnitValue).toHaveBeenCalledWith(
+        expect.objectContaining({ showAllDigits: undefined }),
+        undefined,
+      );
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -223,7 +223,12 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
                       </LText>
                       {maxSpendable && (
                         <LText semiBold color="grey">
-                          <CurrencyUnitValue showCode unit={unit} value={maxSpendable} />
+                          <CurrencyUnitValue
+                            showCode
+                            unit={unit}
+                            value={maxSpendable}
+                            showAllDigits={familySendFlow?.showAllDigits}
+                          />
                         </LText>
                       )}
                     </View>

--- a/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/utils/customSendFlow.ts
@@ -69,6 +69,8 @@ export type CustomSendFlow = {
   AfterAmountInput?: ComponentType<AfterAmountInputProps>;
   /** Suppresses the generic Amount + Fees "Total" row on the Summary screen (e.g. when the family renders its own inside SendRowsFee). */
   hideSummaryTotalSection?: boolean;
+  /** Forces full, unrounded precision on amounts in the send flow instead of the default significant-digits rounding (e.g. the "total available" balance on the Amount screen). */
+  showAllDigits?: boolean;
   /** Imperative navigation from within the SendFunds navigator after account selection. */
   navigateToInitialScreen?: (params: InitialScreenNavParams) => void;
   /** Imperative navigation from within the SendFunds navigator after recipient selection. */


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adjusts Aleo mobile send-flow to always show the amount with full 6-decimal precision. Before the generic logic was applied, so values like `1.000001 ALEO` were rounded to their significant-digit display and shown as 1 ALEO, silently hiding real balance. 

| before | after |
|---|--|
| <img width="722" height="1566" alt="image" src="https://github.com/user-attachments/assets/3350db0a-6d7c-4673-a84b-db477ff5bfdc" /> |  <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/ddba0551-b667-48d1-856f-439ef8223e59" /> |

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34754