### PR TITLE
[LWM] fix(portfolio): fit localized quick action labels (LIVE-33387)

### DIFF
--- a/.changeset/gentle-labels-fit.md
+++ b/.changeset/gentle-labels-fit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix localized quick action labels overflowing their buttons

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/QuickActionsCtasView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/QuickActionsCtasView.tsx
@@ -25,6 +25,8 @@ const QuickActionsCtasView = ({ quickActions, isVariant = false }: QuickActionsC
           {isVariant ? (
             <Text
               typography="body3SemiBold"
+              numberOfLines={1}
+              adjustsFontSizeToFit
               lx={{
                 textAlign: "center",
                 color: action.disabled ? "disabled" : "base",

--- a/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/QuickActionsCtasView.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/QuickActions/components/QuickActionsCtas/__tests__/QuickActionsCtasView.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { ArrowUp } from "@ledgerhq/lumen-ui-rnative/symbols";
+import QuickActionsCtasView from "../QuickActionsCtasView";
+import type { QuickActionCta } from "../../../types";
+
+const quickActions: readonly QuickActionCta[] = [
+  {
+    id: "send",
+    label: "Отправить",
+    icon: ArrowUp,
+    disabled: false,
+    onPress: jest.fn(),
+    testID: "quick-action-send",
+  },
+];
+
+describe("QuickActionsCtasView", () => {
+  it("should shrink a localized variant label to fit on one line", () => {
+    render(<QuickActionsCtasView quickActions={quickActions} isVariant />);
+
+    const label = screen.getByText("Отправить");
+
+    expect(label).toBeVisible();
+    expect(label).toHaveProp("numberOfLines", 1);
+    expect(label).toHaveProp("adjustsFontSizeToFit", true);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The focused View test and the existing Quick Actions integration suite pass (18 tests).
- [x] **Impact of the changes:**
      - Wallet 4.0 Portfolio quick-action label rendering.
      - Long localized labels on compact mobile widths.
      - The standard quick-action layout remains unchanged.

### 📝 Description

The Wallet 4.0 quick-action variant gives each of its four CTA tiles an equal width. Longer localized labels such as the Russian translation of “Send” could overflow their tile.

This change keeps variant labels on one line and lets React Native reduce their font size only when needed. It preserves the existing Lumen typography, translations, tile sizes, navigation, and analytics.

| Before | After |
| ------ | ----- |
| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33387](https://ledgerhq.atlassian.net/browse/LIVE-33387)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33387]: https://ledgerhq.atlassian.net/browse/LIVE-33387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ