### PR TITLE
[LWM] fix(lwm): keep Learn more visible on recipient with keyboard open

### DIFF
--- a/.changeset/weak-coins-deny.md
+++ b/.changeset/weak-coins-deny.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+fix(lwm): keep Learn more visible on recipient with keyboard open

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -14,6 +14,7 @@ import {
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
 import React, { useCallback } from "react";
+import { Keyboard } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import { AccountRowWithBalance } from "./AccountRowWithBalance";
 import { AddressListItem } from "./AddressListItem";
@@ -40,6 +41,7 @@ export function AddressMatchedSection({
   const formatRelativeDate = useFormatRelativeDate();
   const helpSheetRef = useBottomSheetRef();
   const openHelpSheet = useCallback(() => {
+    Keyboard.dismiss();
     helpSheetRef.current?.present();
   }, [helpSheetRef]);
 
@@ -78,7 +80,7 @@ export function AddressMatchedSection({
   };
 
   return (
-    <Box lx={{ flex: 1, flexDirection: "column" }}>
+    <Box lx={{ flexDirection: "column" }}>
       <Subheader lx={{ marginBottom: "s12", marginHorizontal: "s8" }}>
         <SubheaderRow>
           <SubheaderTitle>{t("send.newSendFlow.addressMatched")}</SubheaderTitle>
@@ -158,7 +160,7 @@ export function AddressMatchedSection({
               appearance="info"
               description={t("send.newSendFlow.firstInteraction.description")}
               primaryAction={
-                <Button appearance="transparent" size="sm" onPress={openHelpSheet}>
+                <Button appearance="gray" size="sm" onPress={openHelpSheet}>
                   {t("send.newSendFlow.firstInteraction.learnMore")}
                 </Button>
               }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -8,6 +8,7 @@ import { useMemoViewModel } from "LLM/features/Send/components/Memo/hooks/useMem
 import { shouldShowMatchedAddress } from "@ledgerhq/live-common/flows/send/recipient/utils/shouldShowMatchedAddress";
 import { useSendFlowData } from "LLM/features/Send/context/SendFlowContext";
 import React, { useCallback, useEffect, useMemo } from "react";
+import { KeyboardAvoidingView, Platform, ScrollView } from "react-native";
 import { useRecipientScreenView } from "../hooks/useRecipientScreenView";
 import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
@@ -16,6 +17,7 @@ import { PasteFromClipboard } from "./PasteFromClipboard";
 import { ValidationBanner } from "./ValidationBanner";
 import { useAnalytics } from "~/analytics";
 import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework/tracking/send";
+import { shouldUseKeyboardAvoidance } from "~/logic/keyboardVisible";
 
 type RecipientScreenViewProps = Readonly<{
   account: AccountLike;
@@ -127,56 +129,68 @@ export const RecipientScreenView = ({
     }
   }, [track, trackingProperties, uiConfig.hasMemo, memoVm.hasFilledMemo, memoVm.memoError]);
 
+  const keyboardBehavior = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
+    ? "padding"
+    : undefined;
+
   return (
     <SendFlowLayout>
-      <Box style={{ flex: 1, marginHorizontal: -8 }}>
-        {isLoading && !showMatched && <LoadingState />}
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={keyboardBehavior}>
+        <ScrollView
+          style={{ flex: 1, marginHorizontal: -8 }}
+          contentContainerStyle={{ flexGrow: 1 }}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          showsVerticalScrollIndicator={false}
+        >
+          {isLoading && !showMatched && <LoadingState />}
 
-        {showInitialState && clipboardAddress && (
-          <PasteFromClipboard address={clipboardAddress} onPaste={handlePasteFromClipboard} />
-        )}
+          {showInitialState && clipboardAddress && (
+            <PasteFromClipboard address={clipboardAddress} onPaste={handlePasteFromClipboard} />
+          )}
 
-        {showMemo && <MemoControls vm={memoVm} />}
+          {showMemo && <MemoControls vm={memoVm} />}
 
-        {showMatched && (
-          <AddressMatchedSection
-            searchResult={result}
-            searchValue={searchValue}
-            onSelect={handleMatchedAddress}
-            isSanctioned={showSanctionedBanner}
-            isAddressComplete={isAddressComplete}
-            hasBridgeError={showBridgeRecipientError}
-          />
-        )}
+          {showMatched && (
+            <AddressMatchedSection
+              searchResult={result}
+              searchValue={searchValue}
+              onSelect={handleMatchedAddress}
+              isSanctioned={showSanctionedBanner}
+              isAddressComplete={isAddressComplete}
+              hasBridgeError={showBridgeRecipientError}
+            />
+          )}
 
-        {showAddressValidationError && (
-          <AddressValidationError error={addressValidationErrorType} />
-        )}
+          {showAddressValidationError && (
+            <AddressValidationError error={addressValidationErrorType} />
+          )}
 
-        {shouldShowErrorBanner && (
-          <Box lx={{ marginHorizontal: "s8", gap: "s16" }}>
-            {showBridgeSenderError && (
-              <ValidationBanner type="error" error={bridgeSenderError} variant="sender" />
-            )}
-            {showSanctionedBanner && <ValidationBanner type="sanctioned" />}
-            {showBridgeRecipientError && (
-              <ValidationBanner
-                type="error"
-                error={bridgeRecipientError}
-                variant="recipient"
-                excludeRecipientRequired
-              />
-            )}
-            {showBridgeRecipientWarning && (
-              <ValidationBanner
-                type="warning"
-                warning={bridgeRecipientWarning}
-                variant="recipient"
-              />
-            )}
-          </Box>
-        )}
-      </Box>
+          {shouldShowErrorBanner && (
+            <Box lx={{ marginHorizontal: "s8", gap: "s16" }}>
+              {showBridgeSenderError && (
+                <ValidationBanner type="error" error={bridgeSenderError} variant="sender" />
+              )}
+              {showSanctionedBanner && <ValidationBanner type="sanctioned" />}
+              {showBridgeRecipientError && (
+                <ValidationBanner
+                  type="error"
+                  error={bridgeRecipientError}
+                  variant="recipient"
+                  excludeRecipientRequired
+                />
+              )}
+              {showBridgeRecipientWarning && (
+                <ValidationBanner
+                  type="warning"
+                  warning={bridgeRecipientWarning}
+                  variant="recipient"
+                />
+              )}
+            </Box>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SendFlowLayout>
   );
 };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The first-interaction banner was rendered but clipped under the keyboard. Add keyboard avoidance and scrolling on `RecipientScreenView`
minor layout tweaks in `AddressMatchedSection`

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34882)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
