### PR TITLE
[LWD] feat(contacts): render contact name validation errors

### DIFF
--- a/.changeset/clear-contacts-web-validation.md
+++ b/.changeset/clear-contacts-web-validation.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Render validation errors in the Desktop add contact dialog.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
-import { render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
+import { fireEvent, render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
 import { ContextMenu } from "LLD/features/MyWallet/components/ContextMenu";
@@ -215,8 +215,16 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-add-contact-dialog")).toBeVisible();
     expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
 
-    await user.type(screen.getByTestId("contacts-add-contact-name-input"), "Ada");
+    const input = screen.getByTestId("contacts-add-contact-name-input");
 
+    await user.type(input, "Ada1");
+
+    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Ada" } });
+
+    expect(screen.queryByText("Special characters are not allowed.")).not.toBeInTheDocument();
     expect(screen.getByTestId("contacts-add-contact-save")).toBeEnabled();
 
     await user.click(screen.getByTestId("contacts-add-contact-save"));

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -58,7 +58,7 @@ src/
 │   ├── AddContact/                      # Web dialog + native drawer
 │   │   ├── ContactsAddContactDialog.web.tsx / ContactsAddContactDrawer.native.tsx
 │   │   ├── useAddContactViewModel.ts / useAddContactDrawerViewModel.ts / types.ts
-│   │   ├── components/ContactNameInput/ (native)
+│   │   ├── components/ContactNameInput/ (web + native)
 │   │   ├── model/                       # Contact-name validation and creation contract
 │   │   └── index.ts / web.ts / native.ts
 │   ├── Introduction/                    # Feature intro + Ledger Sync intro (ex featureIntroduction)

--- a/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import { ContactsAddContactDialog } from "./ContactsAddContactDialog.web";
+import type { ContactsAddContactDialogProps } from "./types";
+
+function createViewModel(
+  overrides: Partial<ContactsAddContactDialogProps> = {},
+): ContactsAddContactDialogProps {
+  return {
+    isOpen: true,
+    isConfirmEnabled: false,
+    isSaving: false,
+    draftName: "",
+    avatarInitial: "",
+    invalidNameError: null,
+    labels: {
+      title: "Add contact",
+      namePlaceholder: "Contact name",
+      namingDisclaimer:
+        "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
+      confirmName: "Add contact",
+      nameValidationErrors: {
+        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
+      },
+    },
+    onClose: jest.fn(),
+    onOpen: jest.fn(),
+    onDraftNameChange: jest.fn(),
+    onConfirm: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactsAddContactDialog", () => {
+  it("should render the shared validation error and disable confirmation", () => {
+    render(
+      <ContactsAddContactDialog
+        {...createViewModel({
+          draftName: "Cédric",
+          invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveValue("Cédric");
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
+  });
+
+  it("should forward draft name changes to the parent", () => {
+    const onDraftNameChange = jest.fn();
+
+    render(
+      <ContactsAddContactDialog
+        {...createViewModel({
+          draftName: "Ada",
+          isConfirmEnabled: true,
+          onDraftNameChange,
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("contacts-add-contact-name-input"), {
+      target: { value: "Ada1" },
+    });
+
+    expect(onDraftNameChange).toHaveBeenCalledWith("Ada1");
+  });
+});

--- a/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.tsx
+++ b/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.tsx
@@ -1,13 +1,6 @@
 import React from "react";
-import {
-  Button,
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogHeader,
-  TextInput,
-} from "@ledgerhq/lumen-ui-react";
-import { CONTACT_NAME_MAX_LENGTH } from "./model/constants";
+import { Button, Dialog, DialogBody, DialogContent, DialogHeader } from "@ledgerhq/lumen-ui-react";
+import { ContactNameInput } from "./components/ContactNameInput/ContactNameInput.web";
 import { ContactsAddContactNamingDisclaimer } from "./ContactsAddContactNamingDisclaimer.web";
 import type { ContactsAddContactDialogProps } from "./types";
 
@@ -18,11 +11,15 @@ export function ContactsAddContactDialog({
   isConfirmEnabled,
   isSaving,
   draftName,
+  invalidNameError,
   labels,
   onClose,
   onDraftNameChange,
   onConfirm,
 }: ContactsAddContactDialogProps): React.ReactNode {
+  const nameValidationError =
+    invalidNameError === null ? undefined : labels.nameValidationErrors[invalidNameError];
+
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       onClose();
@@ -42,25 +39,12 @@ export function ContactsAddContactDialog({
           onClose={onClose}
         />
         <DialogBody className="flex flex-col gap-24 px-24 pb-24 pt-12">
-          <div className="flex flex-col gap-8">
-            <TextInput
-              data-testid="contacts-add-contact-name-input"
-              placeholder={labels.namePlaceholder}
-              value={draftName}
-              onChange={(event) =>
-                onDraftNameChange(
-                  event.target.value.slice(0, CONTACT_NAME_MAX_LENGTH),
-                )
-              }
-              maxLength={CONTACT_NAME_MAX_LENGTH}
-            />
-            <p
-              className="body-3 self-end text-muted"
-              data-testid="contacts-add-contact-name-count"
-            >
-              {`${draftName.length}/${CONTACT_NAME_MAX_LENGTH}`}
-            </p>
-          </div>
+          <ContactNameInput
+            value={draftName}
+            placeholder={labels.namePlaceholder}
+            errorMessage={nameValidationError}
+            onChange={onDraftNameChange}
+          />
           <ContactsAddContactNamingDisclaimer
             disclaimerId={NAMING_DISCLAIMER_ID}
             text={labels.namingDisclaimer}

--- a/features/flow/contacts/src/steps/AddContact/components/ContactNameInput/ContactNameInput.web.tsx
+++ b/features/flow/contacts/src/steps/AddContact/components/ContactNameInput/ContactNameInput.web.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { TextInput } from "@ledgerhq/lumen-ui-react";
+import { CONTACT_NAME_MAX_LENGTH } from "../../model/constants";
+
+type ContactNameInputProps = Readonly<{
+  value: string;
+  placeholder: string;
+  errorMessage?: string;
+  onChange: (value: string) => void;
+}>;
+
+export function ContactNameInput({
+  value,
+  placeholder,
+  errorMessage,
+  onChange,
+}: ContactNameInputProps): React.ReactNode {
+  return (
+    <TextInput
+      data-testid="contacts-add-contact-name-input"
+      label={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      maxLength={CONTACT_NAME_MAX_LENGTH}
+      maxCount={CONTACT_NAME_MAX_LENGTH}
+      helperText={errorMessage}
+      status={errorMessage ? "error" : undefined}
+    />
+  );
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request improves validation and error handling for the "Add Contact" dialog in the desktop application, ensuring that validation errors are clearly displayed to users and that the UI responds appropriately to invalid input. It introduces a new reusable `ContactNameInput` component for both web and native platforms, updates integration and unit tests to cover validation scenarios, and refactors the dialog to use the new input component.

**Validation and UI Improvements:**

* The "Add Contact" dialog now renders validation errors (e.g., disallowing special characters in names) and disables the confirmation button when input is invalid. 
* The dialog uses the new `ContactNameInput` component, which handles displaying error messages, character limits, and input status. 

**Testing Enhancements:**

* Integration and unit tests are updated and expanded to verify that validation errors are shown and that the confirm button is enabled/disabled appropriately based on input validity.

**Component and Code Structure:**

* The `ContactNameInput` component is now shared between web and native implementations, improving code reuse and maintainability.


https://github.com/user-attachments/assets/0c586512-1900-4548-a8aa-2c47fffcee95



### 🔗 Context

[LIVE-33902](urlhttps://ledgerhq.atlassian.net/browse/LIVE-33902)


[LIVE-33902]: https://ledgerhq.atlassian.net/browse/LIVE-33902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ