### PR TITLE
[LWD] fix(desktop): stabilize wallet api drawer navigation (LIVE-29181)

### DIFF
--- a/.changeset/bright-drawers-wait.md
+++ b/.changeset/bright-drawers-wait.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Stabilize Wallet API drawer navigation smoke test.

--- a/apps/ledger-live-desktop/tests/component/drawer.component.ts
+++ b/apps/ledger-live-desktop/tests/component/drawer.component.ts
@@ -11,6 +11,9 @@ export class Drawer extends Component {
   readonly selectAssetTitle = this.page.getByText("Select asset").first();
   readonly selectNetworkTitle = this.page.getByText("Select network").first();
   readonly selectAccountTitle = this.page.getByText("Select account").first();
+  private accountSelectionScreen = this.modularDialog.getByTestId(
+    "modular-dialog-screen-ACCOUNT_SELECTION",
+  );
   readonly assetSearchInput = this.page.getByTestId("modular-asset-dialog-search-input");
   readonly backButton = this.page.getByRole("button", {
     name: /^(Back|Go back)$/i,
@@ -97,6 +100,11 @@ export class Drawer extends Component {
 
   back() {
     return this.backButton.click();
+  }
+
+  @step("Wait for account selection to disappear")
+  async waitForAccountTitleToDisappear() {
+    await this.accountSelectionScreen.waitFor({ state: "hidden" });
   }
 
   private async isNetworkStep() {

--- a/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/services/wallet-api.spec.ts
@@ -135,6 +135,7 @@ test("Wallet API methods @smoke", async ({ page, electronApp }) => {
     // Test name and balance for tokens
     await expect(drawer.getAccountButton("Ethereum 3")).toContainText("71.8174 USDT");
     await drawer.back();
+    await drawer.waitForAccountTitleToDisappear();
     await expect(drawer.selectAssetTitle).toBeVisible();
 
     await drawer.selectCurrency("bitcoin");


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Wallet API account-selection navigation in the Desktop mocked E2E suite.

### 📝 Description

The `Wallet API methods @smoke` test asserted the asset-selection screen immediately after returning from account selection, before the previous screen had finished unmounting.

The Drawer page object now waits for the modular account-selection screen to disappear after `drawer.back()` before asserting the asset-selection screen. Feature flags were already injected deterministically through the test fixture, so no flag changes were needed.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29181](https://ledgerhq.atlassian.net/browse/LIVE-29181)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29181]: https://ledgerhq.atlassian.net/browse/LIVE-29181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ