### PR TITLE
feat(pay-card): mount FeatureTour on the Card screen [LIVE-34864]

### DIFF
--- a/features/flow/card/src/screens/CardScreen/__tests__/CardScreen.native.test.tsx
+++ b/features/flow/card/src/screens/CardScreen/__tests__/CardScreen.native.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { configureStore } from "@reduxjs/toolkit";
 import { cleanup, render, screen } from "@testing-library/react-native";
 import { payCardApi, payCardApiExtra } from "@domain/api-pay-card";
-import { payCardSlice } from "@domain/entity-pay-card";
+import { payCardSlice, markPayCardFeatureTourSeen } from "@domain/entity-pay-card";
 import { Provider } from "react-redux";
 import { CardScreen } from "../index.native";
 
@@ -21,9 +21,9 @@ function makeCardStore() {
   });
 }
 
-function renderCardScreen() {
+function renderCardScreen(store = makeCardStore()) {
   return render(
-    <Provider store={makeCardStore()}>
+    <Provider store={store}>
       <CardScreen />
     </Provider>,
   );
@@ -44,5 +44,19 @@ describe("CardScreen (Native)", () => {
     renderCardScreen();
 
     expect(screen.getByText("Card flow scaffold by design system")).toBeTruthy();
+  });
+
+  it("mounts the feature tour on first visit", () => {
+    renderCardScreen();
+
+    expect(screen.getByText("Pay and get paid")).toBeTruthy();
+  });
+
+  it("does not show the feature tour once it has been seen", () => {
+    const store = makeCardStore();
+    store.dispatch(markPayCardFeatureTourSeen());
+    renderCardScreen(store);
+
+    expect(screen.queryByText("Pay and get paid")).toBeNull();
   });
 });

--- a/features/flow/card/src/screens/CardScreen/__tests__/CardScreen.web.test.tsx
+++ b/features/flow/card/src/screens/CardScreen/__tests__/CardScreen.web.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { configureStore } from "@reduxjs/toolkit";
 import { render } from "@testing-library/react";
 import { payCardApi, payCardApiExtra } from "@domain/api-pay-card";
-import { payCardSlice } from "@domain/entity-pay-card";
+import { payCardSlice, markPayCardFeatureTourSeen } from "@domain/entity-pay-card";
 import { StyleProvider } from "@features/platform-style";
 import { Provider } from "react-redux";
 import { CardScreen } from "../index";
@@ -22,9 +22,9 @@ function makeCardStore() {
   });
 }
 
-function renderCardScreen() {
+function renderCardScreen(store = makeCardStore()) {
   return render(
-    <Provider store={makeCardStore()}>
+    <Provider store={store}>
       <StyleProvider colorScheme="light">
         <CardScreen />
       </StyleProvider>
@@ -43,5 +43,19 @@ describe("CardScreen (Web)", () => {
     const { getByText } = renderCardScreen();
 
     expect(getByText("Card flow scaffold by design system")).toBeVisible();
+  });
+
+  it("mounts the feature tour on first visit", () => {
+    const { getByText } = renderCardScreen();
+
+    expect(getByText("Spend with a card and get 1% cashback")).toBeVisible();
+  });
+
+  it("does not show the feature tour once it has been seen", () => {
+    const store = makeCardStore();
+    store.dispatch(markPayCardFeatureTourSeen());
+    const { queryByText } = renderCardScreen(store);
+
+    expect(queryByText("Spend with a card and get 1% cashback")).toBeNull();
   });
 });

--- a/features/flow/card/src/screens/CardScreen/index.native.tsx
+++ b/features/flow/card/src/screens/CardScreen/index.native.tsx
@@ -1,7 +1,14 @@
 import React from "react";
+import { FeatureTour } from "../../components/FeatureTour/index.native";
+import type { FeatureTourProps } from "../../components/FeatureTour/useFeatureTourViewModel";
 import { CardScreenView } from "./CardScreenView.native";
 import { useCardScreenViewModel } from "./useCardScreenViewModel";
 
-export function CardScreen() {
-  return <CardScreenView {...useCardScreenViewModel()} />;
+export function CardScreen(props: FeatureTourProps = {}) {
+  return (
+    <>
+      <CardScreenView {...useCardScreenViewModel()} />
+      <FeatureTour {...props} />
+    </>
+  );
 }

--- a/features/flow/card/src/screens/CardScreen/index.tsx
+++ b/features/flow/card/src/screens/CardScreen/index.tsx
@@ -1,7 +1,14 @@
 import React from "react";
+import { FeatureTour } from "../../components/FeatureTour";
+import type { FeatureTourProps } from "../../components/FeatureTour/useFeatureTourViewModel";
 import { CardScreenView } from "./CardScreenView.web";
 import { useCardScreenViewModel } from "./useCardScreenViewModel";
 
-export function CardScreen() {
-  return <CardScreenView {...useCardScreenViewModel()} />;
+export function CardScreen(props: FeatureTourProps = {}) {
+  return (
+    <>
+      <CardScreenView {...useCardScreenViewModel()} />
+      <FeatureTour {...props} />
+    </>
+  );
 }


### PR DESCRIPTION
## Context

Story 1 (Pay tab first-time feature tour) — plugs the tour into the feature's **main screen**. **Stacked on [LIVE-34863](https://github.com/LedgerHQ/ledger-live/pull/19960)** (the FeatureTour component), which is itself stacked on LIVE-34860. Review/merge in order; bases retarget to `develop` as each lands.

## What

- Render `<FeatureTour>` in the `CardScreen` container on both platforms, so it shows over the Card screen on first visit and disappears once seen. `CardScreenView` stays pure (presentational).
- `CardScreen` now accepts optional `FeatureTourProps` and forwards them — the **props-injection seam** for the host to pass `onTrackScreen`/`onTrackEvent`.
- Native container imports the explicit `.native` entry (the feature's jest projects have no platform-aware resolution, so directory imports would resolve the web file).

## Testing

- CardScreen native + web tests extended: tour visible on first visit, hidden once `hasSeenFeatureTour` is set. **16/16 pass** across the package.
- `tsc --noEmit` green; oxlint + tailwind lint clean.

With this, Story 1 is code-complete pending the per-app persistence wiring (LIVE-34861 mobile / LIVE-34862 desktop) and the debug reset (LIVE-34881).

[LIVE-34863]: https://ledgerhq.atlassian.net/browse/LIVE-34863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ