### PR TITLE
[LWDM] fix(shared-lib): add Solana DMK signer origin token

### DIFF
--- a/.changeset/solana-signer-origin-token.md
+++ b/.changeset/solana-signer-origin-token.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-solana": minor
+---
+
+Set the Solana DMK signer origin token so clear-signing metadata is resolved correctly

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -16,7 +16,10 @@ import {
   TransactionResolutionContext,
   SignMessageVersion,
 } from "@ledgerhq/device-signer-kit-solana";
-import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
+import {
+  DeviceActionStatus,
+  DeviceManagementKit,
+} from "@ledgerhq/device-management-kit";
 import bs58 from "bs58";
 import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 
@@ -31,7 +34,10 @@ export type DAError =
  */
 export class DmkSignerSol implements SolanaSigner {
   private dmkSigner: SignerSolana;
-  private readonly DMKPubKeyDisplayMode: { readonly long: string; readonly short: string } = {
+  private readonly DMKPubKeyDisplayMode: {
+    readonly long: string;
+    readonly short: string;
+  } = {
     long: "long",
     short: "short",
   };
@@ -41,10 +47,12 @@ export class DmkSignerSol implements SolanaSigner {
    * @param sessionId - active session ID of the connected device
    */
   constructor(dmk: DeviceManagementKit, sessionId: string) {
+    const originToken =
+      "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
     this.dmkSigner = new SignerSolanaBuilder({
       dmk,
       sessionId,
-      originToken: "Solana",
+      originToken,
     }).build();
   }
 
@@ -69,12 +77,13 @@ export class DmkSignerSol implements SolanaSigner {
     const { observable } = this.dmkSigner.getAppConfiguration();
     return new Promise<AppConfig>((resolve, reject) => {
       observable.subscribe({
-        next: state => {
+        next: (state) => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<GetAppConfigurationDAError>(state.error));
           }
           if (state.status === DeviceActionStatus.Completed) {
-            const { version, blindSigningEnabled, pubKeyDisplayMode } = state.output;
+            const { version, blindSigningEnabled, pubKeyDisplayMode } =
+              state.output;
             const mode =
               pubKeyDisplayMode === this.DMKPubKeyDisplayMode.long
                 ? PubKeyDisplayMode.LONG
@@ -82,7 +91,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ version, blindSigningEnabled, pubKeyDisplayMode: mode });
           }
         },
-        error: err => {
+        error: (err) => {
           reject(err);
         },
       });
@@ -101,7 +110,7 @@ export class DmkSignerSol implements SolanaSigner {
     });
     return new Promise<SolanaAddress>((resolve, reject) => {
       observable.subscribe({
-        next: state => {
+        next: (state) => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<GetAddressDAError>(state.error));
           }
@@ -111,7 +120,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ address: addressBytes });
           }
         },
-        error: err => {
+        error: (err) => {
           reject(err);
         },
       });
@@ -122,14 +131,17 @@ export class DmkSignerSol implements SolanaSigner {
    * Converts a Resolution from coin-solana to a TransactionResolutionContext for device-signer-kit-solana.
    * The userInputType values are identical between both types ("sol" | "ata") but defined separately
    */
-  private _toTransactionResolutionContext(resolution: Resolution): TransactionResolutionContext {
+  private _toTransactionResolutionContext(
+    resolution: Resolution,
+  ): TransactionResolutionContext {
     return {
       tokenAddress: resolution.tokenAddress,
       tokenInternalId: resolution.tokenInternalId,
       createATA: resolution.createATA,
       templateId: resolution.templateId,
       // Cast is safe: UserInputType enum values ("sol" | "ata") are identical in both types
-      userInputType: resolution.userInputType as TransactionResolutionContext["userInputType"],
+      userInputType:
+        resolution.userInputType as TransactionResolutionContext["userInputType"],
     };
   }
 
@@ -154,7 +166,7 @@ export class DmkSignerSol implements SolanaSigner {
     });
     return new Promise<SolanaSignature>((resolve, reject) => {
       observable.subscribe({
-        next: state => {
+        next: (state) => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<SignTransactionDAError>(state.error));
           }
@@ -163,7 +175,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ signature: signatureBuffer });
           }
         },
-        error: err => {
+        error: (err) => {
           reject(err);
         },
       });
@@ -175,7 +187,10 @@ export class DmkSignerSol implements SolanaSigner {
    * @param path - BIP32 derivation path
    * @param messageHex - message to sign in hexadecimal format
    */
-  async signMessage(path: string, messageHex: string): Promise<SolanaSignature> {
+  async signMessage(
+    path: string,
+    messageHex: string,
+  ): Promise<SolanaSignature> {
     const { observable } = this.dmkSigner.signMessage(
       path,
       new Uint8Array(Buffer.from(messageHex, "hex")),
@@ -183,16 +198,18 @@ export class DmkSignerSol implements SolanaSigner {
     );
     return new Promise<SolanaSignature>((resolve, reject) => {
       observable.subscribe({
-        next: state => {
+        next: (state) => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<SignMessageDAError>(state.error));
           }
           if (state.status === DeviceActionStatus.Completed) {
-            const signatureBuffer = Buffer.from(bs58.decode(state.output.signature));
+            const signatureBuffer = Buffer.from(
+              bs58.decode(state.output.signature),
+            );
             resolve({ signature: signatureBuffer });
           }
         },
-        error: err => {
+        error: (err) => {
           reject(err);
         },
       });


### PR DESCRIPTION
## Summary

Set the `originToken` on the Solana DMK signer (`DmkSignerSol`) to the correct hex identifier instead of the placeholder `"Solana"` value, so the context-module can resolve clear-signing metadata for Solana transactions.

## Changes

- `libs/live-signer-solana/src/DmkSignerSol.ts`: pass the real `originToken` to `SignerSolanaBuilder`.
- Formatting cleanup applied by the local formatter across the file.
- Added a changeset (`minor`) for `@ledgerhq/live-signer-solana`.

## Test

- [ ] Verified Solana transaction signing resolves clear-signing metadata with the new origin token.

Made with [Cursor](https://cursor.com)