### PR TITLE
[LWDM] chore(LIVE-32915): convert coin module error classes to native extends Error

### DIFF
--- a/.changeset/LIVE-32915-tier1a-coin-native-errors.md
+++ b/.changeset/LIVE-32915-tier1a-coin-native-errors.md
@@ -1,0 +1,18 @@
+---
+"@ledgerhq/coin-aleo": patch
+"@ledgerhq/coin-algorand": patch
+"@ledgerhq/coin-aptos": patch
+"@ledgerhq/coin-bitcoin": patch
+"@ledgerhq/coin-canton": patch
+"@ledgerhq/coin-cardano": patch
+"@ledgerhq/coin-casper": patch
+"@ledgerhq/coin-celo": patch
+"@ledgerhq/coin-concordium": patch
+"@ledgerhq/coin-cosmos": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/coin-filecoin": patch
+"@ledgerhq/coin-hedera": patch
+"@ledgerhq/coin-icon": patch
+---
+
+Convert error classes from createCustomErrorClass factory to native extends Error (LIVE-32915 tier 1a)

--- a/libs/coin-modules/coin-aleo/src/errors.ts
+++ b/libs/coin-modules/coin-aleo/src/errors.ts
@@ -1,15 +1,55 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class AleoAmountRecordRequired extends Error {
+  override name = "AleoAmountRecordRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoAmountRecordRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const AleoAmountRecordRequired = createCustomErrorClass("AleoAmountRecordRequired");
-export const AleoFeeRecordRequired = createCustomErrorClass("AleoFeeRecordRequired");
-export const AleoTwoRecordsRequired = createCustomErrorClass("AleoTwoRecordsRequired");
-export const AleoFeeRecordInsufficientBalance = createCustomErrorClass(
-  "AleoFeeRecordInsufficientBalance",
-);
-export const AleoApiConfigurationResetError = createCustomErrorClass(
-  "AleoApiConfigurationResetError",
-);
-export const AleoTooManyRecordsSelected = createCustomErrorClass("AleoTooManyRecordsSelected");
-export const AleoAmountTooLargeForTransaction = createCustomErrorClass(
-  "AleoAmountTooLargeForTransaction",
-);
+export class AleoFeeRecordRequired extends Error {
+  override name = "AleoFeeRecordRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoFeeRecordRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AleoTwoRecordsRequired extends Error {
+  override name = "AleoTwoRecordsRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoTwoRecordsRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AleoFeeRecordInsufficientBalance extends Error {
+  override name = "AleoFeeRecordInsufficientBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoFeeRecordInsufficientBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AleoApiConfigurationResetError extends Error {
+  override name = "AleoApiConfigurationResetError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoApiConfigurationResetError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AleoTooManyRecordsSelected extends Error {
+  override name = "AleoTooManyRecordsSelected";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoTooManyRecordsSelected");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AleoAmountTooLargeForTransaction extends Error {
+  override name = "AleoAmountTooLargeForTransaction";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AleoAmountTooLargeForTransaction");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-algorand/src/errors.ts
+++ b/libs/coin-modules/coin-algorand/src/errors.ts
@@ -1,9 +1,15 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class AlgorandASANotOptInInRecipient extends Error {
+  override name = "AlgorandASANotOptInInRecipient";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AlgorandASANotOptInInRecipient");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const AlgorandASANotOptInInRecipient = createCustomErrorClass(
-  "AlgorandASANotOptInInRecipient",
-);
-
-export const AlgorandMemoExceededSizeError = createCustomErrorClass(
-  "AlgorandMemoExceededSizeError",
-);
+export class AlgorandMemoExceededSizeError extends Error {
+  override name = "AlgorandMemoExceededSizeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AlgorandMemoExceededSizeError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-aptos/src/errors.ts
+++ b/libs/coin-modules/coin-aptos/src/errors.ts
@@ -1,7 +1,23 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class SequenceNumberTooOldError extends Error {
+  override name = "SequenceNumberTooOld";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SequenceNumberTooOld");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SequenceNumberTooOldError = createCustomErrorClass("SequenceNumberTooOld");
+export class SequenceNumberTooNewError extends Error {
+  override name = "SequenceNumberTooNew";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SequenceNumberTooNew");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SequenceNumberTooNewError = createCustomErrorClass("SequenceNumberTooNew");
-
-export const TransactionExpiredError = createCustomErrorClass("TransactionExpired");
+export class TransactionExpiredError extends Error {
+  override name = "TransactionExpired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TransactionExpired");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-bitcoin/src/errors.ts
+++ b/libs/coin-modules/coin-bitcoin/src/errors.ts
@@ -1,26 +1,64 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // AccountNeedResync and RbfBuildError now live in @ledgerhq/wallet-btc; re-exported
 // here for backward compatibility with existing @ledgerhq/coin-bitcoin consumers.
 export { AccountNeedResync, RbfBuildError } from "@ledgerhq/wallet-btc/errors";
 
-export const TaprootNotActivated = createCustomErrorClass("TaprootNotActivated");
+export class TaprootNotActivated extends Error {
+  override name = "TaprootNotActivated";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TaprootNotActivated");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const BitcoinInfrastructureError = createCustomErrorClass("InfrastructureError");
+export class BitcoinInfrastructureError extends Error {
+  override name = "InfrastructureError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InfrastructureError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const FeeTooLow = createCustomErrorClass("FeeTooLow");
+export class FeeTooLow extends Error {
+  override name = "FeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const ZcashSaplingRecipientNotSupported = createCustomErrorClass(
-  "ZcashSaplingRecipientNotSupported",
-);
+export class ZcashSaplingRecipientNotSupported extends Error {
+  override name = "ZcashSaplingRecipientNotSupported";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ZcashSaplingRecipientNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const ZcashSignerNotSupported = createCustomErrorClass("ZcashSignerNotSupported");
+export class ZcashSignerNotSupported extends Error {
+  override name = "ZcashSignerNotSupported";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ZcashSignerNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Typed cancellation marker for the shielded (PCZT) signOperation flow.
-export const ZcashSigningCancelled = createCustomErrorClass("ZcashSigningCancelled");
+export class ZcashSigningCancelled extends Error {
+  override name = "ZcashSigningCancelled";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ZcashSigningCancelled");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Raised when a transparent UTXO about to be spent by a Public→* PCZT flow
 // cannot be mapped to a known account key (missing address, or an address
 // outside the synced receive/change gap limit). Fail-closed: we refuse to sign
 // rather than risk producing an unsignable or wrong input.
-export const ZcashUtxoNotInAccount = createCustomErrorClass("ZcashUtxoNotInAccount");
+export class ZcashUtxoNotInAccount extends Error {
+  override name = "ZcashUtxoNotInAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ZcashUtxoNotInAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-canton/src/types/errors.ts
+++ b/libs/coin-modules/coin-canton/src/types/errors.ts
@@ -1,8 +1,31 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class SimulationError extends Error {
+  override name = "SimulationError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SimulationError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const SimulationError = createCustomErrorClass("SimulationError");
+export class TooManyUtxosCritical extends Error {
+  override name = "TooManyUtxosCritical";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TooManyUtxosCritical");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const TooManyUtxosCritical = createCustomErrorClass("TooManyUtxosCritical");
-export const TooManyUtxosWarning = createCustomErrorClass("TooManyUtxosWarning");
+export class TooManyUtxosWarning extends Error {
+  override name = "TooManyUtxosWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TooManyUtxosWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const TopologyChangeError = createCustomErrorClass("TopologyChangeError");
+export class TopologyChangeError extends Error {
+  override name = "TopologyChangeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TopologyChangeError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-cardano/src/errors.ts
+++ b/libs/coin-modules/coin-cardano/src/errors.ts
@@ -1,28 +1,75 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /**
  * Cardano error thrown when transaction amount is less then minUtxo
  */
-export const CardanoMinAmountError = createCustomErrorClass("CardanoMinAmountError");
+export class CardanoMinAmountError extends Error {
+  override name = "CardanoMinAmountError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoMinAmountError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Cardano error thrown when user don't have enough fund for deposit
  */
-export const CardanoStakeKeyDepositError = createCustomErrorClass("CardanoStakeKeyDepositError");
+export class CardanoStakeKeyDepositError extends Error {
+  override name = "CardanoStakeKeyDepositError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoStakeKeyDepositError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Cardano error thrown when not enough funds to perform transaction
  */
-export const CardanoNotEnoughFunds = createCustomErrorClass("CardanoNotEnoughFunds");
+export class CardanoNotEnoughFunds extends Error {
+  override name = "CardanoNotEnoughFunds";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoNotEnoughFunds");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CardanoInvalidPoolId = createCustomErrorClass("CardanoInvalidPoolId");
+export class CardanoInvalidPoolId extends Error {
+  override name = "CardanoInvalidPoolId";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoInvalidPoolId");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Cardano warning/error for high fees
  */
-export const CardanoFeeHigh = createCustomErrorClass("CardanoFeeHigh");
-export const CardanoFeeTooHigh = createCustomErrorClass("CardanoFeeTooHigh");
+export class CardanoFeeHigh extends Error {
+  override name = "CardanoFeeHigh";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoFeeHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CardanoInvalidProtoParams = createCustomErrorClass("CardanoInvalidProtoParams");
+export class CardanoFeeTooHigh extends Error {
+  override name = "CardanoFeeTooHigh";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoFeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CardanoMemoExceededSizeError = createCustomErrorClass("CardanoMemoExceededSizeError");
+export class CardanoInvalidProtoParams extends Error {
+  override name = "CardanoInvalidProtoParams";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoInvalidProtoParams");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class CardanoMemoExceededSizeError extends Error {
+  override name = "CardanoMemoExceededSizeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CardanoMemoExceededSizeError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-casper/src/errors.ts
+++ b/libs/coin-modules/coin-casper/src/errors.ts
@@ -1,5 +1,23 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class CasperInvalidTransferId extends Error {
+  override name = "CasperInvalidTransferId";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CasperInvalidTransferId");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CasperInvalidTransferId = createCustomErrorClass("CasperInvalidTransferId");
-export const InvalidMinimumAmount = createCustomErrorClass("InvalidMinimumAmount");
-export const MayBlockAccount = createCustomErrorClass("MayBlockAccount");
+export class InvalidMinimumAmount extends Error {
+  override name = "InvalidMinimumAmount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidMinimumAmount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MayBlockAccount extends Error {
+  override name = "MayBlockAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MayBlockAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-celo/src/errors.ts
+++ b/libs/coin-modules/coin-celo/src/errors.ts
@@ -1,5 +1,23 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class CeloAllFundsWarning extends Error {
+  override name = "CeloAllFundsWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CeloAllFundsWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CeloAllFundsWarning = createCustomErrorClass("CeloAllFundsWarning");
-export const CeloGroupNotVotable = createCustomErrorClass("CeloGroupNotVotable");
-export const CeloGroupNotVoted = createCustomErrorClass("CeloGroupNotVoted");
+export class CeloGroupNotVotable extends Error {
+  override name = "CeloGroupNotVotable";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CeloGroupNotVotable");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class CeloGroupNotVoted extends Error {
+  override name = "CeloGroupNotVoted";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CeloGroupNotVoted");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -1,5 +1,9 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 export { ConcordiumMemoTooLong, ConcordiumInsufficientFunds } from "@ledgerhq/errors";
 
-export const SimulationError = createCustomErrorClass("SimulationError");
+export class SimulationError extends Error {
+  override name = "SimulationError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SimulationError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-cosmos/src/errors.ts
+++ b/libs/coin-modules/coin-cosmos/src/errors.ts
@@ -1,10 +1,47 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class CosmosRedelegationInProgress extends Error {
+  override name = "CosmosRedelegationInProgress";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CosmosRedelegationInProgress");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const CosmosRedelegationInProgress = createCustomErrorClass("CosmosRedelegationInProgress");
-export const CosmosDelegateAllFundsWarning = createCustomErrorClass(
-  "CosmosDelegateAllFundsWarning",
-);
-export const CosmosTooManyValidators = createCustomErrorClass("CosmosTooManyValidators");
-export const NotEnoughDelegationBalance = createCustomErrorClass("NotEnoughDelegationBalance");
-export const ClaimRewardsFeesWarning = createCustomErrorClass("ClaimRewardsFeesWarning");
-export const CosmosTooManyRedelegations = createCustomErrorClass("CosmosTooManyRedelegations");
+export class CosmosDelegateAllFundsWarning extends Error {
+  override name = "CosmosDelegateAllFundsWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CosmosDelegateAllFundsWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class CosmosTooManyValidators extends Error {
+  override name = "CosmosTooManyValidators";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CosmosTooManyValidators");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughDelegationBalance extends Error {
+  override name = "NotEnoughDelegationBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughDelegationBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ClaimRewardsFeesWarning extends Error {
+  override name = "ClaimRewardsFeesWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ClaimRewardsFeesWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class CosmosTooManyRedelegations extends Error {
+  override name = "CosmosTooManyRedelegations";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CosmosTooManyRedelegations");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-evm/src/errors.ts
+++ b/libs/coin-modules/coin-evm/src/errors.ts
@@ -1,44 +1,141 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // Etherscan API
-export const EtherscanAPIError = createCustomErrorClass("EtherscanAPIError");
+export class EtherscanAPIError extends Error {
+  override name = "EtherscanAPIError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "EtherscanAPIError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Explorers
-export const UnknownExplorer = createCustomErrorClass("UnknownExplorer");
-export const LedgerExplorerUsedIncorrectly = createCustomErrorClass(
-  "LedgerExplorerUsedIncorrectly",
-);
-export const EtherscanLikeExplorerUsedIncorrectly = createCustomErrorClass(
-  "EtherscanLikeExplorerUsedIncorrectly",
-);
-export const InvalidExplorerResponse = createCustomErrorClass("InvalidExplorerResponse");
+export class UnknownExplorer extends Error {
+  override name = "UnknownExplorer";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnknownExplorer");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LedgerExplorerUsedIncorrectly extends Error {
+  override name = "LedgerExplorerUsedIncorrectly";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerExplorerUsedIncorrectly");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class EtherscanLikeExplorerUsedIncorrectly extends Error {
+  override name = "EtherscanLikeExplorerUsedIncorrectly";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "EtherscanLikeExplorerUsedIncorrectly");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidExplorerResponse extends Error {
+  override name = "InvalidExplorerResponse";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: { cause?: unknown }) {
+    super(message || "InvalidExplorerResponse");
+    if (fields) Object.assign(this, fields);
+    if (options?.cause !== undefined) Object.assign(this, { cause: options.cause });
+  }
+}
 
 // Node
-export const UnknownNode = createCustomErrorClass("UnknownNode");
-export const LedgerNodeUsedIncorrectly = createCustomErrorClass("LedgerNodeUsedIncorrectly");
-export const UnsupportedRpcMethodError = createCustomErrorClass<{
-  method: string;
-  rawError: unknown;
-}>("UnsupportedRpcMethodError");
+export class UnknownNode extends Error {
+  override name = "UnknownNode";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnknownNode");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LedgerNodeUsedIncorrectly extends Error {
+  override name = "LedgerNodeUsedIncorrectly";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerNodeUsedIncorrectly");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UnsupportedRpcMethodError extends Error {
+  override name = "UnsupportedRpcMethodError";
+  method?: string;
+  rawError?: unknown;
+  constructor(message?: string, fields?: { method?: string; rawError?: unknown }) {
+    super(message || "UnsupportedRpcMethodError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Internal-tx source should be skipped (not propagated): not configured, structurally
  * unsupported, best-effort runtime failure (e.g. explorer), or all sources exhausted
  * without `empty`.
  */
-export const SourceUnavailableError = createCustomErrorClass("SourceUnavailableError");
+export class SourceUnavailableError extends Error {
+  override name = "SourceUnavailableError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SourceUnavailableError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // GasTracker errors
-export const LedgerGasTrackerUsedIncorrectly = createCustomErrorClass(
-  "LedgerGasTrackerUsedIncorrectly",
-);
-export const NoGasTrackerFound = createCustomErrorClass("NoGasTrackerFound");
+export class LedgerGasTrackerUsedIncorrectly extends Error {
+  override name = "LedgerGasTrackerUsedIncorrectly";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerGasTrackerUsedIncorrectly");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NoGasTrackerFound extends Error {
+  override name = "NoGasTrackerFound";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NoGasTrackerFound");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Gas
-export const GasPriceTooLow = createCustomErrorClass("GasPriceTooLow");
-export const GasEstimationError = createCustomErrorClass("GasEstimationError");
-export const InsufficientFunds = createCustomErrorClass("InsufficientFunds");
+export class GasPriceTooLow extends Error {
+  override name = "GasPriceTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GasPriceTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class GasEstimationError extends Error {
+  override name = "GasEstimationError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GasEstimationError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InsufficientFunds extends Error {
+  override name = "InsufficientFunds";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InsufficientFunds");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 // Nfts
-export const NotOwnedNft = createCustomErrorClass("NotOwnedNft");
-export const NotEnoughNftOwned = createCustomErrorClass("NotEnoughNftOwned");
+export class NotOwnedNft extends Error {
+  override name = "NotOwnedNft";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotOwnedNft");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughNftOwned extends Error {
+  override name = "NotEnoughNftOwned";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughNftOwned");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-filecoin/src/errors.ts
+++ b/libs/coin-modules/coin-filecoin/src/errors.ts
@@ -1,13 +1,21 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /*
  * When the recipient is non f0, f4 or eth address during token transfer
  */
-export const InvalidRecipientForTokenTransfer = createCustomErrorClass(
-  "InvalidRecipientForTokenTransfer",
-);
+export class InvalidRecipientForTokenTransfer extends Error {
+  override name = "InvalidRecipientForTokenTransfer";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidRecipientForTokenTransfer");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /*
  * When the fee estimation endpoint fails
  */
-export const FilecoinFeeEstimationFailed = createCustomErrorClass("FilecoinFeeEstimationFailed");
+export class FilecoinFeeEstimationFailed extends Error {
+  override name = "FilecoinFeeEstimationFailed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FilecoinFeeEstimationFailed");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-hedera/src/errors.ts
+++ b/libs/coin-modules/coin-hedera/src/errors.ts
@@ -1,27 +1,79 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class HederaAddAccountError extends Error {
+  override name = "HederaAddAccountError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaAddAccountError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const HederaAddAccountError = createCustomErrorClass("HederaAddAccountError");
-export const HederaRecipientInvalidChecksum = createCustomErrorClass(
-  "HederaRecipientInvalidChecksum",
-);
-export const HederaInsufficientFundsForAssociation = createCustomErrorClass(
-  "HederaInsufficientFundsForAssociation",
-);
-export const HederaRecipientTokenAssociationRequired = createCustomErrorClass(
-  "HederaRecipientTokenAssociationRequired",
-);
-export const HederaRecipientTokenAssociationUnverified = createCustomErrorClass(
-  "HederaRecipientTokenAssociationUnverified",
-);
-export const HederaRecipientEvmAddressVerificationRequired = createCustomErrorClass(
-  "HederaRecipientEvmAddressVerificationRequired",
-);
-export const HederaRedundantStakingNodeIdError = createCustomErrorClass(
-  "HederaRedundantStakingNodeIdError",
-);
-export const HederaInvalidStakingNodeIdError = createCustomErrorClass(
-  "HederaInvalidStakingNodeIdError",
-);
-export const HederaNoStakingRewardsError = createCustomErrorClass("HederaNoStakingRewardsError");
+export class HederaRecipientInvalidChecksum extends Error {
+  override name = "HederaRecipientInvalidChecksum";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaRecipientInvalidChecksum");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const HederaMemoExceededSizeError = createCustomErrorClass("HederaMemoExceededSizeError");
+export class HederaInsufficientFundsForAssociation extends Error {
+  override name = "HederaInsufficientFundsForAssociation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaInsufficientFundsForAssociation");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaRecipientTokenAssociationRequired extends Error {
+  override name = "HederaRecipientTokenAssociationRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaRecipientTokenAssociationRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaRecipientTokenAssociationUnverified extends Error {
+  override name = "HederaRecipientTokenAssociationUnverified";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaRecipientTokenAssociationUnverified");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaRecipientEvmAddressVerificationRequired extends Error {
+  override name = "HederaRecipientEvmAddressVerificationRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaRecipientEvmAddressVerificationRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaRedundantStakingNodeIdError extends Error {
+  override name = "HederaRedundantStakingNodeIdError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaRedundantStakingNodeIdError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaInvalidStakingNodeIdError extends Error {
+  override name = "HederaInvalidStakingNodeIdError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaInvalidStakingNodeIdError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaNoStakingRewardsError extends Error {
+  override name = "HederaNoStakingRewardsError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaNoStakingRewardsError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class HederaMemoExceededSizeError extends Error {
+  override name = "HederaMemoExceededSizeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "HederaMemoExceededSizeError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-icon/src/errors.ts
+++ b/libs/coin-modules/coin-icon/src/errors.ts
@@ -1,5 +1,23 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class IconAllFundsWarning extends Error {
+  override name = "IconAllFundsWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "IconAllFundsWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
-export const IconAllFundsWarning = createCustomErrorClass("IconAllFundsWarning");
-export const IconValidatorsRequired = createCustomErrorClass("IconValidatorsRequired");
-export const IconDoMaxSendInstead = createCustomErrorClass("IconDoMaxSendInstead");
+export class IconValidatorsRequired extends Error {
+  override name = "IconValidatorsRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "IconValidatorsRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class IconDoMaxSendInstead extends Error {
+  override name = "IconDoMaxSendInstead";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "IconDoMaxSendInstead");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
### 📝 Description

Converts all error classes in 14 coin modules from `createCustomErrorClass` (factory from `@ledgerhq/errors`) to native `class extends Error` definitions.

Part of the `@ledgerhq/errors` sunset effort — [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915).

Packages converted: coin-aleo, coin-algorand, coin-aptos, coin-bitcoin, coin-canton, coin-cardano, coin-casper, coin-celo, coin-concordium, coin-cosmos, coin-evm, coin-filecoin, coin-hedera, coin-icon.

**Before / after (consumer side):**

```diff
- import { createCustomErrorClass } from "@ledgerhq/errors";
- export const FooError = createCustomErrorClass("FooError");

+ export class FooError extends Error {
+   override name = "FooError";
+   constructor(message?: string, fields?: Record<string, unknown>) {
+     super(message || "FooError");
+     if (fields) Object.assign(this, fields);
+   }
+ }
```

> [!NOTE]
> `instanceof` checks remain valid — callers importing from the coin package directly are unaffected. Only callers that import the same class from `@ledgerhq/errors` would see a difference (none exist for these coin-specific errors).

**Preserved:**
- Re-exports from `@ledgerhq/wallet-btc/errors` (bitcoin) and shared classes from `@ledgerhq/errors` (concordium) where still needed
- JSDoc comments (cardano, evm `SourceUnavailableError`) and section comments (evm)
- 3rd `options` arg with `{ cause }` forwarding on `InvalidExplorerResponse` (coin-evm) where callers use it

### 🔗 Context

- **JIRA**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **ADR**: n/a

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35089