### PR TITLE
[LWDM] feat(shared/env): migrate internal consumers from @ledgerhq/live-env to @shared/env

### DIFF
--- a/e2e/desktop/tests/utils/global.setup.ts
+++ b/e2e/desktop/tests/utils/global.setup.ts
@@ -1,3 +1,4 @@
+import "@shared/env";
 import { parseExtraFeatureFlags } from "@ledgerhq/live-e2e-shared/featureFlagsJsonUtils";
 import { FullConfig } from "@playwright/test";
 import { execFileSync } from "node:child_process";

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -1,3 +1,4 @@
+import "@shared/env";
 import {
   cleanupAllSpeculos,
   attachSpeculinhoLogsToAllure,

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -62,7 +62,6 @@
     "@ledgerhq/hw-transport-mocker": "workspace:*",
     "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:*",
     "@ledgerhq/ledger-auth": "workspace:*",
-    "@ledgerhq/live-env": "workspace:*",
     "@ledgerhq/live-network": "workspace:*",
     "@ledgerhq/logs": "workspace:*",
     "@ledgerhq/speculos-transport": "workspace:*",

--- a/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/integration/mock.sdk.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { RecordStore, TransportReplayer } from "@ledgerhq/hw-transport-mocker";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 import { ScenarioOptions } from "../../../tests/test-helpers/types";
 import { getSdk } from "../..";
 import { WithDevice } from "../../types";

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
@@ -9,7 +9,7 @@ import {
   SoftwareDevice,
   StreamTree,
 } from "@ledgerhq/hw-ledger-key-ring-protocol";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { PutCommandsRequest } from "../../api";
 import { HWDeviceProvider } from "../../HWDeviceProvider";
 import { SDK } from "../../sdk";

--- a/libs/ledger-key-ring-protocol/tests/scenarios/tokenExpires.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/tokenExpires.ts
@@ -1,7 +1,7 @@
 import { ScenarioOptions } from "../test-helpers/types";
 import { HWDeviceProvider } from "../../src/HWDeviceProvider";
 import { SDK } from "../../src/sdk";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export async function scenario(deviceId: string, { withDevice, pauseRecorder }: ScenarioOptions) {
   const apiBaseUrl = getEnv("TRUSTCHAIN_API_STAGING");

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/recordTrustchainSdkTests.ts
@@ -5,7 +5,7 @@ import { RecordStore } from "@ledgerhq/hw-transport-mocker";
 import { createSpeculosDevice, releaseSpeculosDevice } from "@ledgerhq/speculos-transport";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { crypto, TRUSTCHAIN_APP_NAME } from "@ledgerhq/hw-ledger-key-ring-protocol";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
 import { RecorderConfig, ScenarioOptions, genSeed, recorderConfigDefaults } from "./types";
 import { getSdk } from "../../src";

--- a/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
+++ b/libs/ledger-key-ring-protocol/tests/test-helpers/replayTrustchainSdkTests.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { openTransportReplayer, RecordStore } from "@ledgerhq/hw-transport-mocker";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
 import { ScenarioOptions } from "./types";
 import { getSdk } from "../../src";

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -337,7 +337,6 @@
     "@ledgerhq/live-countervalues-react": "workspace:^",
     "@ledgerhq/live-currency-format": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
-    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-hooks": "workspace:*",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/live-promise": "workspace:^",
@@ -410,11 +409,13 @@
     "winston": "^3.4.0",
     "xstate": "catalog:",
     "yargs": "^17.0.0",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@shared/env": "workspace:*"
   },
   "devDependencies": {
     "@features/platform-currencies": "workspace:^",
     "@ledgerhq/device-react": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",

--- a/libs/ledger-live-common/src/__tests__/csvExport.ts
+++ b/libs/ledger-live-common/src/__tests__/csvExport.ts
@@ -1,5 +1,5 @@
 import "./test-helpers/staticTime";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { genAccount } from "../mock/account";
 import { getCryptoCurrencyById, getFiatCurrencyByTicker } from "../currencies";
 import { accountsOpToCSV } from "../csvExport";

--- a/libs/ledger-live-common/src/__tests__/mock-bridges.ts
+++ b/libs/ledger-live-common/src/__tests__/mock-bridges.ts
@@ -4,7 +4,7 @@ import groupBy from "lodash/groupBy";
 import { reduce, filter, map } from "rxjs/operators";
 import "./test-helpers/setup";
 import { getAccountBridge, getCurrencyBridge } from "../bridge";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { getCryptoCurrencyById } from "../currencies";
 import { toAccountRaw, flattenAccounts } from "../account";
 import type { Account, CurrencyBridge } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/__tests__/mocks/account.ts
+++ b/libs/ledger-live-common/src/__tests__/mocks/account.ts
@@ -1,7 +1,7 @@
 import "../test-helpers/staticTime";
 import { genAccount } from "../../mock/account";
 import { getBalanceHistory } from "@ledgerhq/live-countervalues/portfolio";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 
 test("generate an account from seed", () => {
   const a = genAccount("seed");

--- a/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/environment.ts
@@ -1,5 +1,5 @@
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { EnvName, setEnv, setEnvUnsafe } from "@ledgerhq/live-env";
+import { EnvName, setEnv, setEnvUnsafe } from "@shared/env";
 import { listen } from "@ledgerhq/logs";
 import winston from "winston";
 import { liveConfig } from "../../config/sharedConfig";

--- a/libs/ledger-live-common/src/__tests__/user.ts
+++ b/libs/ledger-live-common/src/__tests__/user.ts
@@ -1,5 +1,5 @@
 import { getUserHashes } from "../user";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 test("stable user", () => {
   expect(getUserHashes(getEnv("USER_ID"))).toMatchSnapshot();
 });

--- a/libs/ledger-live-common/src/api/ofacGeoBlockApi.ts
+++ b/libs/ledger-live-common/src/api/ofacGeoBlockApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const ofacGeoBlockApi = createApi({
   reducerPath: "ofacGeoBlockApi",

--- a/libs/ledger-live-common/src/apps/logic.test.ts
+++ b/libs/ledger-live-common/src/apps/logic.test.ts
@@ -18,7 +18,7 @@ import {
   mockExecWithInstalledContext,
 } from "./mock";
 // import { prettyActionPlan, prettyInstalled } from "./formatting";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { Action } from "./types";
 import { firstValueFrom } from "rxjs";
 import { DeviceModelId } from "@ledgerhq/devices";

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -7,7 +7,7 @@ import { AppOp, State, Action, ListAppsResult, AppsDistribution, SkipReason } fr
 import { findCryptoCurrency, findCryptoCurrencyById, isCurrencySupported } from "../currencies";
 import { NoSuchAppOnProvider } from "../errors";
 import { App } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 
 const RESERVED_BLOCKS = 1;

--- a/libs/ledger-live-common/src/apps/runner.ts
+++ b/libs/ledger-live-common/src/apps/runner.ts
@@ -12,7 +12,7 @@ import {
 import type { Exec, State, AppOp, RunnerEvent, Action } from "./types";
 import { reducer, getActionPlan, getNextAppOp } from "./logic";
 import { delay } from "../promise";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const runAppOp = ({
   state,

--- a/libs/ledger-live-common/src/apps/support.ts
+++ b/libs/ledger-live-common/src/apps/support.ts
@@ -1,7 +1,7 @@
 import semver from "semver";
 import { shouldUseTrustedInputForSegwit } from "@ledgerhq/hw-app-btc/shouldUseTrustedInputForSegwit";
 import { getDependencies } from "./polyfill";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { DeviceModelId } from "@ledgerhq/device-management-kit";
 

--- a/libs/ledger-live-common/src/bridge/cache.test.ts
+++ b/libs/ledger-live-common/src/bridge/cache.test.ts
@@ -1,7 +1,7 @@
 import * as cacheModule from "@ledgerhq/live-network/cache";
 import { makeBridgeCacheSystem } from "./cache";
 import { getCryptoCurrencyById } from "../currencies";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { loadMockBridgeForFamily } from "../coin-modules/registry";
 
 describe("Bridge Cache", () => {

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -4,7 +4,7 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { CurrencyNotSupported } from "@ledgerhq/errors";
 import { decodeAccountId, getMainAccount, checkAccountSupported } from "../account";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import {
   Account,

--- a/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
+++ b/libs/ledger-live-common/src/bridge/react/BridgeSync.tsx
@@ -6,7 +6,7 @@ import { ignoreElements } from "rxjs/operators";
 import React, { useEffect, useCallback, useState, useRef, useMemo } from "react";
 import { isUpToDateAccount, getAccountCurrency } from "../../account";
 import { getAccountBridge } from "..";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { SyncAction, SyncState, BridgeSyncState } from "./types";
 import { BridgeSyncContext, BridgeSyncStateContext } from "./context";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/useBridgeTransaction.test.ts
@@ -13,7 +13,7 @@ import useBridgeTransaction, {
   shouldSyncBeforeTx,
 } from "./useBridgeTransaction";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 
 const BTC = getCryptoCurrencyById("bitcoin");
 

--- a/libs/ledger-live-common/src/cg-client/api/index.ts
+++ b/libs/ledger-live-common/src/cg-client/api/index.ts
@@ -1,5 +1,5 @@
 import network from "@ledgerhq/live-network";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import {
   MarketCurrencyChartDataRequestParams,
   MarketCoinDataChart,

--- a/libs/ledger-live-common/src/cg-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/cg-client/state-manager/api.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { log } from "@ledgerhq/logs";
 import { SupportedCoins } from "../utils/types";
 import { GcDataTags, SupportedCoinsSchema, SupportedCounterCurrenciesSchema } from "./types";

--- a/libs/ledger-live-common/src/counterValues/state-manager/api.ts
+++ b/libs/ledger-live-common/src/counterValues/state-manager/api.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 import {
   Tags,

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
@@ -5,9 +5,9 @@ import {
 } from "../api";
 import { AssetCategory } from "../types";
 import type { RawApiResponse } from "../../entities";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn().mockReturnValue("https://dada.api.ledger.com/v1"),
 }));
 

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -10,6 +10,18 @@ import type { CryptoOrTokenCurrency, CryptoCurrencyId } from "@ledgerhq/types-cr
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { convertApiToken } from "@domain/api-currency-token";
 import { RawApiResponse, AssetsData } from "../entities";
+import { getEnv } from "@shared/env";
+import {
+  AssetsAdditionalData,
+  AssetsDataTags,
+  AssetsDataWithPagination,
+  GetAssetsDataParams,
+  GetAssetsByCategoryParams,
+  ONE_DAY_IN_SECONDS,
+  PageParam,
+} from "./types";
+import { chunkCurrencyIds } from "../utils/chunkCurrencyIds";
+import { deepMergeCryptoAssets } from "../utils/deepMergeCryptoAssets";
 
 function convertApiAssets(
   apiAssets: Record<string, ApiAsset>,
@@ -46,18 +58,6 @@ function convertApiAssets(
   }
   return result;
 }
-import { getEnv } from "@ledgerhq/live-env";
-import {
-  AssetsAdditionalData,
-  AssetsDataTags,
-  AssetsDataWithPagination,
-  GetAssetsDataParams,
-  GetAssetsByCategoryParams,
-  ONE_DAY_IN_SECONDS,
-  PageParam,
-} from "./types";
-import { chunkCurrencyIds } from "../utils/chunkCurrencyIds";
-import { deepMergeCryptoAssets } from "../utils/deepMergeCryptoAssets";
 
 const ALLOWED_DADA_HOSTS = new Set(["dada.api.ledger.com", "dada.api.ledger-test.com"]);
 

--- a/libs/ledger-live-common/src/deposit/api.ts
+++ b/libs/ledger-live-common/src/deposit/api.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import network from "@ledgerhq/live-network";
 import { MappedAsset } from "./type";
 

--- a/libs/ledger-live-common/src/device/factories/HttpManagerApiRepositoryFactory.ts
+++ b/libs/ledger-live-common/src/device/factories/HttpManagerApiRepositoryFactory.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { version } from "../../../package.json";
 import { HttpManagerApiRepository } from "@ledgerhq/device-core";
 

--- a/libs/ledger-live-common/src/device/hooks/useLatestFirmware.ts
+++ b/libs/ledger-live-common/src/device/hooks/useLatestFirmware.ts
@@ -1,5 +1,5 @@
 import { getProviderId } from "../../manager/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { useGetLatestFirmware } from "@ledgerhq/device-react";
 import { HttpManagerApiRepositoryFactory } from "../factories/HttpManagerApiRepositoryFactory";
 import { DeviceInfoEntity, HttpManagerApiRepository } from "@ledgerhq/device-core";

--- a/libs/ledger-live-common/src/device/use-cases/getLatestFirmwareForDeviceUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/getLatestFirmwareForDeviceUseCase.ts
@@ -1,7 +1,7 @@
 // From libs/ledger-live-common/src/manager/api.ts
 import { DeviceInfo } from "@ledgerhq/types-live";
 import { getProviderId } from "../../manager/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { HttpManagerApiRepositoryFactory } from "../factories/HttpManagerApiRepositoryFactory";
 import { type ManagerApiRepository, getLatestFirmwareForDevice } from "@ledgerhq/device-core";
 

--- a/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.test.ts
+++ b/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.test.ts
@@ -9,8 +9,8 @@ jest.mock("../../apps/listApps", () => ({
   listApps: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-env", () => {
-  const actual = jest.requireActual("@ledgerhq/live-env");
+jest.mock("@shared/env", () => {
+  const actual = jest.requireActual("@shared/env");
   const { getEnv } = actual;
   return {
     ...actual,

--- a/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
+++ b/libs/ledger-live-common/src/device/use-cases/listAppsUseCase.ts
@@ -3,7 +3,7 @@ import Transport from "@ledgerhq/hw-transport";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import { listApps } from "../../apps/listApps";
 import { ListAppsEvent } from "../../apps";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { HttpManagerApiRepositoryFactory } from "../factories/HttpManagerApiRepositoryFactory";
 import { ManagerApiRepository } from "@ledgerhq/device-core";

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/flashMcuOrBootloader.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/flashMcuOrBootloader.ts
@@ -3,7 +3,7 @@ import URL from "url";
 import Transport from "@ledgerhq/hw-transport";
 import type { DeviceInfo, SocketEvent } from "@ledgerhq/types-live";
 import { version as livecommonversion } from "../../../../package.json";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LocalTracer } from "@ledgerhq/logs";
 import { createDeviceSocket } from "../../../socket";
 import { filter, map } from "rxjs/operators";

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
@@ -3,7 +3,7 @@ import URL from "url";
 import Transport from "@ledgerhq/hw-transport";
 import type { FinalFirmware, OsuFirmware, DeviceInfo, SocketEvent } from "@ledgerhq/types-live";
 import { version as livecommonversion } from "../../../../package.json";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LocalTracer } from "@ledgerhq/logs";
 import { createDeviceSocket } from "../../../socket";
 import { catchError, filter, map } from "rxjs/operators";

--- a/libs/ledger-live-common/src/deviceSDK/commands/genuineCheck.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/genuineCheck.ts
@@ -3,7 +3,7 @@ import URL from "url";
 import Transport from "@ledgerhq/hw-transport";
 import type { DeviceInfo, SocketEvent } from "@ledgerhq/types-live";
 import { version as livecommonversion } from "../../../package.json";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { createMockSocket, resultMock, secureChannelMock } from "../../socket/socket.mock";
 import { log } from "@ledgerhq/logs";
 import { createDeviceSocket } from "../../socket";

--- a/libs/ledger-live-common/src/exchange/index.test.ts
+++ b/libs/ledger-live-common/src/exchange/index.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import calService from "@ledgerhq/ledger-cal-service";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { getCurrencyExchangeConfig } from ".";
 
 jest.mock("@ledgerhq/ledger-cal-service", () => ({
@@ -9,8 +9,8 @@ jest.mock("@ledgerhq/ledger-cal-service", () => ({
   default: { findCurrencyData: jest.fn() },
 }));
 
-jest.mock("@ledgerhq/live-env", () => ({
-  ...jest.requireActual("@ledgerhq/live-env"),
+jest.mock("@shared/env", () => ({
+  ...jest.requireActual("@shared/env"),
   getEnv: jest.fn(),
 }));
 

--- a/libs/ledger-live-common/src/exchange/index.ts
+++ b/libs/ledger-live-common/src/exchange/index.ts
@@ -1,6 +1,6 @@
 import { valid, gte } from "semver";
 import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import calService from "@ledgerhq/ledger-cal-service";
 // Minimum version of a currency app which has exchange capabilities, meaning it can be used
 // for sell/swap, and do silent signing.

--- a/libs/ledger-live-common/src/exchange/providers/index.ts
+++ b/libs/ledger-live-common/src/exchange/providers/index.ts
@@ -2,7 +2,7 @@ import { ExchangeTypes, PartnerKeyInfo } from "@ledgerhq/hw-app-exchange";
 import { getSwapProvider, getAvailableProviders } from "./swap";
 import { getSellProvider } from "./sell";
 import { getFundProvider } from "./fund";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export { getSwapProvider, getAvailableProviders };
 

--- a/libs/ledger-live-common/src/exchange/providers/swap.ts
+++ b/libs/ledger-live-common/src/exchange/providers/swap.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { getTestProviderInfo, type ExchangeProviderNameAndSignature } from ".";
 import calService, { SWAP_DATA_CDN } from "@ledgerhq/ledger-cal-service";
 import { isIntegrationTestEnv } from "../swap/utils/isIntegrationTestEnv";

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyAll.ts
@@ -6,7 +6,7 @@ import { ResponseData as ResponseDataTo } from "./fetchCurrencyTo";
 import { ResponseData as ResponseDataFrom } from "./fetchCurrencyFrom";
 import { flattenV5CurrenciesAll } from "../../utils/flattenV5CurrenciesAll";
 import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 type Props = {
   baseUrl?: string;

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/fetchCurrencyFrom.ts
@@ -3,7 +3,7 @@ import { DEFAULT_SWAP_TIMEOUT_MS } from "../../const/timeout";
 import { flattenV5CurrenciesToAndFrom } from "../../utils/flattenV5CurrenciesToAndFrom";
 import { fetchCurrencyFromMock } from "./__mocks__/fetchCurrencyFrom.mocks";
 import { getSwapAPIBaseURL, getSwapUserIP } from "../..";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 type Props = {
   baseUrl?: string;

--- a/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/v5/useFilteredProviders.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { fetchAndMergeProviderData, getDefaultSwapProviderKeys } from "../../../providers/swap";
 import { useFeature } from "@features/platform-feature-flags";

--- a/libs/ledger-live-common/src/exchange/swap/index.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.test.ts
@@ -1,6 +1,6 @@
 import { isSwapOperationPending, getSwapAPIVersion } from ".";
 
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 
 describe("swap/index", () => {
   describe("isSwapOperationPending", () => {

--- a/libs/ledger-live-common/src/exchange/swap/index.ts
+++ b/libs/ledger-live-common/src/exchange/swap/index.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { TransactionStatus } from "@ledgerhq/wallet-api-exchange-module";
 import {
   AccessDeniedError,

--- a/libs/ledger-live-common/src/exchange/swap/setBroadcastTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/setBroadcastTransaction.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { Operation } from "@ledgerhq/types-live";
 import { postSwapAccepted, postSwapCancelled } from "./index";
 import { DeviceModelId } from "@ledgerhq/devices";

--- a/libs/ledger-live-common/src/exchange/swap/utils/isIntegrationTestEnv.ts
+++ b/libs/ledger-live-common/src/exchange/swap/utils/isIntegrationTestEnv.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const isIntegrationTestEnv = () => getEnv("MOCK") && !getEnv("PLAYWRIGHT_RUN");
 export const isSwapDisableAppsInstall = () => getEnv("SWAP_DISABLE_APPS_INSTALL");

--- a/libs/ledger-live-common/src/explorer.ts
+++ b/libs/ledger-live-common/src/explorer.ts
@@ -1,5 +1,5 @@
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 type LedgerExplorer = {
   version: string;

--- a/libs/ledger-live-common/src/families/aleo/config.ts
+++ b/libs/ledger-live-common/src/families/aleo/config.ts
@@ -1,7 +1,7 @@
 import { TRANSACTION_TYPE } from "@ledgerhq/coin-aleo/constants";
 import type { RecordPickingStrategy, TransactionType } from "@ledgerhq/coin-aleo/types";
 import type { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 // API for fee estimation is not available yet, so for MVP we are using static fee configuration.
 // source of hardcoded values: https://ledgerhq.atlassian.net/wiki/spaces/BI/pages/6218678344/ARCH+-+Aleo+integration+HLD

--- a/libs/ledger-live-common/src/families/algorand/setup.ts
+++ b/libs/ledger-live-common/src/families/algorand/setup.ts
@@ -12,7 +12,7 @@ import type {
 import Algorand from "@ledgerhq/hw-app-algorand";
 import Transport from "@ledgerhq/hw-transport";
 import { Bridge } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
 import type { Resolver } from "../../hw/getAddress/types";
 

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/operation.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/operation.test.ts
@@ -1,11 +1,11 @@
 import type { Account, AccountLike, Operation } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { isEditableOperation, isStuckOperation, getStuckAccountAndOperation } from "./operation";
 
 // Deterministic stuck-timeout threshold, decoupled from the real env default.
 const STUCK_TIMEOUT = 20 * 60 * 1000;
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn(),
 }));
 

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/operation.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/operation.ts
@@ -1,5 +1,5 @@
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import invariant from "invariant";
 

--- a/libs/ledger-live-common/src/families/canton/setup.ts
+++ b/libs/ledger-live-common/src/families/canton/setup.ts
@@ -1,7 +1,7 @@
 // Goal of this file is to inject all necessary device/signer dependency to coin-modules
 
 import { createBridges } from "@ledgerhq/coin-canton/bridge/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import Transport from "@ledgerhq/hw-transport";
 import { CantonSigner } from "@ledgerhq/coin-canton";
 import cantonResolver from "@ledgerhq/coin-canton/signer";

--- a/libs/ledger-live-common/src/families/cosmos/react.test.ts
+++ b/libs/ledger-live-common/src/families/cosmos/react.test.ts
@@ -7,7 +7,7 @@ import cryptoFactory from "@ledgerhq/coin-cosmos/chain/chain";
 import { getCurrentCosmosPreloadData } from "@ledgerhq/coin-cosmos/preloadedData";
 import preloadedMockData from "@ledgerhq/coin-cosmos/preloadedData.mock";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { CurrencyBridge } from "@ledgerhq/types-live";
 import { act, renderHook } from "@testing-library/react";
 import "../../__tests__/test-helpers/dom-polyfill";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getMinEditTransactionFees.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getMinEditTransactionFees.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { BigNumber } from "bignumber.js";
 import type { Transaction } from "@ledgerhq/coin-evm/types/transaction";
 

--- a/libs/ledger-live-common/src/families/evm/editTransaction/hasMinimumFunds.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/hasMinimumFunds.test.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getCoinConfig } from "@ledgerhq/coin-evm/config";
@@ -6,7 +6,7 @@ import type { Transaction } from "@ledgerhq/coin-evm/types/index";
 import { getEstimatedFees } from "@ledgerhq/coin-evm/utils";
 import { hasMinimumFundsToCancel, hasMinimumFundsToSpeedUp } from "./hasMinimumFunds";
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn(),
 }));
 jest.mock("@ledgerhq/coin-evm/logic");

--- a/libs/ledger-live-common/src/families/evm/editTransaction/hasMinimumFunds.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/hasMinimumFunds.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import type { Transaction } from "@ledgerhq/coin-evm/types/index";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/operation.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/operation.ts
@@ -2,7 +2,7 @@ import {
   findSubAccountById,
   getMainAccount,
 } from "@ledgerhq/ledger-wallet-framework/account/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import invariant from "invariant";

--- a/libs/ledger-live-common/src/families/evm/signer.ts
+++ b/libs/ledger-live-common/src/families/evm/signer.ts
@@ -8,7 +8,7 @@ import {
   type EvmSigner,
 } from "@ledgerhq/live-signer-evm";
 import Transport from "@ledgerhq/hw-transport";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { ResolutionConfig, LoadConfig } from "@ledgerhq/hw-app-eth/services/types";
 import { Signature } from "ethers";
 import type { DomainServiceResolution } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/hedera/config.ts
+++ b/libs/ledger-live-common/src/families/hedera/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const hederaConfig: Record<string, ConfigInfo> = {
   config_currency_hedera: {

--- a/libs/ledger-live-common/src/families/hedera/exchange.ts
+++ b/libs/ledger-live-common/src/families/hedera/exchange.ts
@@ -3,7 +3,7 @@ import Exchange from "@ledgerhq/hw-app-exchange";
 import { loadPKI } from "@ledgerhq/hw-bolos";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Account } from "@ledgerhq/types-live";
 

--- a/libs/ledger-live-common/src/families/icon/setup.ts
+++ b/libs/ledger-live-common/src/families/icon/setup.ts
@@ -9,7 +9,7 @@ import type { Bridge } from "@ledgerhq/types-live";
 import { CreateSigner, createResolver, executeWithSigner } from "../../bridge/setup";
 import type { Resolver } from "../../hw/getAddress/types";
 import { IconCoinConfig } from "@ledgerhq/coin-icon/config";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 const createSigner: CreateSigner<Icon> = (transport: Transport) => {
   return new Icon(transport);

--- a/libs/ledger-live-common/src/families/polkadot/config.ts
+++ b/libs/ledger-live-common/src/families/polkadot/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const polkadotConfig: Record<string, ConfigInfo> = {
   config_currency_polkadot: {

--- a/libs/ledger-live-common/src/families/solana/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/mock.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { ChainAPI, Config, getChainAPI, logged } from "@ledgerhq/coin-solana/network/index";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { Functions } from "@ledgerhq/coin-solana/utils";
 import { makeBridges } from "@ledgerhq/coin-solana/bridge/bridge";
 import { PubKeyDisplayMode, SolanaSigner } from "@ledgerhq/coin-solana/signer";

--- a/libs/ledger-live-common/src/families/solana/react.integration.test.ts
+++ b/libs/ledger-live-common/src/families/solana/react.integration.test.ts
@@ -3,7 +3,7 @@
  */
 import "../../__tests__/test-helpers/dom-polyfill";
 import { renderHook } from "@testing-library/react";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import type { Account, CurrencyBridge } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/coin-solana/types";
 import { getCurrentSolanaPreloadData } from "@ledgerhq/coin-solana/preload-data";

--- a/libs/ledger-live-common/src/families/stellar/config.ts
+++ b/libs/ledger-live-common/src/families/stellar/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const stellarConfig: Record<string, ConfigInfo> = {
   config_currency_stellar: {

--- a/libs/ledger-live-common/src/families/sui/config.ts
+++ b/libs/ledger-live-common/src/families/sui/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 // `features.graphql` is intentionally NOT defaulted here — it's an app-level
 // runtime concern owned by the `suiGraphqlTransport` feature flag and

--- a/libs/ledger-live-common/src/families/tezos/config.ts
+++ b/libs/ledger-live-common/src/families/tezos/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const tezosConfig: Record<string, ConfigInfo> = {
   config_currency_tezos: {

--- a/libs/ledger-live-common/src/families/tron/config.ts
+++ b/libs/ledger-live-common/src/families/tron/config.ts
@@ -1,5 +1,5 @@
 import { ConfigInfo } from "@ledgerhq/live-config/LiveConfig";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export const tronConfig: Record<string, ConfigInfo> = {
   config_currency_tron: {

--- a/libs/ledger-live-common/src/firebase/featureFlags.ts
+++ b/libs/ledger-live-common/src/firebase/featureFlags.ts
@@ -1,5 +1,5 @@
 import semver from "semver";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { formatToFirebaseFeatureId } from "@features/platform-feature-flags";
 import type { Feature, FeatureId, Features } from "@shared/feature-flags";

--- a/libs/ledger-live-common/src/hooks/useAddressPoisoningOperationsFamilies.test.ts
+++ b/libs/ledger-live-common/src/hooks/useAddressPoisoningOperationsFamilies.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { renderHook } from "@testing-library/react";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import * as featureFlags from "@features/platform-feature-flags";
 import { useAddressPoisoningOperationsFamilies } from "./useAddressPoisoningOperationsFamilies";
 
@@ -11,7 +11,7 @@ jest.mock("@features/platform-feature-flags", () => ({
   ...jest.requireActual("@features/platform-feature-flags"),
   useFeature: jest.fn(),
 }));
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn(),
 }));
 

--- a/libs/ledger-live-common/src/hooks/useAddressPoisoningOperationsFamilies.ts
+++ b/libs/ledger-live-common/src/hooks/useAddressPoisoningOperationsFamilies.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { useFeature } from "@features/platform-feature-flags";
 import { useMemo } from "react";
 

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -3,7 +3,7 @@
  */
 // oxlint-disable typescript/consistent-type-assertions
 import { act, renderHook } from "@testing-library/react";
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import { getAccountBridge } from "../bridge/index";
 import { useBroadcast } from "./useBroadcast";
 

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -9,7 +9,7 @@ import type {
   TransactionSource,
   TransactionCommon,
 } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { formatOperation, getMainAccount } from "../account/index";
 import { getAccountBridge } from "../bridge/index";
 import { execAndWaitAtLeast } from "../promise";

--- a/libs/ledger-live-common/src/hooks/useManifestWithSessionId.ts
+++ b/libs/ledger-live-common/src/hooks/useManifestWithSessionId.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { appendQueryParamsToManifestURL } from "../wallet-api/utils/appendQueryParamsToManifestURL";
 import { LiveAppManifest } from "../platform/types";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 type Options = {
   manifest: LiveAppManifest | null | undefined;

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -21,7 +21,7 @@ import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { ConnectManagerTimeout } from "../../errors";
 import { LocalTracer } from "@ledgerhq/logs";
 import { LOG_TYPE } from "..";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export enum ImplementationType {
   event = "enum",

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -8,7 +8,7 @@ import {
   DeviceHalted,
 } from "@ledgerhq/errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { open, close, OpenOptions } from ".";
 
 const LOG_TYPE = "hw";

--- a/libs/ledger-live-common/src/load/speculos.ts
+++ b/libs/ledger-live-common/src/load/speculos.ts
@@ -8,7 +8,7 @@ import { promises as fsp } from "fs";
 import { log } from "@ledgerhq/logs";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import { registerTransportModule } from "../hw";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { getDependencies } from "../apps/polyfill";
 import { findCryptoCurrencyByKeyword } from "../currencies";
 import { mustUpgrade, shouldUpgrade } from "../apps";

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -31,7 +31,7 @@ import { catchError, map } from "rxjs/operators";
 import semver from "semver";
 import URL from "url";
 import { version as livecommonversion } from "../../package.json";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { createDeviceSocket } from "../socket";
 import {
   bulkSocketMock,

--- a/libs/ledger-live-common/src/manager/provider.ts
+++ b/libs/ledger-live-common/src/manager/provider.ts
@@ -1,5 +1,5 @@
 import type { DeviceInfo } from "@ledgerhq/types-live";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { getProviderIdUseCase } from "../device/use-cases/getProviderIdUseCase";
 
 export { PROVIDERS } from "../device/use-cases/getProviderIdUseCase";

--- a/libs/ledger-live-common/src/market/api/countervalues.test.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.test.ts
@@ -7,7 +7,7 @@ jest.mock("@ledgerhq/live-network", () => ({
   default: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn((key: string) => {
     if (key === "LEDGER_COUNTERVALUES_API") return "https://countervalues.example.com";
     return "";

--- a/libs/ledger-live-common/src/market/api/countervalues.ts
+++ b/libs/ledger-live-common/src/market/api/countervalues.ts
@@ -1,5 +1,5 @@
 import network from "@ledgerhq/live-network";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import {
   MarketListRequestParams,
   MarketItemResponse,

--- a/libs/ledger-live-common/src/market/state-manager/marketApi.ts
+++ b/libs/ledger-live-common/src/market/state-manager/marketApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { log } from "@ledgerhq/logs";
 import {
   MarketAssetChartDataRequestParams,

--- a/libs/ledger-live-common/src/network-troubleshooting/index.ts
+++ b/libs/ledger-live-common/src/network-troubleshooting/index.ts
@@ -2,7 +2,7 @@ import { WebsocketConnectionError } from "@ledgerhq/errors";
 import axios from "axios";
 import WS from "isomorphic-ws";
 import { Observable } from "rxjs";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import serviceStatusApi from "../notifications/ServiceStatusProvider/api/api";
 
 export type TroubleshootStatus = {

--- a/libs/ledger-live-common/src/network/setup.test.ts
+++ b/libs/ledger-live-common/src/network/setup.test.ts
@@ -1,11 +1,11 @@
-import { getEnv, changes } from "@ledgerhq/live-env";
+import { getEnv, changes } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
 import { bridgeEnvToNetworkState } from "./setup";
 
 const mockUnsubscribe = jest.fn();
 const mockSubscribe = jest.fn().mockReturnValue({ unsubscribe: mockUnsubscribe });
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn().mockImplementation((name: string) => {
     const envValues: Record<string, unknown> = {
       ENABLE_NETWORK_LOGS: false,

--- a/libs/ledger-live-common/src/network/setup.ts
+++ b/libs/ledger-live-common/src/network/setup.ts
@@ -1,4 +1,4 @@
-import { getEnv, changes } from "@ledgerhq/live-env";
+import { getEnv, changes } from "@shared/env";
 import { setNetworkState } from "@ledgerhq/live-network";
 
 /**

--- a/libs/ledger-live-common/src/notifications/ServiceStatusProvider/api/api.ts
+++ b/libs/ledger-live-common/src/notifications/ServiceStatusProvider/api/api.ts
@@ -1,5 +1,5 @@
 import network from "@ledgerhq/live-network";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { ServiceStatusApi, ServiceStatusSummary } from "../types";
 
 const baseStatusUrl = () => getEnv("STATUS_API_URL");

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.test.ts
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.test.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import api from "./index";
 import type { CurrenciesPerProvider, RampCatalog } from "../types";
 
@@ -6,7 +6,7 @@ jest.mock("@ledgerhq/live-network", () => ({
   __esModule: true,
   default: jest.fn(),
 }));
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn((key: string) => {
     if (key === "MOCK") return false;
     if (key === "BUY_API_BASE") return "https://buy.example.com";

--- a/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.ts
+++ b/libs/ledger-live-common/src/platform/providers/RampCatalogProvider/api/index.ts
@@ -1,5 +1,5 @@
 import network from "@ledgerhq/live-network";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { CurrenciesPerProvider, RampCatalog } from "../types";
 import mockData from "./mock.json";
 

--- a/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.ts
+++ b/libs/ledger-live-common/src/platform/providers/RemoteLiveAppProvider/api/index.ts
@@ -1,6 +1,6 @@
 import network from "@ledgerhq/live-network/network";
 import qs from "qs";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { FilterParams } from "../../../filters";
 import type { LiveAppManifest } from "../../../types";
 import mockData from "./mock.json";

--- a/libs/ledger-live-common/src/socket/index.ts
+++ b/libs/ledger-live-common/src/socket/index.ts
@@ -12,7 +12,7 @@ import {
   StatusCodes,
 } from "@ledgerhq/errors";
 import { cancelDeviceAction } from "../hw/deviceAccess";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import type { SocketEvent } from "@ledgerhq/types-live";
 import { sha3_256 } from "@noble/hashes/sha3";
 import { DeviceId } from "@domain/entity-client-identity";

--- a/libs/ledger-live-common/src/wallet-api/ACRE/server.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/ACRE/server.test.ts
@@ -28,7 +28,7 @@ jest.mock("../../bridge", () => ({
   getAccountBridge: jest.fn(),
 }));
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn(),
   changes: { subscribe: jest.fn() },
 }));

--- a/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
@@ -31,7 +31,7 @@ import {
 } from "../converters";
 import { getAccountBridge } from "../../bridge";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import BigNumber from "bignumber.js";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.test.ts
@@ -40,7 +40,7 @@ jest.mock("./normalizer/networkFeeEstimate", () => ({
 // need to satisfy both at module-eval time, so the mock surfaces a no-op
 // `changes` subject alongside `getEnv`. Per-test `getEnv` overrides happen via
 // the `jest.mocked` hook in the suite body.
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn().mockReturnValue(""),
   changes: { subscribe: jest.fn() },
 }));

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/getQuotes.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { getParentAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import type { AccountLike } from "@ledgerhq/types-live";
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchSpotPrices.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/service/fetchSpotPrices.ts
@@ -1,6 +1,6 @@
 import URL from "url";
 
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import network from "@ledgerhq/live-network";
 
 export type FetchSpotPricesArgs = {

--- a/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/server.test.ts
@@ -103,7 +103,7 @@ jest.mock("@ledgerhq/live-network", () => ({
   default: jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn((key: string) => {
     if (key === "SWAP_API_BASE") return "https://swap.ledger.com/v5";
     if (key === "DISABLE_TRANSACTION_BROADCAST") return false;

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -6,7 +6,7 @@ import { Account, AccountLike, AnyMessage, Operation, SignedOperation } from "@l
 import { WalletHandlers, ServerConfig, WalletAPIServer } from "@ledgerhq/wallet-api-server";
 import { Transport, Permission } from "@ledgerhq/wallet-api-core";
 import { first } from "rxjs/operators";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { cryptoAssetsApi } from "@domain/api-currency-token";

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.test.ts
@@ -30,7 +30,7 @@ jest.mock("../bridge", () => ({
   }),
 }));
 
-jest.mock("@ledgerhq/live-env", () => ({
+jest.mock("@shared/env", () => ({
   getEnv: jest.fn().mockReturnValue(true),
   changes: { subscribe: jest.fn() },
 }));
@@ -204,7 +204,7 @@ describe("useDappLogic — onDappMessage async paths", () => {
   beforeEach(() => {
     jest.resetAllMocks();
     // Re-establish the default mock return values for this suite.
-    const { getEnv } = jest.requireMock("@ledgerhq/live-env");
+    const { getEnv } = jest.requireMock("@shared/env");
     getEnv.mockReturnValue(true);
     const { getCryptoAssetsStore } = jest.requireMock(
       "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore",
@@ -346,7 +346,7 @@ describe("useDappLogic — onDappMessage async paths", () => {
 describe("useDappLogic — liveBlindSigningReporter live-app context", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    const { getEnv } = jest.requireMock("@ledgerhq/live-env");
+    const { getEnv } = jest.requireMock("@shared/env");
     getEnv.mockReturnValue(true);
     const { getCryptoAssetsStore } = jest.requireMock(
       "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore",

--- a/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
+++ b/libs/ledger-live-common/src/wallet-api/useDappLogic.ts
@@ -6,7 +6,7 @@ import { AppManifest, DAppTrackingData, DiscoverDB, WalletAPITransaction } from 
 import { getMainAccount, getParentAccount } from "../account";
 import { TrackingAPI } from "./tracking";
 import { getAccountBridge } from "../bridge";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import network from "@ledgerhq/live-network/network";
 import { getWalletAPITransactionSignFlowInfos } from "./converters";
 import { prepareMessageToSign } from "../hw/signMessage/index";

--- a/libs/ledger-live-common/src/walletSync/getEnvironmentParams.test.ts
+++ b/libs/ledger-live-common/src/walletSync/getEnvironmentParams.test.ts
@@ -1,4 +1,4 @@
-import { setEnv } from "@ledgerhq/live-env";
+import { setEnv } from "@shared/env";
 import getEnvironmentParams from "./getEnvironmentParams";
 
 describe("getEnvironmentParams", () => {

--- a/libs/ledger-live-common/src/walletSync/getEnvironmentParams.ts
+++ b/libs/ledger-live-common/src/walletSync/getEnvironmentParams.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { WalletSyncEnvironment } from "@ledgerhq/types-live";
 
 type EnvironmentParams = {

--- a/libs/ledger-services/cal/package.json
+++ b/libs/ledger-services/cal/package.json
@@ -60,11 +60,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/live-env": "workspace:*",
-    "@ledgerhq/live-network": "workspace:*"
+    "@ledgerhq/live-network": "workspace:*",
+    "@shared/env": "workspace:*"
   },
   "devDependencies": {
-    "@shared/env": "workspace:*",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "dotenv": "^16.4.5",

--- a/libs/ledger-services/cal/src/certificate.test.ts
+++ b/libs/ledger-services/cal/src/certificate.test.ts
@@ -1,9 +1,9 @@
 import network from "@ledgerhq/live-network";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { convertCertificateToDeviceData, getCertificate } from "./certificate";
 
 jest.mock("@ledgerhq/live-network", () => ({ __esModule: true, default: jest.fn() }));
-jest.mock("@ledgerhq/live-env", () => ({ getEnv: jest.fn() }));
+jest.mock("@shared/env", () => ({ getEnv: jest.fn() }));
 
 const mockNetwork = jest.mocked(network);
 const mockGetEnv = jest.mocked(getEnv);

--- a/libs/ledger-services/cal/src/certificate.ts
+++ b/libs/ledger-services/cal/src/certificate.ts
@@ -1,6 +1,6 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_OPTION, getCALDomain, type ServiceOption } from "./common";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 const DeviceModel = {
   blue: "blue",

--- a/libs/ledger-services/cal/src/common.ts
+++ b/libs/ledger-services/cal/src/common.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export type ServiceOption = {
   env?: "prod" | "test";

--- a/libs/ledger-services/cal/src/currencies.ts
+++ b/libs/ledger-services/cal/src/currencies.ts
@@ -1,6 +1,6 @@
 import network from "@ledgerhq/live-network";
 import { DEFAULT_OPTION, getCALDomain, type ServiceOption } from "./common";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 // https://github.com/LedgerHQ/crypto-assets-service/blob/master/modules/api/src/main/scala/co/ledger/cal/api/assets/v1/model/asset/Currency.scala#L95
 const OUTPUT_FILTER =

--- a/libs/ledger-services/cal/src/partners/index.ts
+++ b/libs/ledger-services/cal/src/partners/index.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import network from "@ledgerhq/live-network";
 import { AdditionalProviderConfig, SWAP_DATA_CDN } from "./default";
 

--- a/libs/ledger-services/cal/src/tokens.ts
+++ b/libs/ledger-services/cal/src/tokens.ts
@@ -1,7 +1,7 @@
 import network from "@ledgerhq/live-network";
 import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
 import { DEFAULT_OPTION, getCALDomain, type ServiceOption } from "./common";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 const OUTPUT_FILTER =
   "id,name,network,network_family,network_type,exchange_app_config_serialized,live_signature,ticker,decimals,blockchain_name,chain_id,contract_address,descriptor,descriptor_exchange_app,units,symbol";

--- a/libs/ledger-services/trust/package.json
+++ b/libs/ledger-services/trust/package.json
@@ -59,11 +59,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/live-env": "workspace:*",
-    "@ledgerhq/live-network": "workspace:*"
+    "@ledgerhq/live-network": "workspace:*",
+    "@shared/env": "workspace:*"
   },
   "devDependencies": {
-    "@shared/env": "workspace:*",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "dotenv": "^16.4.5",

--- a/libs/ledger-services/trust/src/common.ts
+++ b/libs/ledger-services/trust/src/common.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 export function getTrustedDomain(env: "prod" | "test"): string {
   return env === "prod" ? getEnv("NFT_METADATA_SERVICE") : "https://nft.api.live.ledger-test.com";

--- a/libs/live-dmk-desktop/package.json
+++ b/libs/live-dmk-desktop/package.json
@@ -37,12 +37,11 @@
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
-    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
-    "@ledgerhq/types-devices": "workspace:^"
+    "@ledgerhq/types-devices": "workspace:^",
+    "@shared/env": "workspace:*"
   },
   "devDependencies": {
-    "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-desktop/src/hooks/useDeviceManagementKit.tsx
@@ -6,7 +6,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { webHidTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
 import { LedgerLiveLogger, UserHashService } from "@ledgerhq/live-dmk-shared";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LocalTracer } from "@ledgerhq/logs";
 
 const tracer = new LocalTracer("live-dmk-tracer", { function: "useDeviceManagementKit" });

--- a/libs/live-dmk-mobile/package.json
+++ b/libs/live-dmk-mobile/package.json
@@ -38,14 +38,13 @@
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/live-dmk-shared": "workspace:^",
-    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
-    "purify-ts": "^2.1.0"
+    "purify-ts": "^2.1.0",
+    "@shared/env": "workspace:*"
   },
   "devDependencies": {
     "@ledgerhq/device-transport-kit-react-native-hid": "catalog:",
-    "@shared/env": "workspace:*",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
+++ b/libs/live-dmk-mobile/src/hooks/useDeviceManagementKit.tsx
@@ -7,7 +7,7 @@ import {
 import { RNBleTransportFactory } from "@ledgerhq/device-transport-kit-react-native-ble";
 import { LedgerLiveLogger, UserHashService } from "@ledgerhq/live-dmk-shared";
 import { RNHidTransportFactory } from "@ledgerhq/device-transport-kit-react-native-hid";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { LocalTracer } from "@ledgerhq/logs";
 import { httpProxyTransportFactory, httpProxyUrlSubject } from "../transport/HttpProxyDmkTransport";
 

--- a/libs/live-wallet/package.json
+++ b/libs/live-wallet/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@domain/entity-currency-crypto": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
-    "@ledgerhq/live-env": "workspace:*",
+    "@shared/env": "workspace:*",
     "@ledgerhq/live-network": "workspace:*",
     "@ledgerhq/live-promise": "workspace:*",
     "@ledgerhq/logs": "workspace:*",

--- a/libs/live-wallet/src/cloudsync/__tests__/cipher.test.ts
+++ b/libs/live-wallet/src/cloudsync/__tests__/cipher.test.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { makeCipher } from "../cipher";
 import { MockSDK } from "@ledgerhq/ledger-key-ring-protocol/mockSdk";
 

--- a/libs/live-wallet/src/cloudsync/__tests__/sdk.test.ts
+++ b/libs/live-wallet/src/cloudsync/__tests__/sdk.test.ts
@@ -4,7 +4,7 @@ import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { CloudSyncSDK, UpdateEvent } from "../sdk";
 import { MockSDK } from "@ledgerhq/ledger-key-ring-protocol/mockSdk";
-import { getEnv, setEnv } from "@ledgerhq/live-env";
+import { getEnv, setEnv } from "@shared/env";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { TrustchainOutdated } from "@ledgerhq/ledger-key-ring-protocol/errors";
 

--- a/libs/live-wallet/src/liveqr/importAccounts.ts
+++ b/libs/live-wallet/src/liveqr/importAccounts.ts
@@ -5,7 +5,7 @@ import type {
   TransactionCommon,
 } from "@ledgerhq/types-live";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { Observable, firstValueFrom } from "rxjs";
 import { reduce } from "rxjs/operators";
 

--- a/libs/live-wallet/src/walletsync/__tests__/trustchainLifecyle.test.ts
+++ b/libs/live-wallet/src/walletsync/__tests__/trustchainLifecyle.test.ts
@@ -3,7 +3,7 @@ import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
 import { emptyState, convertLocalToDistantState } from "../__mocks__";
 import { trustchainLifecycle } from "..";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
 describe("trustchainLifecycle", () => {
   let removedCount = 0;

--- a/libs/speculos-transport/package.json
+++ b/libs/speculos-transport/package.json
@@ -22,7 +22,7 @@
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/hw-transport-node-speculos": "workspace:*",
     "@ledgerhq/live-dmk-speculos": "workspace:*",
-    "@ledgerhq/live-env": "workspace:*",
+    "@shared/env": "workspace:*",
     "@ledgerhq/live-promise": "workspace:*",
     "@ledgerhq/logs": "workspace:*"
   },

--- a/libs/speculos-transport/src/index.ts
+++ b/libs/speculos-transport/src/index.ts
@@ -5,7 +5,7 @@ import { log } from "@ledgerhq/logs";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
 import SpeculosTransportWebsocket from "@ledgerhq/hw-transport-node-speculos";
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 import { delay } from "@ledgerhq/live-promise";
 
 export type SpeculosDevice = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8924,9 +8924,6 @@ importers:
       '@ledgerhq/ledger-auth':
         specifier: workspace:*
         version: link:../ledger-auth
-      '@ledgerhq/live-env':
-        specifier: workspace:*
-        version: link:../env
       '@ledgerhq/live-network':
         specifier: workspace:*
         version: link:../live-network
@@ -9231,9 +9228,6 @@ importers:
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       '@ledgerhq/live-hooks':
         specifier: workspace:*
         version: link:../live-hooks
@@ -9303,6 +9297,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../shared/env
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../shared/feature-flags
@@ -9463,6 +9460,9 @@ importers:
       '@ledgerhq/device-react':
         specifier: workspace:^
         version: link:../device-react
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       '@ledgerhq/types-cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-cryptoassets
@@ -9617,16 +9617,13 @@ importers:
 
   libs/ledger-services/cal:
     dependencies:
-      '@ledgerhq/live-env':
-        specifier: workspace:*
-        version: link:../../env
       '@ledgerhq/live-network':
         specifier: workspace:*
         version: link:../../live-network
-    devDependencies:
       '@shared/env':
         specifier: workspace:*
         version: link:../../../shared/env
+    devDependencies:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -9663,16 +9660,13 @@ importers:
 
   libs/ledger-services/trust:
     dependencies:
-      '@ledgerhq/live-env':
-        specifier: workspace:*
-        version: link:../../env
       '@ledgerhq/live-network':
         specifier: workspace:*
         version: link:../../live-network
-    devDependencies:
       '@shared/env':
         specifier: workspace:*
         version: link:../../../shared/env
+    devDependencies:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11691,19 +11685,16 @@ importers:
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
-    devDependencies:
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env
+    devDependencies:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -11764,15 +11755,15 @@ importers:
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../ledgerjs/packages/logs
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-devices
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../shared/env
       purify-ts:
         specifier: ^2.1.0
         version: 2.1.0
@@ -11780,9 +11771,6 @@ importers:
       '@ledgerhq/device-transport-kit-react-native-hid':
         specifier: 'catalog:'
         version: 1.0.4(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(rxjs@7.8.2)
-      '@shared/env':
-        specifier: workspace:*
-        version: link:../../shared/env
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -12614,9 +12602,6 @@ importers:
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../ledger-wallet-framework
-      '@ledgerhq/live-env':
-        specifier: workspace:*
-        version: link:../env
       '@ledgerhq/live-network':
         specifier: workspace:*
         version: link:../live-network
@@ -12632,6 +12617,9 @@ importers:
       '@ledgerhq/types-live':
         specifier: workspace:*
         version: link:../ledgerjs/packages/types-live
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../shared/env
       base64-js:
         specifier: '1'
         version: 1.5.1
@@ -12767,15 +12755,15 @@ importers:
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:*
         version: link:../live-dmk-speculos
-      '@ledgerhq/live-env':
-        specifier: workspace:*
-        version: link:../env
       '@ledgerhq/live-promise':
         specifier: workspace:*
         version: link:../promise
       '@ledgerhq/logs':
         specifier: workspace:*
         version: link:../ledgerjs/packages/logs
+      '@shared/env':
+        specifier: workspace:*
+        version: link:../../shared/env
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -22982,7 +22970,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25371,7 +25359,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -66447,7 +66435,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66571,54 +66559,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Migrates all internal import sources from `@ledgerhq/live-env` to `@shared/env` across 121 files (libs, e2e, shared packages).

The change is mechanical — every diff is one of:

```diff
- import { getEnv } from "@ledgerhq/live-env";
+ import { getEnv } from "@shared/env";
```
```diff
- jest.mock("@ledgerhq/live-env", () => ({
+ jest.mock("@shared/env", () => ({
```

`@shared/env` already exists on `develop` and re-exports the full API from `@ledgerhq/live-env`, so consumers need no other change.

Package deps updated accordingly: `"@ledgerhq/live-env": "workspace:*"` → `"@shared/env": "workspace:*"`.

### 🔗 Context

- **JIRA / GitHub issue**: follow-up to #19748
- **ADR** (if any): N/A