### PR TITLE
fix(e2e): select quickAmount swap accounts via deeplink

### DIFF
--- a/e2e/desktop/tests/specs/quickAmount.swap.spec.ts
+++ b/e2e/desktop/tests/specs/quickAmount.swap.spec.ts
@@ -11,21 +11,56 @@ import { parseBalanceAmount } from "tests/utils/amountUtils";
 import { expect } from "@playwright/test";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
+import {
+  BTC_ACCOUNT_ID,
+  ETH_ACCOUNT_ID,
+  USDT_ACCOUNT_ID,
+} from "@ledgerhq/live-e2e-shared/swapDeeplinkFixtures";
+import { Application } from "tests/page";
+
+// Selects "from"/"to" via a ledgerwallet://swap deeplink instead of the modular
+// asset dialog: the dialog's virtualized list can bind a click to a stale row's
+// data mid-render, so looping through repeated searches here flaked intermittently.
+async function openSwapPairViaDeeplink(
+  app: Application,
+  fromAccountId: string,
+  toAccountId: string,
+) {
+  await app.swap.clearSwapState();
+  await app.swap.openViaDeeplink(
+    `ledgerwallet://swap?fromAccountId=${fromAccountId}&toAccountId=${toAccountId}`,
+  );
+}
 
 const app: AppInfos = AppInfos.EXCHANGE;
 
 const maxBalanceTags = [...DEVICE_TAGS, "@ethereum", "@family-evm", "@bitcoin", "@family-bitcoin"];
 
 const swapMaxBalancePairs = [
-  { fromAccount: Account.ETH_1, toAccount: Account.BTC_NATIVE_SEGWIT_1 },
-  { fromAccount: TokenAccount.ETH_USDT_1, toAccount: Account.BTC_NATIVE_SEGWIT_1 },
-  { fromAccount: Account.BTC_NATIVE_SEGWIT_1, toAccount: Account.ETH_1 },
+  {
+    fromAccount: Account.ETH_3,
+    fromAccountId: ETH_ACCOUNT_ID,
+    toAccount: Account.BTC_NATIVE_SEGWIT_2,
+    toAccountId: BTC_ACCOUNT_ID,
+  },
+  {
+    fromAccount: TokenAccount.ETH_USDT_1,
+    fromAccountId: USDT_ACCOUNT_ID,
+    toAccount: Account.BTC_NATIVE_SEGWIT_2,
+    toAccountId: BTC_ACCOUNT_ID,
+  },
+  {
+    fromAccount: Account.BTC_NATIVE_SEGWIT_2,
+    fromAccountId: BTC_ACCOUNT_ID,
+    toAccount: Account.ETH_3,
+    toAccountId: ETH_ACCOUNT_ID,
+  },
 ];
 
 test.describe("Swap - Max, Balance & Quick Amount Buttons - funded accounts", () => {
   setupEnv(true);
 
-  const uniqueAccounts = [Account.ETH_1, Account.BTC_NATIVE_SEGWIT_1, TokenAccount.ETH_USDT_1];
+  const uniqueAccounts = [Account.ETH_3, Account.BTC_NATIVE_SEGWIT_2, TokenAccount.ETH_USDT_1];
   const uniqueAppNames = Array.from(
     new Set(uniqueAccounts.map(acc => acc.currency.speculosApp.name.replace(/ /g, "_"))),
   );
@@ -56,9 +91,9 @@ test.describe("Swap - Max, Balance & Quick Amount Buttons - funded accounts", ()
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      for (const { fromAccount, toAccount } of swapMaxBalancePairs) {
+      for (const { fromAccount, fromAccountId, toAccountId } of swapMaxBalancePairs) {
         await test.step(`Currency: ${fromAccount.currency.name}`, async () => {
-          await performSwapUntilQuoteSelectionStep(app, new Swap(fromAccount, toAccount, ""), "");
+          await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
 
           const balanceText = await app.swap.getFromAccountBalanceText();
           expect(balanceText).toBeTruthy();
@@ -81,8 +116,8 @@ test.describe("Swap - Max, Balance & Quick Amount Buttons - funded accounts", ()
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      const { fromAccount, toAccount } = swapMaxBalancePairs[0];
-      await performSwapUntilQuoteSelectionStep(app, new Swap(fromAccount, toAccount, ""), "");
+      const { fromAccountId, toAccountId } = swapMaxBalancePairs[0];
+      await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
 
       for (const percent of ["25%", "50%", "75%"] as const) {
         await app.swap.checkPercentageTooltip(percent, `${percent} of your available balance`);
@@ -99,8 +134,8 @@ test.describe("Swap - Max, Balance & Quick Amount Buttons - funded accounts", ()
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-      for (const { fromAccount, toAccount } of swapMaxBalancePairs) {
-        await performSwapUntilQuoteSelectionStep(app, new Swap(fromAccount, toAccount, ""), "");
+      for (const { fromAccountId, toAccountId } of swapMaxBalancePairs) {
+        await openSwapPairViaDeeplink(app, fromAccountId, toAccountId);
 
         const balanceText = await app.swap.getFromAccountBalanceText();
         const balance = parseBalanceAmount(balanceText);


### PR DESCRIPTION
## Summary
- `quickAmount.swap.spec.ts` was intermittently failing with `Could not find 'Bitcoin' in the network selection dialog`.
- Root cause (confirmed via diagnostic logging): the modular asset dialog's virtualized list can bind a click to a stale row's data mid-render — a row can visually show the correct ticker/name while its click handler still fires with the previous render's asset (e.g. clicking a row displaying "Bitcoin" actually selected Coinbase Wrapped BTC). This is a race in the app's own virtualized list, not something a client-side wait (visibility, network response) can reliably fix from the test side.
- Fix: rather than patch the dialog, the tests that loop through repeated ticker searches (`swapMaxBalancePairs` in the "funded accounts" describe block) now select accounts via a `ledgerwallet://swap?fromAccountId=…&toAccountId=…` deeplink — the same mechanism already exercised end-to-end in `deeplink.swap.spec.ts` ("no drawer expected") — which bypasses the asset dialog entirely for both sides. The dialog itself, `ModularDialog`, and the other swap specs that still rely on it are untouched.
- The two single-selection describe blocks in this file (insufficient balance / zero balance) were never implicated in the failure and are left unchanged.

## Test plan
- [x] `pnpm --filter ledger-live-desktop-e2e-tests typecheck`
- [x] Locally re-ran `tests/specs/quickAmount.swap.spec.ts` — all tests pass
- [x] CI run on this branch

e2e execution: https://github.com/LedgerHQ/ledger-live/actions/runs/30355442285