### PR TITLE
[LWM] feat: add the one-time Contacts feature introduction drawer on Mobile

### DIFF
--- a/.changeset/calm-contacts-intro-drawer.md
+++ b/.changeset/calm-contacts-intro-drawer.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Add the one-time Contacts feature introduction drawer on Mobile with shared native content and dismissal preference.

--- a/apps/ledger-live-mobile/src/actions/settings.ts
+++ b/apps/ledger-live-mobile/src/actions/settings.ts
@@ -65,6 +65,7 @@ import {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetHasDismissedContactsFeatureIntroductionPayload,
   SettingsSetDoNotAskAgainSkipMemoPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetHasSeenQ2WalletV4TourPayload,
@@ -295,6 +296,11 @@ export const setSelectedTabPortfolioAssets =
 export const setHasSeenWalletV4Tour = createAction<SettingsSetHasSeenWalletV4TourPayload>(
   SettingsActionTypes.SET_HAS_SEEN_WALLET_V4_TOUR,
 );
+
+export const setHasDismissedContactsFeatureIntroduction =
+  createAction<SettingsSetHasDismissedContactsFeatureIntroductionPayload>(
+    SettingsActionTypes.SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION,
+  );
 
 export const setDoNotAskAgainSkipMemo = createAction<SettingsSetDoNotAskAgainSkipMemoPayload>(
   SettingsActionTypes.SET_DO_NOT_ASK_AGAIN_SKIP_MEMO,

--- a/apps/ledger-live-mobile/src/actions/types.ts
+++ b/apps/ledger-live-mobile/src/actions/types.ts
@@ -321,6 +321,7 @@ export enum SettingsActionTypes {
   ADD_STARRED_MARKET_COINS = "ADD_STARRED_MARKET_COINS",
   REMOVE_STARRED_MARKET_COINS = "REMOVE_STARRED_MARKET_COINS",
   SET_HAS_SEEN_WALLET_V4_TOUR = "SET_HAS_SEEN_WALLET_V4_TOUR",
+  SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION = "SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION",
   SET_PRODUCT_TOUR_COMPLETED = "SET_PRODUCT_TOUR_COMPLETED",
   SET_HAS_SEEN_Q2_WALLET_V4_TOUR = "SET_HAS_SEEN_Q2_WALLET_V4_TOUR",
   SET_DO_NOT_ASK_AGAIN_SKIP_MEMO = "SET_DO_NOT_ASK_AGAIN_SKIP_MEMO",
@@ -410,6 +411,8 @@ export type SettingsSetHasSeenAnalyticsOptInPrompt = SettingsState["hasSeenAnaly
 export type SettingsSetDebugOsUpdateBannerMode = SettingsState["debugOsUpdateBannerMode"];
 export type SettingsSetAnalyticsConsentInfoPayload = SettingsState["analyticsConsentInfo"];
 export type SettingsSetHasSeenWalletV4TourPayload = SettingsState["hasSeenWalletV4Tour"];
+export type SettingsSetHasDismissedContactsFeatureIntroductionPayload =
+  SettingsState["hasDismissedContactsFeatureIntroduction"];
 export type SettingsSetDoNotAskAgainSkipMemoPayload = SettingsState["doNotAskAgainSkipMemo"];
 export type SettingsSetProductTourCompletedPayload = SettingsState["productTourCompleted"];
 export type SettingsSetHasSeenQ2WalletV4TourPayload = SettingsState["hasSeenQ2WalletV4Tour"];
@@ -483,6 +486,7 @@ export type SettingsPayload =
   | SettingsAddStarredMarketcoinsPayload
   | SettingsRemoveStarredMarketcoinsPayload
   | SettingsSetHasSeenWalletV4TourPayload
+  | SettingsSetHasDismissedContactsFeatureIntroductionPayload
   | SettingsSetDoNotAskAgainSkipMemoPayload
   | SettingsSetProductTourCompletedPayload
   | SettingsSetHasSeenQ2WalletV4TourPayload

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10257,6 +10257,26 @@
       "activate": "Turn on Ledger Sync",
       "dismiss": "Got it",
       "checkingAccessibilityLabel": "Checking Ledger Sync status"
+    },
+    "featureIntroduction": {
+      "title": "Introducing Contacts",
+      "description": "Your address book for crypto — save the wallets you send to, all in one place.",
+      "primaryAction": "Try contacts",
+      "secondaryAction": "Maybe later",
+      "highlights": {
+        "saveAddresses": {
+          "title": "Save addresses once",
+          "description": "Keep the addresses you send to in one place."
+        },
+        "sendToRightAddress": {
+          "title": "Send to the right address",
+          "description": "Funds reach the right wallet every time."
+        },
+        "privateAcrossDevices": {
+          "title": "Private across your devices",
+          "description": "End-to-end encrypted with Ledger Sync."
+        }
+      }
     }
   }
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -77,6 +77,23 @@ function renderContactsButton(overrideInitialState: ReturnType<typeof withFlagOv
   return render(<ContactsButton />, { overrideInitialState });
 }
 
+function withContactsPageReadyState(
+  flagOverrides: Parameters<typeof withFlagOverrides>[0],
+  patchState?: Parameters<typeof withFlagOverrides>[1],
+) {
+  return withFlagOverrides(flagOverrides, state => {
+    const nextState = patchState ? patchState(state) : state;
+
+    return {
+      ...nextState,
+      settings: {
+        ...nextState.settings,
+        hasDismissedContactsFeatureIntroduction: true,
+      },
+    };
+  });
+}
+
 describe("Contacts integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -190,7 +207,7 @@ describe("Contacts integration", () => {
 
   it("should render the empty Contacts list when navigated from My Wallet", async () => {
     const { user } = render(<MyWalletNavigator />, {
-      overrideInitialState: withFlagOverrides({
+      overrideInitialState: withContactsPageReadyState({
         lwmContacts: { enabled: true, params: { newBadge: false } },
       }),
     });
@@ -219,7 +236,7 @@ describe("Contacts integration", () => {
       mockContact({ id: "contact-zhanna", name: "Жанна" }),
     ];
     const { user } = render(<MyWalletNavigator />, {
-      overrideInitialState: withFlagOverrides(
+      overrideInitialState: withContactsPageReadyState(
         { lwmContacts: { enabled: true, params: { newBadge: false } } },
         state => ({ ...state, contacts: { contacts } }),
       ),
@@ -240,7 +257,7 @@ describe("Contacts integration", () => {
 
   it("should wire the Mobile query to the shared Contacts search model", async () => {
     const { user } = render(<MyWalletNavigator />, {
-      overrideInitialState: withFlagOverrides({
+      overrideInitialState: withContactsPageReadyState({
         lwmContacts: { enabled: true, params: { newBadge: false } },
       }),
     });
@@ -275,7 +292,7 @@ describe("Contacts integration", () => {
 
   it("should render the empty Me contact detail state", async () => {
     const { user } = render(<MyWalletNavigator />, {
-      overrideInitialState: withFlagOverrides({
+      overrideInitialState: withContactsPageReadyState({
         lwmContacts: { enabled: true, params: { newBadge: false } },
       }),
     });
@@ -294,7 +311,7 @@ describe("Contacts integration", () => {
   it("should render a distinct empty state for another contact", async () => {
     const contact = mockContact({ id: "contact-benoit", name: "Benoit" });
     const { user } = render(<MyWalletNavigator />, {
-      overrideInitialState: withFlagOverrides(
+      overrideInitialState: withContactsPageReadyState(
         { lwmContacts: { enabled: true, params: { newBadge: false } } },
         state => ({
           ...state,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/ContactsFeatureIntroduction.integration.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { Text } from "react-native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { render, screen, waitFor, withFlagOverrides } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import { ContactsScreen } from "LLM/features/Contacts";
+import MyWalletNavigator from "LLM/features/MyWallet/Navigator";
+import { useMyWalletHeaderViewModel } from "LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel";
+
+jest.mock("LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel");
+
+const mockedViewModel = jest.mocked(useMyWalletHeaderViewModel);
+
+const Stack = createNativeStackNavigator();
+
+const contactsNavigationState = {
+  index: 1,
+  routes: [
+    { name: ScreenName.MyWallet, key: "my-wallet" },
+    { name: ScreenName.MyWalletContacts, key: "contacts" },
+  ],
+};
+
+function ContactsFeatureIntroductionTestApp() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen
+        name={ScreenName.MyWallet}
+        component={() => <Text testID="my-wallet-home">My Wallet</Text>}
+      />
+      <Stack.Screen name={ScreenName.MyWalletContacts} component={ContactsScreen} />
+    </Stack.Navigator>
+  );
+}
+
+describe("Contacts feature introduction integration", () => {
+  beforeEach(() => {
+    mockedViewModel.mockReturnValue({
+      onBackPress: jest.fn(),
+      onNotificationsPress: jest.fn(),
+      onSettingsPress: jest.fn(),
+      hasUnreadNotifications: false,
+    });
+  });
+
+  it("should show the introduction drawer over the Contacts page on first visit", async () => {
+    render(<ContactsFeatureIntroductionTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
+        }),
+      ),
+    });
+
+    expect(screen.getByTestId("contacts-screen")).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByText("Introducing Contacts")).toBeVisible();
+      expect(screen.getByTestId("contacts-feature-introduction-primary")).toBeVisible();
+    });
+    expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+  });
+
+  it("should persist dismissal from Try contacts and keep the Contacts page available", async () => {
+    const { user, store } = render(<ContactsFeatureIntroductionTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("contacts-feature-introduction-primary"));
+
+    await waitFor(() => {
+      expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(true);
+      expect(screen.queryByTestId("contacts-feature-introduction-primary")).toBeNull();
+      expect(screen.getByTestId("contacts-screen")).toBeVisible();
+    });
+  });
+
+  it("should defer the introduction from Maybe later without persisting dismissal", async () => {
+    const { user, store } = render(<ContactsFeatureIntroductionTestApp />, {
+      navigationInitialState: contactsNavigationState,
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("contacts-feature-introduction-secondary"));
+
+    await waitFor(() => {
+      expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
+      expect(screen.getByTestId("my-wallet-home")).toBeVisible();
+    });
+  });
+
+  it("should navigate to the introduction from My Wallet when the feature flag is enabled", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          settings: { ...state.settings, hasDismissedContactsFeatureIntroduction: false },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Introducing Contacts")).toBeVisible();
+      expect(screen.getByTestId("contacts-screen")).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
@@ -1,0 +1,22 @@
+import { useCallback, useMemo } from "react";
+import type { ContactsFeatureIntroductionPreferencePort } from "@features/flow-contacts";
+import { useDispatch, useSelector } from "react-redux";
+import { setHasDismissedContactsFeatureIntroduction } from "~/actions/settings";
+import { hasDismissedContactsFeatureIntroductionSelector } from "~/reducers/settings";
+
+export function useContactsFeatureIntroductionPreference(): ContactsFeatureIntroductionPreferencePort {
+  const dispatch = useDispatch();
+  const isDismissed = useSelector(hasDismissedContactsFeatureIntroductionSelector);
+
+  const markDismissed = useCallback(() => {
+    dispatch(setHasDismissedContactsFeatureIntroduction(true));
+  }, [dispatch]);
+
+  return useMemo(
+    () => ({
+      isDismissed,
+      markDismissed,
+    }),
+    [isDismissed, markDismissed],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsFeatureIntroductionPreference.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import type { ContactsFeatureIntroductionPreferencePort } from "@features/flow-contacts";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from "~/context/hooks";
 import { setHasDismissedContactsFeatureIntroduction } from "~/actions/settings";
 import { hasDismissedContactsFeatureIntroductionSelector } from "~/reducers/settings";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useSingleFireDismiss.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useSingleFireDismiss.ts
@@ -1,0 +1,20 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export function useSingleFireDismiss(onDismiss: () => void, open: boolean): () => void {
+  const hasDismissed = useRef(false);
+
+  useEffect(() => {
+    if (open) {
+      hasDismissed.current = false;
+    }
+  }, [open]);
+
+  return useCallback(() => {
+    if (hasDismissed.current) {
+      return;
+    }
+
+    hasDismissed.current = true;
+    onDismiss();
+  }, [onDismiss]);
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/ContactsFeatureIntroductionSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/ContactsFeatureIntroductionSheet.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS } from "@features/flow-contacts";
+import { ContactsFeatureIntroductionSheet } from ".";
+
+const highlights = CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS.map(({ icon, translationKey }) => ({
+  icon,
+  title: `${translationKey}-title`,
+  description: `${translationKey}-description`,
+}));
+
+describe("ContactsFeatureIntroductionSheet", () => {
+  it("should call onComplete once from Try contacts", async () => {
+    const onComplete = jest.fn();
+    const onDefer = jest.fn();
+    const { user } = render(
+      <ContactsFeatureIntroductionSheet
+        isOpen
+        title="Introducing Contacts"
+        description="Your address book for crypto."
+        highlights={highlights}
+        primaryActionLabel="Try contacts"
+        secondaryActionLabel="Maybe later"
+        onComplete={onComplete}
+        onDefer={onDefer}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-feature-introduction-primary")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-feature-introduction-primary"));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onDefer).not.toHaveBeenCalled();
+  });
+
+  it("should call onDefer once from Maybe later", async () => {
+    const onComplete = jest.fn();
+    const onDefer = jest.fn();
+    const { user } = render(
+      <ContactsFeatureIntroductionSheet
+        isOpen
+        title="Introducing Contacts"
+        description="Your address book for crypto."
+        highlights={highlights}
+        primaryActionLabel="Try contacts"
+        secondaryActionLabel="Maybe later"
+        onComplete={onComplete}
+        onDefer={onDefer}
+      />,
+    );
+
+    await user.press(screen.getByTestId("contacts-feature-introduction-secondary"));
+
+    expect(onDefer).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { Platform } from "react-native";
+import {
+  ContactsFeatureIntroductionContent,
+  type ContactsFeatureIntroduction,
+} from "@features/flow-contacts";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBottomSheet";
+import { useSingleFireDismiss } from "../../../../hooks/useSingleFireDismiss";
+
+export type ContactsFeatureIntroductionSheetProps = ContactsFeatureIntroduction;
+
+export function ContactsFeatureIntroductionSheet({
+  isOpen,
+  onComplete,
+  onDefer,
+  ...contentProps
+}: ContactsFeatureIntroductionSheetProps): React.JSX.Element {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const hasCompleted = useRef(false);
+  const defer = useSingleFireDismiss(onDefer, isOpen);
+  const complete = useSingleFireDismiss(() => {
+    hasCompleted.current = true;
+    onComplete();
+  }, isOpen);
+
+  useEffect(() => {
+    if (isOpen) {
+      hasCompleted.current = false;
+    }
+  }, [isOpen]);
+
+  const handleDrawerClose = useCallback(() => {
+    if (!hasCompleted.current) {
+      defer();
+    }
+  }, [defer]);
+
+  return (
+    <QueuedDrawerBottomSheet
+      isRequestingToBeOpened={isOpen}
+      onClose={handleDrawerClose}
+      onHeaderClosePressed={defer}
+      onBackdropPress={defer}
+      testID="contacts-feature-introduction-drawer"
+      enableDynamicSizing
+      // iOS: allow the sheet to grow with content; uncapped on Android to avoid excess empty space.
+      maxDynamicContentSize={Platform.OS === "ios" ? "fullWithOffset" : undefined}
+    >
+      <ContactsFeatureIntroductionContent
+        isOpen={isOpen}
+        onComplete={complete}
+        onDefer={defer}
+        bottomInset={bottomInset}
+        {...contentProps}
+      />
+    </QueuedDrawerBottomSheet>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -7,11 +7,13 @@ import type { ContactsPageContentProps } from "../../types";
 function createViewModel({
   ledgerSyncStatus = "inactive",
   isIntroductionOpen = true,
+  isFeatureIntroductionOpen = false,
   onDismiss = jest.fn(),
   onActivate = jest.fn(),
 }: {
   ledgerSyncStatus?: "ready" | "checking" | "inactive";
   isIntroductionOpen?: boolean;
+  isFeatureIntroductionOpen?: boolean;
   onDismiss?: jest.Mock;
   onActivate?: jest.Mock;
 } = {}): ContactsPageContentProps {
@@ -39,9 +41,20 @@ function createViewModel({
     onOpenContact: jest.fn(),
     onAddContact: jest.fn(),
     ledgerSyncStatus,
-    featureIntroduction: createClosedContactsFeatureIntroduction(),
+    featureIntroduction: isFeatureIntroductionOpen
+      ? {
+          isOpen: true,
+          title: "Introducing Contacts",
+          description: "Your address book for crypto.",
+          highlights: [],
+          primaryActionLabel: "Try contacts",
+          secondaryActionLabel: "Maybe later",
+          onComplete: jest.fn(),
+          onDefer: jest.fn(),
+        }
+      : createClosedContactsFeatureIntroduction(),
     ledgerSyncIntroduction: {
-      isOpen: isIntroductionOpen,
+      isOpen: isFeatureIntroductionOpen ? false : isIntroductionOpen,
       description:
         "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
       dismissLabel: "Got it",
@@ -129,6 +142,36 @@ describe("ContactsPageContent", () => {
       />,
     );
     rerender(<ContactsPageContent {...createViewModel({ ledgerSyncStatus: "inactive" })} />);
+
+    expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
+  });
+
+  it("should defer the Ledger Sync introduction while the feature introduction is open", () => {
+    const onDismiss = jest.fn();
+    const { rerender } = render(
+      <ContactsPageContent
+        {...createViewModel({
+          ledgerSyncStatus: "inactive",
+          isIntroductionOpen: true,
+          onDismiss,
+          isFeatureIntroductionOpen: true,
+        })}
+      />,
+    );
+
+    expect(screen.queryByText("Turn on Ledger Sync to save contacts")).toBeNull();
+    expect(screen.getByTestId("contacts-feature-introduction-primary")).toBeVisible();
+
+    rerender(
+      <ContactsPageContent
+        {...createViewModel({
+          ledgerSyncStatus: "inactive",
+          isIntroductionOpen: true,
+          onDismiss,
+          isFeatureIntroductionOpen: false,
+        })}
+      />,
+    );
 
     expect(screen.getByText("Turn on Ledger Sync to save contacts")).toBeVisible();
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ContactsPage } from "@features/flow-contacts";
 import { ContactsAddContactDrawerSheet } from "../ContactsAddContactDrawerSheet";
+import { ContactsFeatureIntroductionSheet } from "../ContactsFeatureIntroductionSheet";
 import { ContactsLedgerSyncIntroductionSheet } from "../ContactsLedgerSyncIntroductionSheet";
 import type { ContactsPageContentProps } from "../../types";
 
@@ -12,6 +13,7 @@ export function ContactsPageContent({
   return (
     <>
       <ContactsPage {...pageProps} />
+      <ContactsFeatureIntroductionSheet {...pageProps.featureIntroduction} />
       <ContactsLedgerSyncIntroductionSheet
         {...pageProps.ledgerSyncIntroduction}
         {...ledgerSyncIntroductionContent}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -1,9 +1,11 @@
 import {
+  CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   type ContactsLedgerSyncStatus,
   type ContactsPageLabels,
   type ContactsPageNativeProps,
-  createClosedContactsFeatureIntroduction,
+  resolveContactsLedgerSyncIntroductionOpen,
   useContacts,
+  useContactsFeatureIntroductionState,
   useContactsSearchViewModel,
 } from "@features/flow-contacts";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -13,6 +15,7 @@ import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
+import { useContactsFeatureIntroductionPreference } from "../../../hooks/useContactsFeatureIntroductionPreference";
 import type { ContactsPageViewModel } from "../types";
 
 export function useContactsPageViewModel(): ContactsPageViewModel {
@@ -31,8 +34,22 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
     }),
     [t],
   );
+  const preference = useContactsFeatureIntroductionPreference();
+  const featureIntroductionState = useContactsFeatureIntroductionState({
+    isContactsEntryAvailable: true,
+    preference,
+  });
+  const featureIntroductionHighlights = useMemo(
+    () =>
+      CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS.map(({ icon, translationKey }) => ({
+        icon,
+        title: t(`contacts.featureIntroduction.highlights.${translationKey}.title`),
+        description: t(`contacts.featureIntroduction.highlights.${translationKey}.description`),
+      })),
+    [t],
+  );
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
-  const [isIntroductionDismissed, setIsIntroductionDismissed] = useState(false);
+  const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const contacts = useContacts();
   const viewModel = useContactsSearchViewModel(searchQuery);
@@ -47,14 +64,29 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
     },
     [contacts, navigation],
   );
-  const onDismissIntroduction = useCallback(() => setIsIntroductionDismissed(true), []);
+  const onDismissLedgerSyncIntroduction = useCallback(
+    () => setIsLedgerSyncIntroductionDismissed(true),
+    [],
+  );
   const onActivateIntroduction = useCallback(() => undefined, []);
+  const onCompleteFeatureIntroduction = useCallback(() => {
+    featureIntroductionState.dismiss();
+  }, [featureIntroductionState]);
+  const onDeferFeatureIntroduction = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
 
   useEffect(() => {
     if (ledgerSyncStatus !== "inactive") {
-      setIsIntroductionDismissed(false);
+      setIsLedgerSyncIntroductionDismissed(false);
     }
   }, [ledgerSyncStatus]);
+
+  const isLedgerSyncIntroductionOpen = resolveContactsLedgerSyncIntroductionOpen({
+    isFeatureIntroductionRequested: featureIntroductionState.isRequested,
+    ledgerSyncStatus,
+    isLedgerSyncIntroductionDismissed,
+  });
 
   return {
     viewModel,
@@ -64,12 +96,21 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
     meAvatarSrc: USER_AVATAR_URL,
     onOpenContact,
     ledgerSyncStatus,
-    featureIntroduction: createClosedContactsFeatureIntroduction(),
+    featureIntroduction: {
+      isOpen: featureIntroductionState.isRequested,
+      title: t("contacts.featureIntroduction.title"),
+      description: t("contacts.featureIntroduction.description"),
+      highlights: featureIntroductionHighlights,
+      primaryActionLabel: t("contacts.featureIntroduction.primaryAction"),
+      secondaryActionLabel: t("contacts.featureIntroduction.secondaryAction"),
+      onComplete: onCompleteFeatureIntroduction,
+      onDefer: onDeferFeatureIntroduction,
+    },
     ledgerSyncIntroduction: {
-      isOpen: ledgerSyncStatus === "inactive" && !isIntroductionDismissed,
+      isOpen: isLedgerSyncIntroductionOpen,
       description: t("contacts.ledgerSyncIntroduction.description"),
       dismissLabel: t("contacts.ledgerSyncIntroduction.dismiss"),
-      onDismiss: onDismissIntroduction,
+      onDismiss: onDismissLedgerSyncIntroduction,
     },
     ledgerSyncIntroductionContent: {
       title: t("contacts.ledgerSyncIntroduction.title"),

--- a/apps/ledger-live-mobile/src/reducers/settings.ts
+++ b/apps/ledger-live-mobile/src/reducers/settings.ts
@@ -73,6 +73,7 @@ import type {
   SettingsIsOnboardingFlowReceiveSuccessPayload,
   SettingsIsPostOnboardingFlowPayload,
   SettingsSetHasSeenWalletV4TourPayload,
+  SettingsSetHasDismissedContactsFeatureIntroductionPayload,
   SettingsSetDoNotAskAgainSkipMemoPayload,
   SettingsSetProductTourCompletedPayload,
   SettingsSetHasSeenQ2WalletV4TourPayload,
@@ -174,6 +175,7 @@ export const INITIAL_STATE: SettingsState = {
   isPostOnboardingFlow: false,
   generalTermsVersionAccepted: undefined,
   hasSeenWalletV4Tour: false,
+  hasDismissedContactsFeatureIntroduction: false,
   productTourCompleted: false,
   hasSeenQ2WalletV4Tour: false,
   doNotAskAgainSkipMemo: false,
@@ -672,6 +674,13 @@ const handlers: ReducerMap<SettingsState, SettingsPayload> = {
     hasSeenWalletV4Tour: (action as Action<SettingsSetHasSeenWalletV4TourPayload>).payload,
   }),
 
+  [SettingsActionTypes.SET_HAS_DISMISSED_CONTACTS_FEATURE_INTRODUCTION]: (state, action) => ({
+    ...state,
+    hasDismissedContactsFeatureIntroduction: (
+      action as Action<SettingsSetHasDismissedContactsFeatureIntroductionPayload>
+    ).payload,
+  }),
+
   [SettingsActionTypes.SET_DO_NOT_ASK_AGAIN_SKIP_MEMO]: (state, action) => ({
     ...state,
     doNotAskAgainSkipMemo: (action as Action<SettingsSetDoNotAskAgainSkipMemoPayload>).payload,
@@ -961,6 +970,9 @@ export const mevProtectionSelector = (state: State) => state.settings.mevProtect
 export const selectedTabPortfolioAssetsSelector = (state: State) =>
   state.settings.selectedTabPortfolioAssets;
 export const hasSeenWalletV4TourSelector = (state: State) => state.settings.hasSeenWalletV4Tour;
+
+export const hasDismissedContactsFeatureIntroductionSelector = (state: State) =>
+  state.settings.hasDismissedContactsFeatureIntroduction;
 
 export const doNotAskAgainSkipMemoSelector = (state: State) => state.settings.doNotAskAgainSkipMemo;
 export const productTourCompletedSelector = (state: State) => state.settings.productTourCompleted;

--- a/apps/ledger-live-mobile/src/reducers/types.ts
+++ b/apps/ledger-live-mobile/src/reducers/types.ts
@@ -309,6 +309,7 @@ export type SettingsState = {
   mevProtection: boolean;
   selectedTabPortfolioAssets: TabPortfolioAssetsType;
   hasSeenWalletV4Tour: boolean;
+  hasDismissedContactsFeatureIntroduction: boolean;
   productTourCompleted: boolean;
   hasSeenQ2WalletV4Tour: boolean;
   doNotAskAgainSkipMemo: boolean;

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -1,7 +1,6 @@
 # @features/flow-contacts
 
-> [!CAUTION]
-> **Status: UNSTABLE** — In active development as part of the Contacts feature.
+> [!CAUTION] > **Status: UNSTABLE** — In active development as part of the Contacts feature.
 
 Shared Contacts flow package for Desktop and Mobile.
 
@@ -38,7 +37,7 @@ src/
 ├── components/
 │   ├── ContactsButton/                  # My Wallet entry
 │   ├── AddContactDrawer/                # Native add-contact drawer and web dialog
-│   ├── ContactsFeatureIntroduction/      # One-time feature introduction dialog (web)
+│   ├── ContactsFeatureIntroduction/      # One-time feature introduction (web dialog, native drawer content)
 │   ├── ContactAvatar/                    # Shared native list and detail avatar
 │   └── ContactsLedgerSyncIntroduction/  # Shared Ledger Sync introduction content
 ├── add/

--- a/features/flow/contacts/src/components/ContactsFeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
+++ b/features/flow/contacts/src/components/ContactsFeatureIntroduction/ContactsFeatureIntroductionContent.native.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { Image, type ImageSourcePropType } from "react-native";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import * as Icons from "@ledgerhq/lumen-ui-rnative/symbols";
+import { CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE } from "./assets";
+import type { ContactsFeatureIntroductionContentProps } from "./types";
+
+export function ContactsFeatureIntroductionContent({
+  isOpen,
+  title,
+  description,
+  highlights,
+  primaryActionLabel,
+  secondaryActionLabel,
+  heroImageSrc,
+  bottomInset,
+  onComplete,
+  onDefer,
+}: ContactsFeatureIntroductionContentProps): React.JSX.Element {
+  const heroImage = heroImageSrc ?? CONTACTS_FEATURE_INTRODUCTION_HERO_IMAGE;
+
+  return (
+    <BottomSheetView
+      style={{
+        paddingHorizontal: 0,
+        paddingBottom: bottomInset + 24,
+      }}
+    >
+      {isOpen ? (
+        <>
+          <BottomSheetHeader spacing />
+          <Box lx={{ gap: "s16", paddingHorizontal: "s16" }}>
+            <Box
+              testID="contacts-feature-introduction-hero"
+              style={{
+                height: 200,
+                width: "100%",
+                borderRadius: 12,
+                overflow: "hidden",
+              }}
+              lx={{ backgroundColor: "muted" }}
+            >
+              <Image
+                source={heroImage as ImageSourcePropType}
+                accessibilityIgnoresInvertColors
+                style={{ width: "100%", height: "100%" }}
+                resizeMode="cover"
+              />
+            </Box>
+            <Box lx={{ gap: "s8" }}>
+              <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+                {title}
+              </Text>
+              <Text typography="body2" lx={{ color: "muted" }}>
+                {description}
+              </Text>
+            </Box>
+            {highlights.map(highlight => {
+              const HighlightIcon = Icons[highlight.icon];
+
+              return (
+                <Box key={highlight.icon} lx={{ flexDirection: "row", gap: "s12" }}>
+                  <HighlightIcon />
+                  <Box lx={{ flex: 1, gap: "s4" }}>
+                    <Text typography="body1SemiBold" lx={{ color: "base" }}>
+                      {highlight.title}
+                    </Text>
+                    <Text typography="body2" lx={{ color: "muted" }}>
+                      {highlight.description}
+                    </Text>
+                  </Box>
+                </Box>
+              );
+            })}
+            <Box lx={{ gap: "s12", paddingTop: "s8" }}>
+              <Button
+                appearance="base"
+                size="lg"
+                isFull
+                onPress={onComplete}
+                testID="contacts-feature-introduction-primary"
+              >
+                {primaryActionLabel}
+              </Button>
+              <Button
+                appearance="gray"
+                size="lg"
+                isFull
+                onPress={onDefer}
+                testID="contacts-feature-introduction-secondary"
+              >
+                {secondaryActionLabel}
+              </Button>
+            </Box>
+          </Box>
+        </>
+      ) : null}
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/components/ContactsFeatureIntroduction/index.native.ts
+++ b/features/flow/contacts/src/components/ContactsFeatureIntroduction/index.native.ts
@@ -1,0 +1,2 @@
+export { ContactsFeatureIntroductionContent } from "./ContactsFeatureIntroductionContent.native";
+export type { ContactsFeatureIntroductionContentProps } from "./types";

--- a/features/flow/contacts/src/components/ContactsFeatureIntroduction/types.ts
+++ b/features/flow/contacts/src/components/ContactsFeatureIntroduction/types.ts
@@ -1,0 +1,6 @@
+import type { ContactsFeatureIntroduction } from "../../list/types";
+
+export type ContactsFeatureIntroductionContentProps = ContactsFeatureIntroduction &
+  Readonly<{
+    bottomInset: number;
+  }>;

--- a/features/flow/contacts/src/components/index.native.ts
+++ b/features/flow/contacts/src/components/index.native.ts
@@ -1,4 +1,5 @@
 export * from "./AddContactDrawer/index.native";
 export * from "./ContactAvatar/index.native";
 export * from "./ContactsButton/index.native";
+export * from "./ContactsFeatureIntroduction/index.native";
 export * from "./ContactsLedgerSyncIntroduction/index.native";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request introduces the one-time Contacts feature introduction drawer on mobile, including its integration, state management, and user preference handling. It also adds comprehensive tests and new localization strings for the feature. The drawer uses shared native content and persists the user's dismissal preference.

**Contacts Feature Introduction Drawer Implementation:**

- Added the Contacts feature introduction drawer, which appears once for users on mobile with shared native content and persists dismissal preference.
- Implemented the `ContactsFeatureIntroductionSheet` component to display the introduction and handle completion or deferral actions.

**State Management and User Preference:**

- Extended Redux actions, types, and selectors to support tracking and updating the dismissal state for the Contacts feature introduction. 
- Added the `useContactsFeatureIntroductionPreference` hook to provide the dismissal state and a function to mark the introduction as dismissed.
- Added a `useSingleFireDismiss` hook to ensure dismissal actions only fire once per drawer open. 

**Integration and View Model Updates:**

- Updated the Contacts page view model and content components to integrate the feature introduction, ensuring it displays appropriately and defers the Ledger Sync introduction if open.

**Testing:**

- Added integration and unit tests to verify the introduction drawer's behavior, including first visit, dismissal, and deferral scenarios. 

**Localization:**

- Added English localization strings for the Contacts feature introduction and its highlights. 


https://github.com/user-attachments/assets/39fe76cf-97fa-476c-bc25-770edb24fdcd




### 🔗 Context


[LIVE-34642](https://ledgerhq.atlassian.net/browse/LIVE-34642)


[LIVE-34642]: https://ledgerhq.atlassian.net/browse/LIVE-34642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ