### PR TITLE
[LWDM] feat(contacts): render Desktop contact detail empty state

### DIFF
--- a/.changeset/render-contact-detail-empty-state.md
+++ b/.changeset/render-contact-detail-empty-state.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Render Desktop contact detail empty state using shared flow-contacts Detail step.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -323,4 +323,93 @@ describe("Contacts integration", () => {
     expect(mockNavigate).toHaveBeenCalledWith(-1);
     expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
   });
+
+  it("should render the Me empty detail state when Me is selected", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-me-row"));
+
+    expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
+    expect(screen.getByText("No saved addresses for you")).toBeVisible();
+    expect(
+      screen.getByText("Save your wallet addresses to receive crypto by name next time."),
+    ).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
+  });
+
+  it("should render a saved contact empty detail state when an empty contact is selected", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ada"));
+
+    expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
+    expect(screen.getByText("No saved addresses for Ada")).toBeVisible();
+    expect(
+      screen.getByText("Save their wallet addresses to send to them by name next time."),
+    ).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
+  });
+
+  it("should not render the detail state when a contact with addresses is selected", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+
+    expect(screen.queryByTestId("contacts-detail-screen")).not.toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-pane")).toBeEmptyDOMElement();
+  });
+
+  it("should clear the detail state when selecting a contact with addresses after an empty contact", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ada"));
+    expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+
+    expect(screen.queryByTestId("contacts-detail-screen")).not.toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-pane")).toBeEmptyDOMElement();
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Contact, ContactId } from "@domain/entity-contact";
+import {
+  useEmptyContactDetail,
+  type ContactDetailLabels,
+  type ContactDetailViewProps,
+  type ContactsListViewProps,
+} from "@features/flow-contacts";
+import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
+
+const onAddAddress = () => undefined;
+
+export function useContactDetailPaneAdapter(contacts: readonly Contact[]): Readonly<{
+  detail: ContactDetailViewProps | undefined;
+  onOpenMe: ContactsListViewProps["onOpenMe"];
+  onOpenContact: ContactsListViewProps["onOpenContact"];
+}> {
+  const { t } = useTranslation();
+  const [selectedContactId, setSelectedContactId] = useState<ContactId | undefined>();
+  const selectedContact = useEmptyContactDetail(selectedContactId);
+  const labels = useMemo<ContactDetailLabels>(
+    () => ({
+      addAddress: t("contacts.addAddress"),
+      emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
+      emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
+      emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
+      emptyContactDescription: () => t("contacts.detail.emptyState.contactDescription"),
+      formatAddressCount: count => t("contacts.addressCount", { count }),
+    }),
+    [t],
+  );
+  const onOpenMe = useCallback<ContactsListViewProps["onOpenMe"]>(contactId => {
+    setSelectedContactId(contactId);
+  }, []);
+  const onOpenContact = useCallback<ContactsListViewProps["onOpenContact"]>(
+    contactId => {
+      const isEmptyContact = contacts.some(
+        contact => contact.id === contactId && contact.addresses.length === 0,
+      );
+
+      if (!isEmptyContact) {
+        setSelectedContactId(undefined);
+        return;
+      }
+
+      setSelectedContactId(contactId);
+    },
+    [contacts],
+  );
+  const detail = useMemo<ContactDetailViewProps | undefined>(() => {
+    if (!selectedContact) {
+      return undefined;
+    }
+
+    return {
+      contact: selectedContact,
+      labels,
+      meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
+      onAddAddress,
+    };
+  }, [labels, selectedContact]);
+
+  return {
+    detail,
+    onOpenMe,
+    onOpenContact,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -15,6 +15,7 @@ import {
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
 import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
+import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 
 export type ContactsPageViewModel = Omit<ContactsListViewProps, "onAddContact"> &
   Readonly<{
@@ -27,6 +28,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
+  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(contacts);
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const preference = useContactsFeatureIntroductionPreference();
@@ -40,7 +42,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       searchPlaceholder: t("contacts.searchPlaceholder"),
       searchNoResults: t("contacts.searchNoResults"),
       addContact: t("contacts.addContact"),
-      formatAddressCount: count => t("contacts.me.addressCount", { count }),
+      formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
   );
@@ -64,11 +66,6 @@ export function useContactsViewModel(): ContactsPageViewModel {
     setSearchQuery(event.target.value);
   }, []);
   const onClearSearch = useCallback(() => setSearchQuery(""), []);
-  const onOpenMe = useCallback<ContactsListViewProps["onOpenMe"]>(_contactId => undefined, []);
-  const onOpenContact = useCallback<ContactsListViewProps["onOpenContact"]>(
-    _contactId => undefined,
-    [],
-  );
   const onDismissLedgerSyncIntroduction = useCallback(
     () => setIsLedgerSyncIntroductionDismissed(true),
     [],
@@ -101,6 +98,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     onClearSearch,
     onOpenMe,
     onOpenContact,
+    detail,
     ledgerSyncStatus,
     featureIntroduction: {
       isOpen: featureIntroductionState.isRequested,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9372,6 +9372,7 @@
   "contacts": {
     "title": "Contacts",
     "addContact": "Add contact",
+    "addAddress": "Add address",
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
@@ -9379,11 +9380,19 @@
     },
     "searchPlaceholder": "Search contact",
     "searchNoResults": "No contact found",
+    "addressCount_zero": "0 address",
+    "addressCount_one": "{{count}} address",
+    "addressCount_other": "{{count}} addresses",
     "me": {
-      "name": "Me",
-      "addressCount_zero": "0 address",
-      "addressCount_one": "{{count}} address",
-      "addressCount_other": "{{count}} addresses"
+      "name": "Me"
+    },
+    "detail": {
+      "emptyState": {
+        "meTitle": "No saved addresses for you",
+        "contactTitle": "No saved addresses for {{name}}",
+        "meDescription": "Save your wallet addresses to receive crypto by name next time.",
+        "contactDescription": "Save their wallet addresses to send to them by name next time."
+      }
     },
     "ledgerSyncIntroduction": {
       "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -32,10 +32,10 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
-      emptyStateTitle: t("contacts.detail.emptyState.title"),
+      emptyMeTitle: t("contacts.detail.emptyState.title"),
+      emptyContactTitle: () => t("contacts.detail.emptyState.title"),
       emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
-      formatEmptyContactDescription: name =>
-        t("contacts.detail.emptyState.contactDescription", { name }),
+      emptyContactDescription: name => t("contacts.detail.emptyState.contactDescription", { name }),
       formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -8,7 +8,7 @@ Shared Contacts flow package for Desktop and Mobile.
 
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
-- Empty contact detail selection and native presentation
+- Empty contact detail selection and presentation
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Add Address network eligibility and final currency selection state (MAD integration uses an
   injected selection port)
@@ -31,8 +31,8 @@ and are not exported as package subpaths.
 
 Each user-facing screen lives under `src/steps/` and follows the MVVM split used by the app
 features (View + ViewModel + types + colocated components). Web and React Native export their
-respective `ContactsListView` implementations through the root entry point. The native entry also
-exports `ContactsAddContactHeaderButton` and `ContactDetailView` via the step `native.ts` barrels.
+respective `ContactsListView` and `ContactDetailView` implementations through the root entry point. The native entry also
+exports `ContactsAddContactHeaderButton` via the step `native.ts` barrels.
 
 ## Testing
 
@@ -77,10 +77,11 @@ src/
 │   │   ├── useContactsFeatureIntroductionState.ts / resolver.ts / ports.ts / constants.ts / types.ts
 │   │   ├── internals/useSingleFireDismiss.ts
 │   │   └── index.ts / web.ts / native.ts
-│   └── Detail/                          # Native detail screen (consumed by Mobile)
-│       ├── ContactDetailView.native.tsx / useEmptyContactDetail.ts / types.ts
-│       ├── components/                  # Header, EmptyState, Avatar (native)
-│       └── index.ts / native.ts
+│   └── Detail/                          # Contact detail empty state (web + native)
+│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / types.ts
+│       ├── model/                       # resolveContactDetailEmptyStateCopy
+│       ├── components/                  # Header, EmptyState, Avatar (web + native)
+│       └── index.ts / web.ts / native.ts
 ├── components/                          # Cross-step shared UI
 │   ├── ContactsButton/                  # My Wallet entry (web + native)
 │   └── ContactAvatar/                   # Shared native list and detail avatar

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -6,6 +6,7 @@ export * from "./steps/AddAddress";
 export * from "./steps/Introduction";
 export * from "./steps/Introduction/web";
 export * from "./steps/Detail";
+export * from "./steps/Detail/web";
 export * from "./components";
 export * from "./hooks";
 export * from "./featureFlags";

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -6,9 +6,10 @@ import { ContactDetailView } from "./ContactDetailView.native";
 
 const labels: ContactDetailLabels = {
   addAddress: "Add address",
-  emptyStateTitle: "No address yet",
+  emptyMeTitle: "No address yet",
+  emptyContactTitle: () => "No address yet",
   emptyMeDescription: "Save a wallet address to receive crypto.",
-  formatEmptyContactDescription: name => `Save wallet address to send to ${name}`,
+  emptyContactDescription: name => `Save wallet address to send to ${name}`,
   formatAddressCount: count => `${count} address`,
 };
 

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import type { ContactDetailLabels } from "./types";
+import { ContactDetailView } from "./ContactDetailView.web";
+
+const labels: ContactDetailLabels = {
+  addAddress: "Add address",
+  emptyMeTitle: "No saved addresses for you",
+  emptyContactTitle: name => `No saved addresses for ${name}`,
+  emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
+  emptyContactDescription: () =>
+    "Save their wallet addresses to send to them by name next time.",
+  formatAddressCount: count => `${count} address`,
+};
+
+const onAddAddress = () => undefined;
+
+const defaultProps = {
+  labels,
+  meAvatarSrc: "https://example.com/avatar.png",
+  onAddAddress,
+};
+
+describe("ContactDetailView", () => {
+  it("should render the Me empty state", () => {
+    render(<ContactDetailView {...defaultProps} contact={mockMeContact()} />);
+
+    expect(screen.getByTestId("contacts-detail-me-avatar")).toBeInTheDocument();
+    expect(screen.getByText("No saved addresses for you")).toBeInTheDocument();
+    expect(
+      screen.getByText("Save your wallet addresses to receive crypto by name next time."),
+    ).toBeInTheDocument();
+  });
+
+  it("should render a saved contact empty state", () => {
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockContact({ id: "contact-benoit", name: "Benoit" })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-detail-avatar")).toBeInTheDocument();
+    expect(screen.getByText("Benoit")).toBeInTheDocument();
+    expect(screen.getByText("No saved addresses for Benoit")).toBeInTheDocument();
+    expect(
+      screen.getByText("Save their wallet addresses to send to them by name next time."),
+    ).toBeInTheDocument();
+  });
+
+  it("should request adding an address when the action is pressed", () => {
+    const handleAddAddress = jest.fn();
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockMeContact()}
+        onAddAddress={handleAddAddress}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("contacts-detail-add-address"));
+
+    expect(handleAddAddress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import type { ContactDetailViewProps } from "./types";
+import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.web";
+import { ContactDetailHeader } from "./components/ContactDetailHeader.web";
+
+export function ContactDetailView({
+  contact,
+  labels,
+  meAvatarSrc,
+  onAddAddress,
+}: ContactDetailViewProps): React.ReactNode {
+  return (
+    <div className="flex h-full flex-col" data-testid="contacts-detail-screen">
+      <ContactDetailHeader
+        contact={contact}
+        labels={labels}
+        meAvatarSrc={meAvatarSrc}
+        onAddAddress={onAddAddress}
+      />
+      <ContactDetailEmptyState contact={contact} labels={labels} />
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Avatar } from "@ledgerhq/lumen-ui-react";
+import type { Contact } from "@domain/entity-contact";
+import { getContactAvatarColorClass } from "../../List/utils/getContactAvatarColorClass";
+import { getContactInitial } from "../../../utils/getContactInitial";
+
+type ContactDetailAvatarProps = Readonly<{
+  contact: Contact;
+  meAvatarSrc: string;
+}>;
+
+export function ContactDetailAvatar({
+  contact,
+  meAvatarSrc,
+}: ContactDetailAvatarProps): React.ReactNode {
+  if (contact.isMe) {
+    return (
+      <Avatar
+        size="xl"
+        src={meAvatarSrc}
+        aria-hidden
+        data-testid="contacts-detail-me-avatar"
+      />
+    );
+  }
+
+  const avatarColorClass = getContactAvatarColorClass(contact.id);
+  const initial = getContactInitial(contact.name);
+
+  return (
+    <div
+      className={`heading-3-semi-bold flex size-80 shrink-0 items-center justify-center rounded-full ${avatarColorClass}`}
+      aria-hidden
+      data-testid="contacts-detail-avatar"
+    >
+      {initial}
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.native.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactDetailViewProps } from "../types";
+import { resolveContactDetailEmptyStateCopy } from "../model/resolveContactDetailEmptyStateCopy";
 
 type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact" | "labels">;
 
@@ -8,9 +9,7 @@ export function ContactDetailEmptyState({
   contact,
   labels,
 }: ContactDetailEmptyStateProps): React.JSX.Element {
-  const description = contact.isMe
-    ? labels.emptyMeDescription
-    : labels.formatEmptyContactDescription(contact.name);
+  const { title, description } = resolveContactDetailEmptyStateCopy(contact, labels);
 
   return (
     <Box
@@ -24,7 +23,7 @@ export function ContactDetailEmptyState({
       }}
     >
       <Text typography="body1SemiBold" lx={{ color: "base", textAlign: "center" }}>
-        {labels.emptyStateTitle}
+        {title}
       </Text>
       <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
         {description}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailEmptyState.web.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { ContactDetailViewProps } from "../types";
+import { resolveContactDetailEmptyStateCopy } from "../model/resolveContactDetailEmptyStateCopy";
+
+type ContactDetailEmptyStateProps = Pick<ContactDetailViewProps, "contact" | "labels">;
+
+export function ContactDetailEmptyState({
+  contact,
+  labels,
+}: ContactDetailEmptyStateProps): React.ReactNode {
+  const { title, description } = resolveContactDetailEmptyStateCopy(contact, labels);
+
+  return (
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-4 px-24 text-center"
+      data-testid="contacts-detail-empty-state"
+    >
+      <p className="body-1-semi-bold text-base">{title}</p>
+      <p className="body-2 text-muted">{description}</p>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import { Plus } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ContactDetailViewProps } from "../types";
+import { ContactDetailAvatar } from "./ContactDetailAvatar.web";
+
+type ContactDetailHeaderProps = Pick<
+  ContactDetailViewProps,
+  "contact" | "labels" | "meAvatarSrc" | "onAddAddress"
+>;
+
+export function ContactDetailHeader({
+  contact,
+  labels,
+  meAvatarSrc,
+  onAddAddress,
+}: ContactDetailHeaderProps): React.ReactNode {
+  return (
+    <div className="flex flex-col items-center gap-24 pt-24">
+      <div className="flex flex-col items-center gap-16">
+        <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
+        <div className="flex flex-col items-center gap-4">
+          <h2 className="heading-3-semi-bold text-base">{contact.name}</h2>
+          <p className="body-2 text-muted">
+            {labels.formatAddressCount(contact.addresses.length)}
+          </p>
+        </div>
+      </div>
+      <Button
+        appearance="gray"
+        size="sm"
+        icon={Plus}
+        onClick={onAddAddress}
+        data-testid="contacts-detail-add-address"
+      >
+        {labels.addAddress}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactDetailEmptyStateCopy.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactDetailEmptyStateCopy.ts
@@ -1,0 +1,14 @@
+import type { Contact } from "@domain/entity-contact";
+import type { ContactDetailLabels } from "../types";
+
+export function resolveContactDetailEmptyStateCopy(
+  contact: Contact,
+  labels: ContactDetailLabels,
+): Readonly<{ title: string; description: string }> {
+  return {
+    title: contact.isMe ? labels.emptyMeTitle : labels.emptyContactTitle(contact.name),
+    description: contact.isMe
+      ? labels.emptyMeDescription
+      : labels.emptyContactDescription(contact.name),
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactDetailEmptyStateCopy.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactDetailEmptyStateCopy.web.test.ts
@@ -1,0 +1,33 @@
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import type { ContactDetailLabels } from "../types";
+import { resolveContactDetailEmptyStateCopy } from "./resolveContactDetailEmptyStateCopy";
+
+const labels: ContactDetailLabels = {
+  addAddress: "Add address",
+  emptyMeTitle: "No saved addresses for you",
+  emptyContactTitle: name => `No saved addresses for ${name}`,
+  emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
+  emptyContactDescription: name => `Save wallet addresses to send to ${name}`,
+  formatAddressCount: count => `${count} address`,
+};
+
+describe("resolveContactDetailEmptyStateCopy", () => {
+  it("should resolve Me empty state copy", () => {
+    expect(resolveContactDetailEmptyStateCopy(mockMeContact(), labels)).toEqual({
+      title: "No saved addresses for you",
+      description: "Save your wallet addresses to receive crypto by name next time.",
+    });
+  });
+
+  it("should resolve saved contact empty state copy", () => {
+    expect(
+      resolveContactDetailEmptyStateCopy(
+        mockContact({ id: "contact-benoit", name: "Benoit" }),
+        labels,
+      ),
+    ).toEqual({
+      title: "No saved addresses for Benoit",
+      description: "Save wallet addresses to send to Benoit",
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -2,9 +2,10 @@ import type { Contact } from "@domain/entity-contact";
 
 export type ContactDetailLabels = Readonly<{
   addAddress: string;
-  emptyStateTitle: string;
+  emptyMeTitle: string;
+  emptyContactTitle: (name: string) => string;
   emptyMeDescription: string;
-  formatEmptyContactDescription: (name: string) => string;
+  emptyContactDescription: (name: string) => string;
   formatAddressCount: (count: number) => string;
 }>;
 

--- a/features/flow/contacts/src/steps/Detail/useEmptyContactDetail.ts
+++ b/features/flow/contacts/src/steps/Detail/useEmptyContactDetail.ts
@@ -8,10 +8,10 @@ import { useSelector } from "react-redux";
 type ContactsStateRoot = Parameters<typeof selectContactById>[0];
 
 export function useEmptyContactDetail(
-  contactId: ContactId
+  contactId: ContactId | undefined,
 ): Contact | undefined {
   const contact = useSelector((state: ContactsStateRoot) =>
-    selectContactById(state, contactId)
+    contactId ? selectContactById(state, contactId) : undefined,
   );
 
   return contact?.addresses.length === 0 ? contact : undefined;

--- a/features/flow/contacts/src/steps/Detail/useEmptyContactDetail.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useEmptyContactDetail.web.test.tsx
@@ -51,4 +51,13 @@ describe("useEmptyContactDetail", () => {
 
     expect(result.current).toBeUndefined();
   });
+
+  it("should return undefined when no contact is selected", () => {
+    const Wrapper = makeWrapper([mockMeContact()]);
+    const { result } = renderHook(() => useEmptyContactDetail(undefined), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toBeUndefined();
+  });
 });

--- a/features/flow/contacts/src/steps/Detail/web.ts
+++ b/features/flow/contacts/src/steps/Detail/web.ts
@@ -1,0 +1,1 @@
+export { ContactDetailView } from "./ContactDetailView.web";

--- a/features/flow/contacts/src/steps/List/ContactsListView.web.tsx
+++ b/features/flow/contacts/src/steps/List/ContactsListView.web.tsx
@@ -1,10 +1,26 @@
 import React from "react";
+import { ContactDetailView } from "../Detail/ContactDetailView.web";
 import { ContactsLedgerSyncIntroductionDialog } from "../Introduction/LedgerSync/ContactsLedgerSyncIntroductionDialog.web";
 import { ContactsFeatureIntroductionDialog } from "../Introduction/Feature/ContactsFeatureIntroductionDialog.web";
 import type { ContactsListViewProps } from "./types";
 import { ContactsLedgerSyncLoadingPane } from "./components/LedgerSyncLoadingPane/ContactsLedgerSyncLoadingPane.web";
 import { ContactsList } from "./components/ContactsList/ContactsList.web";
 import { ContactsPageLayout } from "./components/PageLayout/ContactsPageLayout.web";
+
+function renderContactsDetailPane(
+  isLedgerSyncChecking: boolean,
+  detail: ContactsListViewProps["detail"],
+): React.ReactNode {
+  if (isLedgerSyncChecking) {
+    return <ContactsLedgerSyncLoadingPane testId="contacts-ledger-sync-detail-loading" />;
+  }
+
+  if (!detail) {
+    return undefined;
+  }
+
+  return <ContactDetailView {...detail} />;
+}
 
 export function ContactsListView(props: ContactsListViewProps): React.ReactNode {
   const isLedgerSyncChecking = props.ledgerSyncStatus === "checking";
@@ -32,11 +48,7 @@ export function ContactsListView(props: ContactsListViewProps): React.ReactNode 
               contactsList
             )
           }
-          detail={
-            isLedgerSyncChecking ? (
-              <ContactsLedgerSyncLoadingPane testId="contacts-ledger-sync-detail-loading" />
-            ) : undefined
-          }
+          detail={renderContactsDetailPane(isLedgerSyncChecking, props.detail)}
         />
       </div>
       <ContactsFeatureIntroductionDialog {...props.featureIntroduction} />

--- a/features/flow/contacts/src/steps/List/types.ts
+++ b/features/flow/contacts/src/steps/List/types.ts
@@ -1,5 +1,6 @@
 import type { ChangeEvent } from "react";
 import type { ContactId } from "@domain/entity-contact";
+import type { ContactDetailViewProps } from "../Detail/types";
 import type {
   ContactsFeatureIntroduction,
   ContactsLedgerSyncIntroduction,
@@ -76,6 +77,7 @@ export type ContactsListViewProps = ContactsPageSharedProps &
   Readonly<{
     onSearchInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
     onOpenMe: (contactId: ContactId) => void;
+    detail?: ContactDetailViewProps;
   }>;
 
 export type ContactsListViewNativeProps = ContactsPageSharedProps &


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This pull request updates the Contacts feature on Desktop to use the shared empty detail state from the `flow-contacts` package, ensuring consistency between Desktop and Mobile. It introduces a new adapter for handling contact detail pane logic, adds comprehensive tests for the new empty state, and refines the shared package to support both platforms. Additionally, it improves i18n coverage and documentation for the shared detail view.

**Desktop integration and UI improvements:**

* Updated the Desktop Contacts detail pane to use the shared `ContactDetailView` from the `flow-contacts` package, displaying appropriate empty states for "Me" and saved contacts without addresses. 
* Added and updated tests to verify correct rendering of the empty detail state for both "Me" and contacts, and to ensure the detail pane is not shown for contacts with addresses.

**Shared flow-contacts package enhancements:**

* Exported the web implementation of `ContactDetailView` and updated the shared package to support both Desktop and Mobile, including improved documentation and directory structure. 
* Added the web implementation of `ContactDetailView` and supporting components, with logic for rendering avatars and empty state copy. 

**Internationalization and copy consistency:**

* Enhanced i18n resources with new keys for empty detail state titles and descriptions, ensuring copy is consistent and translatable across platforms.
* Refactored how empty state copy is resolved and passed to detail views, improving maintainability and consistency between platforms. 

These changes improve the user experience by providing a unified and well-tested empty state for contacts, and make it easier to maintain and extend the Contacts feature across platforms.


https://github.com/user-attachments/assets/d678d68a-420d-4472-8fe7-a3d0c6023855



### 🔗 Context

[LIVE-33937](https://ledgerhq.atlassian.net/browse/LIVE-33937)

[LIVE-33937]: https://ledgerhq.atlassian.net/browse/LIVE-33937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ