### PR TITLE
chore(mobile): rotate swap approval/reapproval flows per platform to fix shared-EOA nightly retries (QAA-1411)

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -523,8 +523,7 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
-      # True when both platform jobs run this workflow. Broadcast swap flows use it to pin each flow to one platform per run and avoid the shared-EOA race
-      # Single-platform runs keep full coverage.
+      # Used by broadcastRotation.ts to avoid shared-account broadcast races (QAA-1411)
       E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
     outputs:
       status: ${{ steps.run-ios.outcome }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -523,6 +523,9 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
+      # True when both platform jobs run this workflow. Broadcast swap flows use it to pin each flow to one platform per run and avoid the shared-EOA race
+      # Single-platform runs keep full coverage.
+      E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
     outputs:
       status: ${{ steps.run-ios.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
@@ -715,6 +718,9 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.android_device }}
+      # True when both platform jobs run this workflow. Broadcast swap flows use it to pin each flow to one platform per run and avoid the shared-EOA race
+      # Single-platform runs keep full coverage.
+      E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
     outputs:
       status: ${{ steps.run-android.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -12,7 +12,7 @@ concurrency:
   # they would otherwise race on the same on-chain accounts across machines, which no per-run
   # mechanism can prevent. Non-broadcast runs keep the original per-ref/tests_type group.
   group: >-
-    ${{ inputs.enable_broadcast && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
+    ${{ (inputs.enable_broadcast || (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1,3,5')) && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -180,6 +180,10 @@ env:
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
   USERDATA_CACHE_ENABLED: ${{ !inputs.production_firebase }}
   E2E_GENERATED_USERDATA_DIR: ${{ !inputs.production_firebase && format('{0}/e2e/userdata/generated', github.workspace) || '' }}
+  # True only when a single run covers BOTH platforms (tests_type = "iOS & Android").
+  # broadcastRotation.ts uses it to pin each broadcast swap flow to one platform per run,
+  # avoiding the shared-EOA nonce race; single-platform runs keep full coverage. (QAA-1411)
+  E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
   # iOS Simulator configuration
   IOS_SIMULATOR_DEVICE: iPhone 15
   # Android AVD configuration
@@ -527,8 +531,6 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
-      # Used by broadcastRotation.ts to avoid shared-account broadcast races (QAA-1411)
-      E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
     outputs:
       status: ${{ steps.run-ios.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
@@ -721,9 +723,6 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.android_device }}
-      # True when both platform jobs run this workflow. Broadcast swap flows use it to pin each flow to one platform per run and avoid the shared-EOA race
-      # Single-platform runs keep full coverage.
-      E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
     outputs:
       status: ${{ steps.run-android.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -7,8 +7,12 @@ run-name: >
 # NB: test_filter is intentionally reduced to a bounded "filtered"/"all" token rather than embedded verbatim.
 # It is free-text and can be very long; the concurrency group name must stay under 400 characters.
 concurrency:
+  # Broadcast runs (enable_broadcast) share ONE group regardless of tests_type, so separate
+  # iOS-Only / Android-Only dispatches QUEUE instead of overlapping —
+  # they would otherwise race on the same on-chain accounts across machines, which no per-run
+  # mechanism can prevent. Non-broadcast runs keep the original per-ref/tests_type group.
   group: >-
-    mobile-e2e-${{ github.ref_name }}-${{ inputs.ref || github.sha }}-${{ github.event_name == 'schedule' && github.event.schedule || inputs.tests_type }}-${{ inputs.test_filter && 'filtered' || 'all' }}
+    ${{ inputs.enable_broadcast && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
   cancel-in-progress: false
 
 on:

--- a/e2e/mobile/helpers/broadcastRotation.ts
+++ b/e2e/mobile/helpers/broadcastRotation.ts
@@ -1,11 +1,9 @@
 /**
- * Decides which platform runs a broadcast-gated swap flow on a given run.
+ * Decide whether this platform should run a broadcast-gated swap flow.
  *
- * On the Monday broadcast nightly iOS and Android drive the SAME on-chain account (same Speculos
- * seed → same address), so running the same broadcast flow on both at once races on the shared
- * allowance/nonce. We avoid it without serializing or locking: each
- * flow runs on exactly ONE platform per run, and the assignment rotates so both platforms still
- * cover both flows over successive runs.
+ * On broadcast nightlies iOS+Android share the same on-chain account, so running both can race on
+ * allowance/nonce. We pin each flow to one platform per run and rotate assignments.
+ * See: https://ledgerhq.atlassian.net/browse/QAA-1411
  */
 
 const PLATFORM_SLOTS = ["ios", "android"] as const;

--- a/e2e/mobile/helpers/broadcastRotation.ts
+++ b/e2e/mobile/helpers/broadcastRotation.ts
@@ -1,0 +1,45 @@
+/**
+ * Decides which platform runs a broadcast-gated swap flow on a given run.
+ *
+ * On the Monday broadcast nightly iOS and Android drive the SAME on-chain account (same Speculos
+ * seed → same address), so running the same broadcast flow on both at once races on the shared
+ * allowance/nonce. We avoid it without serializing or locking: each
+ * flow runs on exactly ONE platform per run, and the assignment rotates so both platforms still
+ * cover both flows over successive runs.
+ */
+
+const PLATFORM_SLOTS = ["ios", "android"] as const;
+
+export const BroadcastFlow = { APPROVAL: 0, REAPPROVAL: 1 } as const;
+export type BroadcastFlow = (typeof BroadcastFlow)[keyof typeof BroadcastFlow];
+
+const MONDAY_EPOCH_UTC_MS = Date.UTC(2024, 0, 1);
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+function currentPlatform(): (typeof PLATFORM_SLOTS)[number] {
+  return process.env.DETOX_CONFIGURATION?.startsWith("ios") ? "ios" : "android";
+}
+
+function broadcastRotationIndex(): number {
+  if (process.env.GITHUB_EVENT_NAME === "schedule") {
+    return Math.floor((Date.now() - MONDAY_EPOCH_UTC_MS) / ONE_WEEK_MS);
+  }
+  return Number.parseInt(process.env.GITHUB_RUN_NUMBER ?? "0", 10) || 0;
+}
+
+/**
+ * Whether a broadcast flow should run in THIS platform's job on this run:
+ *  - broadcast off                  → no (these flows are Monday-nightly / enable_broadcast only)
+ *  - broadcast on, one platform     → yes (a single-platform run owns the account alone)
+ *  - broadcast on, both platforms   → only on the flow's assigned platform this run (rotated)
+ *
+ * `E2E_BOTH_PLATFORMS` is set by the workflow to `tests_type != 'iOS Only' && != 'Android Only'`
+ * — i.e. whether both platform jobs run this workflow (the only case that can collide).
+ */
+export function shouldRunBroadcastFlow(flow: BroadcastFlow): boolean {
+  if (process.env.DISABLE_TRANSACTION_BROADCAST !== "0") return false;
+  if (process.env.E2E_BOTH_PLATFORMS !== "true") return true;
+
+  const assigned = PLATFORM_SLOTS[(broadcastRotationIndex() + flow) % PLATFORM_SLOTS.length];
+  return currentPlatform() === assigned;
+}

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -17,7 +17,13 @@ export function runSwapTokenApprovalFlow(
 ) {
   const runHere = shouldRunBroadcastFlow(BroadcastFlow.APPROVAL);
   if (!runHere) {
-    console.warn("[approval.swap.spec] Skipping — needs broadcast on");
+    const broadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
+    const bothPlatforms = process.env.E2E_BOTH_PLATFORMS === "true";
+    console.warn(
+      broadcastEnabled && bothPlatforms
+        ? "[approval.swap.spec] Skipping — rotated to the other platform for this run (avoids shared-account broadcast race)"
+        : "[approval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0",
+    );
   }
   (runHere ? describe : describe.skip)("Token approval - flow", () => {
     beforeAll(async () => {

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -6,6 +6,7 @@ import { beforeAllFunctionSwap } from "../swap.setup";
 import { getAmountFromUSD } from "@ledgerhq/live-e2e-shared/currencyUtils";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
+import { BroadcastFlow, shouldRunBroadcastFlow } from "../../../helpers/broadcastRotation";
 
 export function runSwapTokenApprovalFlow(
   fromAccount: TokenAccount,
@@ -14,13 +15,11 @@ export function runSwapTokenApprovalFlow(
   tmsLinks: string[],
   tags: string[],
 ) {
-  const isBroadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
-  if (!isBroadcastEnabled) {
-    console.warn(
-      "[approval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0 (Monday nightly only)",
-    );
+  const runHere = shouldRunBroadcastFlow(BroadcastFlow.APPROVAL);
+  if (!runHere) {
+    console.warn("[approval.swap.spec] Skipping — needs broadcast on");
   }
-  (isBroadcastEnabled ? describe : describe.skip)("Token approval - flow", () => {
+  (runHere ? describe : describe.skip)("Token approval - flow", () => {
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunctionSwap({

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -21,7 +21,13 @@ export function runSwapTokenReapprovalFlow(
 ) {
   const runHere = shouldRunBroadcastFlow(BroadcastFlow.REAPPROVAL);
   if (!runHere) {
-    console.warn("[reapproval.swap.spec] Skipping — needs broadcast on");
+    const broadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
+    const bothPlatforms = process.env.E2E_BOTH_PLATFORMS === "true";
+    console.warn(
+      broadcastEnabled && bothPlatforms
+        ? "[reapproval.swap.spec] Skipping — rotated to the other platform for this run (avoids shared-account broadcast race)"
+        : "[reapproval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0",
+    );
   }
   (runHere ? describe : describe.skip)("Token reapproval - flow", () => {
     beforeAll(async () => {

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -10,6 +10,7 @@ import { beforeAllFunctionSwap } from "../swap.setup";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 import BigNumber from "bignumber.js";
 import { pickRotatingProvider } from "@ledgerhq/live-e2e-shared/swap";
+import { BroadcastFlow, shouldRunBroadcastFlow } from "../../../helpers/broadcastRotation";
 
 export function runSwapTokenReapprovalFlow(
   fromAccount: TokenAccount,
@@ -18,13 +19,11 @@ export function runSwapTokenReapprovalFlow(
   tmsLinks: string[],
   tags: string[],
 ) {
-  const isBroadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
-  if (!isBroadcastEnabled) {
-    console.warn(
-      "[reapproval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0 (Monday nightly only)",
-    );
+  const runHere = shouldRunBroadcastFlow(BroadcastFlow.REAPPROVAL);
+  if (!runHere) {
+    console.warn("[reapproval.swap.spec] Skipping — needs broadcast on");
   }
-  (isBroadcastEnabled ? describe : describe.skip)("Token reapproval - flow", () => {
+  (runHere ? describe : describe.skip)("Token reapproval - flow", () => {
     beforeAll(async () => {
       await app.speculos.setExchangeDependencies(fromAccount, toAccount);
       await beforeAllFunctionSwap({


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset needed — only the private `ledger-live-mobile-e2e-tests` package and a CI workflow changed (no published package to version).
- [ ] **Covered by automatic tests.** _This change is E2E test gating. The pure, env-driven rotation logic in `broadcastRotation.ts` was verified with `typecheck` and a manual truth table across every run scenario (broadcast off / single-platform / both-platforms even+odd index). The flows themselves only execute on the Monday broadcast nightly, so there is no separate unit-test harness for them here._
- [x] **Impact of the changes:**
      - Monday broadcast nightly only: `Swap - token approval flow` and `Swap - token reapproval flow`
      - Non-broadcast nightlies (Tue–Fri) and PR runs must be **unaffected** (fully parallel, both flows on both platforms, unchanged concurrency group)
      - Manual `enable_broadcast` runs (release regressions) — a 2nd overlapping broadcast dispatch now **queues** instead of running in parallel

### 📝 Description

The mobile `Swap - token approval flow` and `Swap - token reapproval flow` E2E tests intermittently fail on the first attempt and pass on retry (flaky in Allure) on the Monday broadcast nightly.

**Problem.** iOS and Android use the same Speculos seed, so these tests drive the *same on-chain account* on both platforms. On the Monday run (the only one with `DISABLE_TRANSACTION_BROADCAST=0`) both platforms broadcast `approve`/`revoke` on that account concurrently. The QAA-1323 nonce lock (`crossProcessLock`) is filesystem-based → **per-machine only** → it can't coordinate the two separate runners, so the parallel platform overwrites the allowance between our precondition and the swap live app's read, the app skips the approval step, and the expected button never renders (60 s timeout). It is **not** a too-short timeout (healthy render is ~2–3 s) and **not** test-vs-test concurrency. Full RCA with diagrams and evidence: https://claude.ai/code/artifact/cc329568-8f3c-4e3d-a369-f6e2ff9cb221

**Solution.** Give the shared account a single writer: pin each broadcast flow to **one platform per run** (approval on one, reapproval on the other) and rotate the assignment so both platforms still cover both flows over time. Within a run, full parallelism is kept — no lock, no new funded accounts.

- New `e2e/mobile/helpers/broadcastRotation.ts` → `shouldRunBroadcastFlow(flow)`: broadcast off → skip; single-platform run → run (no cross-platform concurrency); both-platform run → run only on the flow's assigned platform this run.
- Rotation index: weekly (`weekIndex`) on the scheduled Monday nightly (→ biweekly per platform·flow, since broadcast is Monday-only); `GITHUB_RUN_NUMBER` on manual runs so successive release regressions rotate too.
- The two approval specs use the helper in their `describe` gate.
- `test-mobile-e2e-reusable.yml` sets `E2E_BOTH_PLATFORMS` on the detox jobs (= both platform jobs run this workflow) so the specs know when to partition.

**Cross-run serialization for broadcast dispatches.** The partition above only coordinates the iOS + Android jobs *within a single run*. Two **separate** broadcast dispatches (e.g. the release team firing `iOS Only` and `Android Only` at the same time) would still race on the same on-chain accounts across machines — no per-run mechanism can prevent that. To close it, `test-mobile-e2e-reusable.yml` now puts all `enable_broadcast` runs in **one shared concurrency group** (`mobile-e2e-broadcast`, `cancel-in-progress: false`), so a 2nd overlapping broadcast run **queues until the 1st finishes** instead of overlapping.

- Scope: applies **only** when `enable_broadcast` is set. Non-broadcast runs (PRs, branch runs) and the scheduled nightlies keep their original per-`ref`/`tests_type` group and stay fully parallel — the Monday nightly's broadcast comes from the runtime `date +%u` check, not this input, so it is not serialized by this.
- Trade-off: two overlapping *manual* broadcast runs become sequential (~2× wall-clock for that pair) in exchange for not colliding. This is the only case that waits.

Release regressions should be run **per platform** (`iOS Only`, then `Android Only`) for full one-shot coverage. Sequential scheduling and a remote cross-machine lock remain documented fallbacks in the RCA if full per-run coverage on both platforms is ever required.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1411](https://ledgerhq.atlassian.net/browse/QAA-1411)
- **Mobile run (iOS + android)**: https://github.com/LedgerHQ/ledger-live/actions/runs/30005233084
- **iOS run**: https://github.com/LedgerHQ/ledger-live/actions/runs/30020813516
- **Android run**: https://github.com/LedgerHQ/ledger-live/actions/runs/30020835872

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1411]: https://ledgerhq.atlassian.net/browse/QAA-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
