### PR TITLE
chore(oxfmt): ignore markdown files in all configs

### DIFF
--- a/apps/ledger-live-desktop/.oxfmtrc.json
+++ b/apps/ledger-live-desktop/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["static/i18n/**", "**/animations/**/*.json"]
+  "ignorePatterns": ["**/*.md", "static/i18n/**", "**/animations/**/*.json"]
 }

--- a/apps/ledger-live-mobile/.oxfmtrc.json
+++ b/apps/ledger-live-mobile/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/*.json",
     "src/generated/**"
   ]

--- a/apps/wallet-cli/.oxfmtrc.json
+++ b/apps/wallet-cli/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["package.json", "**/*.json", "dist/**", ".bunli/commands.gen.ts"]
+  "ignorePatterns": ["**/*.md", "package.json", "**/*.json", "dist/**", ".bunli/commands.gen.ts"]
 }

--- a/e2e/desktop/.oxfmtrc.json
+++ b/e2e/desktop/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["**/*.json"]
+  "ignorePatterns": ["**/*.md", "**/*.json"]
 }

--- a/e2e/mobile/.oxfmtrc.json
+++ b/e2e/mobile/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["**/*.json"]
+  "ignorePatterns": ["**/*.md", "**/*.json"]
 }

--- a/features/flow/card/.oxfmtrc.json
+++ b/features/flow/card/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/*.json"
   ]
 }

--- a/features/flow/market-banner/.oxfmtrc.json
+++ b/features/flow/market-banner/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/*.json"
   ]
 }

--- a/libs/coin-tester-modules/.oxfmtrc.json
+++ b/libs/coin-tester-modules/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/lib/**",
     "**/lib-es/**",
     "**/__snapshots__/**",

--- a/libs/coin-tester/.oxfmtrc.json
+++ b/libs/coin-tester/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/lib/**",
     "**/lib-es/**",
     "**/__snapshots__/**",

--- a/libs/ledger-services/.oxfmtrc.json
+++ b/libs/ledger-services/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "arrowParens": "avoid",
   "sortPackageJson": false,
   "ignorePatterns": [
+    "**/*.md",
     "**/lib/**",
     "**/lib-es/**",
     "**/__snapshots__/**",

--- a/tests/dummy-wallet-app/.oxfmtrc.json
+++ b/tests/dummy-wallet-app/.oxfmtrc.json
@@ -4,5 +4,5 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["**/*.json"]
+  "ignorePatterns": ["**/*.md", "**/*.json"]
 }


### PR DESCRIPTION
### 📝 Description

Some `.oxfmtrc.json` configs were missing `"**/*.md"` in `ignorePatterns`, causing oxfmt to validate `CHANGELOG.md` files and fail CI on PRs that touch changelogs. This adds the pattern to the 11 configs that lacked it, making the behaviour consistent with the root config and packages that already had it.

Spotted via [a98aff3](https://github.com/LedgerHQ/ledger-live/commit/a98aff3b03678212c57bfcd2d01374a2f5bd3f83) in #19924, where Olivier had to add a dedicated commit solely to satisfy oxfmt formatting on CHANGELOG.md.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34952](https://ledgerhq.atlassian.net/browse/LIVE-34952)
- **ADR** (if any): N/A

[LIVE-34952]: https://ledgerhq.atlassian.net/browse/LIVE-34952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ