### PR TITLE
ci(automation): upgrade nick-fields/retry to v4.0.0

### DIFF
--- a/.github/workflows/test-mobile-build-android-reusable.yml
+++ b/.github/workflows/test-mobile-build-android-reusable.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
-      - uses: nick-fields/retry@v4
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         name: install dependencies
         id: install-dependencies
         with:

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -150,20 +150,6 @@ jobs:
           command: pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm
           new_command_on_retry: rm -rf ~/.cocoapods/ && pnpm clean && pnpm i --filter="live-mobile..." --filter="@ledgerhq/dummy-*-app..." --filter="ledger-live" --unsafe-perm && pnpm nx:write-cache-config --cache-key-prefix "${{ steps.setup-caches.outputs.nx-cache-key-prefix }}"
 
-      - name: Flake alert - ArgumentError
-        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@develop
-        if: failure() && steps.install-dependencies.outputs.error == 'ArgumentError - pathname contains null byte'
-        with:
-          live_bot_token: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
-          halt_runner: true
-
-      - name: Flake alert - Reruns
-        uses: LedgerHQ/ledger-live/tools/actions/composites/ci-flake-notifier@develop
-        if: success() && steps.install-dependencies.outputs.total_attempts == 2
-        with:
-          live_bot_token: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
-          custom_message: "${{ steps.install-dependencies.outputs.total_attempts }} attempts happened on install dependencies and it was eventually successful :face_with_raised_eyebrow:"
-
       - name: Build iOS app for Detox test run
         uses: LedgerHQ/ledger-live/tools/actions/composites/nx-step@develop
         env:

--- a/.github/workflows/test-mobile-build-ios-reusable.yml
+++ b/.github/workflows/test-mobile-build-ios-reusable.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
-      - uses: nick-fields/retry@v4
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         name: install dependencies
         id: install-dependencies
         with:
@@ -231,7 +231,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
-      - uses: nick-fields/retry@v4
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         name: install dependencies
         id: install-dependencies
         with:

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -576,7 +576,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
-      - uses: nick-fields/retry@v4
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         name: install dependencies
         id: install-dependencies
         with:

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -648,7 +648,7 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
-      - uses: nick-fields/retry@v3
+      - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         name: install dependencies
         id: install-dependencies
         with:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Version pin retry action + upgrade mock to bring into v4 alignment
- Remove deprecated flake notifier

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/30096939922