### PR TITLE
feat(LIVE-22457): source EVM/Cosmos currency metadata from registry + dada

### DIFF
--- a/.changeset/dada-currency-color-explorers.md
+++ b/.changeset/dada-currency-color-explorers.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+dada-client: read `color` and `explorersURLs` from the DADA assets API when building crypto currencies not present in the domain registry, instead of the hardcoded `#999999` color and empty explorer views (LIVE-22457).

--- a/domain/entity/currency-crypto/src/registry.evm-cosmos.test.ts
+++ b/domain/entity/currency-crypto/src/registry.evm-cosmos.test.ts
@@ -1,0 +1,44 @@
+import { CRYPTO_CURRENCIES_REGISTRY } from "./registry";
+
+// LIVE-22457: EVM/Cosmos currencies must be fully described by this registry
+// (color + explorerViews), so their metadata no longer depends on the
+// deprecated static `@ledgerhq/cryptoassets` currencies file.
+const EVM_COSMOS_FAMILIES = new Set(["evm", "cosmos"]);
+
+// Legacy dead/obscure EVM chains that never had an explorer. New EVM/Cosmos
+// currencies must ship one, so they are held out of the explorer assertion here
+// rather than relaxing it for everyone.
+const KNOWN_MISSING_EXPLORER = new Set([
+  "atheios",
+  "callisto",
+  "ellaism",
+  "ether1",
+  "ethergem",
+  "ethersocial",
+  "gochain",
+  "mix",
+  "musicoin",
+]);
+
+const evmCosmosEntries = Object.values(CRYPTO_CURRENCIES_REGISTRY).filter(currency =>
+  EVM_COSMOS_FAMILIES.has(currency.family),
+);
+
+describe("EVM/Cosmos currencies coverage (LIVE-22457)", () => {
+  it("registry holds EVM and Cosmos currencies", () => {
+    expect(evmCosmosEntries.length).toBeGreaterThan(0);
+  });
+
+  it.each(evmCosmosEntries.map(c => [c.id, c] as const))(
+    "%s has a non-empty color",
+    (_id, currency) => {
+      expect(currency.color).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+    },
+  );
+
+  it.each(
+    evmCosmosEntries.filter(c => !KNOWN_MISSING_EXPLORER.has(c.id)).map(c => [c.id, c] as const),
+  )("%s has at least one explorer view", (_id, currency) => {
+    expect(currency.explorerViews.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/entities/index.ts
+++ b/libs/ledger-live-common/src/dada-client/entities/index.ts
@@ -18,6 +18,14 @@ export interface ApiTokenCurrency {
   descriptor?: unknown;
 }
 
+// DADA explorer URL templates (mirrors the backend `ExplorerURLs` shape).
+export interface ApiExplorerURLs {
+  address?: string | null;
+  transaction?: string | null;
+  token?: string | null;
+  stakePool?: string | null;
+}
+
 export interface ApiCryptoCurrency {
   type: "crypto_currency";
   id: string;
@@ -33,6 +41,8 @@ export interface ApiCryptoCurrency {
   hasTokens?: boolean;
   hrp?: string | null;
   disableCountervalue?: boolean;
+  color?: string | null;
+  explorersURLs?: ApiExplorerURLs[] | null;
 }
 
 export type ApiAsset = ApiTokenCurrency | ApiCryptoCurrency;

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -5,11 +5,27 @@ import {
   FetchBaseQueryMeta,
   QueryReturnValue,
 } from "@reduxjs/toolkit/query/react";
-import type { ApiAsset } from "../entities";
-import type { CryptoOrTokenCurrency, CryptoCurrencyId } from "@ledgerhq/types-cryptoassets";
+import type { ApiAsset, ApiExplorerURLs } from "../entities";
+import type {
+  CryptoOrTokenCurrency,
+  CryptoCurrencyId,
+  ExplorerView,
+} from "@ledgerhq/types-cryptoassets";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { convertApiToken } from "@domain/api-currency-token";
 import { RawApiResponse, AssetsData } from "../entities";
+
+// DADA serves explorer templates as `explorersURLs` with a `transaction` key;
+// map them to the ledger-live `ExplorerView` shape (which uses `tx`).
+function toExplorerViews(explorersURLs?: ApiExplorerURLs[] | null): ExplorerView[] {
+  if (!explorersURLs) return [];
+  return explorersURLs.map(({ address, transaction, token, stakePool }) => ({
+    ...(address ? { address } : {}),
+    ...(transaction ? { tx: transaction } : {}),
+    ...(token ? { token } : {}),
+    ...(stakePool ? { stakePool } : {}),
+  }));
+}
 
 function convertApiAssets(
   apiAssets: Record<string, ApiAsset>,
@@ -33,9 +49,9 @@ function convertApiAssets(
           managerAppName: asset.name,
           coinType: asset.coinType ?? 0,
           scheme: asset.id.toLowerCase(),
-          color: "#999999",
+          color: asset.color ?? "#999999",
           family: asset.family ?? asset.id,
-          explorerViews: [],
+          explorerViews: toExplorerViews(asset.explorersURLs),
           symbol: asset.symbol,
           disableCountervalue: asset.disableCountervalue,
           supportsSegwit: asset.hasSegwit,


### PR DESCRIPTION
### 📝 Description

Ledger-live slice of [LIVE-22457](https://ledgerhq.atlassian.net/browse/LIVE-22457) (moving per-currency metadata out of the deprecated static `@ledgerhq/cryptoassets` `currencies.ts`).

**1. Guard test — `domain/entity/currency-crypto/src/registry.evm-cosmos.test.ts`**
Asserts the 107 EVM/Cosmos currencies are fully described by the `@domain/entity-currency-crypto` registry (the runtime source of truth injected via `setCryptoCurrenciesStore`):
- every EVM/Cosmos entry has a non-empty `color`;
- every EVM/Cosmos entry has at least one `explorerView`, except a documented allowlist of 9 legacy dead EVM chains (`atheios`, `callisto`, `ellaism`, `ether1`, `ethergem`, `ethersocial`, `gochain`, `mix`, `musicoin`) that never had an explorer. New EVM/Cosmos currencies must ship one.

**2. dada-client wiring — `libs/ledger-live-common/src/dada-client`**
`convertApiAssets` now reads `color` and `explorersURLs` from the DADA assets API when building a crypto currency that is not in the domain registry, instead of the hardcoded `#999999` / empty explorer views. `explorersURLs.transaction` is mapped to the ledger-live `ExplorerView.tx` shape. Both fields are optional, so the change is backward compatible until DADA ships them (see companion PRs below).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-22457](https://ledgerhq.atlassian.net/browse/LIVE-22457)
- **Companion PRs**:
  - CAL / crypto-assets: LedgerHQ/crypto-assets#2799 (adds the 3 sepolia testnets)
  - DADA backend: serves the new `color` field (branch `feat/LIVE-22457-serve-currency-color`)

### 🧪 Tests

- `pnpm --filter @domain/entity-currency-crypto test registry.evm-cosmos` → 206 passing.
- `@ledgerhq/live-common` dada-client hook tests pass (no regression from the `convertApiAssets` change).

[LIVE-22457]: https://ledgerhq.atlassian.net/browse/LIVE-22457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-22457]: https://ledgerhq.atlassian.net/browse/LIVE-22457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ