### PR TITLE
[LWDM] fix(large-screen-upsell): align modal UTM attribution

### DIFF
--- a/.changeset/calm-modals-track.md
+++ b/.changeset/calm-modals-track.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-large-screen-upsell": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Update large-screen upsell modal UTM attribution on mobile and desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -261,8 +261,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       "https://shop.ledger.com/pages/opted-out-offer",
     );
     expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("desktop");
-    expect(openedUrl.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
     expect(track).toHaveBeenCalledWith("button_clicked", {
@@ -312,8 +312,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       "https://shop.ledger.com/pages/opted-in-offer",
     );
     expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("desktop");
-    expect(openedUrl.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(track).toHaveBeenCalledWith("button_clicked", {
       button: "explore large screen devices",

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -260,8 +260,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openedUrl.origin + openedUrl.pathname).toBe(
       "https://shop.ledger.com/pages/opted-out-offer",
     );
-    expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(store.getState().largeScreenUpsellModal.retries).toBe(0);
@@ -311,8 +311,8 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     expect(openedUrl.origin + openedUrl.pathname).toBe(
       "https://shop.ledger.com/pages/opted-in-offer",
     );
-    expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
+    expect(openedUrl.searchParams.get("utm_medium")).toBe("ledger_live");
     expect(openedUrl.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(openedUrl.searchParams.get("utm_content")).toBe("app_start_modal");
     expect(track).toHaveBeenCalledWith("button_clicked", {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellContent.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellContent.test.ts
@@ -38,7 +38,7 @@ describe("buildLargeScreenUpsellContent", () => {
     expect(content.title).toBe("See more. Tap less. Save 20%");
     expect(content.subtitle).toBe("Enjoy clearer signers and an exclusive offer.");
     expect(content.primaryButtonLabel).toBe("Explore touchscreen signers");
-    expect(content.primaryButtonLink).toContain("utm_campaign=upsell_large_screen");
+    expect(content.primaryButtonLink).toContain("utm_campaign=nano_upgrade_program");
     expect(content.imageUrlLight).toContain("large_screen_upsell_light");
     expect(content.imageUrlDark).toContain("large_screen_upsell_dark");
     expect(content.secondaryButtonLabel).toBe("");

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
@@ -6,8 +6,8 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const url = new URL(result);
 
     expect(url.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(url.searchParams.get("utm_medium")).toBe("llm");
-    expect(url.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
+    expect(url.searchParams.get("utm_medium")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(url.searchParams.get("utm_content")).toBe("app_start_modal");
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/__tests__/upsellCta.test.ts
@@ -5,8 +5,8 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer");
     const url = new URL(result);
 
-    expect(url.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(url.searchParams.get("utm_medium")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_medium")).toBe("ledger_live");
     expect(url.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(url.searchParams.get("utm_content")).toBe("app_start_modal");
   });
@@ -16,7 +16,7 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const url = new URL(result);
 
     expect(url.searchParams.get("foo")).toBe("bar");
-    expect(url.searchParams.get("utm_source")).toBe("ledger_live");
+    expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_mobile");
   });
 
   it("should return the trimmed input when URL parsing fails", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
@@ -1,5 +1,5 @@
-const UPSELL_UTM_SOURCE = "ledger_live";
-const UPSELL_UTM_MEDIUM = "ledger_wallet_mobile";
+const UPSELL_UTM_SOURCE = "ledger_wallet_mobile";
+const UPSELL_UTM_MEDIUM = "ledger_live";
 const UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
 const UPSELL_UTM_CONTENT = "app_start_modal";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/utils/upsellCta.ts
@@ -1,6 +1,6 @@
 const UPSELL_UTM_SOURCE = "ledger_live";
-const UPSELL_UTM_MEDIUM = "llm";
-const UPSELL_UTM_CAMPAIGN = "upsell_large_screen";
+const UPSELL_UTM_MEDIUM = "ledger_wallet_mobile";
+const UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
 const UPSELL_UTM_CONTENT = "app_start_modal";
 
 export function buildLargeScreenUpsellCtaLink(link: string): string {

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
@@ -5,15 +5,15 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer", "mobile");
     const url = new URL(result);
 
-    expect(url.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(url.searchParams.get("utm_medium")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_medium")).toBe("ledger_live");
     expect(url.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(url.searchParams.get("utm_content")).toBe("app_start_modal");
   });
 
-  it("should use desktop medium when requested", () => {
+  it("should use desktop source when requested", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer", "desktop");
-    expect(new URL(result).searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
+    expect(new URL(result).searchParams.get("utm_source")).toBe("ledger_wallet_desktop");
   });
 
   it("should preserve existing query params while setting UTM values", () => {
@@ -21,7 +21,7 @@ describe("buildLargeScreenUpsellCtaLink", () => {
     const url = new URL(result);
 
     expect(url.searchParams.get("foo")).toBe("bar");
-    expect(url.searchParams.get("utm_source")).toBe("ledger_live");
+    expect(url.searchParams.get("utm_source")).toBe("ledger_wallet_mobile");
   });
 
   it("should return the trimmed input when URL parsing fails", () => {

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.test.ts
@@ -1,19 +1,19 @@
 import { buildLargeScreenUpsellCtaLink } from "./upsellCta";
 
 describe("buildLargeScreenUpsellCtaLink", () => {
-  it("should append expected UTM parameters for mobile (utm_medium=llm)", () => {
+  it("should append expected UTM parameters for mobile", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer", "mobile");
     const url = new URL(result);
 
     expect(url.searchParams.get("utm_source")).toBe("ledger_live");
-    expect(url.searchParams.get("utm_medium")).toBe("llm");
-    expect(url.searchParams.get("utm_campaign")).toBe("upsell_large_screen");
+    expect(url.searchParams.get("utm_medium")).toBe("ledger_wallet_mobile");
+    expect(url.searchParams.get("utm_campaign")).toBe("nano_upgrade_program");
     expect(url.searchParams.get("utm_content")).toBe("app_start_modal");
   });
 
   it("should use desktop medium when requested", () => {
     const result = buildLargeScreenUpsellCtaLink("https://example.com/offer", "desktop");
-    expect(new URL(result).searchParams.get("utm_medium")).toBe("desktop");
+    expect(new URL(result).searchParams.get("utm_medium")).toBe("ledger_wallet_desktop");
   });
 
   it("should preserve existing query params while setting UTM values", () => {

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.ts
@@ -1,13 +1,16 @@
-const UPSELL_UTM_SOURCE = "ledger_live";
+const UPSELL_UTM_MEDIUM = "ledger_live";
 const UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
 const UPSELL_UTM_CONTENT = "app_start_modal";
 
-const UPSELL_UTM_MEDIUM_BY_PLATFORM = {
+const UPSELL_UTM_SOURCE_BY_PLATFORM = {
   mobile: "ledger_wallet_mobile",
   desktop: "ledger_wallet_desktop",
 } as const;
 
-export function buildLargeScreenUpsellCtaLink(link: string, medium: "mobile" | "desktop"): string {
+export function buildLargeScreenUpsellCtaLink(
+  link: string,
+  platform: "mobile" | "desktop",
+): string {
   const trimmedLink = link.trim();
   if (!trimmedLink) {
     return "";
@@ -15,8 +18,8 @@ export function buildLargeScreenUpsellCtaLink(link: string, medium: "mobile" | "
 
   try {
     const url = new URL(trimmedLink);
-    url.searchParams.set("utm_source", UPSELL_UTM_SOURCE);
-    url.searchParams.set("utm_medium", UPSELL_UTM_MEDIUM_BY_PLATFORM[medium]);
+    url.searchParams.set("utm_source", UPSELL_UTM_SOURCE_BY_PLATFORM[platform]);
+    url.searchParams.set("utm_medium", UPSELL_UTM_MEDIUM);
     url.searchParams.set("utm_campaign", UPSELL_UTM_CAMPAIGN);
     url.searchParams.set("utm_content", UPSELL_UTM_CONTENT);
     return url.toString();

--- a/features/flow/large-screen-upsell/src/utils/upsellCta.ts
+++ b/features/flow/large-screen-upsell/src/utils/upsellCta.ts
@@ -1,10 +1,10 @@
 const UPSELL_UTM_SOURCE = "ledger_live";
-const UPSELL_UTM_CAMPAIGN = "upsell_large_screen";
+const UPSELL_UTM_CAMPAIGN = "nano_upgrade_program";
 const UPSELL_UTM_CONTENT = "app_start_modal";
 
 const UPSELL_UTM_MEDIUM_BY_PLATFORM = {
-  mobile: "llm",
-  desktop: "desktop",
+  mobile: "ledger_wallet_mobile",
+  desktop: "ledger_wallet_desktop",
 } as const;
 
 export function buildLargeScreenUpsellCtaLink(link: string, medium: "mobile" | "desktop"): string {


### PR DESCRIPTION
### ✅ Checklist

- [x] Changeset added for Mobile, Desktop, and the shared large-screen upsell flow.
- [x] Covered by automatic tests.
- [x] No UI or copy changes.

### 📝 Description

This PR updates webshop attribution for the CTA opened from the large-screen upsell `app_start_modal` on Mobile and Desktop.

#### Final UTM mapping

| Parameter | Mobile | Desktop |
| --- | --- | --- |
| `utm_source` | `ledger_wallet_mobile` | `ledger_wallet_desktop` |
| `utm_medium` | `ledger_live` | `ledger_live` |
| `utm_campaign` | `nano_upgrade_program` | `nano_upgrade_program` |
| `utm_content` | `app_start_modal` | `app_start_modal` |

Both CTA builders continue to preserve existing query parameters. The change only affects the UTM values added to valid shop links.

### 🧪 Validation

- Shared CTA utility: 4 tests passed.
- Mobile CTA and content utilities: 5 tests passed.
- Desktop modal integration: 30 tests passed.
- Formatting, lint, and TypeScript checks passed.

### 👀 Review focus

- Confirm the final UTM mapping matches the analytics requirements.
- Confirm Mobile and Desktop use their corresponding `utm_source`.
