### PR TITLE
ci(e2e): reduce nightly iOS simulators to 2

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -523,6 +523,7 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       SPECULOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
+      E2E_WORKER_COUNT: ${{ github.event_name == 'schedule' && '2' || '3' }}
     outputs:
       status: ${{ steps.run-ios.outcome }}
       artifact: ${{ steps.test-artifacts.outputs.artifact-id }}
@@ -588,7 +589,7 @@ jobs:
       - name: Boot iOS Simulator in Background
         uses: LedgerHQ/ledger-live/tools/actions/composites/boot-ios-simulators-background@develop
         with:
-          worker_count: 3
+          worker_count: ${{ env.E2E_WORKER_COUNT }}
           artifacts_root: ${{ env.MOBILE_ARTIFACTS_ROOT }}
 
       - name: Detox Post Install

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -74,7 +74,11 @@ const ESM_PACKAGES = ["ky", "@polkadot", "@ledgerhq", "@shared", "@features", "@
 const config = {
   rootDir: ".",
   modulePaths: [compilerOptions.baseUrl ?? "."],
-  maxWorkers: process.env.CI ? 3 : 1,
+  maxWorkers: process.env.E2E_WORKER_COUNT
+    ? Number(process.env.E2E_WORKER_COUNT)
+    : process.env.CI
+      ? 3
+      : 1,
   transform: {
     "^.+\\.(t|j)sx?$": [
       "@swc/jest",


### PR DESCRIPTION
## Context

Nightly iOS E2E runs the full 12-shard suite with **3 simulators per shard**, which drove one runner from 8.7 GB → 2.5 GB free RAM and stalled the Detox WebSocket bridge (transient `beforeAll` failure in `walletAssets.spec.ts`, passed on retry). Reducing concurrent simulators relieves the memory pressure.

## Change

Cap nightly iOS to **2 simulators / 2 Detox workers**; everything else stays at 3.

- `test-mobile-e2e-reusable.yml`: job-level `E2E_WORKER_COUNT` on the iOS job = `2` for `schedule` (nightly), `3` otherwise. Feeds the simulator pre-boot step (`worker_count`) and is inherited by the Detox run step's process.
- `e2e/mobile/jest.config.js`: `maxWorkers` honors `E2E_WORKER_COUNT` when set, falling back to the previous `CI ? 3 : 1`.

Both the pre-boot count and the Detox worker count are reduced together — pre-booting 3 simulators would consume the memory even if only 2 were used.

## Scope

- **Nightly iOS** → 2 simulators + 2 workers
- **PR / manual iOS** → unchanged (3)
- **Android** (separate job, doesn't set the env) → unchanged (3)

## Not addressed

The same run surfaced a deterministic product bug (buy webview button stays `aria-disabled="true"`, modular drawer never opens in `navigateToBuyFromAssetPage_ETH.spec.ts`) — unrelated to memory, out of scope here.
