### PR TITLE
[LWD] fix(desktop): update large-screen upsell opt-out copy

### DIFF
--- a/.changeset/bright-signers-detect.md
+++ b/.changeset/bright-signers-detect.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-large-screen-upsell": minor
+---
+
+Update the Desktop large-screen upsell opt-out copy and CTA.

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -172,13 +172,13 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
     });
 
-    expect(screen.getByText("Spot scams. See every detail")).toBeVisible();
+    expect(screen.getByText("Spot scams before signing")).toBeVisible();
     expect(
       screen.getByText(
-        "Review clearly on a touchscreen signer and spot scams with advanced security checks.",
+        "Learn more about advanced security features that enable real-time threat detection.",
       ),
     ).toBeVisible();
-    expect(screen.getByRole("button", { name: "Explore touchscreen signers" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
     expect(trackPage).toHaveBeenCalledWith(
       "Modal - Upgrade",
       undefined,
@@ -246,10 +246,10 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Explore touchscreen signers" })).toBeVisible();
+      expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
     });
 
-    await user.click(screen.getByRole("button", { name: "Explore touchscreen signers" }));
+    await user.click(screen.getByRole("button", { name: "Learn more" }));
 
     await waitFor(() => {
       expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();
@@ -384,14 +384,14 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Explore touchscreen signers" })).toBeVisible();
+      expect(screen.getByRole("button", { name: "Learn more" })).toBeVisible();
     });
 
     await waitFor(() => {
       expect(store.getState().largeScreenUpsellModal.retries).toBe(1);
     });
 
-    await user.click(screen.getByRole("button", { name: "Explore touchscreen signers" }));
+    await user.click(screen.getByRole("button", { name: "Learn more" }));
 
     await waitFor(() => {
       expect(screen.queryByTestId("large-screen-upsell-modal")).not.toBeInTheDocument();

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8684,13 +8684,14 @@
   "largeScreenUpsellModal": {
     "optedIn": {
       "title": "See more. Tap less. Save {{discount}}%",
-      "subtitle": "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive {{discount}}% off."
+      "subtitle": "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive {{discount}}% off.",
+      "cta": "Explore touchscreen signers"
     },
     "optedOut": {
-      "title": "Spot scams. See every detail",
-      "subtitle": "Review clearly on a touchscreen signer and spot scams with advanced security checks."
-    },
-    "cta": "Explore touchscreen signers"
+      "title": "Spot scams before signing",
+      "subtitle": "Learn more about advanced security features that enable real-time threat detection.",
+      "cta": "Learn more"
+    }
   },
   "modularAssetDrawer": {
     "addAccounts": {

--- a/features/flow/large-screen-upsell/src/utils/upsellContent.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellContent.ts
@@ -49,12 +49,16 @@ export function buildLargeScreenUpsellContent({
     variant === "opted_in"
       ? "largeScreenUpsellModal.optedIn.subtitle"
       : "largeScreenUpsellModal.optedOut.subtitle";
+  const ctaKey =
+    variant === "opted_in"
+      ? "largeScreenUpsellModal.optedIn.cta"
+      : "largeScreenUpsellModal.optedOut.cta";
 
   return {
     id,
     title: t(titleKey, { discount: discountPercentage }),
     subtitle: t(subtitleKey, { discount: discountPercentage }),
-    primaryButtonLabel: t("largeScreenUpsellModal.cta"),
+    primaryButtonLabel: t(ctaKey),
     primaryButtonLink,
     imageUrlLight,
     imageUrlDark,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop large-screen upsell modal for users who opted out of personalized recommendations
  - Existing opted-in modal copy and CTA
  - CTA dismissal and Desktop shop URL tracking parameters

### 📝 Description

The Desktop large-screen upsell modal used the same CTA and touchscreen-focused messaging for both personalized-recommendation variants.

This PR updates only the opted-out Desktop experience:

- **Before:** “Spot scams. See every detail”, the touchscreen signer description, and “Explore touchscreen signers”
- **After:** “Spot scams before signing”, the advanced security and real-time threat detection description, and “Learn more”

The CTA translation is now variant-specific so the opted-in experience keeps its existing copy. Integration coverage verifies both variants and the opted-out shop link with Desktop UTM parameters.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: N/A — copy update requested directly

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
