### PR TITLE
[LWDM] feat(wallet-api): expose account readiness to live-apps

### DIFF
--- a/.changeset/purple-donkeys-jump.md
+++ b/.changeset/purple-donkeys-jump.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Expose account readiness status to live-apps via the wallet API

--- a/libs/ledger-live-common/src/wallet-api/converters.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.test.ts
@@ -1,14 +1,53 @@
-import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { TokenCurrency } from "@domain/entity-currency-token";
+import { initialState as walletState } from "@ledgerhq/live-wallet/store";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import "../__tests__/test-helpers/setup";
 import type { Transaction } from "../coin-modules/transaction-types";
 import { getAccountBridge } from "../bridge";
 import {
+  accountToWalletAPIAccount,
   getWalletAPITransactionSignFlowInfos,
   resolveWalletApiSpendableBalance,
 } from "./converters";
 import type { WalletAPITransaction } from "./types";
+
+// Minimal hermetic fixtures — only the fields accountToWalletAPIAccount reads, so the
+// test needs no genAccount/currencies-resolver bootstrap.
+const currency = {
+  id: "ethereum",
+  name: "Ethereum",
+} as unknown as CryptoCurrency;
+
+const makeMainAccount = (id: string, readiness?: Account["readiness"]): Account =>
+  ({
+    type: "Account",
+    id,
+    index: 0,
+    currency,
+    freshAddress: "0x0000000000000000000000000000000000000001",
+    balance: new BigNumber(1),
+    spendableBalance: new BigNumber(1),
+    blockHeight: 1,
+    lastSyncDate: new Date(0),
+    readiness,
+  }) as Account;
+
+const makeTokenAccount = (id: string, parentId: string): TokenAccount =>
+  ({
+    type: "TokenAccount",
+    id,
+    parentId,
+    token: {
+      id: "ethereum/erc20/mtk",
+      name: "Mock Token",
+      ticker: "MTK",
+    } as unknown as TokenCurrency,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+  }) as TokenAccount;
 
 const evmBridge = jest.fn();
 const bitcoinBridge = jest.fn();
@@ -150,5 +189,44 @@ describe("resolveWalletApiSpendableBalance", () => {
       expect.stringContaining("falling back to account.spendableBalance"),
       { error: "unsupported family" },
     );
+  });
+});
+
+describe("accountToWalletAPIAccount", () => {
+  it("passes the account readiness through", () => {
+    const account = makeMainAccount("readiness-not-ready", {
+      ready: false,
+      reason: "unrevealed",
+    });
+
+    const walletApiAccount = accountToWalletAPIAccount(walletState, account);
+
+    expect(walletApiAccount.readiness).toEqual({
+      ready: false,
+      reason: "unrevealed",
+    });
+  });
+
+  it("leaves readiness undefined when the account has none", () => {
+    const account = makeMainAccount("readiness-absent");
+
+    const walletApiAccount = accountToWalletAPIAccount(walletState, account);
+
+    expect(walletApiAccount.readiness).toBeUndefined();
+  });
+
+  it("derives a token account's readiness from its parent", () => {
+    const parentAccount = makeMainAccount("readiness-parent", {
+      ready: false,
+      reason: "unrevealed",
+    });
+    const tokenAccount = makeTokenAccount(`${parentAccount.id}|0`, parentAccount.id);
+
+    const walletApiAccount = accountToWalletAPIAccount(walletState, tokenAccount, parentAccount);
+
+    expect(walletApiAccount.readiness).toEqual({
+      ready: false,
+      reason: "unrevealed",
+    });
   });
 });

--- a/libs/ledger-live-common/src/wallet-api/converters.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.test.ts
@@ -1,11 +1,12 @@
 import type { Account, AccountLike, TokenAccount } from "@ledgerhq/types-live";
-import type { CryptoCurrency } from "@domain/entity-currency-crypto";
-import type { TokenCurrency } from "@domain/entity-currency-token";
+import { mockTokenCurrency } from "@domain/entity-currency-token/schema.mock";
 import { initialState as walletState } from "@ledgerhq/live-wallet/store";
+import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
 import "../__tests__/test-helpers/setup";
 import type { Transaction } from "../coin-modules/transaction-types";
+import { getCryptoCurrencyById } from "../currencies";
 import { getAccountBridge } from "../bridge";
 import {
   accountToWalletAPIAccount,
@@ -14,40 +15,13 @@ import {
 } from "./converters";
 import type { WalletAPITransaction } from "./types";
 
-// Minimal hermetic fixtures — only the fields accountToWalletAPIAccount reads, so the
-// test needs no genAccount/currencies-resolver bootstrap.
-const currency = {
-  id: "ethereum",
-  name: "Ethereum",
-} as unknown as CryptoCurrency;
+const makeMainAccount = (id: string, readiness?: Account["readiness"]): Account => ({
+  ...(genAccount(id, { currency: getCryptoCurrencyById("ethereum") }) as Account),
+  readiness,
+});
 
-const makeMainAccount = (id: string, readiness?: Account["readiness"]): Account =>
-  ({
-    type: "Account",
-    id,
-    index: 0,
-    currency,
-    freshAddress: "0x0000000000000000000000000000000000000001",
-    balance: new BigNumber(1),
-    spendableBalance: new BigNumber(1),
-    blockHeight: 1,
-    lastSyncDate: new Date(0),
-    readiness,
-  }) as Account;
-
-const makeTokenAccount = (id: string, parentId: string): TokenAccount =>
-  ({
-    type: "TokenAccount",
-    id,
-    parentId,
-    token: {
-      id: "ethereum/erc20/mtk",
-      name: "Mock Token",
-      ticker: "MTK",
-    } as unknown as TokenCurrency,
-    balance: new BigNumber(0),
-    spendableBalance: new BigNumber(0),
-  }) as TokenAccount;
+const makeTokenAccount = (parentAccount: Account): TokenAccount =>
+  genTokenAccount(0, parentAccount, mockTokenCurrency()) as TokenAccount;
 
 const evmBridge = jest.fn();
 const bitcoinBridge = jest.fn();
@@ -220,7 +194,7 @@ describe("accountToWalletAPIAccount", () => {
       ready: false,
       reason: "unrevealed",
     });
-    const tokenAccount = makeTokenAccount(`${parentAccount.id}|0`, parentAccount.id);
+    const tokenAccount = makeTokenAccount(parentAccount);
 
     const walletApiAccount = accountToWalletAPIAccount(walletState, tokenAccount, parentAccount);
 

--- a/libs/ledger-live-common/src/wallet-api/converters.ts
+++ b/libs/ledger-live-common/src/wallet-api/converters.ts
@@ -59,6 +59,7 @@ export function accountToWalletAPIAccount(
       name: `${parentAccountName} (${account.token.ticker})`,
       currency: account.token.id,
       spendableBalance: account.spendableBalance,
+      readiness: parentAccount.readiness,
     };
   }
   const name = accountNameWithDefaultSelector(walletState, account);
@@ -72,6 +73,7 @@ export function accountToWalletAPIAccount(
     spendableBalance: account.spendableBalance,
     blockHeight: account.blockHeight,
     lastSyncDate: account.lastSyncDate,
+    readiness: account.readiness,
   };
 }
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Forwards each account's `readiness` status across the wallet-api boundary so live-apps
(e.g. Swap) can tell whether an account is ready for outgoing operations — e.g. a Tezos
account pending key revelation — before starting a flow instead of failing mid-device-flow.

Passes `Account.readiness` through `accountToWalletAPIAccount`: main accounts forward their
own value; token accounts inherit the parent's. It's an additive, optional passthrough (no
per-family branching), and needs no wallet-api bump — `develop` already serializes the field
(core 1.34.0 / server 3.4.1). Adds converter tests for the present / absent / token
cases.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34259](https://ledgerhq.atlassian.net/browse/LIVE-34259?atlOrigin=eyJpIjoiMmYwNzUwYTkxODc0NDE3NTk2MWQ5NzFiYjU3Y2I3NjQiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34259]: https://ledgerhq.atlassian.net/browse/LIVE-34259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ