### PR TITLE
[LWDM] feat(lwm): changes bottomsheet to sheet info and minor fixes on lwdm

### DIFF
--- a/.changeset/sharp-schools-argue.md
+++ b/.changeset/sharp-schools-argue.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwm): changes bottomsheet to sheet info and minor fixes on lwm

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -333,6 +333,7 @@ export function useAddressValidation({
       matchedAccounts,
       bridgeErrors: filteredBridgeErrors,
       bridgeWarnings: bridgeValidation.warnings,
+      isBridgeLoading: bridgeValidation.isLoading && bridgeValidation.status === null,
     };
   }, [
     validationState,
@@ -349,12 +350,16 @@ export function useAddressValidation({
     addressForBridgeValidation,
     bridgeValidation.errors,
     bridgeValidation.warnings,
+    bridgeValidation.isLoading,
+    bridgeValidation.status,
   ]);
 
   return {
     result,
     isLoading:
-      validationState.status === "loading" || domainIsLoading || bridgeValidation.isLoading,
+      validationState.status === "loading" ||
+      domainIsLoading ||
+      (bridgeValidation.isLoading && bridgeValidation.status === null),
     validateAddress,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -3,7 +3,6 @@ import { View, Pressable } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Text,
-  Button,
   BottomSheet,
   BottomSheetView,
   BottomSheetHeader,
@@ -13,6 +12,8 @@ import {
 import { Information, ChevronDown, Check } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
 import { useTranslation } from "~/context/Locale";
+import { BottomSheetInfoGradient } from "LLM/components/BottomSheetGradient";
+import { InfoState } from "LLM/components/InfoState";
 import type { FeeSelectorOptionKind, NetworkFeesViewModel } from "../types";
 import { useSendFlowData } from "../context/SendFlowContext";
 import { useAnalytics } from "~/analytics";
@@ -53,14 +54,6 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
         flexDirection: "row",
         alignItems: "center",
         gap: theme.spacings.s4,
-      },
-      infoContent: {
-        paddingHorizontal: theme.spacings.s24,
-        paddingBottom: theme.spacings.s24,
-      },
-      infoDescription: {
-        marginBottom: theme.spacings.s24,
-        textAlign: "center",
       },
       presetOption: {
         flexDirection: "row",
@@ -127,6 +120,17 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
     infoBottomSheetRef.current?.dismiss();
   }, [infoBottomSheetRef]);
 
+  const infoTitle = viewModel.networkFeesInfo
+    ? t(`send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.title`)
+    : viewModel.label;
+
+  const infoDescription = viewModel.networkFeesInfo
+    ? t(
+        `send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.description`,
+        viewModel.networkFeesInfo.values,
+      )
+    : t("send.newSendFlow.feesPaid");
+
   return (
     <>
       <View style={styles.row}>
@@ -160,29 +164,24 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
         </Pressable>
       </View>
 
-      <BottomSheet ref={infoBottomSheetRef} snapPoints="small">
+      <BottomSheet
+        ref={infoBottomSheetRef}
+        enableDynamicSizing
+        snapPoints={null}
+        backgroundComponent={BottomSheetInfoGradient}
+      >
         <BottomSheetView>
-          <BottomSheetHeader
-            title={
-              viewModel.networkFeesInfo
-                ? t(`send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.title`)
-                : viewModel.label
-            }
-            density="compact"
+          <BottomSheetHeader density="compact" />
+          <InfoState
+            preset="info"
+            size="hug"
+            title={infoTitle}
+            description={infoDescription}
+            primaryCta={{
+              label: t("common.gotit"),
+              onPress: handleCloseInfo,
+            }}
           />
-          <View style={styles.infoContent}>
-            <Text typography="body2" lx={{ color: "muted" }} style={styles.infoDescription}>
-              {viewModel.networkFeesInfo
-                ? t(
-                    `send.newSendFlow.${viewModel.networkFeesInfo.translationKey}.description`,
-                    viewModel.networkFeesInfo.values,
-                  )
-                : t("send.newSendFlow.feesPaid")}
-            </Text>
-            <Button appearance="base" size="lg" onPress={handleCloseInfo}>
-              {t("common.gotit")}
-            </Button>
-          </View>
         </BottomSheetView>
       </BottomSheet>
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -8,6 +8,23 @@ const dismiss = jest.fn();
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
 }));
+jest.mock("LLM/components/InfoState", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+  return {
+    InfoState: ({
+      title,
+      description,
+    }: {
+      title?: React.ReactNode;
+      description?: React.ReactNode;
+    }) => (
+      <RN.View>
+        {title ? <RN.Text>{title}</RN.Text> : null}
+        {description ? <RN.Text>{description}</RN.Text> : null}
+      </RN.View>
+    ),
+  };
+});
 jest.mock("@ledgerhq/lumen-ui-rnative", () => {
   const RN = jest.requireActual<typeof import("react-native")>("react-native");
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
@@ -68,9 +68,9 @@ export function AmountScreenView({ viewModel }: AmountScreenViewProps) {
         <NetworkFeesRow viewModel={viewModel.networkFees} />
         <Divider />
 
-        {viewModel.quickActions.show ? (
+        {viewModel.quickActions.show && (
           <QuickActionsRow actions={viewModel.quickActions.actions} />
-        ) : null}
+        )}
 
         <NumberKeyboard
           onKeyPress={handleKeyPress}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -368,7 +368,7 @@ describe("useAddressValidation", () => {
     );
   });
 
-  it("does not surface bridge validation loading as recipient input loading", () => {
+  it("surfaces bridge loading only while awaiting the first result for the recipient", () => {
     mockedUseBridgeRecipientValidation.mockReturnValue({
       errors: {},
       warnings: {},
@@ -377,14 +377,31 @@ describe("useAddressValidation", () => {
       cleanup: jest.fn(),
     });
 
-    const { result } = renderHook(() =>
-      useAddressValidation({
-        searchValue: "address",
-        currency: mockAccount.currency,
-        account: mockAccount,
-      }),
+    const validationProps = {
+      searchValue: "address",
+      currency: mockAccount.currency,
+      account: mockAccount,
+    };
+
+    const { result, rerender } = renderHook(
+      (props: typeof validationProps) => useAddressValidation(props),
+      { initialProps: validationProps },
     );
 
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.result.isBridgeLoading).toBe(true);
+
+    mockedUseBridgeRecipientValidation.mockReturnValue({
+      errors: {},
+      warnings: {},
+      isLoading: true,
+      // Bridge already settled once for this recipient (revalidation in progress).
+      status: { errors: {}, warnings: {} } as never,
+      cleanup: jest.fn(),
+    });
+    rerender(validationProps);
+
+    expect(result.current.result.isBridgeLoading).toBe(false);
     expect(result.current.isLoading).toBe(false);
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -312,6 +312,7 @@ export function useAddressValidation({
       matchedAccounts,
       bridgeErrors: filteredBridgeErrors,
       bridgeWarnings: bridgeValidation.warnings,
+      isBridgeLoading: bridgeValidation.isLoading && bridgeValidation.status === null,
     };
   }, [
     validationState,
@@ -328,11 +329,16 @@ export function useAddressValidation({
     addressForBridgeValidation,
     bridgeValidation.errors,
     bridgeValidation.warnings,
+    bridgeValidation.isLoading,
+    bridgeValidation.status,
   ]);
 
   return {
     result,
-    isLoading: validationState.status === "loading" || domainIsLoading,
+    isLoading:
+      validationState.status === "loading" ||
+      domainIsLoading ||
+      (bridgeValidation.isLoading && bridgeValidation.status === null),
     validateAddress,
   };
 }

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
@@ -322,6 +322,30 @@ describe("useBridgeRecipientValidation", () => {
     });
   });
 
+  it("clears settled status when the recipient changes so first-result loading is detectable", async () => {
+    const { result, rerender } = renderHook(
+      ({ recipient }) =>
+        useBridgeRecipientValidation({
+          recipient,
+          account: mockAccount,
+        }),
+      { initialProps: { recipient: "addr1" } },
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.status).not.toBeNull();
+    });
+
+    rerender({ recipient: "addr2" });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.status).toBeNull();
+    expect(result.current.errors).toEqual({});
+  });
+
   it("returns null status when account is null", () => {
     const { result } = renderHook(() =>
       useBridgeRecipientValidation({

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -121,18 +121,32 @@ describe("useRecipientSearchState", () => {
     expect(result.current.isAddressComplete).toBe(false);
   });
 
-  it("should keep a validated address complete while bridge validation is loading", () => {
+  it("should not set isAddressComplete while awaiting the first bridge result", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "v",
+        result: createDefaultResult({ status: "valid", isBridgeLoading: true }),
+      }),
+    );
+
+    expect(result.current.isAddressComplete).toBe(false);
+    expect(result.current.showMatchedAddress).toBe(false);
+  });
+
+  it("should keep a validated address complete while bridge revalidates after a first result", () => {
     const { result } = renderHook(() =>
       useRecipientSearchState({
         ...defaultProps,
         searchValue: "0xvalid",
-        result: createDefaultResult({ status: "valid" }),
+        result: createDefaultResult({ status: "valid", isBridgeLoading: false }),
         isLoading: true,
       }),
     );
 
     expect(result.current.isAddressComplete).toBe(true);
     expect(result.current.showSearchResults).toBe(true);
+    expect(result.current.showMatchedAddress).toBe(true);
   });
 
   it("should not set isAddressComplete for idle or invalid status", () => {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useBridgeRecipientValidation.ts
@@ -7,7 +7,7 @@ import type {
   TransactionStatus,
 } from "@ledgerhq/live-common/coin-modules/transaction-types";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { BridgeValidationErrors, BridgeValidationWarnings } from "../types";
 
 export type BridgeRecipientValidationResult = {
@@ -61,9 +61,7 @@ export function useBridgeRecipientValidation({
     status: null,
   });
 
-  const lastRecipientRef = useRef<string>("");
-  const lastBaseTransactionRef = useRef<Transaction | null | undefined>(undefined);
-  const validationTriggeredRef = useRef<boolean>(false);
+  const prevRecipientRef = useRef<string>("");
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -162,18 +160,15 @@ export function useBridgeRecipientValidation({
     }
   }, [account, recipient, enabled, parentAccount, baseTransaction, memo]);
 
-  if (
-    recipient !== lastRecipientRef.current ||
-    baseTransaction !== lastBaseTransactionRef.current
-  ) {
-    lastRecipientRef.current = recipient;
-    lastBaseTransactionRef.current = baseTransaction;
-    validationTriggeredRef.current = false;
+  // Reset / schedule validation in an effect — never call setState during render.
+  // useLayoutEffect keeps recipient-change resets synchronous before paint so
+  // consumers can tell "awaiting first bridge result" apart from a revalidation
+  // without a flash of the previous settled status.
+  useLayoutEffect(() => {
+    const recipientChanged = recipient !== prevRecipientRef.current;
+    prevRecipientRef.current = recipient;
 
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
-      debounceTimeoutRef.current = null;
-    }
+    cleanup();
 
     if (!recipient) {
       setValidationState({
@@ -182,22 +177,35 @@ export function useBridgeRecipientValidation({
         isLoading: false,
         status: null,
       });
-    }
-  }
-
-  if (recipient && !validationTriggeredRef.current && enabled) {
-    validationTriggeredRef.current = true;
-
-    if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current);
+      return cleanup;
     }
 
-    setValidationState(prev => ({ ...prev, isLoading: true }));
+    // Clear settled results when the recipient changes so consumers can tell
+    // "awaiting first bridge result" apart from a revalidation of the same address.
+    // Keeping the previous status on transaction-only changes avoids UI flicker.
+    if (recipientChanged) {
+      setValidationState({
+        errors: {},
+        warnings: {},
+        isLoading: enabled,
+        status: null,
+      });
+    }
+
+    if (!enabled) {
+      return cleanup;
+    }
+
+    if (!recipientChanged) {
+      setValidationState(prev => ({ ...prev, isLoading: true }));
+    }
 
     debounceTimeoutRef.current = setTimeout(() => {
       validateRecipient();
     }, debounceMs);
-  }
+
+    return cleanup;
+  }, [recipient, baseTransaction, enabled, debounceMs, validateRecipient, cleanup]);
 
   return useMemo(
     () => ({

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -31,9 +31,12 @@ export function useRecipientSearchState({
 
   const showSearchResults = hasSearchValue && (!isLoading || hasValidatedAddress);
 
+  // Local validation sets status "valid" before the bridge confirms the format.
+  // Wait for the first bridge result for this recipient to avoid briefly treating
+  // incomplete input as a selectable matching address.
   const isAddressComplete = useMemo(() => {
-    return hasValidatedAddress && !isBridgeInvalidAddress;
-  }, [hasValidatedAddress, isBridgeInvalidAddress]);
+    return hasValidatedAddress && !isBridgeInvalidAddress && !result.isBridgeLoading;
+  }, [hasValidatedAddress, isBridgeInvalidAddress, result.isBridgeLoading]);
 
   const hasAnyMatches =
     (result.matchedAccounts && result.matchedAccounts.length > 0) ||
@@ -51,7 +54,7 @@ export function useRecipientSearchState({
   const showMatchedAddress =
     showSearchResults &&
     (hasAnyMatches ||
-      (result.status === "valid" && !result.error && !isBridgeInvalidAddress) ||
+      (isAddressComplete && result.status === "valid" && !result.error) ||
       (isAddressComplete && (hasBridgeRecipientError || hasBridgeRecipientWarning))) &&
     (result.status === "valid" ||
       (recipientSupportsDomain && result.status === "ens_resolved") ||

--- a/libs/ledger-live-common/src/flows/send/recipient/types.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/types.ts
@@ -55,4 +55,5 @@ export type AddressSearchResult = Readonly<{
   matchedAccounts: MatchedAccount[];
   bridgeErrors: BridgeValidationErrors | undefined;
   bridgeWarnings: BridgeValidationWarnings | undefined;
+  isBridgeLoading?: boolean;
 }>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR updates the new Send flow on mobile: the network fees info drawer now uses the shared `InfoState` sheet (info preset + gradient) instead of a custom bottom sheet layout. 

It also fixes a recipient validation race where incomplete input (for exemple `"aa"` oneth for exemple) was briefly shown as a selectable matching address before the bridge rejected it, the UI now waits for the first bridge result via a new `isBridgeLoading` flag in `@ledgerhq/live-common`

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34882)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
