### PR TITLE
[LWDM] chore(coin-modules): convert coin module error classes to native ES6 (LIVE-32915)

### DIFF
--- a/.changeset/LIVE-32915-tier1b-coin-native-errors.md
+++ b/.changeset/LIVE-32915-tier1b-coin-native-errors.md
@@ -1,0 +1,18 @@
+---
+"@ledgerhq/coin-internet_computer": patch
+"@ledgerhq/coin-kaspa": patch
+"@ledgerhq/coin-mina": patch
+"@ledgerhq/coin-module-boilerplate": patch
+"@ledgerhq/coin-multiversx": patch
+"@ledgerhq/coin-near": patch
+"@ledgerhq/coin-polkadot": patch
+"@ledgerhq/coin-solana": patch
+"@ledgerhq/coin-stacks": patch
+"@ledgerhq/coin-sui": patch
+"@ledgerhq/coin-tezos": patch
+"@ledgerhq/coin-ton": patch
+"@ledgerhq/coin-tron": patch
+"@ledgerhq/coin-vechain": patch
+---
+
+Convert coin module errors from createCustomErrorClass to native ES6 classes as part of the @ledgerhq/errors sunset (LIVE-32915).

--- a/libs/coin-modules/coin-internet_computer/src/errors.ts
+++ b/libs/coin-modules/coin-internet_computer/src/errors.ts
@@ -1,6 +1,10 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * When the transferID/Memo is non number
  */
-export const InvalidMemoICP = createCustomErrorClass("InvalidMemoICP");
+export class InvalidMemoICP extends Error {
+  override name = "InvalidMemoICP";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidMemoICP");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-kaspa/src/errors.ts
+++ b/libs/coin-modules/coin-kaspa/src/errors.ts
@@ -1,6 +1,16 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const UnsupportedDerivation = createCustomErrorClass("UnsupportedDerivation");
+export class UnsupportedDerivation extends Error {
+  override name = "UnsupportedDerivation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedDerivation");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /** When a coin-module has no CoinConfig setted */
-export const MissingCoinConfig = createCustomErrorClass("MissingCoinConfig");
+export class MissingCoinConfig extends Error {
+  override name = "MissingCoinConfig";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MissingCoinConfig");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-kaspa/src/types/errors.ts
+++ b/libs/coin-modules/coin-kaspa/src/types/errors.ts
@@ -1,7 +1,39 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class NotEnoughFeeError extends Error {
+  override name = "NotEnoughFeeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughFeeError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const NotEnoughFeeError = createCustomErrorClass("NotEnoughFeeError");
-export const TransactionMassExceededError = createCustomErrorClass("TransactionMassExceededError");
-export const EmptyRecipientError = createCustomErrorClass("EmptyRecipientError");
-export const ReducedAmountUtxoWarning = createCustomErrorClass("ReducedAmountUtxoWarning");
-export const UtxoLimitReachedError = createCustomErrorClass("UtxoLimitReachedError");
+export class TransactionMassExceededError extends Error {
+  override name = "TransactionMassExceededError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TransactionMassExceededError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class EmptyRecipientError extends Error {
+  override name = "EmptyRecipientError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "EmptyRecipientError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ReducedAmountUtxoWarning extends Error {
+  override name = "ReducedAmountUtxoWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ReducedAmountUtxoWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UtxoLimitReachedError extends Error {
+  override name = "UtxoLimitReachedError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UtxoLimitReachedError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-mina/src/types/errors.ts
+++ b/libs/coin-modules/coin-mina/src/types/errors.ts
@@ -1,16 +1,32 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * When the memo is greater than 32 characters
  */
-export const InvalidMemoMina = createCustomErrorClass("InvalidMemoMina");
+export class InvalidMemoMina extends Error {
+  override name = "InvalidMemoMina";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidMemoMina");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the user sends less than the account creation fee of 1 MINA
  */
-export const AccountCreationFeeWarning = createCustomErrorClass("AccountCreationFeeWarning");
+export class AccountCreationFeeWarning extends Error {
+  override name = "AccountCreationFeeWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AccountCreationFeeWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the amount is less than the account creation fee of 1 MINA
  */
-export const AmountTooSmall = createCustomErrorClass("AmountTooSmall");
+export class AmountTooSmall extends Error {
+  override name = "AmountTooSmall";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AmountTooSmall");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-module-boilerplate/src/types/errors.ts
+++ b/libs/coin-modules/coin-module-boilerplate/src/types/errors.ts
@@ -1,3 +1,7 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const SimulationError = createCustomErrorClass("SimulationError");
+export class SimulationError extends Error {
+  override name = "SimulationError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SimulationError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-multiversx/src/errors.ts
+++ b/libs/coin-modules/coin-multiversx/src/errors.ts
@@ -1,19 +1,39 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class MultiversXDecimalsLimitReached extends Error {
+  override name = "MultiversXDecimalsLimitReached";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MultiversXDecimalsLimitReached");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const MultiversXDecimalsLimitReached = createCustomErrorClass(
-  "MultiversXDecimalsLimitReached",
-);
+export class MultiversXMinDelegatedAmountError extends Error {
+  override name = "MultiversXMinDelegatedAmountError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MultiversXMinDelegatedAmountError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const MultiversXMinDelegatedAmountError = createCustomErrorClass(
-  "MultiversXMinDelegatedAmountError",
-);
+export class MultiversXMinUndelegatedAmountError extends Error {
+  override name = "MultiversXMinUndelegatedAmountError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MultiversXMinUndelegatedAmountError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const MultiversXMinUndelegatedAmountError = createCustomErrorClass(
-  "MultiversXMinUndelegatedAmountError",
-);
+export class MultiversXDelegationBelowMinimumError extends Error {
+  override name = "MultiversXDelegationBelowMinimumError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MultiversXDelegationBelowMinimumError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const MultiversXDelegationBelowMinimumError = createCustomErrorClass(
-  "MultiversXDelegationBelowMinimumError",
-);
-
-export const NotEnoughEGLDForFees = createCustomErrorClass("NotEnoughEGLDForFees");
+export class NotEnoughEGLDForFees extends Error {
+  override name = "NotEnoughEGLDForFees";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughEGLDForFees");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-near/src/errors.ts
+++ b/libs/coin-modules/coin-near/src/errors.ts
@@ -1,46 +1,98 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * When the recipient is a new account.
  */
-export const NearNewAccountWarning = createCustomErrorClass("NearNewAccountWarning");
+export class NearNewAccountWarning extends Error {
+  override name = "NearNewAccountWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearNewAccountWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the recipient is a new named account, and needs to be created first.
  */
-export const NearNewNamedAccountError = createCustomErrorClass("NearNewNamedAccountError");
+export class NearNewNamedAccountError extends Error {
+  override name = "NearNewNamedAccountError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearNewNamedAccountError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the recipient is a new account, and the amount doesn't cover the activation fee.
  */
-export const NearActivationFeeNotCovered = createCustomErrorClass("NearActivationFeeNotCovered");
+export class NearActivationFeeNotCovered extends Error {
+  override name = "NearActivationFeeNotCovered";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearActivationFeeNotCovered");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the protocol config can not be loaded.
  */
-export const NearProtocolConfigNotLoaded = createCustomErrorClass("NearProtocolConfigNotLoaded");
+export class NearProtocolConfigNotLoaded extends Error {
+  override name = "NearProtocolConfigNotLoaded";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearProtocolConfigNotLoaded");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When an entire account balance is being staked.
  */
-export const NearUseAllAmountStakeWarning = createCustomErrorClass("NearUseAllAmountStakeWarning");
+export class NearUseAllAmountStakeWarning extends Error {
+  override name = "NearUseAllAmountStakeWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearUseAllAmountStakeWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When trying to unstake more than is staked.
  */
-export const NearNotEnoughStaked = createCustomErrorClass("NearNotEnoughStaked");
+export class NearNotEnoughStaked extends Error {
+  override name = "NearNotEnoughStaked";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearNotEnoughStaked");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When trying to withdraw more than is available.
  */
-export const NearNotEnoughAvailable = createCustomErrorClass("NearNotEnoughAvailable");
+export class NearNotEnoughAvailable extends Error {
+  override name = "NearNotEnoughAvailable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearNotEnoughAvailable");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When sending max while there are existing staking positions.
  */
-export const NearRecommendUnstake = createCustomErrorClass("NearRecommendUnstake");
+export class NearRecommendUnstake extends Error {
+  override name = "NearRecommendUnstake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearRecommendUnstake");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When trying to stake, unstake, or withdraw less than the threshold.
  */
-export const NearStakingThresholdNotMet = createCustomErrorClass("NearStakingThresholdNotMet");
+export class NearStakingThresholdNotMet extends Error {
+  override name = "NearStakingThresholdNotMet";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NearStakingThresholdNotMet");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-polkadot/src/types/errors.ts
+++ b/libs/coin-modules/coin-polkadot/src/types/errors.ts
@@ -1,18 +1,87 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-export const PolkadotUnauthorizedOperation = createCustomErrorClass(
-  "PolkadotUnauthorizedOperation",
-);
-export const PolkadotElectionClosed = createCustomErrorClass("PolkadotElectionClosed");
-export const PolkadotNotValidator = createCustomErrorClass("PolkadotNotValidator");
-export const PolkadotLowBondedBalance = createCustomErrorClass("PolkadotLowBondedBalance");
-export const PolkadotNoUnlockedBalance = createCustomErrorClass("PolkadotNoUnlockedBalance");
-export const PolkadotNoNominations = createCustomErrorClass("PolkadotNoNominations");
-export const PolkadotAllFundsWarning = createCustomErrorClass("PolkadotAllFundsWarning");
-export const PolkadotBondMinimumAmount = createCustomErrorClass("PolkadotBondMinimumAmount");
+export class PolkadotUnauthorizedOperation extends Error {
+  override name = "PolkadotUnauthorizedOperation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotUnauthorizedOperation");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const PolkadotBondMinimumAmountWarning = createCustomErrorClass(
-  "PolkadotBondMinimumAmountWarning",
-);
+export class PolkadotElectionClosed extends Error {
+  override name = "PolkadotElectionClosed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotElectionClosed");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const PolkadotMaxUnbonding = createCustomErrorClass("PolkadotMaxUnbonding");
-export const PolkadotValidatorsRequired = createCustomErrorClass("PolkadotValidatorsRequired");
+export class PolkadotNotValidator extends Error {
+  override name = "PolkadotNotValidator";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotNotValidator");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotLowBondedBalance extends Error {
+  override name = "PolkadotLowBondedBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotLowBondedBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotNoUnlockedBalance extends Error {
+  override name = "PolkadotNoUnlockedBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotNoUnlockedBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotNoNominations extends Error {
+  override name = "PolkadotNoNominations";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotNoNominations");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotAllFundsWarning extends Error {
+  override name = "PolkadotAllFundsWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotAllFundsWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotBondMinimumAmount extends Error {
+  override name = "PolkadotBondMinimumAmount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotBondMinimumAmount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotBondMinimumAmountWarning extends Error {
+  override name = "PolkadotBondMinimumAmountWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotBondMinimumAmountWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotMaxUnbonding extends Error {
+  override name = "PolkadotMaxUnbonding";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotMaxUnbonding");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PolkadotValidatorsRequired extends Error {
+  override name = "PolkadotValidatorsRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PolkadotValidatorsRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/src/errors.ts
+++ b/libs/coin-modules/coin-solana/src/errors.ts
@@ -1,83 +1,223 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class SolanaAccountNotFunded extends Error {
+  override name = "SolanaAccountNotFunded";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaAccountNotFunded");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaAccountNotFunded = createCustomErrorClass("SolanaAccountNotFunded");
+export class SolanaRecipientAccountNotFunded extends Error {
+  override name = "SolanaRecipientAccountNotFunded";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaRecipientAccountNotFunded");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaRecipientAccountNotFunded = createCustomErrorClass(
-  "SolanaRecipientAccountNotFunded",
-);
+export class SolanaRecipientAssociatedTokenAccountWillBeFunded extends Error {
+  override name = "SolanaAssociatedTokenAccountWillBeFunded";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaAssociatedTokenAccountWillBeFunded");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaRecipientAssociatedTokenAccountWillBeFunded = createCustomErrorClass(
-  "SolanaAssociatedTokenAccountWillBeFunded",
-);
+export class SolanaMemoIsTooLong extends Error {
+  override name = "SolanaMemoIsTooLong";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaMemoIsTooLong");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaMemoIsTooLong = createCustomErrorClass("SolanaMemoIsTooLong");
+export class SolanaTokenAccountHoldsAnotherToken extends Error {
+  override name = "SolanaTokenAccountHoldsAnotherToken";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenAccountHoldsAnotherToken");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenAccountHoldsAnotherToken = createCustomErrorClass(
-  "SolanaTokenAccountHoldsAnotherToken",
-);
+export class SolanaTokenAccountWarning extends Error {
+  override name = "SolanaTokenAccountWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenAccountWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenAccountWarning = createCustomErrorClass("SolanaTokenAccountWarning");
+export class SolanaTokenAccountNotAllowed extends Error {
+  override name = "SolanaTokenAccountNotAllowed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenAccountNotAllowed");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenAccountNotAllowed = createCustomErrorClass("SolanaTokenAccountNotAllowed");
+export class SolanaMintAccountNotAllowed extends Error {
+  override name = "SolanaMintAccountNotAllowed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaMintAccountNotAllowed");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaMintAccountNotAllowed = createCustomErrorClass("SolanaMintAccountNotAllowed");
+export class SolanaTokenAccounNotInitialized extends Error {
+  override name = "SolanaTokenAccounNotInitialized";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenAccounNotInitialized");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenAccounNotInitialized = createCustomErrorClass(
-  "SolanaTokenAccounNotInitialized",
-);
+export class SolanaTokenAccountFrozen extends Error {
+  override name = "SolanaTokenAccountFrozen";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenAccountFrozen");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenAccountFrozen = createCustomErrorClass("SolanaTokenAccountFrozen");
+export class SolanaAddressOffEd25519 extends Error {
+  override name = "SolanaAddressOfEd25519";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaAddressOfEd25519");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaAddressOffEd25519 = createCustomErrorClass("SolanaAddressOfEd25519");
+export class SolanaTokenRecipientIsSenderATA extends Error {
+  override name = "SolanaTokenRecipientIsSenderATA";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenRecipientIsSenderATA");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTokenRecipientIsSenderATA = createCustomErrorClass(
-  "SolanaTokenRecipientIsSenderATA",
-);
+export class SolanaValidatorRequired extends Error {
+  override name = "SolanaValidatorRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaValidatorRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaValidatorRequired = createCustomErrorClass("SolanaValidatorRequired");
+export class SolanaInvalidValidator extends Error {
+  override name = "SolanaInvalidValidator";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaInvalidValidator");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaInvalidValidator = createCustomErrorClass("SolanaInvalidValidator");
+export class SolanaStakeAccountRequired extends Error {
+  override name = "SolanaStakeAccountRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountRequired = createCustomErrorClass("SolanaStakeAccountRequired");
+export class SolanaStakeAccountNotFound extends Error {
+  override name = "SolanaStakeAccountNotFound";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountNotFound");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountNotFound = createCustomErrorClass("SolanaStakeAccountNotFound");
+export class SolanaStakeAccountNothingToWithdraw extends Error {
+  override name = "SolanaStakeAccountNothingToWithdraw";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountNothingToWithdraw");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountNothingToWithdraw = createCustomErrorClass(
-  "SolanaStakeAccountNothingToWithdraw",
-);
+export class SolanaStakeAccountIsNotDelegatable extends Error {
+  override name = "SolanaStakeAccountIsNotDelegatable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountIsNotDelegatable");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountIsNotDelegatable = createCustomErrorClass(
-  "SolanaStakeAccountIsNotDelegatable",
-);
+export class SolanaStakeAccountIsNotUndelegatable extends Error {
+  override name = "SolanaStakeAccountIsNotUndelegatable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountIsNotUndelegatable");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountIsNotUndelegatable = createCustomErrorClass(
-  "SolanaStakeAccountIsNotUndelegatable",
-);
+export class SolanaStakeAccountValidatorIsUnchangeable extends Error {
+  override name = "SolanaStakeAccountValidatorIsUnchangeable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountValidatorIsUnchangeable");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountValidatorIsUnchangeable = createCustomErrorClass(
-  "SolanaStakeAccountValidatorIsUnchangeable",
-);
+export class SolanaStakeAccountAmountTooLow extends Error {
+  override name = "SolanaStakeAccountAmountTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeAccountAmountTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeAccountAmountTooLow = createCustomErrorClass(
-  "SolanaStakeAccountAmountTooLow",
-);
+export class SolanaStakeNoWithdrawAuth extends Error {
+  override name = "SolanaStakeNoWithdrawAuth";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeNoWithdrawAuth");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeNoWithdrawAuth = createCustomErrorClass("SolanaStakeNoWithdrawAuth");
+export class SolanaStakeNoStakeAuth extends Error {
+  override name = "SolanaStakeNoStakeAuth";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaStakeNoStakeAuth");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaStakeNoStakeAuth = createCustomErrorClass("SolanaStakeNoStakeAuth");
+export class SolanaUseAllAmountStakeWarning extends Error {
+  override name = "SolanaUseAllAmountStakeWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaUseAllAmountStakeWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaUseAllAmountStakeWarning = createCustomErrorClass(
-  "SolanaUseAllAmountStakeWarning",
-);
+export class SolanaTxSimulationFailedWhilePendingOp extends Error {
+  override name = "SolanaTxSimulationFailedWhilePendingOp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTxSimulationFailedWhilePendingOp");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTxSimulationFailedWhilePendingOp = createCustomErrorClass(
-  "SolanaTxSimulationFailedWhilePendingOp",
-);
+export class SolanaTxConfirmationTimeout extends Error {
+  override name = "SolanaTxConfirmationTimeout";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTxConfirmationTimeout");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaTxConfirmationTimeout = createCustomErrorClass("SolanaTxConfirmationTimeout");
+export class SolanaRecipientMemoIsRequired extends Error {
+  override name = "SolanaRecipientMemoIsRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaRecipientMemoIsRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SolanaRecipientMemoIsRequired = createCustomErrorClass(
-  "SolanaRecipientMemoIsRequired",
-);
-
-export const SolanaTokenNonTransferable = createCustomErrorClass("SolanaTokenNonTransferable");
+export class SolanaTokenNonTransferable extends Error {
+  override name = "SolanaTokenNonTransferable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SolanaTokenNonTransferable");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-stacks/src/errors.ts
+++ b/libs/coin-modules/coin-stacks/src/errors.ts
@@ -1,3 +1,7 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const StacksMemoTooLong = createCustomErrorClass("StacksMemoTooLong");
+export class StacksMemoTooLong extends Error {
+  override name = "StacksMemoTooLong";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "StacksMemoTooLong");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-sui/src/errors.ts
+++ b/libs/coin-modules/coin-sui/src/errors.ts
@@ -1,21 +1,43 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * One SUI is minimal to stake.
  */
-export const OneSuiMinForStake = createCustomErrorClass("OneSuiMinForStake");
+export class OneSuiMinForStake extends Error {
+  override name = "OneSuiMinForStake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OneSuiMinForStake");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * One SUI is minimal for partial unstake.
  */
-export const OneSuiMinForUnstake = createCustomErrorClass("OneSuiMinForUnstake");
+export class OneSuiMinForUnstake extends Error {
+  override name = "OneSuiMinForUnstake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OneSuiMinForUnstake");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * One SUI is minimal to be left when partial unstake.
  */
-export const OneSuiMinForUnstakeToBeLeft = createCustomErrorClass("OneSuiMinForUnstakeToBeLeft");
+export class OneSuiMinForUnstakeToBeLeft extends Error {
+  override name = "OneSuiMinForUnstakeToBeLeft";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OneSuiMinForUnstakeToBeLeft");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * At least 0.1 SUI to unstake
  */
-export const SomeSuiForUnstake = createCustomErrorClass("SomeSuiForUnstake");
+export class SomeSuiForUnstake extends Error {
+  override name = "SomeSuiForUnstake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SomeSuiForUnstake");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-tezos/src/types/errors.ts
+++ b/libs/coin-modules/coin-tezos/src/types/errors.ts
@@ -1,19 +1,42 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
+export class InvalidAddressBecauseAlreadyDelegated extends Error {
+  override name = "InvalidAddressBecauseAlreadyDelegated";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddressBecauseAlreadyDelegated");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const InvalidAddressBecauseAlreadyDelegated = createCustomErrorClass(
-  "InvalidAddressBecauseAlreadyDelegated",
-);
-export const UnsupportedTransactionMode = createCustomErrorClass<
-  { mode: string },
-  LedgerErrorConstructor<{ mode: string }>
->("UnsupportedTransactionMode");
-export const UnsupportedOperationKind = createCustomErrorClass<
-  { kind: string },
-  LedgerErrorConstructor<{ kind: string }>
->("UnsupportedOperationKind");
-export const MustDelegateBeforeStaking = createCustomErrorClass("MustDelegateBeforeStaking");
-export const TezosNotEnoughStaked = createCustomErrorClass("TezosNotEnoughStaked");
+export class UnsupportedTransactionMode extends Error {
+  override name = "UnsupportedTransactionMode";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedTransactionMode");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UnsupportedOperationKind extends Error {
+  override name = "UnsupportedOperationKind";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedOperationKind");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MustDelegateBeforeStaking extends Error {
+  override name = "MustDelegateBeforeStaking";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MustDelegateBeforeStaking");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TezosNotEnoughStaked extends Error {
+  override name = "TezosNotEnoughStaked";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TezosNotEnoughStaked");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Staking with a new delegate is rejected by the protocol while an unfinalizable unstake request
 // to the previous delegate still exists (~4-day freeze). Surfaced during stake fee estimation.

--- a/libs/coin-modules/coin-ton/src/errors.ts
+++ b/libs/coin-modules/coin-ton/src/errors.ts
@@ -1,23 +1,43 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * When the comment is invalid.
  */
-export const TonCommentInvalid = createCustomErrorClass("TonCommentInvalid");
+export class TonCommentInvalid extends Error {
+  override name = "TonCommentInvalid";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TonCommentInvalid");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the transaction is a jetton transfer.
  */
-export const TonMinimumRequired = createCustomErrorClass("TonMinimumRequired");
+export class TonMinimumRequired extends Error {
+  override name = "TonMinimumRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TonMinimumRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the transaction is a jetton transfer.
  */
-export const TonExcessFee = createCustomErrorClass("TonExcessFee");
+export class TonExcessFee extends Error {
+  override name = "TonExcessFee";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TonExcessFee");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the transaction is a jetton transfer.
  */
-export const TonNotEnoughBalanceInParentAccount = createCustomErrorClass(
-  "TonNotEnoughBalanceInParentAccount",
-);
+export class TonNotEnoughBalanceInParentAccount extends Error {
+  override name = "TonNotEnoughBalanceInParentAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TonNotEnoughBalanceInParentAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-tron/src/types/errors.ts
+++ b/libs/coin-modules/coin-tron/src/types/errors.ts
@@ -1,23 +1,135 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class TronNoFrozenForBandwidth extends Error {
+  override name = "TronNoFrozenForBandwidth";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNoFrozenForBandwidth");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const TronNoFrozenForBandwidth = createCustomErrorClass("TronNoFrozenForBandwidth");
-export const TronNoFrozenForEnergy = createCustomErrorClass("TronNoFrozenForEnergy");
-export const TronUnfreezeNotExpired = createCustomErrorClass("TronUnfreezeNotExpired");
-export const TronLegacyUnfreezeNotExpired = createCustomErrorClass("TronLegacyUnfreezeNotExpired");
-export const TronVoteRequired = createCustomErrorClass("TronVoteRequired");
-export const TronInvalidVoteCount = createCustomErrorClass("TronInvalidVoteCount");
-export const TronRewardNotAvailable = createCustomErrorClass("TronRewardNotAvailable");
-export const TronNoReward = createCustomErrorClass("TronNoReward");
-export const TronInvalidFreezeAmount = createCustomErrorClass("TronInvalidFreezeAmount");
-export const TronSendTrc20ToNewAccountForbidden = createCustomErrorClass(
-  "TronSendTrc20ToNewAccountForbidden",
-);
-export const TronUnexpectedFees = createCustomErrorClass("TronUnexpectedFees");
-export const TronNotEnoughTronPower = createCustomErrorClass("TronNotEnoughTronPower");
-export const TronTransactionExpired = createCustomErrorClass("TronTransactionExpired");
-export const TronNotEnoughEnergy = createCustomErrorClass("TronNotEnoughEnergy");
-export const TronNoUnfrozenResource = createCustomErrorClass("TronNoUnfrozenResource");
-export const TronInvalidUnDelegateResourceAmount = createCustomErrorClass(
-  "TronInvalidUnDelegateResourceAmount",
-);
-export const TronEmptyPage = createCustomErrorClass("TronEmptyPage");
+export class TronNoFrozenForEnergy extends Error {
+  override name = "TronNoFrozenForEnergy";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNoFrozenForEnergy");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronUnfreezeNotExpired extends Error {
+  override name = "TronUnfreezeNotExpired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronUnfreezeNotExpired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronLegacyUnfreezeNotExpired extends Error {
+  override name = "TronLegacyUnfreezeNotExpired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronLegacyUnfreezeNotExpired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronVoteRequired extends Error {
+  override name = "TronVoteRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronVoteRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronInvalidVoteCount extends Error {
+  override name = "TronInvalidVoteCount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronInvalidVoteCount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronRewardNotAvailable extends Error {
+  override name = "TronRewardNotAvailable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronRewardNotAvailable");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronNoReward extends Error {
+  override name = "TronNoReward";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNoReward");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronInvalidFreezeAmount extends Error {
+  override name = "TronInvalidFreezeAmount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronInvalidFreezeAmount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronSendTrc20ToNewAccountForbidden extends Error {
+  override name = "TronSendTrc20ToNewAccountForbidden";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronSendTrc20ToNewAccountForbidden");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronUnexpectedFees extends Error {
+  override name = "TronUnexpectedFees";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronUnexpectedFees");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronNotEnoughTronPower extends Error {
+  override name = "TronNotEnoughTronPower";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNotEnoughTronPower");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronTransactionExpired extends Error {
+  override name = "TronTransactionExpired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronTransactionExpired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronNotEnoughEnergy extends Error {
+  override name = "TronNotEnoughEnergy";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNotEnoughEnergy");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronNoUnfrozenResource extends Error {
+  override name = "TronNoUnfrozenResource";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronNoUnfrozenResource");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronInvalidUnDelegateResourceAmount extends Error {
+  override name = "TronInvalidUnDelegateResourceAmount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronInvalidUnDelegateResourceAmount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class TronEmptyPage extends Error {
+  override name = "TronEmptyPage";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronEmptyPage");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-vechain/src/errors.ts
+++ b/libs/coin-modules/coin-vechain/src/errors.ts
@@ -1,7 +1,23 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class NotEnoughVTHO extends Error {
+  override name = "NotEnoughVTHO";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughVTHO");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const NotEnoughVTHO = createCustomErrorClass("NotEnoughVTHO");
-export const MustBeVechain = createCustomErrorClass("MustBeVechain");
-export const ImpossibleToCalculateAmountAndFees = createCustomErrorClass(
-  "ImpossibleToCalculateAmountAndFees",
-);
+export class MustBeVechain extends Error {
+  override name = "MustBeVechain";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MustBeVechain");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ImpossibleToCalculateAmountAndFees extends Error {
+  override name = "ImpossibleToCalculateAmountAndFees";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ImpossibleToCalculateAmountAndFees");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
## Summary

Part of the @ledgerhq/errors sunset effort (LIVE-32915). Converts 14 coin module errors files from the legacy createCustomErrorClass factory to native extends Error classes.

Coins converted:
- coin-internet_computer
- coin-kaspa (2 files: src/errors.ts + src/types/errors.ts)
- coin-mina
- coin-module-boilerplate
- coin-multiversx
- coin-near
- coin-polkadot
- coin-solana (preserves 2 name mismatches: SolanaRecipientAssociatedTokenAccountWillBeFunded -> "SolanaAssociatedTokenAccountWillBeFunded", SolanaAddressOffEd25519 -> "SolanaAddressOfEd25519")
- coin-stacks
- coin-sui
- coin-tezos (preserves existing native TezosStakeBlockedByPendingUnstake class)
- coin-ton
- coin-tron
- coin-vechain

Pattern applied:

```ts
export class FooError extends Error {
  override name = "FooError";
  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
    super(message || "FooError", options);
    if (fields) Object.assign(this, fields);
  }
}
```

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35088