### PR TITLE
[LWDM] chore(LIVE-32915): move network error classes to live-network as native extends Error

### DIFF
--- a/.changeset/LIVE-32915-tier2a-live-network-errors.md
+++ b/.changeset/LIVE-32915-tier2a-live-network-errors.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/live-network": minor
+"@ledgerhq/live-network": major
 ---
 
 Define `LedgerAPI4xx`, `LedgerAPI5xx`, and `NetworkDown` as native error classes in `@ledgerhq/live-network` instead of importing them from `@ledgerhq/errors`. All three are now exported from the package's public index for downstream migrations.

--- a/.changeset/LIVE-32915-tier2a-live-network-errors.md
+++ b/.changeset/LIVE-32915-tier2a-live-network-errors.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-network": minor
+---
+
+Define `LedgerAPI4xx`, `LedgerAPI5xx`, and `NetworkDown` as native error classes in `@ledgerhq/live-network` instead of importing them from `@ledgerhq/errors`. All three are now exported from the package's public index for downstream migrations.

--- a/libs/live-network/package.json
+++ b/libs/live-network/package.json
@@ -67,7 +67,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/live-promise": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "lru-cache": "^7.14.1"

--- a/libs/live-network/src/errors.test.ts
+++ b/libs/live-network/src/errors.test.ts
@@ -1,0 +1,47 @@
+import { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "./errors";
+
+describe("live-network error classes", () => {
+  describe("LedgerAPI4xx", () => {
+    it("sets name and message", () => {
+      const e = new LedgerAPI4xx("Not Found");
+      expect(e.name).toBe("LedgerAPI4xx");
+      expect(e.message).toBe("Not Found");
+      expect(e).toBeInstanceOf(Error);
+    });
+    it("falls back to class name when no message given", () => {
+      expect(new LedgerAPI4xx().message).toBe("LedgerAPI4xx");
+    });
+    it("assigns extra fields", () => {
+      const e = new LedgerAPI4xx("err", { status: 404 });
+      expect((e as Record<string, unknown>).status).toBe(404);
+    });
+  });
+
+  describe("LedgerAPI5xx", () => {
+    it("sets name and message", () => {
+      const e = new LedgerAPI5xx("Server Error");
+      expect(e.name).toBe("LedgerAPI5xx");
+      expect(e.message).toBe("Server Error");
+      expect(e).toBeInstanceOf(Error);
+    });
+    it("falls back to class name when no message given", () => {
+      expect(new LedgerAPI5xx().message).toBe("LedgerAPI5xx");
+    });
+    it("assigns extra fields", () => {
+      const e = new LedgerAPI5xx("err", { status: 503 });
+      expect((e as Record<string, unknown>).status).toBe(503);
+    });
+  });
+
+  describe("NetworkDown", () => {
+    it("sets name", () => {
+      const e = new NetworkDown();
+      expect(e.name).toBe("NetworkDown");
+      expect(e.message).toBe("NetworkDown");
+      expect(e).toBeInstanceOf(Error);
+    });
+    it("accepts a custom message", () => {
+      expect(new NetworkDown("timeout").message).toBe("timeout");
+    });
+  });
+});

--- a/libs/live-network/src/errors.ts
+++ b/libs/live-network/src/errors.ts
@@ -1,23 +1,23 @@
 export class LedgerAPI4xx extends Error {
   override name = "LedgerAPI4xx";
-  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "LedgerAPI4xx", options);
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerAPI4xx");
     if (fields) Object.assign(this, fields);
   }
 }
 
 export class LedgerAPI5xx extends Error {
   override name = "LedgerAPI5xx";
-  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "LedgerAPI5xx", options);
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerAPI5xx");
     if (fields) Object.assign(this, fields);
   }
 }
 
 export class NetworkDown extends Error {
   override name = "NetworkDown";
-  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "NetworkDown", options);
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NetworkDown");
     if (fields) Object.assign(this, fields);
   }
 }

--- a/libs/live-network/src/errors.ts
+++ b/libs/live-network/src/errors.ts
@@ -1,0 +1,23 @@
+export class LedgerAPI4xx extends Error {
+  override name = "LedgerAPI4xx";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "LedgerAPI4xx", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LedgerAPI5xx extends Error {
+  override name = "LedgerAPI5xx";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "LedgerAPI5xx", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NetworkDown extends Error {
+  override name = "NetworkDown";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NetworkDown", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/live-network/src/index.ts
+++ b/libs/live-network/src/index.ts
@@ -2,4 +2,5 @@ import { newImplementation } from "./network";
 export { setNetworkState } from "./network";
 export { getNetworkState } from "./state";
 export type { NetworkState } from "./network";
+export { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "./errors";
 export default newImplementation;

--- a/libs/live-network/src/network.ts
+++ b/libs/live-network/src/network.ts
@@ -5,7 +5,7 @@ import axios, {
   type AxiosError,
   type AxiosRequestConfig,
 } from "axios";
-import { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "@ledgerhq/errors";
+import { LedgerAPI4xx, LedgerAPI5xx, NetworkDown } from "./errors";
 import { getNetworkState } from "./state";
 import type { NetworkState } from "./state";
 import { retry } from "@ledgerhq/live-promise";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12048,9 +12048,6 @@ importers:
 
   libs/live-network:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/live-promise':
         specifier: workspace:^
         version: link:../promise


### PR DESCRIPTION
### 📝 Description

Moves `LedgerAPI4xx`, `LedgerAPI5xx`, and `NetworkDown` out of `@ledgerhq/errors` and into `@ledgerhq/live-network` as native `extends Error` classes.

- Creates `libs/live-network/src/errors.ts` with the three native classes
- Updates `libs/live-network/src/network.ts` to import from local errors.ts
- Re-exports all three from `libs/live-network/src/index.ts` for downstream consumers
- Removes `@ledgerhq/errors` dep from `libs/live-network/package.json`
- Updates `pnpm-lock.yaml`

Downstream packages that import these errors directly from `@ledgerhq/errors` are migrated in follow-up PRs.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-32915
- **ADR** (if any): —

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35087