### PR TITLE
[LWD] fix(asset-detail): prevent live app history stacking (LIVE-31341)

### DIFF
--- a/.changeset/calm-exchanges-return.md
+++ b/.changeset/calm-exchanges-return.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Prevent Asset Detail history from stacking after Buy and Sell live app navigation

--- a/apps/ledger-live-desktop/src/mvvm/features/Exchange/__integrations__/useExchangeBackNavigation.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Exchange/__integrations__/useExchangeBackNavigation.integration.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
+import { render, screen } from "tests/testSetup";
+import { useExchangeBackNavigation } from "../hooks/useExchangeBackNavigation";
+
+function ExchangeNavigation() {
+  const navigate = useNavigate();
+  const navigateBack = useExchangeBackNavigation();
+
+  return (
+    <>
+      <button
+        onClick={() =>
+          navigate("/exchange/provider", {
+            state: { mode: "buy" },
+          })
+        }
+      >
+        Open provider
+      </button>
+      <button
+        onClick={() =>
+          navigate("/exchange?referrer=isExternal", {
+            state: { mode: "buy" },
+          })
+        }
+      >
+        Back to live app
+      </button>
+      <button
+        onClick={() =>
+          navigate("/exchange/provider", {
+            replace: true,
+            state: { mode: "buy" },
+          })
+        }
+      >
+        Replace with provider
+      </button>
+      <button onClick={() => navigate(-1)}>In-webview back</button>
+      <button onClick={navigateBack}>Back to asset</button>
+    </>
+  );
+}
+
+function NavigationHarness() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <span data-testid="pathname">{location.pathname}</span>
+      {location.pathname === "/asset" ? (
+        <>
+          <button
+            onClick={() =>
+              navigate("/exchange", {
+                state: { returnTo: "/asset" },
+              })
+            }
+          >
+            Open live app
+          </button>
+          <button onClick={() => navigate(-1)}>Back to portfolio</button>
+        </>
+      ) : null}
+      {location.pathname.startsWith("/exchange") ? <ExchangeNavigation /> : null}
+    </>
+  );
+}
+
+describe("useExchangeBackNavigation", () => {
+  it("does not stack Asset Detail after three live app round trips", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/portfolio", "/asset"]}>
+        <NavigationHarness />
+      </MemoryRouter>,
+      { skipRouter: true },
+    );
+
+    for (let index = 0; index < 3; index++) {
+      await user.click(screen.getByRole("button", { name: "Open live app" }));
+      await user.click(screen.getByRole("button", { name: "Open provider" }));
+      await user.click(screen.getByRole("button", { name: "Back to live app" }));
+      await user.click(screen.getByRole("button", { name: "Back to asset" }));
+
+      expect(screen.getByTestId("pathname")).toHaveTextContent("/asset");
+    }
+
+    await user.click(screen.getByRole("button", { name: "Back to portfolio" }));
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/portfolio");
+  });
+
+  it("returns to Asset Detail after an in-webview back (POP) within the flow", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/portfolio", "/asset"]}>
+        <NavigationHarness />
+      </MemoryRouter>,
+      { skipRouter: true },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open live app" }));
+    await user.click(screen.getByRole("button", { name: "Open provider" }));
+    // In-webview back is a history POP (mirrors the "go-back" custom handler); depth must decrement
+    // so the header back pops exactly to Asset Detail and not past it to Portfolio.
+    await user.click(screen.getByRole("button", { name: "In-webview back" }));
+    await user.click(screen.getByRole("button", { name: "Back to asset" }));
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/asset");
+  });
+
+  it("ignores REPLACE navigations when counting the Exchange depth", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/portfolio", "/asset"]}>
+        <NavigationHarness />
+      </MemoryRouter>,
+      { skipRouter: true },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open live app" }));
+    // A REPLACE does not add a history entry, so it must not inflate the depth counter.
+    await user.click(screen.getByRole("button", { name: "Replace with provider" }));
+    await user.click(screen.getByRole("button", { name: "Back to asset" }));
+
+    expect(screen.getByTestId("pathname")).toHaveTextContent("/asset");
+  });
+
+  it("falls back to Portfolio when Exchange has no return route", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/exchange"]}>
+        <NavigationHarness />
+      </MemoryRouter>,
+      { skipRouter: true },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Back to asset" }));
+
+    expect(screen.getByTestId("pathname").textContent).toBe("/");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Exchange/hooks/useExchangeBackNavigation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Exchange/hooks/useExchangeBackNavigation.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useLocation, useNavigate, useNavigationType } from "react-router";
+
+function parseExchangeBackPath(state: unknown): string | undefined {
+  if (typeof state !== "object" || state === null || !("returnTo" in state)) {
+    return undefined;
+  }
+
+  return typeof state.returnTo === "string" && state.returnTo !== "" ? state.returnTo : undefined;
+}
+
+export function useExchangeBackNavigation(): () => void {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  // Keep returnTo and the depth in refs so they survive in-webview navigations that overwrite
+  // location.state, letting a single "back" pop the whole Exchange segment instead of a duplicate.
+  const returnToRef = useRef(parseExchangeBackPath(location.state));
+  const previousLocationKeyRef = useRef(location.key);
+  const exchangeHistoryDepthRef = useRef(1);
+
+  useEffect(() => {
+    returnToRef.current ??= parseExchangeBackPath(location.state);
+
+    if (previousLocationKeyRef.current === location.key) {
+      return;
+    }
+
+    if (navigationType === "PUSH") {
+      exchangeHistoryDepthRef.current += 1;
+    } else if (navigationType === "POP") {
+      exchangeHistoryDepthRef.current = Math.max(1, exchangeHistoryDepthRef.current - 1);
+    }
+
+    previousLocationKeyRef.current = location.key;
+  }, [location.key, location.state, navigationType]);
+
+  return useCallback(() => {
+    if (!returnToRef.current) {
+      navigate("/", { replace: true });
+      return;
+    }
+
+    navigate(-exchangeHistoryDepthRef.current);
+  }, [navigate]);
+}

--- a/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/exchange/index.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useMemo } from "react";
 import semver from "semver";
-import { useLocation, useNavigate, useParams } from "react-router";
+import { useLocation, useParams } from "react-router";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "LLD/hooks/redux";
 import {
@@ -35,6 +35,7 @@ import { ProviderInterstitial } from "LLD/components/ProviderInterstitial";
 import PageHeader from "LLD/components/PageHeader";
 import { getWallet40HeaderKey } from "./helpers";
 import Box from "~/renderer/components/Box/Box";
+import { useExchangeBackNavigation } from "LLD/features/Exchange/hooks/useExchangeBackNavigation";
 
 type ExchangeState = { account?: string; returnTo?: string };
 const LiveAppExchange = ({ appId }: { appId: string }) => {
@@ -60,17 +61,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
   const walletState = useSelector(walletSelector);
 
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  // Persist initial returnTo in a ref so it survives in-webview navigations that push
-  // new React Router locations and overwrite location.state.
-  const returnToRef = useRef<string | null>(null);
-  useEffect(() => {
-    const value = urlParams?.returnTo;
-    if (returnToRef.current === null && value != null && value !== "") {
-      returnToRef.current = value;
-    }
-  }, [urlParams?.returnTo]);
-  const returnTo = returnToRef.current ?? urlParams?.returnTo ?? "/";
+  const navigateBack = useExchangeBackNavigation();
   const providerInterstitialEnabled = useProviderInterstitalEnabled({
     manifest,
   });
@@ -119,9 +110,7 @@ const LiveAppExchange = ({ appId }: { appId: string }) => {
 
   return (
     <>
-      {headerKey ? (
-        <PageHeader title={t(headerKey)} onBack={() => navigate(returnTo, { replace: true })} />
-      ) : null}
+      {headerKey ? <PageHeader title={t(headerKey)} onBack={navigateBack} /> : null}
       <Box
         grow
         style={{


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added an integration test covering three Asset Detail → Exchange → provider → Exchange → Asset Detail round trips and direct-entry fallback.
- [x] **Impact of the changes:**
      Verify Buy and Sell from Asset Detail, including provider redirects, then confirm one back action returns to Portfolio after repeated round trips.

### 📝 Description

Pop the complete Exchange segment from React Router history instead of replacing the current entry with another Asset Detail entry. The original return route is retained across provider navigations, while direct Exchange entries safely fall back to Portfolio.

### ❓ Context

https://github.com/user-attachments/assets/b4691291-1cb6-4936-a554-e3b937369f04



- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-31341

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
