### PR TITLE
[LWD] feat(contacts): start desktop add address flow (LIVE-33910)

### DIFF
--- a/.changeset/live-33910-start-add-address-desktop.md
+++ b/.changeset/live-33910-start-add-address-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Start the shared Add Address flow from Desktop contact details

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,14 +1,22 @@
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
-import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import type { ContactId } from "@domain/entity-contact";
+import {
+  mockContact,
+  mockMeContact,
+  mockPopulatedContacts,
+} from "@domain/entity-contact/schema.mock";
 import { fireEvent, render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
+import { useContactsViewModel } from "LLD/features/Contacts/screens/Contacts/useContactsViewModel";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
 import { ContextMenu } from "LLD/features/MyWallet/components/ContextMenu";
 import { CONTEXT_MENU_VIEW } from "LLD/features/MyWallet/components/ContextMenu/types";
 
 const mockNavigate = jest.fn();
 const mockClose = jest.fn();
+const meContactId = mockMeContact().id;
+const savedContactId = mockContact({ id: "contact-ada" }).id;
 
 jest.mock("react-router", () => ({
   ...jest.requireActual<typeof import("react-router")>("react-router"),
@@ -48,6 +56,37 @@ function contactsPageInitialState(extra: Record<string, unknown> = {}) {
     },
     ...extra,
   };
+}
+
+function ContactsViewModelProbe({
+  contactId,
+  contactType,
+}: Readonly<{
+  contactId: ContactId;
+  contactType: "me" | "saved";
+}>) {
+  const viewModel = useContactsViewModel();
+  const stateLabel =
+    viewModel.addAddressFlowState.status === "closed"
+      ? "closed"
+      : `${viewModel.addAddressFlowState.status}:${viewModel.addAddressFlowState.selectedContactId}`;
+
+  return (
+    <>
+      <div data-testid="contacts-add-address-flow-state">{stateLabel}</div>
+      <button
+        type="button"
+        onClick={() =>
+          contactType === "me" ? viewModel.onOpenMe(contactId) : viewModel.onOpenContact(contactId)
+        }
+      >
+        Open contact
+      </button>
+      <button type="button" onClick={viewModel.detail?.onAddAddress} disabled={!viewModel.detail}>
+        Start Add Address
+      </button>
+    </>
+  );
 }
 
 describe("Contacts integration", () => {
@@ -370,6 +409,52 @@ describe("Contacts integration", () => {
       screen.getByText("Save their wallet addresses to send to them by name next time."),
     ).toBeVisible();
     expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
+  });
+
+  it("should expose the Add Address session started for Me", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={meContactId} contactType="me" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
+      "selectingCurrency:contact-me",
+    );
+  });
+
+  it("should expose the Add Address session started for a saved contact", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={savedContactId} contactType="saved" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
+      "selectingCurrency:contact-ada",
+    );
   });
 
   it("should not render the detail state when a contact with addresses is selected", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -3,22 +3,24 @@ import { useTranslation } from "react-i18next";
 import type { Contact, ContactId } from "@domain/entity-contact";
 import {
   useEmptyContactDetail,
+  type AddAddressFlowViewModel,
   type ContactDetailLabels,
   type ContactDetailViewProps,
   type ContactsListViewProps,
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
 
-const onAddAddress = () => undefined;
-
-export function useContactDetailPaneAdapter(contacts: readonly Contact[]): Readonly<{
+export function useContactDetailPaneAdapter(
+  contacts: readonly Contact[],
+  startAddAddress: AddAddressFlowViewModel["start"],
+): Readonly<{
   detail: ContactDetailViewProps | undefined;
   onOpenMe: ContactsListViewProps["onOpenMe"];
   onOpenContact: ContactsListViewProps["onOpenContact"];
 }> {
   const { t } = useTranslation();
-  const [selectedContactId, setSelectedContactId] = useState<ContactId | undefined>();
-  const selectedContact = useEmptyContactDetail(selectedContactId);
+  const [detailContactId, setDetailContactId] = useState<ContactId | undefined>();
+  const selectedContact = useEmptyContactDetail(detailContactId);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
@@ -31,7 +33,7 @@ export function useContactDetailPaneAdapter(contacts: readonly Contact[]): Reado
     [t],
   );
   const onOpenMe = useCallback<ContactsListViewProps["onOpenMe"]>(contactId => {
-    setSelectedContactId(contactId);
+    setDetailContactId(contactId);
   }, []);
   const onOpenContact = useCallback<ContactsListViewProps["onOpenContact"]>(
     contactId => {
@@ -40,11 +42,11 @@ export function useContactDetailPaneAdapter(contacts: readonly Contact[]): Reado
       );
 
       if (!isEmptyContact) {
-        setSelectedContactId(undefined);
+        setDetailContactId(undefined);
         return;
       }
 
-      setSelectedContactId(contactId);
+      setDetailContactId(contactId);
     },
     [contacts],
   );
@@ -57,9 +59,9 @@ export function useContactDetailPaneAdapter(contacts: readonly Contact[]): Reado
       contact: selectedContact,
       labels,
       meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
-      onAddAddress,
+      onAddAddress: () => startAddAddress(selectedContact.id),
     };
-  }, [labels, selectedContact]);
+  }, [labels, selectedContact, startAddAddress]);
 
   return {
     detail,

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -6,9 +6,11 @@ import {
   createContactsListViewModel,
   createContactsSearchViewModel,
   resolveContactsLedgerSyncIntroductionOpen,
+  useAddAddressFlowViewModel,
   useContacts,
   useContactsFeatureIntroductionState,
   useContactsMeContact,
+  type AddAddressFlowState,
   type ContactsLedgerSyncStatus,
   type ContactsListViewLabels,
   type ContactsListViewProps,
@@ -19,6 +21,7 @@ import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 
 export type ContactsPageViewModel = Omit<ContactsListViewProps, "onAddContact"> &
   Readonly<{
+    addAddressFlowState: AddAddressFlowState;
     onClearSearch: () => void;
   }>;
 
@@ -28,7 +31,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
-  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(contacts);
+  const { state: addAddressFlowState, start: startAddAddress } = useAddAddressFlowViewModel();
+  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(
+    contacts,
+    startAddAddress,
+  );
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const preference = useContactsFeatureIntroductionPreference();
@@ -90,6 +97,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   }, [navigate]);
 
   return {
+    addAddressFlowState,
     viewModel,
     labels,
     searchQuery,


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Desktop integration tests cover Me, saved contacts, exact ContactId forwarding, and verify that selecting a detail alone does not start Add Address.
- [x] **Impact of the changes:**
      Desktop contact-detail Add address wiring for Me and saved contacts.

### 📝 Description

The Desktop contact-detail Add address CTA was intentionally inert.

This PR consumes the shared Add Address session already available on `develop` and wires the Desktop detail CTA to start a fresh session with the exact selected `ContactId`. The session state is owned by the Contacts page ViewModel and exposed for the future Add Address container.

The branch has been rebuilt directly on the latest `develop` after the Desktop detail view and Mobile session foundation merged. It now contains only the Desktop-specific adapter, ViewModel, integration tests, and Desktop changeset.

No MAD integration, service, navigation, analytics, translation, or visual behavior is added here. No screenshots are required because the Add Address wiring does not change the UI.

### Validation

- Desktop Contacts integration tests
- Desktop typecheck
- Targeted Oxlint and Oxfmt checks
- `git diff --check`

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33910](https://ledgerhq.atlassian.net/browse/LIVE-33910)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33910]: https://ledgerhq.atlassian.net/browse/LIVE-33910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ