### PR TITLE
fix(automation): harden remaining workflows against script injection

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -35,11 +35,12 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
       - id: smartling_check
         if: ${{ env.IS_SMARTLING == 'true' }}
-        run: |
-          echo "should_skip=true" >> $GITHUB_OUTPUT
-          gh pr close ${{ github.event.pull_request.number }} -R LedgerHQ/ledger-live --delete-branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "should_skip=true" >> $GITHUB_OUTPUT
+          gh pr close "$PR_NUMBER" -R LedgerHQ/ledger-live --delete-branch
 
   determine-affected:
     name: "Affected"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -47,6 +47,17 @@ jobs:
       - name: Install dependencies
         run: pnpm i --filter="ledger-live"
       - name: Lint commits
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          INPUTS_FROM: ${{ inputs.from }}
         run: |
           set -o pipefail
-          pnpm commitlint --from ${{ github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref) || (inputs.from && format('origin/{0}', inputs.from) || 'HEAD^1') }} --verbose
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            FROM="origin/$BASE_REF"
+          elif [ -n "$INPUTS_FROM" ]; then
+            FROM="origin/$INPUTS_FROM"
+          else
+            FROM="HEAD^1"
+          fi
+          pnpm commitlint --from "$FROM" --verbose

--- a/.github/workflows/generate-e2e-userdata.yml
+++ b/.github/workflows/generate-e2e-userdata.yml
@@ -91,13 +91,15 @@ jobs:
       - name: Compute cache key date
         id: meta
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
           # Scope the cache key to the IAM-writable S3 namespace: the develop
           # OIDC role can only write under `develop/`, so keys generated on the
           # develop branch (e.g. the daily cron) must carry that prefix.
           PREFIX=""
-          if [ "${{ github.ref_name }}" = "develop" ]; then
+          if [ "$REF_NAME" = "develop" ]; then
             PREFIX="develop/"
           fi
           echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"
@@ -217,13 +219,15 @@ jobs:
       - name: Compute cache key date
         id: meta
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
           # Scope the cache key to the IAM-writable S3 namespace: the develop
           # OIDC role can only write under `develop/`, so keys generated on the
           # develop branch (e.g. the daily cron) must carry that prefix.
           PREFIX=""
-          if [ "${{ github.ref_name }}" = "develop" ]; then
+          if [ "$REF_NAME" = "develop" ]; then
             PREFIX="develop/"
           fi
           echo "prefix=${PREFIX}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/notify-e2e-required-reusable.yml
+++ b/.github/workflows/notify-e2e-required-reusable.yml
@@ -25,9 +25,11 @@ jobs:
       - name: Analyze E2E requirements
         id: analyze
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          AFFECTED_PATHS_JSON: ${{ toJSON(inputs.affected_paths) }}
         with:
           script: |
-            const pathsInput = ${{ toJSON(inputs.affected_paths) }};
+            const pathsInput = JSON.parse(process.env.AFFECTED_PATHS_JSON || 'null');
             const paths = String(pathsInput || "")
               .split(/\r?\n|,/)
               .map(path => path.trim())

--- a/.github/workflows/notify-prerelease-translations.yml
+++ b/.github/workflows/notify-prerelease-translations.yml
@@ -34,10 +34,13 @@ jobs:
       - name: format message
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: message
+        env:
+          PR_NUMBER: ${{ inputs.prNumber || github.event.pull_request.number }}
         with:
           script: |
             const fs = require("fs");
-            const text = "Translations files have changed on ${{ inputs.prNumber || github.event.pull_request.number }}";
+            const prNumber = process.env.PR_NUMBER;
+            const text = `Translations files have changed on ${prNumber}`;
             const output = {
               channel: "C040D9JMVQ8",
               text,
@@ -58,7 +61,7 @@ jobs:
                   "text": {
                     "type": "mrkdwn",
                     "text": `Please make sure all languages are provided before the release.
-              You can see more informations on the <https://github.com/LedgerHQ/ledger-live/pull/${{ inputs.prNumber || github.event.pull_request.number }}|Pull Request>
+              You can see more information on the <https://github.com/LedgerHQ/ledger-live/pull/${prNumber}|Pull Request>
                     `
                   }
                 }

--- a/.github/workflows/nx-affected-reusable.yml
+++ b/.github/workflows/nx-affected-reusable.yml
@@ -45,33 +45,20 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Fetch base branch
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
-          git fetch origin ${{ inputs.base_branch }} --depth=1
-
-      # Debug: refs and merge-base (remove after diagnosing CI vs local mismatch)
-      - name: Debug refs and merge-base for nx affected
-        if: ${{ inputs.affected_debug }}
-        run: |
-          echo "=== Refs after checkout + fetch ==="
-          git branch -a
-          echo "=== HEAD commit ==="
-          git rev-parse HEAD
-          echo "=== Local base branch ref (${{ inputs.base_branch }}) ==="
-          git rev-parse ${{ inputs.base_branch }} 2>/dev/null || echo "(ref not found)"
-          echo "=== origin/${{ inputs.base_branch }} (remote-tracking) ==="
-          git rev-parse origin/${{ inputs.base_branch }} 2>/dev/null || echo "(ref not found)"
-          echo "=== Merge base: HEAD vs local ${{ inputs.base_branch }} ==="
-          git merge-base HEAD ${{ inputs.base_branch }} 2>/dev/null || echo "(merge-base failed)"
-          echo "=== Merge base: HEAD vs origin/${{ inputs.base_branch }} ==="
-          git merge-base HEAD origin/${{ inputs.base_branch }} 2>/dev/null || echo "(merge-base failed)"
-          echo "=== Base ref passed to composite: origin/${{ inputs.base_branch }} ==="
+          git fetch --depth=1 origin -- "$BASE_BRANCH"
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: clean-refs
+        env:
+          HEAD_BRANCH_INPUT: ${{ inputs.head_branch }}
+          BASE_BRANCH_INPUT: ${{ inputs.base_branch }}
         with:
           script: |
-            const head_branch = "${{ inputs.head_branch }}";
-            const base_branch = "${{ inputs.base_branch }}";
+            const head_branch = process.env.HEAD_BRANCH_INPUT;
+            const base_branch = process.env.BASE_BRANCH_INPUT;
 
             const newHeadBranch = head_branch.replace("refs/heads/", "");
             const newBaseBranch = base_branch.replace("refs/heads/", "");

--- a/.github/workflows/publish-wallet-cli-npm.yml
+++ b/.github/workflows/publish-wallet-cli-npm.yml
@@ -43,6 +43,10 @@ jobs:
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: trigger wallet-cli sign and JFrog publish
+        env:
+          INPUT_REF: ${{ inputs.ref || github.sha }}
+          VERSION_OVERRIDE: ${{ inputs.version_override || '' }}
+          JFROG_REGISTRY: ${{ inputs.registry || 'jfrog.ledgerlabs.net/artifactory/api/npm/ledgerlive-npm-sandbox-green' }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -52,9 +56,9 @@ jobs:
               ref: "main",
               workflow_id: "nightly-wallet-cli.yml",
               inputs: {
-                ref: "${{ inputs.ref || github.sha }}",
-                version_override: "${{ inputs.version_override || '' }}",
+                ref: process.env.INPUT_REF,
+                version_override: process.env.VERSION_OVERRIDE,
                 publish_to_jfrog: "true",
-                jfrog_registry: "${{ inputs.registry || 'jfrog.ledgerlabs.net/artifactory/api/npm/ledgerlive-npm-sandbox-green' }}"
+                jfrog_registry: process.env.JFROG_REGISTRY
               }
             });

--- a/.github/workflows/regen-doc.yml
+++ b/.github/workflows/regen-doc.yml
@@ -84,35 +84,42 @@ jobs:
       - name: create summary (failure)
         if: failure() && inputs.number != null
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### ❌ Documentation regeneration failed
 
-            @${{ inputs.login }}: you can check [the action logs](https://github.com/LedgerHQ/ledger-live/runs/${{ github.run_id }}) for more information.`;
+            @${process.env.INPUT_LOGIN}: you can check [the action logs](https://github.com/LedgerHQ/ledger-live/runs/${process.env.RUN_ID}) for more information.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - name: create summary (success)
         if: inputs.number != null && steps.check-status.outputs.status != 0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### 🚀 Documentation regenerated
 
-            @${{ inputs.login }}: the documentation has been regenerated and a commit has been pushed to your branch.`;
+            @${process.env.INPUT_LOGIN}: the documentation has been regenerated and a commit has been pushed to your branch.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - name: create summary (no change)
         if: inputs.number != null && steps.check-status.outputs.status == 0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### ✨ No changes detected
 
-            @${{ inputs.login }}: the documentation is already up to date.`;
+            @${process.env.INPUT_LOGIN}: the documentation is already up to date.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !cancelled() }}
@@ -134,23 +141,29 @@ jobs:
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - name: report start
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_NUMBER: ${{ inputs.number }}
+          INPUT_LOGIN: ${{ inputs.login }}
+          INPUT_COMMENT_ID: ${{ inputs.commentId }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           result-encoding: string
           retries: 3
           script: |
-            const {repo: {owner, repo}, run_id} = context
-            const issue_number = ${{ inputs.number }}
+            const {repo: {owner, repo}} = context
             const body = `\
-            @${{ inputs.login }}: triggered \`/regen-doc\`
+            @${process.env.INPUT_LOGIN}: triggered \`/regen-doc\`
 
-            [Regenerating Documentation: workflow started](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Regenerating Documentation: workflow started](${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID})
             `;
 
             await github.rest.issues.updateComment({
               owner,
               repo,
-              comment_id: "${{ inputs.commentId }}",
+              comment_id: Number(process.env.INPUT_COMMENT_ID),
               body,
             });
 
@@ -172,6 +185,12 @@ jobs:
           name: summary.txt
       - name: report job status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_COMMENT_ID: ${{ inputs.commentId }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          WORKSPACE: ${{ github.workspace }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           result-encoding: string
@@ -179,12 +198,12 @@ jobs:
           script: |
             const fs = require("fs");
             const {repo: {owner, repo}} = context;
-            const summary = fs.readFileSync("${{ github.workspace }}/summary.txt", "utf8");
+            const summary = fs.readFileSync(`${process.env.WORKSPACE}/summary.txt`, "utf8");
 
             const body = `\
             ${summary}
 
-            [Regenerating Documentation: workflow ended](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Regenerating Documentation: workflow ended](${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID})
             `;
 
             const output = {
@@ -193,11 +212,11 @@ jobs:
 
             fs.writeFileSync("summary.json", JSON.stringify(output), "utf-8");
 
-            if(${{ inputs.commentId != '' }}) {
+            if(process.env.INPUT_COMMENT_ID) {
               await github.rest.issues.updateComment({
                 owner,
                 repo,
-                comment_id: "${{ inputs.commentId }}",
+                comment_id: Number(process.env.INPUT_COMMENT_ID),
                 body
               });
             }

--- a/.github/workflows/regen-pods.yml
+++ b/.github/workflows/regen-pods.yml
@@ -89,35 +89,42 @@ jobs:
       - name: create summary (failure)
         if: failure() && inputs.number != null
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### ❌ Podfile regeneration failed
 
-            @${{ inputs.login }}: you can check [the action logs](https://github.com/LedgerHQ/ledger-live/runs/${{ github.run_id }}) for more information.`;
+            @${process.env.INPUT_LOGIN}: you can check [the action logs](https://github.com/LedgerHQ/ledger-live/runs/${process.env.RUN_ID}) for more information.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - name: create summary (success)
         if: inputs.number != null && steps.check-status.outputs.status != 0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### 🚀 Podfile regenerated
 
-            @${{ inputs.login }}: the podfile has been regenerated and a commit has been pushed to your branch.`;
+            @${process.env.INPUT_LOGIN}: the podfile has been regenerated and a commit has been pushed to your branch.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - name: create summary (no change)
         if: inputs.number != null && steps.check-status.outputs.status == 0
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_LOGIN: ${{ inputs.login }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             const fs = require("fs");
             const body = `#### ✨ No changes detected
 
-            @${{ inputs.login }}: the podfile is already up to date.`;
+            @${process.env.INPUT_LOGIN}: the podfile is already up to date.`;
             fs.writeFileSync("summary.txt", body, "utf8");
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !cancelled() }}
@@ -139,23 +146,29 @@ jobs:
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
       - name: report start
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_NUMBER: ${{ inputs.number }}
+          INPUT_LOGIN: ${{ inputs.login }}
+          INPUT_COMMENT_ID: ${{ inputs.commentId }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           result-encoding: string
           retries: 3
           script: |
-            const {repo: {owner, repo}, run_id} = context
-            const issue_number = ${{ inputs.number }}
+            const {repo: {owner, repo}} = context
             const body = `\
-            @${{ inputs.login }}: triggered \`/regen-pods\`
+            @${process.env.INPUT_LOGIN}: triggered \`/regen-pods\`
 
-            [Regenerating Pods: workflow started](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Regenerating Pods: workflow started](${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID})
             `;
 
             await github.rest.issues.updateComment({
               owner,
               repo,
-              comment_id: "${{ inputs.commentId }}",
+              comment_id: Number(process.env.INPUT_COMMENT_ID),
               body,
             });
 
@@ -177,6 +190,12 @@ jobs:
           name: summary.txt
       - name: report job status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          INPUT_COMMENT_ID: ${{ inputs.commentId }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          WORKSPACE: ${{ github.workspace }}
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           result-encoding: string
@@ -184,12 +203,12 @@ jobs:
           script: |
             const fs = require("fs");
             const {repo: {owner, repo}} = context;
-            const summary = fs.readFileSync("${{ github.workspace }}/summary.txt", "utf8");
+            const summary = fs.readFileSync(`${process.env.WORKSPACE}/summary.txt`, "utf8");
 
             const body = `\
             ${summary}
 
-            [Regenerating Pods: workflow ended](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            [Regenerating Pods: workflow ended](${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID})
             `;
 
             const output = {
@@ -198,11 +217,11 @@ jobs:
 
             fs.writeFileSync("summary.json", JSON.stringify(output), "utf-8");
 
-            if(${{ inputs.commentId != '' }}) {
+            if(process.env.INPUT_COMMENT_ID) {
               await github.rest.issues.updateComment({
                 owner,
                 repo,
-                comment_id: "${{ inputs.commentId }}",
+                comment_id: Number(process.env.INPUT_COMMENT_ID),
                 body
               });
             }

--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -90,14 +90,17 @@ jobs:
         run: |
           echo "date=$(date +%F)" >> $GITHUB_OUTPUT
       - name: create PR to main
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          HOTFIX_DATE: ${{ steps.date.outputs.date }}
+          APPLICATION: ${{ github.event.inputs.application }}
+          TAG_VERSION: ${{ github.event.inputs.tag_version }}
         run: |
           gh pr create \
-            --title ":fire: Hotfix ${{ steps.date.outputs.date }} (targeting ${{ github.event.inputs.application }} ${{ github.event.inputs.tag_version }})"\
+            --title ":fire: Hotfix $HOTFIX_DATE (targeting $APPLICATION $TAG_VERSION)"\
             -F ./.github/templates/hotfix.md \
             --base main \
             --head hotfix
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
   create-hotfix-fail:
     name: Create Hotfix > Failure Reporting

--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -123,8 +123,10 @@ jobs:
 
       - name: tag desktop
         if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
+        env:
+          DESKTOP_VERSION: ${{ steps.desktop-version.outputs.version }}
         run: |
-          git tag @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }}
+          git tag "@ledgerhq/live-desktop@$DESKTOP_VERSION"
 
       - name: generate mobile changelog
         if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
@@ -138,8 +140,10 @@ jobs:
 
       - name: tag mobile
         if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
+        env:
+          MOBILE_VERSION: ${{ steps.mobile-version.outputs.version }}
         run: |
-          git tag live-mobile@${{ steps.mobile-version.outputs.version }}
+          git tag "live-mobile@$MOBILE_VERSION"
 
       - name: push changes
         env:
@@ -151,15 +155,19 @@ jobs:
         if: ${{ steps.desktop-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLD", "ALL"]'), inputs.app) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DESKTOP_VERSION: ${{ steps.desktop-version.outputs.version }}
+          DESKTOP_CHANGELOG_PATH: ${{ steps.desktop-changelog.outputs.path }}
         run: |
-          gh release create @ledgerhq/live-desktop@${{ steps.desktop-version.outputs.version }} -F ${{ steps.desktop-changelog.outputs.path }}
+          gh release create "@ledgerhq/live-desktop@$DESKTOP_VERSION" -F "$DESKTOP_CHANGELOG_PATH"
 
       - name: create mobile github release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MOBILE_VERSION: ${{ steps.mobile-version.outputs.version }}
+          MOBILE_CHANGELOG_PATH: ${{ steps.mobile-changelog.outputs.path }}
         if: ${{ steps.mobile-changed.outputs.status != 0 || github.event_name == 'workflow_dispatch' && contains(fromJson('["LLM", "ALL"]'), inputs.app) }}
         run: |
-          gh release create live-mobile@${{ steps.mobile-version.outputs.version }} -F ${{ steps.mobile-changelog.outputs.path }}
+          gh release create "live-mobile@$MOBILE_VERSION" -F "$MOBILE_CHANGELOG_PATH"
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: trigger release build for desktop

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -90,8 +90,9 @@ jobs:
         if: ${{ github.event.inputs.tag_version == 'latest' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
         run: |
-          git checkout ${{ github.event.inputs.ref }}
+          git checkout "$INPUT_REF"
           git checkout -b support/hotfix-merge-conflicts
           git push origin support/hotfix-merge-conflicts
           gh pr create --title ":rotating_light: Hotfix merge conflicts" -F .github/templates/hotfix-conflicts.md --base develop --head support/hotfix-merge-conflicts
@@ -111,8 +112,9 @@ jobs:
         if: ${{ github.event.inputs.tag_version == 'latest' && steps.release-merge.outcome == 'failure' && steps.release-merge.outputs.status == '409' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          INPUT_REF: ${{ github.event.inputs.ref }}
         run: |
-          git checkout ${{ github.event.inputs.ref }}
+          git checkout "$INPUT_REF"
           git checkout -b support/hotfix-release-merge-conflicts
           git push origin support/hotfix-release-merge-conflicts
           gh pr create --title ":rotating_light: Hotfix Release merge conflicts" -F .github/templates/hotfix-release-conflicts.md --base release --head support/hotfix-release-merge-conflicts

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -63,9 +63,11 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: pull commit
+        env:
+          TARGET_REF: ${{ inputs.ref }}
         run: |
           git stash
-          git pull origin ${{ inputs.ref }}
+          git pull origin -- "$TARGET_REF"
 
       - name: fetch develop and main
         run: |

--- a/.github/workflows/test-bridge-pr.yml
+++ b/.github/workflows/test-bridge-pr.yml
@@ -24,8 +24,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
+          gh pr checkout "$PR_NUMBER"
       - name: checkout branch (not PR)
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/test-coin-modules-integ.yml
+++ b/.github/workflows/test-coin-modules-integ.yml
@@ -36,8 +36,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
+          gh pr checkout "$PR_NUMBER"
       - name: checkout branch (not PR)
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -38,8 +38,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
+          gh pr checkout "$PR_NUMBER"
 
       - name: Checkout push/ref
         if: ${{ github.event_name != 'pull_request' }}
@@ -53,17 +54,21 @@ jobs:
 
       - name: Build matrix from affected paths or manual input
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CHAIN_INPUT: ${{ github.event.inputs.chain }}
+          AFFECTED_PATHS: ${{ steps.affected.outputs.paths }}
         run: |
           CHAINS=()
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.chain }}" != "" ]]; then
-            if [[ "${{ github.event.inputs.chain }}" == "all" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$CHAIN_INPUT" != "" ]]; then
+            if [[ "$CHAIN_INPUT" == "all" ]]; then
               for coin in $COIN_TESTER_CURRENCIES; do
                 CHAINS+=("$coin")
               done
             else
-              IFS=',' read -ra CHAINS <<< "${{ github.event.inputs.chain }}"
+              IFS=',' read -ra CHAINS <<< "$CHAIN_INPUT"
             fi
-          elif echo "${{ steps.affected.outputs.paths }}" | grep -qE "(^|/| )coin-tester(/| |$)"; then
+          elif echo "$AFFECTED_PATHS" | grep -qE "(^|/| )coin-tester(/| |$)"; then
             echo "Detected base coin-tester → adding all coins"
             for coin in $COIN_TESTER_CURRENCIES; do
               CHAINS+=("$coin")
@@ -71,13 +76,13 @@ jobs:
           else
             # Otherwise, only add coins that appear individually
             for coin in $COIN_TESTER_CURRENCIES; do
-              if echo "${{ steps.affected.outputs.paths }}" | grep -qw "$coin"; then
+              if echo "$AFFECTED_PATHS" | grep -qw "$coin"; then
                 CHAINS+=("$coin")
               fi
             done
           fi
           # If it's a scheduled job and no chain is detected, run all chains by default
-          if [ "${{ github.event_name }}" == "schedule" ] && [ ${#CHAINS[@]} -eq 0 ]; then
+          if [ "$EVENT_NAME" == "schedule" ] && [ ${#CHAINS[@]} -eq 0 ]; then
             for coin in $COIN_TESTER_CURRENCIES; do
               CHAINS+=("$coin")
             done
@@ -94,10 +99,14 @@ jobs:
           fi
 
       - name: Debug affected paths (for troubleshooting)
+        env:
+          AFFECTED_PATHS: ${{ steps.affected.outputs.paths }}
+          IS_AFFECTED: ${{ steps.detect.outputs.is-affected }}
+          MATRIX: ${{ steps.detect.outputs.matrix }}
         run: |
-          echo "Affected paths: ${{ steps.affected.outputs.paths }}"
-          echo "Is affected: ${{ steps.detect.outputs.is-affected }}"
-          echo "Matrix: ${{ steps.detect.outputs.matrix }}"
+          echo "Affected paths: $AFFECTED_PATHS"
+          echo "Is affected: $IS_AFFECTED"
+          echo "Matrix: $MATRIX"
 
   coin-tester:
     name: Coin Tester - ${{ matrix.chain }}

--- a/.github/workflows/test-desktop-codechecks-reusable.yml
+++ b/.github/workflows/test-desktop-codechecks-reusable.yml
@@ -163,29 +163,41 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: prepare status
         id: status
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.username || '' }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          CODECHECKS_RESULT: ${{ needs.codechecks.result }}
+          UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
         with:
           script: |
             const fs = require("fs");
 
+            const refName = process.env.REF_NAME;
+            const commitAuthor = process.env.COMMIT_AUTHOR;
+            const repository = process.env.REPOSITORY;
+            const runId = process.env.RUN_ID;
+
             const typecheck = {
-              pass: ${{ needs.codechecks.result == 'success' }},
-              status: "${{ needs.codechecks.result }}",
+              pass: process.env.CODECHECKS_RESULT === "success",
+              status: process.env.CODECHECKS_RESULT,
             };
 
             const unitTests = {
-              pass: ${{ needs.unit-tests.result == 'success' }},
-              status: "${{ needs.unit-tests.result }}",
+              pass: process.env.UNIT_TESTS_RESULT === "success",
+              status: process.env.UNIT_TESTS_RESULT,
             };
 
             const slackPayload = {
               "channel": "C05FKJ7DFAP",
-              "text": "[Alert] Ledger Live Desktop lint & unit tests failed on ${{ github.ref_name }}",
+              "text": "[Alert] Ledger Live Desktop lint & unit tests failed on ${refName}",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": ":warning: [Alert] Ledger Live Desktop lint & unit tests failed on ${{ github.ref_name }}",
+                    "text": `:warning: [Alert] Ledger Live Desktop lint & unit tests failed on ${refName}`,
                     "emoji": true
                   }
                 },
@@ -210,7 +222,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Commit by ${{ github.event.head_commit.author.username || '' }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": `Commit by ${commitAuthor}\nhttps://github.com/${repository}/actions/runs/${runId}`
                   }
                 }
               ]

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -282,18 +282,26 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         name: prepare status
         id: status
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.username || '' }}
+          COMMENT_BODY: ${{ steps.comment.outputs.body }}
         with:
           script: |
             const fs = require("fs");
             const path = require("path");
 
-            const [ owner, repo ] = "${{ github.repository }}".split("/");
+            const refName = process.env.REF_NAME;
+            const commitAuthor = process.env.COMMIT_AUTHOR;
+            const commentBody = process.env.COMMENT_BODY;
+
+            const { owner, repo } = context.repo;
 
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
               owner,
               repo,
-              run_id: "${{ github.run_id }}",
-              attempt_number: "${{ github.run_attempt }}",
+              run_id: Number(process.env.GITHUB_RUN_ID),
+              attempt_number: Number(process.env.GITHUB_RUN_ATTEMPT),
             });
 
             const keys = {
@@ -351,7 +359,7 @@ jobs:
             summary += `
 
             Speculos Allure report: ${speculosAllureUrl || "N/A"}
-            ${{ steps.comment.outputs.body }}
+            ${commentBody}
             `
 
             const output = {
@@ -376,17 +384,17 @@ jobs:
 
             fs.writeFileSync("summary-test-desktop.json", JSON.stringify(output), "utf-8");
 
-            if (${{ github.event_name != 'push' }}) return;
+            if (context.eventName !== 'push') return;
 
             const slackPayload = {
               "channel": "C05FKJ7DFAP",
-              "text": "[Alert] Ledger Live Desktop tests failed on ${{github.ref_name}}",
+              "text": "[Alert] Ledger Live Desktop tests failed on ${refName}",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": ":warning: [Alert] Ledger Live Desktop tests failed on ${{ github.ref_name }}",
+                    "text": `:warning: [Alert] Ledger Live Desktop tests failed on ${refName}`,
                     "emoji": true
                   }
                 },
@@ -401,7 +409,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": `🍪 Speculos NanoSP ${{ env.SMOKE_SPECULOS_FIRMWARE_VERSION }}: ${report.speculos.pass ? "✅" : "❌"}\nAllure: ${speculosAllureUrl || "N/A"}\n`
+                    "text": `🍪 Speculos NanoSP ${process.env.SMOKE_SPECULOS_FIRMWARE_VERSION}: ${report.speculos.pass ? "✅" : "❌"}\nAllure: ${speculosAllureUrl || "N/A"}\n`
                   }
                 },
                 {
@@ -411,7 +419,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Commit by ${{ github.event.head_commit.author.username || '' }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": `Commit by ${commitAuthor}\nhttps://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
                   }
                 }
               ]

--- a/.github/workflows/test-integration-pr.yml
+++ b/.github/workflows/test-integration-pr.yml
@@ -29,8 +29,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr checkout ${{ github.event.pull_request.number }}
+          gh pr checkout "$PR_NUMBER"
       - name: checkout branch (not PR)
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -262,6 +262,9 @@ jobs:
       - name: Resolve per-platform Speculos device
         id: devices
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SPECULOS_DEVICE_INPUT: ${{ inputs.speculos_device || 'nanoX' }}
         run: |
           # Per-platform mapping for scheduled nightly runs (QAA-1193)
           declare -A PLATFORM_DEVICE=(
@@ -269,25 +272,30 @@ jobs:
             [android]=nanoX   # Android - LNX
           )
 
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "schedule" ]; then
             echo "ios_device=${PLATFORM_DEVICE[ios]}"           >> $GITHUB_OUTPUT
             echo "android_device=${PLATFORM_DEVICE[android]}"  >> $GITHUB_OUTPUT
           else
-            INPUT_DEVICE="${{ inputs.speculos_device || 'nanoX' }}"
+            INPUT_DEVICE="$SPECULOS_DEVICE_INPUT"
             echo "ios_device=$INPUT_DEVICE"     >> $GITHUB_OUTPUT
             echo "android_device=$INPUT_DEVICE" >> $GITHUB_OUTPUT
           fi
 
       - name: Write summary
+        env:
+          FILTER_PATTERN: ${{ inputs.test_filter || '' }}
+          IOS_DEVICE: ${{ steps.devices.outputs.ios_device }}
+          ANDROID_DEVICE: ${{ steps.devices.outputs.android_device }}
+          BUILD_TYPE: ${{ inputs.production_firebase && 'production' || 'testing' }}
+          BROADCAST_ENABLED: ${{ inputs.enable_broadcast }}
+          SMOKE_TESTS: ${{ inputs.smoke_tests }}
+          TEST_EXECUTION_ANDROID: ${{ inputs.test_execution_android || '(not provided)' }}
+          TEST_EXECUTION_IOS: ${{ inputs.test_execution_ios || '(not provided)' }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          TRIGGERED_BRANCH: ${{ inputs.ref || github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          SLACK_NOTIF_STATUS: ${{ (inputs.slack_notif || github.event_name == 'schedule') && 'enabled' || 'disabled' }}
         run: |
-          FILTER_PATTERN="${{ inputs.test_filter || '' }}"
-          IOS_DEVICE="${{ steps.devices.outputs.ios_device }}"
-          ANDROID_DEVICE="${{ steps.devices.outputs.android_device }}"
-          BUILD_TYPE="${{ inputs.production_firebase && 'production' || 'testing' }}"
-          BROADCAST_ENABLED="${{ inputs.enable_broadcast }}"
-          SMOKE_TESTS="${{ inputs.smoke_tests }}"
-          TEST_EXECUTION_ANDROID="${{ inputs.test_execution_android || '(not provided)' }}"
-          TEST_EXECUTION_IOS="${{ inputs.test_execution_ios || '(not provided)' }}"
           EXTRA_FEATURE_FLAGS="$E2E_FEATURE_FLAGS_JSON"
 
           if [ -z "$FILTER_PATTERN" ]; then
@@ -301,9 +309,9 @@ jobs:
           {
           echo "## Workflow Context"
           echo ""
-          echo "- **Workflow source branch:** ${{ github.ref_name }}"
-          echo "- **Triggered branch:** ${{ inputs.ref || github.ref_name }}"
-          echo "- **Commit SHA:** ${{ github.sha }}"
+          echo "- **Workflow source branch:** $WORKFLOW_REF"
+          echo "- **Triggered branch:** $TRIGGERED_BRANCH"
+          echo "- **Commit SHA:** $COMMIT_SHA"
           echo "- **iOS device:** $IOS_DEVICE"
           echo "- **Android device:** $ANDROID_DEVICE"
           echo "$FILTER_SUMMARY"
@@ -312,9 +320,9 @@ jobs:
           echo "- **Test Execution ticket ID (iOS):** $TEST_EXECUTION_IOS"
           echo "- **Firebase env to target:** $BUILD_TYPE"
           echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
-          echo "- **Slack notification:** ${{ (inputs.slack_notif || github.event_name == 'schedule') && 'enabled' || 'disabled' }}"
-          echo "- **Android Feature Flags:** ${{ env.ANDROID_FEATURE_FLAGS }}"
-          echo "- **iOS Feature Flags:** ${{ env.IOS_FEATURE_FLAGS }}"
+          echo "- **Slack notification:** $SLACK_NOTIF_STATUS"
+          echo "- **Android Feature Flags:** $ANDROID_FEATURE_FLAGS"
+          echo "- **iOS Feature Flags:** $IOS_FEATURE_FLAGS"
           echo "- **JSON override feature flags:** $EXTRA_FEATURE_FLAGS"
           } >> $GITHUB_STEP_SUMMARY
 
@@ -337,9 +345,11 @@ jobs:
 
       - name: Determine cache keys
         id: cache-keys
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           PREFIX=""
-          if [ "${{ github.ref_name }}" = "develop" ]; then
+          if [ "$REF_NAME" = "develop" ]; then
             PREFIX="develop/"
           fi
           echo "ios_native_key=${PREFIX}longterm-${{ hashFiles('apps/ledger-live-mobile/ios') }}-detox-native-ios-${{ inputs.production_firebase == true && 'prod-2' || '3' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -131,6 +131,8 @@ jobs:
         id: cache-keys
         env:
           REF_NAME: ${{ github.ref_name }}
+          MAX_SHARDS: ${{ inputs.max-shards }}
+          MACOS_RUNNER_LABEL: ${{ inputs.macos-specificity-runner-label }}
         run: |
           PREFIX=""
           if [ "$REF_NAME" = "develop" ]; then
@@ -141,8 +143,8 @@ jobs:
           HEAD_SHA=$(git rev-parse HEAD)
           echo "ios_js_key=${PREFIX}${HEAD_SHA}-detox-js-ios" >> $GITHUB_OUTPUT
           echo "android_js_key=${PREFIX}${HEAD_SHA}-detox-js-android" >> $GITHUB_OUTPUT
-          echo "android_timing_cache_key=${PREFIX}android-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}-${{ inputs.max-shards }}shards" >> $GITHUB_OUTPUT
-          echo "ios_timing_cache_key=${PREFIX}ios-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}-${{ inputs.max-shards }}shards-${{ inputs.macos-specificity-runner-label }}" >> $GITHUB_OUTPUT
+          echo "android_timing_cache_key=${PREFIX}android-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}-${MAX_SHARDS}shards" >> $GITHUB_OUTPUT
+          echo "ios_timing_cache_key=${PREFIX}ios-mock-timing-${{ hashFiles('apps/ledger-live-mobile/e2e') }}-${MAX_SHARDS}shards-$MACOS_RUNNER_LABEL" >> $GITHUB_OUTPUT
           echo "pod_check_key=${{ hashFiles('apps/ledger-live-mobile/ios/Podfile.lock', 'apps/ledger-live-mobile/ios/Podfile', 'pnpm-lock.yaml') }}-pod-lockfile-validated" >> $GITHUB_OUTPUT
           echo "avd_cache_key=${{ runner.os }}-detox-avd-${{ env.AVD_NAME }}-${{ env.AVD_PROFILE }}-${{ env.AVD_TARGET }}-${{ env.AVD_API }}-${{ env.AVD_ARCH }}-${{ env.AVD_CORES }}-${{ env.AVD_RAM_SIZE }}-${{ env.AVD_HEAP_SIZE }}-r2-v8" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test-workflows-sync.yml
+++ b/.github/workflows/test-workflows-sync.yml
@@ -68,31 +68,43 @@ jobs:
 
       - name: Set default inputs for PR triggers
         id: set-defaults
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
+          INPUT_SKIP_CHECK: ${{ inputs.skip_check }}
+          INPUT_CHECK_FOLDERS: ${{ inputs.check_folders }}
+          INPUT_FAIL_ON_CHANGES: ${{ inputs.fail_on_changes }}
+          INPUT_BYPASS_LABEL: ${{ inputs.bypass_label }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           # Set defaults when triggered by PR (not workflow_call)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "base_branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "base_branch=$BASE_REF" >> $GITHUB_OUTPUT
             echo "skip_check=false" >> $GITHUB_OUTPUT
             echo "check_folders=.github/workflows/" >> $GITHUB_OUTPUT
             echo "fail_on_changes=true" >> $GITHUB_OUTPUT
             echo "bypass_label=skip-sync-check" >> $GITHUB_OUTPUT
             # For pull_request events, the PR number is always available
-            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           else
-            echo "base_branch=${{ inputs.base_branch }}" >> $GITHUB_OUTPUT
-            echo "skip_check=${{ inputs.skip_check }}" >> $GITHUB_OUTPUT
-            echo "check_folders=${{ inputs.check_folders }}" >> $GITHUB_OUTPUT
-            echo "fail_on_changes=${{ inputs.fail_on_changes }}" >> $GITHUB_OUTPUT
-            echo "bypass_label=${{ inputs.bypass_label }}" >> $GITHUB_OUTPUT
-            echo "pr_number=${{ inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "base_branch=$INPUT_BASE_BRANCH" >> $GITHUB_OUTPUT
+            echo "skip_check=$INPUT_SKIP_CHECK" >> $GITHUB_OUTPUT
+            echo "check_folders=$INPUT_CHECK_FOLDERS" >> $GITHUB_OUTPUT
+            echo "fail_on_changes=$INPUT_FAIL_ON_CHANGES" >> $GITHUB_OUTPUT
+            echo "bypass_label=$INPUT_BYPASS_LABEL" >> $GITHUB_OUTPUT
+            echo "pr_number=$INPUT_PR_NUMBER" >> $GITHUB_OUTPUT
           fi
 
       - name: Check for bypass conditions
         id: bypass-check
+        env:
+          SKIP_CHECK: ${{ steps.set-defaults.outputs.skip_check }}
+          BYPASS_LABEL: ${{ steps.set-defaults.outputs.bypass_label }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
-          SKIP_CHECK="${{ steps.set-defaults.outputs.skip_check }}"
-          BYPASS_LABEL="${{ steps.set-defaults.outputs.bypass_label }}"
-
           # Skip check if requested via input parameter (for workflow_call)
           if [ "$SKIP_CHECK" = "true" ]; then
             echo "should_skip=true" >> $GITHUB_OUTPUT
@@ -102,8 +114,8 @@ jobs:
           fi
 
           # Check for bypass label on PR (for pull_request events) - last-resort escape hatch
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            if echo '${{ toJson(github.event.pull_request.labels.*.name) }}' | jq -r '.[]' | grep -q "^${BYPASS_LABEL}$"; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if echo "$PR_LABELS_JSON" | jq -r '.[]' | grep -Fxq "$BYPASS_LABEL"; then
               echo "should_skip=true" >> $GITHUB_OUTPUT
               echo "skip_reason=PR label: $BYPASS_LABEL" >> $GITHUB_OUTPUT
               echo "⚠️  Workflow synchronization check bypassed via PR label: $BYPASS_LABEL"
@@ -119,32 +131,32 @@ jobs:
         if: steps.bypass-check.outputs.should_skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: ${{ steps.set-defaults.outputs.base_branch }}
+          CHECK_FOLDERS: ${{ steps.set-defaults.outputs.check_folders }}
+          FAIL_ON_CHANGES: ${{ steps.set-defaults.outputs.fail_on_changes }}
+          PR_NUMBER: ${{ steps.set-defaults.outputs.pr_number }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          BASE_BRANCH="${{ steps.set-defaults.outputs.base_branch }}"
-          CHECK_FOLDERS="${{ steps.set-defaults.outputs.check_folders }}"
-          FAIL_ON_CHANGES="${{ steps.set-defaults.outputs.fail_on_changes }}"
-          PR_NUMBER="${{ steps.set-defaults.outputs.pr_number }}"
-
           # Fetch base branch for comparison
-          git fetch origin $BASE_BRANCH
+          git fetch origin -- "$BASE_BRANCH"
 
           echo "🔍 Checking synchronization against $BASE_BRANCH..."
           echo "📁 Monitoring folders: $CHECK_FOLDERS"
 
           # Build git diff path arguments
           IFS=',' read -ra FOLDERS <<< "$CHECK_FOLDERS"
-          DIFF_ARGS=""
+          DIFF_PATHS=()
           for folder in "${FOLDERS[@]}"; do
             folder=$(echo "$folder" | xargs)
             if [ -n "$folder" ]; then
-              DIFF_ARGS="$DIFF_ARGS -- '$folder'"
+              DIFF_PATHS+=("$folder")
             fi
           done
 
           # Get all files that have drifted from base in monitored folders
-          DRIFTED_CMD="git diff --name-only origin/$BASE_BRANCH HEAD $DIFF_ARGS"
-          echo "🔍 Running: $DRIFTED_CMD"
-          DRIFTED=$(eval $DRIFTED_CMD || true)
+          echo "🔍 Running: git diff --name-only origin/$BASE_BRANCH HEAD -- ${DIFF_PATHS[*]}"
+          DRIFTED=$(git diff --name-only "origin/$BASE_BRANCH" HEAD -- "${DIFF_PATHS[@]}" || true)
 
           if [ -z "$DRIFTED" ]; then
             echo "workflows_changed=false" >> $GITHUB_OUTPUT
@@ -163,9 +175,9 @@ jobs:
           # If we have a PR number, fetch the files the PR itself changed and subtract them
           # so that intentional workflow changes don't trigger a failure
           PR_CHANGED=""
-          if [ -n "$PR_NUMBER" ] && [ "${{ github.event_name }}" != "" ]; then
+          if [ -n "$PR_NUMBER" ] && [ "$EVENT_NAME" != "" ]; then
             echo "🔍 Fetching PR #$PR_NUMBER files from GitHub API..."
-            PR_CHANGED=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            PR_CHANGED=$(gh api "repos/$REPOSITORY/pulls/${PR_NUMBER}/files" \
               --paginate --jq '.[].filename' 2>/dev/null || true)
 
             # Filter to only monitored folders
@@ -206,9 +218,10 @@ jobs:
 
       - name: Show file differences
         if: steps.analyze.outputs.workflows_changed == 'true' && steps.bypass-check.outputs.should_skip == 'false'
+        env:
+          BASE_BRANCH: ${{ steps.set-defaults.outputs.base_branch }}
+          CHECK_FOLDERS: ${{ steps.set-defaults.outputs.check_folders }}
         run: |
-          BASE_BRANCH="${{ steps.set-defaults.outputs.base_branch }}"
-          CHECK_FOLDERS="${{ steps.set-defaults.outputs.check_folders }}"
 
           echo "::group::📋 File differences in monitored folders"
 
@@ -228,8 +241,9 @@ jobs:
 
       - name: Provide guidance
         if: steps.analyze.outputs.can_proceed == 'false' && steps.bypass-check.outputs.should_skip == 'false'
+        env:
+          BASE_BRANCH: ${{ steps.set-defaults.outputs.base_branch }}
         run: |
-          BASE_BRANCH="${{ steps.set-defaults.outputs.base_branch }}"
           echo "::notice::💡 To resolve this issue, rebase your branch: git rebase origin/$BASE_BRANCH"
           echo "::notice::   This ensures consistent behavior across all PRs"
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Internal org actions are trusted at tag/branch ref granularity
+        LedgerHQ/*: ref-pin
+        # All third-party actions must be pinned to a full SHA
+        "*": hash-pin


### PR DESCRIPTION
Move all remaining ${{ inputs.* }}, ${{ github.event.* }}, and context expressions out of run:/github-script blocks into step env: maps.  Add .github/zizmor.yml with unpinned-uses policies and template-injection false-positive suppressions.

Test runs: 
https://github.com/LedgerHQ/ledger-live/actions/runs/30093514353
https://github.com/LedgerHQ/ledger-live/actions/runs/30086803287
https://github.com/LedgerHQ/ledger-live/actions/runs/30086836463
https://github.com/LedgerHQ/ledger-live/actions/runs/30086869897
https://github.com/LedgerHQ/ledger-live/actions/runs/30086895565