### PR TITLE
fix(portfolio): filter expanded token operations (LIVE-26869)

### DIFF
--- a/.changeset/bright-portfolios-filter.md
+++ b/.changeset/bright-portfolios-filter.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-wallet-framework": minor
+---
+
+Fix filtering of expanded account operations

--- a/libs/ledger-wallet-framework/src/account/groupOperations.test.ts
+++ b/libs/ledger-wallet-framework/src/account/groupOperations.test.ts
@@ -2,6 +2,9 @@ import { groupAccountsOperationsByDay } from "./groupOperations";
 import type { AccountLike, Operation } from "@ledgerhq/types-live";
 import { createOperation, createAccount as baseCreateAccount } from "./pending.test";
 import BigNumber from "bignumber.js";
+import { genAccount } from "../mocks/account";
+import type { TokenCurrency } from "../types";
+import { makeEmptyTokenAccount } from "./helpers";
 
 // Wrapper around createOperation to set transactionSequenceNumber and optional date override
 const createOp = (id: string, isoDate: string, sequence?: bigint, isPending = false): Operation => {
@@ -122,5 +125,48 @@ describe("groupAccountOperationsByDay", () => {
 
     expect(result.sections.length).toBe(1);
     expect(result.sections[0].data.map((op: Operation) => op.id)).toEqual(["op1"]);
+  });
+
+  it("filters expanded internal operations with their owning account", () => {
+    const parentAccount = genAccount("parent", { operationsSize: 0 });
+    // oxlint-disable-next-line typescript/consistent-type-assertions
+    const token = {
+      parentCurrencyId: parentAccount.currency.id,
+      contractAddress: "0xtoken",
+    } as TokenCurrency;
+    const tokenAccount = makeEmptyTokenAccount(parentAccount, token);
+    const zeroValueTokenOperation = {
+      ...createOp("zero-value-token", "2024-01-01T10:00:00Z"),
+      accountId: tokenAccount.id,
+      value: new BigNumber(0),
+    };
+    const nonZeroValueTokenOperation = {
+      ...createOp("non-zero-value-token", "2024-01-01T10:00:00Z"),
+      accountId: tokenAccount.id,
+      value: new BigNumber(1),
+    };
+    const parentOperation = {
+      ...createOp("parent-operation", "2024-01-01T10:00:00Z"),
+      accountId: parentAccount.id,
+      type: "NONE" as const,
+      internalOperations: [zeroValueTokenOperation, nonZeroValueTokenOperation],
+    };
+    parentAccount.operations = [parentOperation];
+    parentAccount.operationsCount = 1;
+    parentAccount.subAccounts = [tokenAccount];
+
+    for (const withSubAccounts of [false, true]) {
+      const result = groupAccountsOperationsByDay([parentAccount], {
+        count: 10,
+        withSubAccounts,
+        filterOperation: (operation, account) =>
+          !(account.type === "TokenAccount" && operation.value.isZero()),
+      });
+
+      expect(result.sections).toHaveLength(1);
+      expect(result.sections[0].data.map(operation => operation.id)).toEqual([
+        "non-zero-value-token",
+      ]);
+    }
   });
 });

--- a/libs/ledger-wallet-framework/src/account/groupOperations.ts
+++ b/libs/ledger-wallet-framework/src/account/groupOperations.ts
@@ -88,7 +88,9 @@ export function groupAccountsOperationsByDay(
   inputAccounts: AccountLikeArray,
   { count, withSubAccounts, filterOperation }: GroupOpsByDayOpts,
 ): DailyOperations {
-  const accounts = withSubAccounts ? flattenAccounts(inputAccounts) : inputAccounts;
+  const allAccounts = flattenAccounts(inputAccounts);
+  const accounts = withSubAccounts ? allAccounts : inputAccounts;
+  const accountsById = new Map(allAccounts.map(account => [account.id, account]));
   // Track indexes of account.operations[] for each account
   const indexes: number[] = Array(accounts.length).fill(0);
   // Track indexes of account.pendingOperations[] for each account
@@ -155,7 +157,12 @@ export function groupAccountsOperationsByDay(
         indexes[bestOpInfo.accountI]++;
       }
 
-      const ops = flattenOperationWithInternalsAndNfts(bestOp);
+      const fallbackAccount = accounts[bestOpInfo.accountI];
+      const ops = flattenOperationWithInternalsAndNfts(bestOp).filter(
+        operation =>
+          !filterOperation ||
+          filterOperation(operation, accountsById.get(operation.accountId) ?? fallbackAccount),
+      );
       return {
         ops,
         date: bestOp.date,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a regression test for expanded internal token operations and ran the Portfolio view-model tests.
- [x] **Impact of the changes:**
      Verify Portfolio latest operations with the zero-value filter enabled and disabled. Check Account pages and operation lists that consume the shared grouping helper.

### 📝 Description

Apply operation predicates after expanding parent operations into their internal and NFT operations. Each expanded operation is evaluated against its owning account, so zero-value token operations no longer leak into Portfolio history.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-26869

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
