### PR TITLE
test(mobile): fix flaky earn v2 cold start e2e

### DIFF
--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -45,7 +45,7 @@ export default class EarnV2DashboardPage {
 
   @Step("Verify cold start page")
   async verifyColdStartPage() {
-    await detoxExpect(getWebElementByTestId(this.tokensToEarnBanner)).toExist();
+    await waitWebElementByTestId(this.tokensToEarnBanner);
   }
 
   @Step("Verify asset ready to earn")


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required — changes are limited to E2E test files under `e2e/`.
- [x] **Covered by automatic tests.** _Change is confined to the E2E suite itself; the `Earn V2 - Cold start` specs (ATOM & ETH) exercise the fixed assertion._
- [x] **Impact of the changes:**
  - Earn V2 "cold start" dashboard flow on mobile (ATOM & ETH)
  - Timing/population of the `tokens-to-earn-banner` in the earn web app
  - No production code touched — mobile E2E page object only

### 📝 Description

The `Earn V2 - Cold start` E2E tests for **ATOM** and **ETH** were failing intermittently on CI at `verifyColdStartPage`:

```
Test Failed: 'not <[]>' doesn't match: []
Expected: not <[]>
     Got: was <[]>
    at EarnV2DashboardPage.verifyColdStartPage (e2e/mobile/page/trade/earnV2Dashboard.page.ts:50)
```

**Problem.** `verifyColdStartPage()` asserted the `tokens-to-earn-banner` with an immediate, no-retry matcher (`detoxExpect(getWebElementByTestId(...)).toExist()`). That banner is populated by a secondary async fetch that lands *after* `max-potential-rewards` — the element `waitForColdStartPage()` already polls for. So the one-shot assertion raced the fetch and saw an empty match set (`[]`). Fast local machines usually win the race; slower / more variable CI runners hit the empty window. That intermittent-but-not-100% pattern is the classic flaky signature, and matches the Allure cross-check ("tokens-to-earn-banner empty though page rendered").

**Solution.** Replace the one-shot assertion with the polling helper `waitWebElementByTestId`, which retries every 2 s up to 60 s — consistent with `waitForColdStartPage()` directly above it. A poll strictly dominates a one-shot check: it can only widen the tolerance window, never reduce correctness. If the banner were genuinely missing (e.g. a feature-flag or data regression) the poll would time out and still fail loudly, so this does not mask real breakage.

```diff
  @Step("Verify cold start page")
  async verifyColdStartPage() {
-   await detoxExpect(getWebElementByTestId(this.tokensToEarnBanner)).toExist();
+   await waitWebElementByTestId(this.tokensToEarnBanner);
  }
```

### ❓ Context

- **JIRA or GitHub link**: Flaky failure observed in [CI run 29889996345](https://github.com/LedgerHQ/ledger-live/actions/runs/29889996345)
- **Android CI**: https://github.com/LedgerHQ/ledger-live/actions/runs/29930696824
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
