### PR TITLE
[LWM] fix(LIVE-34563): reset swap webview on history redirect

### DIFF
--- a/.changeset/swap-history-back-to-input.md
+++ b/.changeset/swap-history-back-to-input.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Swap: pressing "<" from the History screen after a multi-step swap now returns to the initial input form instead of the transaction success screen. The webview is remounted when redirecting to History so the success screen is no longer left mounted underneath.

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -215,6 +215,7 @@ describe("useSwapCustomHandlers", () => {
       const { result } = render();
 
       const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
+      expect(typeof handler).toBe("function");
 
       (handler as () => void)();
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -211,6 +211,16 @@ describe("useSwapCustomHandlers", () => {
       });
     });
 
+    it("resets the webview when swapRedirectToHistory handler is called", () => {
+      const { result } = render();
+
+      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
+
+      (handler as () => void)();
+
+      expect(mockResetWebview).toHaveBeenCalledTimes(1);
+    });
+
     it("passes swapId to SwapHistory when swapRedirectToHistory handler is called with params", () => {
       const { result } = render();
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -110,8 +110,14 @@ export function useSwapCustomHandlers(
         screen: ScreenName.SwapHistory,
         ...(params?.swapId ? { params: { swapId: params.swapId } } : {}),
       });
+
+      // Remount the webview while the History screen is on top so that pressing
+      // "<" (which pops back to SwapTab) lands on a clean swap form instead of
+      // the multi-step success screen still mounted underneath. Mirrors
+      // navigateToSwapPendingOperation. See LIVE-34563.
+      resetWebview();
     },
-    [navigation],
+    [navigation, resetWebview],
   );
 
   const walletAPISwapHandlers = useCustomExchangeHandlers({


### PR DESCRIPTION
## What

Fixes [LIVE-34563](https://ledgerhq.atlassian.net/browse/LIVE-34563): on mobile, after a multi-step swap, tapping **See details** → **Swap History** → the `<` back button showed the stale transaction success screen instead of the initial swap input form.

## Root cause

The multi-step success screen is rendered **inside the swap live-app webview** (`SwapTab`). `See details` triggers the `custom.swapRedirectToHistory` handler → `navigateToSwapHistory`, which pushes the native `SwapHistory` screen on top of `SwapTab`. The History `<` back button runs `navigateBackToSwapTab`, which pops back to the **still-mounted** `SwapTab` webview — frozen on the success screen.

`navigateToSwapPendingOperation` (the native single-step success path) already calls `resetWebview()` for exactly this reason; the multi-step history-redirect path was missing it.

## Change

- `navigateToSwapHistory` now calls `resetWebview()` after navigating, remounting the webview to a clean form behind the History screen so the back navigation lands on the input form. Mirrors `navigateToSwapPendingOperation`.
- Added a unit test asserting `resetWebview` is invoked by the `custom.swapRedirectToHistory` handler (all 10 tests in the suite pass).
- Changeset (`live-mobile` patch).

No changes to the recently-fixed navigation from LIVE-34263 (swapId history redirect) or LIVE-28726 (success back-to-input) — only the missing webview reset on the multi-step path is added.

## Test plan

- [x] `useSwapCustomHandlers.test.ts` — 10/10 pass
- [ ] Manual: multi-step swap → See details → History → `<` → lands on initial input form

## Pre-push review

Reviewed by the tracks-reviewer subagent. All findings hint-level (fix mirrors existing pattern, test/changeset conventions match). **REVIEW OUTCOME: pass**


[LIVE-34563]: https://ledgerhq.atlassian.net/browse/LIVE-34563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ