### PR TITLE
[LWDM] feat(shared/env): add team-scoped env variable definitions

### DIFF
--- a/libs/env/src/env.ts
+++ b/libs/env/src/env.ts
@@ -10,24 +10,25 @@ type EnvDef<T extends string> = T extends EnvName ? EnvDefs[T] : undefined;
 export type EnvName = keyof EnvDefs;
 export type EnvValue<Name extends EnvName> = $ElementType<Env, Name>;
 
-const intParser = (v: any): number | undefined => {
+export const intParser = (v: any): number | undefined => {
   if (!Number.isNaN(v)) return parseInt(v, 10);
 };
 
-const floatParser = (v: any): number | undefined => {
+export const floatParser = (v: any): number | undefined => {
   if (!Number.isNaN(v)) return parseFloat(v);
 };
 
-const boolParser = (v: unknown): boolean | undefined => {
+export const boolParser = (v: unknown): boolean | undefined => {
   if (typeof v === "boolean") return v;
   return !(v === "0" || v === "false");
 };
 
-const stringParser = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+export const stringParser = (v: unknown): string | undefined =>
+  typeof v === "string" ? v : undefined;
 
 type JSONValue = string | number | boolean | { [x: string]: JSONValue } | Array<JSONValue>;
 
-const jsonParser = (v: unknown): JSONValue | undefined => {
+export const jsonParser = (v: unknown): JSONValue | undefined => {
   try {
     if (typeof v !== "string") throw new Error();
     return JSON.parse(v);
@@ -36,7 +37,7 @@ const jsonParser = (v: unknown): JSONValue | undefined => {
   }
 };
 
-const stringArrayParser = (v: unknown): string[] | undefined => {
+export const stringArrayParser = (v: unknown): string[] | undefined => {
   const v_array = typeof v === "string" ? v.split(",") : null;
   if (Array.isArray(v_array) && v_array.length > 0) return v_array;
 };

--- a/shared/env/src/definitions/index.ts
+++ b/shared/env/src/definitions/index.ts
@@ -1,0 +1,23 @@
+import teamCoinIntegration from "./team-coin-integration";
+import teamBlockchainSupport from "./team-blockchain-support";
+import teamLedgerPartnerHoodies from "./team-ledger-partner-hoodies";
+import teamLedgerPartnerBlockydevs from "./team-ledger-partner-blockydevs";
+import teamPtx from "./team-ptx";
+import teamPlatform from "./team-platform";
+import teamLiveDevices from "./team-live-devices";
+import teamWalletXp from "./team-wallet-xp";
+import teamEngagement from "./team-engagement";
+import teamQaa from "./team-qaa";
+
+export const allDefinitions = {
+  ...teamCoinIntegration,
+  ...teamBlockchainSupport,
+  ...teamLedgerPartnerHoodies,
+  ...teamLedgerPartnerBlockydevs,
+  ...teamPtx,
+  ...teamPlatform,
+  ...teamLiveDevices,
+  ...teamWalletXp,
+  ...teamEngagement,
+  ...teamQaa,
+};

--- a/shared/env/src/definitions/team-blockchain-support/index.ts
+++ b/shared/env/src/definitions/team-blockchain-support/index.ts
@@ -1,0 +1,56 @@
+import { boolParser, stringParser } from "@ledgerhq/live-env";
+
+const teamBlockchainSupport = {
+  APTOS_API_ENDPOINT: {
+    def: "https://apt.coin.ledger.com/node/v1",
+    parser: stringParser,
+    desc: "API endpoint for Aptos",
+  },
+  APTOS_TESTNET_API_ENDPOINT: {
+    def: "https://api.testnet.aptoslabs.com/v1",
+    parser: stringParser,
+    desc: "API endpoint for Aptos testnet",
+  },
+  APTOS_INDEXER_ENDPOINT: {
+    def: "https://apt.coin.ledger.com/node/v1/graphql",
+    parser: stringParser,
+    desc: "Indexer endpoint for Aptos",
+  },
+  APTOS_TESTNET_INDEXER_ENDPOINT: {
+    def: "https://api.testnet.aptoslabs.com/v1/graphql",
+    parser: stringParser,
+    desc: "Indexer endpoint for Aptos testnet",
+  },
+  APTOS_ENABLE_TOKENS: {
+    def: false,
+    parser: boolParser,
+    desc: "Enable tokens on Aptos",
+  },
+  APTOS_ENABLE_STAKING: {
+    def: false,
+    parser: boolParser,
+    desc: "Enable staking for Aptos",
+  },
+  API_FILECOIN_ENDPOINT: {
+    parser: stringParser,
+    def: "https://filecoin.coin.ledger.com",
+    desc: "Filecoin API url",
+  },
+  API_STACKS_ENDPOINT: {
+    parser: stringParser,
+    def: "https://stacks.coin.ledger.com",
+    desc: "Stacks API url",
+  },
+  API_KASPA_ENDPOINT: {
+    parser: stringParser,
+    def: "https://kaspa.coin.ledger.com",
+    desc: "Kaspa API url",
+  },
+  API_VECHAIN_THOREST: {
+    def: "https://vechain.coin.ledger.com",
+    parser: stringParser,
+    desc: "Thorest API for VeChain",
+  },
+};
+
+export default teamBlockchainSupport;

--- a/shared/env/src/definitions/team-coin-integration/index.ts
+++ b/shared/env/src/definitions/team-coin-integration/index.ts
@@ -1,0 +1,452 @@
+import {
+  intParser,
+  floatParser,
+  boolParser,
+  stringParser,
+  stringArrayParser,
+} from "@ledgerhq/live-env";
+
+const teamCoinIntegration = {
+  API_ALGORAND_BLOCKCHAIN_EXPLORER_API_ENDPOINT: {
+    def: "https://algorand.coin.ledger.com",
+    parser: stringParser,
+    desc: "Node API endpoint for algorand",
+  },
+  BITCOIN_STUCK_TRANSACTION_TIMEOUT: {
+    def: 20 * 60 * 1000,
+    parser: intParser,
+    desc: "Time after which an optimistic operation is considered stuck",
+  },
+  COSMOS_GAS_AMPLIFIER: {
+    def: 1.3, // Same as Keplr
+    parser: floatParser,
+    desc: "Cosmos gas estimate multiplier",
+  },
+  API_POLKADOT_INDEXER: {
+    parser: stringParser,
+    def: "https://polkadot.coin.ledger.com",
+    desc: "Explorer API for polkadot",
+  },
+  API_POLKADOT_SIDECAR: {
+    parser: stringParser,
+    def: "https://polkadot-mainnet-rest-api.coin.ledger.com/v1/rc",
+    desc: "Polkadot rest-api base URL",
+  },
+  API_POLKADOT_SIDECAR_CREDENTIALS: {
+    parser: stringParser,
+    def: "",
+    desc: "Polkadot Sidecar API credentials",
+  },
+  API_POLKADOT_NODE: {
+    parser: stringParser,
+    def: "https://polkadot-fullnodes.api.live.ledger.com",
+    desc: "Polkadot Node",
+  },
+  POLKADOT_ELECTION_STATUS_THRESHOLD: {
+    def: 25,
+    parser: intParser,
+    desc: "in blocks - number of blocks before Polkadot election effectively opens to consider it as open and disable all staking features",
+  },
+  MULTIVERSX_API_ENDPOINT: {
+    parser: stringParser,
+    def: "https://elrond.coin.ledger.com",
+    desc: "MultiversX API url",
+  },
+  MULTIVERSX_DELEGATION_API_ENDPOINT: {
+    parser: stringParser,
+    def: "https://delegations-elrond.coin.ledger.com",
+    desc: "MultiversX DELEGATION API url",
+  },
+  API_STELLAR_HORIZON: {
+    parser: stringParser,
+    def: "https://stellar.coin.ledger.com",
+    desc: "Stellar Horizon API url",
+  },
+  API_STELLAR_HORIZON_FETCH_LIMIT: {
+    parser: intParser,
+    def: 100,
+    desc: "Limit of operation that Horizon will fetch per page",
+  },
+  API_STELLAR_HORIZON_STATIC_FEE: {
+    def: false,
+    parser: boolParser,
+    desc: "Static fee for Stellar account",
+  },
+  API_TRONGRID_PROXY: {
+    parser: stringParser,
+    def: "https://tron.coin.ledger.com",
+    desc: "proxy url for trongrid API",
+  },
+  API_SOLANA_PROXY: {
+    parser: stringParser,
+    def: "https://solana.coin.ledger.com",
+    desc: "proxy url for solana API",
+  },
+  SOLANA_VALIDATORS_APP_BASE_URL: {
+    parser: stringParser,
+    def: "https://earn.api.live.ledger.com/v0/network/solana/validator-details",
+    desc: "base url for validators.app validator list",
+  },
+  SOLANA_VALIDATORS_SUMMARY_BASE_URL: {
+    parser: stringParser,
+    def: "https://earn.api.live.ledger.com/figment/solana/validators_summary",
+    desc: "base url for validators.app validator summary",
+  },
+  SOLANA_TESTNET_VALIDATORS_APP_BASE_URL: {
+    parser: stringParser,
+    def: "https://validators-solana.coin.ledger.com/api/v1/validators",
+    desc: "base url for testnet validators.app validator list",
+  },
+  SOLANA_TX_CONFIRMATION_TIMEOUT: {
+    def: 100 * 1000,
+    parser: intParser,
+    desc: "solana transaction broadcast confirmation timeout",
+  },
+  ICON_NODE_ENDPOINT: {
+    parser: stringParser,
+    def: "https://icon.coin.ledger.com/api/v3",
+    desc: "ICON RPC url",
+  },
+  ICON_DEBUG_ENDPOINT: {
+    parser: stringParser,
+    def: "https://icon.coin.ledger.com/api/v3d",
+    desc: "ICON debug RPC url",
+  },
+  ICON_INDEXER_ENDPOINT: {
+    parser: stringParser,
+    def: "https://icon.coin.ledger.com/api/v1",
+    desc: "ICON API url",
+  },
+  ICON_TESTNET_NODE_ENDPOINT: {
+    parser: stringParser,
+    def: "https://berlin.net.solidwallet.io/api/v3",
+    desc: "ICON Berlin Testnet API url",
+  },
+  ICON_TESTNET_DEBUG_ENDPOINT: {
+    parser: stringParser,
+    def: "https://berlin.net.solidwallet.io/api/v3d",
+    desc: "ICON Berlin Testnet debug",
+  },
+  ICON_TESTNET_INDEXER_ENDPOINT: {
+    parser: stringParser,
+    def: "https://tracker.berlin.icon.community/api/v1",
+    desc: "ICON Berlin Testnet API url",
+  },
+  CRYPTO_ORG_INDEXER: {
+    def: "https://cryptoorg-rpc-indexer.coin.ledger.com",
+    parser: stringParser,
+    desc: "location of the Cronos POS Chain (formerly Crypto.org) indexer API",
+  },
+  CRYPTO_ORG_TESTNET_INDEXER: {
+    def: "https://cronos-pos.org/explorer/croeseid4",
+    parser: stringParser,
+    desc: "location of the Cronos POS Chain (formerly Crypto.org) indexer testnet API",
+  },
+  CRYPTO_ORG_RPC_URL: {
+    def: "https://cryptoorg-rpc-node.coin.ledger.com",
+    parser: stringParser,
+    desc: "location of the Cronos POS Chain (formerly Crypto.org) chain node",
+  },
+  CRYPTO_ORG_TESTNET_RPC_URL: {
+    def: "https://rpc-testnet-croeseid-4.crypto.org",
+    parser: stringParser,
+    desc: "location of the Cronos POS Chain (formerly Crypto.org) chain testnet node",
+  },
+  EIP1559_MINIMUM_FEES_GATE: {
+    def: true,
+    parser: boolParser,
+    desc: "prevents the user from doing an EIP1559 transaction with fees too low",
+  },
+  EIP1559_PRIORITY_FEE_LOWER_GATE: {
+    def: 0.85,
+    parser: floatParser,
+    desc: "minimum priority fee percents allowed compared to network conditions allowed when EIP1559_MINIMUM_FEES_GATE is activated",
+  },
+  EIP1559_BASE_FEE_MULTIPLIER: {
+    def: 1.27,
+    parser: floatParser,
+    desc: "multiplier for the base fee that is composing the maxFeePerGas property",
+  },
+  ETHEREUM_STUCK_TRANSACTION_TIMEOUT: {
+    def: 5 * 60 * 1000,
+    parser: intParser,
+    desc: "Time after which an optimistic operation is considered stuck",
+  },
+  EVM_REPLACE_TX_LEGACY_GASPRICE_FACTOR: {
+    def: 1.3,
+    parser: floatParser,
+    desc: "Replace transaction gasprice factor for legacy evm transaction. This value should be 1.1 minimum since this is the minimum increase required by most nodes",
+  },
+  EVM_REPLACE_TX_EIP1559_MAXFEE_FACTOR: {
+    def: 1.3,
+    parser: floatParser,
+    desc: "Replace transaction max fee factor for EIP1559 evm transaction. This value should be 1.1 minimum since this is the minimum increase required by most nodes",
+  },
+  EVM_REPLACE_TX_EIP1559_MAXPRIORITYFEE_FACTOR: {
+    def: 1.1,
+    parser: floatParser,
+    desc: "Replace transaction max priority fee factor for EIP1559 evm transaction. This value should be 1.1 minimum since this is the minimum increase required by most nodes",
+  },
+  EVM_FORCE_LEGACY_TRANSACTIONS: {
+    def: false,
+    parser: boolParser,
+    desc: "Force transaction type 0 on EVM networks",
+  },
+  PLATFORM_DEBUG: {
+    def: false,
+    parser: boolParser,
+    desc: "enable visibility of debug apps and tools in Platform Catalog",
+  },
+  PLATFORM_EXPERIMENTAL_APPS: {
+    def: false,
+    parser: boolParser,
+    desc: "enable visibility of experimental apps and tools in Platform Catalog",
+  },
+  PLATFORM_MANIFEST_API_URL: {
+    def: "https://live-app-catalog.ledger.com/api/v1/apps",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests",
+  },
+  PLATFORM_LOCAL_MANIFEST_JSON: {
+    def: "",
+    parser: stringParser,
+    desc: 'json manifest for a local (test) platform app manifests. How to use: PLATFORM_LOCAL_MANIFEST_JSON="$(cat /path/to/file.json)"',
+  },
+  PLATFORM_GLOBAL_CATALOG_API_URL: {
+    def: "https://cdn.live.ledger.com/platform/catalog/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests",
+  },
+  PLATFORM_GLOBAL_CATALOG_STAGING_API_URL: {
+    def: "https://cdn.live.ledger-stg.com/platform/catalog/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests (staging)",
+  },
+  PLATFORM_RAMP_CATALOG_API_URL: {
+    def: "https://cdn.live.ledger.com/platform/trade/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests",
+  },
+  PLATFORM_RAMP_CATALOG_STAGING_API_URL: {
+    def: "https://cdn.live.ledger-stg.com/platform/trade/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests (staging)",
+  },
+  PLATFORM_API_URL: {
+    def: "",
+    parser: stringParser,
+    desc: "url used to fetch platform catalog",
+  },
+  PLATFORM_API_VERSION: {
+    def: 1,
+    parser: intParser,
+    desc: "version used for the platform api",
+  },
+  WALLETCONNECT: {
+    def: false,
+    parser: boolParser,
+    desc: "is walletconnect enabled",
+  },
+  WALLETCONNECT_PROJECT_ID: {
+    def: "053f3301d5f72cf59dbab8ebeab71f23",
+    parser: stringParser,
+    desc: "WalletConnect Project ID",
+  },
+  NFT_CURRENCIES: {
+    def: ["avalanche_c_chain", "bsc", "ethereum", "polygon", "solana"],
+    parser: stringArrayParser,
+    desc: "set the currencies where NFT is active",
+  },
+  NFT_METADATA_SERVICE: {
+    def: "https://nft.api.live.ledger.com",
+    parser: stringParser,
+    desc: "service uri used to get the metadata of an nft",
+  },
+  ADDRESS_POISONING_FAMILIES: {
+    def: "evm,tron,stellar,hedera,algorand,cardano,cosmos,solana,xrp",
+    parser: stringParser,
+    desc: "List of families impacted by the address poisoning attack",
+  },
+  FILTER_ZERO_AMOUNT_ERC20_EVENTS: {
+    def: true,
+    parser: boolParser,
+    desc: "Remove filter of address poisoning",
+  },
+  SANCTIONED_ADDRESSES_URL: {
+    def: "https://compliance.ledger.com/all_sanctioned_addresses_without_ticker.json",
+    parser: stringParser,
+    desc: "List of sanctioned addresses",
+  },
+  EXPERIMENTAL_EXPLORERS: {
+    def: false,
+    parser: boolParser,
+    desc: "enable experimental explorer APIs",
+  },
+  EXPERIMENTAL_SEND_MAX: {
+    def: false,
+    parser: boolParser,
+    desc: "force enabling SEND MAX even if not yet stable",
+  },
+  MOCK_REMOTE_LIVE_MANIFEST: {
+    def: "",
+    parser: stringParser,
+    desc: "mock remote live app manifest",
+  },
+  EXPLORER: {
+    def: "https://explorers.api.live.ledger.com",
+    parser: stringParser,
+    desc: "Ledger generic explorer API",
+  },
+  EXPLORER_REGTEST: {
+    def: "http://localhost:9876",
+    parser: stringParser,
+    desc: "Ledger regtest Bitcoin explorer API",
+  },
+  LEDGER_REST_API_BASE: {
+    def: "https://explorers.api.live.ledger.com",
+    parser: stringParser,
+    desc: "DEPRECATED",
+  },
+  CAL_REF: {
+    def: "",
+    parser: stringParser,
+    desc: "(dev feature) allows to target a different reference of the CAL for testing purposes",
+  },
+  DYNAMIC_CAL_BASE_URL: {
+    def: "https://cdn.live.ledger.com/cryptoassets",
+    parser: stringParser,
+    desc: "bucket S3 of the dynamic cryptoassets list",
+  },
+  CAL_SERVICE_URL: {
+    def: "https://global.api.prd.ledger.com/cal",
+    parser: stringParser,
+    desc: "Cryptoassets list service url",
+  },
+  CAL_SERVICE_URL_STAGING: {
+    def: "https://global.api.stg.ledger-test.com/cal",
+    parser: stringParser,
+    desc: "Cryptoassets list service url (staging)",
+  },
+  LEDGER_CLIENT_VERSION: {
+    def: "",
+    parser: stringParser,
+    desc: "the 'X-Ledger-Client-Version' HTTP header to use for queries to Ledger APIs",
+  },
+  BOT_TIMEOUT_SCAN_ACCOUNTS: {
+    def: 10 * 60 * 1000,
+    parser: intParser,
+    desc: "bot's default timeout for scanAccounts",
+  },
+  BOT_SPEC_DEFAULT_TIMEOUT: {
+    def: 30 * 60 * 1000,
+    parser: intParser,
+    desc: "define the default value of spec.skipMutationsTimeout (if not overriden by spec)",
+  },
+  BOT_MAX_CONCURRENT: {
+    def: 10,
+    parser: intParser,
+    desc: "maximum limit to run bot spec in parallel",
+  },
+  SYNC_ALL_INTERVAL: {
+    def: 8 * 60 * 1000,
+    parser: intParser,
+    desc: "delay between successive sync",
+  },
+  SYNC_BOOT_DELAY: {
+    def: 2 * 1000,
+    parser: intParser,
+    desc: "delay before the sync starts",
+  },
+  SYNC_PENDING_INTERVAL: {
+    def: 10 * 1000,
+    parser: intParser,
+    desc: "delay between sync when an operation is still pending",
+  },
+  SYNC_OUTDATED_CONSIDERED_DELAY: {
+    def: 10 * 60 * 1000,
+    parser: intParser,
+    desc: "delay until Live consider a sync outdated",
+  },
+  SYNC_MAX_CONCURRENT: {
+    def: 4,
+    parser: intParser,
+    desc: "maximum limit to synchronize accounts concurrently to limit overload",
+  },
+  OPERATION_ADDRESSES_LIMIT: {
+    def: 100,
+    parser: intParser,
+    desc: "limit the number of addresses in from/to of operations",
+  },
+  OPERATION_OPTIMISTIC_RETENTION: {
+    def: 30 * 60 * 1000,
+    parser: intParser,
+    desc: "timeout to keep an optimistic operation that was broadcasted but not yet visible from the coin implementation or the API",
+  },
+  OPERATION_PAGE_SIZE_INITIAL: {
+    def: 100,
+    parser: intParser,
+    desc: "defines the initial default operation length page to use",
+  },
+  DISABLE_SYNC_TOKEN: {
+    def: true,
+    parser: boolParser,
+    desc: "disable a problematic mechanism of our API",
+  },
+  DISABLE_TRANSACTION_BROADCAST: {
+    def: false,
+    parser: boolParser,
+    desc: "disable broadcast of transactions",
+  },
+  GET_CALLS_RETRY: {
+    def: 2,
+    parser: intParser,
+    desc: "how many times to retry a GET http call",
+  },
+  GET_CALLS_TIMEOUT: {
+    def: 60 * 1000,
+    parser: intParser,
+    desc: "how much time to timeout a GET http call",
+  },
+  SCAN_FOR_INVALID_PATHS: {
+    def: false,
+    parser: boolParser,
+    desc: "enable searching accounts in exotic derivation paths",
+  },
+  KEYCHAIN_OBSERVABLE_RANGE: {
+    def: 0,
+    parser: intParser,
+    desc: "overrides the gap limit specified by BIP44 (default to 20)",
+  },
+  DEFAULT_TRANSACTION_POLLING_INTERVAL: {
+    def: 30 * 1000,
+    parser: intParser,
+    desc: "Default interval to poll for transaction confirmation in speedup/cancel evm flow (in ms)",
+  },
+  DEBUG_HTTP_RESPONSE: {
+    def: false,
+    parser: boolParser,
+    desc: "includes HTTP response body in logs",
+  },
+  ENABLE_NETWORK_LOGS: {
+    def: false,
+    parser: boolParser,
+    desc: "Enable network request and responses logs. Errors are always logged",
+  },
+  DEBUG_UTXO_DISPLAY: {
+    def: 4,
+    parser: intParser,
+    desc: "define maximum number of utxos to display in CLI",
+  },
+  INDEXER_BOILERPLATE: {
+    def: "",
+    parser: stringParser,
+    desc: "Indexer endpoint for the boilerplate coin module",
+  },
+  NODE_BOILERPLATE: {
+    def: "",
+    parser: stringParser,
+    desc: "Node endpoint for the boilerplate coin module",
+  },
+};
+
+export default teamCoinIntegration;

--- a/shared/env/src/definitions/team-engagement/index.ts
+++ b/shared/env/src/definitions/team-engagement/index.ts
@@ -1,0 +1,16 @@
+import { boolParser } from "@ledgerhq/live-env";
+
+const teamEngagement = {
+  SKIP_ONBOARDING: {
+    def: false,
+    parser: boolParser,
+    desc: "dev flag to skip onboarding flow",
+  },
+  ANALYTICS_CONSOLE: {
+    def: false,
+    parser: boolParser,
+    desc: "Show tracking overlays on the app UI",
+  },
+};
+
+export default teamEngagement;

--- a/shared/env/src/definitions/team-ledger-partner-blockydevs/index.ts
+++ b/shared/env/src/definitions/team-ledger-partner-blockydevs/index.ts
@@ -1,0 +1,61 @@
+import { intParser, floatParser, stringParser } from "@ledgerhq/live-env";
+
+const teamLedgerPartnerBlockydevs = {
+  HEDERA_CLAIM_REWARDS_RECIPIENT_ACCOUNT_ID: {
+    def: "0.0.163372",
+    parser: stringParser,
+    desc: "dead address that receives 1 tinybar from tx that is made to trigger rewards claiming",
+  },
+  HEDERA_STAKING_REWARD_ACCOUNT_ID: {
+    def: "0.0.800",
+    parser: stringParser,
+    desc: "hedera staking reward account id",
+  },
+  HEDERA_STAKING_LEDGER_NODE_ID: {
+    def: -1,
+    parser: intParser,
+    desc: "hedera staking ledger node id, used to determine the default validator",
+  },
+  HEDERA_TOKEN_ASSOCIATION_MIN_USD: {
+    def: 0.05,
+    parser: floatParser,
+    desc: "Minimum USD value an account must hold to perform a token association",
+  },
+  API_HEDERA_MIRROR: {
+    def: "https://hedera.coin.ledger.com",
+    parser: stringParser,
+    desc: "mirror node API for Hedera",
+  },
+  API_HEDERA_MIRROR_TESTNET: {
+    def: "https://hedera-testnet.coin.ledger.com",
+    parser: stringParser,
+    desc: "testnet mirror node API for Hedera",
+  },
+  API_HEDERA_HGRAPH: {
+    def: "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql",
+    parser: stringParser,
+    desc: "Hgraph API for Hedera (ERC20 data source)",
+  },
+  API_HEDERA_HGRAPH_TESTNET: {
+    def: "https://hedera-indexer-testnet.coin.ledger.com/v1/graphql",
+    parser: stringParser,
+    desc: "testnet hgraph API for Hedera",
+  },
+  ALEO_NODE_ENDPOINT: {
+    def: "https://aleo.coin.ledger.com",
+    parser: stringParser,
+    desc: "Aleo mainnet node URL",
+  },
+  ALEO_MAINNET_SDK_ENDPOINT: {
+    def: "https://aleo-backend.api.live.ledger.com/network/mainnet",
+    parser: stringParser,
+    desc: "Aleo mainnet SDK URL",
+  },
+  ALEO_TESTNET_SDK_ENDPOINT: {
+    def: "https://aleo-backend.api.live.ledger.com/network/testnet",
+    parser: stringParser,
+    desc: "Aleo testnet SDK URL",
+  },
+};
+
+export default teamLedgerPartnerBlockydevs;

--- a/shared/env/src/definitions/team-ledger-partner-hoodies/index.ts
+++ b/shared/env/src/definitions/team-ledger-partner-hoodies/index.ts
@@ -1,0 +1,106 @@
+import { intParser, boolParser, stringParser } from "@ledgerhq/live-env";
+
+const teamLedgerPartnerHoodies = {
+  API_CELO_INDEXER: {
+    def: "https://celo.coin.ledger.com/indexer/",
+    parser: stringParser,
+    desc: "Explorer API for celo",
+  },
+  API_CELO_NODE: {
+    def: "https://celo.coin.ledger.com/archive/",
+    parser: stringParser,
+    desc: "Node endpoint for celo",
+  },
+  ENABLE_CELO_TOKENS: {
+    def: true,
+    parser: boolParser,
+    desc: "Enable token send and receive for Celo",
+  },
+  API_TEZOS_BAKER: {
+    parser: stringParser,
+    def: "https://tezos-bakers.api.live.ledger.com",
+    desc: "bakers API for tezos",
+  },
+  API_TEZOS_BLOCKCHAIN_EXPLORER_API_ENDPOINT: {
+    def: "https://xtz-explorer.api.live.ledger.com/explorer",
+    parser: stringParser,
+    desc: "Ledger explorer API for tezos",
+  },
+  API_TEZOS_TZKT_API: {
+    def: "https://xtz-tzkt-explorer.api.live.ledger.com",
+    parser: stringParser,
+    desc: "tzkt.io explorer",
+  },
+  API_TEZOS_NODE: {
+    def: "https://xtz-node.api.live.ledger.com",
+    parser: stringParser,
+    desc: "node API for tezos (for broadcast only)",
+  },
+  TEZOS_MAX_TX_QUERIES: {
+    def: 100,
+    parser: intParser,
+    desc: "safe max on maximum number of queries to synchronize a tezos account",
+  },
+  API_SUI_TESTNET_NODE_PROXY: {
+    parser: stringParser,
+    def: "https://fullnode.testnet.sui.io:443",
+    desc: "public fullnode url for sui testnet node",
+  },
+  API_SUI_NODE_PROXY: {
+    parser: stringParser,
+    def: "https://sui.coin.ledger.com",
+    desc: "reverse proxy url for sui node",
+  },
+  API_SUI_GRAPHQL_PROXY: {
+    parser: stringParser,
+    def: "https://sui.coin.ledger.com/graphql",
+    desc: "reverse proxy url for sui graphql",
+  },
+  API_SUI_TESTNET_GRAPHQL_PROXY: {
+    parser: stringParser,
+    def: "https://graphql.testnet.sui.io/graphql",
+    desc: "GraphQL endpoint url for sui testnet",
+  },
+  SUI_ENABLE_TOKENS: {
+    parser: boolParser,
+    def: true,
+    desc: "Enable tokens on Sui",
+  },
+  CANTON_API_KEY: {
+    def: "",
+    parser: stringParser,
+    desc: "API key for Canton network gateway authentication",
+  },
+  CANTON_NODE_ID_OVERRIDE: {
+    def: "",
+    parser: stringParser,
+    desc: "(dev feature) Switch Canton gateway nodeId for testing different presets.",
+  },
+  CARDANO_API_ENDPOINT: {
+    def: "https://cardano.coin.ledger.com/api",
+    parser: stringParser,
+    desc: "Cardano API url",
+  },
+  CARDANO_TESTNET_API_ENDPOINT: {
+    def: "https://ledger-preprod.cardanoscan.io/api",
+    parser: stringParser,
+    desc: "Cardano API url",
+  },
+  CARDANO_EPOCH_PARAMS_ENDPOINT: {
+    def: "https://ada.api.live.ledger.com/api/rest/params",
+    parser: stringParser,
+    desc: "Cardano current-epoch protocol params url (validator APY)",
+  },
+  CARDANO_TESTNET_EPOCH_PARAMS_ENDPOINT: {
+    def: "https://ada-testnet.api.live.ledger-test.com/api/rest/params",
+    parser: stringParser,
+    desc: "Cardano testnet current-epoch protocol params url (validator APY)",
+  },
+  LEGACY_KT_SUPPORT_TO_YOUR_OWN_RISK: {
+    def: false,
+    parser: boolParser,
+    desc: "enable sending to KT accounts. Not tested.",
+  },
+};
+
+export default teamLedgerPartnerHoodies;

--- a/shared/env/src/definitions/team-live-devices/index.ts
+++ b/shared/env/src/definitions/team-live-devices/index.ts
@@ -1,0 +1,133 @@
+import { intParser, floatParser, boolParser, stringParser } from "@ledgerhq/live-env";
+
+const teamLiveDevices = {
+  MANAGER_API_BASE: {
+    def: "https://manager.api.live.ledger.com/api",
+    parser: stringParser,
+    desc: "Ledger Manager API",
+  },
+  MANAGER_DEV_MODE: {
+    def: false,
+    parser: boolParser,
+    desc: "enable visibility of utility apps in Manager",
+  },
+  MANAGER_INSTALL_DELAY: {
+    def: 1000,
+    parser: intParser,
+    desc: "defines the time to wait before installing apps to prevent known glitch (<=1.5.5) when chaining installs",
+  },
+  DEVICE_CANCEL_APDU_FLUSH_MECHANISM: {
+    def: true,
+    parser: boolParser,
+    desc: "enable a mechanism that send a 0x00 apdu to force device to awake from its 'Processing' UI state",
+  },
+  DEVICE_PROXY_URL: {
+    def: "",
+    parser: stringParser,
+    desc: "enable a proxy to use instead of a physical device",
+  },
+  DEVICE_PROXY_MODEL: {
+    def: "nanoS",
+    parser: stringParser,
+    desc: "allow to override the default model of a proxied device",
+  },
+  BASE_SOCKET_URL: {
+    def: "wss://scriptrunner.api.live.ledger.com/update",
+    parser: stringParser,
+    desc: "Ledger script runner API",
+  },
+  DISABLE_FW_UPDATE_VERSION_CHECK: {
+    def: false,
+    parser: boolParser,
+    desc: "disable the version check for firmware update eligibility",
+  },
+  DISABLE_APP_VERSION_REQUIREMENTS: {
+    def: false,
+    parser: boolParser,
+    desc: "force an old application version to be accepted regardless of its version",
+  },
+  WITH_DEVICE_POLLING_DELAY: {
+    def: 500,
+    parser: floatParser,
+    desc: "delay when polling device",
+  },
+  LOW_BATTERY_PERCENTAGE: {
+    def: 20,
+    parser: intParser,
+    desc: "Configure the low battery percentage threshold",
+  },
+  USER_ID: {
+    def: "",
+    parser: stringParser,
+    desc: "unique identifier of app instance. used to derivate dissociated ids for difference purposes (e.g. the firmware update incremental deployment).",
+  },
+  COINAPPS: {
+    def: "",
+    parser: stringParser,
+    desc: "(dev feature) defines the folder for speculos mode that contains Nano apps binaries (.elf) in a specific structure: <device>/<firmware>/<appName>/app_<appVersion>.elf",
+  },
+  SEED: {
+    def: "",
+    parser: stringParser,
+    desc: "(dev feature) seed to be used by speculos (device simulator)",
+  },
+  SPECULOS_API_PORT: {
+    def: 0,
+    parser: intParser,
+    desc: "API port for speculos",
+  },
+  SPECULOS_DEVICE: {
+    def: "",
+    parser: stringParser,
+    desc: "Device model id for speculos",
+  },
+  SPECULOS_FIRMWARE_VERSION: {
+    def: "",
+    parser: stringParser,
+    desc: "Firmware version for speculos",
+  },
+  SPECULOS_PID_OFFSET: {
+    def: 0,
+    parser: intParser,
+    desc: "offset to be added to the speculos pid and avoid collision with other instances",
+  },
+  /**
+   * It's just here as a backup, the REST API is supposed to be the right mode
+   * We can always fallback on the previous method if we need to.
+   * The websocket option is harmless, we can remove it at some point but let's
+   * keep it for a while just in case.
+   * Introduced on June 27th 2023 by https://github.com/LedgerHQ/ledger-live/pull/3824
+   */
+  SPECULOS_USE_WEBSOCKET: {
+    def: false,
+    parser: boolParser,
+    desc: "Use speculos websocket interface instead of Rest API",
+  },
+  EXPERIMENTAL_BLE: {
+    def: false,
+    parser: boolParser,
+    desc: "enable experimental support of Bluetooth",
+  },
+  EXPERIMENTAL_MANAGER: {
+    def: false,
+    parser: boolParser,
+    desc: "enable an experimental version of Manager",
+  },
+  EXPERIMENTAL_USB: {
+    def: false,
+    parser: boolParser,
+    desc: "enable an experimental implementation of USB support",
+  },
+  MOCK_APP_UPDATE: {
+    def: false,
+    parser: boolParser,
+    desc: "Always shows app update in the manager",
+  },
+  FORCE_PROVIDER: {
+    def: 1,
+    parser: intParser,
+    desc: "use a different provider for app store (for developers only)",
+  },
+};
+
+export default teamLiveDevices;

--- a/shared/env/src/definitions/team-platform/index.ts
+++ b/shared/env/src/definitions/team-platform/index.ts
@@ -1,0 +1,102 @@
+import {
+  intParser,
+  boolParser,
+  stringParser,
+  jsonParser,
+  stringArrayParser,
+} from "@ledgerhq/live-env";
+
+const teamPlatform = {
+  FEATURE_FLAGS: {
+    def: {},
+    parser: jsonParser,
+    desc: "key value map for feature flags: {[key in FeatureId]?: Feature}",
+  },
+  MOCK: {
+    def: "",
+    parser: stringParser,
+    desc: "switch the app into a MOCK mode for test purpose, the value will be used as a seed for the rng. Avoid falsy values.",
+  },
+  MOCK_OS_VERSION: {
+    def: "",
+    parser: stringParser,
+    desc: "if defined, overrides the os and version. format: os@version. Example: Windows_NT@6.1.7601",
+  },
+  MOCK_NO_BYPASS: {
+    def: false,
+    parser: boolParser,
+    desc: "if defined, avoids bypass of the currentDevice in the store.",
+  },
+  STATUS_API_URL: {
+    def: "https://ledger.statuspage.io/api",
+    parser: stringParser,
+    desc: "url used to fetch ledger status",
+  },
+  STATUS_API_VERSION: {
+    def: 2,
+    parser: intParser,
+    desc: "version used for ledger status api",
+  },
+  PUSH_DEVICES_SERVICE_URL: {
+    def: "https://device-gateway.api.ledger.com",
+    parser: stringParser,
+    desc: "Push Devices Service url for device tracking",
+  },
+  VERBOSE: {
+    def: [] as Array<string>,
+    parser: stringArrayParser,
+    desc: 'Sets up debug console printing of logs. `VERBOSE=1` or `VERBOSE=true`: to print all logs | `VERBOSE="apdu,hw,transport,hid-verbose"` : filtering on a list of log `type` separated by a `,`',
+  },
+  EXPORT_EXCLUDED_LOG_TYPES: {
+    def: "ble-frame",
+    parser: stringParser,
+    desc: "comma-separated list of excluded log types for exported logs",
+  },
+  EXPORT_MAX_LOGS: {
+    def: 5000,
+    parser: intParser,
+    desc: "maximum logs to keep for export",
+  },
+  LOG_DRAWERS: {
+    def: false,
+    parser: boolParser,
+    desc: "Enable logs for drawers",
+  },
+  PERFORMANCE_CONSOLE: {
+    def: false,
+    parser: boolParser,
+    desc: "Show a performance overlay on the app UI",
+  },
+  STORAGE_PERFORMANCE_OVERLAY: {
+    def: false,
+    parser: boolParser,
+    desc: "Show a performance overlay on the app storage",
+  },
+  JS_THREAD_MONITOR: {
+    def: false,
+    parser: boolParser,
+    desc: "Show JS thread stall monitor overlay",
+  },
+  CLOUD_SYNC_API_STAGING: {
+    def: "https://cloud-sync-backend.api.aws.stg.ldg-tech.com",
+    parser: stringParser,
+    desc: "wallet sync api staging base url",
+  },
+  CLOUD_SYNC_API_PROD: {
+    def: "https://cloud-sync.api.live.ledger.com",
+    parser: stringParser,
+    desc: "wallet sync api production base url",
+  },
+  TRUSTCHAIN_API_STAGING: {
+    def: "https://trustchain-backend.api.aws.stg.ldg-tech.com",
+    parser: stringParser,
+    desc: "Trustchain API Staging",
+  },
+  TRUSTCHAIN_API_PROD: {
+    def: "https://trustchain.api.live.ledger.com",
+    parser: stringParser,
+    desc: "Trustchain API Prod",
+  },
+};
+
+export default teamPlatform;

--- a/shared/env/src/definitions/team-ptx/index.ts
+++ b/shared/env/src/definitions/team-ptx/index.ts
@@ -1,0 +1,55 @@
+import { boolParser, stringParser } from "@ledgerhq/live-env";
+
+const teamPtx = {
+  SWAP_API_BASE: {
+    def: "https://swap.ledger.com/v5",
+    parser: stringParser,
+    desc: "Swap API base",
+  },
+  SWAP_USER_IP: {
+    def: "",
+    parser: stringParser,
+    desc: "Swap IP",
+  },
+  SWAP_DISABLE_APPS_INSTALL: {
+    def: false,
+    parser: boolParser,
+    desc: "bypass app checks on Nano for speculos swap tests",
+  },
+  /**
+   * Note: the mocked cryptoassets config and test partner are signed with the
+   * Ledger test private key
+   */
+  MOCK_EXCHANGE_TEST_CONFIG: {
+    def: false,
+    parser: boolParser,
+    desc: "mock the cryptoassets config and test partner (in the context of app-exchange)",
+  },
+  MOCK_EXCHANGE_TEST_PARTNER: {
+    def: false,
+    parser: boolParser,
+    desc: "change CAL partner context to test",
+  },
+  EXPERIMENTAL_SWAP: {
+    def: false,
+    parser: boolParser,
+    desc: "enable an experimental swap interface",
+  },
+  BUY_API_BASE: {
+    def: "https://buy.api.live.ledger.com/buy/v1",
+    parser: stringParser,
+    desc: "Buy crypto API base url - version 1",
+  },
+  SELL_API_BASE: {
+    def: "https://buy.api.live.ledger.com/sell/v1",
+    parser: stringParser,
+    desc: "Sell crypto API base url - version 1",
+  },
+  PROVIDER_SESSION_ID_ENDPOINT: {
+    def: "https://buy.api.live.ledger.com/session",
+    parser: stringParser,
+    desc: "Request provider session id",
+  },
+};
+
+export default teamPtx;

--- a/shared/env/src/definitions/team-qaa/index.ts
+++ b/shared/env/src/definitions/team-qaa/index.ts
@@ -1,0 +1,21 @@
+import { boolParser, stringParser } from "@ledgerhq/live-env";
+
+const teamQaa = {
+  DETOX: {
+    def: "",
+    parser: stringParser,
+    desc: "switch the app into a DETOX mode for test purpose. Avoid falsy values.",
+  },
+  PLAYWRIGHT_RUN: {
+    def: false,
+    parser: boolParser,
+    desc: "true when launched for E2E testing",
+  },
+  E2E_NANO_APP_VERSION_PATH: {
+    def: "",
+    parser: stringParser,
+    desc: "Path for e2e nanoApp version artifacts (LLD and LLM)",
+  },
+};
+
+export default teamQaa;

--- a/shared/env/src/definitions/team-wallet-xp/index.ts
+++ b/shared/env/src/definitions/team-wallet-xp/index.ts
@@ -1,0 +1,91 @@
+import { intParser, boolParser, stringParser, stringArrayParser } from "@ledgerhq/live-env";
+
+const teamWalletXp = {
+  LEDGER_COUNTERVALUES_API: {
+    def: "https://countervalues.live.ledger.com",
+    parser: stringParser,
+    desc: "Ledger countervalues API",
+  },
+  LEDGER_COUNTERVALUES_API_STAGING: {
+    def: "https://countervalues-service.api.ledger-test.com",
+    parser: stringParser,
+    desc: "Ledger countervalues API (staging)",
+  },
+  DADA_API_STAGING: {
+    def: "https://dada.api.ledger-test.com/v1",
+    parser: stringParser,
+    desc: "Dynamic Assets Data Aggregator API Staging",
+  },
+  DADA_API_PROD: {
+    def: "https://dada.api.ledger.com/v1",
+    parser: stringParser,
+    desc: "Dynamic Assets Data Aggregator API Prod",
+  },
+  CMC_API_URL: {
+    def: "https://proxycmc.api.live.ledger.com/v3",
+    parser: stringParser,
+    desc: "CoinMarketCap API",
+  },
+  COINGECKO_API_URL: {
+    def: "https://proxycg.api.live.ledger.com/api/v3",
+    parser: stringParser,
+    desc: "Coingecko API",
+  },
+  MAPPING_SERVICE: {
+    def: "https://mapping-service.api.ledger.com",
+    parser: stringParser,
+    desc: "",
+  },
+  MAX_ACCOUNT_NAME_SIZE: {
+    def: 50,
+    parser: intParser,
+    desc: "maximum size of account names",
+  },
+  BIG_NUMBER_DECIMAL_PLACES: {
+    def: 40,
+    parser: intParser,
+    desc: "bignumber.js decimal places configuration",
+  },
+  CRYPTO_ASSET_SEARCH_KEYS: {
+    def: ["ticker", "name", "keywords"],
+    parser: stringArrayParser,
+    desc: "Fuse search attributes to find a currency according to user input",
+  },
+  DEBUG_THEME: {
+    def: false,
+    parser: boolParser,
+    desc: "Show theme debug overlay UI",
+  },
+  MOCK_COUNTERVALUES: {
+    def: "",
+    parser: stringParser,
+    desc: "switch the countervalues resolution into a MOCK mode for test purpose",
+  },
+  HIDE_EMPTY_TOKEN_ACCOUNTS: {
+    def: false,
+    parser: boolParser,
+    desc: "hide the sub accounts when they are empty",
+  },
+  SHOW_LEGACY_NEW_ACCOUNT: {
+    def: false,
+    parser: boolParser,
+    desc: "allow the creation of legacy accounts",
+  },
+  LW_ICONS_AVATARS_CDN_BASE_URL: {
+    def: "https://lw-icons.ledger.com/cdn/Avatars/v1/192x192",
+    parser: stringParser,
+    desc: "Base URL for Ledger Wallet icons CDN",
+  },
+  EXPERIMENTAL_LANGUAGES: {
+    def: false,
+    parser: boolParser,
+    desc: "enable experimental languages",
+  },
+  EXPERIMENTAL_ROI_CALCULATION: {
+    def: false,
+    parser: boolParser,
+    desc: "enable an experimental version of the portfolio percentage calculation",
+  },
+};
+
+export default teamWalletXp;

--- a/shared/env/src/index.ts
+++ b/shared/env/src/index.ts
@@ -1,1 +1,4 @@
+import { allDefinitions } from "./definitions";
+void allDefinitions; // will be replaced by injectDefinitions(allDefinitions) in follow-up PR
+
 export * from "@ledgerhq/live-env";


### PR DESCRIPTION
### 📝 Description

Adds `shared/env/src/definitions/` — a set of per-team env variable declarations organized by team folder (team-coin-integration, team-ptx, team-platform, etc.).

This is a **preparatory PR**. The files are inert at this stage: `@shared/env` does not yet import from `./definitions`. The follow-up PR will wire these definitions into `injectDefinitions()` inside `@shared/env/src/index.ts` and migrate all consumers from `@ledgerhq/live-env` to `@shared/env`.

### 🔗 Context

- **JIRA / GitHub issue**: follow-up to #19748
- **ADR** (if any): N/A