### PR TITLE
test(mobile): move SEI EVM delegate into Coin Integration > Delegate suite

### DIFF
--- a/e2e/mobile/specs/delegate/delegateSEI.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateSEI.spec.ts
@@ -14,8 +14,8 @@ const delegation = new Delegate(Account.SEI_EVM_1, DELEGATION_AMOUNT, "first-ava
 const tmsLinks: string[] = ["B2CQA-5740"];
 const tags = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@sei_evm", "@family-evm"];
 
-describe("SEI EVM Native Staking - Delegate flow", () => {
-  setTeamOwner(Team.COIN_INTEGRATION);
+setTeamOwner(Team.COIN_INTEGRATION);
+describe("Delegate", () => {
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
 
@@ -34,7 +34,7 @@ describe("SEI EVM Native Staking - Delegate flow", () => {
     await app.portfolio.waitForPortfolioPageToLoad();
   });
 
-  it(`Delegate on ${delegation.account.currency.name}: start delegate, validator list shown, validator selected`, async () => {
+  it(`Delegate on ${delegation.account.currency.name}`, async () => {
     const amountWithCode = DELEGATION_AMOUNT + " " + delegation.account.currency.ticker;
 
     await app.portfolio.goToAccounts(delegation.account.currency.name);


### PR DESCRIPTION
## Summary
- Moves SEI EVM Native Staking delegate test into the `Delegate` suite under Coin Integration in Allure
- Fixes `setTeamOwner` placement (must be outside `describe()` to correctly set `$ParentSuite`)
- Renames describe block from `SEI EVM Native Staking - Delegate flow` to `Delegate`
- Simplifies test name to match other coins pattern: `Delegate on <CurrencyName>`

## Test plan
- [ ] Verify in Allure report that test appears under Coin Integration > Delegate alongside other coins