### PR TITLE
[LWM] fix(mobile): center market empty states (LIVE-32601)

### DIFF
--- a/.changeset/market-empty-placeholders.md
+++ b/.changeset/market-empty-placeholders.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Center empty placeholders in the Mobile Market screen.

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/MarketAssetsList.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@tests/test-renderer";
+import { act, render, screen } from "@tests/test-renderer";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
 import { createMarketAssetDisplayData } from "LLM/features/Market/__tests__/helpers";
 import { MARKET_SCREEN_TEST_IDS } from "../../../testIds";
@@ -51,6 +51,7 @@ describe("MarketAssetsList", () => {
   it("should render the header, subheader, and asset rows when ready", () => {
     render(<MarketAssetsList {...defaultProps} />);
 
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.style).toEqual({ flex: 1 });
     expect(screen.getByTestId("market-assets-list-header")).toBeVisible();
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsSubHeader)).toBeVisible();
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
@@ -75,6 +76,22 @@ describe("MarketAssetsList", () => {
     expect(screen.getAllByTestId(MARKET_SCREEN_TEST_IDS.assetsSkeleton)).toHaveLength(3);
   });
 
+  it("should preserve the loading footer minimum height", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} loading />);
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onLayout({
+        nativeEvent: { layout: { height: 500 } },
+      });
+    });
+
+    expect(
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListFooterComponent.props.style,
+    ).toEqual({
+      minHeight: 500,
+    });
+  });
+
   it("should render the search empty state when search returns no assets", () => {
     render(
       <MarketAssetsList {...defaultProps} assets={[]} header={undefined} showSubheader={false} />,
@@ -84,11 +101,51 @@ describe("MarketAssetsList", () => {
     expect(screen.getByText("No assets found")).toBeVisible();
   });
 
+  it("should size the search empty state to the measured list height", () => {
+    render(
+      <MarketAssetsList {...defaultProps} assets={[]} header={undefined} showSubheader={false} />,
+    );
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onLayout({
+        nativeEvent: { layout: { height: 500 } },
+      });
+    });
+
+    expect(
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListFooterComponent.props.style,
+    ).toEqual({
+      height: 500,
+    });
+  });
+
   it("should render the favorites empty state", () => {
     render(<MarketAssetsList {...defaultProps} assets={[]} emptyState="favorites" />);
 
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsFavoritesEmptyIcon)).toBeVisible();
     expect(screen.getByText("No favorites yet")).toBeVisible();
+  });
+
+  it("should size the favorites empty state to the measured list height", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} emptyState="favorites" />);
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onLayout({
+        nativeEvent: { layout: { height: 500 } },
+      });
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListHeaderComponent.props.onLayout({
+        nativeEvent: { layout: { height: 100 } },
+      });
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcherContainer).props.onLayout({
+        nativeEvent: { layout: { height: 50 } },
+      });
+    });
+
+    expect(
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListFooterComponent.props.style,
+    ).toEqual({
+      height: 350,
+    });
   });
 
   it("should render the stocks empty state", () => {
@@ -98,10 +155,49 @@ describe("MarketAssetsList", () => {
     expect(screen.getByText("No stocks found")).toBeVisible();
   });
 
+  it("should size the stocks empty state to the measured list height", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} emptyState="stocks" />);
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onLayout({
+        nativeEvent: { layout: { height: 500 } },
+      });
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListHeaderComponent.props.onLayout({
+        nativeEvent: { layout: { height: 100 } },
+      });
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcherContainer).props.onLayout({
+        nativeEvent: { layout: { height: 50 } },
+      });
+    });
+
+    expect(
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListFooterComponent.props.style,
+    ).toEqual({
+      height: 350,
+    });
+    expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsCategorySwitcher)).toBeVisible();
+  });
+
   it("should render the error banner", () => {
     render(<MarketAssetsList {...defaultProps} assets={[]} error />);
 
     expect(screen.getByTestId(MARKET_SCREEN_TEST_IDS.assetsError)).toBeVisible();
+  });
+
+  it("should preserve the error footer minimum height", () => {
+    render(<MarketAssetsList {...defaultProps} assets={[]} error />);
+
+    act(() => {
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.onLayout({
+        nativeEvent: { layout: { height: 500 } },
+      });
+    });
+
+    expect(
+      screen.getByTestId(MARKET_SCREEN_TEST_IDS.list).props.ListFooterComponent.props.style,
+    ).toEqual({
+      minHeight: 500,
+    });
   });
 
   it("should render the footer spinner while fetching the next page", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/useMarketAssetsList.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/__tests__/useMarketAssetsList.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@tests/test-renderer";
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  SectionList,
+} from "react-native";
+import type { MarketAssetDisplayData } from "LLM/components/AssetListItem";
+import type { MarketListCategory } from "~/reducers/types";
+import { useMarketAssetsList } from "../useMarketAssetsList";
+
+const headerHeight = 128;
+const categorySwitcherHeight = 48;
+const listHeight = 500;
+
+function layoutEvent(height: number): LayoutChangeEvent {
+  return { nativeEvent: { layout: { height } } } as LayoutChangeEvent;
+}
+
+function scrollEvent(y: number): NativeSyntheticEvent<NativeScrollEvent> {
+  return { nativeEvent: { contentOffset: { y } } } as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function assignScrollResponder(
+  ref: React.RefObject<SectionList<MarketAssetDisplayData> | null>,
+  scrollTo: jest.Mock,
+) {
+  const listRef = ref as React.MutableRefObject<SectionList<MarketAssetDisplayData> | null>;
+  listRef.current = {
+    getScrollResponder: () => ({ scrollTo }),
+  } as unknown as SectionList<MarketAssetDisplayData>;
+}
+
+describe("useMarketAssetsList", () => {
+  it("should reserve the viewport space below the header and category tabs for empty states", () => {
+    const { result } = renderHook(() =>
+      useMarketAssetsList({ assets: [], selectedCategory: "favorites", showSubheader: true }),
+    );
+
+    act(() => {
+      result.current.handleListLayout(layoutEvent(listHeight));
+      result.current.handleHeaderLayout(layoutEvent(headerHeight));
+      result.current.handleCategorySwitcherLayout(layoutEvent(categorySwitcherHeight));
+    });
+
+    expect(result.current.contentMinHeight).toBe(headerHeight + listHeight);
+    expect(result.current.footerMinHeight).toBe(listHeight);
+    expect(result.current.emptyFooterHeight).toBe(
+      listHeight - headerHeight - categorySwitcherHeight,
+    );
+  });
+
+  it("should keep the category tabs pinned when changing category after the header", () => {
+    let selectedCategory: MarketListCategory = "all";
+    const scrollTo = jest.fn();
+    const { result, rerender } = renderHook(() =>
+      useMarketAssetsList({ assets: [], selectedCategory, showSubheader: true }),
+    );
+
+    assignScrollResponder(result.current.listRef, scrollTo);
+    act(() => {
+      result.current.handleHeaderLayout(layoutEvent(headerHeight));
+      result.current.handleScrollEnd(scrollEvent(headerHeight + 1));
+    });
+
+    selectedCategory = "stocks";
+    rerender(undefined);
+
+    expect(scrollTo).toHaveBeenCalledWith({ y: headerHeight, animated: false });
+  });
+
+  it("should not scroll when changing category before the header", () => {
+    let selectedCategory: MarketListCategory = "all";
+    const scrollTo = jest.fn();
+    const { result, rerender } = renderHook(() =>
+      useMarketAssetsList({ assets: [], selectedCategory, showSubheader: true }),
+    );
+
+    assignScrollResponder(result.current.listRef, scrollTo);
+    act(() => {
+      result.current.handleHeaderLayout(layoutEvent(headerHeight));
+      result.current.handleScrollEnd(scrollEvent(headerHeight));
+    });
+
+    selectedCategory = "stocks";
+    rerender(undefined);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/index.tsx
@@ -17,6 +17,10 @@ import { useMarketAssetsList } from "./useMarketAssetsList";
 
 const HORIZONTAL_PADDING = 16;
 
+const listStyle = {
+  flex: 1,
+};
+
 type Props = Readonly<{
   assets: MarketAssetDisplayData[];
   loading: boolean;
@@ -54,9 +58,11 @@ export function MarketAssetsList({
     sections,
     contentMinHeight,
     footerMinHeight,
+    emptyFooterHeight,
     handleScrollEnd,
     handleListLayout,
     handleHeaderLayout,
+    handleCategorySwitcherLayout,
     keyExtractor,
   } = useMarketAssetsList({ assets, selectedCategory, showSubheader });
 
@@ -70,6 +76,26 @@ export function MarketAssetsList({
     [assets.length, contentMinHeight, bottom],
   );
 
+  const emptyFooterStyle = useMemo(() => {
+    const minHeightStyle = { minHeight: footerMinHeight };
+    const shouldCenterEmptyState =
+      assets.length === 0 &&
+      !loading &&
+      !error &&
+      (emptyState !== undefined || !showSubheader) &&
+      emptyFooterHeight > 0;
+
+    return shouldCenterEmptyState ? { height: emptyFooterHeight } : minHeightStyle;
+  }, [
+    assets.length,
+    emptyFooterHeight,
+    emptyState,
+    error,
+    footerMinHeight,
+    loading,
+    showSubheader,
+  ]);
+
   const renderRow = useCallback(
     ({ item }: SectionListRenderItemInfo<MarketAssetDisplayData>) => (
       <AssetListItem variant="market" market={item} onPress={onAssetPress} lx={rowStyle} />
@@ -79,7 +105,11 @@ export function MarketAssetsList({
 
   const renderCategorySwitcher = useCallback(
     () => (
-      <Box lx={stickyCategorySwitcherStyle}>
+      <Box
+        testID={MARKET_SCREEN_TEST_IDS.assetsCategorySwitcherContainer}
+        lx={stickyCategorySwitcherStyle}
+        onLayout={handleCategorySwitcherLayout}
+      >
         <MarketCategorySwitcher
           selectedCategory={selectedCategory}
           tabs={categoryTabs}
@@ -87,7 +117,7 @@ export function MarketAssetsList({
         />
       </Box>
     ),
-    [selectedCategory, categoryTabs, onSelectCategory],
+    [selectedCategory, categoryTabs, onSelectCategory, handleCategorySwitcherLayout],
   );
 
   const footerSpinner = fetchingNextPage ? (
@@ -101,7 +131,7 @@ export function MarketAssetsList({
 
   const listFooter =
     assets.length === 0 ? (
-      <Box style={{ minHeight: footerMinHeight }}>
+      <Box style={emptyFooterStyle}>
         <MarketAssetsEmptyState
           loading={loading}
           error={error}
@@ -118,6 +148,7 @@ export function MarketAssetsList({
       <SectionList
         ref={listRef}
         testID={MARKET_SCREEN_TEST_IDS.list}
+        style={listStyle}
         sections={sections}
         onScrollEndDrag={handleScrollEnd}
         onMomentumScrollEnd={handleScrollEnd}

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/useMarketAssetsList.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/components/MarketAssetsList/useMarketAssetsList.ts
@@ -21,6 +21,7 @@ export function useMarketAssetsList({
 }: UseMarketAssetsListParams) {
   const [listHeight, setListHeight] = useState(0);
   const [headerHeight, setHeaderHeight] = useState(0);
+  const [categorySwitcherHeight, setCategorySwitcherHeight] = useState(0);
   const listRef = useRef<SectionList<MarketAssetDisplayData>>(null);
   const scrollOffsetRef = useRef(0);
   const previousCategoryRef = useRef(selectedCategory);
@@ -35,6 +36,10 @@ export function useMarketAssetsList({
 
   const handleHeaderLayout = useCallback((event: LayoutChangeEvent) => {
     setHeaderHeight(event.nativeEvent.layout.height);
+  }, []);
+
+  const handleCategorySwitcherLayout = useCallback((event: LayoutChangeEvent) => {
+    setCategorySwitcherHeight(event.nativeEvent.layout.height);
   }, []);
 
   const keyExtractor = useCallback((item: MarketAssetDisplayData) => item.id, []);
@@ -55,9 +60,13 @@ export function useMarketAssetsList({
     sections,
     contentMinHeight: showSubheader ? headerHeight + listHeight : undefined,
     footerMinHeight: listHeight,
+    emptyFooterHeight: showSubheader
+      ? Math.max(listHeight - headerHeight - categorySwitcherHeight, 0)
+      : listHeight,
     handleScrollEnd,
     handleListLayout,
     handleHeaderLayout,
+    handleCategorySwitcherLayout,
     keyExtractor,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/screens/MarketScreen/testIds.ts
@@ -7,6 +7,7 @@ export const MARKET_SCREEN_TEST_IDS = {
   assetsSubHeader: "market-screen-assets-subheader",
   assetsFilterButton: "market-screen-assets-filter-button",
   assetsCategorySwitcher: "market-screen-assets-category-switcher",
+  assetsCategorySwitcherContainer: "market-screen-assets-category-switcher-container",
   assetsFavoritesEmptyIcon: "market-screen-assets-favorites-empty-icon",
   assetsStocksEmpty: "market-screen-assets-stocks-empty",
   filtersDrawer: "market-screen-filters-drawer",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Empty search, Favorites, and Stocks placeholders in the Wallet 4.0 Market screen.
      - Scrolling to the sticky category tabs and switching categories after they become pinned.
      - Loading and network-error placeholders retain their previous sizing.

### 📝 Description

The Wallet 4.0 Market no-result placeholders were centered inside a footer as tall as the complete list viewport. Because that footer starts below the highlights, Assets header, and category tabs, its content was pushed below the visible center of the screen.

The Market list now measures both its header and category switcher, then sizes no-result footers to the remaining visible space below them. The list still reserves its original minimum content height, preserving the scroll range required for the category tabs to reach the top and remain sticky. Empty search continues to use the full list viewport, while loading and network-error states retain their existing minimum-height behavior.


https://github.com/user-attachments/assets/d4ecfb7a-2f7a-4a12-9e7e-76bf0967a822



### ❓ Context

- **JIRA or GitHub link**: [LIVE-32601](https://ledgerhq.atlassian.net/browse/LIVE-32601)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-32601]: https://ledgerhq.atlassian.net/browse/LIVE-32601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ