### PR TITLE
[LWDM] feat(send): track input mode on new send flow review [LIVE-33795]

### DIFF
--- a/.changeset/teal-wolves-track.md
+++ b/.changeset/teal-wolves-track.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Track input mode (fiat or crypto) when clicking review on the new send flow amount screen

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenInner.tsx
@@ -80,10 +80,17 @@ export function AmountScreenInner({
       page: "step amount",
       quick_amount: activeQuickAction,
       fee_strategy: viewModel.selectedFeeStrategy ?? null,
+      input_mode: viewModel.inputMode,
       ...sendFlowTrackingProperties,
     });
     onReview();
-  }, [onReview, viewModel.quickActions, viewModel.selectedFeeStrategy, sendFlowTrackingProperties]);
+  }, [
+    onReview,
+    viewModel.quickActions,
+    viewModel.selectedFeeStrategy,
+    viewModel.inputMode,
+    sendFlowTrackingProperties,
+  ]);
 
   return (
     <AmountScreenView

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -55,6 +55,7 @@ jest.mock("../useAmountInput", () => ({
     currencyText: "BTC",
     currencyPosition: "right",
     secondaryValue: "$0",
+    inputMode: "crypto",
     onAmountChange: jest.fn(),
     onToggleInputMode: jest.fn(),
     cancelPendingUpdates: jest.fn(),

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreenViewModel.ts
@@ -192,6 +192,7 @@ export function useAmountScreenViewModel({
     onToggleInputMode: amountInput.onToggleInputMode,
     toggleLabel: t("newSendFlow.switchInputMode"),
     secondaryValue: amountInput.secondaryValue,
+    inputMode: amountInput.inputMode,
     quickActions: trackedQuickActions,
     showQuickActions: quickActionsAvailableBalance.gt(0),
     amountMessage,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -81,4 +81,5 @@ export type AmountScreenViewModel = Omit<
   Readonly<{
     showFeePresets: boolean;
     onOpenCustomFees: () => void;
+    inputMode: "fiat" | "crypto";
   }>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/useAmountScreen.ts
@@ -12,6 +12,7 @@ import type { SendFlowNavigationProp } from "../../../types";
 import { useSendSignature } from "../../../context/SendSignatureContext";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
 import { useAnalytics } from "~/analytics";
+import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
 
 type AmountScreenViewModelBase = Readonly<{
   onReview: () => void;
@@ -52,11 +53,17 @@ export function useAmountScreen(): AmountScreenViewModel {
   const trackingProperties = useMemo(() => {
     return getSendFlowTrackingProperties(account, parentAccount);
   }, [account, parentAccount]);
+  const { displayMode: inputMode } = useSendAmountDisplayMode();
 
   const onReview = useCallback(() => {
-    track("button_clicked", { ...trackingProperties, button: "review", page: "step amount" });
+    track("button_clicked", {
+      ...trackingProperties,
+      button: "review",
+      page: "step amount",
+      input_mode: inputMode,
+    });
     startSigning(() => navigation.navigate(ScreenName.SendFlowConfirmation));
-  }, [startSigning, navigation, track, trackingProperties]);
+  }, [startSigning, navigation, track, trackingProperties, inputMode]);
 
   const onSelectCoinControl = useCallback(() => {
     navigation.navigate(ScreenName.SendFlowCoinControl);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _The existing ViewModel test mock is updated. No new dedicated test for the tracking call itself — the tracking logic is trivial (single property addition) and covered by the analytics integration layer._
- [x] **Impact of the changes:**
      - Send flow amount screen: verify `input_mode: 'fiat'` is sent when the user is in fiat input mode and clicks Review
      - Send flow amount screen: verify `input_mode: 'crypto'` is sent when the user is in crypto input mode and clicks Review
      - No visual changes, no behavior changes — analytics only

### 📝 Description

When a user clicks "Review" on the new send flow amount screen, the `button_clicked` analytics event is fired without any indication of which input mode was active (fiat or crypto). This makes it impossible to understand user preferences around fiat vs. crypto input.

This PR adds `input_mode: 'fiat' | 'crypto'` to the `button_clicked` event fired on review:

- **LLD**: `inputMode` is exposed from `useAmountInput` through `useAmountScreenViewModel` and read in `AmountScreenInner` at the tracking call site.
- **LLM**: `displayMode` is read directly from `useSendAmountDisplayMode` context in `useAmountScreen`, where the `onReview` callback with the `track()` call lives.

> **Note**: The original ticket (LIVE-33795) also included USD amount tracking. That property requires data committee approval and is **not included here**.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33795](https://ledgerhq.atlassian.net/browse/LIVE-33795)

---
<img width="1109" height="233" alt="Screenshot 2026-07-24 at 11 46 08" src="https://github.com/user-attachments/assets/2643dee0-5263-42b4-a3ad-ee4fb49c4af8" />


### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33795]: https://ledgerhq.atlassian.net/browse/LIVE-33795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ