### PR TITLE
[LWD] fix: no default selection when validator is not a ledger one

### DIFF
--- a/.changeset/gorgeous-crabs-know.md
+++ b/.changeset/gorgeous-crabs-know.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix: no default selection when validator is not a ledger one

--- a/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/fields/ValidatorField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/DelegationFlowModal/fields/ValidatorField.tsx
@@ -7,6 +7,7 @@ import type {
   StakingValidatorItem,
 } from "@ledgerhq/live-common/families/evm/staking/types";
 import { useEvmStakingValidators } from "@ledgerhq/live-common/families/evm/staking/react";
+import { getLedgerValidatorAddress } from "@ledgerhq/live-common/families/evm/staking/ledgerValidator";
 import Box from "~/renderer/components/Box";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import ScrollLoadingList from "~/renderer/components/ScrollLoadingList";
@@ -29,6 +30,7 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr, status 
   const [search, setSearch] = useState("");
   const unit = useAccountUnit(account);
   const currencyId = account.currency.id;
+  const ledgerValidatorAddress = getLedgerValidatorAddress(currencyId);
 
   const { validators, loading, error } = useEvmStakingValidators(currencyId, search);
 
@@ -53,8 +55,12 @@ const ValidatorField = ({ account, onChangeValidator, chosenVoteAccAddr, status 
   // (StrictMode warnings, possible flicker / inconsistent state).
   useEffect(() => {
     if (chosenVoteAccAddr !== "" || validators.length === 0 || loading) return;
-    onChangeValidator(validators[0].validatorAddress, validators[0].validatorId);
-  }, [chosenVoteAccAddr, onChangeValidator, validators, loading]);
+    if (validators[0].validatorAddress?.toLowerCase() === ledgerValidatorAddress?.toLowerCase()) {
+      onChangeValidator(validators[0].validatorAddress, validators[0].validatorId);
+      return;
+    }
+    setShowAll(true);
+  }, [chosenVoteAccAddr, onChangeValidator, validators, loading, ledgerValidatorAddress]);
 
   const valAddressError = status.errors.valAddress;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

No pre selection when first validator is not a ledger one

<img width="808" height="759" alt="Screenshot 2026-07-23 at 09 42 12" src="https://github.com/user-attachments/assets/b358cebf-921e-4f82-a4da-e50ae4c8ddd1" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34713](https://ledgerhq.atlassian.net/browse/LIVE-34713)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34713]: https://ledgerhq.atlassian.net/browse/LIVE-34713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ