### PR TITLE
chore(LIVE-28085): patch @hiero-ledger/proto to remove console log

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,7 +314,8 @@
       "@callstack/repack@5.2.5": "patches/@callstack__repack@5.2.5.patch",
       "bigint-buffer@1.1.5": "patches/bigint-buffer@1.1.5.patch",
       "usb@2.17.0": "patches/usb@2.17.0.patch",
-      "react-native-worklets@0.8.1": "patches/react-native-worklets@0.8.1.patch"
+      "react-native-worklets@0.8.1": "patches/react-native-worklets@0.8.1.patch",
+      "@hiero-ledger/proto@2.25.0": "patches/@hiero-ledger__proto@2.25.0.patch"
     },
     "packageExtensions": {
       "detox-allure2-adapter": {

--- a/patches/@hiero-ledger__proto@2.25.0.patch
+++ b/patches/@hiero-ledger__proto@2.25.0.patch
@@ -1,0 +1,24 @@
+diff --git a/lib/index.js b/lib/index.js
+index eaaea6c359631b56d31b1de8e701847bdee3c87d..313b10c08e65f313cd49512b3a78466ec7c1d2f4 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -13,7 +13,6 @@ function _interopRequireWildcard(e, r) { if (!r && e && e.__esModule) return e;
+ (() => {
+   var $util = $protobuf.util;
+   if ($util.Long == null) {
+-    console.log(`Patching Protobuf Long.js instance...`);
+     $util.Long = _long.default;
+     if ($protobuf.Reader._configure != null) {
+       $protobuf.Reader._configure($protobuf.BufferReader);
+diff --git a/src/index.js b/src/index.js
+index aab22c7c39e6a40a022f25bd8e545e3ba0705905..f0072bef2ee3a9aaac482a818be2f46b10f29699 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -10,7 +10,6 @@ import * as $proto from "./proto.js";
+     var $util = $protobuf.util;
+ 
+     if ($util.Long == null) {
+-        console.log(`Patching Protobuf Long.js instance...`);
+         $util.Long = Long;
+ 
+         if ($protobuf.Reader._configure != null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ patchedDependencies:
   '@exodus/patch-broken-hermes-typed-arrays':
     hash: 7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732
     path: patches/@exodus__patch-broken-hermes-typed-arrays.patch
+  '@hiero-ledger/proto@2.25.0':
+    hash: 3db17dbc9a7f2fe6248f2f94d98f3ad73afecaf999c190595e95da9c6a0eff29
+    path: patches/@hiero-ledger__proto@2.25.0.patch
   '@taquito/http-utils':
     hash: fa57afa8cde2dca5953b33875e5797001987caeb346d5a479e7de0c4dd941cb3
     path: patches/@taquito__http-utils.patch
@@ -22888,7 +22891,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25277,7 +25280,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -45485,7 +45488,7 @@ snapshots:
       '@ethersproject/rlp': 5.8.0
       '@grpc/grpc-js': 1.12.6
       '@hiero-ledger/cryptography': 1.15.0
-      '@hiero-ledger/proto': 2.25.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)
+      '@hiero-ledger/proto': 2.25.0(patch_hash=3db17dbc9a7f2fe6248f2f94d98f3ad73afecaf999c190595e95da9c6a0eff29)(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3
       bignumber.js: 9.1.2
@@ -45545,7 +45548,7 @@ snapshots:
       - react-native
       - supports-color
 
-  '@hiero-ledger/proto@2.25.0(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
+  '@hiero-ledger/proto@2.25.0(patch_hash=3db17dbc9a7f2fe6248f2f94d98f3ad73afecaf999c190595e95da9c6a0eff29)(ansi-regex@6.2.2)(ansi-styles@6.2.3)(debug@4.4.1)(protobufjs@7.5.4)(strip-ansi@7.1.2)':
     dependencies:
       ansi-regex: 6.2.2
       ansi-styles: 6.2.3


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds a pnpm patch for `@hiero-ledger/proto@2.25.0` that strips a console.log("Patching Protobuf Long.js instance...") call left in the package's built and source index.js. The log fired on every import and polluted app logs/console output with no diagnostic value.

<img width="1800" height="1169" alt="hedera-proto-log" src="https://github.com/user-attachments/assets/a560baae-0058-406a-a16d-0dc27ac99196" />

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-28085