### PR TITLE
ci(harden): upgrade composite packages to match other ci usages

### DIFF
--- a/tools/actions/composites/check-branch/action.yml
+++ b/tools/actions/composites/check-branch/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: check-branch
       with:
         result-encoding: string

--- a/tools/actions/composites/ci-flake-notifier/action.yml
+++ b/tools/actions/composites/ci-flake-notifier/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       name: prepare status
       id: status
       with:

--- a/tools/actions/composites/configure-nx-remote-cache-profile/action.yml
+++ b/tools/actions/composites/configure-nx-remote-cache-profile/action.yml
@@ -55,7 +55,7 @@ runs:
         LEGACY_ACCOUNT_ID: ${{ inputs.legacy-account-id }}
         LEGACY_ROLE_NAME: ${{ inputs.legacy-role-name }}
         ACTION_PATH: ${{ github.action_path }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const fs = require('fs');

--- a/tools/actions/composites/create-branch/action.yml
+++ b/tools/actions/composites/create-branch/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: "Create branch ${{ inputs.branch-name }} from ${{ inputs.base-branch }}"
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: create-branch
       with:
         github-token: ${{ inputs.github-token }}

--- a/tools/actions/composites/create-or-update-tag/action.yml
+++ b/tools/actions/composites/create-or-update-tag/action.yml
@@ -28,7 +28,7 @@ runs:
   steps:
     - name: Create or update tag
       id: tag
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         github-token: ${{ inputs.token }}
         script: |

--- a/tools/actions/composites/merge-branch/action.yml
+++ b/tools/actions/composites/merge-branch/action.yml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: "Merge ${{ inputs.head-branch }} into ${{ inputs.base-branch }}"
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: merge
       with:
         github-token: ${{ inputs.github-token }}

--- a/tools/actions/composites/merge-e2e-detox-timings/action.yml
+++ b/tools/actions/composites/merge-e2e-detox-timings/action.yml
@@ -74,7 +74,7 @@ runs:
         region: ${{ inputs.aws_region }}
 
     - name: Download timing files
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: "${{ inputs.test_results_prefix }}-*"
         merge-multiple: true

--- a/tools/actions/composites/monitor/action.yml
+++ b/tools/actions/composites/monitor/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       with:
         version: 10.24.0
     - uses: actions/setup-node@v4

--- a/tools/actions/composites/nx-affected-packages/action.yml
+++ b/tools/actions/composites/nx-affected-packages/action.yml
@@ -26,7 +26,7 @@ runs:
         BASE: ${{ inputs.base }}
         HEAD: ${{ inputs.head }}
         ACTION_PATH: ${{ github.action_path }}
-      uses: actions/github-script@v8
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const path = require('path');

--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -129,7 +129,7 @@ runs:
         use-fallback: false
 
     - name: Cache LLM pods
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       if: inputs.skip-pod-cache != 'true'
       with:
         path: |

--- a/tools/actions/composites/update-snapshots-desktop/action.yml
+++ b/tools/actions/composites/update-snapshots-desktop/action.yml
@@ -71,7 +71,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
 
     - name: Upload playwright results [On Failure]
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       if: failure() && !cancelled()
       with:
         name: ${{ format('playwright-results-{0}', inputs.os) }}

--- a/tools/actions/composites/upload-allure-report/action.yml
+++ b/tools/actions/composites/upload-allure-report/action.yml
@@ -29,7 +29,7 @@ runs:
 
   steps:
     - id: branch-name
-      uses: tj-actions/branch-names@v6
+      uses: tj-actions/branch-names@6c999acf206f5561e19f46301bb310e9e70d8815 # v6
     - name: Set report path
       id: report-path
       shell: bash


### PR DESCRIPTION
## Summary

- Upgrades five action references in `tools/actions/composites/` to align with versions already in use across `.github/workflows/`, then pins each to its SHA
- SHA-pins one additional action (`tj-actions/branch-names`) at its existing version
- All upgrade paths checked for breaking changes — no input or behaviour changes required in any composite

## What changed

| Action | Old | New | SHA |
|---|---|---|---|
| `actions/github-script` | `@v8` | `@v9.0.0` | `3a2844b7e9c422d3c10d287c895573f7108da1b3` |
| `actions/download-artifact` | `@v7` | `@v8.0.1` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/upload-artifact` | `@v4` | `@v6.0.0` | `b7c566a772e6b6bfb58ed0dc250532a479d7789f` |
| `actions/cache` | `@v3` | `@v6.1.0` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` |
| `pnpm/action-setup` | `@v2` | `@v4` | `b906affcce14559ad1aafd4ab0e942779e9f58b1` |
| `tj-actions/branch-names` | `@v6` (unpinned) | `@v6` (pinned) | `6c999acf206f5561e19f46301bb310e9e70d8815` |

## Breaking change analysis

**`github-script` v8→v9**: The only breaking change in v9 is that `require('@actions/github')` fails at runtime (package is now ESM-only). None of the 7 affected composites call `require('@actions/github')` — they only use Node built-ins and local scripts. No changes needed.

**`download-artifact` v7→v8**: Hash mismatches now error instead of warn (a security improvement), and decompression is Content-Type-gated. The `pattern` and `merge-multiple` inputs are unchanged; standard zip artifacts continue to decompress correctly. No changes needed.

**`upload-artifact` v4→v6**: The `name` and `path` inputs are unchanged across all versions. No changes needed.

**`cache` v3→v6**: The `path` and `key` inputs used in `setup-caches` are stable across all versions. No changes needed.

**`pnpm/action-setup` v2→v4**: v4 errors if the `version` input and `packageManager` in `package.json` differ. The root `package.json` specifies `"packageManager": "pnpm@10.24.0"`, which exactly matches `version: 10.24.0` in `monitor/action.yml`. No changes needed.

## Files affected

- `tools/actions/composites/check-branch/action.yml`
- `tools/actions/composites/ci-flake-notifier/action.yml`
- `tools/actions/composites/configure-nx-remote-cache-profile/action.yml`
- `tools/actions/composites/create-branch/action.yml`
- `tools/actions/composites/create-or-update-tag/action.yml`
- `tools/actions/composites/merge-branch/action.yml`
- `tools/actions/composites/nx-affected-packages/action.yml`
- `tools/actions/composites/merge-e2e-detox-timings/action.yml`
- `tools/actions/composites/monitor/action.yml`
- `tools/actions/composites/setup-caches/action.yml`
- `tools/actions/composites/update-snapshots-desktop/action.yml`
- `tools/actions/composites/upload-allure-report/action.yml`

Tests:
https://github.com/LedgerHQ/ledger-live/actions/runs/30258494326
https://github.com/LedgerHQ/ledger-live/actions/runs/30259299969
https://github.com/LedgerHQ/ledger-live/actions/runs/30259339032