### PR TITLE
feat(pay-card): add hasSeenFeatureTour to payCard slice [LIVE-34860]

### DIFF
--- a/domain/entity/pay-card/src/selectors.ts
+++ b/domain/entity/pay-card/src/selectors.ts
@@ -1,4 +1,4 @@
-import type { PayCardParams, PayCardState } from "./types";
+import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
 
 type PayCardStateRoot = {
   payCard: PayCardState;
@@ -14,4 +14,12 @@ export function selectPayCardIsOpen(state: PayCardStateRoot): boolean {
 
 export function selectPayCardParams(state: PayCardStateRoot): PayCardParams | null {
   return state.payCard.params;
+}
+
+export function selectPayCardHasSeenFeatureTour(state: PayCardStateRoot): boolean {
+  return state.payCard.hasSeenFeatureTour;
+}
+
+export function payCardPersistedSelector(state: PayCardStateRoot): PayCardPersistedState {
+  return { hasSeenFeatureTour: state.payCard.hasSeenFeatureTour };
 }

--- a/domain/entity/pay-card/src/slice.test.ts
+++ b/domain/entity/pay-card/src/slice.test.ts
@@ -1,23 +1,53 @@
-import { payCardSlice, payCardInitialState, openPayCard, closePayCard } from "./slice";
-import { selectPayCard, selectPayCardIsOpen, selectPayCardParams } from "./selectors";
+import {
+  payCardSlice,
+  payCardInitialState,
+  openPayCard,
+  closePayCard,
+  markPayCardFeatureTourSeen,
+  restorePayCardPersistedState,
+} from "./slice";
+import {
+  selectPayCard,
+  selectPayCardIsOpen,
+  selectPayCardParams,
+  selectPayCardHasSeenFeatureTour,
+  payCardPersistedSelector,
+} from "./selectors";
 
 const reducer = payCardSlice.reducer;
 const params = { platform: "cl-card", name: "CL Card" };
 const root = (state = payCardInitialState) => ({ payCard: state });
 
 describe("payCard slice", () => {
-  it("initializes closed with no params", () => {
+  it("initializes closed, with no params and the tour unseen", () => {
     expect(reducer(undefined, { type: "unknown" })).toEqual(payCardInitialState);
+    expect(payCardInitialState.hasSeenFeatureTour).toBe(false);
   });
 
   it("opens with the given params", () => {
     const state = reducer(undefined, openPayCard(params));
-    expect(state).toEqual({ isOpen: true, params });
+    expect(state).toEqual({ ...payCardInitialState, isOpen: true, params });
   });
 
   it("closes and clears params", () => {
     const opened = reducer(undefined, openPayCard(params));
     expect(reducer(opened, closePayCard())).toEqual(payCardInitialState);
+  });
+
+  it("marks the feature tour as seen without touching isOpen/params", () => {
+    const opened = reducer(undefined, openPayCard(params));
+    const seen = reducer(opened, markPayCardFeatureTourSeen());
+    expect(seen.hasSeenFeatureTour).toBe(true);
+    expect(seen.isOpen).toBe(true);
+    expect(seen.params).toEqual(params);
+  });
+
+  it("restores the persisted subset without clobbering isOpen/params", () => {
+    const opened = reducer(undefined, openPayCard(params));
+    const restored = reducer(opened, restorePayCardPersistedState({ hasSeenFeatureTour: true }));
+    expect(restored.hasSeenFeatureTour).toBe(true);
+    expect(restored.isOpen).toBe(true);
+    expect(restored.params).toEqual(params);
   });
 });
 
@@ -35,5 +65,17 @@ describe("payCard selectors", () => {
   it("selectPayCardParams returns params when open, null when closed", () => {
     expect(selectPayCardParams(root())).toBeNull();
     expect(selectPayCardParams(root(reducer(undefined, openPayCard(params))))).toEqual(params);
+  });
+
+  it("selectPayCardHasSeenFeatureTour reflects the flag", () => {
+    expect(selectPayCardHasSeenFeatureTour(root())).toBe(false);
+    expect(
+      selectPayCardHasSeenFeatureTour(root(reducer(undefined, markPayCardFeatureTourSeen()))),
+    ).toBe(true);
+  });
+
+  it("payCardPersistedSelector returns only the persisted subset", () => {
+    const seen = reducer(undefined, markPayCardFeatureTourSeen());
+    expect(payCardPersistedSelector(root(seen))).toEqual({ hasSeenFeatureTour: true });
   });
 });

--- a/domain/entity/pay-card/src/slice.ts
+++ b/domain/entity/pay-card/src/slice.ts
@@ -1,9 +1,10 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { PayCardParams, PayCardState } from "./types";
+import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
 
 export const payCardInitialState: PayCardState = {
   isOpen: false,
   params: null,
+  hasSeenFeatureTour: false,
 };
 
 export const payCardSlice = createSlice({
@@ -18,7 +19,18 @@ export const payCardSlice = createSlice({
       state.isOpen = false;
       state.params = null;
     },
+    markPayCardFeatureTourSeen: state => {
+      state.hasSeenFeatureTour = true;
+    },
+    restorePayCardPersistedState: (state, action: PayloadAction<PayCardPersistedState>) => {
+      state.hasSeenFeatureTour = action.payload.hasSeenFeatureTour;
+    },
   },
 });
 
-export const { openPayCard, closePayCard } = payCardSlice.actions;
+export const {
+  openPayCard,
+  closePayCard,
+  markPayCardFeatureTourSeen,
+  restorePayCardPersistedState,
+} = payCardSlice.actions;

--- a/domain/entity/pay-card/src/types.ts
+++ b/domain/entity/pay-card/src/types.ts
@@ -29,4 +29,9 @@ export type PayCardParams = z.infer<typeof PayCardParamsSchema>;
 export type PayCardState = Readonly<{
   isOpen: boolean;
   params: PayCardParams | null;
+  hasSeenFeatureTour: boolean;
+}>;
+
+export type PayCardPersistedState = Readonly<{
+  hasSeenFeatureTour: boolean;
 }>;


### PR DESCRIPTION
## Context

First task of the Pay tab **Story 1 — first-time feature tour** ([LIVE-34860](https://ledgerhq.atlassian.net/browse/LIVE-34860)). Shared domain change in `@domain/entity-pay-card`, consumed by both apps.

## What

- `hasSeenFeatureTour: boolean` added to `PayCardState` (default `false`)
- `markPayCardFeatureTourSeen` reducer (sets it `true`)
- `restorePayCardPersistedState` reducer — merges the rehydrated persisted subset without touching transient `isOpen`/`params`
- `selectPayCardHasSeenFeatureTour` selector
- `payCardPersistedSelector` — returns **only** the persisted subset (`{ hasSeenFeatureTour }`), the guard against persisting transient nav state. Extended by Story 2's `balanceFilter` later.

## Why this shape

The flag lives in the `payCard` domain slice (cohesion) rather than app settings. Per-app persistence (LIVE-34861 mobile / LIVE-34862 desktop) is generic: it persists whatever `payCardPersistedSelector` returns, so future persisted fields need no extra wiring.

## Testing

- `slice.test.ts`: initial value, mark-seen (no clobber), restore-merge (no clobber), selectors, persisted subset. 10/10 pass.
- `tsc --noEmit` green. No consumer constructs a `PayCardState` literal (type-only usages), so the new required field is safe.

Blocks: LIVE-34861, LIVE-34862, LIVE-34863, LIVE-34894, LIVE-34881.

[LIVE-34860]: https://ledgerhq.atlassian.net/browse/LIVE-34860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ