### PR TITLE
feat: wire Contacts feature introduction settings

### DIFF
--- a/.changeset/lwd-contacts-feature-introduction.md
+++ b/.changeset/lwd-contacts-feature-introduction.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Wire the Contacts feature introduction on Desktop with persisted dismissal, defer navigation, integration coverage, and a dev-menu toggle to reset the intro.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -38,6 +38,18 @@ function renderContactsButton(initialState: ReturnType<typeof withFlagOverrides>
   );
 }
 
+function contactsPageInitialState(extra: Record<string, unknown> = {}) {
+  return {
+    ...withFlagOverrides({
+      lwdContacts: { enabled: true, params: { newBadge: false } },
+    }),
+    settings: {
+      hasDismissedContactsFeatureIntroduction: true,
+    },
+    ...extra,
+  };
+}
+
 describe("Contacts integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -118,9 +130,7 @@ describe("Contacts integration", () => {
       </MemoryRouter>,
       {
         skipRouter: true,
-        initialState: withFlagOverrides({
-          lwdContacts: { enabled: true, params: { newBadge: false } },
-        }),
+        initialState: contactsPageInitialState(),
       },
     );
 
@@ -151,12 +161,7 @@ describe("Contacts integration", () => {
       </MemoryRouter>,
       {
         skipRouter: true,
-        initialState: {
-          ...withFlagOverrides({
-            lwdContacts: { enabled: true, params: { newBadge: false } },
-          }),
-          contacts: { contacts: [] },
-        },
+        initialState: contactsPageInitialState({ contacts: { contacts: [] } }),
       },
     );
 
@@ -173,12 +178,7 @@ describe("Contacts integration", () => {
       </MemoryRouter>,
       {
         skipRouter: true,
-        initialState: {
-          ...withFlagOverrides({
-            lwdContacts: { enabled: true, params: { newBadge: false } },
-          }),
-          contacts: { contacts: mockPopulatedContacts() },
-        },
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
       },
     );
 
@@ -204,12 +204,7 @@ describe("Contacts integration", () => {
       </MemoryRouter>,
       {
         skipRouter: true,
-        initialState: {
-          ...withFlagOverrides({
-            lwdContacts: { enabled: true, params: { newBadge: false } },
-          }),
-          contacts: { contacts: mockPopulatedContacts() },
-        },
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
       },
     );
 
@@ -229,12 +224,7 @@ describe("Contacts integration", () => {
       </MemoryRouter>,
       {
         skipRouter: true,
-        initialState: {
-          ...withFlagOverrides({
-            lwdContacts: { enabled: true, params: { newBadge: false } },
-          }),
-          contacts: { contacts: mockPopulatedContacts() },
-        },
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
       },
     );
 
@@ -243,5 +233,54 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-search-no-results")).toBeVisible();
     expect(screen.getByText("No contact found")).toBeVisible();
     expect(screen.queryByTestId("contacts-saved-row-contact-ben")).not.toBeInTheDocument();
+  });
+
+  it("should show the one-time feature introduction on first visit and complete it from Try contacts", async () => {
+    const { user, store } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({
+          settings: { hasDismissedContactsFeatureIntroduction: false },
+        }),
+      },
+    );
+
+    expect(screen.getByTestId("contacts-feature-introduction-dialog")).toBeVisible();
+
+    await user.click(screen.getByTestId("contacts-feature-introduction-primary"));
+
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+    expect(screen.queryByTestId("contacts-feature-introduction-dialog")).not.toBeInTheDocument();
+    expect(screen.getByTestId("contacts-list")).toBeVisible();
+  });
+
+  it("should defer the feature introduction on Maybe later without persisting dismissal", async () => {
+    mockNavigate.mockClear();
+
+    const { user, store } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({
+          settings: { hasDismissedContactsFeatureIntroduction: false },
+        }),
+      },
+    );
+
+    expect(screen.getByTestId("contacts-feature-introduction-dialog")).toBeVisible();
+
+    await user.click(screen.getByTestId("contacts-feature-introduction-secondary"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo } from "react";
+import type { ContactsFeatureIntroductionPreferencePort } from "@features/flow-contacts";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { setHasDismissedContactsFeatureIntroduction } from "~/renderer/actions/settings";
+import { hasDismissedContactsFeatureIntroductionSelector } from "~/renderer/reducers/settings";
+
+export function useContactsFeatureIntroductionPreference(): ContactsFeatureIntroductionPreferencePort {
+  const dispatch = useDispatch();
+  const isDismissed = useSelector(hasDismissedContactsFeatureIntroductionSelector);
+
+  const markDismissed = useCallback(() => {
+    dispatch(setHasDismissedContactsFeatureIntroduction(true));
+  }, [dispatch]);
+
+  return useMemo(
+    () => ({
+      isDismissed,
+      markDismissed,
+    }),
+    [isDismissed, markDismissed],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,27 +1,36 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 import {
-  createClosedContactsFeatureIntroduction,
+  CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   createContactsListViewModel,
   createContactsSearchViewModel,
   resolveContactsLedgerSyncIntroductionOpen,
   useContacts,
+  useContactsFeatureIntroductionState,
   useContactsMeContact,
   type ContactsLedgerSyncStatus,
   type ContactsPageLabels,
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
+import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
 import type { ContactsViewProps } from "./ContactsView";
 
 export type ContactsViewModel = ContactsViewProps;
 
 export function useContactsViewModel(): ContactsViewModel {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
+  const preference = useContactsFeatureIntroductionPreference();
+  const featureIntroductionState = useContactsFeatureIntroductionState({
+    isContactsEntryAvailable: true,
+    preference,
+  });
   const labels = useMemo<ContactsPageLabels>(
     () => ({
       title: t("contacts.title"),
@@ -30,6 +39,15 @@ export function useContactsViewModel(): ContactsViewModel {
       addContact: t("contacts.addContact"),
       formatAddressCount: count => t("contacts.me.addressCount", { count }),
     }),
+    [t],
+  );
+  const featureIntroductionHighlights = useMemo(
+    () =>
+      CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS.map(({ icon, translationKey }) => ({
+        icon,
+        title: t(`contacts.featureIntroduction.highlights.${translationKey}.title`),
+        description: t(`contacts.featureIntroduction.highlights.${translationKey}.description`),
+      })),
     [t],
   );
   const viewModel = useMemo(() => {
@@ -60,10 +78,16 @@ export function useContactsViewModel(): ContactsViewModel {
   }, [ledgerSyncStatus]);
 
   const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
-    isFeatureIntroductionRequested: false,
+    isFeatureIntroductionRequested: featureIntroductionState.isRequested,
     ledgerSyncStatus,
     isLedgerSyncIntroductionDismissed,
   });
+  const onCompleteFeatureIntroduction = useCallback(() => {
+    featureIntroductionState.dismiss();
+  }, [featureIntroductionState]);
+  const onDeferFeatureIntroduction = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
 
   return {
     viewModel,
@@ -75,7 +99,16 @@ export function useContactsViewModel(): ContactsViewModel {
     onOpenContact,
     onAddContact,
     ledgerSyncStatus,
-    featureIntroduction: createClosedContactsFeatureIntroduction(),
+    featureIntroduction: {
+      isOpen: featureIntroductionState.isRequested,
+      title: t("contacts.featureIntroduction.title"),
+      description: t("contacts.featureIntroduction.description"),
+      highlights: featureIntroductionHighlights,
+      primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
+      secondaryActionLabel: t("contacts.featureIntroduction.secondaryAction"),
+      onComplete: onCompleteFeatureIntroduction,
+      onDefer: onDeferFeatureIntroduction,
+    },
     ledgerSyncIntroduction: {
       isOpen: isLedgerSyncIntroductionOpen,
       description: t("contacts.ledgerSyncIntroduction.description"),

--- a/apps/ledger-live-desktop/src/renderer/actions/constants.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/constants.ts
@@ -4,6 +4,8 @@
 export const PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS =
   "settings/purgeExpiredAnonymousUserNotifications";
 export const SET_PRODUCT_TOUR_COMPLETED = "settings/setProductTourCompleted";
+export const SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION =
+  "settings/setHasDismissedContactsFeatureIntroduction";
 export const TOGGLE_MEMOTAG_INFO = "settings/toggleShouldDisplayMemoTagInfo";
 export const TOGGLE_MEV = "settings/toggleMEV";
 export const UPDATE_ANONYMOUS_USER_NOTIFICATIONS = "settings/updateAnonymousUserNotifications";

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -21,6 +21,7 @@ import { useRefreshAccountsOrdering } from "~/renderer/actions/general";
 import { Language, Locale } from "~/config/languages";
 import {
   PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS,
+  SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION,
   SET_PRODUCT_TOUR_COMPLETED,
   TOGGLE_MEMOTAG_INFO,
   TOGGLE_MEV,
@@ -438,6 +439,13 @@ export const setHasSeenQ2Tour = (hasSeenQ2Tour: boolean) => ({
 export const setProductTourCompleted = (productTourCompleted: boolean) => ({
   type: SET_PRODUCT_TOUR_COMPLETED,
   payload: productTourCompleted,
+});
+
+export const setHasDismissedContactsFeatureIntroduction = (
+  hasDismissedContactsFeatureIntroduction: boolean,
+) => ({
+  type: SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION,
+  payload: hasDismissedContactsFeatureIntroduction,
 });
 
 export const setHasClickedRecover = (hasClickedRecover: boolean) => ({

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -33,6 +33,7 @@ import regionsByKey from "~/renderer/screens/settings/sections/General/regions.j
 import { State } from ".";
 import {
   PURGE_EXPIRED_ANONYMOUS_USER_NOTIFICATIONS,
+  SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION,
   SET_PRODUCT_TOUR_COMPLETED,
   TOGGLE_MEMOTAG_INFO,
   TOGGLE_MEV,
@@ -136,6 +137,7 @@ export type SettingsState = {
   hasSeenWalletV4Tour: boolean;
   hasSeenQ2Tour: boolean;
   productTourCompleted: boolean;
+  hasDismissedContactsFeatureIntroduction: boolean;
   hasClickedRecover: boolean;
   doNotAskAgainSkipMemo: boolean;
   deprecationDoNotRemind: string[];
@@ -242,6 +244,7 @@ export const INITIAL_STATE: SettingsState = {
   hasSeenWalletV4Tour: false,
   hasSeenQ2Tour: false,
   productTourCompleted: false,
+  hasDismissedContactsFeatureIntroduction: false,
   hasClickedRecover: false,
   doNotAskAgainSkipMemo: false,
   deprecationDoNotRemind: [],
@@ -310,6 +313,7 @@ type HandlersPayloads = {
   SET_HAS_SEEN_WALLET_V4_TOUR: boolean;
   SET_HAS_SEEN_Q2_TOUR: boolean;
   [SET_PRODUCT_TOUR_COMPLETED]: boolean;
+  [SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION]: boolean;
   SET_HAS_CLICKED_RECOVER: boolean;
 };
 type SettingsHandlers<PreciseKey = true> = Handlers<SettingsState, HandlersPayloads, PreciseKey>;
@@ -551,6 +555,10 @@ const handlers: SettingsHandlers = {
   [SET_PRODUCT_TOUR_COMPLETED]: (state: SettingsState, { payload }) => ({
     ...state,
     productTourCompleted: payload,
+  }),
+  [SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION]: (state: SettingsState, { payload }) => ({
+    ...state,
+    hasDismissedContactsFeatureIntroduction: payload,
   }),
   SET_HAS_CLICKED_RECOVER: (state: SettingsState, { payload }) => ({
     ...state,
@@ -879,6 +887,9 @@ export const anonymousUserNotificationsSelector = (state: State) =>
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
 export const hasSeenQ2TourSelector = (state: State) => state.settings.hasSeenQ2Tour;
 export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;
+
+export const hasDismissedContactsFeatureIntroductionSelector = (state: State) =>
+  state.settings.hasDismissedContactsFeatureIntroduction;
 export const hasClickedRecoverSelector = (state: State) => state.settings.hasClickedRecover;
 
 // Last onboarded device is the device set when a user goes through the onboarding flow.

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/ContactsDevToolContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Divider } from "@ledgerhq/lumen-ui-react";
+import { Button, Divider, Switch } from "@ledgerhq/lumen-ui-react";
 import {
   FeatureFlagPreview,
   FeatureParamRow,
@@ -26,6 +26,8 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
     handleLoadPopulatedContacts,
     handleResetContacts,
     handleResetOverride,
+    hasDismissedFeatureIntroduction,
+    handleToggleFeatureIntroductionDismissed,
   } = useContactsDevToolViewModel();
 
   return (
@@ -71,6 +73,32 @@ export const ContactsDevToolContent = ({ expanded }: ContactsDevToolContentProps
                 onCustomFamiliesInputChange={setCustomFamiliesInput}
                 onApplyCustomFamilies={handleApplyCustomFamilies}
               />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <span className="body-2-semi-bold text-muted">
+              {t("settings.developer.contactsDevTool.featureIntroduction.title")}
+            </span>
+            <Divider />
+            <div className="flex flex-col rounded-md bg-surface px-4 py-1">
+              <div className="flex items-center justify-between p-10">
+                <div className="flex flex-col gap-1">
+                  <span className="body-3">
+                    {t("settings.developer.contactsDevTool.featureIntroduction.label")}
+                  </span>
+                  <span className="body-3 text-muted">
+                    {hasDismissedFeatureIntroduction
+                      ? t("settings.developer.contactsDevTool.featureIntroduction.dismissed")
+                      : t("settings.developer.contactsDevTool.featureIntroduction.willShow")}
+                  </span>
+                </div>
+                <Switch
+                  name="contacts-feature-introduction-dismissed"
+                  selected={!hasDismissedFeatureIntroduction}
+                  onChange={handleToggleFeatureIntroductionDismissed}
+                />
+              </div>
             </div>
           </div>
 

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
@@ -192,4 +192,20 @@ describe("useContactsDevToolViewModel", () => {
       expect.objectContaining({ id: "contact-me", isMe: true, name: "Me", addresses: [] }),
     ]);
   });
+
+  it("should toggle hasDismissedContactsFeatureIntroduction", () => {
+    const { result, store } = renderHook(() => useContactsDevToolViewModel(), {
+      initialState: {
+        settings: { hasDismissedContactsFeatureIntroduction: true },
+      },
+    });
+
+    expect(result.current.hasDismissedFeatureIntroduction).toBe(true);
+
+    act(() => {
+      result.current.handleToggleFeatureIntroductionDismissed();
+    });
+
+    expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
+  });
 });

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/useContactsDevToolViewModel.ts
@@ -9,13 +9,18 @@ import {
   type ContactsFeatureValuePatch,
 } from "@features/flow-contacts";
 import { setOverride } from "@shared/feature-flags";
-import { useDispatch } from "LLD/hooks/redux";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { setHasDismissedContactsFeatureIntroduction } from "~/renderer/actions/settings";
+import { hasDismissedContactsFeatureIntroductionSelector } from "~/renderer/reducers/settings";
 import { CONTACTS_FLAG } from "../constants";
 import { ContactsDevToolViewModel } from "../types";
 
 export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
   const dispatch = useDispatch();
   const featureFlag = useFeature(CONTACTS_FLAG);
+  const hasDismissedFeatureIntroduction = useSelector(
+    hasDismissedContactsFeatureIntroductionSelector,
+  );
   const [customFamiliesInput, setCustomFamiliesInput] = useState("");
 
   const isEnabled = featureFlag?.enabled === true;
@@ -71,13 +76,19 @@ export const useContactsDevToolViewModel = (): ContactsDevToolViewModel => {
     dispatch(setOverride({ key: CONTACTS_FLAG, value: undefined }));
   }, [dispatch]);
 
+  const handleToggleFeatureIntroductionDismissed = useCallback(() => {
+    dispatch(setHasDismissedContactsFeatureIntroduction(!hasDismissedFeatureIntroduction));
+  }, [dispatch, hasDismissedFeatureIntroduction]);
+
   return {
     featureFlag,
     isEnabled,
     params,
     customFamiliesInput,
+    hasDismissedFeatureIntroduction,
     handleToggleEnabled,
     handleToggleNewBadge,
+    handleToggleFeatureIntroductionDismissed,
     handleSetEligibleAddressFamilies,
     setCustomFamiliesInput,
     handleApplyCustomFamilies,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/types.ts
@@ -9,8 +9,10 @@ export interface ContactsDevToolViewModel {
   readonly isEnabled: boolean;
   readonly params: ContactsFeatureParams;
   readonly customFamiliesInput: string;
+  readonly hasDismissedFeatureIntroduction: boolean;
   readonly handleToggleEnabled: () => void;
   readonly handleToggleNewBadge: () => void;
+  readonly handleToggleFeatureIntroductionDismissed: () => void;
   readonly handleSetEligibleAddressFamilies: (families: readonly string[]) => void;
   readonly setCustomFamiliesInput: (value: string) => void;
   readonly handleApplyCustomFamilies: () => void;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -5287,7 +5287,13 @@
         "contactsData": "Contacts data",
         "loadPopulatedContacts": "Load populated contacts",
         "resetContacts": "Reset contacts",
-        "resetOverride": "Reset override"
+        "resetOverride": "Reset override",
+        "featureIntroduction": {
+          "title": "Feature introduction",
+          "label": "Show Contacts feature introduction",
+          "dismissed": "Dismissed — turn on to show the intro again on Contacts.",
+          "willShow": "Will show on Contacts until dismissed."
+        }
       },
       "cryptoAssetsList": {
         "title": "Crypto Assets List",
@@ -9350,6 +9356,26 @@
     "ledgerSyncIntroduction": {
       "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
       "dismiss": "Got it"
+    },
+    "featureIntroduction": {
+      "title": "Introducing Contacts",
+      "description": "Your address book for crypto — save the wallets you send to, all in one place.",
+      "primaryAction": "Try contacts",
+      "secondaryAction": "Maybe later",
+      "highlights": {
+        "saveAddresses": {
+          "title": "Save addresses once",
+          "description": "Keep the addresses you send to in one place."
+        },
+        "sendToRightAddress": {
+          "title": "Send to the right address",
+          "description": "Funds reach the right wallet every time."
+        },
+        "privateAcrossDevices": {
+          "title": "Private across your devices",
+          "description": "End-to-end encrypted with Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails": {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces the Contacts feature introduction dialog to the Ledger Live Desktop app, along with the necessary UI, state management, and integration test coverage. The changes ensure that users see a one-time introduction dialog for the Contacts feature, with persisted dismissal, the ability to defer, and a developer menu toggle for resetting the introduction state. The implementation also refactors and centralizes the state handling for this feature introduction.

**Contacts Feature Introduction Implementation:**

* Added the Contacts feature introduction dialog, hero asset, and shared wiring with a closed default state for all apps. 
* Wired the Contacts feature introduction on Desktop with persisted dismissal, defer navigation, integration test coverage, and a dev-menu toggle to reset the intro. 
* Added the `useContactsFeatureIntroductionPreference` hook to encapsulate reading and updating the dismissal state for the feature introduction. 
* Refactored `useContactsViewModel` to consume the new feature introduction state, expose dialog props, and handle completion/defer actions. 

**State Management Enhancements:**

* Added `hasDismissedContactsFeatureIntroduction` to the Redux settings state, with actions, reducer handling, and a selector for reading/updating the dismissal state. 

**Integration and Developer Tooling:**

* Updated integration tests to cover the feature introduction dialog's display, completion, and defer behaviors using a new centralized initial state helper.
* Extended the Contacts developer tool to include the feature introduction dismissal state and a handler to toggle it. 


https://github.com/user-attachments/assets/69da5075-9691-49d5-8adc-dc100ae97912



### 🔗 Context

[LIVE-34641](https://ledgerhq.atlassian.net/browse/LIVE-34641)


[LIVE-34641]: https://ledgerhq.atlassian.net/browse/LIVE-34641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ