### PR TITLE
fix(contacts): remove orphaned jest.setup.js

### DIFF
--- a/features/flow/contacts/jest.setup.js
+++ b/features/flow/contacts/jest.setup.js
@@ -1,1 +1,0 @@
-require("@testing-library/jest-dom");


### PR DESCRIPTION
### 📝 Description

`features/flow/contacts/jest.setup.js` was deleted in 6b6f59e (\"align Jest config with shared tooling\") but accidentally re-added by a PR that was based on an older branch. The file is now unreferenced — `createFlowJestConfig()` already handles `@testing-library/jest-dom` via `setupFilesAfterEnv`.

This fixes the failing `nx run @features/flow-contacts:unimported` check on develop.

> [!NOTE]
> **Why this wasn't caught at PR time:** the PR that re-added the file was based on a branch that still had the old custom `jest.config.js`, which referenced `jest.setup.js`. CI passed because the file was still referenced in that branch state. After merge, develop ended up with the new `jest.config.js` (from the alignment PR) but the re-added `jest.setup.js` — a combination neither CI run ever validated.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A