### PR TITLE
[LWM] fix(portfolio): update touchscreen offers title (LIVE-34757)

### DIFF
--- a/.changeset/sweet-screens-smile.md
+++ b/.changeset/sweet-screens-smile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Update the Mobile touchscreen offers carousel title.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -2873,7 +2873,7 @@
       "desc": "Simply send crypto assets to your receiving address and wait for the app to sync."
     },
     "carousel": {
-      "title": "For you"
+      "title": "Touchscreen offers"
     },
     "perpsEntry": {
       "title": "Perpetuals",


### PR DESCRIPTION
## Description

Updates the Mobile Portfolio carousel title to **Touchscreen offers** as requested in [LIVE-34757](https://ledgerhq.atlassian.net/browse/LIVE-34757).

## Changes

- Update the English source value for `portfolio.carousel.title`.
- Add a `live-mobile` changeset.

## Testing

- ✅ `pnpm nx run live-mobile:lint:i18n --outputStyle=static`
- ✅ `pnpm nx run live-mobile:format:check --outputStyle=static`
- ✅ `pnpm nx run live-mobile:lint --outputStyle=static`
- ✅ `pnpm nx run live-mobile:typecheck --outputStyle=static`
- ✅ `pnpm commitlint --from origin/develop`
- ℹ️ No Jest test added because this is a static translation-only change; the value is covered by the localization lint and manual QA below.

## Impact

- Mobile only.
- Other locales remain managed by the localization workflow.

## QA

- Open Portfolio with at least one carousel card visible.
- Verify the section heading is exactly **Touchscreen offers**.
- Check the heading on both iOS and Android.

## Screenshots

| Before | After |
| --- | --- |
| Add the screenshot from the Jira | Add a screenshot from the Mobile build |

[LIVE-34757]: https://ledgerhq.atlassian.net/browse/LIVE-34757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ