### PR TITLE
test(desktop): verify swap form shown after closing swap success drawer

### DIFF
--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -245,6 +245,8 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
           await app.swapDrawer.verifyExchangeCompletedTextContent(
             swap.accountToCredit.currency.name,
           );
+          await app.swapDrawer.closeDrawer();
+          await app.swap.goAndWaitForSwapToBeReady(async () => {});
         }
       },
     );


### PR DESCRIPTION
## Summary
- After `verifyExchangeCompletedTextContent` in `send.swap.spec.ts`, the test now closes the swap success drawer via its header X (`app.swapDrawer.closeDrawer()`, clicking `data-testid="drawer-close-button"` — the drawer is rendered by `LiveAppDrawer` → `SideDrawer`, titled "Confirm your Exchange") instead of leaving it open.
- Then verifies the initial swap input form is shown again via `app.swap.goAndWaitForSwapToBeReady(async () => {})`, reusing the existing helper as a pure "swap page is ready" check (no new page-object method needed).
- We assert the initial swap form rather than the Swap History tab: this suite forces `DISABLE_TRANSACTION_BROADCAST=1` (`setupEnv(true)`), which makes the swap live-app report the swap as cancelled internally and skip the History redirect it would otherwise trigger on a real broadcast — so History would never be reachable here regardless of timing.
- Mirrors the equivalent mobile change in #19785.

## Test plan
- [ ] Run a case from `send.swap.spec.ts` (e.g. `-g "Swap ETH to BTC"`) against Speculos/CI and confirm the drawer close + swap-page-ready check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)