### PR TITLE
[LWM] fix(mobile): stay on the first story when clicking left (LIVE-24300)

### DIFF
--- a/.changeset/brave-welcome-stories-stay.md
+++ b/.changeset/brave-welcome-stories-stay.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix welcome page first story looping to last on left tap

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/StoryProgressBar.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/StoryProgressBar.tsx
@@ -11,6 +11,7 @@ type StoryProgressBarProps = {
   durationMs?: number;
   isActivated?: boolean;
   isCompleted?: boolean;
+  restartKey?: number;
 };
 
 /**
@@ -22,6 +23,7 @@ export function StoryProgressBar({
   durationMs = 5000,
   isActivated = false,
   isCompleted = false,
+  restartKey = 0,
 }: Readonly<StoryProgressBarProps>) {
   const progress = useSharedValue(0);
 
@@ -30,7 +32,7 @@ export function StoryProgressBar({
     if (isActivated) {
       progress.value = withTiming(100, { duration: durationMs, easing: Easing.linear });
     }
-  }, [durationMs, isActivated, isCompleted, progress]);
+  }, [durationMs, isActivated, isCompleted, progress, restartKey]);
 
   const animatedStyles = useAnimatedStyle(() => {
     return {

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/components/VideoBackground.tsx
@@ -9,6 +9,7 @@ type VideoBackgroundProps = {
   videoSource: ReactVideoSource;
   titleKey: string;
   isOnStage?: boolean;
+  restartKey?: number;
   onVideoLoad?: (data: OnLoadData) => void;
   onVideoEnd?: () => void;
 };
@@ -22,6 +23,7 @@ export function VideoBackground({
   videoSource,
   titleKey,
   isOnStage = false,
+  restartKey = 0,
   onVideoLoad,
   onVideoEnd,
 }: Readonly<VideoBackgroundProps>) {
@@ -34,6 +36,12 @@ export function VideoBackground({
       videoRef.current?.seek(0);
     }
   }, [isOnStage]);
+
+  useEffect(() => {
+    if (isOnStage && restartKey > 0) {
+      videoRef.current?.seek(0);
+    }
+  }, [isOnStage, restartKey]);
 
   return (
     <View style={[styles.container, { display: isOnStage ? "flex" : "none" }]}>

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/hooks/__tests__/useWelcomeStories.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/hooks/__tests__/useWelcomeStories.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@tests/test-renderer";
+import { useWelcomeStories } from "../useWelcomeStories";
+
+const mockUseIsFocused = jest.fn(() => true);
+const mockUseIsAppInBackground = jest.fn(() => false);
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useIsFocused: () => mockUseIsFocused(),
+}));
+
+jest.mock("~/components/useIsAppInBackground", () => ({
+  __esModule: true,
+  default: () => mockUseIsAppInBackground(),
+}));
+
+describe("useWelcomeStories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsFocused.mockReturnValue(true);
+    mockUseIsAppInBackground.mockReturnValue(false);
+  });
+
+  it("should expose the welcome videos and initial story state", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    expect(result.current.welcomeVideos).toHaveLength(3);
+    expect(result.current.welcomeVideos.map(video => video.id)).toEqual([
+      "welcome-basic-1",
+      "welcome-basic-2",
+      "welcome-basic-3",
+    ]);
+    expect(result.current.currentVideoIndex).toBe(0);
+    expect(result.current.currentStoryRestartKey).toBe(0);
+    expect(result.current.videoDurations).toEqual([
+      { id: "welcome-basic-1", durationMs: 0 },
+      { id: "welcome-basic-2", durationMs: 0 },
+      { id: "welcome-basic-3", durationMs: 0 },
+    ]);
+  });
+
+  it("should stay on the first story when going previous from the first story", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onPrevious();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(0);
+  });
+
+  it("should restart the first story when going previous from the first story", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onPrevious();
+    });
+
+    expect(result.current.currentStoryRestartKey).toBe(1);
+
+    act(() => {
+      result.current.onPrevious();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(0);
+    expect(result.current.currentStoryRestartKey).toBe(2);
+  });
+
+  it("should go to the previous story when not on the first story", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onNext();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(1);
+
+    act(() => {
+      result.current.onPrevious();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(0);
+    expect(result.current.currentStoryRestartKey).toBe(0);
+  });
+
+  it("should advance to the next story and wrap from the last story", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onNext();
+      result.current.onNext();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(2);
+
+    act(() => {
+      result.current.onNext();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(0);
+  });
+
+  it("should store video duration in milliseconds when a story loads", () => {
+    const { result } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onLoad(1)({ duration: 4.567 } as never);
+    });
+
+    expect(result.current.videoDurations).toEqual([
+      { id: "welcome-basic-1", durationMs: 0 },
+      { id: "welcome-basic-2", durationMs: 4567 },
+      { id: "welcome-basic-3", durationMs: 0 },
+    ]);
+  });
+
+  it("should reset to the first story when the app goes to the background", () => {
+    const { result, rerender } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onNext();
+      result.current.onNext();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(2);
+
+    mockUseIsAppInBackground.mockReturnValue(true);
+    rerender({});
+
+    expect(result.current.currentVideoIndex).toBe(0);
+  });
+
+  it("should reset to the first story when the screen is re-focused", () => {
+    mockUseIsFocused.mockReturnValue(false);
+    const { result, rerender } = renderHook(() => useWelcomeStories());
+
+    act(() => {
+      result.current.onNext();
+      result.current.onNext();
+    });
+
+    expect(result.current.currentVideoIndex).toBe(2);
+
+    mockUseIsFocused.mockReturnValue(true);
+    rerender({});
+
+    expect(result.current.currentVideoIndex).toBe(0);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/hooks/useWelcomeStories.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/hooks/useWelcomeStories.ts
@@ -16,6 +16,7 @@ const welcomeVideos: { source: ReactVideoSource; id: string }[] = [
  */
 export function useWelcomeStories() {
   const [currentVideoIndex, setCurrentVideoIndex] = useState<number>(0);
+  const [currentStoryRestartKey, setCurrentStoryRestartKey] = useState<number>(0);
   const [durations, setDurations] = useState<number[]>(new Array(welcomeVideos.length).fill(0));
 
   const isAppActive = !useIsAppInBackground();
@@ -48,8 +49,13 @@ export function useWelcomeStories() {
   );
 
   const onPrevious = useCallback(() => {
-    setCurrentVideoIndex(index => (index - 1 + welcomeVideos.length) % welcomeVideos.length);
-  }, []);
+    if (currentVideoIndex > 0) {
+      setCurrentVideoIndex(currentVideoIndex - 1);
+      return;
+    }
+
+    setCurrentStoryRestartKey(restartKey => restartKey + 1);
+  }, [currentVideoIndex]);
 
   const onNext = useCallback(() => {
     setCurrentVideoIndex(index => (index + 1) % welcomeVideos.length);
@@ -65,6 +71,7 @@ export function useWelcomeStories() {
   return {
     welcomeVideos,
     currentVideoIndex,
+    currentStoryRestartKey,
     videoDurations: durationsWithId,
     onLoad,
     onPrevious,

--- a/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WelcomePage/index.tsx
@@ -21,8 +21,15 @@ export default function WelcomePage() {
 
   useMarkWalletV4TourSeenAtOnboardingStart();
 
-  const { welcomeVideos, currentVideoIndex, videoDurations, onLoad, onPrevious, onNext } =
-    useWelcomeStories();
+  const {
+    welcomeVideos,
+    currentVideoIndex,
+    currentStoryRestartKey,
+    videoDurations,
+    onLoad,
+    onPrevious,
+    onNext,
+  } = useWelcomeStories();
   const { onLogoTouchStart, onLogoTouchEnd } = useWelcomeNavigation();
 
   return (
@@ -35,6 +42,7 @@ export default function WelcomePage() {
               videoSource={source}
               titleKey={`onboarding.stepWelcome.videoTitles.${index}`}
               isOnStage={currentVideoIndex === index}
+              restartKey={currentVideoIndex === index ? currentStoryRestartKey : 0}
               key={`welcome-video-${id}`}
               onVideoEnd={onNext}
               onVideoLoad={onLoad(index)}
@@ -53,6 +61,7 @@ export default function WelcomePage() {
                 durationMs={durationMs}
                 isActivated={currentVideoIndex === index}
                 isCompleted={currentVideoIndex > index}
+                restartKey={currentVideoIndex === index ? currentStoryRestartKey : 0}
               />
             ))}
         </StoryProgressView>


### PR DESCRIPTION
## Summary

Fixes [LIVE-24300](https://ledgerhq.atlassian.net/browse/LIVE-24300): on the LWM Welcome page, tapping the left side of the first story no longer wraps to the last story.

**Before:** `onPrevious` used modulo arithmetic, so story 1 → story 3.

**After:** On the first story, left tap stays on story 1 and restarts the video + progress bar. From later stories, left tap still goes to the previous story as before.

## Changes

- **`useWelcomeStories`** — clamp `onPrevious` at index `0`; bump `currentStoryRestartKey` to signal a restart
- **`VideoBackground`** — seek to `0` when `restartKey` changes on the active story
- **`StoryProgressBar`** — restart progress animation when `restartKey` changes
- **`WelcomePage`** — wire `currentStoryRestartKey` into video and progress bar
- **Tests** — add `useWelcomeStories.test.ts` covering first-story restart and normal previous navigation

## Test plan

- [x] Unit tests: `pnpm test:jest src/mvvm/features/WelcomePage/hooks/__tests__/useWelcomeStories.test.ts --watchman=false`
- [ ] Manual: open Welcome page → tap left on story 1 → stays on story 1, video/progress restart (does not jump to story 3)
- [ ] Manual: advance to story 2 → tap left → returns to story 1

[LIVE-24300]: https://ledgerhq.atlassian.net/browse/LIVE-24300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ