### PR TITLE
[LWD] feat(desktop): persist payCard slice [LIVE-34862]

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -12,6 +12,7 @@ import {
   LARGE_SCREEN_UPSELL_MODAL,
   restoreLargeScreenUpsellModalState,
 } from "@domain/entity-large-screen-upsell-modal";
+import { restorePayCardPersistedState } from "@domain/entity-pay-card";
 import i18n from "i18next";
 import { webFrame, ipcRenderer } from "electron";
 import each from "lodash/each";
@@ -347,6 +348,11 @@ async function init() {
   const largeScreenUpsellModalState = await getKey("app", LARGE_SCREEN_UPSELL_MODAL);
   if (largeScreenUpsellModalState !== undefined) {
     store.dispatch(restoreLargeScreenUpsellModalState(largeScreenUpsellModalState));
+  }
+
+  const payCardState = await getKey("app", "payCard");
+  if (payCardState !== undefined) {
+    store.dispatch(restorePayCardPersistedState(payCardState));
   }
 
   r(<ReactRoot store={store} language={language} initialCountervalues={initialCountervalues} />);

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -26,6 +26,7 @@ import {
 
 import { marketStoreSelector } from "../reducers/market";
 import { marketBannerStoreSelector } from "../reducers/marketBanner";
+import { payCardPersistedSelector } from "@domain/entity-pay-card";
 import {
   LARGE_SCREEN_UPSELL_MODAL,
   persistedLargeScreenUpsellModalSelector,
@@ -118,6 +119,18 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
 
     if (oldState.marketBanner !== newState.marketBanner) {
       setKey("app", "marketBanner", marketBannerStoreSelector(newState));
+    }
+
+    return res;
+  }
+
+  if (action.type.startsWith("payCard/")) {
+    const oldState = store.getState();
+    const res = next(action);
+    const newState = store.getState();
+
+    if (oldState.payCard !== newState.payCard) {
+      setKey("app", "payCard", payCardPersistedSelector(newState));
     }
 
     return res;

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -22,6 +22,7 @@ import type { PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
 import type { FeatureFlagsState } from "@shared/feature-flags";
 import type { RestorableLargeScreenUpsellModalState } from "@domain/entity-large-screen-upsell-modal";
+import type { PayCardPersistedState } from "@domain/entity-pay-card";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -56,6 +57,7 @@ type DatabaseValues = {
   wallet: ExportedWalletState;
   market: Market;
   marketBanner: MarketBanner;
+  payCard: PayCardPersistedState;
   knownDevices: KnownDevices;
   cryptoAssets: PersistedCAL;
   featureFlags: Pick<FeatureFlagsState, "overrides" | "bannerVisible">;


### PR DESCRIPTION
## Context

Story 1 (Pay tab feature tour) — desktop persistence. **Stacked on [LIVE-34860](https://github.com/LedgerHQ/ledger-live/pull/19959)**. Base retargets to `develop` once 34860 lands.

## What (mirrors the `largeScreenUpsellModal` / `marketBanner` precedent)

- **`middlewares/db.ts`**: on `payCard/*` actions, `setKey("app", "payCard", payCardPersistedSelector(newState))` (guarded by `oldState.payCard !== newState.payCard`).
- **`storage.ts`**: add `payCard` to `DatabaseValues`.
- **`init.tsx`**: `getKey("app", "payCard")` at startup → `dispatch(restorePayCardPersistedState(...))`.

Only the `payCardPersistedSelector` subset (`hasSeenFeatureTour`) is written.

## Acceptance

After pressing "Got it", restarting the app → the tour does not reappear.

## Verification note

Followed the existing precedent 1:1 and self-reviewed the types (`setKey` key + value, `getKey` return). Desktop app is too large to fully `tsc` in my environment — **relying on CI**. The domain slice it depends on is unit-tested + typechecked (34860).

[LIVE-34860]: https://ledgerhq.atlassian.net/browse/LIVE-34860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ