### PR TITLE
refactor(shared-lib): split currency-id brand into per-entity ids (LIVE-34812)

### DIFF
--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -1,9 +1,13 @@
-import { CurrencyIdSchema, NonEmptyStringSchema, TokenIdSchema } from "@shared/schema-primitives";
+import {
+  CryptoCurrencyIdSchema,
+  NonEmptyStringSchema,
+  TokenCurrencyIdSchema,
+} from "@shared/schema-primitives";
 import { z } from "zod";
 
 export const ContactIdSchema = NonEmptyStringSchema;
 export const ContactAddressIdSchema = NonEmptyStringSchema;
-export const ContactCurrencyIdSchema = z.union([CurrencyIdSchema, TokenIdSchema]);
+export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCurrencyIdSchema]);
 
 const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;

--- a/domain/entity/currency-crypto/README.md
+++ b/domain/entity/currency-crypto/README.md
@@ -29,7 +29,7 @@ parity test compares by `.id`.
 
 | Package | Why |
 |---|---|
-| `@shared/schema-primitives` | `CurrencyIdSchema` branded value object |
+| `@shared/schema-primitives` | `CryptoCurrencyIdSchema` branded value object |
 | `@domain/entity-currency-unit` | `UnitSchema` embedded value object |
 
 ## Public API
@@ -77,8 +77,8 @@ NODE_OPTIONS="--conditions=@ledgerhq/source" npx tsx scripts/generate-currencies
 
 **Zod-first, not a wrapper.** `CryptoCurrencySchema` is written from scratch. TypeScript types are derived via `z.infer<>`.
 
-**`currency()` is a branded-type constructor, not a validator.** `CryptoCurrency.id` is typed as `CurrencyId` — a branded string (`string & { __brand: "CurrencyId" }`). A plain type annotation (`const bitcoin: CryptoCurrency = { id: "bitcoin", ... }`) fails because `"bitcoin"` is not assignable to the branded type. `currency()` calls `CryptoCurrencySchema.parse()` which applies the brand, eliminating the need for `as CurrencyId` casts across all currency files.
+**`currency()` is a branded-type constructor, not a validator.** `CryptoCurrency.id` is typed as `CryptoCurrencyId` — a branded string (`string & { __brand: "CryptoCurrencyId" }`). A plain type annotation (`const bitcoin: CryptoCurrency = { id: "bitcoin", ... }`) fails because `"bitcoin"` is not assignable to the branded type. `currency()` calls `CryptoCurrencySchema.parse()` which applies the brand, eliminating the need for `as CryptoCurrencyId` casts across all currency files.
 
 **Static registry, no store.** Currency data never changes at runtime. Putting it in Redux would imply reactivity that doesn't exist — consumers resolve currencies directly from `CRYPTO_CURRENCIES_REGISTRY`.
 
-**No embedded parent reference.** `@domain/entity-currency-token` uses `parentCurrencyId: CurrencyId` (FK) instead of an embedded `CryptoCurrency` object, which eliminates the `fromTokenCurrencyRaw` lookup-at-restore problem that made `cal-client/persistence.ts` complex.
+**No embedded parent reference.** `@domain/entity-currency-token` uses `parentCurrencyId: CryptoCurrencyId` (FK) instead of an embedded `CryptoCurrency` object, which eliminates the `fromTokenCurrencyRaw` lookup-at-restore problem that made `cal-client/persistence.ts` complex.

--- a/domain/entity/currency-crypto/src/define.ts
+++ b/domain/entity/currency-crypto/src/define.ts
@@ -8,7 +8,7 @@ import type { CryptoCurrency } from "./schema";
  *
  * Used by each file in `src/currencies/` to declare a single currency.
  * Calling `CryptoCurrencySchema.parse()` constructs branded value objects
- * (e.g. `CurrencyId`) without explicit casts.
+ * (e.g. `CryptoCurrencyId`) without explicit casts.
  *
  * @example
  * ```ts

--- a/domain/entity/currency-crypto/src/schema.mock.ts
+++ b/domain/entity/currency-crypto/src/schema.mock.ts
@@ -1,10 +1,10 @@
-import { CurrencyIdSchema } from "@shared/schema-primitives";
+import { CryptoCurrencyIdSchema } from "@shared/schema-primitives";
 import type { CryptoCurrency } from "./schema";
 
 export function mockCryptoCurrency(overrides?: Partial<CryptoCurrency>): CryptoCurrency {
   return {
     type: "CryptoCurrency",
-    id: CurrencyIdSchema.parse("bitcoin"),
+    id: CryptoCurrencyIdSchema.parse("bitcoin"),
     name: "Bitcoin",
     ticker: "BTC",
     units: [
@@ -29,7 +29,7 @@ export function mockCryptoCurrency(overrides?: Partial<CryptoCurrency>): CryptoC
 
 export function mockEthereumCurrency(overrides?: Partial<CryptoCurrency>): CryptoCurrency {
   return mockCryptoCurrency({
-    id: CurrencyIdSchema.parse("ethereum"),
+    id: CryptoCurrencyIdSchema.parse("ethereum"),
     name: "Ethereum",
     ticker: "ETH",
     units: [

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CurrencyIdSchema } from "@shared/schema-primitives";
+import { CryptoCurrencyIdSchema } from "@shared/schema-primitives";
 import { UnitSchema } from "@domain/entity-currency-unit";
 
 /**
@@ -49,7 +49,7 @@ export const CryptoCurrencySchema = z.object({
   /** Discriminant for the currency union — always `"CryptoCurrency"`. */
   type: z.literal("CryptoCurrency"),
   /** Unique opaque id (e.g. `"bitcoin"`, `"ethereum"`). */
-  id: CurrencyIdSchema,
+  id: CryptoCurrencyIdSchema,
   /** Human-readable display name (e.g. `"Bitcoin"`). */
   name: z.string(),
   /** Ticker used in exchanges and countervalue APIs (e.g. `"BTC"`). */

--- a/domain/entity/currency-fiat/README.md
+++ b/domain/entity/currency-fiat/README.md
@@ -29,7 +29,7 @@ parity test compares on that.
 
 | Package | Why |
 |---|---|
-| `@shared/schema-primitives` | `CurrencyIdSchema` branded value object |
+| `@shared/schema-primitives` | `FiatCurrencyIdSchema` branded value object |
 | `@domain/entity-currency-unit` | `UnitSchema` embedded value object |
 | `@reduxjs/toolkit` | `createSlice` for `supportedFiatsSlice` |
 
@@ -70,7 +70,7 @@ const usd = fiat({
 | Field                 | Type            | Required | Description                                      |
 | --------------------- | --------------- | -------- | ------------------------------------------------ |
 | `type`                | `"FiatCurrency"` | yes     | Discriminant literal                             |
-| `id`                  | `CurrencyId`    | yes      | Unique opaque id (e.g. `"usd"`, `"eur"`)         |
+| `id`                  | `FiatCurrencyId`    | yes      | Unique opaque id (e.g. `"usd"`, `"eur"`)         |
 | `name`                | `string`        | yes      | Human-readable name (e.g. `"US Dollar"`)         |
 | `ticker`              | `string`        | yes      | ISO 4217 ticker (e.g. `"USD"`, `"EUR"`)          |
 | `units`               | `Unit[]`        | yes      | Display units — at least one required            |

--- a/domain/entity/currency-fiat/src/schema.mock.ts
+++ b/domain/entity/currency-fiat/src/schema.mock.ts
@@ -1,4 +1,4 @@
-import { CurrencyIdSchema } from "@shared/schema-primitives";
+import { FiatCurrencyIdSchema } from "@shared/schema-primitives";
 import type { FiatCurrency } from "./schema";
 
 /**
@@ -8,7 +8,7 @@ import type { FiatCurrency } from "./schema";
 export function mockFiatCurrency(overrides?: Partial<FiatCurrency>): FiatCurrency {
   return {
     type: "FiatCurrency",
-    id: CurrencyIdSchema.parse("usd"),
+    id: FiatCurrencyIdSchema.parse("usd"),
     name: "US Dollar",
     ticker: "USD",
     symbol: "$",

--- a/domain/entity/currency-fiat/src/schema.ts
+++ b/domain/entity/currency-fiat/src/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CurrencyIdSchema } from "@shared/schema-primitives";
+import { FiatCurrencyIdSchema } from "@shared/schema-primitives";
 import { UnitSchema } from "@domain/entity-currency-unit";
 
 /**
@@ -14,7 +14,7 @@ export const FiatCurrencySchema = z.object({
   /** Discriminant for the currency union — always `"FiatCurrency"`. */
   type: z.literal("FiatCurrency"),
   /** Unique opaque id (e.g. `"usd"`, `"eur"`). */
-  id: CurrencyIdSchema,
+  id: FiatCurrencyIdSchema,
   /** Human-readable display name (e.g. `"US Dollar"`). */
   name: z.string(),
   /** ISO 4217 ticker (e.g. `"USD"`, `"EUR"`). */

--- a/domain/entity/currency-token/README.md
+++ b/domain/entity/currency-token/README.md
@@ -7,7 +7,7 @@ Domain entity for token currencies: Zod-first schema with FK-based parent curren
 
 ## Key Design
 
-`parentCurrencyId: CurrencyId` (FK) replaces the legacy `parentCurrency: CryptoCurrency` (embedded object). This eliminates the lookup-at-restore problem in `cal-client/persistence.ts` — the serialized form equals the domain form, so no `toTokenCurrencyRaw`/`fromTokenCurrencyRaw` conversion is needed. Resolving the parent for display: `cryptoCurrencyByIdSelector(state, token.parentCurrencyId)`.
+`parentCurrencyId: CryptoCurrencyId` (FK) replaces the legacy `parentCurrency: CryptoCurrency` (embedded object). This eliminates the lookup-at-restore problem in `cal-client/persistence.ts` — the serialized form equals the domain form, so no `toTokenCurrencyRaw`/`fromTokenCurrencyRaw` conversion is needed. Resolving the parent for display: `cryptoCurrencyByIdSelector(state, token.parentCurrencyId)`.
 
 No Redux slice, no static registry — tokens are served dynamically via `@domain/api/crypto-assets` (RTK Query).
 
@@ -46,8 +46,8 @@ const usdt = token({
 | Field                 | Type       | Required | Description                                           |
 | --------------------- | ---------- | -------- | ----------------------------------------------------- |
 | `type`                | `"TokenCurrency"` | yes | Discriminant literal                           |
-| `id`                  | `TokenId`  | yes      | Unique opaque token id (e.g. `"ethereum/erc20/usd-tether"`) |
-| `parentCurrencyId`    | `CurrencyId` | yes    | FK to parent crypto currency (e.g. `"ethereum"`)      |
+| `id`                  | `TokenCurrencyId`  | yes      | Unique opaque token id (e.g. `"ethereum/erc20/usd-tether"`) |
+| `parentCurrencyId`    | `CryptoCurrencyId` | yes    | FK to parent crypto currency (e.g. `"ethereum"`)      |
 | `contractAddress`     | `string`   | yes      | On-chain contract address                             |
 | `tokenType`           | `string`   | yes      | Token standard (e.g. `"erc20"`, `"bep20"`)            |
 | `name`                | `string`   | yes      | Human-readable name (e.g. `"Tether USD"`)             |

--- a/domain/entity/currency-token/src/define.ts
+++ b/domain/entity/currency-token/src/define.ts
@@ -6,7 +6,7 @@ import { TokenCurrencySchema, type TokenCurrency } from "./schema";
  * {@link TokenCurrencySchema} and returning a fully-typed domain object.
  *
  * Calling `TokenCurrencySchema.parse()` constructs branded value objects
- * (e.g. `TokenId`, `CurrencyId`) without explicit casts.
+ * (e.g. `TokenCurrencyId`, `CryptoCurrencyId`) without explicit casts.
  *
  * @example
  * ```ts

--- a/domain/entity/currency-token/src/schema.mock.ts
+++ b/domain/entity/currency-token/src/schema.mock.ts
@@ -1,4 +1,4 @@
-import { TokenIdSchema, CurrencyIdSchema } from "@shared/schema-primitives";
+import { TokenCurrencyIdSchema, CryptoCurrencyIdSchema } from "@shared/schema-primitives";
 import type { TokenCurrency } from "./schema";
 
 /**
@@ -8,8 +8,8 @@ import type { TokenCurrency } from "./schema";
 export function mockTokenCurrency(overrides?: Partial<TokenCurrency>): TokenCurrency {
   return {
     type: "TokenCurrency",
-    id: TokenIdSchema.parse("ethereum/erc20/usd-tether"),
-    parentCurrencyId: CurrencyIdSchema.parse("ethereum"),
+    id: TokenCurrencyIdSchema.parse("ethereum/erc20/usd-tether"),
+    parentCurrencyId: CryptoCurrencyIdSchema.parse("ethereum"),
     contractAddress: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     tokenType: "erc20",
     name: "Tether USD",

--- a/domain/entity/currency-token/src/schema.ts
+++ b/domain/entity/currency-token/src/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { TokenIdSchema, CurrencyIdSchema } from "@shared/schema-primitives";
+import { TokenCurrencyIdSchema, CryptoCurrencyIdSchema } from "@shared/schema-primitives";
 import { UnitSchema } from "@domain/entity-currency-unit";
 
 /**
@@ -11,12 +11,12 @@ export const TokenCurrencySchema = z.object({
   /** Discriminant for the currency union — always `"TokenCurrency"`. */
   type: z.literal("TokenCurrency"),
   /** Unique opaque token id (e.g. `"ethereum/erc20/usd-tether"`). */
-  id: TokenIdSchema,
+  id: TokenCurrencyIdSchema,
   /**
    * Id of the parent crypto currency (e.g. `"ethereum"` for ERC-20 tokens).
    * FK reference — resolved at display time via the crypto-currency registry.
    */
-  parentCurrencyId: CurrencyIdSchema,
+  parentCurrencyId: CryptoCurrencyIdSchema,
   /** On-chain contract address (e.g. `"0xdAC17F958D2ee523a2206206994597C13D831ec7"`). */
   contractAddress: z.string(),
   /** Token standard (e.g. `"erc20"`, `"bep20"`, `"trc10"`). */

--- a/shared/schema-primitives/README.md
+++ b/shared/schema-primitives/README.md
@@ -13,8 +13,9 @@ Branded Zod value objects shared across the `domain/` layer. Provides common typ
 
 | Schema                  | Type              | Validates                                               |
 | ----------------------- | ----------------- | ------------------------------------------------------- |
-| `CurrencyIdSchema`      | `CurrencyId`      | Non-empty string                                        |
-| `TokenIdSchema`         | `TokenId`         | Non-empty string                                        |
+| `CryptoCurrencyIdSchema`      | `CryptoCurrencyId`      | Non-empty string                                        |
+| `TokenCurrencyIdSchema`         | `TokenCurrencyId`         | Non-empty string                                        |
+| `FiatCurrencyIdSchema`          | `FiatCurrencyId`          | Non-empty string                                        |
 | `BigNumberStrSchema`    | `BigNumberStr`    | Decimal number string (e.g. `"123"`, `"-1.5"`)          |
 | `NonEmptyStringSchema`  | `NonEmptyString`  | Trimmed string with length ≥ 1                          |
 | `DateTimeIsoSchema`     | `DateTimeIso`     | RFC 3339 datetime with UTC offset (e.g. `"2024-01-31T12:00:00Z"`) |
@@ -27,19 +28,19 @@ All schemas are [Zod branded types](https://zod.dev/?id=brand), preventing accid
 
 ```ts
 import {
-  CurrencyIdSchema,
+  CryptoCurrencyIdSchema,
   DateTimeIsoSchema,
-  type CurrencyId,
+  type CryptoCurrencyId,
   type DateTimeIso,
 } from "@shared/schema-primitives";
 
 const AssetSchema = z.object({
-  id: CurrencyIdSchema,
+  id: CryptoCurrencyIdSchema,
   lastSeen: DateTimeIsoSchema,
 });
 
 // Type-safe branded values
-const id: CurrencyId = CurrencyIdSchema.parse("bitcoin");
+const id: CryptoCurrencyId = CryptoCurrencyIdSchema.parse("bitcoin");
 const t: DateTimeIso = DateTimeIsoSchema.parse("2024-01-31T12:00:00Z");
 
 // Compatible with both Date and Temporal

--- a/shared/schema-primitives/src/string.test.ts
+++ b/shared/schema-primitives/src/string.test.ts
@@ -1,29 +1,41 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   BigNumberStrSchema,
-  CurrencyIdSchema,
+  CryptoCurrencyIdSchema,
   DateTimeIsoSchema,
+  FiatCurrencyIdSchema,
   HttpUrlSchema,
   NonEmptyStringSchema,
   SemVerSchema,
-  TokenIdSchema,
+  TokenCurrencyIdSchema,
 } from "./string";
 
-describe("CurrencyIdSchema", () => {
+describe("CryptoCurrencyIdSchema", () => {
   it("accepts a non-empty string", () => {
-    expect(CurrencyIdSchema.parse("bitcoin")).toBe("bitcoin");
+    expect(CryptoCurrencyIdSchema.parse("bitcoin")).toBe("bitcoin");
   });
   it("rejects an empty string", () => {
-    expect(() => CurrencyIdSchema.parse("")).toThrow();
+    expect(() => CryptoCurrencyIdSchema.parse("")).toThrow();
   });
 });
 
-describe("TokenIdSchema", () => {
+describe("TokenCurrencyIdSchema", () => {
   it("accepts a non-empty string", () => {
-    expect(TokenIdSchema.parse("ethereum/erc20/usd-tether")).toBe("ethereum/erc20/usd-tether");
+    expect(TokenCurrencyIdSchema.parse("ethereum/erc20/usd-tether")).toBe(
+      "ethereum/erc20/usd-tether",
+    );
   });
   it("rejects an empty string", () => {
-    expect(() => TokenIdSchema.parse("")).toThrow();
+    expect(() => TokenCurrencyIdSchema.parse("")).toThrow();
+  });
+});
+
+describe("FiatCurrencyIdSchema", () => {
+  it("accepts a non-empty string", () => {
+    expect(FiatCurrencyIdSchema.parse("usd")).toBe("usd");
+  });
+  it("rejects an empty string", () => {
+    expect(() => FiatCurrencyIdSchema.parse("")).toThrow();
   });
 });
 

--- a/shared/schema-primitives/src/string.ts
+++ b/shared/schema-primitives/src/string.ts
@@ -1,10 +1,13 @@
 import { z } from "zod";
 
-/** Opaque identifier for a currency (e.g. `"bitcoin"`, `"ethereum"`). Non-empty string. */
-export const CurrencyIdSchema = z.string().min(1).brand<"CurrencyId">();
+/** Opaque identifier for a crypto currency (e.g. `"bitcoin"`, `"ethereum"`). Non-empty string. */
+export const CryptoCurrencyIdSchema = z.string().min(1).brand<"CryptoCurrencyId">();
 
 /** Opaque identifier for a token (e.g. `"ethereum/erc20/usd-tether"`). Non-empty string. */
-export const TokenIdSchema = z.string().min(1).brand<"TokenId">();
+export const TokenCurrencyIdSchema = z.string().min(1).brand<"TokenCurrencyId">();
+
+/** Opaque identifier for a fiat currency (e.g. `"usd"`, `"eur"`). Non-empty string. */
+export const FiatCurrencyIdSchema = z.string().min(1).brand<"FiatCurrencyId">();
 
 /**
  * Arbitrary-precision decimal number encoded as a string.
@@ -48,8 +51,9 @@ export const SemVerSchema = z
   .regex(/^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/, "Expected a semver string (e.g. 1.2.3)")
   .brand<"SemVer">();
 
-export type CurrencyId = z.infer<typeof CurrencyIdSchema>;
-export type TokenId = z.infer<typeof TokenIdSchema>;
+export type CryptoCurrencyId = z.infer<typeof CryptoCurrencyIdSchema>;
+export type TokenCurrencyId = z.infer<typeof TokenCurrencyIdSchema>;
+export type FiatCurrencyId = z.infer<typeof FiatCurrencyIdSchema>;
 export type BigNumberStr = z.infer<typeof BigNumberStrSchema>;
 export type NonEmptyString = z.infer<typeof NonEmptyStringSchema>;
 export type DateTimeIso = z.infer<typeof DateTimeIsoSchema>;


### PR DESCRIPTION
## What

Splits the single shared `CurrencyId` brand in `@shared/schema-primitives` into one branded id per currency namespace, and wires each domain entity schema to its own:

- `CryptoCurrencyId` → `CryptoCurrency.id` **+** `TokenCurrency.parentCurrencyId` (FK to the parent chain)
- `TokenCurrencyId` → `TokenCurrency.id`
- `FiatCurrencyId` → `FiatCurrency.id`

## Why

The previous single `CurrencyId` brand **conflated crypto and fiat ids** (disjoint namespaces — `"bitcoin"` vs `"usd"`), so a fiat id was assignable where a crypto id was expected, defeating the brand's purpose (this addresses the review comment on the earlier revision). It was also used for `TokenCurrency.parentCurrencyId`, which is always a **crypto** id.

Per-entity brands restore type-level separation and type `parentCurrencyId` as a crypto id specifically. No generic `CurrencyId` alias is kept — nothing consumes a currency id generically, and `Currency["id"]` yields the union automatically where needed.

## Verification

- `pnpm nx run-many -t typecheck` **repo-wide green** (101 projects + 145 dep tasks; desktop/mobile "All Good!", pre-existing filtered baseline unchanged).
- Unit tests green, incl. a new `FiatCurrencyIdSchema` test.
- `apps/wallet-cli/src/wallet/models.ts` has its own **local** `CurrencyIdSchema` (unrelated to `@shared`) — deliberately left untouched.
- No changeset — all affected packages are private (not published).