### PR TITLE
feat(contacts): resolve mad eligible currencies (LIVE-33912)

### DIFF
--- a/.changeset/live-33912-mad-currencies.md
+++ b/.changeset/live-33912-mad-currencies.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Resolve Contacts MAD eligible native and token currencies from feature flags

--- a/.changeset/live-33912-mad-currencies.md
+++ b/.changeset/live-33912-mad-currencies.md
@@ -2,4 +2,5 @@
 "@features/flow-contacts": minor
 ---
 
-Resolve Contacts MAD eligible native and token currencies from feature flags
+Resolve Contacts MAD eligible production networks from feature flags and store the final currency
+selection

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -10,10 +10,18 @@ Shared Contacts flow package for Desktop and Mobile.
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Empty contact detail selection and native presentation
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
+- Add Address currency eligibility and selection state (MAD integration injects its normalized
+  crypto-and-token catalog and selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 
 App layers own routing, screen composition, i18n, and analytics.
+
+For Add Address, the consuming MAD adapter supplies ordered `{ id, networkFamily }` descriptors for
+every selectable native or token currency. Token descriptors use the family of their parent
+network. The Flow filters this catalog from `eligibleAddressFamilies`, sends only the resulting IDs
+to MAD, and stores only an eligible final crypto-or-token `currencyId` returned after asset and
+optional network selection. MAD is not opened when the filter resolves to no currency.
 
 ## Public API
 
@@ -61,6 +69,9 @@ src/
 │   │   ├── components/ContactNameInput/ (web + native)
 │   │   ├── model/                       # Contact-name validation and creation contract
 │   │   └── index.ts / web.ts / native.ts
+│   ├── AddAddress/                      # Shared eligible-currency resolution and selection state
+│   │   ├── model/                       # Injected catalog resolver and MAD selection port
+│   │   └── useAddAddressCurrencySelectionViewModel.ts / index.ts
 │   ├── Introduction/                    # Feature intro + Ledger Sync intro (ex featureIntroduction)
 │   │   ├── Feature/ (web dialog + native content) / LedgerSync/ (web dialog + native content)
 │   │   ├── useContactsFeatureIntroductionState.ts / resolver.ts / ports.ts / constants.ts / types.ts

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -10,18 +10,18 @@ Shared Contacts flow package for Desktop and Mobile.
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Empty contact detail selection and native presentation
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
-- Add Address currency eligibility and selection state (MAD integration injects its normalized
-  crypto-and-token catalog and selection port)
+- Add Address network eligibility and final currency selection state (MAD integration uses an
+  injected selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Empty, populated, and search Contacts list view models and their Desktop and Mobile page shells
 
 App layers own routing, screen composition, i18n, and analytics.
 
-For Add Address, the consuming MAD adapter supplies ordered `{ id, networkFamily }` descriptors for
-every selectable native or token currency. Token descriptors use the family of their parent
-network. The Flow filters this catalog from `eligibleAddressFamilies`, sends only the resulting IDs
-to MAD, and stores only an eligible final crypto-or-token `currencyId` returned after asset and
-optional network selection. MAD is not opened when the filter resolves to no currency.
+For Add Address, the Flow resolves ordered production network IDs from
+`eligibleAddressFamilies` and sends only those IDs to MAD. The consuming adapter filters MAD content
+by native network ID or token parent network ID. The Flow stores only the final crypto-or-token
+`currencyId` returned after asset and optional network selection. MAD is not opened when no
+production network matches the feature-flag families.
 
 ## Public API
 
@@ -69,8 +69,8 @@ src/
 │   │   ├── components/ContactNameInput/ (web + native)
 │   │   ├── model/                       # Contact-name validation and creation contract
 │   │   └── index.ts / web.ts / native.ts
-│   ├── AddAddress/                      # Shared eligible-currency resolution and selection state
-│   │   ├── model/                       # Injected catalog resolver and MAD selection port
+│   ├── AddAddress/                      # Shared eligible-network resolution and selection state
+│   │   ├── model/                       # Production network resolver and MAD selection port
 │   │   └── useAddAddressCurrencySelectionViewModel.ts / index.ts
 │   ├── Introduction/                    # Feature intro + Ledger Sync intro (ex featureIntroduction)
 │   │   ├── Feature/ (web dialog + native content) / LedgerSync/ (web dialog + native content)

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@domain/entity-contact": "workspace:*",
+    "@domain/entity-currency-crypto": "workspace:*",
     "@features/platform-feature-flags": "workspace:^",
     "@shared/feature-flags": "workspace:^"
   },

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -2,6 +2,7 @@ export * from "./steps/List";
 export * from "./steps/List/native";
 export * from "./steps/AddContact";
 export * from "./steps/AddContact/native";
+export * from "./steps/AddAddress";
 export * from "./steps/Introduction";
 export * from "./steps/Introduction/native";
 export * from "./steps/Detail";

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -2,6 +2,7 @@ export * from "./steps/List";
 export * from "./steps/List/web";
 export * from "./steps/AddContact";
 export * from "./steps/AddContact/web";
+export * from "./steps/AddAddress";
 export * from "./steps/Introduction";
 export * from "./steps/Introduction/web";
 export * from "./steps/Detail";

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -1,0 +1,10 @@
+export type { ContactsCurrencySelectionPort } from "./model/ports";
+export {
+  resolveEligibleAddressCurrencyIds,
+  type ContactsAddressCurrencyDescriptor,
+} from "./model/resolveEligibleAddressCurrencyIds";
+export {
+  useAddAddressCurrencySelectionViewModel,
+  type AddAddressCurrencySelectionViewModel,
+  type UseAddAddressCurrencySelectionViewModelOptions,
+} from "./useAddAddressCurrencySelectionViewModel";

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -1,7 +1,7 @@
 export type { ContactsCurrencySelectionPort } from "./model/ports";
 export {
   resolveEligibleAddressCurrencyIds,
-  type ContactsAddressCurrencyDescriptor,
+  type EligibleAddressNetwork,
 } from "./model/resolveEligibleAddressCurrencyIds";
 export {
   useAddAddressCurrencySelectionViewModel,

--- a/features/flow/contacts/src/steps/AddAddress/model/ports.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/ports.ts
@@ -1,5 +1,8 @@
 import type { ContactAddress } from "@domain/entity-contact";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 
 export type ContactsCurrencySelectionPort = Readonly<{
-  selectCurrency(currencyIds: readonly string[]): Promise<ContactAddress["currencyId"] | null>;
+  selectCurrency(
+    networkIds: readonly CryptoCurrency["id"][],
+  ): Promise<ContactAddress["currencyId"] | null>;
 }>;

--- a/features/flow/contacts/src/steps/AddAddress/model/ports.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/ports.ts
@@ -1,0 +1,5 @@
+import type { ContactAddress } from "@domain/entity-contact";
+
+export type ContactsCurrencySelectionPort = Readonly<{
+  selectCurrency(currencyIds: readonly string[]): Promise<ContactAddress["currencyId"] | null>;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.ts
@@ -1,0 +1,22 @@
+import type { ContactAddress } from "@domain/entity-contact";
+
+export type ContactsAddressCurrencyDescriptor = Readonly<{
+  id: ContactAddress["currencyId"];
+  networkFamily: string;
+}>;
+
+export function resolveEligibleAddressCurrencyIds(
+  eligibleFamilies: readonly string[],
+  currencyCatalog: readonly ContactsAddressCurrencyDescriptor[],
+): string[] {
+  const families = new Set(eligibleFamilies);
+  const currencyIds = new Set<string>();
+
+  for (const currency of currencyCatalog) {
+    if (families.has(currency.networkFamily)) {
+      currencyIds.add(currency.id);
+    }
+  }
+
+  return [...currencyIds];
+}

--- a/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.ts
@@ -1,22 +1,19 @@
-import type { ContactAddress } from "@domain/entity-contact";
+import { listCryptoCurrencies, type CryptoCurrency } from "@domain/entity-currency-crypto";
 
-export type ContactsAddressCurrencyDescriptor = Readonly<{
-  id: ContactAddress["currencyId"];
-  networkFamily: string;
-}>;
+export type EligibleAddressNetwork = Readonly<Pick<CryptoCurrency, "id" | "family">>;
 
 export function resolveEligibleAddressCurrencyIds(
   eligibleFamilies: readonly string[],
-  currencyCatalog: readonly ContactsAddressCurrencyDescriptor[],
-): string[] {
+  networks: readonly EligibleAddressNetwork[] = listCryptoCurrencies(),
+): CryptoCurrency["id"][] {
   const families = new Set(eligibleFamilies);
-  const currencyIds = new Set<string>();
+  const networkIds = new Set<CryptoCurrency["id"]>();
 
-  for (const currency of currencyCatalog) {
-    if (families.has(currency.networkFamily)) {
-      currencyIds.add(currency.id);
+  for (const network of networks) {
+    if (families.has(network.family)) {
+      networkIds.add(network.id);
     }
   }
 
-  return [...currencyIds];
+  return [...networkIds];
 }

--- a/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.web.test.ts
@@ -1,0 +1,51 @@
+import { ContactCurrencyIdSchema } from "@domain/entity-contact";
+import {
+  resolveEligibleAddressCurrencyIds,
+  type ContactsAddressCurrencyDescriptor,
+} from "./resolveEligibleAddressCurrencyIds";
+
+const currencyId = (value: string) => ContactCurrencyIdSchema.parse(value);
+
+const CURRENCY_CATALOG: readonly ContactsAddressCurrencyDescriptor[] = [
+  { id: currencyId("ethereum"), networkFamily: "evm" },
+  { id: currencyId("ethereum/erc20/usd-tether"), networkFamily: "evm" },
+  { id: currencyId("bitcoin"), networkFamily: "bitcoin" },
+  { id: currencyId("base"), networkFamily: "evm" },
+  { id: currencyId("base/erc20/usd-coin"), networkFamily: "evm" },
+  { id: currencyId("tron/trc20/usd-tether"), networkFamily: "tron" },
+  { id: currencyId("solana"), networkFamily: "solana" },
+];
+
+describe("resolveEligibleAddressCurrencyIds", () => {
+  it("resolves native and token currency ids from eligible networks", () => {
+    expect(resolveEligibleAddressCurrencyIds(["evm"], CURRENCY_CATALOG)).toEqual([
+      "ethereum",
+      "ethereum/erc20/usd-tether",
+      "base",
+      "base/erc20/usd-coin",
+    ]);
+  });
+
+  it("resolves future multi-family values in currency order", () => {
+    expect(resolveEligibleAddressCurrencyIds(["evm", "bitcoin"], CURRENCY_CATALOG)).toEqual([
+      "ethereum",
+      "ethereum/erc20/usd-tether",
+      "bitcoin",
+      "base",
+      "base/erc20/usd-coin",
+    ]);
+  });
+
+  it("returns no currencies for unknown families", () => {
+    expect(resolveEligibleAddressCurrencyIds(["unknown"], CURRENCY_CATALOG)).toEqual([]);
+  });
+
+  it("deduplicates currency ids while preserving their first occurrence", () => {
+    expect(
+      resolveEligibleAddressCurrencyIds(
+        ["evm"],
+        [...CURRENCY_CATALOG, { id: currencyId("ethereum"), networkFamily: "evm" }],
+      ),
+    ).toEqual(["ethereum", "ethereum/erc20/usd-tether", "base", "base/erc20/usd-coin"]);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/resolveEligibleAddressCurrencyIds.web.test.ts
@@ -1,51 +1,52 @@
-import { ContactCurrencyIdSchema } from "@domain/entity-contact";
+import { getCryptoCurrencyById, listCryptoCurrencies } from "@domain/entity-currency-crypto";
 import {
   resolveEligibleAddressCurrencyIds,
-  type ContactsAddressCurrencyDescriptor,
+  type EligibleAddressNetwork,
 } from "./resolveEligibleAddressCurrencyIds";
 
-const currencyId = (value: string) => ContactCurrencyIdSchema.parse(value);
-
-const CURRENCY_CATALOG: readonly ContactsAddressCurrencyDescriptor[] = [
-  { id: currencyId("ethereum"), networkFamily: "evm" },
-  { id: currencyId("ethereum/erc20/usd-tether"), networkFamily: "evm" },
-  { id: currencyId("bitcoin"), networkFamily: "bitcoin" },
-  { id: currencyId("base"), networkFamily: "evm" },
-  { id: currencyId("base/erc20/usd-coin"), networkFamily: "evm" },
-  { id: currencyId("tron/trc20/usd-tether"), networkFamily: "tron" },
-  { id: currencyId("solana"), networkFamily: "solana" },
+const NETWORKS: readonly EligibleAddressNetwork[] = [
+  { id: getCryptoCurrencyById("ethereum").id, family: "evm" },
+  { id: getCryptoCurrencyById("bitcoin").id, family: "bitcoin" },
+  { id: getCryptoCurrencyById("base").id, family: "evm" },
+  { id: getCryptoCurrencyById("solana").id, family: "solana" },
 ];
 
 describe("resolveEligibleAddressCurrencyIds", () => {
-  it("resolves native and token currency ids from eligible networks", () => {
-    expect(resolveEligibleAddressCurrencyIds(["evm"], CURRENCY_CATALOG)).toEqual([
-      "ethereum",
-      "ethereum/erc20/usd-tether",
-      "base",
-      "base/erc20/usd-coin",
-    ]);
+  it("resolves the default EVM family from production networks", () => {
+    const expectedNetworkIds = listCryptoCurrencies()
+      .filter(network => network.family === "evm")
+      .map(network => network.id);
+    const excludedNetworkIds = listCryptoCurrencies(true)
+      .filter(
+        network => network.family === "evm" && Boolean(network.isTestnetFor || network.delisted),
+      )
+      .map(network => network.id);
+    const networkIds = resolveEligibleAddressCurrencyIds(["evm"]);
+
+    expect(networkIds).toEqual(expectedNetworkIds);
+    expect(expectedNetworkIds).not.toHaveLength(0);
+    expect(excludedNetworkIds).not.toHaveLength(0);
+    expect(networkIds).toEqual(expect.not.arrayContaining(excludedNetworkIds));
   });
 
-  it("resolves future multi-family values in currency order", () => {
-    expect(resolveEligibleAddressCurrencyIds(["evm", "bitcoin"], CURRENCY_CATALOG)).toEqual([
+  it("resolves future multi-family values in network order", () => {
+    expect(resolveEligibleAddressCurrencyIds(["evm", "bitcoin"], NETWORKS)).toEqual([
       "ethereum",
-      "ethereum/erc20/usd-tether",
       "bitcoin",
       "base",
-      "base/erc20/usd-coin",
     ]);
   });
 
-  it("returns no currencies for unknown families", () => {
-    expect(resolveEligibleAddressCurrencyIds(["unknown"], CURRENCY_CATALOG)).toEqual([]);
+  it("returns no networks for unknown families", () => {
+    expect(resolveEligibleAddressCurrencyIds(["unknown"], NETWORKS)).toEqual([]);
   });
 
-  it("deduplicates currency ids while preserving their first occurrence", () => {
+  it("deduplicates network ids while preserving their first occurrence", () => {
     expect(
       resolveEligibleAddressCurrencyIds(
         ["evm"],
-        [...CURRENCY_CATALOG, { id: currencyId("ethereum"), networkFamily: "evm" }],
+        [...NETWORKS, { id: getCryptoCurrencyById("ethereum").id, family: "evm" }],
       ),
-    ).toEqual(["ethereum", "ethereum/erc20/usd-tether", "base", "base/erc20/usd-coin"]);
+    ).toEqual(["ethereum", "base"]);
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
@@ -2,14 +2,10 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import type { ContactAddress } from "@domain/entity-contact";
 import { useContactsFeature, type ContactsFeaturePlatform } from "../../featureFlags";
 import type { ContactsCurrencySelectionPort } from "./model/ports";
-import {
-  resolveEligibleAddressCurrencyIds,
-  type ContactsAddressCurrencyDescriptor,
-} from "./model/resolveEligibleAddressCurrencyIds";
+import { resolveEligibleAddressCurrencyIds } from "./model/resolveEligibleAddressCurrencyIds";
 
 export type UseAddAddressCurrencySelectionViewModelOptions = Readonly<{
   platform: ContactsFeaturePlatform;
-  currencyCatalog: readonly ContactsAddressCurrencyDescriptor[];
   currencySelection: ContactsCurrencySelectionPort;
 }>;
 
@@ -20,36 +16,34 @@ export type AddAddressCurrencySelectionViewModel = Readonly<{
 
 export function useAddAddressCurrencySelectionViewModel({
   platform,
-  currencyCatalog,
   currencySelection,
 }: UseAddAddressCurrencySelectionViewModelOptions): AddAddressCurrencySelectionViewModel {
   const { eligibleAddressFamilies } = useContactsFeature(platform);
-  const eligibleCurrencyIds = useMemo(
-    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies, currencyCatalog),
-    [currencyCatalog, eligibleAddressFamilies],
+  const eligibleNetworkIds = useMemo(
+    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies),
+    [eligibleAddressFamilies],
   );
-  const eligibleCurrencyIdSet = useMemo(() => new Set(eligibleCurrencyIds), [eligibleCurrencyIds]);
   const isSelectingRef = useRef(false);
   const [selectedCurrencyId, setSelectedCurrencyId] = useState<ContactAddress["currencyId"] | null>(
     null,
   );
   const selectCurrency = useCallback(async () => {
-    if (eligibleCurrencyIds.length === 0 || isSelectingRef.current) {
+    if (eligibleNetworkIds.length === 0 || isSelectingRef.current) {
       return;
     }
 
     isSelectingRef.current = true;
 
     try {
-      const currencyId = await currencySelection.selectCurrency(eligibleCurrencyIds);
+      const currencyId = await currencySelection.selectCurrency(eligibleNetworkIds);
 
-      if (currencyId !== null && eligibleCurrencyIdSet.has(currencyId)) {
+      if (currencyId !== null) {
         setSelectedCurrencyId(currencyId);
       }
     } finally {
       isSelectingRef.current = false;
     }
-  }, [currencySelection, eligibleCurrencyIds, eligibleCurrencyIdSet]);
+  }, [currencySelection, eligibleNetworkIds]);
 
   return {
     selectedCurrencyId,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
@@ -1,0 +1,58 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { ContactAddress } from "@domain/entity-contact";
+import { useContactsFeature, type ContactsFeaturePlatform } from "../../featureFlags";
+import type { ContactsCurrencySelectionPort } from "./model/ports";
+import {
+  resolveEligibleAddressCurrencyIds,
+  type ContactsAddressCurrencyDescriptor,
+} from "./model/resolveEligibleAddressCurrencyIds";
+
+export type UseAddAddressCurrencySelectionViewModelOptions = Readonly<{
+  platform: ContactsFeaturePlatform;
+  currencyCatalog: readonly ContactsAddressCurrencyDescriptor[];
+  currencySelection: ContactsCurrencySelectionPort;
+}>;
+
+export type AddAddressCurrencySelectionViewModel = Readonly<{
+  selectedCurrencyId: ContactAddress["currencyId"] | null;
+  selectCurrency: () => Promise<void>;
+}>;
+
+export function useAddAddressCurrencySelectionViewModel({
+  platform,
+  currencyCatalog,
+  currencySelection,
+}: UseAddAddressCurrencySelectionViewModelOptions): AddAddressCurrencySelectionViewModel {
+  const { eligibleAddressFamilies } = useContactsFeature(platform);
+  const eligibleCurrencyIds = useMemo(
+    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies, currencyCatalog),
+    [currencyCatalog, eligibleAddressFamilies],
+  );
+  const eligibleCurrencyIdSet = useMemo(() => new Set(eligibleCurrencyIds), [eligibleCurrencyIds]);
+  const isSelectingRef = useRef(false);
+  const [selectedCurrencyId, setSelectedCurrencyId] = useState<ContactAddress["currencyId"] | null>(
+    null,
+  );
+  const selectCurrency = useCallback(async () => {
+    if (eligibleCurrencyIds.length === 0 || isSelectingRef.current) {
+      return;
+    }
+
+    isSelectingRef.current = true;
+
+    try {
+      const currencyId = await currencySelection.selectCurrency(eligibleCurrencyIds);
+
+      if (currencyId !== null && eligibleCurrencyIdSet.has(currencyId)) {
+        setSelectedCurrencyId(currencyId);
+      }
+    } finally {
+      isSelectingRef.current = false;
+    }
+  }, [currencySelection, eligibleCurrencyIds, eligibleCurrencyIdSet]);
+
+  return {
+    selectedCurrencyId,
+    selectCurrency,
+  };
+}

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
@@ -2,7 +2,7 @@ import React, { type FC, type ReactNode } from "react";
 import { configureStore } from "@reduxjs/toolkit";
 import { act, renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { ContactCurrencyIdSchema } from "@domain/entity-contact";
+import { getCryptoCurrencyById, listCryptoCurrencies } from "@domain/entity-currency-crypto";
 import {
   FEATURE_FLAGS_DEFAULTS,
   FEATURE_FLAGS_INITIAL_STATE,
@@ -10,18 +10,9 @@ import {
   type Features,
 } from "@shared/feature-flags";
 import type { ContactsCurrencySelectionPort } from "./model/ports";
-import type { ContactsAddressCurrencyDescriptor } from "./model/resolveEligibleAddressCurrencyIds";
 import { useAddAddressCurrencySelectionViewModel } from "./useAddAddressCurrencySelectionViewModel";
 
-const currencyId = (value: string) => ContactCurrencyIdSchema.parse(value);
-const ETHEREUM_CURRENCY_ID = currencyId("ethereum");
-
-const CURRENCY_CATALOG: readonly ContactsAddressCurrencyDescriptor[] = [
-  { id: ETHEREUM_CURRENCY_ID, networkFamily: "evm" },
-  { id: currencyId("ethereum/erc20/usd-tether"), networkFamily: "evm" },
-  { id: currencyId("bitcoin"), networkFamily: "bitcoin" },
-  { id: currencyId("tron/trc20/usd-tether"), networkFamily: "tron" },
-];
+const ETHEREUM_CURRENCY_ID = getCryptoCurrencyById("ethereum").id;
 
 function makeWrapper(contactsFeature?: Features["lwdContacts"]) {
   const resolved: Features = {
@@ -52,7 +43,6 @@ function renderViewModel(
     () =>
       useAddAddressCurrencySelectionViewModel({
         platform: "desktop",
-        currencyCatalog: CURRENCY_CATALOG,
         currencySelection,
       }),
     { wrapper: makeWrapper(contactsFeature) },
@@ -60,16 +50,19 @@ function renderViewModel(
 }
 
 describe("useAddAddressCurrencySelectionViewModel", () => {
-  it("passes native and token EVM currency ids when feature params are missing", async () => {
+  it("passes production EVM network ids when feature params are missing", async () => {
     const selectCurrency = jest.fn().mockResolvedValue(null);
     const { result } = renderViewModel({ selectCurrency }, { enabled: true });
+    const expectedNetworkIds = listCryptoCurrencies()
+      .filter(network => network.family === "evm")
+      .map(network => network.id);
 
     await act(() => result.current.selectCurrency());
 
-    expect(selectCurrency).toHaveBeenCalledWith(["ethereum", "ethereum/erc20/usd-tether"]);
+    expect(selectCurrency).toHaveBeenCalledWith(expectedNetworkIds);
   });
 
-  it("stores only the final network-specific currency id selected by MAD", async () => {
+  it("stores the final eligible crypto-or-token currency id selected by MAD", async () => {
     const selectCurrency = jest.fn().mockResolvedValue("ethereum/erc20/usd-tether");
     const { result } = renderViewModel(
       { selectCurrency },
@@ -81,14 +74,13 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
         },
       },
     );
+    const expectedNetworkIds = listCryptoCurrencies()
+      .filter(network => network.family === "evm" || network.family === "bitcoin")
+      .map(network => network.id);
 
     await act(() => result.current.selectCurrency());
 
-    expect(selectCurrency).toHaveBeenCalledWith([
-      "ethereum",
-      "ethereum/erc20/usd-tether",
-      "bitcoin",
-    ]);
+    expect(selectCurrency).toHaveBeenCalledWith(expectedNetworkIds);
     expect(result.current.selectedCurrencyId).toBe("ethereum/erc20/usd-tether");
   });
 
@@ -102,7 +94,7 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
     expect(result.current.selectedCurrencyId).toBe("ethereum");
   });
 
-  it("does not open MAD when no catalog currency matches the eligible families", async () => {
+  it("does not open MAD when no production network matches the eligible families", async () => {
     const selectCurrency = jest.fn().mockResolvedValue(null);
     const { result } = renderViewModel(
       { selectCurrency },
@@ -110,7 +102,7 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
         enabled: true,
         params: {
           newBadge: false,
-          eligibleAddressFamilies: ["solana"],
+          eligibleAddressFamilies: ["unknown"],
         },
       },
     );
@@ -118,15 +110,6 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
     await act(() => result.current.selectCurrency());
 
     expect(selectCurrency).not.toHaveBeenCalled();
-  });
-
-  it("ignores a currency id returned outside the eligible MAD filter", async () => {
-    const selectCurrency = jest.fn().mockResolvedValue("tron/trc20/usd-tether");
-    const { result } = renderViewModel({ selectCurrency });
-
-    await act(() => result.current.selectCurrency());
-
-    expect(result.current.selectedCurrencyId).toBeNull();
   });
 
   it("ignores concurrent selection requests while MAD is open", async () => {

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
@@ -1,0 +1,153 @@
+import React, { type FC, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { ContactCurrencyIdSchema } from "@domain/entity-contact";
+import {
+  FEATURE_FLAGS_DEFAULTS,
+  FEATURE_FLAGS_INITIAL_STATE,
+  featureFlagsReducer,
+  type Features,
+} from "@shared/feature-flags";
+import type { ContactsCurrencySelectionPort } from "./model/ports";
+import type { ContactsAddressCurrencyDescriptor } from "./model/resolveEligibleAddressCurrencyIds";
+import { useAddAddressCurrencySelectionViewModel } from "./useAddAddressCurrencySelectionViewModel";
+
+const currencyId = (value: string) => ContactCurrencyIdSchema.parse(value);
+const ETHEREUM_CURRENCY_ID = currencyId("ethereum");
+
+const CURRENCY_CATALOG: readonly ContactsAddressCurrencyDescriptor[] = [
+  { id: ETHEREUM_CURRENCY_ID, networkFamily: "evm" },
+  { id: currencyId("ethereum/erc20/usd-tether"), networkFamily: "evm" },
+  { id: currencyId("bitcoin"), networkFamily: "bitcoin" },
+  { id: currencyId("tron/trc20/usd-tether"), networkFamily: "tron" },
+];
+
+function makeWrapper(contactsFeature?: Features["lwdContacts"]) {
+  const resolved: Features = {
+    ...FEATURE_FLAGS_DEFAULTS,
+    ...(contactsFeature ? { lwdContacts: contactsFeature } : undefined),
+  };
+  const store = configureStore({
+    reducer: { featureFlags: featureFlagsReducer },
+    preloadedState: {
+      featureFlags: {
+        ...FEATURE_FLAGS_INITIAL_STATE,
+        resolved,
+      },
+    },
+  });
+  const Wrapper: FC<{ children: ReactNode }> = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return Wrapper;
+}
+
+function renderViewModel(
+  currencySelection: ContactsCurrencySelectionPort,
+  contactsFeature?: Features["lwdContacts"],
+) {
+  return renderHook(
+    () =>
+      useAddAddressCurrencySelectionViewModel({
+        platform: "desktop",
+        currencyCatalog: CURRENCY_CATALOG,
+        currencySelection,
+      }),
+    { wrapper: makeWrapper(contactsFeature) },
+  );
+}
+
+describe("useAddAddressCurrencySelectionViewModel", () => {
+  it("passes native and token EVM currency ids when feature params are missing", async () => {
+    const selectCurrency = jest.fn().mockResolvedValue(null);
+    const { result } = renderViewModel({ selectCurrency }, { enabled: true });
+
+    await act(() => result.current.selectCurrency());
+
+    expect(selectCurrency).toHaveBeenCalledWith(["ethereum", "ethereum/erc20/usd-tether"]);
+  });
+
+  it("stores only the final network-specific currency id selected by MAD", async () => {
+    const selectCurrency = jest.fn().mockResolvedValue("ethereum/erc20/usd-tether");
+    const { result } = renderViewModel(
+      { selectCurrency },
+      {
+        enabled: true,
+        params: {
+          newBadge: false,
+          eligibleAddressFamilies: ["evm", "bitcoin"],
+        },
+      },
+    );
+
+    await act(() => result.current.selectCurrency());
+
+    expect(selectCurrency).toHaveBeenCalledWith([
+      "ethereum",
+      "ethereum/erc20/usd-tether",
+      "bitcoin",
+    ]);
+    expect(result.current.selectedCurrencyId).toBe("ethereum/erc20/usd-tether");
+  });
+
+  it("preserves the selected currency id when MAD is cancelled", async () => {
+    const selectCurrency = jest.fn().mockResolvedValueOnce("ethereum").mockResolvedValueOnce(null);
+    const { result } = renderViewModel({ selectCurrency });
+
+    await act(() => result.current.selectCurrency());
+    await act(() => result.current.selectCurrency());
+
+    expect(result.current.selectedCurrencyId).toBe("ethereum");
+  });
+
+  it("does not open MAD when no catalog currency matches the eligible families", async () => {
+    const selectCurrency = jest.fn().mockResolvedValue(null);
+    const { result } = renderViewModel(
+      { selectCurrency },
+      {
+        enabled: true,
+        params: {
+          newBadge: false,
+          eligibleAddressFamilies: ["solana"],
+        },
+      },
+    );
+
+    await act(() => result.current.selectCurrency());
+
+    expect(selectCurrency).not.toHaveBeenCalled();
+  });
+
+  it("ignores a currency id returned outside the eligible MAD filter", async () => {
+    const selectCurrency = jest.fn().mockResolvedValue("tron/trc20/usd-tether");
+    const { result } = renderViewModel({ selectCurrency });
+
+    await act(() => result.current.selectCurrency());
+
+    expect(result.current.selectedCurrencyId).toBeNull();
+  });
+
+  it("ignores concurrent selection requests while MAD is open", async () => {
+    let resolveSelection: (currencyId: typeof ETHEREUM_CURRENCY_ID) => void = () => undefined;
+    const selectCurrency = jest.fn(
+      () =>
+        new Promise<typeof ETHEREUM_CURRENCY_ID>(resolve => {
+          resolveSelection = resolve;
+        }),
+    );
+    const { result } = renderViewModel({ selectCurrency });
+
+    let firstSelection: Promise<void>;
+    await act(async () => {
+      firstSelection = result.current.selectCurrency();
+      await result.current.selectCurrency();
+      resolveSelection(ETHEREUM_CURRENCY_ID);
+      await firstSelection;
+    });
+
+    expect(selectCurrency).toHaveBeenCalledTimes(1);
+    expect(result.current.selectedCurrencyId).toBe("ethereum");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4283,6 +4283,9 @@ importers:
       '@domain/entity-contact':
         specifier: workspace:*
         version: link:../../../domain/entity/contact
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../../../domain/entity/currency-crypto
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../../platform/feature-flags


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Contacts Add Address EVM-only default currency resolution
      - Future multi-family feature-flag overrides
      - MAD port payload and selected currency ID state

### 📝 Description

Contacts needs to filter the Add Address MAD entry point from the `eligibleAddressFamilies` feature-flag parameter without owning MAD presentation models.

This PR adds shared Add Address currency-selection logic to `@features/flow-contacts`. It resolves production crypto network IDs from eligible families, sends only those IDs through an injected selection port, and stores only MAD's final selected `currencyId`. Desktop and Mobile MAD adapters remain in their dedicated follow-up tickets.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33912](https://ledgerhq.atlassian.net/browse/LIVE-33912)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33912]: https://ledgerhq.atlassian.net/browse/LIVE-33912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ