### PR TITLE
[LWM] feat(contacts): start mobile add address flow (LIVE-33911)

### DIFF
--- a/.changeset/live-33910-start-add-address-session.md
+++ b/.changeset/live-33910-start-add-address-session.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared Add Address session state with selected contact identity

--- a/.changeset/live-33910-start-add-address-session.md
+++ b/.changeset/live-33910-start-add-address-session.md
@@ -1,5 +1,0 @@
----
-"@features/flow-contacts": minor
----
-
-Add shared Add Address session state with selected contact identity

--- a/.changeset/live-33911-start-add-address-mobile.md
+++ b/.changeset/live-33911-start-add-address-mobile.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Add shared Add Address session state and start it from Mobile contact details

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Text } from "react-native";
+import { Pressable, Text } from "react-native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { render, screen, withFlagOverrides, waitFor } from "@tests/test-renderer";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { ScreenName } from "~/const";
 import { ContactsButton, ContactsScreen } from "LLM/features/Contacts";
 import { ContactDetailScreen } from "LLM/features/Contacts/screens/ContactDetail";
+import { useContactDetailScreenViewModel } from "LLM/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel";
 import MyWalletNavigator from "LLM/features/MyWallet/Navigator";
 import { useMyWalletHeaderViewModel } from "LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel";
 
@@ -32,6 +33,18 @@ const contactDetailNavigationState = {
       name: ScreenName.MyWalletContactDetail,
       key: "contact-detail",
       params: { contactId: "contact-me" },
+    },
+  ],
+};
+
+const savedContactDetailNavigationState = {
+  index: 1,
+  routes: [
+    { name: ScreenName.MyWallet, key: "my-wallet" },
+    {
+      name: ScreenName.MyWalletContactDetail,
+      key: "contact-detail",
+      params: { contactId: "contact-benoit" },
     },
   ],
 };
@@ -69,6 +82,44 @@ function ContactsGatingTestApp() {
       <Stack.Screen name={ScreenName.MyWallet} component={MyWalletHomeTestScreen} />
       <Stack.Screen name={ScreenName.MyWalletContacts} component={ContactsScreen} />
       <Stack.Screen name={ScreenName.MyWalletContactDetail} component={ContactDetailScreen} />
+    </Stack.Navigator>
+  );
+}
+
+function ContactDetailViewModelProbe() {
+  const viewModel = useContactDetailScreenViewModel();
+
+  if (viewModel.status === "redirecting") {
+    return null;
+  }
+
+  const stateLabel =
+    viewModel.addAddressFlowState.status === "closed"
+      ? "closed"
+      : `${viewModel.addAddressFlowState.status}:${viewModel.addAddressFlowState.selectedContactId}`;
+
+  return (
+    <>
+      <Text testID="contacts-add-address-flow-state">{stateLabel}</Text>
+      <Pressable
+        accessibilityRole="button"
+        testID="contacts-start-add-address"
+        onPress={viewModel.pageProps.onAddAddress}
+      >
+        <Text>Start Add Address</Text>
+      </Pressable>
+    </>
+  );
+}
+
+function ContactDetailViewModelTestApp() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={ScreenName.MyWallet} component={MyWalletHomeTestScreen} />
+      <Stack.Screen
+        name={ScreenName.MyWalletContactDetail}
+        component={ContactDetailViewModelProbe}
+      />
     </Stack.Navigator>
   );
 }
@@ -328,5 +379,42 @@ describe("Contacts integration", () => {
       expect(screen.getByText("Save a wallet address to send to Benoit")).toBeVisible();
       expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
     });
+  });
+
+  it("should expose the Add Address session started for Me", async () => {
+    const { user } = render(<ContactDetailViewModelTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+
+    await user.press(screen.getByTestId("contacts-start-add-address"));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
+      "selectingCurrency:contact-me",
+    );
+  });
+
+  it("should expose the Add Address session started for a saved contact", async () => {
+    const contact = mockContact({ id: "contact-benoit", name: "Benoit" });
+    const { user } = render(<ContactDetailViewModelTestApp />, {
+      navigationInitialState: savedContactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          contacts: { contacts: [mockMeContact(), contact] },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("contacts-start-add-address"));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
+      `selectingCurrency:${contact.id}`,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -1,10 +1,12 @@
-import { useLayoutEffect, useMemo } from "react";
+import { useCallback, useLayoutEffect, useMemo } from "react";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import type { RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
+  type AddAddressFlowState,
   type ContactDetailLabels,
   type ContactDetailViewProps,
+  useAddAddressFlowViewModel,
   useContactsFeature,
   useEmptyContactDetail,
 } from "@features/flow-contacts";
@@ -17,10 +19,9 @@ type ContactDetailScreenViewModel =
   | Readonly<{ status: "redirecting" }>
   | Readonly<{
       status: "ready";
+      addAddressFlowState: AddAddressFlowState;
       pageProps: ContactDetailViewProps;
     }>;
-
-const onAddAddress = () => undefined;
 
 export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel {
   const navigation = useNavigation<NativeStackNavigationProp<MyWalletNavigatorStackParamList>>();
@@ -29,6 +30,12 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const { isEnabled } = useContactsFeature("mobile");
   const { t } = useTranslation();
   const contact = useEmptyContactDetail(route.params.contactId);
+  const { state: addAddressFlowState, start: startAddAddress } = useAddAddressFlowViewModel();
+  const onAddAddress = useCallback(() => {
+    if (contact) {
+      startAddAddress(contact.id);
+    }
+  }, [contact, startAddAddress]);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
@@ -58,6 +65,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
 
   return {
     status: "ready",
+    addAddressFlowState,
     pageProps: {
       contact,
       labels,

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -10,6 +10,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Empty contact detail selection and native presentation
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
+- Add Address session state
 - Add Address network eligibility and final currency selection state (MAD integration uses an
   injected selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -8,3 +8,5 @@ export {
   type AddAddressCurrencySelectionViewModel,
   type UseAddAddressCurrencySelectionViewModelOptions,
 } from "./useAddAddressCurrencySelectionViewModel";
+export type { AddAddressFlowState, AddAddressFlowViewModel } from "./types";
+export { useAddAddressFlowViewModel } from "./useAddAddressFlowViewModel";

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -1,0 +1,14 @@
+import type { ContactId } from "@domain/entity-contact";
+
+export type AddAddressFlowState =
+  | Readonly<{ status: "closed" }>
+  | Readonly<{
+      status: "selectingCurrency";
+      selectedContactId: ContactId;
+    }>;
+
+export type AddAddressFlowViewModel = Readonly<{
+  state: AddAddressFlowState;
+  start: (contactId: ContactId) => void;
+  close: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from "react";
+import type { ContactId } from "@domain/entity-contact";
+import type { AddAddressFlowState, AddAddressFlowViewModel } from "./types";
+
+const CLOSED_ADD_ADDRESS_FLOW_STATE = {
+  status: "closed",
+} as const satisfies AddAddressFlowState;
+
+export function useAddAddressFlowViewModel(): AddAddressFlowViewModel {
+  const [state, setState] = useState<AddAddressFlowState>(CLOSED_ADD_ADDRESS_FLOW_STATE);
+  const start = useCallback((selectedContactId: ContactId) => {
+    setState({
+      status: "selectingCurrency",
+      selectedContactId,
+    });
+  }, []);
+  const close = useCallback(() => {
+    setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
+  }, []);
+
+  return {
+    state,
+    start,
+    close,
+  };
+}

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { useAddAddressFlowViewModel } from "./useAddAddressFlowViewModel";
+
+describe("useAddAddressFlowViewModel", () => {
+  it("should be closed initially", () => {
+    const { result } = renderHook(() => useAddAddressFlowViewModel());
+
+    expect(result.current.state).toEqual({ status: "closed" });
+  });
+
+  it("should start currency selection for Me", () => {
+    const contactId = mockMeContact().id;
+    const { result } = renderHook(() => useAddAddressFlowViewModel());
+
+    act(() => result.current.start(contactId));
+
+    expect(result.current.state).toEqual({
+      status: "selectingCurrency",
+      selectedContactId: contactId,
+    });
+  });
+
+  it("should replace the selected contact when restarted", () => {
+    const firstContactId = mockMeContact().id;
+    const nextContactId = mockContact().id;
+    const { result } = renderHook(() => useAddAddressFlowViewModel());
+
+    act(() => result.current.start(firstContactId));
+    act(() => result.current.start(nextContactId));
+
+    expect(result.current.state).toEqual({
+      status: "selectingCurrency",
+      selectedContactId: nextContactId,
+    });
+  });
+
+  it("should remain closed when closed repeatedly", () => {
+    const { result } = renderHook(() => useAddAddressFlowViewModel());
+
+    act(() => result.current.start(mockContact().id));
+    act(() => result.current.close());
+    act(() => result.current.close());
+
+    expect(result.current.state).toEqual({ status: "closed" });
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Shared Flow and Mobile integration tests cover the session lifecycle and exact ContactId propagation.
- [x] **Impact of the changes:**
      Shared Add Address session state and Mobile contact-detail wiring for Me and saved contacts.

### 📝 Description

The shared Contacts Flow had no Add Address session capable of retaining the selected contact, and the Mobile contact-detail Add address CTA was intentionally inert.

This PR now sits directly on #20022. It introduces the shared `useAddAddressFlowViewModel` session and connects the Mobile detail CTA to start it with the exact displayed `ContactId`. The Mobile screen ViewModel exposes the resulting `addAddressFlowState`, allowing its container to observe `selectingCurrency` without introducing the future Add Address UI yet. The detail remains mounted and no navigation or external call is introduced.

The review stack is now:

1. #20022 — shared MAD currency-selection contract
2. This PR — shared Add Address session and Mobile wiring
3. #20023 — Desktop detail dependency and Desktop wiring

The integration tests exercise the real Flow hook and observe the exact selected contact in the exposed state. Mobile MAD integration remains owned by LIVE-33914.

No screenshots are required because this PR does not change the UI.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33911](https://ledgerhq.atlassian.net/browse/LIVE-33911)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33911]: https://ledgerhq.atlassian.net/browse/LIVE-33911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ