### PR TITLE
fix(lwd): hide sidebar on Recover and Perps fullscreen routes (LIVE-27044)

### DIFF
--- a/.changeset/calm-sidebar-hide-recover.md
+++ b/.changeset/calm-sidebar-hide-recover.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Hide sidebar on Recover and Perps fullscreen webview routes

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/__tests__/utils.test.ts
@@ -1,6 +1,26 @@
-import { isWallet40Page, shouldDisplayRightPanel } from "../utils";
+import { isFullscreenOverlayRoute, isWallet40Page, shouldDisplayRightPanel } from "../utils";
 
 describe("Page utils", () => {
+  describe("isFullscreenOverlayRoute", () => {
+    it("returns true for Recover player routes matching /recover/:appId", () => {
+      expect(isFullscreenOverlayRoute("/recover/protect-prod")).toBe(true);
+    });
+
+    it("returns true for Perps webview routes matching /perps prefix", () => {
+      expect(isFullscreenOverlayRoute("/perps")).toBe(true);
+      expect(isFullscreenOverlayRoute("/perps/market")).toBe(true);
+    });
+
+    it("returns false for standard app routes", () => {
+      expect(isFullscreenOverlayRoute("/")).toBe(false);
+      expect(isFullscreenOverlayRoute("/accounts")).toBe(false);
+      expect(isFullscreenOverlayRoute("/recover-restore")).toBe(false);
+      expect(isFullscreenOverlayRoute("/recover")).toBe(false);
+      expect(isFullscreenOverlayRoute("/recover/")).toBe(false);
+      expect(isFullscreenOverlayRoute("/perps-extra")).toBe(false);
+    });
+  });
+
   describe("isWallet40Page", () => {
     it("returns true for each wallet 4.0 exact-match route", () => {
       expect(isWallet40Page("/")).toBe(true);

--- a/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/Page/utils.ts
@@ -64,6 +64,21 @@ export const isWallet40Page = (pathname: string, options: IsWallet40PageOptions 
 };
 
 // =============================================================================
+// Fullscreen overlay routes (Recover, Perps webviews)
+// =============================================================================
+
+const isRecoverPlayerRoute = (pathname: string): boolean => /^\/recover\/[^/]+$/.test(pathname);
+
+const isPerpsWebviewRoute = (pathname: string): boolean =>
+  pathname === "/perps" || pathname.startsWith("/perps/");
+
+/**
+ * Routes that render a fullscreen webview overlay and should not show the main app shell.
+ */
+export const isFullscreenOverlayRoute = (pathname: string): boolean =>
+  isRecoverPlayerRoute(pathname) || isPerpsWebviewRoute(pathname);
+
+// =============================================================================
 // Right panel (swap sidebar)
 // =============================================================================
 

--- a/apps/ledger-live-desktop/src/renderer/Default.tsx
+++ b/apps/ledger-live-desktop/src/renderer/Default.tsx
@@ -25,7 +25,7 @@ import DebugUpdater from "~/renderer/components/debug/DebugUpdater";
 import DebugFirmwareUpdater from "~/renderer/components/debug/DebugFirmwareUpdater";
 import Page from "LLD/components/Page";
 import NightlyLayer from "LLD/components/NightlyLayer";
-import { isWallet40Page } from "LLD/components/Page/utils";
+import { isFullscreenOverlayRoute, isWallet40Page } from "LLD/components/Page/utils";
 import AnalyticsConsole from "~/renderer/components/AnalyticsConsole";
 import ThemeConsole from "~/renderer/components/ThemeConsole";
 import DebugMock from "~/renderer/components/debug/DebugMock";
@@ -203,84 +203,99 @@ const RecoverPlayerWithFeatureToggle = () => {
 };
 
 // Shared content for the main app layout
-const MainAppContent = ({
-  shouldDisplayAssetSection,
-  shouldDisplayAggregatedAssets,
-}: {
+type MainAppContentProps = Readonly<{
   shouldDisplayAssetSection: boolean;
   shouldDisplayAggregatedAssets: boolean;
-}) => (
-  <>
-    <Routes>
-      <Route path="/recover/:appId" element={<RecoverPlayerWithFeatureToggle />} />
-      <Route path="/perps/*" element={withFullscreenSuspense(Perps)({})} />
-    </Routes>
-    <SideBar />
+}>;
 
-    <Page>
-      <TopBannerContainer>
-        <VaultSignerBanner />
-      </TopBannerContainer>
+function MainAppContent({
+  shouldDisplayAssetSection,
+  shouldDisplayAggregatedAssets,
+}: MainAppContentProps) {
+  const { pathname } = useLocation();
+  const hideMainShell = isFullscreenOverlayRoute(pathname);
+
+  return (
+    <>
       <Routes>
-        <Route path="/" element={withSuspense(PortfolioPage)({})} />
-        <Route path="/settings/*" element={withSuspense(Settings)({})} />
-        <Route path="/devtools" element={withSuspense(DevToolsScreen)({})} />
-        <Route path="/accounts" element={withSuspense(Accounts)({})} />
-        <Route
-          path="/cryptos"
-          element={
-            shouldDisplayAssetSection ? (
-              withSuspense(CryptoAddresses)({})
-            ) : (
-              <Navigate to="/accounts" replace />
-            )
-          }
-        />
-        <Route
-          path="/assets"
-          element={
-            shouldDisplayAssetSection ? (
-              withSuspense(CryptoAssets)({})
-            ) : (
-              <Navigate to="/accounts" replace />
-            )
-          }
-        />
-        <Route path="/card-new-wallet" element={withSuspense(CardW40)({})} />
-        <Route path="/card/:appId?" element={withSuspense(Card)({})} />
-        <Route path="/paytab" element={withSuspense(PayTab)({})} />
-        <Route path="/manager/reload" element={<Navigate to="/manager" replace />} />
-        <Route path="/manager/*" element={withSuspense(Manager)({})} />
-        <Route path="/platform" element={withSuspense(PlatformCatalog)({})} />
-        <Route path="/platform/:appId" element={<LiveApp />} />
-        <Route path="/earn/*" element={withSuspense(Earn)({})} />
-        <Route path="/borrow/*" element={withSuspense(Borrow)({})} />
-        <Route path="/exchange/:appId?" element={withSuspense(Exchange)({})} />
-        <Route path="/swap-web" element={withSuspense(SwapWeb)({})} />
-        <Route path="/account/:parentId/:id/*" element={withSuspense(Account)({})} />
-        <Route path="/account/:id/*" element={withSuspense(Account)({})} />
-        <Route
-          path="/asset/*"
-          element={withSuspense(shouldDisplayAggregatedAssets ? AssetDetails : Asset)({})}
-        />
-        <Route path="/swap/*" element={withSuspense(Swap2)({})} />
-        <Route
-          path="/market/:currencyId"
-          element={
-            shouldDisplayAggregatedAssets ? <RedirectMarketToAsset /> : withSuspense(MarketCoin)({})
-          }
-        />
-        <Route path="/market" element={withSuspense(Market)({})} />
-        <Route path="/bank/*" element={withSuspense(Bank)({})} />
-        <Route path="/analytics" element={withSuspense(Analytics)({})} />
-        <Route path="/history" element={withSuspense(History)({})} />
-        <Route path="/contacts" element={withSuspense(Contacts)({})} />
+        <Route path="/recover/:appId" element={<RecoverPlayerWithFeatureToggle />} />
+        <Route path="/perps/*" element={withFullscreenSuspense(Perps)({})} />
       </Routes>
-    </Page>
-    <Drawer />
-    <ToastOverlay />
-  </>
-);
+      {!hideMainShell && (
+        <>
+          <SideBar />
+
+          <Page>
+            <TopBannerContainer>
+              <VaultSignerBanner />
+            </TopBannerContainer>
+            <Routes>
+              <Route path="/" element={withSuspense(PortfolioPage)({})} />
+              <Route path="/settings/*" element={withSuspense(Settings)({})} />
+              <Route path="/devtools" element={withSuspense(DevToolsScreen)({})} />
+              <Route path="/accounts" element={withSuspense(Accounts)({})} />
+              <Route
+                path="/cryptos"
+                element={
+                  shouldDisplayAssetSection ? (
+                    withSuspense(CryptoAddresses)({})
+                  ) : (
+                    <Navigate to="/accounts" replace />
+                  )
+                }
+              />
+              <Route
+                path="/assets"
+                element={
+                  shouldDisplayAssetSection ? (
+                    withSuspense(CryptoAssets)({})
+                  ) : (
+                    <Navigate to="/accounts" replace />
+                  )
+                }
+              />
+              <Route path="/card-new-wallet" element={withSuspense(CardW40)({})} />
+              <Route path="/card/:appId?" element={withSuspense(Card)({})} />
+              <Route path="/paytab" element={withSuspense(PayTab)({})} />
+              <Route path="/manager/reload" element={<Navigate to="/manager" replace />} />
+              <Route path="/manager/*" element={withSuspense(Manager)({})} />
+              <Route path="/platform" element={withSuspense(PlatformCatalog)({})} />
+              <Route path="/platform/:appId" element={<LiveApp />} />
+              <Route path="/earn/*" element={withSuspense(Earn)({})} />
+              <Route path="/borrow/*" element={withSuspense(Borrow)({})} />
+              <Route path="/exchange/:appId?" element={withSuspense(Exchange)({})} />
+              <Route path="/swap-web" element={withSuspense(SwapWeb)({})} />
+              <Route path="/account/:parentId/:id/*" element={withSuspense(Account)({})} />
+              <Route path="/account/:id/*" element={withSuspense(Account)({})} />
+              <Route
+                path="/asset/*"
+                element={withSuspense(shouldDisplayAggregatedAssets ? AssetDetails : Asset)({})}
+              />
+              <Route path="/swap/*" element={withSuspense(Swap2)({})} />
+              <Route
+                path="/market/:currencyId"
+                element={
+                  shouldDisplayAggregatedAssets ? (
+                    <RedirectMarketToAsset />
+                  ) : (
+                    withSuspense(MarketCoin)({})
+                  )
+                }
+              />
+              <Route path="/market" element={withSuspense(Market)({})} />
+              <Route path="/bank/*" element={withSuspense(Bank)({})} />
+              <Route path="/analytics" element={withSuspense(Analytics)({})} />
+              <Route path="/history" element={withSuspense(History)({})} />
+              <Route path="/contacts" element={withSuspense(Contacts)({})} />
+            </Routes>
+          </Page>
+          <Drawer />
+          <ToastOverlay />
+        </>
+      )}
+    </>
+  );
+}
 
 // Main app layout component that handles the main navigation after onboarding (exported for testing)
 export const MainAppLayout = () => {


### PR DESCRIPTION
## Summary

Fixes [LIVE-27044](https://ledgerhq.atlassian.net/browse/LIVE-27044): after sync onboarding completes, the sidebar no longer flashes in the wrong position while the Recover upsell webview loads.

**Before:** Post-onboarding redirect to `/recover/...` entered `MainAppLayout`, which always rendered `SideBar` + `Page` alongside the fullscreen Recover overlay — causing a visible sidebar flash and layout glitch during lazy load (~13s in QA recordings).

**After:** Recover and Perps fullscreen routes hide the main app shell (`SideBar`, `Page`, `Drawer`, `ToastOverlay`), matching the pre-onboarding Recover behavior.

Follow-up to [LIVE-31929](https://ledgerhq.atlassian.net/browse/LIVE-31929), which fixed fullscreen loader positioning but left the sidebar visible underneath.

## Changes

- **`Page/utils.ts`** — add `isFullscreenOverlayRoute()` for `/recover/*` and `/perps/*`
- **`Default.tsx`** — skip main app shell in `MainAppContent` on fullscreen overlay routes
- **`utils.test.ts`** — unit tests for route detection

## Test plan

- [x] Unit tests: `pnpm desktop test:jest src/mvvm/components/Page/__tests__/utils.test.ts`
- [ ] Manual: complete sync onboarding on Recover-eligible device → no sidebar flash before Recover upsell
- [ ] Manual: open `/recover/...` from main app → still fullscreen, no sidebar
- [ ] Manual: open `/perps/*` → still fullscreen, no sidebar
- [ ] Regression: portfolio and other main routes still show sidebar normally

[LIVE-27044]: https://ledgerhq.atlassian.net/browse/LIVE-27044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-31929]: https://ledgerhq.atlassian.net/browse/LIVE-31929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ