### PR TITLE
[LWDM] chore(LIVE-34998): widen id/parentCurrencyId to any in legacy types

### DIFF
--- a/libs/coin-modules/coin-tron/src/network/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/index.ts
@@ -306,7 +306,7 @@ export async function craftStandardTransaction(
 const getTokenInfo = (subAccount: TokenAccount | null | undefined): string[] | undefined[] => {
   const tokenInfo =
     subAccount && subAccount.type === "TokenAccount"
-      ? drop(subAccount.token.id.split("/"), 1)
+      ? drop(String(subAccount.token.id).split("/"), 1)
       : [undefined, undefined];
   return tokenInfo;
 };

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts
@@ -116,13 +116,13 @@ export function mergeSubAccounts(
   }
 
   const oldSubAccountsByTokenId = Object.fromEntries(
-    oldSubAccounts.map(account => [account.token.id, account]),
+    oldSubAccounts.map((account): [string, TokenAccount] => [String(account.token.id), account]),
   );
 
   const newSubAccountsToAdd: Array<TokenAccount> = [];
 
   for (const newSubAccount of newSubAccounts) {
-    const existingSubAccount = oldSubAccountsByTokenId[newSubAccount.token.id];
+    const existingSubAccount = oldSubAccountsByTokenId[String(newSubAccount.token.id)];
 
     if (!existingSubAccount) {
       // New sub account does not exist yet. Just add it as is.
@@ -132,7 +132,7 @@ export function mergeSubAccounts(
 
     // New sub account is already known, probably outdated
     const operations = mergeOps(existingSubAccount.operations, newSubAccount.operations);
-    oldSubAccountsByTokenId[newSubAccount.token.id] = {
+    oldSubAccountsByTokenId[String(newSubAccount.token.id)] = {
       ...existingSubAccount,
       balance: newSubAccount.balance,
       spendableBalance: newSubAccount.spendableBalance,

--- a/libs/ledger-wallet-framework/src/types.ts
+++ b/libs/ledger-wallet-framework/src/types.ts
@@ -20,7 +20,7 @@ export interface ExplorerView {
 
 export interface CryptoCurrency {
   type: "CryptoCurrency";
-  id: string;
+  id: any;
   name: string;
   ticker: string;
   deviceTicker?: string;
@@ -52,11 +52,11 @@ export interface CryptoCurrency {
 
 export interface TokenCurrency {
   type: "TokenCurrency";
-  id: string;
+  id: any;
   name: string;
   ticker: string;
   contractAddress: string;
-  parentCurrencyId: string;
+  parentCurrencyId: any;
   units: Unit[];
   tokenType: string;
   delisted?: boolean;

--- a/libs/ledgerjs/packages/types-cryptoassets/src/index.ts
+++ b/libs/ledgerjs/packages/types-cryptoassets/src/index.ts
@@ -53,11 +53,11 @@ type CurrencyCommon = {
  */
 export type TokenCurrency = CurrencyCommon & {
   type: "TokenCurrency";
-  id: string;
+  id: any;
   ledgerSignature?: string;
   contractAddress: string;
   // id of the currency it belongs to. e.g. 'ethereum'
-  parentCurrencyId: string;
+  parentCurrencyId: any;
   // the type of token in the blockchain it belongs. e.g. 'erc20'
   tokenType: string;
 };
@@ -95,7 +95,7 @@ export type BitcoinLikeInfo = {
 export type CryptoCurrency = CurrencyCommon & {
   type: "CryptoCurrency";
   // unique internal id of a crypto currency
-  id: CryptoCurrencyId;
+  id: any;
   // define if a crypto is a fork from another coin. helps dealing with split/unsplit
   forkedFrom?: string;
   // name of the app as shown in the Manager


### PR DESCRIPTION
## Summary

Prerequisite for [LIVE-34652](https://ledgerhq.atlassian.net/browse/LIVE-34652) — widens `id` and `parentCurrencyId` fields from `string`/`CryptoCurrencyId` → `any` in `@ledgerhq/types-cryptoassets` and `@ledgerhq/ledger-wallet-framework`.

This makes domain-branded ids (`string & $brand<"CryptoCurrencyId">`) structurally assignable to legacy types without any call-site `as` casts, enabling zero-cast consumer migrations.

- `libs/ledgerjs/packages/types-cryptoassets/src/index.ts` — `CryptoCurrency.id`, `TokenCurrency.id`, `TokenCurrency.parentCurrencyId`
- `libs/ledger-wallet-framework/src/types.ts` — same fields

**`any` propagation fixes** (two consumers broke):
- `libs/coin-modules/coin-tron/src/network/index.ts` — `String()` before `.split()` prevents lodash `drop()` returning `unknown[]`
- `libs/ledger-live-common/src/bridge/generic-coin-framework/buildSubAccounts.ts` — explicit `[string, TokenAccount]` tuple type on `Object.fromEntries` map callback keeps TypeScript 5 on the typed overload

## Test plan

- [ ] `pnpm nx run ledger-live-desktop:typecheck --parallel=100%` green
- [ ] `pnpm nx run @ledgerhq/coin-tron:build` green
- [ ] `pnpm nx run @ledgerhq/live-common:build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIVE-34652]: https://ledgerhq.atlassian.net/browse/LIVE-34652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ