### PR TITLE
[LWM] feat(mobile): gate Nano S upsell banners by placement

### DIFF
--- a/.changeset/gentle-banners-toggle.md
+++ b/.changeset/gentle-banners-toggle.md
@@ -1,0 +1,6 @@
+---
+"@shared/feature-flags": minor
+"live-mobile": minor
+---
+
+Gate each existing mobile Nano S upsell banner placement through the shared large-screen upsell flag.

--- a/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/LNSUpsellBanner.test.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "~/context/Locale";
 import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { render, screen, fireEvent, renderHook } from "@tests/test-renderer";
+import { FEATURE_FLAGS_DEFAULTS } from "@shared/feature-flags";
 import { track } from "~/analytics";
 import { LNSUpsellBanner } from ".";
 
@@ -16,11 +17,15 @@ describe("LNSUpsellBanner", () => {
   });
 
   describe.each([
-    { location: "accounts", page: "Accounts" },
-    { location: "manager", page: "Manager" },
-    { location: "wallet", page: "Wallet" },
-    { location: "notification_center", page: "NotificationPanel" },
-  ] as const)("on the $page page", ({ location, page }) => {
+    { location: "accounts", placement: "accounts", page: "Accounts" },
+    { location: "manager", placement: "my-ledger", page: "Manager" },
+    { location: "wallet", placement: "homepage", page: "Wallet" },
+    {
+      location: "notification_center",
+      placement: "notification-center",
+      page: "NotificationPanel",
+    },
+  ] as const)("on the $page page", ({ location, placement, page }) => {
     it("should not render if the feature flag is disabled", () => {
       renderBanner({ ffEnabled: false });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
@@ -31,8 +36,23 @@ describe("LNSUpsellBanner", () => {
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
 
+    it("should not render if its large-screen upsell placement is disabled", () => {
+      renderBanner({ largeScreenPlacementEnabled: false });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should render with legacy large-screen upsell params missing banners", () => {
+      renderBanner({ hasLargeScreenBannersParam: false });
+      expect(screen.getByText(t(`lnsUpsell.opted_in.cta`))).toBeVisible();
+    });
+
     it("should not render if the user uses another device", () => {
       renderBanner({ devicesModelList: [DeviceModelId.nanoSP] });
+      expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
+    });
+
+    it("should not render if the user also owns a large-screen device", () => {
+      renderBanner({ devicesModelList: [DeviceModelId.nanoS, DeviceModelId.stax] });
       expect(screen.queryByText(t(`lnsUpsell.opted_in.cta`))).toBeNull();
     });
 
@@ -108,11 +128,32 @@ describe("LNSUpsellBanner", () => {
       devicesModelList = [DeviceModelId.nanoS],
       targetedByHighTierUpsell = false,
       brazePlacement = false,
+      largeScreenPlacementEnabled = true,
+      hasLargeScreenBannersParam = true,
     }) {
       const defaultParams = { [location]: ffLocationEnabled, "%": 10, img: "" };
       const ffParams = {
         opted_in: { ...defaultParams, link: "https://example.com/optInCta" },
         opted_out: { ...defaultParams, link: "https://example.com/optOutCta" },
+      };
+      const largeScreenUpsellParams = FEATURE_FLAGS_DEFAULTS.largeScreenUpsell.params;
+
+      if (!largeScreenUpsellParams) {
+        throw new Error("Expected large-screen upsell default params");
+      }
+
+      const { banners: _banners, ...legacyLargeScreenUpsellParams } = largeScreenUpsellParams;
+      const largeScreenUpsell = {
+        ...FEATURE_FLAGS_DEFAULTS.largeScreenUpsell,
+        params: hasLargeScreenBannersParam
+          ? {
+              ...largeScreenUpsellParams,
+              banners: {
+                ...largeScreenUpsellParams.banners,
+                [placement]: largeScreenPlacementEnabled,
+              },
+            }
+          : legacyLargeScreenUpsellParams,
       };
 
       render(<LNSUpsellBanner location={location} />, {
@@ -127,6 +168,7 @@ describe("LNSUpsellBanner", () => {
             featureFlags: {
               overrides: {
                 llmNanoSUpsellBanners: { enabled: ffEnabled, params: ffParams },
+                largeScreenUpsell,
                 ...(brazePlacement
                   ? {
                       lwmWallet40: {

--- a/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LNSUpsell/hooks/useLNSUpsellBannerState.ts
@@ -1,6 +1,7 @@
 import { useSelector } from "~/context/hooks";
 import { useFeature } from "@features/platform-feature-flags";
 import type { LlmNanoSUpsellBannersConfig } from "@ledgerhq/types-live/lnsUpsell";
+import type { Features } from "@shared/feature-flags";
 import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import {
   knownDeviceModelIdsSelector,
@@ -14,13 +15,26 @@ type LNSUpsellBannerState = {
   tracking: "opted_in" | "opted_out";
 };
 
+type LargeScreenUpsellParams = NonNullable<Features["largeScreenUpsell"]["params"]>;
+type LargeScreenUpsellBannerPlacement = keyof LargeScreenUpsellParams["banners"];
+
+const LARGE_SCREEN_UPSELL_BANNER_PLACEMENT_BY_LOCATION = {
+  manager: "my-ledger",
+  accounts: "accounts",
+  notification_center: "notification-center",
+  wallet: "homepage",
+} as const satisfies Record<LNSBannerLocation, LargeScreenUpsellBannerPlacement>;
+
 const LNS_UPSELL_HIGH_TIER = "LNS_UPSELL_HIGH_TIER";
 
 export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSUpsellBannerState {
   const isOptIn = useSelector(personalizedRecommendationsEnabledSelector);
   const ff = useFeature("llmNanoSUpsellBanners");
+  const largeScreenUpsell = useFeature("largeScreenUpsell");
   const tracking = isOptIn ? "opted_in" : "opted_out";
   const params = ff?.params?.[tracking];
+  const placement = LARGE_SCREEN_UPSELL_BANNER_PLACEMENT_BY_LOCATION[location];
+  const isPlacementEnabled = largeScreenUpsell?.params?.banners?.[placement] ?? true;
 
   const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
   const hasOnlySeenOneModel = Object.values(knownDeviceModelIds).filter(Boolean).length === 1;
@@ -29,7 +43,7 @@ export function useLNSUpsellBannerState(location: LNSBannerLocation): LNSUpsellB
   const { mobileCards } = useDynamicContent();
   const isExcluded = isOptIn && mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER);
 
-  const isEnabled = Boolean(ff?.enabled && params?.[location]);
+  const isEnabled = Boolean(ff?.enabled && params?.[location] && isPlacementEnabled);
   const isShown = isEnabled && hasOnlySeenLNS && !isExcluded;
 
   return { isShown, params, tracking };

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.test.ts
@@ -1,6 +1,58 @@
 import { largeScreenUpsell } from "./largeScreenUpsell";
 
 describe("largeScreenUpsell", () => {
+  it("should enable every banner placement by default", () => {
+    const defaults = largeScreenUpsell.parse(undefined);
+
+    expect(defaults.params?.banners).toEqual({
+      "my-ledger": true,
+      "notification-center": true,
+      accounts: true,
+      homepage: true,
+    });
+  });
+
+  it("should default missing banner placements to enabled", () => {
+    const defaults = largeScreenUpsell.parse(undefined);
+
+    if (!defaults.params) {
+      throw new Error("Expected large-screen upsell default params");
+    }
+
+    const result = largeScreenUpsell.parse({
+      enabled: true,
+      params: {
+        ...defaults.params,
+        banners: { homepage: false },
+      },
+    });
+
+    expect(result.params?.banners).toEqual({
+      "my-ledger": true,
+      "notification-center": true,
+      accounts: true,
+      homepage: false,
+    });
+  });
+
+  it("should add banner defaults to legacy params", () => {
+    const defaults = largeScreenUpsell.parse(undefined);
+
+    if (!defaults.params) {
+      throw new Error("Expected large-screen upsell default params");
+    }
+
+    const { banners: _banners, ...legacyParams } = defaults.params;
+    const result = largeScreenUpsell.parse({ enabled: true, params: legacyParams });
+
+    expect(result.params?.banners).toEqual({
+      "my-ledger": true,
+      "notification-center": true,
+      accounts: true,
+      homepage: true,
+    });
+  });
+
   it("should default variant enabled states to false when they are missing", () => {
     const defaults = largeScreenUpsell.parse(undefined);
 

--- a/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
+++ b/shared/feature-flags/src/flags/team-engagement/largeScreenUpsell.ts
@@ -27,9 +27,26 @@ const ctaSchema = z.object({
   link: z.string(),
 });
 
+const DEFAULT_BANNERS = {
+  "my-ledger": true,
+  "notification-center": true,
+  accounts: true,
+  homepage: true,
+} as const;
+
+const bannersSchema = z
+  .object({
+    "my-ledger": z.boolean().default(true),
+    "notification-center": z.boolean().default(true),
+    accounts: z.boolean().default(true),
+    homepage: z.boolean().default(true),
+  })
+  .default(DEFAULT_BANNERS);
+
 export const largeScreenUpsell = flagWith(
   {
     audience: z.object({ models: audienceModelsSchema }),
+    banners: bannersSchema,
     cooldownDays: cooldownDaysSchema,
     discount: z.number().min(0).max(1),
     modal: modalSchema,
@@ -40,6 +57,7 @@ export const largeScreenUpsell = flagWith(
     enabled: false,
     params: {
       audience: { models: { nanoS: true, nanoSP: true, nanoX: true } },
+      banners: DEFAULT_BANNERS,
       cooldownDays: { default: 30, nanoS: 0 },
       discount: 0.2,
       modal: { enabled: true, killThreshold: 3, cadenceDays: 30 },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - My Ledger, Notification Center, Accounts, and Homepage Nano S banner placement toggles
  - Nano S-only targeting and large-screen owner exclusion
  - Backward compatibility with Remote Config payloads that do not include `banners`
  - Existing opt-in/opt-out copy, links, and analytics

### 📝 Description

The existing Nano S upsell banners are controlled by hard-coded placement keys in `llmNanoSUpsellBanners`, while the shared `largeScreenUpsell` flag cannot independently enable or disable each banner surface.

This PR adds a backward-compatible `banners` parameter to `largeScreenUpsell` and combines it with the existing banner gate in Mobile:

```json
{
  "banners": {
    "my-ledger": true,
    "notification-center": true,
    "accounts": true,
    "homepage": true
  }
}
```

The Mobile hook maps each existing location to its shared placement key. Missing legacy configuration defaults to `true`, while setting a placement to `false` hides only that banner. The global `largeScreenUpsell.enabled` value is intentionally not used because it defaults to `false`; this preserves the current banner behavior. Nano S-only targeting, large-screen owner exclusion, copy, links, cooldown behavior, and analytics remain unchanged.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-34519
---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34519]: https://ledgerhq.atlassian.net/browse/LIVE-34519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ