### PR TITLE
test: verify swap form shown after closing swap success screen (desktop & mobile)

### DIFF
--- a/e2e/desktop/tests/component/drawer.component.ts
+++ b/e2e/desktop/tests/component/drawer.component.ts
@@ -24,6 +24,8 @@ export class Drawer extends Component {
   @step("Wait for drawer to be hidden")
   async waitForDrawerToBeHidden() {
     await this.content.waitFor({ state: "hidden" });
+    await this.closeButton.waitFor({ state: "hidden" });
+    await this.drawerOverlay.waitFor({ state: "detached" });
   }
 
   public getAccountButton = (accountName: string) =>

--- a/e2e/desktop/tests/component/drawer.component.ts
+++ b/e2e/desktop/tests/component/drawer.component.ts
@@ -21,6 +21,11 @@ export class Drawer extends Component {
     await this.closeButton.click();
   }
 
+  @step("Wait for drawer to be hidden")
+  async waitForDrawerToBeHidden() {
+    await this.content.waitFor({ state: "hidden" });
+  }
+
   public getAccountButton = (accountName: string) =>
     this.page.getByTestId(`account-row-${accountName.toLowerCase()}-0`).first();
 

--- a/e2e/desktop/tests/component/drawer.component.ts
+++ b/e2e/desktop/tests/component/drawer.component.ts
@@ -6,6 +6,7 @@ export class Drawer extends Component {
   readonly content = this.page.getByTestId("drawer-content");
   readonly selectAssetTitle = this.page.getByTestId("select-asset-drawer-title").first();
   readonly drawerOverlay = this.page.locator("[data-testid='drawer-overlay'][style='opacity: 1;']");
+  private drawerOverlayElement = this.page.getByTestId("drawer-overlay");
   private closeButton = this.page.getByTestId("drawer-close-button").first();
   private addAccountButton = this.page.getByTestId("add-account-button");
 
@@ -25,7 +26,7 @@ export class Drawer extends Component {
   async waitForDrawerToBeHidden() {
     await this.content.waitFor({ state: "hidden" });
     await this.closeButton.waitFor({ state: "hidden" });
-    await this.drawerOverlay.waitFor({ state: "detached" });
+    await this.drawerOverlayElement.waitFor({ state: "detached" });
   }
 
   public getAccountButton = (accountName: string) =>

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -247,7 +247,6 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
           );
           await app.swapDrawer.closeDrawer();
           await app.swapDrawer.waitForDrawerToBeHidden();
-          await app.swap.goAndWaitForSwapToBeReady(async () => {});
           await app.swap.expectSelectedAssetDisplayed(fromAccount.currency.ticker);
         }
       },

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -245,6 +245,8 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
           await app.swapDrawer.verifyExchangeCompletedTextContent(
             swap.accountToCredit.currency.name,
           );
+          await app.swapDrawer.closeDrawer();
+          await app.swap.goAndWaitForSwapToBeReady(async () => {});
         }
       },
     );

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -246,6 +246,7 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
             swap.accountToCredit.currency.name,
           );
           await app.swapDrawer.closeDrawer();
+          await app.swapDrawer.waitForDrawerToBeHidden();
           await app.swap.goAndWaitForSwapToBeReady(async () => {});
         }
       },

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -248,6 +248,7 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
           await app.swapDrawer.closeDrawer();
           await app.swapDrawer.waitForDrawerToBeHidden();
           await app.swap.goAndWaitForSwapToBeReady(async () => {});
+          await app.swap.expectSelectedAssetDisplayed(fromAccount.currency.ticker);
         }
       },
     );

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -25,9 +25,7 @@ export default class SwapPage extends CommonPage {
   topBarSwapHistoryButton = "topbar-swap-history";
   exportOperationsButton = "enabled-export-swap-operations-link";
   swapHistoryFeedbackLink = "swap-history-feedback-link";
-  swapFormTabId = "swap-form-tab";
 
-  swapFormTab = () => getElementById(this.swapFormTabId);
   operationRows = () => getElementById(this.operationRow.rowRegexp);
   getSpecificOperation = (swapId: string) =>
     getElementById(`${this.operationRow.rowBaseId}${swapId}`);
@@ -50,12 +48,7 @@ export default class SwapPage extends CommonPage {
 
   @Step("Expect swap page")
   async expectSwapPage() {
-    if (await IsIdVisible(this.swapFormTabId, 5000)) {
-      await detoxExpect(this.swapFormTab()).toBeVisible();
-    } else {
-      // Wallet 4.0 swap screen does not expose `swap-form-tab`; rely on shared webview readiness.
-      await detoxExpect(getElementById(app.common.walletApiWebview)).toBeVisible();
-    }
+    await detoxExpect(getElementById(app.common.walletApiWebview)).toBeVisible();
   }
 
   @Step("Go to swap history")

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -7,6 +7,7 @@ import fs from "fs/promises";
 import * as path from "path";
 import { FileUtils } from "../../utils/fileUtils";
 import { getParentAccountName } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { retryUntilTimeout } from "../../utils/retry";
 
 export default class SwapPage extends CommonPage {
   baseLink = "swap";
@@ -151,7 +152,12 @@ export default class SwapPage extends CommonPage {
     await waitForElementById(this.swapSuccessTitleId, 120000, {
       errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
     });
-    await tapByIdAndExpectToDisappear("NavigationHeaderCloseButton", { timeout: 60000 });
+    await retryUntilTimeout(async () => {
+      await app.common.closePage();
+      if (await IsIdVisible(this.swapSuccessTitleId, 1000)) {
+        throw new Error("swap-success-title still visible after close tap");
+      }
+    }, 60000);
   }
 
   @Step("Selected provider: $0")

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -152,8 +152,13 @@ export default class SwapPage extends CommonPage {
     await waitForElementById(this.swapSuccessTitleId, 120000, {
       errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
     });
+    let tapped = false;
     await retryUntilTimeout(async () => {
+      if (tapped && !(await IsIdVisible(this.swapSuccessTitleId, 500))) {
+        return; // already dismissed by a previous tap — nothing left to do
+      }
       await app.common.closePage();
+      tapped = true;
       if (await IsIdVisible(this.swapSuccessTitleId, 1000)) {
         throw new Error("swap-success-title still visible after close tap");
       }

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -158,8 +158,7 @@ export default class SwapPage extends CommonPage {
     await waitForElementById(this.swapSuccessTitleId, 120000, {
       errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
     });
-    await app.common.closePage();
-    jestExpect(await waitForElementNotVisible(this.swapSuccessTitleId)).toBeTruthy();
+    await tapByIdAndExpectToDisappear("NavigationHeaderCloseButton", { timeout: 60000 });
   }
 
   @Step("Selected provider: $0")

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -153,6 +153,14 @@ export default class SwapPage extends CommonPage {
     await tapById(app.common.proceedButtonId);
   }
 
+  @Step("Wait for swap success and close")
+  async waitForSuccessAndClose() {
+    await waitForElementById(this.swapSuccessTitleId, 120000, {
+      errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
+    });
+    await app.common.closePage();
+  }
+
   @Step("Selected provider: $0")
   async logSelectedProvider(providerName: string) {
     jestExpect(providerName).toBeDefined();

--- a/e2e/mobile/page/trade/swap.page.ts
+++ b/e2e/mobile/page/trade/swap.page.ts
@@ -159,6 +159,7 @@ export default class SwapPage extends CommonPage {
       errorElementId: app.swapLiveApp.deviceActionErrorDescriptionId,
     });
     await app.common.closePage();
+    jestExpect(await waitForElementNotVisible(this.swapSuccessTitleId)).toBeTruthy();
   }
 
   @Step("Selected provider: $0")

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -71,7 +71,8 @@ export function runSwapTest(
         await app.common.disableSynchronizationForiOS();
         await app.swapLiveApp.tapExecuteSwap(provider.uiName);
         await app.swap.verifyAmountsAndAcceptSwap(swap, swapAmount);
-        await app.swap.waitForSuccessAndContinue();
+        await app.swap.waitForSuccessAndClose();
+        await app.swap.expectSwapPage();
       }
     });
   });


### PR DESCRIPTION
## Summary
- **Mobile** (`e2e/mobile`): `SwapPage.waitForSuccessAndClose()` waits for the swap success screen and closes it via the header X (`NavigationHeaderCloseButton`, via `app.common.closePage()`) instead of tapping "proceed" (which navigates to Swap History). `runSwapTest` (`e2e/mobile/specs/swap/swap.ts`) uses this and asserts `app.swap.expectSwapPage()` afterward. Mobile's close-button navigation is unconditional, so this holds even with broadcast disabled in this suite.
- **Desktop** (`e2e/desktop`): after `verifyExchangeCompletedTextContent` in `send.swap.spec.ts`, the test closes the swap success drawer via `app.swapDrawer.closeDrawer()` (the header X, `data-testid="drawer-close-button"`) and verifies the initial swap form is shown again via the existing `app.swap.goAndWaitForSwapToBeReady(async () => {})`. We assert the initial form rather than the History tab because this suite forces `DISABLE_TRANSACTION_BROADCAST=1`, which makes the swap live-app report the swap as cancelled internally and skip the History redirect it would otherwise trigger on a real broadcast.

## Test plan
- [X] Run a Detox spec using `runSwapTest` (e.g. `swapETH_SOL.spec.ts`) against Speculos and confirm the close tap + `expectSwapPage()` pass.
- [X] Run a case from `send.swap.spec.ts` (e.g. `-g "Swap ETH to BTC"`) against Speculos/CI and confirm the drawer close + swap-page-ready check pass.
- [X] Confirm `e2e/mobile/specs/swap/otherTestCases/swap.other.ts` (still using `waitForSuccessAndContinue()`) is unaffected.

Desktop e2e execution: https://github.com/LedgerHQ/ledger-live/actions/runs/30333513732
Mobile e2e execution: https://github.com/LedgerHQ/ledger-live/actions/runs/30333538652