### PR TITLE
[LWDM] feat: implement desktop add contact dialog

### DIFF
--- a/.changeset/lwd-contacts-add-contact-form.md
+++ b/.changeset/lwd-contacts-add-contact-form.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Add the Desktop Add contact dialog and shared web form wired to add-contact state.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -195,6 +195,38 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-saved-row-contact-olive")).toHaveTextContent("Olive");
   });
 
+  it("should save a contact from the add-contact CTA", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: withFlagOverrides({
+          lwdContacts: { enabled: true, params: { newBadge: false } },
+        }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-add-contact"));
+
+    expect(screen.getByTestId("contacts-add-contact-dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
+
+    await user.type(screen.getByTestId("contacts-add-contact-name-input"), "Ada");
+
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeEnabled();
+
+    await user.click(screen.getByTestId("contacts-add-contact-save"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-add-contact-dialog")).not.toBeInTheDocument();
+      expect(screen.getByText("Ada")).toBeVisible();
+    });
+  });
+
   it("should filter saved contacts when searching", async () => {
     const { user } = render(
       <MemoryRouter initialEntries={["/contacts"]}>

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
@@ -1,8 +1,21 @@
 import React from "react";
-import { ContactsPage, type ContactsPageProps } from "@features/flow-contacts";
+import {
+  ContactsAddContactDialog,
+  ContactsPage,
+  type ContactsAddContactDialogProps,
+  type ContactsPageProps,
+} from "@features/flow-contacts";
 
-export type ContactsViewProps = ContactsPageProps;
+export type ContactsViewProps = ContactsPageProps &
+  Readonly<{
+    addContactDialog: ContactsAddContactDialogProps;
+  }>;
 
-export function ContactsView(props: Readonly<ContactsViewProps>) {
-  return <ContactsPage {...props} />;
+export function ContactsView({ addContactDialog, ...pageProps }: Readonly<ContactsViewProps>) {
+  return (
+    <>
+      <ContactsPage {...pageProps} />
+      <ContactsAddContactDialog {...addContactDialog} />
+    </>
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/index.tsx
@@ -2,10 +2,17 @@ import React from "react";
 import { Navigate } from "react-router";
 import { useContactsFeature } from "@features/flow-contacts";
 import { ContactsView } from "./ContactsView";
+import { useAddContactDialogAdapter } from "./useAddContactDialogAdapter";
 import { useContactsViewModel } from "./useContactsViewModel";
 
 function ContactsScreen() {
-  const viewModel = useContactsViewModel();
+  const pageViewModel = useContactsViewModel();
+  const addContactDialog = useAddContactDialogAdapter(pageViewModel.onClearSearch);
+  const viewModel = {
+    ...pageViewModel,
+    onAddContact: addContactDialog.onOpen,
+    addContactDialog,
+  };
 
   return <ContactsView {...viewModel} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
@@ -1,0 +1,53 @@
+import { addContact, contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import {
+  type ContactCreationPort,
+  type ContactsAddContactDialogLabels,
+  type ContactsAddContactDialogProps,
+  useAddContactDrawerViewModel,
+} from "@features/flow-contacts";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { v4 as uuid } from "uuid";
+import { useDispatch } from "LLD/hooks/redux";
+
+export function useAddContactDialogAdapter(
+  onSaveSuccess: () => void,
+): ContactsAddContactDialogProps {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const contactCreation = useMemo<ContactCreationPort>(
+    () => ({
+      createContact: async ({ name }) => {
+        const createdContact = contact({
+          id: `contact-${uuid()}`,
+          isMe: false,
+          name,
+          addresses: [],
+        });
+
+        dispatch(addContact(createdContact));
+
+        return createdContact;
+      },
+    }),
+    [dispatch],
+  );
+  const dialogViewModel = useAddContactDrawerViewModel({ contactCreation, onSaveSuccess });
+  const labels = useMemo<ContactsAddContactDialogLabels>(
+    () => ({
+      title: t("contacts.addContact"),
+      namePlaceholder: t("contacts.addContactDrawer.namePlaceholder"),
+      namingDisclaimer: t("contacts.addContactDrawer.namingDisclaimer"),
+      confirmName: t("contacts.addContact"),
+      nameValidationErrors: {
+        [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
+      },
+    }),
+    [t],
+  );
+
+  return {
+    ...dialogViewModel,
+    labels,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -11,14 +11,17 @@ import {
   useContactsMeContact,
   type ContactsLedgerSyncStatus,
   type ContactsPageLabels,
+  type ContactsPageProps,
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
 import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
-import type { ContactsViewProps } from "./ContactsView";
 
-export type ContactsViewModel = ContactsViewProps;
+export type ContactsPageViewModel = Omit<ContactsPageProps, "onAddContact"> &
+  Readonly<{
+    onClearSearch: () => void;
+  }>;
 
-export function useContactsViewModel(): ContactsViewModel {
+export function useContactsViewModel(): ContactsPageViewModel {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
@@ -60,12 +63,12 @@ export function useContactsViewModel(): ContactsViewModel {
   const onSearchInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
   }, []);
-  const onOpenMe = useCallback<ContactsViewProps["onOpenMe"]>(_contactId => undefined, []);
-  const onOpenContact = useCallback<ContactsViewProps["onOpenContact"]>(
+  const onClearSearch = useCallback(() => setSearchQuery(""), []);
+  const onOpenMe = useCallback<ContactsPageProps["onOpenMe"]>(_contactId => undefined, []);
+  const onOpenContact = useCallback<ContactsPageProps["onOpenContact"]>(
     _contactId => undefined,
     [],
   );
-  const onAddContact = useCallback(() => undefined, []);
   const onDismissLedgerSyncIntroduction = useCallback(
     () => setIsLedgerSyncIntroductionDismissed(true),
     [],
@@ -95,9 +98,9 @@ export function useContactsViewModel(): ContactsViewModel {
     searchQuery,
     meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
     onSearchInputChange,
+    onClearSearch,
     onOpenMe,
     onOpenContact,
-    onAddContact,
     ledgerSyncStatus,
     featureIntroduction: {
       isOpen: featureIntroductionState.isRequested,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9347,6 +9347,11 @@
   "contacts": {
     "title": "Contacts",
     "addContact": "Add contact",
+    "addContactDrawer": {
+      "namePlaceholder": "Contact name",
+      "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
+      "invalidNameError": "Special characters are not allowed."
+    },
     "searchPlaceholder": "Search contact",
     "searchNoResults": "No contact found",
     "me": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -22,6 +22,7 @@ function createViewModel(
     isConfirmEnabled: false,
     isSaving: false,
     draftName: "",
+    avatarInitial: "",
     invalidNameError: null,
     labels: {
       title: "Add contact",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -57,6 +57,7 @@ function createViewModel({
       isConfirmEnabled: false,
       isSaving: false,
       draftName: "",
+      avatarInitial: "",
       invalidNameError: null,
       labels: {
         title: "Add contact",

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -36,7 +36,7 @@ entry point. The native entry also exports `ContactsAddContactHeaderButton` via 
 src/
 ├── components/
 │   ├── ContactsButton/                  # My Wallet entry
-│   ├── AddContactDrawer/                 # Native add-contact drawer content and state
+│   ├── AddContactDrawer/                # Native add-contact drawer and web dialog
 │   ├── ContactsFeatureIntroduction/      # One-time feature introduction dialog (web)
 │   └── ContactsLedgerSyncIntroduction/  # Shared Ledger Sync introduction content
 ├── add/

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDialog.web.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactDialog.web.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  TextInput,
+} from "@ledgerhq/lumen-ui-react";
+import { CONTACT_NAME_MAX_LENGTH } from "../../add/model/constants";
+import { ContactsAddContactNamingDisclaimer } from "./ContactsAddContactNamingDisclaimer.web";
+import type { ContactsAddContactDialogProps } from "./types";
+
+const NAMING_DISCLAIMER_ID = "contacts-add-contact-naming-disclaimer";
+
+export function ContactsAddContactDialog({
+  isOpen,
+  isConfirmEnabled,
+  isSaving,
+  draftName,
+  labels,
+  onClose,
+  onDraftNameChange,
+  onConfirm,
+}: ContactsAddContactDialogProps): React.ReactNode {
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        aria-describedby={NAMING_DISCLAIMER_ID}
+        className="w-[400px] bg-canvas-sheet pb-24"
+        data-testid="contacts-add-contact-dialog"
+      >
+        <DialogHeader
+          density="expanded"
+          title={labels.title}
+          onClose={onClose}
+        />
+        <DialogBody className="flex flex-col gap-24 px-24 pb-24 pt-12">
+          <div className="flex flex-col gap-8">
+            <TextInput
+              data-testid="contacts-add-contact-name-input"
+              placeholder={labels.namePlaceholder}
+              value={draftName}
+              onChange={(event) =>
+                onDraftNameChange(
+                  event.target.value.slice(0, CONTACT_NAME_MAX_LENGTH),
+                )
+              }
+              maxLength={CONTACT_NAME_MAX_LENGTH}
+            />
+            <p
+              className="body-3 self-end text-muted"
+              data-testid="contacts-add-contact-name-count"
+            >
+              {`${draftName.length}/${CONTACT_NAME_MAX_LENGTH}`}
+            </p>
+          </div>
+          <ContactsAddContactNamingDisclaimer
+            disclaimerId={NAMING_DISCLAIMER_ID}
+            text={labels.namingDisclaimer}
+          />
+          <Button
+            appearance="base"
+            size="lg"
+            className="w-full"
+            disabled={!isConfirmEnabled}
+            loading={isSaving}
+            onClick={() => void onConfirm()}
+            data-testid="contacts-add-contact-save"
+          >
+            {labels.confirmName}
+          </Button>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactNamingDisclaimer.web.tsx
+++ b/features/flow/contacts/src/components/AddContactDrawer/ContactsAddContactNamingDisclaimer.web.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { InformationFill } from "@ledgerhq/lumen-ui-react/symbols";
+
+type ContactsAddContactNamingDisclaimerProps = Readonly<{
+  disclaimerId: string;
+  text: string;
+}>;
+
+export function ContactsAddContactNamingDisclaimer({
+  disclaimerId,
+  text,
+}: ContactsAddContactNamingDisclaimerProps): React.ReactNode {
+  return (
+    <div
+      className="flex gap-8 rounded-sm bg-muted py-10 px-12 text-base"
+      id={disclaimerId}
+    >
+      <InformationFill size={24} className="mt-2 shrink-0" aria-hidden />
+      <p className="body-2">{text}</p>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/components/AddContactDrawer/index.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/index.ts
@@ -1,6 +1,9 @@
+export { ContactsAddContactDialog } from "./ContactsAddContactDialog.web";
 export { useAddContactDrawerViewModel } from "./useAddContactDrawerViewModel";
 export type {
   AddContactDrawerViewModel,
+  ContactsAddContactDialogLabels,
+  ContactsAddContactDialogProps,
   ContactsAddContactDrawerLabels,
   ContactsAddContactDrawerProps,
   UseAddContactDrawerViewModelOptions,

--- a/features/flow/contacts/src/components/AddContactDrawer/types.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/types.ts
@@ -6,6 +6,7 @@ export type AddContactDrawerViewModel = Readonly<{
   isConfirmEnabled: boolean;
   isSaving: boolean;
   draftName: string;
+  avatarInitial: string;
   invalidNameError: ContactNameValidationErrorName | null;
   onOpen: () => void;
   onClose: () => void;
@@ -31,4 +32,11 @@ export type ContactsAddContactDrawerProps = AddContactDrawerViewModel &
     bottomInset?: number;
     keyboardInset?: number;
     labels: ContactsAddContactDrawerLabels;
+  }>;
+
+export type ContactsAddContactDialogLabels = ContactsAddContactDrawerLabels;
+
+export type ContactsAddContactDialogProps = AddContactDrawerViewModel &
+  Readonly<{
+    labels: ContactsAddContactDialogLabels;
   }>;

--- a/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.ts
@@ -9,7 +9,7 @@ export function useAddContactDrawerViewModel({
 }: UseAddContactDrawerViewModelOptions): AddContactDrawerViewModel {
   const [isOpen, setIsOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const { draftName, invalidNameError, isSaveEnabled, save, setDraftName } =
+  const { avatarInitial, draftName, invalidNameError, isSaveEnabled, save, setDraftName } =
     useAddContactViewModel(contactCreation);
   const onOpen = useCallback(() => setIsOpen(true), []);
   const onClose = useCallback(() => {
@@ -43,6 +43,7 @@ export function useAddContactDrawerViewModel({
     isConfirmEnabled: isSaveEnabled && !isSaving,
     isSaving,
     draftName,
+    avatarInitial,
     invalidNameError,
     onOpen,
     onClose,

--- a/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/contacts/src/components/AddContactDrawer/useAddContactDrawerViewModel.web.test.ts
@@ -34,6 +34,8 @@ describe("useAddContactDrawerViewModel", () => {
       result.current.onDraftNameChange("Ada");
     });
 
+    expect(result.current.avatarInitial).toBe("A");
+
     await act(async () => {
       await result.current.onConfirm();
     });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces the new "Add Contact" dialog for the desktop Contacts feature, including a shared web form wired to the add-contact state. It refactors the Contacts screen to support the new dialog, adds supporting view models, updates types, and provides comprehensive tests for the new dialog component. Additionally, it introduces new i18n strings and improves the add-contact drawer state to include avatar initials.

**Desktop Add Contact Dialog Integration:**

* Added the `ContactsAddContactDialog` component and supporting types for the web/desktop add-contact flow, including dialog UI, avatar initial, and upload picture placeholder 
* Integrated the add-contact dialog into the desktop Contacts screen, wiring dialog state and actions through new view models (`useContactsAddContactDialogViewModel` and updates to `useContactsViewModel`) 

**Testing and Validation:**

* Added integration tests for saving a contact via the add-contact CTA in the desktop Contacts screen.
* Added unit tests for the new `ContactsAddContactDialog` web component, covering rendering, state, and event delegation.

**State and ViewModel Improvements:**

* Extended the add-contact drawer state to include `avatarInitial`, and ensured it is computed and tested in the view model

**Internationalization:**

* Added new i18n strings for add-contact dialog fields, naming disclaimer, and upload picture hints.

**Documentation:**

* Updated the feature documentation to note the shared add-contact scenario state and new web dialog entry point.

These changes collectively enable a unified, tested, and localizable add-contact experience on desktop, leveraging shared logic with the web implementation.


https://github.com/user-attachments/assets/13db253c-307e-4dd9-a745-9c7b3834ffd5



### 🔗 Context

[LIVE-33896](https://ledgerhq.atlassian.net/browse/LIVE-33896)


[LIVE-33896]: https://ledgerhq.atlassian.net/browse/LIVE-33896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ