### PR TITLE
[LWM] fix: aleo empty accounts handling in mobile app

### DIFF
--- a/.changeset/perfect-mugs-grow.md
+++ b/.changeset/perfect-mugs-grow.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix: aleo empty accounts handling in mobile

--- a/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/AccountBalanceHeader.tsx
@@ -99,7 +99,7 @@ export default function AccountBalanceHeader({
       ? aleoAccount.transparentBalance !== undefined
       : Boolean(aleoAccount.aleoResources);
 
-  if (!hasBalances || aleoAccount.balance.lte(0)) return null;
+  if (!hasBalances) return null;
 
   return <AleoBalanceSummary account={aleoAccount} mainAccount={mainAccount} />;
 }

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/AccountBalanceHeader.test.tsx
@@ -91,24 +91,22 @@ describe("AccountBalanceHeader", () => {
     expect(toJSON()).toBeNull();
   });
 
-  it("returns null when balance is zero", () => {
+  it("renders the balances breakdown when balance is zero but resources are present", () => {
     const account: AleoAccount = {
       ...baseAccount,
       balance: new BigNumber(0),
+      aleoResources: {
+        ...baseAleoResources,
+        transparentBalance: new BigNumber(0),
+        privateBalance: new BigNumber(0),
+      },
     };
 
-    const { toJSON } = render(<AccountBalanceHeader account={account} />);
-    expect(toJSON()).toBeNull();
-  });
+    render(<AccountBalanceHeader account={account} />);
 
-  it("returns null when balance is negative", () => {
-    const account: AleoAccount = {
-      ...baseAccount,
-      balance: new BigNumber(-1),
-    };
-
-    const { toJSON } = render(<AccountBalanceHeader account={account} />);
-    expect(toJSON()).toBeNull();
+    expect(screen.getByText("aleo.balancesSection")).toBeOnTheScreen();
+    expect(screen.getByText("aleo.info.transparent.title")).toBeOnTheScreen();
+    expect(screen.getByText("aleo.info.private.title")).toBeOnTheScreen();
   });
 
   it("shows the private sync button for a regular account", () => {
@@ -160,13 +158,19 @@ describe("AccountBalanceHeader", () => {
       expect(toJSON()).toBeNull();
     });
 
-    it("returns null when the token's balance is zero", () => {
-      const account: AleoTokenAccount = { ...tokenAccount, balance: new BigNumber(0) };
+    it("renders the balances breakdown when the token's balance is zero but transparentBalance is present", () => {
+      const account: AleoTokenAccount = {
+        ...tokenAccount,
+        balance: new BigNumber(0),
+        transparentBalance: new BigNumber(0),
+        privateBalance: new BigNumber(0),
+      };
 
-      const { toJSON } = render(
-        <AccountBalanceHeader account={account} parentAccount={baseAccount} />,
-      );
-      expect(toJSON()).toBeNull();
+      render(<AccountBalanceHeader account={account} parentAccount={baseAccount} />);
+
+      expect(screen.getByText("aleo.balancesSection")).toBeOnTheScreen();
+      expect(screen.getByText("aleo.info.transparent.title")).toBeOnTheScreen();
+      expect(screen.getByText("aleo.info.private.title")).toBeOnTheScreen();
     });
 
     it("returns null instead of throwing when parentAccount is missing", () => {

--- a/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/__tests__/accountActions.test.tsx
@@ -1,15 +1,22 @@
 import { IconsLegacy } from "@ledgerhq/native-ui";
+import BigNumber from "bignumber.js";
 import accountActions from "../accountActions";
 import { ALEO_ACCOUNT_1 } from "../__mocks__/account.mock";
 import { aleoCurrency } from "../__mocks__/currency.mock";
 import { NavigatorName, ScreenName } from "~/const";
+import ZeroBalanceDisabledModalContent from "~/components/FabActions/modals/ZeroBalanceDisabledModalContent";
 
 jest.mock("@ledgerhq/native-ui", () => ({
   IconsLegacy: { TransferMedium: "TransferMedium" },
 }));
 
+jest.mock("~/components/FabActions/modals/ZeroBalanceDisabledModalContent", () => ({
+  __esModule: true,
+  default: "ZeroBalanceDisabledModalContent",
+}));
+
 jest.mock("~/context/Locale", () => ({
-  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
+  i18n: { t: (key: string) => key },
 }));
 
 describe("accountActions.getMainActions", () => {
@@ -17,9 +24,7 @@ describe("accountActions.getMainActions", () => {
     const [action] = accountActions.getMainActions({ account: ALEO_ACCOUNT_1 });
 
     expect(action.id).toBe("public_to_private");
-    expect((action.label as { props: { i18nKey: string } }).props.i18nKey).toBe(
-      "aleo.accountActions.publicToPrivate",
-    );
+    expect(action.label).toBe("aleo.accountActions.publicToPrivate");
     expect(action.Icon).toBe(IconsLegacy.TransferMedium);
     expect(action.event).toBe("button_clicked");
     expect(action.eventProperties).toEqual({
@@ -34,6 +39,29 @@ describe("accountActions.getMainActions", () => {
         params: expect.objectContaining({ isSelfTransfer: true }),
       }),
     ]);
+  });
+
+  it("is disabled with the zero-balance modal when account balance is zero", () => {
+    const [action] = accountActions.getMainActions({
+      account: { ...ALEO_ACCOUNT_1, balance: new BigNumber(0) },
+    });
+
+    expect(action.disabled).toBe(true);
+    expect(action.modalOnDisabledClick?.component).toBe(ZeroBalanceDisabledModalContent);
+  });
+
+  it("uses a plain string label so ZeroBalanceDisabledModalContent can interpolate it as actionName", () => {
+    const [action] = accountActions.getMainActions({ account: ALEO_ACCOUNT_1 });
+
+    expect(typeof action.label).toBe("string");
+  });
+
+  it("is enabled when account balance is positive", () => {
+    const [action] = accountActions.getMainActions({
+      account: { ...ALEO_ACCOUNT_1, balance: new BigNumber(1000000) },
+    });
+
+    expect(action.disabled).toBe(false);
   });
 });
 
@@ -84,5 +112,35 @@ describe("accountActions.getAdditionalAssetActions", () => {
         }),
       }),
     ]);
+  });
+
+  it("is disabled when defaultAccount balance is zero", () => {
+    const [action] = accountActions.getAdditionalAssetActions({
+      currency: aleoCurrency,
+      defaultAccount: { ...ALEO_ACCOUNT_1, balance: new BigNumber(0) },
+      parentAccount: undefined,
+    });
+
+    expect(action.disabled).toBe(true);
+  });
+
+  it("leaves disabled unset when there is no defaultAccount", () => {
+    const [action] = accountActions.getAdditionalAssetActions({
+      currency: aleoCurrency,
+      defaultAccount: undefined,
+      parentAccount: undefined,
+    });
+
+    expect(action.disabled).toBeUndefined();
+  });
+
+  it("is enabled when defaultAccount balance is positive", () => {
+    const [action] = accountActions.getAdditionalAssetActions({
+      currency: aleoCurrency,
+      defaultAccount: { ...ALEO_ACCOUNT_1, balance: new BigNumber(1000000) },
+      parentAccount: undefined,
+    });
+
+    expect(action.disabled).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
+++ b/apps/ledger-live-mobile/src/families/aleo/accountActions.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import { Trans } from "~/context/Locale";
+import { i18n } from "~/context/Locale";
 import { IconsLegacy } from "@ledgerhq/native-ui";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 import type { AleoAccount } from "@ledgerhq/live-common/families/aleo/types";
 import { NavigatorName, ScreenName } from "~/const";
 import type { ActionButtonEvent } from "~/components/FabActions";
+import ZeroBalanceDisabledModalContent from "~/components/FabActions/modals/ZeroBalanceDisabledModalContent";
 
 const getMainActions = ({
   account,
@@ -16,13 +16,17 @@ const getMainActions = ({
 }): ActionButtonEvent[] => [
   {
     id: "public_to_private",
-    label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
+    label: i18n.t("aleo.accountActions.publicToPrivate"),
     Icon: IconsLegacy.TransferMedium,
     event: "button_clicked",
     eventProperties: {
       button: "public_to_private",
       currency: "ALEO",
       page: "Account Page",
+    },
+    disabled: !account.balance.gt(0),
+    modalOnDisabledClick: {
+      component: ZeroBalanceDisabledModalContent,
     },
     navigationParams: [
       NavigatorName.SendFunds,
@@ -61,10 +65,14 @@ const getAdditionalAssetActions = ({
 }): ActionButtonEvent[] => [
   {
     id: "self_transfer",
-    label: <Trans i18nKey="aleo.accountActions.publicToPrivate" />,
+    label: i18n.t("aleo.accountActions.publicToPrivate"),
     Icon: IconsLegacy.TransferMedium,
     event: "button_clicked",
     eventProperties: { button: "self_transfer", currency: currency?.ticker },
+    ...(defaultAccount && { disabled: !defaultAccount.balance.gt(0) }),
+    modalOnDisabledClick: {
+      component: ZeroBalanceDisabledModalContent,
+    },
     navigationParams: [
       NavigatorName.SendFunds,
       defaultAccount


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR fixes Aleo empty-account display and action-availability inconsistency on mobile. Previously the balance header hid itself whenever balance was zero or negative, even when the account had balances to show - now it only hides when there are truly no balances. 

Complementary to that, the `Self transfer` actions weren't guarding against a zero balance at all, so tapping them on an empty account led into a dead flow; they're now disabled with a ZeroBalanceDisabledModalContent explainer when balance is zero, just like with the default `Send` quick action.

Empty account view:

| before | after |
|---|--|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/4b23900e-7529-4eae-b1be-8fbcb4e01230" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/661c527e-6c5f-41a1-bde2-5b4dbb41a13e" /> |


<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-34892
- https://ledgerhq.atlassian.net/browse/LIVE-34891