### PR TITLE
[LWM] feat(contacts): render mobile Me contact detail (LIVE-33998)

### DIFF
--- a/.changeset/bright-wallets-connect.md
+++ b/.changeset/bright-wallets-connect.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Render Me-specific contact detail actions and copy on mobile.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10228,6 +10228,7 @@
     "title": "Contacts",
     "addContact": "Add contact",
     "addAddress": "Add address",
+    "addYourAddress": "Add your address",
     "searchPlaceholder": "Search contact",
     "searchNoResults": "No contact found",
     "addContactDrawer": {
@@ -10246,9 +10247,12 @@
       "addressCount_other": "{{count}} addresses"
     },
     "detail": {
+      "ledgerWalletAddresses": "Ledger Wallet addresses",
+      "myAddresses": "My addresses",
       "emptyState": {
         "title": "No address yet",
-        "meDescription": "Save a wallet address to receive crypto.",
+        "meTitle": "Save your own addresses",
+        "meDescription": "Save the external addresses you own on exchanges or other wallets. Next time you send to yourself, your Ledger device will show the name you chose.",
         "contactDescription": "Save a wallet address to send to {{name}}"
       }
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Pressable, Text } from "react-native";
+import type { RouteProp } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { render, screen, withFlagOverrides, waitFor } from "@tests/test-renderer";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
-import { ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
+import type { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import { ContactsButton, ContactsScreen } from "LLM/features/Contacts";
 import { ContactDetailScreen } from "LLM/features/Contacts/screens/ContactDetail";
 import { useContactDetailScreenViewModel } from "LLM/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel";
@@ -15,6 +17,7 @@ jest.mock("LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel");
 const mockedViewModel = jest.mocked(useMyWalletHeaderViewModel);
 
 const Stack = createNativeStackNavigator();
+const AccountsStack = createNativeStackNavigator<AccountsNavigatorParamList>();
 const noop = () => undefined;
 
 const contactsNavigationState = {
@@ -49,6 +52,16 @@ const savedContactDetailNavigationState = {
   ],
 };
 
+const ledgerWalletAddressesNavigationState = {
+  index: 0,
+  routes: [
+    {
+      name: NavigatorName.MyWallet,
+      state: contactDetailNavigationState,
+    },
+  ],
+};
+
 const missingContactDetailNavigationState = {
   index: 1,
   routes: [
@@ -74,6 +87,42 @@ const initialMissingContactDetailNavigationState = {
 
 function MyWalletHomeTestScreen() {
   return <Text testID="my-wallet-home">My Wallet</Text>;
+}
+
+function AccountsListTestScreen() {
+  return <Text testID="accounts-list-screen">Accounts list</Text>;
+}
+
+function CryptoAddressesTestScreen({
+  route,
+}: Readonly<{
+  route: RouteProp<AccountsNavigatorParamList, typeof ScreenName.CryptoAddresses>;
+}>) {
+  return <Text testID="crypto-addresses-screen">{route.params.sourceScreenName}</Text>;
+}
+
+function AccountsNavigationTestApp() {
+  return (
+    <AccountsStack.Navigator
+      initialRouteName={ScreenName.AccountsList}
+      screenOptions={{ headerShown: false }}
+    >
+      <AccountsStack.Screen name={ScreenName.AccountsList} component={AccountsListTestScreen} />
+      <AccountsStack.Screen
+        name={ScreenName.CryptoAddresses}
+        component={CryptoAddressesTestScreen}
+      />
+    </AccountsStack.Navigator>
+  );
+}
+
+function LedgerWalletAddressesNavigationTestApp() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name={NavigatorName.MyWallet} component={MyWalletNavigator} />
+      <Stack.Screen name={NavigatorName.Accounts} component={AccountsNavigationTestApp} />
+    </Stack.Navigator>
+  );
 }
 
 function ContactsGatingTestApp() {
@@ -353,8 +402,19 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
-      expect(screen.getByText("No address yet")).toBeVisible();
-      expect(screen.getByText("Save a wallet address to receive crypto.")).toBeVisible();
+      expect(screen.getByText("My addresses")).toBeVisible();
+      expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent(
+        "Add your address",
+      );
+      expect(screen.getByTestId("contacts-detail-ledger-wallet-addresses")).toHaveTextContent(
+        "Ledger Wallet addresses",
+      );
+      expect(screen.getByText("Save your own addresses")).toBeVisible();
+      expect(
+        screen.getByText(
+          "Save the external addresses you own on exchanges or other wallets. Next time you send to yourself, your Ledger device will show the name you chose.",
+        ),
+      ).toBeVisible();
       expect(screen.getByTestId("contacts-detail-add-address")).toBeEnabled();
     });
   });
@@ -376,11 +436,12 @@ describe("Contacts integration", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+      expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
       expect(screen.getByText("Save a wallet address to send to Benoit")).toBeVisible();
       expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
+      expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
     });
   });
-
   it("should expose the Add Address session started for Me", async () => {
     const { user } = render(<ContactDetailViewModelTestApp />, {
       navigationInitialState: contactDetailNavigationState,
@@ -416,5 +477,21 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
       `selectingCurrency:${contact.id}`,
     );
+  });
+
+  it("should open Ledger Wallet addresses from the Me contact detail", async () => {
+    const { user } = render(<LedgerWalletAddressesNavigationTestApp />, {
+      navigationInitialState: ledgerWalletAddressesNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: { enabled: true, params: { newBadge: false } },
+      }),
+    });
+
+    await user.press(await screen.findByTestId("contacts-detail-ledger-wallet-addresses"));
+
+    expect(await screen.findByTestId("crypto-addresses-screen")).toHaveTextContent(
+      ScreenName.MyWalletContactDetail,
+    );
+    expect(screen.queryByTestId("accounts-list-screen")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -10,7 +10,8 @@ import {
   useContactsFeature,
   useEmptyContactDetail,
 } from "@features/flow-contacts";
-import { ScreenName } from "~/const";
+import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
+import { NavigatorName, ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
 import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
@@ -23,8 +24,12 @@ type ContactDetailScreenViewModel =
       pageProps: ContactDetailViewProps;
     }>;
 
+type NavigationProp = BaseNavigationComposite<
+  NativeStackNavigationProp<MyWalletNavigatorStackParamList>
+>;
+
 export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel {
-  const navigation = useNavigation<NativeStackNavigationProp<MyWalletNavigatorStackParamList>>();
+  const navigation = useNavigation<NavigationProp>();
   const route =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWalletContactDetail>>();
   const { isEnabled } = useContactsFeature("mobile");
@@ -36,13 +41,24 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       startAddAddress(contact.id);
     }
   }, [contact, startAddAddress]);
+  const onOpenLedgerWalletAddresses = useCallback(() => {
+    navigation.navigate(NavigatorName.Accounts, {
+      screen: ScreenName.CryptoAddresses,
+      params: {
+        sourceScreenName: ScreenName.MyWalletContactDetail,
+      },
+    });
+  }, [navigation]);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
-      emptyMeTitle: t("contacts.detail.emptyState.title"),
+      addYourAddress: t("contacts.addYourAddress"),
+      emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
       emptyContactTitle: () => t("contacts.detail.emptyState.title"),
       emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
       emptyContactDescription: name => t("contacts.detail.emptyState.contactDescription", { name }),
+      ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),
+      myAddresses: t("contacts.detail.myAddresses"),
       formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
@@ -71,6 +87,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       labels,
       meAvatarSrc: USER_AVATAR_URL,
       onAddAddress,
+      onOpenLedgerWalletAddresses,
     },
   };
 }

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -6,19 +6,24 @@ import { ContactDetailView } from "./ContactDetailView.native";
 
 const labels: ContactDetailLabels = {
   addAddress: "Add address",
-  emptyMeTitle: "No address yet",
+  addYourAddress: "Add your address",
+  emptyMeTitle: "Save your own addresses",
   emptyContactTitle: () => "No address yet",
-  emptyMeDescription: "Save a wallet address to receive crypto.",
+  emptyMeDescription: "Save external addresses for Me.",
   emptyContactDescription: name => `Save wallet address to send to ${name}`,
+  ledgerWalletAddresses: "Ledger Wallet addresses",
+  myAddresses: "My addresses",
   formatAddressCount: count => `${count} address`,
 };
 
 const onAddAddress = () => undefined;
+const onOpenLedgerWalletAddresses = () => undefined;
 
 const defaultProps = {
   labels,
   meAvatarSrc: "https://example.com/avatar.png",
   onAddAddress,
+  onOpenLedgerWalletAddresses,
 };
 
 describe("ContactDetailPage", () => {
@@ -26,8 +31,13 @@ describe("ContactDetailPage", () => {
     render(<ContactDetailView {...defaultProps} contact={mockMeContact()} />);
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
-    expect(screen.getByText("No address yet")).toBeVisible();
-    expect(screen.getByText("Save a wallet address to receive crypto.")).toBeVisible();
+    expect(screen.getByText("My addresses")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add your address");
+    expect(screen.getByTestId("contacts-detail-ledger-wallet-addresses")).toHaveTextContent(
+      "Ledger Wallet addresses",
+    );
+    expect(screen.getByText("Save your own addresses")).toBeVisible();
+    expect(screen.getByText("Save external addresses for Me.")).toBeVisible();
   });
 
   it("should render a saved contact empty state", () => {
@@ -40,7 +50,34 @@ describe("ContactDetailPage", () => {
 
     expect(screen.getByTestId("contacts-detail-avatar")).toBeVisible();
     expect(screen.getByText("Benoit")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
+    expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
+    expect(screen.getByText("No address yet")).toBeVisible();
     expect(screen.getByText("Save wallet address to send to Benoit")).toBeVisible();
+  });
+
+  it("should keep the shared detail defaults without Mobile-specific props", () => {
+    const sharedLabels: ContactDetailLabels = {
+      addAddress: labels.addAddress,
+      emptyMeTitle: labels.emptyMeTitle,
+      emptyContactTitle: labels.emptyContactTitle,
+      emptyMeDescription: labels.emptyMeDescription,
+      emptyContactDescription: labels.emptyContactDescription,
+      formatAddressCount: labels.formatAddressCount,
+    };
+
+    render(
+      <ContactDetailView
+        contact={mockMeContact()}
+        labels={sharedLabels}
+        meAvatarSrc={defaultProps.meAvatarSrc}
+        onAddAddress={onAddAddress}
+      />,
+    );
+
+    expect(screen.getByText("Me")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-add-address")).toHaveTextContent("Add address");
+    expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).toBeNull();
   });
 
   it("should request adding an address when the action is pressed", () => {
@@ -52,5 +89,20 @@ describe("ContactDetailPage", () => {
     fireEvent.press(screen.getByTestId("contacts-detail-add-address"));
 
     expect(onAddAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should request opening Ledger Wallet addresses for Me", () => {
+    const onOpenLedgerWalletAddresses = jest.fn();
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockMeContact()}
+        onOpenLedgerWalletAddresses={onOpenLedgerWalletAddresses}
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId("contacts-detail-ledger-wallet-addresses"));
+
+    expect(onOpenLedgerWalletAddresses).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
@@ -3,12 +3,14 @@ import { Box } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactDetailViewProps } from "./types";
 import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.native";
 import { ContactDetailHeader } from "./components/ContactDetailHeader.native";
+import { LedgerWalletAddressesCard } from "./components/LedgerWalletAddressesCard.native";
 
 export function ContactDetailView({
   contact,
   labels,
   meAvatarSrc,
   onAddAddress,
+  onOpenLedgerWalletAddresses,
 }: ContactDetailViewProps): React.JSX.Element {
   return (
     <Box testID="contacts-detail-screen" lx={{ flex: 1, backgroundColor: "base" }}>
@@ -18,6 +20,12 @@ export function ContactDetailView({
         meAvatarSrc={meAvatarSrc}
         onAddAddress={onAddAddress}
       />
+      {contact.isMe && labels.ledgerWalletAddresses && onOpenLedgerWalletAddresses ? (
+        <LedgerWalletAddressesCard
+          label={labels.ledgerWalletAddresses}
+          onPress={onOpenLedgerWalletAddresses}
+        />
+      ) : null}
       <ContactDetailEmptyState contact={contact} labels={labels} />
     </Box>
   );

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -9,8 +9,7 @@ const labels: ContactDetailLabels = {
   emptyMeTitle: "No saved addresses for you",
   emptyContactTitle: name => `No saved addresses for ${name}`,
   emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
-  emptyContactDescription: () =>
-    "Save their wallet addresses to send to them by name next time.",
+  emptyContactDescription: () => "Save their wallet addresses to send to them by name next time.",
   formatAddressCount: count => `${count} address`,
 };
 

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.native.tsx
@@ -21,7 +21,7 @@ export function ContactDetailHeader({
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
         <Box lx={{ alignItems: "center", gap: "s4" }}>
           <Text typography="heading3SemiBold" lx={{ color: "base" }}>
-            {contact.name}
+            {contact.isMe ? (labels.myAddresses ?? contact.name) : contact.name}
           </Text>
           <Text typography="body2" lx={{ color: "muted" }}>
             {labels.formatAddressCount(contact.addresses.length)}
@@ -35,7 +35,7 @@ export function ContactDetailHeader({
         onPress={onAddAddress}
         testID="contacts-detail-add-address"
       >
-        {labels.addAddress}
+        {contact.isMe ? (labels.addYourAddress ?? labels.addAddress) : labels.addAddress}
       </Button>
     </Box>
   );

--- a/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.native.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  Card,
+  CardContent,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  CardTrailing,
+} from "@ledgerhq/lumen-ui-rnative";
+import { ChevronRight, Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
+type LedgerWalletAddressesCardProps = Readonly<{
+  label: string;
+  onPress: () => void;
+}>;
+
+export function LedgerWalletAddressesCard({
+  label,
+  onPress,
+}: LedgerWalletAddressesCardProps): React.JSX.Element {
+  return (
+    <Card
+      onPress={onPress}
+      testID="contacts-detail-ledger-wallet-addresses"
+      lx={{ marginHorizontal: "s16", marginTop: "s32" }}
+    >
+      <CardHeader lx={{ minHeight: "s48" }}>
+        <CardLeading>
+          <Wallet size={20} />
+          <CardContent>
+            <CardContentTitle>{label}</CardContentTitle>
+          </CardContent>
+        </CardLeading>
+        <CardTrailing>
+          <ChevronRight size={20} color="muted" />
+        </CardTrailing>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -2,10 +2,13 @@ import type { Contact } from "@domain/entity-contact";
 
 export type ContactDetailLabels = Readonly<{
   addAddress: string;
+  addYourAddress?: string;
   emptyMeTitle: string;
   emptyContactTitle: (name: string) => string;
   emptyMeDescription: string;
   emptyContactDescription: (name: string) => string;
+  ledgerWalletAddresses?: string;
+  myAddresses?: string;
   formatAddressCount: (count: number) => string;
 }>;
 
@@ -14,4 +17,5 @@ export type ContactDetailViewProps = Readonly<{
   labels: ContactDetailLabels;
   meAvatarSrc: string;
   onAddAddress: () => void;
+  onOpenLedgerWalletAddresses?: () => void;
 }>;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Mobile `Me` contact detail copy and Add Address label
      - Ledger Wallet addresses card visibility and navigation
      - Existing saved-contact detail behavior

### 📝 Description

The Mobile `Me` contact detail was missing the dedicated Ledger Wallet addresses entry and still used the generic empty-state copy.

This PR adds the Me-only Lumen card, opens the existing Crypto Addresses screen when it is pressed, changes the Me title to `My addresses` and its CTA to `Add your address`, and aligns the card height and empty-state copy with the Contacts exploration. Saved contacts keep their existing copy and do not render the new card.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-07-27 at 14 19 05" src="https://github.com/user-attachments/assets/1a88b2b0-aec6-4ff8-8bfe-1bf315f82f7c" />

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33998](https://ledgerhq.atlassian.net/browse/LIVE-33998)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33998]: https://ledgerhq.atlassian.net/browse/LIVE-33998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ