### PR TITLE
feat(support): add @support/ts-config-{base,web,web-x-native} TypeScript preset packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "@react-native-community/cli-platform-android": "15.1.0",
     "@react-native-community/cli-platform-ios": "15.1.0",
     "@react-native/babel-plugin-codegen": "catalog:",
+    "@support/ts-config-base-legacy": "workspace:*",
     "@ton/crypto": "^3.3.0",
     "@typescript-eslint/parser": "catalog:",
     "@vitest/mocker": "4.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4337,12 +4337,12 @@ importers:
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(typescript@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-test-renderer:
-        specifier: 'catalog:'
-        version: 19.1.4(react@19.1.4)
       react-redux:
         specifier: 'catalog:'
         version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       tailwind-merge:
         specifier: 'catalog:'
         version: 3.4.0
@@ -13718,6 +13718,20 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
+
+  support/ts-config-base: {}
+
+  support/ts-config-web:
+    devDependencies:
+      '@support/ts-config-base':
+        specifier: workspace:*
+        version: link:../ts-config-base
+
+  support/ts-config-web-x-native:
+    devDependencies:
+      '@support/ts-config-base':
+        specifier: workspace:*
+        version: link:../ts-config-base
 
   tests/dummy-live-app:
     dependencies:
@@ -66116,7 +66130,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66240,6 +66254,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9991,7 +9991,7 @@ importers:
         version: 1.1.1
       '@cardano-foundation/ledgerjs-hw-app-cardano':
         specifier: ^7.1.2
-        version: 7.1.2
+        version: 7.1.4
       '@domain/api-aggregated-assets':
         specifier: workspace:^
         version: link:../../domain/api/aggregated-assets
@@ -14882,6 +14882,20 @@ importers:
         specifier: 19.1.4
         version: 19.1.4
 
+  support/ts-config-base: {}
+
+  support/ts-config-web:
+    devDependencies:
+      '@support/ts-config-base':
+        specifier: workspace:*
+        version: link:../ts-config-base
+
+  support/ts-config-web-x-native:
+    devDependencies:
+      '@support/ts-config-base':
+        specifier: workspace:*
+        version: link:../ts-config-base
+
   tests/dummy-live-app:
     dependencies:
       '@ledgerhq/live-app-sdk':
@@ -16978,8 +16992,8 @@ packages:
       webpack:
         optional: true
 
-  '@cardano-foundation/ledgerjs-hw-app-cardano@7.1.2':
-    resolution: {integrity: sha512-bSR8MdKzotnf9WGO0BtDpTXsH4ObaQjCDSHA6MhJuAKoJEaLl7ASS4ctzqzGlKWoEvjdsgx+M8hJbWDLJ63TFw==}
+  '@cardano-foundation/ledgerjs-hw-app-cardano@7.1.4':
+    resolution: {integrity: sha512-bkZ78H0m6E22Fe4nN+K0HY0O2lrPk9Pjs/gv0U5xvJyrMqwmR4wm9h8QXd/AwJ084KIhfpCSGDCQ0CN/K++vNw==}
 
   '@casperlabs/ts-results@3.3.5':
     resolution: {integrity: sha512-ymSQqqb4mOSet592li02u1Gd28LoOFJUm6R3jkdNQ+nqsnbHvN+izBigtP4aYmNwh6gFyCwDgjYporEJgDT4eA==}
@@ -19569,8 +19583,11 @@ packages:
   '@ledgerhq/errors@5.50.0':
     resolution: {integrity: sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==}
 
-  '@ledgerhq/errors@6.37.0':
-    resolution: {integrity: sha512-T5yiKI5UX7ugeocdTF3TUsCIN2BH41Bio4ZeN410YFjFOf3es08n/5JyMzzKwzRgP0blG3HfBf7s7vJKqCSAeg==}
+  '@ledgerhq/errors@6.32.0':
+    resolution: {integrity: sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==}
+
+  '@ledgerhq/errors@6.36.0':
+    resolution: {integrity: sha512-o2Q5hNvf2TzAzlH8ORAozppRbzixRPYDfmSQrP7FOcM997OEH7qDleXgp/uMpvRdxR/t3CJCG+n0i+bU/oYMKA==}
 
   '@ledgerhq/hw-bolos@6.35.1':
     resolution: {integrity: sha512-+osQFmZAKv1JOMZPiYU3G8wgW/JqxA0HCe/Y/O+b72TyH0SOyiXybdyIc1//We6AUyrJ2CiG8cev3vPYfjsjwQ==}
@@ -19611,6 +19628,9 @@ packages:
 
   '@ledgerhq/logs@6.12.0':
     resolution: {integrity: sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA==}
+
+  '@ledgerhq/logs@6.16.0':
+    resolution: {integrity: sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==}
 
   '@ledgerhq/logs@6.17.0':
     resolution: {integrity: sha512-yra33g5q/AU7+PwAws+GaVpQGUuxnDREjVBnviJjcaJLVKuLzI4pnj8Bd3nY3fypM5k1yZEYKEXfUuGFUjP2+w==}
@@ -19950,6 +19970,10 @@ packages:
   '@near-js/wallet-account@1.0.2':
     resolution: {integrity: sha512-bbouucpBgFtZ3bI7KvcYT8/r1q4w5UVIbbZqTUnuXpkceSQ7IxjeKCR00Iastj9EOXWAAAJBYkn0942QJjBC5w==}
 
+  '@noble/ciphers@1.1.3':
+    resolution: {integrity: sha512-Ygv6WnWJHLLiW4fnNDC1z+i13bud+enXOFRBlpxI+NJliPWx5wdR+oWlTjLuBPTqjUjtHXtjkU6w3kuuH6upZA==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
     engines: {node: ^14.21.3 || >=16}
@@ -20202,6 +20226,9 @@ packages:
   '@octokit/openapi-types@20.0.0':
     resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
 
+  '@octokit/openapi-types@22.2.0':
+    resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
+
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
 
@@ -20252,6 +20279,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@13.5.0':
+    resolution: {integrity: sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -24308,37 +24338,37 @@ packages:
     resolution: {integrity: sha512-7gTcQ2XtyGzXRPuph0mBRd2AfwOzagGrIZ6OPwlurl3RlOvUSInA0v8GOud7JwNVgLJJCz4L4EEfkdOZY9/LIg==}
     engines: {node: '>=20'}
 
-  '@taquito/http-utils@23.1.0':
-    resolution: {integrity: sha512-720BWBvkYAhuRbKYpU7ebNV8EWlUp5eD0/ra2ZfWrLV6iYxDf1tayER/cKYkLvJhw4B0ZK12/G+B3urf8ot+OQ==}
+  '@taquito/http-utils@23.0.0-beta.1':
+    resolution: {integrity: sha512-sF8FEguCTm+NuILpLvtS0yHQixH+sQL9RktOyTvBwUxgBo+d0+V2V/LUjNYLtAVzO1kdHWTM2h44zLP39hvgvw==}
+    engines: {node: '>=18'}
+
+  '@taquito/ledger-signer@23.0.0-beta.1':
+    resolution: {integrity: sha512-cvZTECjcLyn2w1fqzxVwvgt8UE0amJ7giZSuNJArCT/GL/paPj6Wv2euAz9ZtlQBtlNAIgXdOrjBPQCOseWBsg==}
+    engines: {node: '>=18'}
+
+  '@taquito/local-forging@23.0.0-beta.1':
+    resolution: {integrity: sha512-iNAGDLGrp8FRAiSh33J+r57XNok2U+xcJEbiEh80zKlXx+OcsR6BfWPgA+yM4Gw8HJkO01b12GnUXuuERmpQrA==}
+    engines: {node: '>=18'}
+
+  '@taquito/michel-codec@23.0.0-beta.1':
+    resolution: {integrity: sha512-ZOn8/ueL4f6LBAxskm55jK3fj5bCGGEZ76utdFbahO5g9sJ1MVUlIdlIrmTEEC85Cgq75O1v0ocBKx9HTQSxOQ==}
+    engines: {node: '>=18'}
+
+  '@taquito/michelson-encoder@23.0.0-beta.1':
+    resolution: {integrity: sha512-15G9P2qmF3AZ/1wSklvULp3qTvlsz6VqZi9MEjz26bnl09aNBCOX0wRTr4fAz8MQcYN3s7c2gQuiAojtPz84zg==}
+    engines: {node: '>=18'}
+
+  '@taquito/rpc@23.0.0-beta.1':
+    resolution: {integrity: sha512-RggdLEEtAV69ULiwuHK2nAyB8KP9YonmG0eGeev9PoHGLZoO2Ic5Zpe/s5CVn++fw/yBCQUW01sKSCwwKjWIZA==}
+    engines: {node: '>=18'}
+
+  '@taquito/taquito@23.0.0-beta.1':
+    resolution: {integrity: sha512-eBs0y+SZrLYD45r6o+BmQzxtYaVdROLfZvIHys8cU9zqiLYglVko+hm49cio6cFkMi9yZiO+yxgen069mF4rOA==}
+    engines: {node: '>=18'}
+
+  '@taquito/utils@23.1.0':
+    resolution: {integrity: sha512-CC6dLj6Ppjn28HZEok3q/7IjwCAyCUUC9olczz1S9diEAByxgI+XKKbkCXAOjAC8ogpCosHvU3n3crQuCd8ycg==}
     engines: {node: '>=20'}
-
-  '@taquito/ledger-signer@23.0.1':
-    resolution: {integrity: sha512-uTz7fQFWXHo8clFNiZAe+pRyLgmx/v4zkxdkPJEA1OPR+cJ+gpKAp3Jkr769s1zDhJ6pFDsIRmvVGruqdO3JDw==}
-    engines: {node: '>=18'}
-
-  '@taquito/local-forging@23.0.1':
-    resolution: {integrity: sha512-aL/aMwjjFFxS6/33dcFFkQX68h6mNsI7RSLGHC2jiz3sUyQ9yRqQu5xq09+0FrkmpvNBVWzGu8YIKH/z6dFj0Q==}
-    engines: {node: '>=18'}
-
-  '@taquito/michel-codec@23.0.1':
-    resolution: {integrity: sha512-7mCaBwi765wtW42RH//pjTzXP54Otk8e+w/gnfZbVoHb2dvNCSRQApjSmdb/al8CIoXQnQ3z918/w64JQ0QUTw==}
-    engines: {node: '>=18'}
-
-  '@taquito/michelson-encoder@23.0.1':
-    resolution: {integrity: sha512-86gMGqCAL0+/RV1vBIa4KCeWMVVUfeLutMyqD7H9FjsE64Ymmn56rojKrZFTNS/WAHy1kJGWCnt7PZH2JOAY6A==}
-    engines: {node: '>=18'}
-
-  '@taquito/rpc@23.0.1':
-    resolution: {integrity: sha512-9wsgjnMdvPFXOGSyIFH+H7xDhqpzucXvrd2Vhyhv4MHsAGQRSV5j1aW3mXE7ksc10FwV8BZ2XDv0qOdJfNQWng==}
-    engines: {node: '>=18'}
-
-  '@taquito/taquito@23.0.1':
-    resolution: {integrity: sha512-NNrly5ffSQt4vNYpAkmzg49Ur74K5LgLDXHcewDIWnH7pT3XaUtXikV5v5WSUKyVSaj3ScAQ4tpGmsnABAb07w==}
-    engines: {node: '>=18'}
-
-  '@taquito/utils@23.0.1':
-    resolution: {integrity: sha512-zAYoxaw977cJwpD+dHSaSbjt7ls9+0I7Ni6xK4jyK7UjNksNXdB0u2vQZDsBBFGuzGpqcd+yJ3Vr49u7s55VDg==}
-    engines: {node: '>=18'}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -27855,8 +27885,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  conventional-commits-parser@7.1.1:
-    resolution: {integrity: sha512-B0f42jI++V5Vb7qK+DDw68r0dNxz5hk+RdKUkx2NOi39emc9hsHa3u2M3doF7QQhRFzCrAj7uM90teG+RBTaYQ==}
+  conventional-commits-parser@7.1.2:
+    resolution: {integrity: sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -28048,7 +28078,6 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
-    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -31014,9 +31043,8 @@ packages:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
     engines: {node: '>=12.0.0'}
 
-  int64-buffer@1.0.1:
-    resolution: {integrity: sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==}
-    engines: {node: '>= 4.5.0'}
+  int64-buffer@1.1.1:
+    resolution: {integrity: sha512-xp/v0/im2q7n7ISFJXcYsr/aVsUdZKPUZS1uYtoM9I9Cfmm5YuAi7SQts2TrEXwAKIE0wyn3KxJbo35goJgvwQ==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -35357,6 +35385,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -38247,6 +38276,10 @@ packages:
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
+
+  undici@6.19.2:
+    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
+    engines: {node: '>=18.17'}
 
   undici@6.21.1:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
@@ -43159,12 +43192,12 @@ snapshots:
       - uglify-js
       - utf-8-validate
 
-  '@cardano-foundation/ledgerjs-hw-app-cardano@7.1.2':
+  '@cardano-foundation/ledgerjs-hw-app-cardano@7.1.4':
     dependencies:
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       base-x: 3.0.9
       bech32: 1.1.4
-      int64-buffer: 1.0.1
+      int64-buffer: 1.1.1
 
   '@casperlabs/ts-results@3.3.5':
     dependencies:
@@ -43509,7 +43542,7 @@ snapshots:
     dependencies:
       '@commitlint/types': 21.2.0
       conventional-changelog-angular: 9.2.1
-      conventional-commits-parser: 7.1.1
+      conventional-commits-parser: 7.1.2
 
   '@commitlint/prompt-cli@17.8.1':
     dependencies:
@@ -43579,7 +43612,7 @@ snapshots:
 
   '@commitlint/types@21.2.0':
     dependencies:
-      conventional-commits-parser: 7.1.1
+      conventional-commits-parser: 7.1.2
       picocolors: 1.1.1
 
   '@conventional-changelog/template@1.2.1': {}
@@ -44736,7 +44769,7 @@ snapshots:
       structured-headers: 0.4.1
       tar: 7.4.3
       terminal-link: 2.1.1
-      undici: 6.21.1
+      undici: 6.19.2
       wrap-ansi: 7.0.0
       ws: 8.21.0
     transitivePeerDependencies:
@@ -44808,7 +44841,7 @@ snapshots:
       structured-headers: 0.4.1
       tar: 7.5.16
       terminal-link: 2.1.1
-      undici: 6.21.1
+      undici: 6.19.2
       wrap-ansi: 7.0.0
       ws: 8.21.0
     optionalDependencies:
@@ -44886,7 +44919,7 @@ snapshots:
       structured-headers: 0.4.1
       tar: 7.5.16
       terminal-link: 2.1.1
-      undici: 6.21.1
+      undici: 6.19.2
       wrap-ansi: 7.0.0
       ws: 8.21.0
     optionalDependencies:
@@ -44903,7 +44936,7 @@ snapshots:
 
   '@expo/code-signing-certificates@0.0.5':
     dependencies:
-      node-forge: 1.4.0
+      node-forge: 1.3.1
       nullthrows: 1.1.1
 
   '@expo/code-signing-certificates@0.0.6':
@@ -47580,10 +47613,10 @@ snapshots:
   '@ledgerhq/coin-tezos@7.12.0':
     dependencies:
       '@ledgerhq/coin-module-framework': 5.0.0
-      '@taquito/ledger-signer': 23.0.1
-      '@taquito/rpc': 23.0.1
-      '@taquito/taquito': 23.0.1
-      '@taquito/utils': 23.0.1
+      '@taquito/ledger-signer': 23.0.0-beta.1
+      '@taquito/rpc': 23.0.0-beta.1
+      '@taquito/taquito': 23.0.0-beta.1
+      '@taquito/utils': 23.1.0
     transitivePeerDependencies:
       - encoding
 
@@ -47592,10 +47625,10 @@ snapshots:
       '@ledgerhq/coin-module-framework': 5.0.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': 6.17.0
-      '@taquito/ledger-signer': 23.0.1
-      '@taquito/rpc': 23.0.1
-      '@taquito/taquito': 23.0.1
-      '@taquito/utils': 23.0.1
+      '@taquito/ledger-signer': 23.0.0-beta.1
+      '@taquito/rpc': 23.0.0-beta.1
+      '@taquito/taquito': 23.0.0-beta.1
+      '@taquito/utils': 23.1.0
     transitivePeerDependencies:
       - encoding
 
@@ -47860,7 +47893,9 @@ snapshots:
 
   '@ledgerhq/errors@5.50.0': {}
 
-  '@ledgerhq/errors@6.37.0': {}
+  '@ledgerhq/errors@6.32.0': {}
+
+  '@ledgerhq/errors@6.36.0': {}
 
   '@ledgerhq/hw-bolos@6.35.1':
     dependencies:
@@ -47898,20 +47933,22 @@ snapshots:
 
   '@ledgerhq/live-network@2.4.3':
     dependencies:
-      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/errors': 6.36.0
       '@ledgerhq/live-env': 2.31.0
       '@ledgerhq/live-promise': 0.2.2
-      '@ledgerhq/logs': 6.17.0
+      '@ledgerhq/logs': 6.16.0
       axios: 1.13.2
       lru-cache: 7.18.3
 
   '@ledgerhq/live-promise@0.2.2':
     dependencies:
-      '@ledgerhq/logs': 6.17.0
+      '@ledgerhq/logs': 6.16.0
 
   '@ledgerhq/logs@5.50.0': {}
 
   '@ledgerhq/logs@6.12.0': {}
+
+  '@ledgerhq/logs@6.16.0': {}
 
   '@ledgerhq/logs@6.17.0': {}
 
@@ -48229,7 +48266,7 @@ snapshots:
 
   '@ledgerhq/wallet-api-core@1.35.0(@ton/crypto@3.3.0)':
     dependencies:
-      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/errors': 6.36.0
       '@stacks/transactions': 6.17.0
       '@ton/core': 0.62.0(patch_hash=9329da4fb3122df62d833d0c4d847d33a35a9457ee48997870bc044fc80b7324)(@ton/crypto@3.3.0)
       bignumber.js: 9.1.2
@@ -48418,7 +48455,7 @@ snapshots:
   '@mysten/ledgerjs-hw-app-sui@0.8.0':
     dependencies:
       '@ledgerhq/devices': link:libs/ledgerjs/packages/devices
-      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/errors': 6.32.0
       '@ledgerhq/hw-bolos': 6.35.1
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       '@ledgerhq/ledger-cal-service': 1.15.1
@@ -48641,6 +48678,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@noble/ciphers@1.1.3': {}
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.2.0':
@@ -48849,7 +48888,7 @@ snapshots:
 
   '@octokit/endpoint@9.0.6':
     dependencies:
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.5.0
       universal-user-agent: 6.0.1
 
   '@octokit/graphql@7.0.2':
@@ -48859,6 +48898,8 @@ snapshots:
       universal-user-agent: 6.0.1
 
   '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@22.2.0': {}
 
   '@octokit/openapi-types@24.2.0': {}
 
@@ -48888,7 +48929,7 @@ snapshots:
 
   '@octokit/request-error@5.1.1':
     dependencies:
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.5.0
       deprecation: 2.3.1
       once: 1.4.0
 
@@ -48896,7 +48937,7 @@ snapshots:
     dependencies:
       '@octokit/endpoint': 9.0.6
       '@octokit/request-error': 5.1.1
-      '@octokit/types': 13.10.0
+      '@octokit/types': 13.5.0
       universal-user-agent: 6.0.1
 
   '@octokit/rest@20.1.2':
@@ -48913,6 +48954,10 @@ snapshots:
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@13.5.0':
+    dependencies:
+      '@octokit/openapi-types': 22.2.0
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -54857,69 +54902,69 @@ snapshots:
     dependencies:
       json-stringify-safe: 5.0.1
 
-  '@taquito/http-utils@23.1.0(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)':
+  '@taquito/http-utils@23.0.0-beta.1(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)':
     dependencies:
       '@taquito/core': 23.1.0
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
-  '@taquito/ledger-signer@23.0.1':
+  '@taquito/ledger-signer@23.0.0-beta.1':
     dependencies:
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       '@stablelib/blake2b': 1.0.1
       '@taquito/core': 23.1.0
-      '@taquito/taquito': 23.0.1
-      '@taquito/utils': 23.0.1
+      '@taquito/taquito': 23.0.0-beta.1
+      '@taquito/utils': 23.1.0
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
     transitivePeerDependencies:
       - encoding
 
-  '@taquito/local-forging@23.0.1':
+  '@taquito/local-forging@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.1.0
-      '@taquito/utils': 23.0.1
+      '@taquito/utils': 23.1.0
       bignumber.js: 9.1.2
 
-  '@taquito/michel-codec@23.0.1':
+  '@taquito/michel-codec@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.1.0
 
-  '@taquito/michelson-encoder@23.0.1':
+  '@taquito/michelson-encoder@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.1.0
-      '@taquito/rpc': 23.0.1
-      '@taquito/utils': 23.0.1
+      '@taquito/rpc': 23.0.0-beta.1
+      '@taquito/utils': 23.1.0
       bignumber.js: 9.1.2
       elliptic: 6.6.1
       fast-json-stable-stringify: 2.1.0
     transitivePeerDependencies:
       - encoding
 
-  '@taquito/rpc@23.0.1':
+  '@taquito/rpc@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.1.0
-      '@taquito/http-utils': 23.1.0(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)
-      '@taquito/utils': 23.0.1
+      '@taquito/http-utils': 23.0.0-beta.1(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)
+      '@taquito/utils': 23.1.0
       bignumber.js: 9.1.2
     transitivePeerDependencies:
       - encoding
 
-  '@taquito/taquito@23.0.1':
+  '@taquito/taquito@23.0.0-beta.1':
     dependencies:
       '@taquito/core': 23.1.0
-      '@taquito/http-utils': 23.1.0(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)
-      '@taquito/local-forging': 23.0.1
-      '@taquito/michel-codec': 23.0.1
-      '@taquito/michelson-encoder': 23.0.1
-      '@taquito/rpc': 23.0.1
-      '@taquito/utils': 23.0.1
+      '@taquito/http-utils': 23.0.0-beta.1(patch_hash=74970a17ec07ec4fa7e3a168cec614cd9350646589f9b3dbffee742b2b15d90e)
+      '@taquito/local-forging': 23.0.0-beta.1
+      '@taquito/michel-codec': 23.0.0-beta.1
+      '@taquito/michelson-encoder': 23.0.0-beta.1
+      '@taquito/rpc': 23.0.0-beta.1
+      '@taquito/utils': 23.1.0
       bignumber.js: 9.1.2
       rxjs: 7.8.2
     transitivePeerDependencies:
       - encoding
 
-  '@taquito/utils@23.0.1':
+  '@taquito/utils@23.1.0':
     dependencies:
       '@noble/curves': 1.9.7
       '@stablelib/blake2b': 1.0.1
@@ -54930,7 +54975,6 @@ snapshots:
       blakejs: 1.2.1
       bs58check: 3.0.1
       buffer: 6.0.3(patch_hash=42321bf7b7c77317e644bb216138271640fb39808e74312037dac216f4b9bc5d)
-      elliptic: 6.6.1
       typedarray-to-buffer: 4.0.0
 
   '@testing-library/dom@10.4.0':
@@ -56129,7 +56173,7 @@ snapshots:
   '@vechain/sdk-core@2.0.0(@typescript/typescript6@6.0.2)':
     dependencies:
       '@ethereumjs/rlp': 5.0.2
-      '@noble/ciphers': 1.3.0
+      '@noble/ciphers': 1.1.3
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
@@ -56137,7 +56181,7 @@ snapshots:
       '@scure/bip39': 1.6.0
       '@vechain/sdk-errors': 2.0.0
       '@vechain/sdk-logging': 2.0.0
-      abitype: 1.2.4(@typescript/typescript6@6.0.2)
+      abitype: 1.1.0(@typescript/typescript6@6.0.2)
       ethers: 6.15.0
       fast-json-stable-stringify: 2.1.0
       viem: 2.37.4(@typescript/typescript6@6.0.2)
@@ -57175,10 +57219,6 @@ snapshots:
       typescript: '@typescript/typescript6@6.0.2'
 
   abitype@1.1.0(@typescript/typescript6@6.0.2):
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
-
-  abitype@1.2.4(@typescript/typescript6@6.0.2):
     optionalDependencies:
       typescript: '@typescript/typescript6@6.0.2'
 
@@ -59508,7 +59548,7 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
 
-  conventional-commits-parser@7.1.1:
+  conventional-commits-parser@7.1.2:
     dependencies:
       '@simple-libs/stream-utils': 2.0.0
       argue-cli: 3.1.0
@@ -63584,7 +63624,7 @@ snapshots:
       through: 2.3.8
       wrap-ansi: 6.2.0
 
-  int64-buffer@1.0.1: {}
+  int64-buffer@1.1.1: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -63913,7 +63953,7 @@ snapshots:
   iso-filecoin@7.4.7(@typescript/typescript6@6.0.2):
     dependencies:
       '@ipld/dag-cbor': 9.2.7
-      '@ledgerhq/errors': 6.37.0
+      '@ledgerhq/errors': 6.32.0
       '@noble/curves': 1.9.7
       '@noble/hashes': 2.0.1
       '@scure/bip32': 1.7.0
@@ -66968,7 +67008,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66988,7 +67028,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
+      metro: 0.83.7(metro-transform-worker@0.83.7)
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -67095,54 +67135,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
-      - supports-color
-      - utf-8-validate
-
   metro@0.83.7:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -67186,6 +67178,53 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.7(metro-transform-worker@0.83.7):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.7)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.7
+      metro-cache: 0.83.7
+      metro-cache-key: 0.83.7
+      metro-config: 0.83.7(metro-transform-worker@0.83.7)
+      metro-core: 0.83.7
+      metro-file-map: 0.83.7(metro@0.83.7)
+      metro-resolver: 0.83.7
+      metro-runtime: 0.83.7
+      metro-source-map: 0.83.7
+      metro-symbolicate: 0.83.7
+      metro-transform-plugins: 0.83.7
+      metro-transform-worker: 0.83.7
+      mime-types: 3.0.1
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -70195,7 +70234,7 @@ snapshots:
   react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       prop-types: 15.8.1
-      qrcode: 1.5.4
+      qrcode: 1.5.3
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -70203,7 +70242,7 @@ snapshots:
   react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       prop-types: 15.8.1
-      qrcode: 1.5.4
+      qrcode: 1.5.3
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -71481,7 +71520,7 @@ snapshots:
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.11
-      node-forge: 1.4.0
+      node-forge: 1.3.1
 
   semver-compare@1.0.0:
     optional: true
@@ -73668,6 +73707,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.19.2: {}
 
   undici@6.21.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       '@react-native/babel-plugin-codegen':
         specifier: 'catalog:'
         version: 0.81.6
+      '@support/ts-config-base-legacy':
+        specifier: workspace:*
+        version: link:support/ts-config-base-legacy
       '@ton/crypto':
         specifier: ^3.3.0
         version: 3.3.0
@@ -14882,7 +14885,13 @@ importers:
         specifier: 19.1.4
         version: 19.1.4
 
-  support/ts-config-base: {}
+  support/ts-config-base:
+    devDependencies:
+      '@support/ts-config-base-legacy':
+        specifier: workspace:*
+        version: link:../ts-config-base-legacy
+
+  support/ts-config-base-legacy: {}
 
   support/ts-config-web:
     devDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
   - "domain/entity/*"
   - "domain/api/*"
   - "shared/*"
+  - "support/*"
   - "devtools/*"
 
 catalog:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ packages:
   - "domain/entity/*"
   - "domain/api/*"
   - "shared/*"
+  - "support/*"
   - "devtools/*"
   - "support/*"
 

--- a/support/ts-config-base-legacy/package.json
+++ b/support/ts-config-base-legacy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@support/ts-config-base-legacy",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Monorepo base TypeScript config (NodeNext, strict) — extended by root tsconfig.base.json and @support/ts-config-base",
+  "exports": {
+    ".": "./tsconfig.json",
+    "./tsconfig.json": "./tsconfig.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/support/ts-config-base-legacy/project.json
+++ b/support/ts-config-base-legacy/project.json
@@ -1,0 +1,1 @@
+{ "name": "@support/ts-config-base-legacy", "targets": { "build": { "executor": "nx:noop" } } }

--- a/support/ts-config-base-legacy/tsconfig.json
+++ b/support/ts-config-base-legacy/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "pretty": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "customConditions": ["@ledgerhq/source"]
+  }
+}

--- a/support/ts-config-base/README.md
+++ b/support/ts-config-base/README.md
@@ -1,0 +1,37 @@
+# @support/ts-config-base
+
+Base TypeScript config preset for new-arch packages (`domain/*`, `shared/*`) that contain no JSX and no browser APIs.
+
+Extends the monorepo root `tsconfig.base.json` and locks in the standard new-arch compiler profile: ES2022, ESNext modules, bundler resolution, `noEmit`, and `jest` types.
+
+`include`/`exclude` use `${configDir}` (TypeScript 5.5+) so they resolve relative to the **consuming package's directory**, not this preset's location.
+
+## When to use
+
+- `domain/entity/*` — Zod schemas, selectors, slices
+- `domain/api/*` — RTK Query createApi, network calls
+- `shared/*` — framework-agnostic utilities, Redux tooling
+
+## Consumption
+
+```json
+// your-package/tsconfig.json
+{ "extends": "@support/ts-config-base" }
+```
+
+Override `types` when you need extras beyond the default `["jest"]`:
+
+```json
+{
+  "extends": "@support/ts-config-base",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
+}
+```
+
+Add `@support/ts-config-base` to the package's `devDependencies`:
+
+```json
+{ "devDependencies": { "@support/ts-config-base": "workspace:*" } }
+```

--- a/support/ts-config-base/package.json
+++ b/support/ts-config-base/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@support/ts-config-base",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Base TypeScript config preset for new-arch packages without JSX",
+  "exports": {
+    ".": "./tsconfig.json",
+    "./tsconfig.json": "./tsconfig.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/support/ts-config-base/package.json
+++ b/support/ts-config-base/package.json
@@ -2,7 +2,10 @@
   "name": "@support/ts-config-base",
   "version": "0.1.0",
   "private": true,
-  "description": "Base TypeScript config preset for new-arch packages without JSX",
+  "description": "Base TypeScript config preset for new-arch packages without JSX (ESNext/bundler/noEmit)",
+  "devDependencies": {
+    "@support/ts-config-base-legacy": "workspace:*"
+  },
   "exports": {
     ".": "./tsconfig.json",
     "./tsconfig.json": "./tsconfig.json",

--- a/support/ts-config-base/project.json
+++ b/support/ts-config-base/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "@support/ts-config-base",
+  "targets": {
+    "build": { "executor": "nx:noop" }
+  }
+}

--- a/support/ts-config-base/tsconfig.json
+++ b/support/ts-config-base/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["${configDir}/src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/support/ts-config-base/tsconfig.json
+++ b/support/ts-config-base/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "@support/ts-config-base-legacy",
   "compilerOptions": {
     "lib": ["ES2022"],
     "target": "ES2022",

--- a/support/ts-config-web-x-native/README.md
+++ b/support/ts-config-web-x-native/README.md
@@ -1,0 +1,50 @@
+# @support/ts-config-web-x-native
+
+TypeScript config preset for packages that target **both web and React Native** using `.web.tsx` / `.native.tsx` file extensions.
+
+Uses TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) so each platform gets its own `moduleSuffixes` and exclusion list. `${configDir}` (TypeScript 5.5+) makes `include`/`exclude` in this preset resolve relative to the consuming package's directory.
+
+## When to use
+
+`features/flow/*` packages that ship both `.web.tsx` and `.native.tsx` variants of the same component.
+
+## Consumption
+
+Each consuming package needs **3 files** (TypeScript project references require local sub-configs):
+
+```json
+// tsconfig.json — solution file, orchestrates sub-configs
+{
+  "extends": "@support/ts-config-web-x-native",
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}
+```
+
+```json
+// tsconfig.web.json
+{ "extends": "@support/ts-config-web-x-native/tsconfig.web.json" }
+```
+
+```json
+// tsconfig.native.json
+{ "extends": "@support/ts-config-web-x-native/tsconfig.native.json" }
+```
+
+Add `@support/ts-config-web-x-native` to `devDependencies`:
+
+```json
+{ "devDependencies": { "@support/ts-config-web-x-native": "workspace:*" } }
+```
+
+## What each sub-config provides
+
+| File | `moduleSuffixes` | Excludes |
+|------|-----------------|---------|
+| `tsconfig.web.json` | `[".web", ""]` | `src/**/*.native.*` |
+| `tsconfig.native.json` | `[".native", ""]` | `src/**/*.web.*` |
+
+The solution `tsconfig.json` (`extends @support/ts-config-base` + `jsx: react-jsx`) is used as the base by both sub-configs — **no DOM lib** since React Native does not have `window`/`document`.

--- a/support/ts-config-web-x-native/package.json
+++ b/support/ts-config-web-x-native/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@support/ts-config-web-x-native",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TypeScript config preset for packages targeting both web and React Native",
+  "exports": {
+    ".": "./tsconfig.json",
+    "./tsconfig.json": "./tsconfig.json",
+    "./tsconfig.web.json": "./tsconfig.web.json",
+    "./tsconfig.native.json": "./tsconfig.native.json",
+    "./package.json": "./package.json"
+  },
+  "devDependencies": {
+    "@support/ts-config-base": "workspace:*"
+  }
+}

--- a/support/ts-config-web-x-native/project.json
+++ b/support/ts-config-web-x-native/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "@support/ts-config-web-x-native",
+  "targets": {
+    "build": { "executor": "nx:noop" }
+  }
+}

--- a/support/ts-config-web-x-native/tsconfig.json
+++ b/support/ts-config-web-x-native/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@support/ts-config-base",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
+}

--- a/support/ts-config-web-x-native/tsconfig.native.json
+++ b/support/ts-config-web-x-native/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["${configDir}/src/**/*"],
+  "exclude": ["node_modules", "${configDir}/src/**/*.web.*"]
+}

--- a/support/ts-config-web-x-native/tsconfig.web.json
+++ b/support/ts-config-web-x-native/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["${configDir}/src/**/*"],
+  "exclude": ["node_modules", "${configDir}/src/**/*.native.*"]
+}

--- a/support/ts-config-web-x-native/tsconfig.web.json
+++ b/support/ts-config-web-x-native/tsconfig.web.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "moduleSuffixes": [".web", ""]
+    "lib": ["ES2022", "DOM"],
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["${configDir}/src/**/*"],
   "exclude": ["node_modules", "${configDir}/src/**/*.native.*"]

--- a/support/ts-config-web/README.md
+++ b/support/ts-config-web/README.md
@@ -1,0 +1,34 @@
+# @support/ts-config-web
+
+TypeScript config preset for new-arch packages that target **web only** (`features/flow/*`, `features/platform/*`).
+
+Extends `@support/ts-config-base` and adds `jsx: react-jsx`, DOM lib, and `moduleSuffixes: [".web", ""]` so TypeScript resolves `.web.tsx` variants before plain `.tsx`.
+
+## When to use
+
+- `features/platform/*` — NFR platform packages (feature flags, style, analytics)
+- `features/flow/*` packages that only ship web UI (no `.native.tsx` files)
+
+## Consumption
+
+```json
+// your-package/tsconfig.json
+{ "extends": "@support/ts-config-web" }
+```
+
+Override `types` when you need extras beyond the default `["jest"]`:
+
+```json
+{
+  "extends": "@support/ts-config-web",
+  "compilerOptions": {
+    "types": ["jest", "@testing-library/jest-dom"]
+  }
+}
+```
+
+Add `@support/ts-config-web` to `devDependencies`:
+
+```json
+{ "devDependencies": { "@support/ts-config-web": "workspace:*" } }
+```

--- a/support/ts-config-web/package.json
+++ b/support/ts-config-web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@support/ts-config-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TypeScript config preset for web-only new-arch packages (React + DOM)",
+  "exports": {
+    ".": "./tsconfig.json",
+    "./tsconfig.json": "./tsconfig.json",
+    "./package.json": "./package.json"
+  },
+  "devDependencies": {
+    "@support/ts-config-base": "workspace:*"
+  }
+}

--- a/support/ts-config-web/project.json
+++ b/support/ts-config-web/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "@support/ts-config-web",
+  "targets": {
+    "build": { "executor": "nx:noop" }
+  }
+}

--- a/support/ts-config-web/tsconfig.json
+++ b/support/ts-config-web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@support/ts-config-base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["${configDir}/src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/support/ts-config-web/tsconfig.json
+++ b/support/ts-config-web/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "lib": ["ES2022", "DOM"],
-    "moduleSuffixes": [".web", ""]
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["${configDir}/src/**/*"],
   "exclude": ["node_modules"]

--- a/tools/nx-plugins/project-tags/plugin.js
+++ b/tools/nx-plugins/project-tags/plugin.js
@@ -63,6 +63,10 @@ function inferTags(projectRoot, packageName) {
     tags.add("scope:tools");
   }
 
+  if (projectRoot.startsWith("support/")) {
+    tags.add("scope:support");
+  }
+
   if (!(projectRoot === "apps" || projectRoot.startsWith("apps/"))) {
     tags.add("scope:no-apps");
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,18 +1,3 @@
 {
-  "compilerOptions": {
-    "allowJs": true, // we might want to change to false
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
-    "pretty": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "ESNext",
-    "moduleResolution": "NodeNext",
-    "module": "NodeNext",
-    "customConditions": ["@ledgerhq/source"]
-  }
+  "extends": "@support/ts-config-base-legacy"
 }


### PR DESCRIPTION
- [ ] make sure to keep docs/tsconfig-in-ddd.md up to date (follow up https://github.com/LedgerHQ/ledger-live/pull/21024)
 
## Summary

- Adds four shared TypeScript config presets under `support/` to eliminate repeated `compilerOptions` across `domain/`, `shared/`, and `features/` packages
- Registers `support/*` in `pnpm-workspace.yaml` and adds `scope:support` Nx tag inference
- Inverts root `tsconfig.base.json`: it now extends `@support/ts-config-base-legacy` (the package is the source of truth, not the root file)
- Migration of existing packages: PR #20563 (same stack)

### Presets

| Package | Use case | Key additions vs base |
|---|---|---|
| `@support/ts-config-base-legacy` | Root `tsconfig.base.json` + `@support/ts-config-base` base | NodeNext, strict, interop flags (monorepo source of truth) |
| `@support/ts-config-base` | `domain/*`, `shared/*` — no JSX, no DOM | ES2022, ESNext, bundler resolution, noEmit |
| `@support/ts-config-web` | `features/platform/*`, web-only `features/flow/*` | `jsx:react-jsx`, DOM lib, `.web` moduleSuffixes |
| `@support/ts-config-web-x-native` | cross-platform `features/flow/*` (`.web.tsx`/`.native.tsx`) | 3-file project references pattern, no DOM |

### `${configDir}` for portable include/exclude

`include`/`exclude` in the presets use `${configDir}` (TypeScript 5.5+, repo uses TS 6.0.2). When a base config defines `include: ["${configDir}/src/**/*"]`, TypeScript resolves `${configDir}` to the **leaf consumer's directory**, so consumers inherit the correct path without repeating it.

### `@support/ts-config-web-x-native` — 3-file pattern

Cross-platform packages need separate `moduleSuffixes` per build target and a solution file for `tsc -b`. Consuming packages require 3 minimal files:

```jsonc
// tsconfig.json — solution file
{ "extends": "@support/ts-config-web-x-native", "files": [], "references": [...] }

// tsconfig.web.json
{ "extends": "@support/ts-config-web-x-native/tsconfig.web.json" }

// tsconfig.native.json
{ "extends": "@support/ts-config-web-x-native/tsconfig.native.json" }
```

Reference: `devtools/shell/tsconfig.{json,web.json,native.json}`.

### Root tsconfig inversion

`tsconfig.base.json` previously held the monorepo-wide strict/interop settings directly. It now extends `@support/ts-config-base-legacy`, making the support package the single edit point for those settings. This is required for `@support/ts-config-base` to chain through a shared source rather than duplicating the root file's content.

```
tsconfig.base.json  →extends→  @support/ts-config-base-legacy
@support/ts-config-base  →extends→  @support/ts-config-base-legacy
```

## Test plan

- [x] `pnpm install` — packages registered, symlinks created
- [x] `tsc --showConfig` on a test consumer extending `@support/ts-config-base` — `include` resolves to consumer's `src/`, all `compilerOptions` inherited correctly
- [x] `tsc --showConfig` on `support/ts-config-web-x-native/tsconfig.{web,native}.json` — correct `moduleSuffixes` and exclusion lists

## Stack

Part of stack #20564 — followed by PR #20529 (validation script) and PR #20563 (migration).

[LIVE-34844]: https://ledgerhq.atlassian.net/browse/LIVE-34844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34845]: https://ledgerhq.atlassian.net/browse/LIVE-34845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34846]: https://ledgerhq.atlassian.net/browse/LIVE-34846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ