### PR TITLE
[LWM] feat(mobile): persist payCard slice [LIVE-34861]

### DIFF
--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -1,5 +1,6 @@
 import { trustchainStoreSelector } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { largeScreenUpsellModalSelector } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
+import { payCardPersistedSelector } from "@domain/entity-pay-card";
 import { postOnboardingSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { exportWalletState, walletStateExportShouldDiffer } from "@ledgerhq/live-wallet/store";
 import isEqual from "lodash/isEqual";
@@ -22,6 +23,7 @@ import {
   saveMarketState,
   saveMarketListConfig,
   saveMarketBannerState,
+  savePayCardState,
   savePostOnboardingState,
   saveSettings,
   saveTrustchainState,
@@ -262,6 +264,14 @@ export const ConfigureDBSaveEffects = () => {
     throttle: 500,
     getChangesStats: getLargeScreenUpsellModalStateChanged,
     lense: largeScreenUpsellModalSelector,
+  });
+
+  useDBSaveEffect({
+    stateSelector: (state: State) => state.payCard,
+    save: savePayCardState,
+    throttle: 500,
+    getChangesStats: (a: State, b: State) => a.payCard !== b.payCard,
+    lense: payCardPersistedSelector,
   });
 
   useDBSaveEffect({

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { Store } from "redux";
 import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/actions";
 import { restoreLargeScreenUpsellModalState } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
+import { restorePayCardPersistedState } from "@domain/entity-pay-card";
 import { backfillOnboardingDate } from "~/logic/postOnboarding/backfillOnboardingDate";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -24,6 +25,7 @@ import {
   getHistory,
   getKnownDevices,
   getLargeScreenUpsellModalState,
+  getPayCardState,
   getPostOnboardingState,
   getProtect,
   getMarketState,
@@ -116,6 +118,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         persistedFeatureFlags,
         legacyUser,
         historyState,
+        payCardState,
       ] = await Promise.all([
         retry(getBle, MAX_RETRIES, RETRY_DELAY),
         retry(getKnownDevices, MAX_RETRIES, RETRY_DELAY),
@@ -136,6 +139,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         retry(getFeatureFlagsState, MAX_RETRIES, RETRY_DELAY),
         retry(getUser, MAX_RETRIES, RETRY_DELAY),
         retry(getHistory, MAX_RETRIES, RETRY_DELAY),
+        retry(getPayCardState, MAX_RETRIES, RETRY_DELAY),
       ]).finally(() => {
         logStartupEvent<StoreStorageData>(STARTUP_EVENTS.STORE_STORAGE_READ, {
           readTime: Date.now() - readStorageStart,
@@ -188,6 +192,10 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       if (largeScreenUpsellModalState) {
         store.dispatch(restoreLargeScreenUpsellModalState(largeScreenUpsellModalState));
+      }
+
+      if (payCardState) {
+        store.dispatch(restorePayCardPersistedState(payCardState));
       }
 
       if (marketState) {

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -31,6 +31,7 @@ import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { ExportedWalletState } from "@ledgerhq/live-wallet/store";
 import { type PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
+import type { PayCardPersistedState } from "@domain/entity-pay-card";
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";
@@ -283,6 +284,14 @@ export async function saveLargeScreenUpsellModalState(
   largeScreenUpsellModalState: LargeScreenUpsellModalState,
 ): Promise<void> {
   await storage.save("largeScreenUpsellModal", largeScreenUpsellModalState);
+}
+
+export function getPayCardState(): Promise<PayCardPersistedState | null> {
+  return storage.get("payCard") as Promise<PayCardPersistedState | null>;
+}
+
+export async function savePayCardState(payCardState: PayCardPersistedState): Promise<void> {
+  await storage.save("payCard", payCardState);
 }
 
 export function getMarketState(): Promise<MarketState> {


### PR DESCRIPTION
## Context

Story 1 (Pay tab feature tour) — mobile persistence. **Stacked on [LIVE-34860](https://github.com/LedgerHQ/ledger-live/pull/19959)** (the slice + `payCardPersistedSelector` + `restorePayCardPersistedState`). Base retargets to `develop` once 34860 lands.

## What (mirrors the `largeScreenUpsellModal` precedent)

- **`db.ts`**: `getPayCardState` / `savePayCardState` (storage key `payCard`).
- **`DBSave.ts`**: `useDBSaveEffect` on `state.payCard`, `lense = payCardPersistedSelector`, `save = savePayCardState`.
- **`LedgerStore.tsx`**: read `getPayCardState` at startup (in the existing `Promise.all`) and `dispatch(restorePayCardPersistedState(...))`.

Only the `payCardPersistedSelector` subset (`hasSeenFeatureTour`) is written — never the transient `isOpen`/`params`. The wiring is generic, so Story 2's `balanceFilter` will be covered without extra work once added to the selector.

## Acceptance

After pressing "Got it", killing and reopening the app → the tour does not reappear.

## Verification note

Followed the `largeScreenUpsellModal`/`marketBanner` pattern exactly and self-reviewed the `useDBSaveEffect` generics (lense/save/getChangesStats line up). The mobile app is too large to fully `tsc` in my environment — **relying on CI for the full typecheck**. The domain slice it depends on is unit-tested + typechecked (34860).

[LIVE-34860]: https://ledgerhq.atlassian.net/browse/LIVE-34860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ