### PR TITLE
[LWDM] fix(i18n): add _few/_many plural forms to en source locales (LIVE-33399)

### DIFF
--- a/.changeset/plural-forms-russian-fix.md
+++ b/.changeset/plural-forms-russian-fix.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add missing `_few` / `_many` plural forms to the English source locales so Smartling can translate them for Russian, French, Spanish and Portuguese (fixes count strings falling back to English, e.g. "accounts")

--- a/.github/workflows/test-additional.yml
+++ b/.github/workflows/test-additional.yml
@@ -35,3 +35,50 @@ jobs:
 
       - name: Validate Changesets
         uses: LedgerHQ/ledger-live/tools/actions/composites/validate-changesets@develop
+
+  # TEMPORARY check (LIVE-33399): the English source locales must expose the
+  # `_few` / `_many` plural forms so Smartling can translate them for Russian /
+  # French / Spanish / Portuguese. Runs only when an English locale file is
+  # modified and blocks the PR (through the "OK" gate) when a plural group is
+  # missing those forms. Fix with:
+  #   node scripts/i18n-plurals.mjs --fix
+  i18n-plurals-validation:
+    name: i18n Plural Validation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      # Gate on the English source files changing. On a PR we inspect the diff;
+      # on merge_group / manual runs we always run (the check is cheap and safe).
+      - name: Detect English locale changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          EN_FILES="apps/ledger-live-desktop/static/i18n/en/app.json apps/ledger-live-mobile/src/locales/en/common.json"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$PR_NUMBER" ]; then
+            CHANGED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate -q '.[].filename')
+            SHOULD_RUN=false
+            for f in $EN_FILES; do
+              if grep -qxF "$f" <<< "$CHANGED"; then SHOULD_RUN=true; fi
+            done
+          else
+            SHOULD_RUN=true
+          fi
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          if [ "$SHOULD_RUN" != "true" ]; then
+            echo "No English locale file changed — skipping plural check."
+          fi
+
+      # No dependency install: the check is pure Node (no deps) and the runner
+      # ships Node preinstalled.
+      - name: Check plural coverage
+        if: steps.changes.outputs.should_run == 'true'
+        run: node scripts/i18n-plurals.mjs

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -143,7 +143,9 @@
       "refresh": "Refresh",
       "devTools": "Dev tools",
       "failingSync_one": "Account failing to sync:",
-      "failingSync_other": "Accounts failing to sync:"
+      "failingSync_other": "Accounts failing to sync:",
+      "failingSync_few": "Accounts failing to sync:",
+      "failingSync_many": "Accounts failing to sync:"
     },
     "exchange": "Exchange",
     "info": "Info",
@@ -275,12 +277,18 @@
   "time": {
     "minute": "Minute",
     "minute_other": "Minutes",
+    "minute_few": "Minutes",
+    "minute_many": "Minutes",
     "minute_short": "min",
     "second": "Second",
     "second_other": "Seconds",
+    "second_few": "Seconds",
+    "second_many": "Seconds",
     "second_short": "sec",
     "hour": "Hour",
     "hour_other": "Hours",
+    "hour_few": "Hours",
+    "hour_many": "Hours",
     "range": {
       "day": "1D",
       "week": "1W",
@@ -651,6 +659,8 @@
       "from": "From",
       "fromAddress": "Origin address",
       "fromAddress_other": "Origin addresses",
+      "fromAddress_few": "Origin addresses",
+      "fromAddress_many": "Origin addresses",
       "to": "To",
       "toProvider": "Provider address",
       "initialAmount": "Initial amount",
@@ -1767,6 +1777,8 @@
     "hideTokens": "Hide tokens ({{tokenCount}})",
     "countTooltip": "1 token",
     "countTooltip_other": "{{nbCount}} tokens",
+    "countTooltip_few": "{{nbCount}} tokens",
+    "countTooltip_many": "{{nbCount}} tokens",
     "algorand": {
       "title": "ASA (Assets)",
       "cta": "Add ASA",
@@ -1789,7 +1801,9 @@
     "seeSubAccounts": "Show subaccounts ({{tokenCount}})",
     "hideSubAccounts": "Hide subaccounts ({{tokenCount}})",
     "countTooltip": "1 subaccount",
-    "countTooltip_other": "{{nbCount}} subaccounts"
+    "countTooltip_other": "{{nbCount}} subaccounts",
+    "countTooltip_few": "{{nbCount}} subaccounts",
+    "countTooltip_many": "{{nbCount}} subaccounts"
   },
   "addAccounts": {
     "title": "Add accounts",
@@ -1801,13 +1815,19 @@
     },
     "tokensTip": "{{token}} ({{ticker}}) is an {{tokenType}} token. You can receive tokens directly on a/an {{currency}} account.",
     "accountToImportSubtitle_other": "Add existing accounts",
+    "accountToImportSubtitle_few": "Add existing accounts",
+    "accountToImportSubtitle_many": "Add existing accounts",
     "selectAll": "Select all ({{count}})",
     "unselectAll": "Deselect all ({{count}})",
     "noAccountToImport": "No existing {{currencyName}} accounts to add",
     "success": "Account added successfully",
     "success_other": "Accounts added successfully",
+    "success_few": "Accounts added successfully",
+    "success_many": "Accounts added successfully",
     "successDescription": "Add other accounts or return to Portfolio",
     "successDescription_other": "Add other accounts or return to Portfolio",
+    "successDescription_few": "Add other accounts or return to Portfolio",
+    "successDescription_many": "Add other accounts or return to Portfolio",
     "createNewAccount": {
       "noOperationOnLastAccount": "Can't add a new account before you've received assets on your <1><0>{{accountName}}</0></1> account",
       "noAccountToCreate": "No <1><0>{{currencyName}}</0></1> account was found to be created",
@@ -1821,6 +1841,8 @@
       "addMore": "Add more",
       "add": "Add account",
       "add_other": "Add accounts",
+      "add_few": "Add accounts",
+      "add_many": "Add accounts",
       "addAccountName": "Add {{currencyName}} account",
       "receive": "Receive"
     },
@@ -1922,8 +1944,12 @@
     "quitApp": "Quit the application on your device",
     "appNotInstalledTitle": "Missing required app",
     "appNotInstalledTitle_other": "Missing required apps",
+    "appNotInstalledTitle_few": "Missing required apps",
+    "appNotInstalledTitle_many": "Missing required apps",
     "appNotInstalled": "The {{appName}} app is required to complete this action. Please go to My Ledger and install it on your device",
     "appNotInstalled_other": "The {{appName}} apps are required to complete this action. Please go to My Ledger and install them on your device",
+    "appNotInstalled_few": "The {{appName}} apps are required to complete this action. Please go to My Ledger and install them on your device",
+    "appNotInstalled_many": "The {{appName}} apps are required to complete this action. Please go to My Ledger and install them on your device",
     "openManager": "Open My Ledger",
     "openOnboarding": "Setup device",
     "outdated": "App version outdated",
@@ -2020,13 +2046,19 @@
       "installSuccess": {
         "title": "App installed successfully. You can now add your {{app}} accounts",
         "title_other": "Apps installed successfully. You can now add your accounts",
+        "title_few": "Apps installed successfully. You can now add your accounts",
+        "title_many": "Apps installed successfully. You can now add your accounts",
         "manageAccount": "Manage my accounts"
       },
       "updatable": {
         "title": "Update available",
         "title_other": "Updates available",
+        "title_few": "Updates available",
+        "title_many": "Updates available",
         "progressTitle": "{{number}} App update",
         "progressTitle_other": "{{number}} App updates",
+        "progressTitle_few": "{{number}} App updates",
+        "progressTitle_many": "{{number}} App updates",
         "progressWarning": "Do not quit My Ledger during update.",
         "progress": "Updating all..."
       },
@@ -2563,10 +2595,16 @@
       "justNow": "Just now",
       "minutesAgo_one": "1 min ago",
       "minutesAgo_other": "{{count}} min ago",
+      "minutesAgo_few": "{{count}} min ago",
+      "minutesAgo_many": "{{count}} min ago",
       "hoursAgo_one": "1 hour ago",
       "hoursAgo_other": "{{count}} hours ago",
+      "hoursAgo_few": "{{count}} hours ago",
+      "hoursAgo_many": "{{count}} hours ago",
       "daysAgo_one": "1 day ago",
-      "daysAgo_other": "{{count}} days ago"
+      "daysAgo_other": "{{count}} days ago",
+      "daysAgo_few": "{{count}} days ago",
+      "daysAgo_many": "{{count}} days ago"
     },
     "remove": "Remove",
     "enterTag": "Enter {{tag}}",
@@ -4942,6 +4980,8 @@
     "durationJustStarted": "Just started",
     "durationDays": "{{count}} day",
     "durationDays_other": "{{count}} days",
+    "durationDays_few": "{{count}} days",
+    "durationDays_many": "{{count}} days",
     "howItWorks": "How delegation works",
     "delegationEarn": "You can now earn {{name}} staking rewards by delegating your account.",
     "earnRewards": "Earn rewards",
@@ -5146,6 +5186,8 @@
         "importing": "Importing...",
         "success": "Imported {{count}} account successfully.",
         "success_other": "Imported {{count}} accounts successfully.",
+        "success_few": "Imported {{count}} accounts successfully.",
+        "success_many": "Imported {{count}} accounts successfully.",
         "lastDeviceSeen": "Last device seen: {{device}}",
         "invalidFileType": "Invalid file type. Expected a .json file.",
         "missingDataField": "Invalid app.json: missing top-level data field.",
@@ -5157,7 +5199,9 @@
         "importFailed": "Import failed: {{message}}",
         "unknownError": "Unknown error during import.",
         "failedCount": "{{count}} account could not be loaded.",
-        "failedCount_other": "{{count}} accounts could not be loaded."
+        "failedCount_other": "{{count}} accounts could not be loaded.",
+        "failedCount_few": "{{count}} accounts could not be loaded.",
+        "failedCount_many": "{{count}} accounts could not be loaded."
       },
       "mockAccounts": {
         "title": "Generate mock accounts",
@@ -5188,7 +5232,9 @@
           "noCurrenciesFound": "No currencies found",
           "noCurrenciesAvailable": "No currencies available",
           "selectedCount": "{{count}} currency selected",
-          "selectedCount_other": "{{count}} currencies selected"
+          "selectedCount_other": "{{count}} currencies selected",
+          "selectedCount_few": "{{count}} currencies selected",
+          "selectedCount_many": "{{count}} currencies selected"
         },
         "tokenIds": {
           "label": "Token IDs (optional)",
@@ -5197,12 +5243,18 @@
         "buttons": {
           "generateAccounts": "Generate {{count}} account",
           "generateAccounts_other": "Generate {{count}} accounts",
+          "generateAccounts_few": "Generate {{count}} accounts",
+          "generateAccounts_many": "Generate {{count}} accounts",
           "generateAccountsQuick": "Generate {{count}} accounts",
           "generateEmptyAccount": "Generate empty account",
           "generateStablecoinAccounts": "Generate {{count}} stablecoin account",
           "generateStablecoinAccounts_other": "Generate {{count}} stablecoin accounts",
+          "generateStablecoinAccounts_few": "Generate {{count}} stablecoin accounts",
+          "generateStablecoinAccounts_many": "Generate {{count}} stablecoin accounts",
           "generateStockAccounts": "Generate {{count}} stock account",
           "generateStockAccounts_other": "Generate {{count}} stock accounts",
+          "generateStockAccounts_few": "Generate {{count}} stock accounts",
+          "generateStockAccounts_many": "Generate {{count}} stock accounts",
           "loadingStocks": "Loading stock data…"
         },
         "alerts": {
@@ -5585,7 +5637,9 @@
         "title": "Hidden tokens",
         "desc": "You can hide tokens by going to the parent account then right-clicking on the token and selecting 'Hide token'.",
         "count": "1 token",
-        "count_other": "{{count}} tokens"
+        "count_other": "{{count}} tokens",
+        "count_few": "{{count}} tokens",
+        "count_many": "{{count}} tokens"
       },
       "filterTokenOperationsZeroAmount": {
         "title": "Hide token transactions when value is 0",
@@ -5662,6 +5716,8 @@
     "noAccounts": "No accounts to export",
     "selectedAccounts": "Accounts to be included",
     "selectedAccounts_other": "Accounts to be included ({{count}})",
+    "selectedAccounts_few": "Accounts to be included ({{count}})",
+    "selectedAccounts_many": "Accounts to be included ({{count}})",
     "disclaimer": "The countervalues in the export is provided for information purposes only. Do not rely on such data for accounting, tax, regulation or legal purposes, as they only represent an estimation of the price of the assets at the time of transactions and export, under the valuation methods provided by our service provider, Kaiko"
   },
   "language": {
@@ -5700,6 +5756,8 @@
     "tooltip": "Information center",
     "ongoingIncidentsTooltip": "There is {{count}} ongoing incident",
     "ongoingIncidentsTooltip_other": "There are {{count}} ongoing incidents",
+    "ongoingIncidentsTooltip_few": "There are {{count}} ongoing incidents",
+    "ongoingIncidentsTooltip_many": "There are {{count}} ongoing incidents",
     "tabs": {
       "announcements": "News",
       "announcementsUnseen": "News ({{unseenCount}})",
@@ -8537,6 +8595,8 @@
       "instance": {
         "label": "1 Ledger Wallet app synched",
         "label_other": "{{count}} Ledger Wallet apps synched",
+        "label_few": "{{count}} Ledger Wallet apps synched",
+        "label_many": "{{count}} Ledger Wallet apps synched",
         "cta": "Manage"
       }
     },
@@ -8754,6 +8814,8 @@
         "foundAccounts_zero": "No account was found",
         "foundAccounts": "We found {{count}} account",
         "foundAccounts_other": "We found {{count}} accounts",
+        "foundAccounts_few": "We found {{count}} accounts",
+        "foundAccounts_many": "We found {{count}} accounts",
         "scanning": "Scanning accounts..."
       },
       "title": "Checking the blockchain..."
@@ -8768,9 +8830,13 @@
     "selectAccount": "Select account",
     "accountCount_one": "{{count}} account",
     "accountCount_other": "{{count}} accounts",
+    "accountCount_few": "{{count}} accounts",
+    "accountCount_many": "{{count}} accounts",
     "accountsAdded": {
       "title": "Account added to your portfolio",
       "title_other": "{{count}} Accounts added to your portfolio",
+      "title_few": "{{count}} Accounts added to your portfolio",
+      "title_many": "{{count}} Accounts added to your portfolio",
       "cta": {
         "addFunds": "Add funds to my account",
         "selectAccount": "Continue",
@@ -8875,6 +8941,8 @@
     "cryptoAccounts": "Crypto accounts",
     "accountsCount_one": "{{count}} account",
     "accountsCount_other": "{{count}} accounts",
+    "accountsCount_few": "{{count}} accounts",
+    "accountsCount_many": "{{count}} accounts",
     "noCryptoAccounts": "No accounts yet",
     "add": "Add",
     "columns": {
@@ -9101,12 +9169,16 @@
         "description": "Confirm sharing the view key on your device",
         "cancelAlert": "You can reject individual accounts on your device. Cancelling all will stop adding any accounts to your portfolio.",
         "cancelAllBtn_one": "Cancel",
-        "cancelAllBtn_other": "Cancel all"
+        "cancelAllBtn_other": "Cancel all",
+        "cancelAllBtn_few": "Cancel all",
+        "cancelAllBtn_many": "Cancel all"
       },
       "stepScanAccounts": {
         "cta": {
           "shareKey_one": "Share view key",
-          "shareKey_other": "Share view keys"
+          "shareKey_other": "Share view keys",
+          "shareKey_few": "Share view keys",
+          "shareKey_many": "Share view keys"
         }
       },
       "warnings": {
@@ -9134,6 +9206,8 @@
         },
         "recordCount_one": "{{count}} record",
         "recordCount_other": "{{count}} records",
+        "recordCount_few": "{{count}} records",
+        "recordCount_many": "{{count}} records",
         "unavailable": "Unavailable",
         "spendableBalance": "Max Spendable Balance:"
       },
@@ -9286,6 +9360,8 @@
     "title": "Transaction history",
     "pending": "Pending transaction",
     "pending_other": "Pending transactions",
+    "pending_few": "Pending transactions",
+    "pending_many": "Pending transactions",
     "columns": {
       "type": "Type",
       "address": "Address",
@@ -9328,7 +9404,9 @@
     "avatar": {
       "label": "Avatar",
       "labelWithNotifications_one": "Avatar, {{count}} unseen notification",
-      "labelWithNotifications_other": "Avatar, {{count}} unseen notifications"
+      "labelWithNotifications_other": "Avatar, {{count}} unseen notifications",
+      "labelWithNotifications_few": "Avatar, {{count}} unseen notifications",
+      "labelWithNotifications_many": "Avatar, {{count}} unseen notifications"
     },
     "actionsList": {
       "help": "Help",
@@ -9384,6 +9462,8 @@
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",
     "addressCount_other": "{{count}} addresses",
+    "addressCount_few": "{{count}} addresses",
+    "addressCount_many": "{{count}} addresses",
     "me": {
       "name": "Me"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -59,8 +59,12 @@
     "add": "Add",
     "token_one": "Token",
     "token_other": "Tokens",
+    "token_few": "Tokens",
+    "token_many": "Tokens",
     "subaccount_one": "Subaccount",
     "subaccount_other": "Subaccounts",
+    "subaccount_few": "Subaccounts",
+    "subaccount_many": "Subaccounts",
     "forgetDevice": "Remove device",
     "help": "Help",
     "saveLogs": "Save logs",
@@ -75,22 +79,38 @@
     "fromNow": {
       "seconds_one": "in one second",
       "seconds_other": "in {{time}} seconds",
+      "seconds_few": "in {{time}} seconds",
+      "seconds_many": "in {{time}} seconds",
       "minutes_one": "in one minute",
       "minutes_other": "in {{time}} minutes",
+      "minutes_few": "in {{time}} minutes",
+      "minutes_many": "in {{time}} minutes",
       "hours_one": "in one hour",
       "hours_other": "in {{time}} hours",
+      "hours_few": "in {{time}} hours",
+      "hours_many": "in {{time}} hours",
       "days_one": "in one day",
-      "days_other": "in {{time}} days"
+      "days_other": "in {{time}} days",
+      "days_few": "in {{time}} days",
+      "days_many": "in {{time}} days"
     },
     "timeAgo": {
       "seconds_one": "one second ago",
       "seconds_other": "{{time}} seconds ago",
+      "seconds_few": "{{time}} seconds ago",
+      "seconds_many": "{{time}} seconds ago",
       "minutes_one": "one minute ago",
       "minutes_other": "{{time}} minutes ago",
+      "minutes_few": "{{time}} minutes ago",
+      "minutes_many": "{{time}} minutes ago",
       "hours_one": "one hour ago",
       "hours_other": "{{time}} hours ago",
+      "hours_few": "{{time}} hours ago",
+      "hours_many": "{{time}} hours ago",
       "days_one": "yesterday",
-      "days_other": "{{time}} days ago"
+      "days_other": "{{time}} days ago",
+      "days_few": "{{time}} days ago",
+      "days_many": "{{time}} days ago"
     },
     "seeMore": "See more",
     "moreInfo": "More info",
@@ -2902,6 +2922,8 @@
       "title": "Accounts",
       "count_one": "{{count}} account",
       "count_other": "{{count}} accounts",
+      "count_few": "{{count}} accounts",
+      "count_many": "{{count}} accounts",
       "noAccountsYet": "No accounts yet",
       "add": "Add"
     },
@@ -3168,8 +3190,12 @@
     "selectAll": "Select all",
     "tokenCount_one": "+1 token",
     "tokenCount_other": "+{{count}} tokens",
+    "tokenCount_few": "+{{count}} tokens",
+    "tokenCount_many": "+{{count}} tokens",
     "subaccountCount_one": "+1 subaccount",
-    "subaccountCount_other": "+{{count}} subaccounts"
+    "subaccountCount_other": "+{{count}} subaccounts",
+    "subaccountCount_few": "+{{count}} subaccounts",
+    "subaccountCount_many": "+{{count}} subaccounts"
   },
   "account": {
     "subHeader": {
@@ -3367,7 +3393,9 @@
     "emptyState": "No accounts yet",
     "errorState": "An error occurred while loading your accounts",
     "assetsCount": "{{count}} assets",
-    "assetsCount_one": "{{count}} asset"
+    "assetsCount_one": "{{count}} asset",
+    "assetsCount_few": "{{count}} assets",
+    "assetsCount_many": "{{count}} assets"
   },
   "crypto": {
     "title": "Crypto",
@@ -3389,23 +3417,39 @@
       "queued": "Awaiting",
       "showTokens_one": "Show {{length}} token",
       "showTokens_other": "Show {{length}} tokens",
+      "showTokens_few": "Show {{length}} tokens",
+      "showTokens_many": "Show {{length}} tokens",
       "showSubAccounts_one": "Show {{length}} subaccount",
       "showSubAccounts_other": "Show {{length}} subaccounts",
+      "showSubAccounts_few": "Show {{length}} subaccounts",
+      "showSubAccounts_many": "Show {{length}} subaccounts",
       "hideTokens_one": "Hide token",
       "hideTokens_other": "Hide tokens",
+      "hideTokens_few": "Hide tokens",
+      "hideTokens_many": "Hide tokens",
       "hideSubAccounts_one": "Hide subaccount",
       "hideSubAccounts_other": "Hide subaccounts",
+      "hideSubAccounts_few": "Hide subaccounts",
+      "hideSubAccounts_many": "Hide subaccounts",
       "algorand": {
         "showTokens_one": "Show {{length}} ASA",
         "showTokens_other": "Show {{length}} ASA",
+        "showTokens_few": "Show {{length}} ASA",
+        "showTokens_many": "Show {{length}} ASA",
         "hideTokens_one": "Hide ASA",
-        "hideTokens_other": "Hide ASA"
+        "hideTokens_other": "Hide ASA",
+        "hideTokens_few": "Hide ASA",
+        "hideTokens_many": "Hide ASA"
       },
       "stellar": {
         "showTokens_one": "Show {{length}} asset",
         "showTokens_other": "Show {{length}} assets",
+        "showTokens_few": "Show {{length}} assets",
+        "showTokens_many": "Show {{length}} assets",
         "hideTokens_one": "Hide asset",
-        "hideTokens_other": "Hide assets"
+        "hideTokens_other": "Hide assets",
+        "hideTokens_few": "Hide assets",
+        "hideTokens_many": "Hide assets"
       }
     },
     "noResultsFound": "No asset found",
@@ -3422,6 +3466,8 @@
     "list": "Asset allocation ({{count}})",
     "assets_one": "asset",
     "assets_other": "assets",
+    "assets_few": "assets",
+    "assets_many": "assets",
     "total": "Total balance:",
     "listAccount": "Asset allocation ({{count}})",
     "title": "Assets",
@@ -3915,6 +3961,8 @@
         "title": "Select the network for the chosen crypto",
         "account_one": "{{count}} account",
         "account_other": "{{count}} accounts",
+        "account_few": "{{count}} accounts",
+        "account_many": "{{count}} accounts",
         "subtitle": "This must match the network chosen on the wallet or exchange transferring the crypto.",
         "bannerTitle": "Make sure to select the right network. Learn how.",
         "depositFromCexBannerTitle": "Deposit crypto from your Coinbase account"
@@ -3933,6 +3981,8 @@
         "subtitle": "Checking if you already have an account for {{currencyName}} on the blockchain.",
         "foundAccount_one": "{{count}} account found",
         "foundAccount_other": "{{count}} accounts found",
+        "foundAccount_few": "{{count}} accounts found",
+        "foundAccount_many": "{{count}} accounts found",
         "stopSynchronization": "Stop synchronization",
         "addingAccount": "No accounts found. Creating a new account for {{currencyName}}..."
       },
@@ -4419,8 +4469,12 @@
         "selectAccount": {
           "enabledAccountsAmount_one": "You have {{number}} account that approved {{amount}}",
           "enabledAccountsAmount_other": "You have {{number}} accounts that approved {{amount}}",
+          "enabledAccountsAmount_few": "You have {{number}} accounts that approved {{amount}}",
+          "enabledAccountsAmount_many": "You have {{number}} accounts that approved {{amount}}",
           "enabledAccountsNoLimit_one": "You have {{number}} account that approved an unlimited amount of {{ currency }}",
           "enabledAccountsNoLimit_other": "You have {{number}} accounts that approved an unlimited amount of {{ currency }}",
+          "enabledAccountsNoLimit_few": "You have {{number}} accounts that approved an unlimited amount of {{ currency }}",
+          "enabledAccountsNoLimit_many": "You have {{number}} accounts that approved an unlimited amount of {{ currency }}",
           "noEnabledAccounts": "You need to approve an account before you can lend."
         },
         "enable": {
@@ -4534,10 +4588,16 @@
         "justNow": "Just now",
         "minutesAgo_one": "1 min ago",
         "minutesAgo_other": "{{count}} min ago",
+        "minutesAgo_few": "{{count}} min ago",
+        "minutesAgo_many": "{{count}} min ago",
         "hoursAgo_one": "1 hour ago",
         "hoursAgo_other": "{{count}} hours ago",
+        "hoursAgo_few": "{{count}} hours ago",
+        "hoursAgo_many": "{{count}} hours ago",
         "daysAgo_one": "1 day ago",
-        "daysAgo_other": "{{count}} days ago"
+        "daysAgo_other": "{{count}} days ago",
+        "daysAgo_few": "{{count}} days ago",
+        "daysAgo_many": "{{count}} days ago"
       },
       "firstInteraction": {
         "description": "This address isn’t in your recent history. In case of doubt try a small amount first.",
@@ -4974,6 +5034,8 @@
     "imported": "Asset added successfully",
     "added_one": "Account added to your portfolio",
     "added_other": "{{count}} Accounts added to your portfolio",
+    "added_few": "{{count}} Accounts added to your portfolio",
+    "added_many": "{{count}} Accounts added to your portfolio",
     "sections": {
       "importable": {
         "title": "Add existing account"
@@ -5040,7 +5102,9 @@
       "sections": {
         "importable": {
           "title_one": "We found {{count}} account",
-          "title_other": "We found {{count}} accounts"
+          "title_other": "We found {{count}} accounts",
+          "title_few": "We found {{count}} accounts",
+          "title_many": "We found {{count}} accounts"
         },
         "creatable": {
           "title": "New account"
@@ -5347,6 +5411,8 @@
     "quitApp": "Quit the application on your device",
     "appNotInstalled_one": "Please install the {{appName}} app",
     "appNotInstalled_other": "Please install the {{appName}} apps",
+    "appNotInstalled_few": "Please install the {{appName}} apps",
+    "appNotInstalled_many": "Please install the {{appName}} apps",
     "useAnotherDevice": "Use another device",
     "deviceNotOnboarded": {
       "title": "Your Ledger is not ready to use yet",
@@ -5509,7 +5575,9 @@
   "RemoveDevice": {
     "button": {
       "title_one": "Remove {{nbDevices}} device",
-      "title_other": "Remove {{nbDevices}} devices"
+      "title_other": "Remove {{nbDevices}} devices",
+      "title_few": "Remove {{nbDevices}} devices",
+      "title_many": "Remove {{nbDevices}} devices"
     }
   },
   "manager": {
@@ -5579,14 +5647,20 @@
       "genuine": "Your device is genuine",
       "appsInstalled_one": "<0>{{number}}</0> app",
       "appsInstalled_other": "<0>{{number}}</0> apps",
+      "appsInstalled_few": "<0>{{number}}</0> apps",
+      "appsInstalled_many": "<0>{{number}}</0> apps",
       "storageAvailable": "available",
       "noFreeSpace": "No storage left",
       "appsToUpdate": "<0>{{number}}</0> update",
-      "appsToUpdate_other": "<0>{{number}}</0> updates"
+      "appsToUpdate_other": "<0>{{number}}</0> updates",
+      "appsToUpdate_few": "<0>{{number}}</0> updates",
+      "appsToUpdate_many": "<0>{{number}}</0> updates"
     },
     "installSuccess": {
       "title": "App successfully installed",
       "title_other": "Apps successfully installed",
+      "title_few": "Apps successfully installed",
+      "title_many": "Apps successfully installed",
       "notSupported": "App installed successfully, find out more about the installed apps on our website.",
       "manageAccount": "Add accounts",
       "learnMore": "Learn more",
@@ -5619,7 +5693,9 @@
         "desc": "Please wait for the {{appName}} app to be installed",
         "button": "Installing...",
         "queued": "Queued",
-        "button_other": "Installing... {{progressPercentage}}%"
+        "button_other": "Installing... {{progressPercentage}}%",
+        "button_few": "Installing... {{progressPercentage}}%",
+        "button_many": "Installing... {{progressPercentage}}%"
       },
       "done": {
         "title": "App Successfully installed",
@@ -5636,6 +5712,8 @@
     "update": {
       "title_one": "{{number}} app update",
       "title_other": "{{number}} app updates",
+      "title_few": "{{number}} app updates",
+      "title_many": "{{number}} app updates",
       "step": "Update step {{step}}:",
       "updateWarn": "Do not quit My Ledger during the update.",
       "progress": "Updating all...",
@@ -8033,9 +8111,13 @@
     "durationForDays0": "Just now",
     "durationForDays_one": "For a day",
     "durationForDays_other": "For {{count}} days",
+    "durationForDays_few": "For {{count}} days",
+    "durationForDays_many": "For {{count}} days",
     "durationDays0": "Just now",
     "durationDays_one": "1 day",
     "durationDays_other": "{{count}} days",
+    "durationDays_few": "{{count}} days",
+    "durationDays_many": "{{count}} days",
     "selectValidatorTitle": "Select validator",
     "started": {
       "title": "Earn rewards",
@@ -8250,18 +8332,32 @@
       "time": {
         "second_one": "1 second ago",
         "second_other": "{{count}} seconds ago",
+        "second_few": "{{count}} seconds ago",
+        "second_many": "{{count}} seconds ago",
         "minute_one": "1 minute ago",
         "minute_other": "{{count}} minutes ago",
+        "minute_few": "{{count}} minutes ago",
+        "minute_many": "{{count}} minutes ago",
         "hour_one": "1 hour ago",
         "hour_other": "{{count}} hours ago",
+        "hour_few": "{{count}} hours ago",
+        "hour_many": "{{count}} hours ago",
         "day_one": "1 day ago",
         "day_other": "{{count}} days ago",
+        "day_few": "{{count}} days ago",
+        "day_many": "{{count}} days ago",
         "week_one": "1 week ago",
         "week_other": "{{count}} weeks ago",
+        "week_few": "{{count}} weeks ago",
+        "week_many": "{{count}} weeks ago",
         "month_one": "1 month ago",
         "month_other": "{{count}} months ago",
+        "month_few": "{{count}} months ago",
+        "month_many": "{{count}} months ago",
         "year_one": "1 year ago",
-        "year_other": "{{count}} years ago"
+        "year_other": "{{count}} years ago",
+        "year_few": "{{count}} years ago",
+        "year_many": "{{count}} years ago"
       }
     },
     "status": {
@@ -8760,7 +8856,9 @@
     "title": "Your {{assetName}}",
     "accountsSection": {
       "title_one": "Your {{currencyName}} account",
-      "title_other": "Your {{currencyName}} accounts"
+      "title_other": "Your {{currencyName}} accounts",
+      "title_few": "Your {{currencyName}} accounts",
+      "title_many": "Your {{currencyName}} accounts"
     }
   },
   "customImage": {
@@ -9264,6 +9362,8 @@
         "cta": "Manage",
         "title_one": "{{count}} Ledger Wallet app synched",
         "title_other": "{{count}} Ledger Wallet apps synched",
+        "title_few": "{{count}} Ledger Wallet apps synched",
+        "title_many": "{{count}} Ledger Wallet apps synched",
         "error": "Instances",
         "unsecuredError": {
           "title": "Connect the same Ledger device you used for enabling Ledger Sync",
@@ -9538,7 +9638,9 @@
     "selectNetwork": {
       "title": "Select the blockchain network the asset belongs to",
       "detectedAccounts_one": "{{count}} account (detected)",
-      "detectedAccounts_other": "{{count}} accounts (detected)"
+      "detectedAccounts_other": "{{count}} accounts (detected)",
+      "detectedAccounts_few": "{{count}} accounts (detected)",
+      "detectedAccounts_many": "{{count}} accounts (detected)"
     }
   },
   "emptyList": {
@@ -9597,16 +9699,28 @@
     "timeAgo": {
       "years_one": "({{count}} year ago)",
       "years_other": "({{count}} years ago)",
+      "years_few": "({{count}} years ago)",
+      "years_many": "({{count}} years ago)",
       "months_one": "({{count}} month ago)",
       "months_other": "({{count}} months ago)",
+      "months_few": "({{count}} months ago)",
+      "months_many": "({{count}} months ago)",
       "days_one": "({{count}} day ago)",
       "days_other": "({{count}} days ago)",
+      "days_few": "({{count}} days ago)",
+      "days_many": "({{count}} days ago)",
       "hours_one": "({{count}} hour ago)",
       "hours_other": "({{count}} hours ago)",
+      "hours_few": "({{count}} hours ago)",
+      "hours_many": "({{count}} hours ago)",
       "minutes_one": "({{count}} minute ago)",
       "minutes_other": "({{count}} minutes ago)",
+      "minutes_few": "({{count}} minutes ago)",
+      "minutes_many": "({{count}} minutes ago)",
       "seconds_one": "({{count}} second ago)",
-      "seconds_other": "({{count}} seconds ago)"
+      "seconds_other": "({{count}} seconds ago)",
+      "seconds_few": "({{count}} seconds ago)",
+      "seconds_many": "({{count}} seconds ago)"
     },
     "performance": "Performance",
     "low": "Low",
@@ -9643,6 +9757,8 @@
     "emptyAssetList": "No assets found",
     "accountCount_one": "{{count}} account",
     "accountCount_other": "{{count}} accounts",
+    "accountCount_few": "{{count}} accounts",
+    "accountCount_many": "{{count}} accounts",
     "perpetualsBanner": "Currently only supported with USDC on Arbitrum chain.",
     "errors": {
       "title": "Connection failed",
@@ -10137,6 +10253,8 @@
         "cancelAlert": "You can reject individual accounts on your device. Cancelling all will stop adding any accounts to your portfolio.",
         "cancelAllBtn_one": "Cancel",
         "cancelAllBtn_other": "Cancel all",
+        "cancelAllBtn_few": "Cancel all",
+        "cancelAllBtn_many": "Cancel all",
         "redirecting": "Redirecting..."
       },
       "stepNoAccountsAdded": {
@@ -10146,7 +10264,9 @@
       "stepScanAccounts": {
         "cta": {
           "shareKey_one": "Share view key",
-          "shareKey_other": "Share view keys"
+          "shareKey_other": "Share view keys",
+          "shareKey_few": "Share view keys",
+          "shareKey_many": "Share view keys"
         }
       }
     },
@@ -10182,6 +10302,8 @@
         },
         "recordCount_one": "{{count}} record",
         "recordCount_other": "{{count}} records",
+        "recordCount_few": "{{count}} records",
+        "recordCount_many": "{{count}} records",
         "unavailable": "Unavailable",
         "noValue": "—",
         "spendableBalance": "Max Spendable Balance:",
@@ -10239,11 +10361,15 @@
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",
     "addressCount_other": "{{count}} addresses",
+    "addressCount_few": "{{count}} addresses",
+    "addressCount_many": "{{count}} addresses",
     "me": {
       "name": "Me",
       "addressCount_zero": "0 address",
       "addressCount_one": "{{count}} address",
-      "addressCount_other": "{{count}} addresses"
+      "addressCount_other": "{{count}} addresses",
+      "addressCount_few": "{{count}} addresses",
+      "addressCount_many": "{{count}} addresses"
     },
     "detail": {
       "emptyState": {

--- a/scripts/i18n-plurals.mjs
+++ b/scripts/i18n-plurals.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// @flow-off
+/**
+ * i18n plural coverage check / fixer for the English source locales.
+ *
+ * Context (LIVE-33399): i18next (v4 JSON) resolves plurals using the display
+ * language's CLDR categories. Smartling only produces the plural forms that
+ * exist in the English source. English uses `_one` / `_other`, so languages
+ * that need extra categories (Russian: `_few` + `_many`, French/Spanish/
+ * Portuguese: `_many`) never get those keys and fall back to English.
+ *
+ * TEMPORARY fix: duplicate every genuine plural group's plural value into the
+ * missing `_few` / `_many` keys so Smartling has a source string to translate.
+ *
+ * Usage:
+ *   node scripts/i18n-plurals.mjs            # check, exits 1 if keys are missing
+ *   node scripts/i18n-plurals.mjs --fix      # add the missing keys in place
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const FILES = [
+  "apps/ledger-live-desktop/static/i18n/en/app.json",
+  "apps/ledger-live-mobile/src/locales/en/common.json",
+];
+
+// CLDR plural categories we recognise as suffixes.
+const CLDR = new Set(["zero", "one", "two", "few", "many", "other"]);
+// Categories every genuine plural group must expose for our supported languages
+// (ru needs few + many; fr/es/pt need many). Arabic (zero/two) is not enabled.
+const REQUIRED = ["few", "many"];
+
+const KEYED = /^(\s*)"((?:[^"\\]|\\.)*)"\s*:\s*(.*)$/;
+
+/**
+ * Parse a pretty-printed JSON file line-by-line, tracking object frames so we
+ * can locate sibling plural keys with their exact source line & value. We stay
+ * at the text level (rather than JSON.parse) to keep insertions surgical and
+ * avoid reordering integer-like keys on a round-trip.
+ */
+function parse(lines) {
+  const frames = []; // stack of { children: [] }
+  const completed = []; // frames popped, in completion order
+  const pushFrame = () => frames.push({ children: [] });
+  const popFrame = () => completed.push(frames.pop());
+  pushFrame(); // implicit root
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    if (trimmed === "") continue;
+
+    const m = raw.match(KEYED);
+    if (m) {
+      const [, indent, key, rest] = m;
+      if (rest === "{" || rest === "[") {
+        frames[frames.length - 1].children.push({ key, line: i, indent, isLeaf: false });
+        pushFrame();
+      } else {
+        const hasComma = /,\s*$/.test(rest);
+        const rawValue = rest.replace(/,\s*$/, "").trim();
+        frames[frames.length - 1].children.push({
+          key,
+          line: i,
+          indent,
+          isLeaf: true,
+          rawValue,
+          hasComma,
+        });
+      }
+      continue;
+    }
+
+    // Non-keyed structural lines.
+    if (trimmed === "{" || trimmed === "[") {
+      pushFrame();
+    } else if (trimmed[0] === "}" || trimmed[0] === "]") {
+      popFrame();
+    }
+    // Bare leaf array items ("foo",) are ignored: never plural groups.
+  }
+  return completed;
+}
+
+/** Build plural groups from a frame's direct children. */
+function groupsOf(frame) {
+  const byStem = new Map();
+  for (const child of frame.children) {
+    const idx = child.key.lastIndexOf("_");
+    if (idx <= 0) continue;
+    const suf = child.key.slice(idx + 1);
+    if (!CLDR.has(suf)) continue;
+    const stem = child.key.slice(0, idx);
+    if (!byStem.has(stem)) byStem.set(stem, { stem, forms: new Map(), base: null });
+    byStem.get(stem).forms.set(suf, child);
+  }
+  if (byStem.size === 0) return [];
+  // Attach base key (a sibling whose name equals the stem) when present.
+  for (const child of frame.children) {
+    if (byStem.has(child.key)) byStem.get(child.key).base = child;
+  }
+  return [...byStem.values()];
+}
+
+/**
+ * Decide whether a group is a genuine count-plural and, if so, what to add.
+ * Returns null for non-plurals / false positives.
+ */
+function planGroup(group) {
+  const other = group.forms.get("other");
+  const base = group.base && group.base.isLeaf ? group.base : null;
+  // Genuine = has an `_other` form OR a leaf base key acting as the plural.
+  if (!other && !base) return null;
+  // `_two` in an English source signals explicit index keys (e.g. dependency
+  // step messages), not CLDR plurals. Skip to avoid corrupting them.
+  if (group.forms.has("two")) return null;
+
+  const source = other || base || group.forms.get("one");
+  if (!source || !source.isLeaf) return null;
+
+  const missing = REQUIRED.filter(suf => !group.forms.has(suf));
+  if (missing.length === 0) return null;
+
+  // Anchor = the last existing member line of the group.
+  const members = [...group.forms.values()];
+  if (base) members.push(base);
+  const anchor = members.reduce((a, b) => (b.line > a.line ? b : a));
+
+  return { stem: group.stem, missing, value: source.rawValue, anchor };
+}
+
+function run({ fix }) {
+  let totalMissing = 0;
+  let totalGroups = 0;
+
+  for (const rel of FILES) {
+    const abs = join(REPO_ROOT, rel);
+    const original = readFileSync(abs, "utf8");
+    const lines = original.split("\n");
+    const frames = parse(lines);
+
+    const plans = [];
+    for (const frame of frames) {
+      for (const group of groupsOf(frame)) {
+        const plan = planGroup(group);
+        if (plan) plans.push(plan);
+      }
+    }
+
+    if (plans.length === 0) {
+      console.log(`✓ ${rel}: all plural groups expose [${REQUIRED.join(", ")}]`);
+      continue;
+    }
+
+    totalGroups += plans.length;
+    for (const p of plans) {
+      totalMissing += p.missing.length;
+      console.log(
+        `${fix ? "＋" : "✗"} ${rel}: "${p.stem}" missing ${p.missing.map(s => `_${s}`).join(", ")}`,
+      );
+    }
+
+    if (!fix) continue;
+
+    // Apply insertions bottom-up so line indices stay valid.
+    const insertions = plans
+      .map(p => {
+        const newLines = p.missing.map(suf => `${p.anchor.indent}"${p.stem}_${suf}": ${p.value}`);
+        return { line: p.anchor.line, appendComma: !p.anchor.hasComma, newLines };
+      })
+      .sort((a, b) => b.line - a.line);
+
+    for (const ins of insertions) {
+      if (ins.appendComma) {
+        lines[ins.line] = lines[ins.line].replace(/\s*$/, "") + ",";
+      }
+      const withCommas = ins.newLines.map((l, i) =>
+        ins.appendComma && i === ins.newLines.length - 1 ? l : `${l},`,
+      );
+      lines.splice(ins.line + 1, 0, ...withCommas);
+    }
+
+    const out = lines.join("\n");
+    // Validate we produced parseable JSON before writing.
+    JSON.parse(out);
+    writeFileSync(abs, out);
+    console.log(`✓ ${rel}: added ${plans.reduce((n, p) => n + p.missing.length, 0)} keys`);
+  }
+
+  if (!fix && totalMissing > 0) {
+    console.error(
+      `\n✗ ${totalMissing} plural key(s) across ${totalGroups} group(s) are missing ` +
+        `required forms [${REQUIRED.join(", ")}].\n` +
+        `  Russian and other languages fall back to English for these counts.\n` +
+        `  Run:  node scripts/i18n-plurals.mjs --fix\n` +
+        `  (adds the missing _few/_many keys so Smartling can translate them).`,
+    );
+    process.exit(1);
+  }
+  console.log(fix ? "\nDone." : "\n✓ All plural groups covered.");
+}
+
+run({ fix: process.argv.includes("--fix") });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No unit test asserts the translated output (that lives in Smartling, downstream of this repo). Instead, a temporary CI check (`scripts/i18n-plurals.mjs`) guards the invariant and blocks PRs that reintroduce the gap. The fixer output was verified: both files parse as JSON and the re-check is clean/idempotent._
- [x] **Impact of the changes:**
      - Russian rendering of count/plural strings (the reported bug — `accounts` on `LWD > Main`), especially counts of 2–4 (`_few`) and 5+/0 (`_many`).
      - French, Spanish, Portuguese rendering of large-count strings (`_many`).
      - Regression check that English, German, Turkish, Japanese, Korean, Chinese, Thai are **unchanged** (they only ever select `_one`/`_other`).
      - Any screen showing pluralised counts: portfolio account/asset counts, address counts, "found N accounts", relative time ("N minutes ago"), app install/update counts, delegation durations, etc.

### 📝 Description

**Problem.** With the app in Russian, some count strings (e.g. `accounts`) render in English. i18next (v4 JSON) resolves plurals using the **display** language's CLDR categories. The English source locales only define English's categories (`_one`/`_other`, or a base key + `_other`). Smartling mirrors that key set into the other locales, so `ru/*.json` only ever contains `_one`/`_other`. Russian additionally needs `_few` (2–4) and `_many` (0, 5–20, …); when `count` lands in one of those buckets, i18next finds no Russian key and falls back to the English source string.

**Solution (quick fix).** Duplicate every genuine plural group's plural value into the missing `_few` / `_many` keys **in the English source only**. This gives Smartling a source string to translate, so the translated locales gain the forms they were missing. The values are copies of the existing `_other` (plural) English text — placeholders that Smartling re-translates per form.

- Desktop `static/i18n/en/app.json`: +80 keys (40 groups)
- Mobile `src/locales/en/common.json`: +126 keys (63 groups)
- Only `_few` and `_many` were added. Supported UI languages are `en, fr, es, de, ja, ko, pt, ru, tr, zh, th` — **no Arabic** — so Arabic-only `_zero`/`_two` would be dead keys and were intentionally omitted.
- Existing `_one`/`_other`/base keys are never modified; keys are inserted adjacent to their group with correct comma handling.

**Guard against regressions.** A **temporary** CI check (`scripts/i18n-plurals.mjs`) is added as an `i18n Plural Validation` job in the existing `test-additional.yml` workflow, so it runs inside the standard **Build and Test - PR** flow and blocks the required **`OK`** gate — no branch-protection config change needed. The job **only runs when an English locale file changed** in the PR (it queries the PR's changed files first and self-skips otherwise). When a plural group is missing `_few`/`_many` it fails with the list of offending keys and a `--fix` hint, so devs adding a new plural key are told to add the variations. The step is pure Node with no dependencies (no install/setup needed).

Example (desktop `accountsCount`):
```diff
  "accountsCount_one": "{{count}} account",
  "accountsCount_other": "{{count}} accounts",
+ "accountsCount_few": "{{count}} accounts",
+ "accountsCount_many": "{{count}} accounts",
```

### ⚠️ Risks & trade-offs

- **This PR alone does not fix production.** It only changes the English **source**. The Russian/French/… strings still have to flow through Smartling and be re-imported before users see translated plurals. Until then, the new forms fall back to the English placeholder text baked in here (same as today, no regression). QA of the actual Russian output must happen **after** the translation round-trip.
- **Placeholder English text in `_few`/`_many`.** Until Smartling translates them, these keys contain English. For English users this is irrelevant (English never selects `few`/`many`). For any language whose `_few`/`_many` aren't translated yet, the count string shows English — identical to current behaviour, so no new regression, but not fixed until translations land.
- **Duplication / maintenance debt.** ~206 near-duplicate source strings. If a dev edits `_other` later they must also update `_few`/`_many`. The CI check enforces *presence*, not *value consistency* — it will not catch a stale `_few` that no longer matches `_other`. This is the accepted cost of the "quick fix"; a proper fix is Smartling ICU/CLDR plural handling or generating forms at build time.
- **Heuristic plural detection.** The script treats a group as a plural when it has `_other` or a leaf base key, and skips groups containing `_two` (used in this repo as explicit index keys, e.g. `AppAction.*.dependency.description_one/_two`, not CLDR plurals). Three such false positives are correctly excluded. A future genuinely-Arabic `_two` key would be skipped by this guard — acceptable while Arabic is disabled.
- **`_zero`/`_two` intentionally omitted.** If Arabic (or another `zero`/`two` language) is ever enabled, this fix and the CI `REQUIRED` set must be extended.
- **CI check activates after merge.** The new `test-additional.yml` job is referenced by the PR flow as `@develop`, so it starts guarding PRs only once this lands on `develop` (this PR runs `develop`'s current version harmlessly — no bootstrap failure). The locale fix itself was produced/verified locally via `node scripts/i18n-plurals.mjs --fix`.
- **Merge-conflict surface.** Touches two large, frequently-edited locale files; may need a rebase if other locale PRs merge first.
- **No behavioural code change.** Only JSON data + a CI script/job; no app logic touched, so runtime risk in the apps is limited to string resolution described above.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33399](https://ledgerhq.atlassian.net/browse/LIVE-33399)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33399]: https://ledgerhq.atlassian.net/browse/LIVE-33399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ