### PR TITLE
[LWM] fix(wallet-sync): correct QR setup instructions (LIVE-33390)

### DIFF
--- a/.changeset/clear-sync-paths.md
+++ b/.changeset/clear-sync-paths.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the Ledger Sync QR instructions on mobile

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9304,7 +9304,7 @@
             "steps": {
               "step1": "Make sure Ledger Sync is activated on one of your apps.",
               "step2": "Open the Ledger Wallet app you want to sync.",
-              "step3": "Go to <0>Settings</0> <1>></1> <0>General</0> <1>></1> <0>Ledger Sync</0> <1>></1> <0>I already turned it on</0> <1>></1> <0>Scan QR code</0>",
+              "step3": "Go to <0>Settings</0> <1>></1> <0>General</0> <1>></1> <0>Ledger Sync</0> <1>></1> <0>Sync with another Ledger Wallet app</0> <1>></1> <0>Scan QR code</0>",
               "step4": "Scan QR code."
             }
           }
@@ -9317,7 +9317,7 @@
             "steps": {
               "step1": "Make sure Ledger Sync is activated on one of your apps.",
               "step2": "Open the Ledger Wallet you want to sync with.",
-              "step3": "Go to <0>Settings</0> <1>></1> <0>General</0> <1>></1> <0>Ledger Sync</0> <1>></1> <0>I already turned it on</0> <1>></1> <0>Show QR</0>",
+              "step3": "Go to <0>Settings</0> <1>></1> <0>General</0> <1>></1> <0>Ledger Sync</0> <1>></1> <0>Sync with another Ledger Wallet app</0> <1>></1> <0>Show QR</0>",
               "step4": "Scan QR code."
             }
           }

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/scanQRCode.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/scanQRCode.integration.test.tsx
@@ -14,6 +14,7 @@ describe("scanQRCode", () => {
     await user.press(await screen.findByText(/scan qr code/i));
 
     expect(screen.queryAllByText(/show qr/i)).toHaveLength(2);
+    expect(screen.getByText("Sync with another Ledger Wallet app")).toBeVisible();
     expect(screen.getByTestId("ws-scan-camera")).toBeVisible();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/synchronizeWithQrCode.integration.test.tsx
@@ -45,6 +45,7 @@ describe("SynchronizeWithQrCode", () => {
 
     // First verify Show QR tab works
     await user.press(screen.queryAllByText(/show qr/i)[0]);
+    expect(screen.getByText("Sync with another Ledger Wallet app")).toBeVisible();
     expect(screen.getByTestId("ws-qr-code-displayed")).toBeVisible();
 
     // Switch to Scan tab to enable camera scanning


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Ledger Sync QR instructions on the Scan and Show QR tabs
      - English mobile copy only

### 📝 Description

The Ledger Sync QR instructions still directed users through the former **I already turned it on** action, which no longer matches the current Desktop navigation.

This change updates both QR instruction variants to use **Sync with another Ledger Wallet app** while preserving the final Scan QR code or Show QR action. Both render paths now have integration-test coverage.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33390](https://ledgerhq.atlassian.net/browse/LIVE-33390)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33390]: https://ledgerhq.atlassian.net/browse/LIVE-33390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ