### PR TITLE
test(e2e): add swap deeplink E2E tests (B2CQA-4152)

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -35,6 +35,7 @@ export class SwapPage extends WebViewAppPage {
   // Swap Amount and Currency components
   private maxSpendableToggle = this.page.getByTestId("swap-max-spendable-toggle");
   private fromAccountCoinSelector = "from-account-coin-selector";
+  private readonly fromAccountAccountNameTag = "from-account-account-name-tag";
   private fromAccountAmountInput = "from-account-amount-input";
   private readonly fromAccountError = "from-account-error";
   private readonly noQuotesPlaceholder = "quotes-error-state";
@@ -372,6 +373,12 @@ export class SwapPage extends WebViewAppPage {
     this._webviewPage = undefined;
     const webview = await this.getWebView();
     await expect(webview.getByTestId(this.fromAccountCoinSelector)).toContainText(expected);
+  }
+
+  @step("Check currency to swap from account name contains $0")
+  async checkAssetFromAccountNameContains(expected: string) {
+    const webview = await this.getWebView();
+    await expect(webview.getByTestId(this.fromAccountAccountNameTag)).toContainText(expected);
   }
 
   @step("Expect asset or account selected $0 to be displayed")

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -2,6 +2,7 @@ import { WebViewAppPage } from "./webViewApp.page";
 import { step } from "tests/misc/reporters/step";
 import { expect, Page } from "@playwright/test";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { sendDeepLink } from "tests/utils/deeplink";
 import { ChooseAssetDrawer } from "./drawer/choose.asset.drawer";
 import { SwapProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
 import { Device } from "@ledgerhq/live-e2e-shared/enum/Device";
@@ -533,6 +534,11 @@ export class SwapPage extends WebViewAppPage {
       surface === "embedded" ? this.embeddedSwapContainer : this.fullSwapContainer;
     await swapContainer.waitFor();
     await this.getWebView();
+  }
+
+  @step("Open swap via deeplink: $0")
+  async openViaDeeplink(url: string) {
+    await this.goAndWaitForSwapToBeReady(() => sendDeepLink(this.page, url));
   }
 
   @step("Go to swap history")

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -541,6 +541,15 @@ export class SwapPage extends WebViewAppPage {
     await this.goAndWaitForSwapToBeReady(() => sendDeepLink(this.page, url));
   }
 
+  @step("Clear swap account selection from localStorage")
+  async clearSwapState() {
+    const webview = await this.getWebView();
+    await webview.evaluate(() => {
+      localStorage.removeItem("from-account");
+      localStorage.removeItem("to-account");
+    });
+  }
+
   @step("Go to swap history")
   async goToSwapHistory() {
     await this.historyButton.click();

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -9,7 +9,6 @@ import {
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
 import { addTmsLink } from "tests/utils/allureUtils";
-import { getDescription } from "tests/utils/customJsonReporter";
 import {
   setupEnv,
   selectAccountFromDeeplinkDrawer,
@@ -44,21 +43,12 @@ const TAGS = [
   "@family-evm",
 ];
 
-test.describe.configure({ mode: "serial" });
-
 test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
   setupEnv(true);
 
   const btcAccount = Account.BTC_NATIVE_SEGWIT_2;
   const ethAccount = Account.ETH_3;
   const usdtAccount = TokenAccount.ETH_USDT_1;
-
-  test.beforeEach(async () => {
-    setExchangeDependencies([
-      { name: btcAccount.currency.speculosApp.name.replace(/ /g, "_") },
-      { name: ethAccount.currency.speculosApp.name.replace(/ /g, "_") },
-    ]);
-  });
 
   test.use({
     teamOwner: Team.SWAP,
@@ -77,236 +67,191 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
     ],
   });
 
-  // Navigate to home before each test so the swap live app is unmounted,
-  // ensuring no prior-selection state bleeds into the next test.
-  test.beforeEach(async ({ app }) => {
-    await app.mainNavigation.openTargetFromMainNavigation("home");
-  });
-
-  // ─── Group A: token params only, no accountIds ──────────────────────────────
-
   test(
-    "A1: no params — both fields default to highest-cap asset",
+    "[B2CQA-4152] Swap deeplinks — all scenarios",
     { tag: TAGS, annotation: { type: "TMS", description: TMS } },
     async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap");
-      await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains(DEFAULT_TO);
-    },
-  );
+      await addTmsLink([TMS]);
 
-  test(
-    "A2: fromToken=ETH toToken=BTC",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin");
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await selectAccountFromDeeplinkDrawer(app, btcAccount);
-      await app.swap.checkAssetFromContains("ETH");
-      await app.swap.checkAssetToContains("BTC");
-    },
-  );
+      setExchangeDependencies([
+        { name: btcAccount.currency.speculosApp.name.replace(/ /g, "_") },
+        { name: ethAccount.currency.speculosApp.name.replace(/ /g, "_") },
+      ]);
 
-  test(
-    "A3: fromToken=USDT(ERC20) toToken=ETH",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=ethereum`,
+      // helper: reset state between scenarios
+      const reset = async () => {
+        await app.swap.clearSwapState();
+        await app.mainNavigation.openTargetFromMainNavigation("home");
+      };
+
+      // ─── Group A: token params only, no accountIds ────────────────────────────
+
+      await test.step("A1: no params — both fields default to highest-cap asset", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap");
+        await app.swap.checkAssetFromContains(DEFAULT_FROM);
+        await app.swap.checkAssetToContains(DEFAULT_TO);
+        await reset();
+      });
+
+      await test.step("A2: fromToken=ETH toToken=BTC", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin");
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await selectAccountFromDeeplinkDrawer(app, btcAccount);
+        await app.swap.checkAssetFromContains("ETH");
+        await app.swap.checkAssetToContains("BTC");
+        await reset();
+      });
+
+      await test.step("A3: fromToken=USDT(ERC20) toToken=ETH", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=ethereum`,
+        );
+        await selectAccountFromDeeplinkDrawer(app, usdtAccount);
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await app.swap.checkAssetFromContains("USDT");
+        await app.swap.checkAssetToContains("ETH");
+        await reset();
+      });
+
+      await test.step("A4: fromToken=ETH toToken=USDT(ERC20)", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromToken=ethereum&toToken=${USDT_TOKEN_ID}`,
+        );
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await selectAccountFromDeeplinkDrawer(app, usdtAccount);
+        await app.swap.checkAssetFromContains("ETH");
+        await app.swap.checkAssetToContains("USDT");
+        await reset();
+      });
+
+      // A5 (FDUSD/BSC) is manual-only — no E2E account available.
+
+      await test.step("A6: fromToken=BTC only — receive defaults to highest-cap asset", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=bitcoin");
+        await selectAccountFromDeeplinkDrawer(app, btcAccount);
+        await app.swap.checkAssetFromContains("BTC");
+        await app.swap.checkAssetToContains(DEFAULT_TO);
+        await reset();
+      });
+
+      await test.step("A7: toToken=ETH only — send defaults to highest-cap asset", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?toToken=ethereum");
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await app.swap.checkAssetFromContains(DEFAULT_FROM);
+        await app.swap.checkAssetToContains("ETH");
+        await reset();
+      });
+
+      await test.step("A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=bitcoin");
+        await closeDeeplinkDrawer(app); // fromToken=123 is invalid — close its drawer
+        await selectAccountFromDeeplinkDrawer(app, btcAccount); // receive drawer: BTC account
+        await app.swap.checkAssetFromContains(DEFAULT_FROM);
+        await app.swap.checkAssetToContains("BTC");
+        await reset();
+      });
+
+      await test.step("A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=456");
+        await selectAccountFromDeeplinkDrawer(app, ethAccount); // only send drawer; invalid to has no drawer
+        await app.swap.checkAssetFromContains("ETH");
+        await app.swap.checkAssetToContains(DEFAULT_TO);
+        await reset();
+      });
+
+      await test.step("A10: fromToken=INVALID toToken=INVALID — both default", async () => {
+        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=456");
+        await app.swap.checkAssetFromContains(DEFAULT_FROM);
+        await app.swap.checkAssetToContains(DEFAULT_TO);
+        await reset();
+      });
+
+      // ─── Group B: with amount ──────────────────────────────────────────────────
+
+      await test.step("B1: ETH→BTC with valid amountFrom=0.01", async () => {
+        await app.swap.openViaDeeplink(
+          "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=0.01",
+        );
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await selectAccountFromDeeplinkDrawer(app, btcAccount);
+        await app.swap.checkAssetFromContains("ETH");
+        await app.swap.checkAssetToContains("BTC");
+        const amount = await app.swap.getAmountToSend();
+        expect(amount).toBe("0.01");
+        await reset();
+      });
+
+      await test.step("B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero", async () => {
+        await app.swap.openViaDeeplink(
+          "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=abc",
+        );
+        await selectAccountFromDeeplinkDrawer(app, ethAccount);
+        await selectAccountFromDeeplinkDrawer(app, btcAccount);
+        await app.swap.checkAssetFromContains("ETH");
+        await app.swap.checkAssetToContains("BTC");
+        const amount = await app.swap.getAmountToSend();
+        expect(amount).toMatch(/^(0\.?0*|)$/);
+        await reset();
+      });
+
+      // ─── Group C: with accountIds — no drawer expected ────────────────────────
+
+      await test.step("C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
+            `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
+        );
+        await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
+        await app.swap.checkAssetToContains(getParentAccountName(btcAccount));
+        const amount = await app.swap.getAmountToSend();
+        expect(amount).toBe("20");
+        await reset();
+      });
+
+      await test.step(
+        "C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer",
+        async () => {
+          await app.swap.openViaDeeplink(
+            `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
+          );
+          await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+          await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
+          await reset();
+        },
       );
-      await selectAccountFromDeeplinkDrawer(app, usdtAccount);
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await app.swap.checkAssetFromContains("USDT");
-      await app.swap.checkAssetToContains("ETH");
-    },
-  );
 
-  test(
-    "A4: fromToken=ETH toToken=USDT(ERC20)",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromToken=ethereum&toToken=${USDT_TOKEN_ID}`,
+      await test.step("C3: USDT+fromAccountId only — receive defaults, no drawer", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
+        );
+        await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
+        await app.swap.checkAssetToContains(DEFAULT_TO);
+        await reset();
+      });
+
+      await test.step("C4: toToken=ETH+toAccountId only — send defaults, no drawer", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`,
+        );
+        await app.swap.checkAssetFromContains(DEFAULT_FROM);
+        await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
+        await reset();
+      });
+
+      await test.step(
+        "C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins",
+        async () => {
+          await app.swap.openViaDeeplink(
+            `ledgerwallet://swap?fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
+              `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
+          );
+          // fromAccountId takes precedence over conflicting fromToken
+          await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+          // toAccountId takes precedence over conflicting toToken
+          await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
+          // no reset needed after last step
+        },
       );
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await selectAccountFromDeeplinkDrawer(app, usdtAccount);
-      await app.swap.checkAssetFromContains("ETH");
-      await app.swap.checkAssetToContains("USDT");
-    },
-  );
-
-  // A5 (FDUSD/BSC) is manual-only — no E2E account available.
-
-  test(
-    "A6: fromToken=BTC only — receive defaults to highest-cap asset",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=bitcoin");
-      await selectAccountFromDeeplinkDrawer(app, btcAccount);
-      await app.swap.checkAssetFromContains("BTC");
-      await app.swap.checkAssetToContains(DEFAULT_TO);
-    },
-  );
-
-  test(
-    "A7: toToken=ETH only — send defaults to highest-cap asset",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?toToken=ethereum");
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains("ETH");
-    },
-  );
-
-  test(
-    "A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=bitcoin");
-      await closeDeeplinkDrawer(app); // fromToken=123 is invalid — close its drawer
-      await selectAccountFromDeeplinkDrawer(app, btcAccount); // receive drawer: BTC account
-      await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains("BTC");
-    },
-  );
-
-  test(
-    "A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=456");
-      await selectAccountFromDeeplinkDrawer(app, ethAccount); // only send drawer; invalid to has no drawer
-      await app.swap.checkAssetFromContains("ETH");
-      await app.swap.checkAssetToContains(DEFAULT_TO);
-    },
-  );
-
-  test(
-    "A10: fromToken=INVALID toToken=INVALID — both default",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=456");
-      await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains(DEFAULT_TO);
-    },
-  );
-
-  // ─── Group B: with amount ────────────────────────────────────────────────────
-
-  test(
-    "B1: ETH→BTC with valid amountFrom=0.01",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=0.01",
-      );
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await selectAccountFromDeeplinkDrawer(app, btcAccount);
-      await app.swap.checkAssetFromContains("ETH");
-      await app.swap.checkAssetToContains("BTC");
-      const amount = await app.swap.getAmountToSend();
-      expect(amount).toBe("0.01");
-    },
-  );
-
-  test(
-    "B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=abc",
-      );
-      await selectAccountFromDeeplinkDrawer(app, ethAccount);
-      await selectAccountFromDeeplinkDrawer(app, btcAccount);
-      await app.swap.checkAssetFromContains("ETH");
-      await app.swap.checkAssetToContains("BTC");
-      const amount = await app.swap.getAmountToSend();
-      expect(amount).toMatch(/^(0\.?0*|)$/);
-    },
-  );
-
-  // ─── Group C: with accountIds — no drawer expected ──────────────────────────
-
-  test(
-    "C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
-          `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
-      );
-      await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
-      await app.swap.checkAssetToContains(getParentAccountName(btcAccount));
-      const amount = await app.swap.getAmountToSend();
-      expect(amount).toBe("20");
-    },
-  );
-
-  test(
-    "C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
-      );
-      await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
-      await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
-    },
-  );
-
-  test(
-    "C3: USDT+fromAccountId only — receive defaults, no drawer",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
-      );
-      await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
-      await app.swap.checkAssetToContains(DEFAULT_TO);
-    },
-  );
-
-  test(
-    "C4: toToken=ETH+toAccountId only — send defaults, no drawer",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`,
-      );
-      await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
-    },
-  );
-
-  test(
-    "C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins",
-    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
-          `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
-      );
-      // fromAccountId takes precedence over conflicting fromToken
-      await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
-      // toAccountId takes precedence over conflicting toToken
-      await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
     },
   );
 });

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -1,0 +1,312 @@
+import test from "tests/fixtures/common";
+import { expect } from "@playwright/test";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
+import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { setupEnv, selectAccountFromDeeplinkDrawer, closeDeeplinkDrawer } from "tests/utils/swapUtils";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+
+// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
+// Must match the accounts loaded by cliCommandsOnApp below.
+const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
+const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
+const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
+
+const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
+
+// On a fresh session (no prior swap), the live app defaults to the highest
+// market-cap assets: BTC for the send field, ETH for the receive field.
+const DEFAULT_FROM = "BTC";
+const DEFAULT_TO = "";
+
+const TMS = "B2CQA-4152";
+const TAGS = [
+  "@NanoSP",
+  "@LNS",
+  "@NanoX",
+  "@Stax",
+  "@Flex",
+  "@NanoGen5",
+  "@bitcoin",
+  "@family-bitcoin",
+  "@ethereum",
+  "@family-evm",
+];
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
+  setupEnv(true);
+
+  const btcAccount = Account.BTC_NATIVE_SEGWIT_1;
+  const ethAccount = Account.ETH_1;
+  const usdtAccount = TokenAccount.ETH_USDT_1;
+
+  test.beforeEach(async () => {
+    setExchangeDependencies([
+      { name: btcAccount.currency.speculosApp.name.replace(/ /g, "_") },
+      { name: ethAccount.currency.speculosApp.name.replace(/ /g, "_") },
+    ]);
+  });
+
+  test.use({
+    teamOwner: Team.SWAP,
+    userdata: "skip-onboarding-with-last-seen-device",
+    speculosApp: AppInfos.EXCHANGE,
+    cliCommandsOnApp: [
+      [
+        { app: btcAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(btcAccount) },
+        { app: ethAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(ethAccount) },
+        {
+          app: usdtAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(usdtAccount),
+        },
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  // Navigate to home before each test so the swap live app is unmounted,
+  // ensuring no prior-selection state bleeds into the next test.
+  test.beforeEach(async ({ app }) => {
+    await app.mainNavigation.openTargetFromMainNavigation("home");
+  });
+
+  // ─── Group A: token params only, no accountIds ──────────────────────────────
+
+  test(
+    "A1: no params — both fields default to highest-cap asset",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap");
+      await app.swap.checkAssetFromContains(DEFAULT_FROM);
+      await app.swap.checkAssetToContains(DEFAULT_TO);
+    },
+  );
+
+  test(
+    "A2: fromToken=ETH toToken=BTC",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin");
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await selectAccountFromDeeplinkDrawer(app, btcAccount);
+      await app.swap.checkAssetFromContains("ETH");
+      await app.swap.checkAssetToContains("BTC");
+    },
+  );
+
+  test(
+    "A3: fromToken=USDT(ERC20) toToken=ETH",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=ethereum`,
+      );
+      await selectAccountFromDeeplinkDrawer(app, usdtAccount);
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await app.swap.checkAssetFromContains("USDT");
+      await app.swap.checkAssetToContains("ETH");
+    },
+  );
+
+  test(
+    "A4: fromToken=ETH toToken=USDT(ERC20)",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromToken=ethereum&toToken=${USDT_TOKEN_ID}`,
+      );
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await selectAccountFromDeeplinkDrawer(app, usdtAccount);
+      await app.swap.checkAssetFromContains("ETH");
+      await app.swap.checkAssetToContains("USDT");
+    },
+  );
+
+  // A5 (FDUSD/BSC) is manual-only — no E2E account available.
+
+  test(
+    "A6: fromToken=BTC only — receive defaults to highest-cap asset",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=bitcoin");
+      await selectAccountFromDeeplinkDrawer(app, btcAccount);
+      await app.swap.checkAssetFromContains("BTC");
+      await app.swap.checkAssetToContains(DEFAULT_TO);
+    },
+  );
+
+  test(
+    "A7: toToken=ETH only — send defaults to highest-cap asset",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?toToken=ethereum");
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await app.swap.checkAssetFromContains(DEFAULT_FROM);
+      await app.swap.checkAssetToContains("ETH");
+    },
+  );
+
+  test(
+    "A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=bitcoin");
+      await closeDeeplinkDrawer(app); // fromToken=123 is invalid — close its drawer
+      await selectAccountFromDeeplinkDrawer(app, btcAccount); // receive drawer: BTC account
+      await app.swap.checkAssetFromContains(DEFAULT_FROM);
+      await app.swap.checkAssetToContains("BTC");
+    },
+  );
+
+  test(
+    "A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=456");
+      await selectAccountFromDeeplinkDrawer(app, ethAccount); // only send drawer; invalid to has no drawer
+      await app.swap.checkAssetFromContains("ETH");
+      await app.swap.checkAssetToContains(DEFAULT_TO);
+    },
+  );
+
+  test(
+    "A10: fromToken=INVALID toToken=INVALID — both default",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=456");
+      await app.swap.checkAssetFromContains(DEFAULT_FROM);
+      await app.swap.checkAssetToContains(DEFAULT_TO);
+    },
+  );
+
+  // ─── Group B: with amount ────────────────────────────────────────────────────
+
+  test(
+    "B1: ETH→BTC with valid amountFrom=0.01",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=0.01",
+      );
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await selectAccountFromDeeplinkDrawer(app, btcAccount);
+      await app.swap.checkAssetFromContains("ETH");
+      await app.swap.checkAssetToContains("BTC");
+      const amount = await app.swap.getAmountToSend();
+      expect(amount).toBe("0.01");
+    },
+  );
+
+  test(
+    "B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        "ledgerwallet://swap?fromToken=ethereum&toToken=bitcoin&amountFrom=abc",
+      );
+      await selectAccountFromDeeplinkDrawer(app, ethAccount);
+      await selectAccountFromDeeplinkDrawer(app, btcAccount);
+      await app.swap.checkAssetFromContains("ETH");
+      await app.swap.checkAssetToContains("BTC");
+      const amount = await app.swap.getAmountToSend();
+      expect(amount).toMatch(/^(0\.?0*|)$/);
+    },
+  );
+
+  // ─── Group C: with accountIds — no drawer expected ──────────────────────────
+
+  test(
+    "C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
+          `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
+      );
+      await app.swap.checkAssetFromContains("USDT");
+      await app.swap.checkAssetFromContains(usdtAccount.accountName);
+      await app.swap.checkAssetToContains("BTC");
+      await app.swap.checkAssetToContains(btcAccount.accountName);
+      const amount = await app.swap.getAmountToSend();
+      expect(amount).toBe("20");
+    },
+  );
+
+  test(
+    "C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
+      );
+      await app.swap.checkAssetFromContains("BTC");
+      await app.swap.checkAssetFromContains(btcAccount.accountName);
+      await app.swap.checkAssetToContains("USDT");
+      await app.swap.checkAssetToContains(usdtAccount.accountName);
+    },
+  );
+
+  test(
+    "C3: USDT+fromAccountId only — receive defaults, no drawer",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
+      );
+      await app.swap.checkAssetFromContains("USDT");
+      await app.swap.checkAssetFromContains(usdtAccount.accountName);
+      await app.swap.checkAssetToContains(DEFAULT_TO);
+    },
+  );
+
+  test(
+    "C4: toToken=BTC+toAccountId only — send defaults, no drawer",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?toToken=bitcoin&toAccountId=${BTC_ACCOUNT_ID}`,
+      );
+      await app.swap.checkAssetFromContains(DEFAULT_FROM);
+      await app.swap.checkAssetToContains("BTC");
+      await app.swap.checkAssetToContains(btcAccount.accountName);
+    },
+  );
+
+  test(
+    "C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins",
+    { tag: TAGS, annotation: { type: "TMS", description: TMS } },
+    async ({ app }) => {
+      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+      await app.swap.openViaDeeplink(
+        `ledgerwallet://swap?fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
+          `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
+      );
+      // fromAccountId takes precedence over conflicting fromToken
+      await app.swap.checkAssetFromContains("BTC");
+      await app.swap.checkAssetFromContains(btcAccount.accountName);
+      // toAccountId takes precedence over conflicting toToken
+      await app.swap.checkAssetToContains("ETH");
+      await app.swap.checkAssetToContains(ethAccount.accountName);
+    },
+  );
+});

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -9,11 +9,7 @@ import {
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
 import { addTmsLink } from "tests/utils/allureUtils";
-import {
-  setupEnv,
-  selectAccountFromDeeplinkDrawer,
-  closeDeeplinkDrawer,
-} from "tests/utils/swapUtils";
+import { setupEnv, selectAccountFromDeeplinkDrawer } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 // Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
@@ -82,6 +78,7 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
       const reset = async () => {
         await app.swap.clearSwapState();
         await app.mainNavigation.openTargetFromMainNavigation("home");
+        await app.mainNavigation.validateTargetFromMainNavigation("home");
       };
 
       // ─── Group A: token params only, no accountIds ────────────────────────────
@@ -142,30 +139,6 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         await reset();
       });
 
-      await test.step("A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults", async () => {
-        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=bitcoin");
-        await closeDeeplinkDrawer(app); // fromToken=123 is invalid — close its drawer
-        await selectAccountFromDeeplinkDrawer(app, btcAccount); // receive drawer: BTC account
-        await app.swap.checkAssetFromContains(DEFAULT_FROM);
-        await app.swap.checkAssetToContains("BTC");
-        await reset();
-      });
-
-      await test.step("A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults", async () => {
-        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=ethereum&toToken=456");
-        await selectAccountFromDeeplinkDrawer(app, ethAccount); // only send drawer; invalid to has no drawer
-        await app.swap.checkAssetFromContains("ETH");
-        await app.swap.checkAssetToContains(DEFAULT_TO);
-        await reset();
-      });
-
-      await test.step("A10: fromToken=INVALID toToken=INVALID — both default", async () => {
-        await app.swap.openViaDeeplink("ledgerwallet://swap?fromToken=123&toToken=456");
-        await app.swap.checkAssetFromContains(DEFAULT_FROM);
-        await app.swap.checkAssetToContains(DEFAULT_TO);
-        await reset();
-      });
-
       // ─── Group B: with amount ──────────────────────────────────────────────────
 
       await test.step("B1: ETH→BTC with valid amountFrom=0.01", async () => {
@@ -208,17 +181,14 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         await reset();
       });
 
-      await test.step(
-        "C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer",
-        async () => {
-          await app.swap.openViaDeeplink(
-            `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
-          );
-          await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
-          await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
-          await reset();
-        },
-      );
+      await test.step("C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
+        );
+        await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+        await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
+        await reset();
+      });
 
       await test.step("C3: USDT+fromAccountId only — receive defaults, no drawer", async () => {
         await app.swap.openViaDeeplink(
@@ -238,20 +208,17 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         await reset();
       });
 
-      await test.step(
-        "C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins",
-        async () => {
-          await app.swap.openViaDeeplink(
-            `ledgerwallet://swap?fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
-              `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
-          );
-          // fromAccountId takes precedence over conflicting fromToken
-          await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
-          // toAccountId takes precedence over conflicting toToken
-          await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
-          // no reset needed after last step
-        },
-      );
+      await test.step("C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins", async () => {
+        await app.swap.openViaDeeplink(
+          `ledgerwallet://swap?fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
+            `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
+        );
+        // fromAccountId takes precedence over conflicting fromToken
+        await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+        // toAccountId takes precedence over conflicting toToken
+        await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
+        // no reset needed after last step
+      });
     },
   );
 });

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -23,7 +23,7 @@ const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
 // On a fresh session (no prior swap), the live app defaults to the highest
 // market-cap assets: BTC for the send field, ETH for the receive field.
 const DEFAULT_FROM = "BTC";
-const DEFAULT_TO = "";
+const DEFAULT_TO = "Choose asset";
 
 const TMS = "B2CQA-4152";
 const TAGS = [

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -11,14 +11,12 @@ import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { setupEnv, selectAccountFromDeeplinkDrawer } from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
-
-// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
-// Must match the accounts loaded by cliCommandsOnApp below.
-const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
-const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
-const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
-
-const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
+import {
+  BTC_ACCOUNT_ID,
+  ETH_ACCOUNT_ID,
+  USDT_ACCOUNT_ID,
+  USDT_TOKEN_ID,
+} from "@ledgerhq/live-e2e-shared/swapDeeplinkFixtures";
 
 // On a fresh session (no prior swap), the live app defaults to the highest
 // market-cap assets: BTC for the send field, ETH for the receive field.

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -37,7 +37,7 @@ const TAGS = [
   "@family-evm",
 ];
 
-test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
+test.describe("Swap deeplinks", () => {
   setupEnv(true);
 
   const btcAccount = Account.BTC_NATIVE_SEGWIT_2;
@@ -62,7 +62,7 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
   });
 
   test(
-    "[B2CQA-4152] Swap deeplinks — all scenarios",
+    "Swap deeplinks — all scenarios",
     { tag: TAGS, annotation: { type: "TMS", description: TMS } },
     async ({ app }) => {
       await addTmsLink([TMS]);

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -1,16 +1,16 @@
 import test from "tests/fixtures/common";
 import { expect } from "@playwright/test";
-import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import {
   Account,
   TokenAccount,
   getParentAccountName,
-} from "@ledgerhq/live-common/e2e/enum/Account";
-import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
-import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
+} from "@ledgerhq/live-e2e-shared/enum/Account";
+import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
+import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { setupEnv, selectAccountFromDeeplinkDrawer } from "tests/utils/swapUtils";
-import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 
 // Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
 // Must match the accounts loaded by cliCommandsOnApp below.
@@ -174,8 +174,10 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
           `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
             `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
         );
-        await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
-        await app.swap.checkAssetToContains(getParentAccountName(btcAccount));
+        await app.swap.checkAssetFromContains(usdtAccount.currency.ticker);
+        await app.swap.checkAssetFromAccountNameContains(getParentAccountName(usdtAccount));
+        await app.swap.checkAssetToContains(btcAccount.currency.ticker);
+        await app.swap.checkAssetToAccountNameContains(getParentAccountName(btcAccount));
         const amount = await app.swap.getAmountToSend();
         expect(amount).toBe("20");
         await reset();
@@ -185,8 +187,10 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         await app.swap.openViaDeeplink(
           `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
         );
-        await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
-        await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
+        await app.swap.checkAssetFromContains(btcAccount.currency.ticker);
+        await app.swap.checkAssetFromAccountNameContains(getParentAccountName(btcAccount));
+        await app.swap.checkAssetToContains(usdtAccount.currency.ticker);
+        await app.swap.checkAssetToAccountNameContains(getParentAccountName(usdtAccount));
         await reset();
       });
 
@@ -194,7 +198,8 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         await app.swap.openViaDeeplink(
           `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
         );
-        await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
+        await app.swap.checkAssetFromContains(usdtAccount.currency.ticker);
+        await app.swap.checkAssetFromAccountNameContains(getParentAccountName(usdtAccount));
         await app.swap.checkAssetToContains(DEFAULT_TO);
         await reset();
       });
@@ -204,7 +209,8 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
           `ledgerwallet://swap?toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`,
         );
         await app.swap.checkAssetFromContains(DEFAULT_FROM);
-        await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
+        await app.swap.checkAssetToContains(ethAccount.currency.ticker);
+        await app.swap.checkAssetToAccountNameContains(getParentAccountName(ethAccount));
         await reset();
       });
 
@@ -214,9 +220,11 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
             `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
         );
         // fromAccountId takes precedence over conflicting fromToken
-        await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+        await app.swap.checkAssetFromContains(btcAccount.currency.ticker);
+        await app.swap.checkAssetFromAccountNameContains(getParentAccountName(btcAccount));
         // toAccountId takes precedence over conflicting toToken
-        await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
+        await app.swap.checkAssetToContains(ethAccount.currency.ticker);
+        await app.swap.checkAssetToAccountNameContains(getParentAccountName(ethAccount));
         // no reset needed after last step
       });
     },

--- a/e2e/desktop/tests/specs/deeplink.swap.spec.ts
+++ b/e2e/desktop/tests/specs/deeplink.swap.spec.ts
@@ -1,12 +1,20 @@
 import test from "tests/fixtures/common";
 import { expect } from "@playwright/test";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
-import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import {
+  Account,
+  TokenAccount,
+  getParentAccountName,
+} from "@ledgerhq/live-common/e2e/enum/Account";
 import { AppInfos } from "@ledgerhq/live-common/e2e/enum/AppInfos";
 import { setExchangeDependencies } from "@ledgerhq/live-common/e2e/speculos";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
-import { setupEnv, selectAccountFromDeeplinkDrawer, closeDeeplinkDrawer } from "tests/utils/swapUtils";
+import {
+  setupEnv,
+  selectAccountFromDeeplinkDrawer,
+  closeDeeplinkDrawer,
+} from "tests/utils/swapUtils";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 // Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
@@ -41,8 +49,8 @@ test.describe.configure({ mode: "serial" });
 test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
   setupEnv(true);
 
-  const btcAccount = Account.BTC_NATIVE_SEGWIT_1;
-  const ethAccount = Account.ETH_1;
+  const btcAccount = Account.BTC_NATIVE_SEGWIT_2;
+  const ethAccount = Account.ETH_3;
   const usdtAccount = TokenAccount.ETH_USDT_1;
 
   test.beforeEach(async () => {
@@ -240,10 +248,8 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
         `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
           `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
       );
-      await app.swap.checkAssetFromContains("USDT");
-      await app.swap.checkAssetFromContains(usdtAccount.accountName);
-      await app.swap.checkAssetToContains("BTC");
-      await app.swap.checkAssetToContains(btcAccount.accountName);
+      await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
+      await app.swap.checkAssetToContains(getParentAccountName(btcAccount));
       const amount = await app.swap.getAmountToSend();
       expect(amount).toBe("20");
     },
@@ -257,10 +263,8 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
       await app.swap.openViaDeeplink(
         `ledgerwallet://swap?fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
       );
-      await app.swap.checkAssetFromContains("BTC");
-      await app.swap.checkAssetFromContains(btcAccount.accountName);
-      await app.swap.checkAssetToContains("USDT");
-      await app.swap.checkAssetToContains(usdtAccount.accountName);
+      await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
+      await app.swap.checkAssetToContains(getParentAccountName(usdtAccount));
     },
   );
 
@@ -272,23 +276,21 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
       await app.swap.openViaDeeplink(
         `ledgerwallet://swap?fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
       );
-      await app.swap.checkAssetFromContains("USDT");
-      await app.swap.checkAssetFromContains(usdtAccount.accountName);
+      await app.swap.checkAssetFromContains(getParentAccountName(usdtAccount));
       await app.swap.checkAssetToContains(DEFAULT_TO);
     },
   );
 
   test(
-    "C4: toToken=BTC+toAccountId only — send defaults, no drawer",
+    "C4: toToken=ETH+toAccountId only — send defaults, no drawer",
     { tag: TAGS, annotation: { type: "TMS", description: TMS } },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
       await app.swap.openViaDeeplink(
-        `ledgerwallet://swap?toToken=bitcoin&toAccountId=${BTC_ACCOUNT_ID}`,
+        `ledgerwallet://swap?toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`,
       );
       await app.swap.checkAssetFromContains(DEFAULT_FROM);
-      await app.swap.checkAssetToContains("BTC");
-      await app.swap.checkAssetToContains(btcAccount.accountName);
+      await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
     },
   );
 
@@ -302,11 +304,9 @@ test.describe("[B2CQA-4152] Swap deeplinks — LWD", () => {
           `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
       );
       // fromAccountId takes precedence over conflicting fromToken
-      await app.swap.checkAssetFromContains("BTC");
-      await app.swap.checkAssetFromContains(btcAccount.accountName);
+      await app.swap.checkAssetFromContains(getParentAccountName(btcAccount));
       // toAccountId takes precedence over conflicting toToken
-      await app.swap.checkAssetToContains("ETH");
-      await app.swap.checkAssetToContains(ethAccount.accountName);
+      await app.swap.checkAssetToContains(getParentAccountName(ethAccount));
     },
   );
 });

--- a/e2e/desktop/tests/utils/deeplink.ts
+++ b/e2e/desktop/tests/utils/deeplink.ts
@@ -1,0 +1,8 @@
+import { Page } from "@playwright/test";
+
+export function sendDeepLink(page: Page, link: string) {
+  return page.evaluate(l => {
+    const { ipcRenderer } = require("electron");
+    ipcRenderer.send("deep-linking", l);
+  }, link);
+}

--- a/e2e/desktop/tests/utils/deeplink.ts
+++ b/e2e/desktop/tests/utils/deeplink.ts
@@ -1,8 +1,1 @@
-import { Page } from "@playwright/test";
-
-export function sendDeepLink(page: Page, link: string) {
-  return page.evaluate(l => {
-    const { ipcRenderer } = require("electron");
-    ipcRenderer.send("deep-linking", l);
-  }, link);
-}
+export { sendDeepLink } from "../../../../apps/ledger-live-desktop/tests/utils/deeplink";

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -91,13 +91,10 @@ export async function selectAccountMAD(selector: ModularDialog, account: Account
 // Uses a 30s wait for the modular dialog to accommodate cases where it appears
 // after a previous dialog (e.g. invalid-token drawer) was just closed.
 export async function selectAccountFromDeeplinkDrawer(app: Application, account: Account) {
-  const page = app.getPage();
-  try {
-    await page
-      .getByTestId("modular-dialog-screen-ACCOUNT_SELECTION")
-      .waitFor({ state: "visible", timeout: 30_000 });
+  const isModularDialogVisible = await app.modularDialog.waitForAccountSelectionVisible(30_000);
+  if (isModularDialogVisible) {
     await app.modularDialog.selectAccountByName(account);
-  } catch {
+  } else {
     await app.swapDrawer.selectAccountByName(account);
   }
 }

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -85,6 +85,29 @@ export async function selectAccountMAD(selector: ModularDialog, account: Account
   await selector.selectAccountByName(account);
 }
 
+// Called after a deeplink that specifies a token but no accountId.
+// The live app requests account resolution via a native picker; this handles
+// both the modular dialog (Wallet 4.0+) and the legacy Electron drawer.
+export async function selectAccountFromDeeplinkDrawer(app: Application, account: Account) {
+  const selector = await getModularSelector(app, "ACCOUNT");
+  if (selector) {
+    await selector.selectAccountByName(account);
+  } else {
+    await app.swapDrawer.selectAccountByName(account);
+  }
+}
+
+// Called when a deeplink specifies an invalid token and the live app opens an
+// account picker that has no valid accounts to select — close it instead.
+export async function closeDeeplinkDrawer(app: Application) {
+  const selector = await getModularSelector(app, "ACCOUNT");
+  if (selector) {
+    await selector.closeButton.click();
+  } else {
+    await app.getPage().locator('[aria-label="Close"]').first().click();
+  }
+}
+
 export async function handleSwapErrorOrSuccess(
   app: Application,
   swap: Swap,

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -88,23 +88,17 @@ export async function selectAccountMAD(selector: ModularDialog, account: Account
 // Called after a deeplink that specifies a token but no accountId.
 // The live app requests account resolution via a native picker; this handles
 // both the modular dialog (Wallet 4.0+) and the legacy Electron drawer.
+// Uses a 30s wait for the modular dialog to accommodate cases where it appears
+// after a previous dialog (e.g. invalid-token drawer) was just closed.
 export async function selectAccountFromDeeplinkDrawer(app: Application, account: Account) {
-  const selector = await getModularSelector(app, "ACCOUNT");
-  if (selector) {
-    await selector.selectAccountByName(account);
-  } else {
+  const page = app.getPage();
+  try {
+    await page
+      .getByTestId("modular-dialog-screen-ACCOUNT_SELECTION")
+      .waitFor({ state: "visible", timeout: 30_000 });
+    await app.modularDialog.selectAccountByName(account);
+  } catch {
     await app.swapDrawer.selectAccountByName(account);
-  }
-}
-
-// Called when a deeplink specifies an invalid token and the live app opens an
-// account picker that has no valid accounts to select — close it instead.
-export async function closeDeeplinkDrawer(app: Application) {
-  const selector = await getModularSelector(app, "ACCOUNT");
-  if (selector) {
-    await selector.closeButton.click();
-  } else {
-    await app.getPage().locator('[aria-label="Close"]').first().click();
   }
 }
 

--- a/e2e/desktop/tests/utils/swapUtils.ts
+++ b/e2e/desktop/tests/utils/swapUtils.ts
@@ -85,11 +85,8 @@ export async function selectAccountMAD(selector: ModularDialog, account: Account
   await selector.selectAccountByName(account);
 }
 
-// Called after a deeplink that specifies a token but no accountId.
-// The live app requests account resolution via a native picker; this handles
-// both the modular dialog (Wallet 4.0+) and the legacy Electron drawer.
-// Uses a 30s wait for the modular dialog to accommodate cases where it appears
-// after a previous dialog (e.g. invalid-token drawer) was just closed.
+// Resolves the native account picker after a token-only deeplink: the modular
+// dialog (Wallet 4.0+) or the legacy drawer. 30s covers back-to-back dialogs.
 export async function selectAccountFromDeeplinkDrawer(app: Application, account: Account) {
   const isModularDialogVisible = await app.modularDialog.waitForAccountSelectionVisible(30_000);
   if (isModularDialogVisible) {

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -409,10 +409,11 @@ export default class SwapLiveAppPage {
   @Step("Check currency to swap from matches account $0")
   async checkAssetFromMatchesAccount(account: Account) {
     const selectedAccountText: string = await getWebElementText(this.fromSelector);
+    const expectedAccountName = account.parentAccount?.accountName ?? account.accountName;
     jestExpect(selectedAccountText).toContain(account.currency.ticker);
     await waitWebElementByTestId(this.fromAccountAccountNameTag);
     const accountNameText: string = await getWebElementText(this.fromAccountAccountNameTag);
-    jestExpect(accountNameText).toContain(account.accountName);
+    jestExpect(accountNameText).toContain(expectedAccountName);
   }
 
   @Step("Check currency to swap to is $0 with amount $1")
@@ -446,6 +447,14 @@ export default class SwapLiveAppPage {
 
     jestExpect(selectedAccountTicker).toContain(account.currency.ticker);
     jestExpect(selectedAccountNameTag).toContain(expectedAccountName);
+  }
+
+  @Step("Clear swap account selection from localStorage")
+  async clearSwapState() {
+    await this.swapMainContainerWebElement.runScript(() => {
+      localStorage.removeItem("from-account");
+      localStorage.removeItem("to-account");
+    });
   }
 
   @Step("Check Ledger Nano S not supported banner for $0")

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -41,8 +41,8 @@ export default class SwapPage extends CommonPage {
 
   @Step("Open swap via deeplink")
   async openViaDeeplink(params?: string) {
-    const path = params ? `${this.baseLink}?${params}` : this.baseLink;
-    await openDeeplink(path);
+    const deeplinkPath = params ? `${this.baseLink}?${params}` : this.baseLink;
+    await openDeeplink(deeplinkPath);
     await waitForElementById(app.common.walletApiWebview);
   }
 

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -43,11 +43,8 @@ export default class SwapPage extends CommonPage {
   async openViaDeeplink(params?: string) {
     const deeplinkPath = params ? `${this.baseLink}?${params}` : this.baseLink;
     await openDeeplink(deeplinkPath);
-    // checkVisibility: false — an ambiguous fromToken/toToken can surface a native
-    // "Select account" drawer on top of the webview before it's fully visible (iOS
-    // requires ~75% visible area; the drawer can cover it). Callers already assert
-    // visibility themselves afterward (expectSwapLiveApp/Form, drawer handling), so
-    // this only needs to confirm the webview exists in the tree.
+    // checkVisibility: false — an ambiguous token can open an account-picker drawer
+    // that covers the webview first; callers already check visibility themselves.
     await waitForElementById(app.common.walletApiWebview, undefined, { checkVisibility: false });
   }
 

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -40,8 +40,9 @@ export default class SwapPage extends CommonPage {
   specificOperationAmountToId = (swapId: string) => `${this.operationRow.baseToAmount}${swapId}`;
 
   @Step("Open swap via deeplink")
-  async openViaDeeplink() {
-    await openDeeplink(this.baseLink);
+  async openViaDeeplink(params?: string) {
+    const path = params ? `${this.baseLink}?${params}` : this.baseLink;
+    await openDeeplink(path);
     await waitForElementById(app.common.walletApiWebview);
   }
 

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -43,7 +43,12 @@ export default class SwapPage extends CommonPage {
   async openViaDeeplink(params?: string) {
     const deeplinkPath = params ? `${this.baseLink}?${params}` : this.baseLink;
     await openDeeplink(deeplinkPath);
-    await waitForElementById(app.common.walletApiWebview);
+    // checkVisibility: false — an ambiguous fromToken/toToken can surface a native
+    // "Select account" drawer on top of the webview before it's fully visible (iOS
+    // requires ~75% visible area; the drawer can cover it). Callers already assert
+    // visibility themselves afterward (expectSwapLiveApp/Form, drawer handling), so
+    // this only needs to confirm the webview exists in the tree.
+    await waitForElementById(app.common.walletApiWebview, undefined, { checkVisibility: false });
   }
 
   @Step("Expect swap page")

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -1,0 +1,225 @@
+import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
+import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { swapSetup } from "../../../bridge/server";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
+
+// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
+// Must match the accounts loaded by cliCommandsOnApp below.
+const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
+const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
+const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
+
+const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
+
+// On a fresh session (no prior swap), the live app defaults to the highest
+// market-cap assets: BTC for send, ETH for receive.
+const DEFAULT_FROM = "BTC";
+const DEFAULT_TO = "ETH";
+
+setTeamOwner(Team.SWAP);
+$TmsLink("B2CQA-4152");
+const tags: string[] = [
+  "@NanoSP",
+  "@LNS",
+  "@NanoX",
+  "@Stax",
+  "@Flex",
+  "@NanoGen5",
+  "@bitcoin",
+  "@family-bitcoin",
+  "@ethereum",
+  "@family-evm",
+];
+tags.forEach(tag => $Tag(tag));
+
+describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
+  const btcAccount = Account.BTC_NATIVE_SEGWIT_1;
+  const ethAccount = Account.ETH_1;
+  const usdtAccount = TokenAccount.ETH_USDT_1;
+
+  beforeAll(async () => {
+    await app.init({
+      speculosApp: btcAccount.currency.speculosApp,
+      featureFlags: {
+        ptxSwapLiveAppMobile: {
+          enabled: true,
+          params: {
+            manifest_id:
+              process.env.PRODUCTION === "true" ? "swap-live-app-aws" : "swap-live-app-stg-aws",
+          },
+        },
+      },
+      cliCommandsOnApp: [
+        { app: btcAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(btcAccount) },
+        { app: ethAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(ethAccount) },
+        {
+          app: usdtAccount.currency.speculosApp,
+          cmd: liveDataWithAddressCommand(usdtAccount),
+        },
+      ],
+    });
+    await app.portfolio.waitForPortfolioPageToLoad();
+    await swapSetup();
+  });
+
+  // Navigate to portfolio before each test so the swap live app is unmounted,
+  // ensuring no prior-selection state bleeds into the next test.
+  beforeEach(async () => {
+    await app.portfolio.openViaDeeplink();
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
+
+  // ─── Group A: token params only, no accountIds ──────────────────────────────
+
+  it("A1: no params — both fields default to highest-cap asset", async () => {
+    await app.swap.openViaDeeplink();
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
+    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
+  });
+
+  it("A2: fromToken=ETH toToken=BTC", async () => {
+    await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin");
+    await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("ETH");
+    await app.swapLiveApp.checkAssetToContains("BTC");
+  });
+
+  it("A3: fromToken=USDT(ERC20) toToken=ETH", async () => {
+    await app.swap.openViaDeeplink(`fromToken=${USDT_TOKEN_ID}&toToken=ethereum`);
+    await app.modularDrawer.selectFirstAccount(); // send drawer: USDT/ETH account
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("USDT");
+    await app.swapLiveApp.checkAssetToContains("ETH");
+  });
+
+  it("A4: fromToken=ETH toToken=USDT(ERC20)", async () => {
+    await app.swap.openViaDeeplink(`fromToken=ethereum&toToken=${USDT_TOKEN_ID}`);
+    await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: USDT/ETH account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("ETH");
+    await app.swapLiveApp.checkAssetToContains("USDT");
+  });
+
+  // A5 (FDUSD/BSC) is manual-only — no E2E account available.
+
+  it("A6: fromToken=BTC only — receive defaults to highest-cap asset", async () => {
+    await app.swap.openViaDeeplink("fromToken=bitcoin");
+    await app.modularDrawer.selectFirstAccount(); // send drawer: BTC account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("BTC");
+    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
+  });
+
+  it("A7: toToken=ETH only — send defaults to highest-cap asset", async () => {
+    await app.swap.openViaDeeplink("toToken=ethereum");
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
+    await app.swapLiveApp.checkAssetToContains("ETH");
+  });
+
+  it("A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults", async () => {
+    await app.swap.openViaDeeplink("fromToken=123&toToken=bitcoin");
+    await app.modularDrawer.tapDrawerCloseButton(); // fromToken=123 is invalid — close its drawer
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
+    await app.swapLiveApp.checkAssetToContains("BTC");
+  });
+
+  it("A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults", async () => {
+    await app.swap.openViaDeeplink("fromToken=ethereum&toToken=456");
+    await app.modularDrawer.selectFirstAccount(); // send drawer only: ETH account; invalid to has no drawer
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("ETH");
+    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
+  });
+
+  it("A10: fromToken=INVALID toToken=INVALID — both default", async () => {
+    await app.swap.openViaDeeplink("fromToken=123&toToken=456");
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
+    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
+  });
+
+  // ─── Group B: with amount ────────────────────────────────────────────────────
+
+  it("B1: ETH→BTC with valid amountFrom=0.01", async () => {
+    await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=0.01");
+    await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("ETH");
+    await app.swapLiveApp.checkAssetToContains("BTC");
+    const amount = await app.swapLiveApp.getAmountToSend();
+    jestExpect(amount).toBe("0.01");
+  });
+
+  it("B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero", async () => {
+    await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=abc");
+    await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
+    await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains("ETH");
+    await app.swapLiveApp.checkAssetToContains("BTC");
+    const amount = await app.swapLiveApp.getAmountToSend();
+    jestExpect(amount).toMatch(/^(0\.?0*|)$/);
+  });
+
+  // ─── Group C: with accountIds — no drawer expected ──────────────────────────
+
+  it("C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer", async () => {
+    await app.swap.openViaDeeplink(
+      `fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
+        `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
+    );
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
+    await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
+    const amount = await app.swapLiveApp.getAmountToSend();
+    jestExpect(amount).toBe("20");
+  });
+
+  it("C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer", async () => {
+    await app.swap.openViaDeeplink(
+      `fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
+    );
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
+    await app.swapLiveApp.checkAssetToMatchesAccount(usdtAccount);
+  });
+
+  it("C3: USDT+fromAccountId only — receive defaults, no drawer", async () => {
+    await app.swap.openViaDeeplink(
+      `fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
+    );
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
+    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
+  });
+
+  it("C4: toToken=BTC+toAccountId only — send defaults, no drawer", async () => {
+    await app.swap.openViaDeeplink(`toToken=bitcoin&toAccountId=${BTC_ACCOUNT_ID}`);
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
+    await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
+  });
+
+  it("C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins", async () => {
+    await app.swap.openViaDeeplink(
+      `fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
+        `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
+    );
+    await app.swapLiveApp.expectSwapLiveAppForm();
+    // fromAccountId takes precedence over conflicting fromToken
+    await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
+    // toAccountId takes precedence over conflicting toToken
+    await app.swapLiveApp.checkAssetToMatchesAccount(ethAccount);
+  });
+});

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -9,9 +9,7 @@ import {
 import { swapSetup } from "../../../bridge/server";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
-// On a fresh session (no prior swap), the live app defaults the send field
-// to the highest market-cap asset (BTC); the receive field has no default
-// and shows the "Choose asset" placeholder until a token is selected.
+// Fresh session: send defaults to BTC; receive has no default ("Choose asset").
 const DEFAULT_FROM = "BTC";
 const DEFAULT_TO = "";
 

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -29,7 +29,7 @@ const tags: string[] = [
 ];
 tags.forEach(tag => $Tag(tag));
 
-describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
+describe("Swap deeplinks", () => {
   const btcAccount = Account.BTC_NATIVE_SEGWIT_2;
   const ethAccount = Account.ETH_3;
   const usdtAccount = TokenAccount.ETH_USDT_1;
@@ -51,7 +51,7 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await swapSetup();
   });
 
-  it("[B2CQA-4152] Swap deeplinks — all scenarios", async () => {
+  it("Swap deeplinks — all scenarios", async () => {
     const reset = async () => {
       await app.swapLiveApp.clearSwapState();
       await app.portfolio.openViaDeeplink();

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -1,5 +1,5 @@
-import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
-import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
+import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { swapSetup } from "../../../bridge/server";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 
@@ -183,9 +183,7 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await reset();
 
     // C3: USDT+fromAccountId only — receive defaults, no drawer
-    await app.swap.openViaDeeplink(
-      `fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
-    );
+    await app.swap.openViaDeeplink(`fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`);
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -2,10 +2,9 @@ import { Account, TokenAccount } from "@ledgerhq/live-common/e2e/enum/Account";
 import { Team } from "@ledgerhq/live-common/e2e/enum/Team";
 import { swapSetup } from "../../../bridge/server";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
-import { liveDataWithAddressCommand } from "@ledgerhq/live-common/e2e/cliCommandsUtils";
 
 // Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
-// Must match the accounts loaded by cliCommandsOnApp below.
+// Must match the accounts in e2e/mobile/userdata/swap-deeplinks.json.
 const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
 const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
 const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
@@ -40,7 +39,7 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
 
   beforeAll(async () => {
     await app.init({
-      speculosApp: btcAccount.currency.speculosApp,
+      userdata: "swap-deeplinks",
       featureFlags: {
         ptxSwapLiveAppMobile: {
           enabled: true,
@@ -50,14 +49,6 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
           },
         },
       },
-      cliCommandsOnApp: [
-        { app: btcAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(btcAccount) },
-        { app: ethAccount.currency.speculosApp, cmd: liveDataWithAddressCommand(ethAccount) },
-        {
-          app: usdtAccount.currency.speculosApp,
-          cmd: liveDataWithAddressCommand(usdtAccount),
-        },
-      ],
     });
     await app.portfolio.waitForPortfolioPageToLoad();
     await swapSetup();

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -51,70 +51,69 @@ describe("Swap deeplinks", () => {
     await swapSetup();
   });
 
-  it("Swap deeplinks — all scenarios", async () => {
-    const reset = async () => {
-      await app.swapLiveApp.clearSwapState();
-      await app.portfolio.openViaDeeplink();
-      await app.portfolio.waitForPortfolioPageToLoad();
-    };
+  afterEach(async () => {
+    await app.swapLiveApp.clearSwapState();
+    await app.portfolio.openViaDeeplink();
+    await app.portfolio.waitForPortfolioPageToLoad();
+  });
 
-    // ─── Group A: token params only, no accountIds ──────────────────────────────
+  // ─── Group A: token params only, no accountIds ────────────────────────────────
 
-    // A1: no params — both fields default to highest-cap asset
+  it("A1: no params — both fields default to highest-cap asset", async () => {
     await app.swap.openViaDeeplink();
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-    await reset();
+  });
 
-    // A2: fromToken=ETH toToken=BTC
+  it("A2: fromToken=ETH toToken=BTC", async () => {
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
-    await reset();
+  });
 
-    // A3: fromToken=USDT(ERC20) toToken=ETH
+  it("A3: fromToken=USDT(ERC20) toToken=ETH", async () => {
     await app.swap.openViaDeeplink(`fromToken=${USDT_TOKEN_ID}&toToken=ethereum`);
     await app.modularDrawer.selectFirstAccount(); // send drawer: USDT/ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("USDT");
     await app.swapLiveApp.checkAssetToContains("ETH");
-    await reset();
+  });
 
-    // A4: fromToken=ETH toToken=USDT(ERC20)
+  it("A4: fromToken=ETH toToken=USDT(ERC20)", async () => {
     await app.swap.openViaDeeplink(`fromToken=ethereum&toToken=${USDT_TOKEN_ID}`);
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: USDT/ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("USDT");
-    await reset();
+  });
 
-    // A5 (FDUSD/BSC) is manual-only — no E2E account available.
+  // A5 (FDUSD/BSC) is manual-only — no E2E account available.
 
-    // A6: fromToken=BTC only — receive defaults to highest-cap asset
+  it("A6: fromToken=BTC only — receive defaults to highest-cap asset", async () => {
     await app.swap.openViaDeeplink("fromToken=bitcoin");
     await app.modularDrawer.selectFirstAccount(); // send drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("BTC");
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-    await reset();
+  });
 
-    // A7: toToken=ETH only — send defaults to highest-cap asset
+  it("A7: toToken=ETH only — send defaults to highest-cap asset", async () => {
     await app.swap.openViaDeeplink("toToken=ethereum");
     await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains("ETH");
-    await reset();
+  });
 
-    // ─── Group B: with amount ────────────────────────────────────────────────────
+  // ─── Group B: with amount ─────────────────────────────────────────────────────
 
-    // B1: ETH→BTC with valid amountFrom=0.01
+  it("B1: ETH→BTC with valid amountFrom=0.01", async () => {
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=0.01");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
@@ -122,9 +121,9 @@ describe("Swap deeplinks", () => {
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
     jestExpect(await app.swapLiveApp.getAmountToSend()).toBe("0.01");
-    await reset();
+  });
 
-    // B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero
+  it("B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero", async () => {
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=abc");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
@@ -132,11 +131,11 @@ describe("Swap deeplinks", () => {
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
     jestExpect(await app.swapLiveApp.getAmountToSend()).toMatch(/^(0\.?0*|)$/);
-    await reset();
+  });
 
-    // ─── Group C: with accountIds — no drawer expected ──────────────────────────
+  // ─── Group C: with accountIds — no drawer expected ────────────────────────────
 
-    // C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer
+  it("C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer", async () => {
     await app.swap.openViaDeeplink(
       `fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
         `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
@@ -145,32 +144,32 @@ describe("Swap deeplinks", () => {
     await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
     await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
     jestExpect(await app.swapLiveApp.getAmountToSend()).toBe("20");
-    await reset();
+  });
 
-    // C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer
+  it("C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer", async () => {
     await app.swap.openViaDeeplink(
       `fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
     );
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
     await app.swapLiveApp.checkAssetToMatchesAccount(usdtAccount);
-    await reset();
+  });
 
-    // C3: USDT+fromAccountId only — receive defaults, no drawer
+  it("C3: USDT+fromAccountId only — receive defaults, no drawer", async () => {
     await app.swap.openViaDeeplink(`fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`);
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-    await reset();
+  });
 
-    // C4: toToken=ETH+toAccountId only — send defaults, no drawer
+  it("C4: toToken=ETH+toAccountId only — send defaults, no drawer", async () => {
     await app.swap.openViaDeeplink(`toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`);
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToMatchesAccount(ethAccount);
-    await reset();
+  });
 
-    // C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins
+  it("C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins", async () => {
     await app.swap.openViaDeeplink(
       `fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
         `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
@@ -180,6 +179,5 @@ describe("Swap deeplinks", () => {
     await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
     // toAccountId takes precedence over conflicting toToken
     await app.swapLiveApp.checkAssetToMatchesAccount(ethAccount);
-    // no reset needed after last scenario
   });
 });

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -11,10 +11,11 @@ const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
 
 const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
 
-// On a fresh session (no prior swap), the live app defaults to the highest
-// market-cap assets: BTC for send, ETH for receive.
+// On a fresh session (no prior swap), the live app defaults the send field
+// to the highest market-cap asset (BTC); the receive field has no default
+// and shows the "Choose asset" placeholder until a token is selected.
 const DEFAULT_FROM = "BTC";
-const DEFAULT_TO = "ETH";
+const DEFAULT_TO = "";
 
 setTeamOwner(Team.SWAP);
 $TmsLink("B2CQA-4152");

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -34,8 +34,8 @@ const tags: string[] = [
 tags.forEach(tag => $Tag(tag));
 
 describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
-  const btcAccount = Account.BTC_NATIVE_SEGWIT_1;
-  const ethAccount = Account.ETH_1;
+  const btcAccount = Account.BTC_NATIVE_SEGWIT_2;
+  const ethAccount = Account.ETH_3;
   const usdtAccount = TokenAccount.ETH_USDT_1;
 
   beforeAll(async () => {
@@ -57,6 +57,7 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
 
   it("[B2CQA-4152] Swap deeplinks — all scenarios", async () => {
     const reset = async () => {
+      await app.swapLiveApp.clearSwapState();
       await app.portfolio.openViaDeeplink();
       await app.portfolio.waitForPortfolioPageToLoad();
     };
@@ -115,30 +116,6 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await app.swapLiveApp.checkAssetToContains("ETH");
     await reset();
 
-    // A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults
-    await app.swap.openViaDeeplink("fromToken=123&toToken=bitcoin");
-    await app.modularDrawer.tapDrawerCloseButton(); // fromToken=123 is invalid — close its drawer
-    await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
-    await app.swapLiveApp.expectSwapLiveAppForm();
-    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
-    await app.swapLiveApp.checkAssetToContains("BTC");
-    await reset();
-
-    // A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults
-    await app.swap.openViaDeeplink("fromToken=ethereum&toToken=456");
-    await app.modularDrawer.selectFirstAccount(); // send drawer only: ETH account; invalid to has no drawer
-    await app.swapLiveApp.expectSwapLiveAppForm();
-    await app.swapLiveApp.checkAssetFromContains("ETH");
-    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-    await reset();
-
-    // A10: fromToken=INVALID toToken=INVALID — both default
-    await app.swap.openViaDeeplink("fromToken=123&toToken=456");
-    await app.swapLiveApp.expectSwapLiveAppForm();
-    await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
-    await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-    await reset();
-
     // ─── Group B: with amount ────────────────────────────────────────────────────
 
     // B1: ETH→BTC with valid amountFrom=0.01
@@ -190,11 +167,11 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
     await reset();
 
-    // C4: toToken=BTC+toAccountId only — send defaults, no drawer
-    await app.swap.openViaDeeplink(`toToken=bitcoin&toAccountId=${BTC_ACCOUNT_ID}`);
+    // C4: toToken=ETH+toAccountId only — send defaults, no drawer
+    await app.swap.openViaDeeplink(`toToken=ethereum&toAccountId=${ETH_ACCOUNT_ID}`);
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
-    await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
+    await app.swapLiveApp.checkAssetToMatchesAccount(ethAccount);
     await reset();
 
     // C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -63,118 +63,115 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await swapSetup();
   });
 
-  // Navigate to portfolio before each test so the swap live app is unmounted,
-  // ensuring no prior-selection state bleeds into the next test.
-  beforeEach(async () => {
-    await app.portfolio.openViaDeeplink();
-    await app.portfolio.waitForPortfolioPageToLoad();
-  });
+  it("[B2CQA-4152] Swap deeplinks — all scenarios", async () => {
+    const reset = async () => {
+      await app.portfolio.openViaDeeplink();
+      await app.portfolio.waitForPortfolioPageToLoad();
+    };
 
-  // ─── Group A: token params only, no accountIds ──────────────────────────────
+    // ─── Group A: token params only, no accountIds ──────────────────────────────
 
-  it("A1: no params — both fields default to highest-cap asset", async () => {
+    // A1: no params — both fields default to highest-cap asset
     await app.swap.openViaDeeplink();
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-  });
+    await reset();
 
-  it("A2: fromToken=ETH toToken=BTC", async () => {
+    // A2: fromToken=ETH toToken=BTC
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
-  });
+    await reset();
 
-  it("A3: fromToken=USDT(ERC20) toToken=ETH", async () => {
+    // A3: fromToken=USDT(ERC20) toToken=ETH
     await app.swap.openViaDeeplink(`fromToken=${USDT_TOKEN_ID}&toToken=ethereum`);
     await app.modularDrawer.selectFirstAccount(); // send drawer: USDT/ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("USDT");
     await app.swapLiveApp.checkAssetToContains("ETH");
-  });
+    await reset();
 
-  it("A4: fromToken=ETH toToken=USDT(ERC20)", async () => {
+    // A4: fromToken=ETH toToken=USDT(ERC20)
     await app.swap.openViaDeeplink(`fromToken=ethereum&toToken=${USDT_TOKEN_ID}`);
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: USDT/ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("USDT");
-  });
+    await reset();
 
-  // A5 (FDUSD/BSC) is manual-only — no E2E account available.
+    // A5 (FDUSD/BSC) is manual-only — no E2E account available.
 
-  it("A6: fromToken=BTC only — receive defaults to highest-cap asset", async () => {
+    // A6: fromToken=BTC only — receive defaults to highest-cap asset
     await app.swap.openViaDeeplink("fromToken=bitcoin");
     await app.modularDrawer.selectFirstAccount(); // send drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("BTC");
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-  });
+    await reset();
 
-  it("A7: toToken=ETH only — send defaults to highest-cap asset", async () => {
+    // A7: toToken=ETH only — send defaults to highest-cap asset
     await app.swap.openViaDeeplink("toToken=ethereum");
     await app.modularDrawer.selectFirstAccount(); // receive drawer: ETH account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains("ETH");
-  });
+    await reset();
 
-  it("A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults", async () => {
+    // A8: fromToken=INVALID(123) toToken=BTC — invalid send defaults
     await app.swap.openViaDeeplink("fromToken=123&toToken=bitcoin");
     await app.modularDrawer.tapDrawerCloseButton(); // fromToken=123 is invalid — close its drawer
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains("BTC");
-  });
+    await reset();
 
-  it("A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults", async () => {
+    // A9: fromToken=ETH toToken=INVALID(456) — invalid receive defaults
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=456");
     await app.modularDrawer.selectFirstAccount(); // send drawer only: ETH account; invalid to has no drawer
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-  });
+    await reset();
 
-  it("A10: fromToken=INVALID toToken=INVALID — both default", async () => {
+    // A10: fromToken=INVALID toToken=INVALID — both default
     await app.swap.openViaDeeplink("fromToken=123&toToken=456");
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-  });
+    await reset();
 
-  // ─── Group B: with amount ────────────────────────────────────────────────────
+    // ─── Group B: with amount ────────────────────────────────────────────────────
 
-  it("B1: ETH→BTC with valid amountFrom=0.01", async () => {
+    // B1: ETH→BTC with valid amountFrom=0.01
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=0.01");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
-    const amount = await app.swapLiveApp.getAmountToSend();
-    jestExpect(amount).toBe("0.01");
-  });
+    jestExpect(await app.swapLiveApp.getAmountToSend()).toBe("0.01");
+    await reset();
 
-  it("B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero", async () => {
+    // B2: ETH→BTC with invalid amountFrom=abc — amount field empty or zero
     await app.swap.openViaDeeplink("fromToken=ethereum&toToken=bitcoin&amountFrom=abc");
     await app.modularDrawer.selectFirstAccount(); // send drawer: ETH account
     await app.modularDrawer.selectFirstAccount(); // receive drawer: BTC account
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains("ETH");
     await app.swapLiveApp.checkAssetToContains("BTC");
-    const amount = await app.swapLiveApp.getAmountToSend();
-    jestExpect(amount).toMatch(/^(0\.?0*|)$/);
-  });
+    jestExpect(await app.swapLiveApp.getAmountToSend()).toMatch(/^(0\.?0*|)$/);
+    await reset();
 
-  // ─── Group C: with accountIds — no drawer expected ──────────────────────────
+    // ─── Group C: with accountIds — no drawer expected ──────────────────────────
 
-  it("C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer", async () => {
+    // C1: USDT+fromAccountId → BTC+toAccountId + amount=20, no drawer
     await app.swap.openViaDeeplink(
       `fromToken=${USDT_TOKEN_ID}&toToken=bitcoin` +
         `&fromAccountId=${USDT_ACCOUNT_ID}&toAccountId=${BTC_ACCOUNT_ID}&amountFrom=20`,
@@ -182,36 +179,35 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
     await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
-    const amount = await app.swapLiveApp.getAmountToSend();
-    jestExpect(amount).toBe("20");
-  });
+    jestExpect(await app.swapLiveApp.getAmountToSend()).toBe("20");
+    await reset();
 
-  it("C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer", async () => {
+    // C2: fromAccountId=BTC + toAccountId=USDT (no token params) — accountId resolves, no drawer
     await app.swap.openViaDeeplink(
       `fromAccountId=${BTC_ACCOUNT_ID}&toAccountId=${USDT_ACCOUNT_ID}`,
     );
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
     await app.swapLiveApp.checkAssetToMatchesAccount(usdtAccount);
-  });
+    await reset();
 
-  it("C3: USDT+fromAccountId only — receive defaults, no drawer", async () => {
+    // C3: USDT+fromAccountId only — receive defaults, no drawer
     await app.swap.openViaDeeplink(
       `fromToken=${USDT_TOKEN_ID}&fromAccountId=${USDT_ACCOUNT_ID}`,
     );
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromMatchesAccount(usdtAccount);
     await app.swapLiveApp.checkAssetToContains(DEFAULT_TO);
-  });
+    await reset();
 
-  it("C4: toToken=BTC+toAccountId only — send defaults, no drawer", async () => {
+    // C4: toToken=BTC+toAccountId only — send defaults, no drawer
     await app.swap.openViaDeeplink(`toToken=bitcoin&toAccountId=${BTC_ACCOUNT_ID}`);
     await app.swapLiveApp.expectSwapLiveAppForm();
     await app.swapLiveApp.checkAssetFromContains(DEFAULT_FROM);
     await app.swapLiveApp.checkAssetToMatchesAccount(btcAccount);
-  });
+    await reset();
 
-  it("C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins", async () => {
+    // C5: mismatch (fromToken=ETH+fromAccountId=BTC, toToken=USDT+toAccountId=ETH) — accountId wins
     await app.swap.openViaDeeplink(
       `fromToken=ethereum&fromAccountId=${BTC_ACCOUNT_ID}` +
         `&toToken=${USDT_TOKEN_ID}&toAccountId=${ETH_ACCOUNT_ID}`,
@@ -221,5 +217,6 @@ describe("[B2CQA-4152] Swap deeplinks — LWM", () => {
     await app.swapLiveApp.checkAssetFromMatchesAccount(btcAccount);
     // toAccountId takes precedence over conflicting toToken
     await app.swapLiveApp.checkAssetToMatchesAccount(ethAccount);
+    // no reset needed after last scenario
   });
 });

--- a/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapDeeplinks.spec.ts
@@ -1,15 +1,13 @@
 import { Account, TokenAccount } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import {
+  BTC_ACCOUNT_ID,
+  ETH_ACCOUNT_ID,
+  USDT_ACCOUNT_ID,
+  USDT_TOKEN_ID,
+} from "@ledgerhq/live-e2e-shared/swapDeeplinkFixtures";
 import { swapSetup } from "../../../bridge/server";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
-
-// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
-// Must match the accounts in e2e/mobile/userdata/swap-deeplinks.json.
-const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
-const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
-const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
-
-const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";
 
 // On a fresh session (no prior swap), the live app defaults the send field
 // to the highest market-cap asset (BTC); the receive field has no default

--- a/e2e/mobile/userdata/swap-deeplinks.json
+++ b/e2e/mobile/userdata/swap-deeplinks.json
@@ -1,0 +1,291 @@
+{
+  "data": {
+    "settings": {
+      "hasCompletedOnboarding": true,
+      "readOnlyModeEnabled": false,
+      "counterValue": "USD",
+      "language": "en",
+      "locale": "en-US",
+      "theme": null,
+      "region": null,
+      "orderAccounts": "balance|desc",
+      "countervalueFirst": false,
+      "autoLockTimeout": 10,
+      "selectedTimeRange": "week",
+      "currenciesSettings": {},
+      "pairExchanges": {},
+      "developerMode": false,
+      "loaded": true,
+      "shareAnalytics": false,
+      "sharePersonalizedRecommandations": false,
+      "hasSeenAnalyticsOptInPrompt": true,
+      "sentryLogs": true,
+      "lastUsedVersion": "99.99.99",
+      "dismissedBanners": [],
+      "accountsViewMode": "list",
+      "showAccountsHelperBanner": true,
+      "hideEmptyTokenAccounts": false,
+      "filterTokenOperationsZeroAmount": true,
+      "sidebarCollapsed": false,
+      "discreetMode": false,
+      "preferredDeviceModel": "nanoSP",
+      "hasInstalledApps": true,
+      "lastSeenDevice": null,
+      "mevProtection": true,
+      "devicesModelList": [],
+      "lastSeenCustomImage": {
+        "size": 0,
+        "hash": ""
+      },
+      "latestFirmware": null,
+      "blacklistedTokenIds": [],
+      "deepLinkUrl": null,
+      "firstTimeLend": false,
+      "showClearCacheBanner": false,
+      "allowDebugApps": false,
+      "allowReactQueryDebug": false,
+      "allowExperimentalApps": false,
+      "enablePlatformDevTools": false,
+      "catalogProvider": "production",
+      "enableLearnPageStagingUrl": false,
+      "swap": {
+        "hasAcceptedIPSharing": false,
+        "acceptedProviders": [],
+        "selectableCurrencies": []
+      },
+      "vaultSigner": {
+        "enabled": false,
+        "host": "",
+        "token": "",
+        "workspace": ""
+      },
+      "supportedCounterValues": [],
+      "dismissedContentCards": {},
+      "anonymousBrazeId": "anonymous_id_9",
+      "starredMarketCoins": [],
+      "hasBeenUpsoldRecover": true,
+      "hasBeenRedirectedToPostOnboarding": true,
+      "onboardingUseCase": null,
+      "lastOnboardedDevice": null,
+      "alwaysShowMemoTagInfo": true,
+      "anonymousUserNotifications": {},
+      "hasSeenWalletV4Tour": false,
+      "doNotAskAgainSkipMemo": false
+    },
+    "PLAYWRIGHT_RUN": {
+      "localStorage": {
+        "acceptedTermsVersion": "2042-01-01"
+      }
+    },
+    "user": {
+      "id": "08cf3393-c5eb-4ea7-92de-0deea22e3971"
+    },
+    "accounts": [
+      {
+        "data": {
+          "id": "js:2:bitcoin:xpub6D4fy7nrbPLSDDu7LCkeDAEiku1vtEEXMWELR8dc7wWbcJ3vTre9JYBbvfPjhLpxExRJjCBiJQi2B4jZcdz5HYnkA2u9Up2SiPDej9fMndw:native_segwit",
+          "seedIdentifier": "xpub6D4fy7nrbPLSDDu7LCkeDAEiku1vtEEXMWELR8dc7wWbcJ3vTre9JYBbvfPjhLpxExRJjCBiJQi2B4jZcdz5HYnkA2u9Up2SiPDej9fMndw",
+          "used": true,
+          "derivationMode": "native_segwit",
+          "index": 1,
+          "freshAddress": "bc1q8n5cpkp5qkz2xy2yax5kxrctpqkwf4hf2n2nw3",
+          "freshAddressPath": "84'/0'/1'/0/0",
+          "blockHeight": 939622,
+          "syncHash": "0xb2deeplinks01",
+          "creationDate": "2026-03-05T12:10:19.000Z",
+          "operationsCount": 1,
+          "operations": [
+            {
+              "id": "js:2:bitcoin:xpub6D4fy7nrbPLSDDu7LCkeDAEiku1vtEEXMWELR8dc7wWbcJ3vTre9JYBbvfPjhLpxExRJjCBiJQi2B4jZcdz5HYnkA2u9Up2SiPDej9fMndw:native_segwit-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2-IN",
+              "hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+              "type": "IN",
+              "senders": [
+                "bc1qvetxlfzzqucpuyduemmehwjs95dg547j9rzecr"
+              ],
+              "recipients": [
+                "bc1q8n5cpkp5qkz2xy2yax5kxrctpqkwf4hf2n2nw3"
+              ],
+              "accountId": "js:2:bitcoin:xpub6D4fy7nrbPLSDDu7LCkeDAEiku1vtEEXMWELR8dc7wWbcJ3vTre9JYBbvfPjhLpxExRJjCBiJQi2B4jZcdz5HYnkA2u9Up2SiPDej9fMndw:native_segwit",
+              "blockHash": "00000000000000000001a0ca1e9439fa43984b9ce3ff063d204d98604883e068",
+              "blockHeight": 939620,
+              "extra": {},
+              "date": "2026-03-05T12:00:00.000Z",
+              "value": "100000",
+              "fee": "2000",
+              "transactionSequenceNumber": "0",
+              "hasFailed": false
+            }
+          ],
+          "pendingOperations": [],
+          "currencyId": "bitcoin",
+          "balance": "100000",
+          "spendableBalance": "100000",
+          "balanceHistoryCache": {
+            "HOUR": { "latestDate": 1772827200000, "balances": [100000] },
+            "DAY": { "latestDate": 1772751600000, "balances": [100000] },
+            "WEEK": { "latestDate": 1772319600000, "balances": [100000] }
+          },
+          "xpub": "xpub6D4fy7nrbPLSDDu7LCkeDAEiku1vtEEXMWELR8dc7wWbcJ3vTre9JYBbvfPjhLpxExRJjCBiJQi2B4jZcdz5HYnkA2u9Up2SiPDej9fMndw",
+          "bitcoinResources": {
+            "utxos": [
+              ["a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", 0, 939620, "bc1q8n5cpkp5qkz2xy2yax5kxrctpqkwf4hf2n2nw3", "100000", 0, 0]
+            ]
+          },
+          "swapHistory": [],
+          "name": "Bitcoin 2",
+          "starred": false
+        },
+        "version": 1
+      },
+      {
+        "data": {
+          "id": "js:2:ethereum:0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15:",
+          "seedIdentifier": "0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15",
+          "used": true,
+          "derivationMode": "",
+          "index": 2,
+          "freshAddress": "0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15",
+          "freshAddressPath": "44'/60'/2'/0/0",
+          "blockHeight": 24600648,
+          "syncHash": "0xe2deeplinks03",
+          "creationDate": "2026-03-05T15:32:23.000Z",
+          "operationsCount": 1,
+          "operations": [
+            {
+              "id": "js:2:ethereum:0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15:-0xd3b4aabbccddeeff0011223344556677aabbccddeeff00112233445566778899-IN",
+              "hash": "0xd3b4aabbccddeeff0011223344556677aabbccddeeff00112233445566778899",
+              "type": "IN",
+              "senders": [
+                "0xce12D0A5cFf4A88ECab96ff8923215Dff366127b"
+              ],
+              "recipients": [
+                "0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15"
+              ],
+              "accountId": "js:2:ethereum:0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15:",
+              "blockHash": "0x1a273ad4db1f73ba8e29127d4da31b1fb893025e21e6b21c5e506901ed9c0e35",
+              "blockHeight": 24600640,
+              "extra": {},
+              "date": "2026-03-05T15:00:00.000Z",
+              "value": "1000000000000000000",
+              "fee": "1584949863000",
+              "transactionSequenceNumber": "0",
+              "hasFailed": false,
+              "internalOperations": []
+            }
+          ],
+          "pendingOperations": [],
+          "currencyId": "ethereum",
+          "balance": "1000000000000000000",
+          "spendableBalance": "1000000000000000000",
+          "balanceHistoryCache": {
+            "HOUR": { "latestDate": 1772827200000, "balances": [1000000000000000000] },
+            "DAY": { "latestDate": 1772751600000, "balances": [1000000000000000000] },
+            "WEEK": { "latestDate": 1772319600000, "balances": [1000000000000000000] }
+          },
+          "xpub": "0xD3b4d15c3aB0c0A3Ad3609BF84f6993F7d763A15",
+          "subAccounts": [],
+          "swapHistory": [],
+          "name": "Ethereum 3",
+          "starred": false
+        },
+        "version": 1
+      },
+      {
+        "data": {
+          "id": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:",
+          "seedIdentifier": "040ccf12de0c09ce1c151204a2268a410251d60c75965cf5b3a3fa829ac88a473bebde57c229f39f6bd0aa160ddb6cdffdcc34149c6196b7409c4e00ba3b12a942",
+          "used": true,
+          "derivationMode": "",
+          "index": 0,
+          "freshAddress": "0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a",
+          "freshAddressPath": "44'/60'/0'/0/0",
+          "blockHeight": 24600648,
+          "syncHash": "0xe1deeplinks00",
+          "creationDate": "2026-03-05T15:32:23.000Z",
+          "operationsCount": 1,
+          "operations": [
+            {
+              "id": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:-0xe32aaabbccddeeff0011223344556677aabbccddeeff00112233445566778899-IN",
+              "hash": "0xe32aaabbccddeeff0011223344556677aabbccddeeff00112233445566778899",
+              "type": "IN",
+              "senders": [
+                "0xce12D0A5cFf4A88ECab96ff8923215Dff366127b"
+              ],
+              "recipients": [
+                "0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a"
+              ],
+              "accountId": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:",
+              "blockHash": "0x1a273ad4db1f73ba8e29127d4da31b1fb893025e21e6b21c5e506901ed9c0e35",
+              "blockHeight": 24600640,
+              "extra": {},
+              "date": "2026-03-05T15:00:00.000Z",
+              "value": "1000000000000000000",
+              "fee": "1584949863000",
+              "transactionSequenceNumber": "0",
+              "hasFailed": false,
+              "internalOperations": []
+            }
+          ],
+          "pendingOperations": [],
+          "currencyId": "ethereum",
+          "balance": "1000000000000000000",
+          "spendableBalance": "1000000000000000000",
+          "balanceHistoryCache": {
+            "HOUR": { "latestDate": 1772827200000, "balances": [1000000000000000000] },
+            "DAY": { "latestDate": 1772751600000, "balances": [1000000000000000000] },
+            "WEEK": { "latestDate": 1772319600000, "balances": [1000000000000000000] }
+          },
+          "xpub": "0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a",
+          "subAccounts": [
+            {
+              "type": "TokenAccountRaw",
+              "id": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:+ethereum%2Ferc20%2Fusd_tether__erc20_",
+              "parentId": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:",
+              "tokenId": "ethereum/erc20/usd_tether__erc20_",
+              "balance": "61350270",
+              "spendableBalance": "61350270",
+              "creationDate": "2026-03-06T13:22:59.000Z",
+              "operationsCount": 1,
+              "operations": [
+                {
+                  "id": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:+ethereum%2Ferc20%2Fusd_tether__erc20_-0xbbbb1111aabbccddeeff0011223344556677aabbccddeeff0011223344556677-IN",
+                  "hash": "0xbbbb1111aabbccddeeff0011223344556677aabbccddeeff0011223344556677",
+                  "type": "IN",
+                  "senders": [
+                    "0xce12D0A5cFf4A88ECab96ff8923215Dff366127b"
+                  ],
+                  "recipients": [
+                    "0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a"
+                  ],
+                  "accountId": "js:2:ethereum:0xE32ad14b89F334dF1CD1036c2a0E39A19248b75a:+ethereum%2Ferc20%2Fusd_tether__erc20_",
+                  "blockHash": "0x1a273ad4db1f73ba8e29127d4da31b1fb893025e21e6b21c5e506901ed9c0e35",
+                  "blockHeight": 24555000,
+                  "extra": {},
+                  "date": "2026-03-06T13:22:59.000Z",
+                  "value": "61350270",
+                  "fee": "1584949863000",
+                  "transactionSequenceNumber": "0",
+                  "hasFailed": false,
+                  "internalOperations": []
+                }
+              ],
+              "pendingOperations": [],
+              "swapHistory": [],
+              "balanceHistoryCache": {
+                "HOUR": { "latestDate": 1772827200000, "balances": [61350270] },
+                "DAY": { "latestDate": 1772751600000, "balances": [61350270] },
+                "WEEK": { "latestDate": 1772319600000, "balances": [61350270] }
+              },
+              "starred": false
+            }
+          ],
+          "swapHistory": [],
+          "name": "Ethereum 1",
+          "starred": false
+        },
+        "version": 1
+      }
+    ],
+    "countervalues": {}
+  }
+}

--- a/libs/live-e2e-shared/src/swapDeeplinkFixtures.ts
+++ b/libs/live-e2e-shared/src/swapDeeplinkFixtures.ts
@@ -1,6 +1,5 @@
-// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
-// Must match the accounts loaded by the "swap-deeplinks" userdata/CLI fixtures used by
-// both the desktop (deeplink.swap.spec.ts) and mobile (swapDeeplinks.spec.ts) B2CQA-4152 tests.
+// Account UUIDs (uuidv5-derived) and token id shared by the desktop and mobile
+// B2CQA-4152 swap-deeplink specs; must match their "swap-deeplinks" fixtures.
 export const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
 export const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
 export const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";

--- a/libs/live-e2e-shared/src/swapDeeplinkFixtures.ts
+++ b/libs/live-e2e-shared/src/swapDeeplinkFixtures.ts
@@ -1,0 +1,8 @@
+// Account UUIDs derived from the E2E test seed via uuidv5 (namespace c3c78073-…).
+// Must match the accounts loaded by the "swap-deeplinks" userdata/CLI fixtures used by
+// both the desktop (deeplink.swap.spec.ts) and mobile (swapDeeplinks.spec.ts) B2CQA-4152 tests.
+export const BTC_ACCOUNT_ID = "62d8d0c0-3550-5f0c-9755-c6fb7866828b";
+export const ETH_ACCOUNT_ID = "1258dc17-fbc6-5a99-ba85-2969da766f65";
+export const USDT_ACCOUNT_ID = "84024965-a385-52d5-90cd-38dfc8bab5e9";
+
+export const USDT_TOKEN_ID = "ethereum/erc20/usd_tether__erc20_";


### PR DESCRIPTION
## Summary
- Adds E2E coverage for swap deeplinks (`ledgerwallet://swap`) on both Desktop (Playwright) and Mobile (Detox), covering token params, account IDs, amounts, and precedence rules (B2CQA-4152).

## Test plan
- [x] `npx playwright test tests/specs/deeplink.swap.spec.ts` passes on Desktop (LWD)
- [x] Detox `swapDeeplinks.spec.ts` passes on Mobile (LWM, android.emu.release)