### PR TITLE
docs(git-conventions): update guidelines and commit lint (LIVE-27608)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,11 @@ The canonical rules live in [Git conventions](docs/contributing/git-conventions.
 ## Updating your branch with develop
 
 **Always prefer rebasing** unless your branch contains merge commits from
-sub-features:
+sub-features.
 
-- Small, self-contained branches -> rebase: `git rebase origin/develop`
-- Branches with cross-branch merges -> merge: `git merge origin/develop`
+- Small, self-contained branches -> rebase on `develop`.
+- Branches with cross-branch merges -> merge `develop` into them to stay up to
+  date.
 
 ## The PR Lifecycle
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ titles and merge commits.
 
 The canonical rules live in [Git conventions](docs/contributing/git-conventions.md).
 
-### Updating your branch with develop
+## Updating your branch with develop
 
 **Always prefer rebasing** unless your branch contains merge commits from
-sub-features
+sub-features:
 
 - Small, self-contained branches -> rebase: `git rebase origin/develop`
 - Branches with cross-branch merges -> merge: `git merge origin/develop`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,14 +19,13 @@ titles and merge commits.
 
 The canonical rules live in [Git conventions](docs/contributing/git-conventions.md).
 
-### Rebase & merge strategy
+### Updating your branch with develop
 
 **Always prefer rebasing** unless your branch contains merge commits from
-sub-features.
+sub-features
 
-- Small, self-contained branches -> rebase on `develop`.
-- Branches with cross-branch merges -> merge `develop` into them to stay up to
-  date.
+- Small, self-contained branches -> rebase: `git rebase origin/develop`
+- Branches with cross-branch merges -> merge: `git merge origin/develop`
 
 ## The PR Lifecycle
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,12 @@ Tools and resources for building on Ledger are at the [Ledger Developer Portal](
 
 #### Request Copilot while still in Draft
 
-> [!TIP] > <img width="500" alt="Request Copilot on a Draft PR" src="https://github.com/user-attachments/assets/1326c947-61bc-4793-b70c-9e39b04eb630" />
+> [!TIP]
+>
+> <img width="500" alt="Request Copilot on a Draft PR" src="https://github.com/user-attachments/assets/1326c947-61bc-4793-b70c-9e39b04eb630" />
 
 #### Re-request review after pushing fixes
 
-> [!TIP] > <img width="500" alt="Re-request review on a reviewer that did the review" src="https://github.com/user-attachments/assets/80f83822-0557-4375-8ed6-a4aebfcb5d10" />
+> [!TIP]
+>
+> <img width="500" alt="Re-request review on a reviewer that did the review" src="https://github.com/user-attachments/assets/80f83822-0557-4375-8ed6-a4aebfcb5d10" />

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,32 +15,9 @@ Thanks for contributing! These guidelines apply to internal and external contrib
 ## Branch, Commit & PR Conventions
 
 We use repo-wide conventions for branch names, commit messages, pull request
-titles and merge commit titles. The canonical rules live in
-[Git conventions](docs/contributing/git-conventions.md).
+titles and merge commits.
 
-Short version:
-
-```text
-branch: <type>/<scope>-<ticket>-<short-description>
-commit: <type>(<scope>): <description>
-pr:     <type>(<scope>): <description> (<ticket>)
-```
-
-The Jira ticket is optional. Include it when one exists.
-
-Examples:
-
-```text
-branch: chore/automation-LIVE-27608-update-git-guidelines
-commit: chore(automation): harmonize git guidelines
-pr:     chore(automation): harmonize git guidelines (LIVE-27608)
-```
-
-Use `fix/` instead of the legacy `bugfix/` branch prefix, use `chore/` instead
-of `support/`, and do not use gitmoji.
-
-Use `pnpm commit` for an interactive prompt, or
-`pnpm commitlint --from <target-branch>` to validate your branch.
+The canonical rules live in [Git conventions](docs/contributing/git-conventions.md).
 
 ### Rebase & merge strategy
 
@@ -106,10 +83,8 @@ Tools and resources for building on Ledger are at the [Ledger Developer Portal](
 
 #### Request Copilot while still in Draft
 
-> [!TIP]
-> <img width="500" alt="Request Copilot on a Draft PR" src="https://github.com/user-attachments/assets/1326c947-61bc-4793-b70c-9e39b04eb630" />
+> [!TIP] > <img width="500" alt="Request Copilot on a Draft PR" src="https://github.com/user-attachments/assets/1326c947-61bc-4793-b70c-9e39b04eb630" />
 
 #### Re-request review after pushing fixes
 
-> [!TIP]
-> <img width="500" alt="Re-request review on a reviewer that did the review" src="https://github.com/user-attachments/assets/80f83822-0557-4375-8ed6-a4aebfcb5d10" />
+> [!TIP] > <img width="500" alt="Re-request review on a reviewer that did the review" src="https://github.com/user-attachments/assets/80f83822-0557-4375-8ed6-a4aebfcb5d10" />

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,9 @@
-module.exports = { extends: ["@commitlint/config-conventional"] };
+const LEVEL_ERROR = 2;
+const LEVEL_WARN = 1;
+
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "scope-empty": [LEVEL_ERROR, "never"],
+  },
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,7 @@ const LEVEL_WARN = 1;
 module.exports = {
   extends: ["@commitlint/config-conventional"],
   rules: {
+    "header-max-length": [LEVEL_ERROR, "always", 72],
     "scope-empty": [LEVEL_ERROR, "never"],
   },
 };

--- a/docs/contributing/git-conventions.md
+++ b/docs/contributing/git-conventions.md
@@ -94,7 +94,7 @@ Rules:
 - Never mix refactor, fix and feature work in a single commit.
 - Do not use `--no-verify` when committing or pushing. Fix hook failures; if a hook is broken, surface it.
 
-Use `pnpm commit` to create a valid commit message, using tab-completion for type and scope.
+Use `pnpm commit` to create a valid commit message, using tab-completion for type.
 
 Use `pnpm commitlint --from <target-branch>` to check every commit on the branch.
 

--- a/docs/contributing/git-conventions.md
+++ b/docs/contributing/git-conventions.md
@@ -62,11 +62,11 @@ Avoid multiple scopes – prefer a single more informative value, e.g. use `port
 
 Avoid broad scopes – prefer specifics, e.g. use `coin-modules` instead of `shared`.
 
-Do not use ticket IDs as scopes: `fix(LIVE-1234)` is not valid.
+Do not use ticket IDs as scope: `fix(LIVE-1234)` is not a valid scope. Use in the PR title instead.
 
-## Ticket
+## Tickets
 
-The Jira ticket is optional. Include it when one exists.
+Internal contributions should be related to a Jira ticket. If a ticket does not exist you should create one. If you are making an open source contribution, create a Github issue instead.
 
 ## Description
 

--- a/docs/contributing/git-conventions.md
+++ b/docs/contributing/git-conventions.md
@@ -43,7 +43,7 @@ Types come from Conventional Commit types:
 - `style`
 - `test`
 
-Do not use the legacy `bugfix/` or `support/` branch prefixes. Use `fix/` for bug fixes and `chore/` for maintenance or support work.
+Do not use the legacy `bugfix` or `support`. Use `fix` for bug fixes and `chore` for maintenance or support work.
 
 ## Scope
 

--- a/docs/contributing/git-conventions.md
+++ b/docs/contributing/git-conventions.md
@@ -1,120 +1,109 @@
 # Git conventions
 
-This is the canonical source for branch names, commit messages, pull request
-titles and merge commits in this repository.
+This is the canonical guidance for Git conventions in this repo.
 
-The goal is to make related Jira tickets, branches, pull requests and merge
-commits easy to connect from the git history alone.
+The goal is for Git history to surface the **type** and **scope** of changes, and reference a related Jira ticket when possible.
 
 ## Summary
 
+The structure below is based on [Conventional Commits](https://www.conventionalcommits.org/):
+
 ```text
-branch: <type>/<scope>-<ticket>-<short-description>
-commit: <type>(<scope>): <description>
-pr:     <type>(<scope>): <description> (<ticket>)
-merge:  <pull request title>
+branch:    <type>/<scope>-<ticket>-<short-description>
+commit:    <type>(<scope>): <description>
+PR title:  <type>(<scope>): <description> (<ticket>)
 ```
+
+e.g.
+
+```text
+branch: feat/ui-LIVE-1234-add-dark-mode-toggle
+commit: feat(ui): add dark mode toggle
+PR title: feat(ui): add dark mode toggle (LIVE-1234)
+```
+
+We will enforce this struture for commit messages and PR titles (which will be used for merge commits).
+This makes it easier to extract reliable data from Git history.
+
+Consistent naming of branches is entirely optional as these do not remain in Git History.
+
+## Type
+
+Types come from Conventional Commit types:
+
+- `build`
+- `chore`
+- `ci`
+- `docs`
+- `feat`
+- `fix`
+- `perf`
+- `refactor`
+- `revert`
+- `style`
+- `test`
+
+Do not use the legacy `bugfix/` or `support/` branch prefixes. Use `fix/` for bug fixes and `chore/` for maintenance or support work.
+
+## Scope
+
+Scopes give context around the changes. They name the related concern, domain or feature related to the work.
+
+Examples:
+
+- `architecture`
+- `coin-evm`
+- `counter-values`
+- `e2e`
+- `portfolio`
+- `swap`
+
+Avoid multiple scopes – prefer a single more informative value, e.g. use `portfolio` rather than `desktop,mobile`.
+
+Avoid broad scopes – prefer specifics, e.g. use `coin-modules` instead of `shared`.
+
+Do not use ticket IDs as scopes: `fix(LIVE-1234)` is not valid.
+
+## Ticket
 
 The Jira ticket is optional. Include it when one exists.
 
-## Types and scopes
+## Description
 
-Use Conventional Commit types for commit messages, pull request titles and branch
-prefixes: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`,
-`revert`, `style` and `test`.
-
-Do not use the legacy `bugfix/` or `support/` branch prefixes. Use `fix/` for
-bug fixes and `chore/` for maintenance or support work.
-
-Scope identifies the main monorepo area affected by the change. The GitHub
-labeler primarily assigns scope labels based on file changes; see
-[`labeler.yml`](../../.github/labeler.yml) for the clearest link between affected
-files and scope labels. Use lowercase kebab-case and prefer the existing app,
-package or repository area name. Common scopes include `desktop`, `mobile`,
-`common`, `ui`, `ledgerjs`, `coin-modules`, `shared-lib`, `cli`, `wallet-cli`,
-`tools`, `automation`, `deps`, `release` and `docs`.
-
-Use one primary scope. If a change spans several areas equally, use the closest
-shared scope or omit the scope. Do not use ticket IDs as scopes:
-`fix(LIVE-1234)` is not valid.
+A short description of the changes. This should add to the information provided by type and scope.
 
 ## Branch names
 
-Use:
+e.g. `feat/ui-LIVE-1234-add-dark-mode-toggle`
 
-```text
-<type>/<scope>[-<ticket>]-<short-description>
-```
+Use kebab-case, keep branch names short and keep each branch focused on one concern.
 
-Examples:
-
-```text
-feat/desktop-LIVE-1234-add-dark-mode-toggle
-fix/mobile-LIVE-2345-resolve-transaction-signing
-chore/automation-LIVE-27608-update-git-guidelines
-```
-
-Without a Jira ticket:
-
-```text
-docs/common-update-api-documentation
-```
-
-Use kebab-case, keep branch names short and keep each branch focused on one
-concern.
+Rules are not enforced on branch names. Following this structure is entirely optional.
 
 ## Commit messages
 
-Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
-
-```text
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer(s)]
-```
+e.g. `feat(ui): add dark mode toggle`
 
 Rules:
 
-- `scope` is optional but recommended.
+- `type` and `scope` are required – see guidelines above
 - `description` is imperative, lowercase and has no trailing period.
-- Keep the subject line at or below 72 characters when possible.
+- Keep the subject line at or below 72 characters.
 - Do not use gitmoji.
-- Add a body for complex or user-facing changes.
-- Add footers when needed, for example `BREAKING CHANGE: ...` or
-  `Refs: LIVE-1234`.
 - Keep commits small, isolated and meaningful.
 - Never mix refactor, fix and feature work in a single commit.
-- Do not use `--no-verify` when committing or pushing. Fix hook failures; if a
-  hook is broken, surface it.
+- Do not use `--no-verify` when committing or pushing. Fix hook failures; if a hook is broken, surface it.
 
-Examples:
+Use `pnpm commit` to create a valid commit message, using tab-completion for type and scope.
 
-```text
-feat(desktop): add dark mode toggle
-fix(mobile): resolve transaction signing issue
-docs(common): update api documentation
-```
-
-Use `pnpm commit` to create a valid commit message, or
-`pnpm commitlint --from <target-branch>` to check every commit on the branch.
+Use `pnpm commitlint --from <target-branch>` to check every commit on the branch.
 
 ## Pull request and merge titles
 
-Pull request titles use the same Conventional Commit shape as commit messages,
-with the Jira ticket at the end when one exists:
+e.g. `feat(ui): add dark mode toggle (LIVE-1234)`
 
-```text
-feat(desktop): add dark mode toggle (LIVE-1234)
-fix(coin-modules): correct bitcoin fee estimation (LIVE-2345)
-chore(automation): harmonize git guidelines (LIVE-27608)
-```
+Pull request titles use the same Conventional Commit shape as commit messages, with the Jira ticket at the end when one exists.
 
-A GitHub workflow may automatically prepend a platform prefix based on PR labels:
-`[LWD]` for Desktop-only changes, `[LWM]` for Mobile-only changes, or `[LWDM]`
-for shared, common, coin-module or cross-platform changes. Leave that prefix in
-place if automation adds it.
+A GitHub workflow may automatically prepend a platform prefix based on PR labels, e.g. "LWD" or "LWM". Leave that prefix in place if automation adds it.
 
-When creating a merge commit for a pull request, use the pull request title as
-the merge commit title.
+When creating a merge commit for a pull request, use the pull request title as the merge commit title.


### PR DESCRIPTION
### 📝 Description

1.. Refine config for commitlint
2. Update Git Convention docs

The reference to `labeler.yml` has been removed from [docs/contributing/git-conventions.md](https://github.com/LedgerHQ/ledger-live/blob/develop/docs/contributing/git-conventions.md) 

### 🔗 Context

- JIRA: https://ledgerhq.atlassian.net/browse/LIVE-27608 
- ADR: https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7266992139

### 🤔 Considerations

#### What is scope for?

Since the latest discussion with @thesan we agreed scope should not be tied to the paths of files changed and instead be chosen by a developer (or agent).

Consider the value of these two options:

`refactor(architecture): move counter-values into domains directory` (chosen by developer) vs
`refactor(desktop,mobile,shared): move counter-values into domains directory` (based on file changes)

The former makes the reason for the change clearer from the scope alone, and lets us filter PRs related to architecture.

The latter blurs architectural changes with work done directly on apps.

#### Scope required but open

- Failing to provide a scope will now `error` in commitlint
- We have chosen not to introduce an enum as the effort of maintaining it is not worth the benefits
