### PR TITLE
chore(LIVE-32915): convert LWF error classes from createCustomErrorClass to native extends Error

### DIFF
--- a/.changeset/LIVE-32915-tier0-lwf-native-errors.md
+++ b/.changeset/LIVE-32915-tier0-lwf-native-errors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-wallet-framework": patch
+---
+
+Convert internal error classes from createCustomErrorClass to native extends Error.

--- a/libs/ledger-wallet-framework/src/errors.ts
+++ b/libs/ledger-wallet-framework/src/errors.ts
@@ -1,3 +1,7 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const UnsupportedDerivation = createCustomErrorClass("UnsupportedDerivation");
+export class UnsupportedDerivation extends Error {
+  override name = "UnsupportedDerivation";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "UnsupportedDerivation", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledger-wallet-framework/src/sanction/errors.ts
+++ b/libs/ledger-wallet-framework/src/sanction/errors.ts
@@ -1,5 +1,9 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const AddressesSanctionedError = createCustomErrorClass<{
+export class AddressesSanctionedError extends Error {
+  override name = "AddressesSanctionedError";
   addresses: string[];
-}>("AddressesSanctionedError");
+  constructor(message?: string, fields?: { addresses: string[] }, options?: ErrorOptions) {
+    super(message || "AddressesSanctionedError", options);
+    this.addresses = fields?.addresses ?? [];
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
### 📝 Description

Converts `@ledgerhq/ledger-wallet-framework` error classes from the legacy `createCustomErrorClass` factory to native `extends Error`:

- `libs/ledger-wallet-framework/src/errors.ts` — `UnsupportedDerivation`
- `libs/ledger-wallet-framework/src/sanction/errors.ts` — `AddressesSanctionedError`

No callsite changes — consumers already import from LWF paths.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-32915
- **ADR** (if any): —

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35086