### PR TITLE
[LWM] fix(mobile): update large-screen upsell opt-out copy

### DIFF
--- a/.changeset/gentle-mobile-signers.md
+++ b/.changeset/gentle-mobile-signers.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the Mobile large-screen upsell opt-out copy and CTA.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1401,13 +1401,14 @@
   "largeScreenUpsellModal": {
     "optedIn": {
       "title": "See more. Tap less. Save {{discount}}%",
-      "subtitle": "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive {{discount}}% off."
+      "subtitle": "Enjoy a larger screen, smarter transaction reviews, enhanced protection, and an exclusive {{discount}}% off.",
+      "cta": "Explore touchscreen signers"
     },
     "optedOut": {
-      "title": "Spot scams. See every detail",
-      "subtitle": "Review clearly on a touchscreen signer and spot scams with advanced security checks."
-    },
-    "cta": "Explore touchscreen signers"
+      "title": "Spot scams before signing",
+      "subtitle": "Learn more about advanced security features that enable real-time threat detection.",
+      "cta": "Learn more"
+    }
   },
   "earn": {
     "simulator": {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -134,6 +134,14 @@ describe("LargeScreenUpsellModal on Portfolio (integration)", () => {
     await waitFor(() => {
       expect(screen.getByTestId("large-screen-upsell-modal-drawer")).toBeVisible();
     });
+
+    expect(screen.getByText("Spot scams before signing")).toBeVisible();
+    expect(
+      screen.getByText(
+        "Learn more about advanced security features that enable real-time threat detection.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByText("Learn more")).toBeVisible();
   });
 
   it("should track the modal view with shared analytics properties when it auto-opens", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellContent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellContent.test.ts
@@ -1,8 +1,12 @@
 import { buildLargeScreenUpsellContent } from "../upsellContent";
 
 const t = (key: string, options?: Record<string, unknown>) => {
-  if (key === "largeScreenUpsellModal.cta") {
+  if (key === "largeScreenUpsellModal.optedIn.cta") {
     return "Explore touchscreen signers";
+  }
+
+  if (key === "largeScreenUpsellModal.optedOut.cta") {
+    return "Learn more";
   }
 
   if (key === "largeScreenUpsellModal.optedIn.title") {
@@ -14,11 +18,11 @@ const t = (key: string, options?: Record<string, unknown>) => {
   }
 
   if (key === "largeScreenUpsellModal.optedOut.title") {
-    return "Spot scams. See every detail";
+    return "Spot scams before signing";
   }
 
   if (key === "largeScreenUpsellModal.optedOut.subtitle") {
-    return "Review each transaction detail with confidence.";
+    return "Learn more about advanced security features that enable real-time threat detection.";
   }
 
   return key;
@@ -55,8 +59,11 @@ describe("buildLargeScreenUpsellContent", () => {
       t,
     });
 
-    expect(content.title).toBe("Spot scams. See every detail");
-    expect(content.subtitle).toBe("Review each transaction detail with confidence.");
+    expect(content.title).toBe("Spot scams before signing");
+    expect(content.subtitle).toBe(
+      "Learn more about advanced security features that enable real-time threat detection.",
+    );
+    expect(content.primaryButtonLabel).toBe("Learn more");
     expect(content.primaryButtonLink).toContain("support.ledger.com/limits");
     expect(content.imageUrlLight).toContain("large_screen_upsell_light");
     expect(content.imageUrlDark).toContain("large_screen_upsell_dark");

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellContent.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellContent.ts
@@ -54,6 +54,10 @@ export function buildLargeScreenUpsellContent({
     variant === "opted_in"
       ? "largeScreenUpsellModal.optedIn.subtitle"
       : "largeScreenUpsellModal.optedOut.subtitle";
+  const ctaKey =
+    variant === "opted_in"
+      ? "largeScreenUpsellModal.optedIn.cta"
+      : "largeScreenUpsellModal.optedOut.cta";
 
   return {
     id,
@@ -61,7 +65,7 @@ export function buildLargeScreenUpsellContent({
     ...heroImageUrls,
     title: t(titleKey, { discount: discountPercentage }),
     subtitle: t(subtitleKey, { discount: discountPercentage }),
-    primaryButtonLabel: t("largeScreenUpsellModal.cta"),
+    primaryButtonLabel: t(ctaKey),
     primaryButtonLink,
     secondaryButtonLabel: "",
     secondaryButtonLink: "",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile large-screen upsell modal for users who opted out of personalized recommendations
  - Existing opted-in modal copy and CTA
  - Mobile CTA link and analytics behavior

### 📝 Description

The Mobile large-screen upsell modal used the same CTA and touchscreen-focused messaging for both personalized-recommendation variants.

This PR updates only the opted-out Mobile experience:

- **Before:** “Spot scams. See every detail”, the touchscreen signer description, and “Explore touchscreen signers”
- **After:** “Spot scams before signing”, the advanced security and real-time threat detection description, and “Learn more”

The CTA translation is now variant-specific so the opted-in experience keeps its existing copy. Unit and integration coverage verify both variants and the rendered opt-out content.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: Related Desktop change: #19927

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
