### PR TITLE
feat(contacts): add shared populated contact detail view model

### DIFF
--- a/.changeset/flow-contacts-populated-contact-detail.md
+++ b/.changeset/flow-contacts-populated-contact-detail.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared populated contact detail view model with network-ordered address rows, address count, and open-detail intents.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -9,6 +9,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Feature-flag configuration (`useContactsFeature`, resolvers)
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Empty contact detail selection and presentation
+- Populated contact detail view model (address rows, count, and open-detail intents)
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Add Address session state
 - Add Address network eligibility and final currency selection state (MAD integration uses an
@@ -79,8 +80,8 @@ src/
 │   │   ├── internals/useSingleFireDismiss.ts
 │   │   └── index.ts / web.ts / native.ts
 │   └── Detail/                          # Contact detail empty state (web + native)
-│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / types.ts
-│       ├── model/                       # resolveContactDetailEmptyStateCopy
+│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / types.ts
+│       ├── model/                       # resolveContactDetailEmptyStateCopy / address ordering + populated detail view-model builders
 │       ├── components/                  # Header, EmptyState, Avatar (web + native)
 │       └── index.ts / web.ts / native.ts
 ├── components/                          # Cross-step shared UI

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -1,2 +1,15 @@
 export { useEmptyContactDetail } from "./useEmptyContactDetail";
-export type { ContactDetailLabels, ContactDetailViewProps } from "./types";
+export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+export {
+  createContactDetailAddressRowIntent,
+  createPopulatedContactDetailViewModel,
+} from "./model/viewModel";
+export { sortContactAddressesByNetwork } from "./model/sortContactAddressesByNetwork";
+export type { ContactAddressCurrencyPort } from "./model/ports";
+export type {
+  ContactDetailAddressRow,
+  ContactDetailAddressRowIntent,
+  ContactDetailLabels,
+  ContactDetailViewProps,
+  PopulatedContactDetailViewModel,
+} from "./types";

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -1,0 +1,7 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactAddressCurrencyPort = Readonly<{
+  resolveNetworkId(currencyId: ContactAddress["currencyId"]): CryptoCurrency["id"] | undefined;
+}>;

--- a/features/flow/contacts/src/steps/Detail/model/sortContactAddressesByNetwork.ts
+++ b/features/flow/contacts/src/steps/Detail/model/sortContactAddressesByNetwork.ts
@@ -1,0 +1,56 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import { listCryptoCurrencies, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./ports";
+
+function createNetworkOrderIndex(
+  networkIds: readonly CryptoCurrency["id"][] = listCryptoCurrencies().map(network => network.id),
+): ReadonlyMap<CryptoCurrency["id"], number> {
+  return new Map(networkIds.map((networkId, index) => [networkId, index]));
+}
+
+function compareContactAddressesByNetwork(
+  left: ContactAddress,
+  right: ContactAddress,
+  resolveNetworkId: ContactAddressCurrencyPort["resolveNetworkId"],
+  networkOrderIndex: ReadonlyMap<CryptoCurrency["id"], number>,
+): number {
+  const leftNetworkId = resolveNetworkId(left.currencyId);
+  const rightNetworkId = resolveNetworkId(right.currencyId);
+  const leftIndex =
+    leftNetworkId === undefined
+      ? Number.MAX_SAFE_INTEGER
+      : (networkOrderIndex.get(leftNetworkId) ?? Number.MAX_SAFE_INTEGER);
+  const rightIndex =
+    rightNetworkId === undefined
+      ? Number.MAX_SAFE_INTEGER
+      : (networkOrderIndex.get(rightNetworkId) ?? Number.MAX_SAFE_INTEGER);
+
+  if (leftIndex !== rightIndex) {
+    return leftIndex - rightIndex;
+  }
+
+  const labelComparison = left.label.localeCompare(right.label);
+
+  if (labelComparison !== 0) {
+    return labelComparison;
+  }
+
+  return left.id.localeCompare(right.id);
+}
+
+export function sortContactAddressesByNetwork(
+  addresses: readonly ContactAddress[],
+  currencyPort: ContactAddressCurrencyPort,
+  networkIds?: readonly CryptoCurrency["id"][],
+): ContactAddress[] {
+  const networkOrderIndex = createNetworkOrderIndex(networkIds);
+
+  return [...addresses].sort((left, right) =>
+    compareContactAddressesByNetwork(
+      left,
+      right,
+      currencyPort.resolveNetworkId,
+      networkOrderIndex,
+    ),
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/viewModel.ts
@@ -1,0 +1,48 @@
+import type { Contact, ContactAddressId, ContactId } from "@domain/entity-contact";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./ports";
+import { sortContactAddressesByNetwork } from "./sortContactAddressesByNetwork";
+import type { ContactDetailAddressRow, PopulatedContactDetailViewModel } from "../types";
+
+export function createContactDetailAddressRowIntent(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactDetailAddressRow["intent"] {
+  return {
+    type: "open-address-detail",
+    contactId,
+    addressId,
+  };
+}
+
+function createContactDetailAddressRow(
+  contact: Contact,
+  address: Contact["addresses"][number],
+): ContactDetailAddressRow {
+  return {
+    addressId: address.id,
+    label: address.label,
+    address: address.address,
+    currencyId: address.currencyId,
+    intent: createContactDetailAddressRowIntent(contact.id, address.id),
+  };
+}
+
+export function createPopulatedContactDetailViewModel(
+  contact: Contact,
+  currencyPort: ContactAddressCurrencyPort,
+  networkIds?: readonly CryptoCurrency["id"][],
+): PopulatedContactDetailViewModel {
+  const orderedAddresses = sortContactAddressesByNetwork(
+    contact.addresses,
+    currencyPort,
+    networkIds,
+  );
+
+  return {
+    displayMode: "populated",
+    contact,
+    addressCount: contact.addresses.length,
+    addressRows: orderedAddresses.map(address => createContactDetailAddressRow(contact, address)),
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/viewModel.web.test.ts
@@ -1,0 +1,174 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./ports";
+import { sortContactAddressesByNetwork } from "./sortContactAddressesByNetwork";
+import {
+  createContactDetailAddressRowIntent,
+  createPopulatedContactDetailViewModel,
+} from "./viewModel";
+
+const TEST_NETWORK_ORDER = [
+  getCryptoCurrencyById("ethereum").id,
+  getCryptoCurrencyById("polygon").id,
+  getCryptoCurrencyById("bitcoin").id,
+] as const;
+
+function createCurrencyPort(
+  resolveNetworkId: ContactAddressCurrencyPort["resolveNetworkId"],
+): ContactAddressCurrencyPort {
+  return { resolveNetworkId };
+}
+
+describe("sortContactAddressesByNetwork", () => {
+  const currencyPort = createCurrencyPort(currencyId => {
+    if (currencyId === getCryptoCurrencyById("ethereum").id) {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("polygon").id) {
+      return getCryptoCurrencyById("polygon").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("bitcoin").id) {
+      return getCryptoCurrencyById("bitcoin").id;
+    }
+
+    if (currencyId === "ethereum/erc20/usd-coin") {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    return undefined;
+  });
+
+  it("orders address rows by production network order", () => {
+    const addresses = [
+      mockContactAddress({
+        id: "address-polygon",
+        currencyId: "polygon",
+        label: "Polygon",
+      }),
+      mockContactAddress({
+        id: "address-ethereum",
+        currencyId: "ethereum",
+        label: "Ethereum",
+      }),
+      mockContactAddress({
+        id: "address-bitcoin",
+        currencyId: "bitcoin",
+        label: "Bitcoin",
+      }),
+    ];
+
+    expect(
+      sortContactAddressesByNetwork(addresses, currencyPort, TEST_NETWORK_ORDER).map(
+        address => address.id,
+      ),
+    ).toEqual(["address-ethereum", "address-polygon", "address-bitcoin"]);
+  });
+
+  it("groups token addresses under their parent network order", () => {
+    const addresses = [
+      mockContactAddress({
+        id: "address-usdc",
+        currencyId: "ethereum/erc20/usd-coin",
+        label: "USDC",
+      }),
+      mockContactAddress({
+        id: "address-polygon",
+        currencyId: "polygon",
+        label: "Polygon",
+      }),
+    ];
+
+    expect(
+      sortContactAddressesByNetwork(addresses, currencyPort, TEST_NETWORK_ORDER).map(
+        address => address.id,
+      ),
+    ).toEqual(["address-usdc", "address-polygon"]);
+  });
+});
+
+describe("createPopulatedContactDetailViewModel", () => {
+  const currencyPort = createCurrencyPort(currencyId => {
+    if (currencyId === getCryptoCurrencyById("ethereum").id) {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("polygon").id) {
+      return getCryptoCurrencyById("polygon").id;
+    }
+
+    return undefined;
+  });
+
+  it("returns populated detail state when the contact has addresses", () => {
+    const contact = mockContactWithMultipleAddresses();
+
+    expect(createPopulatedContactDetailViewModel(contact, currencyPort)).toMatchObject({
+      displayMode: "populated",
+      contact,
+    });
+  });
+
+  it("exposes the address count", () => {
+    const contact = mockContactWithMultipleAddresses();
+
+    expect(createPopulatedContactDetailViewModel(contact, currencyPort).addressCount).toBe(2);
+  });
+
+  it("orders address rows by network", () => {
+    const contact = mockContactWithMultipleAddresses();
+
+    expect(
+      createPopulatedContactDetailViewModel(contact, currencyPort, TEST_NETWORK_ORDER).addressRows.map(
+        row => row.addressId,
+      ),
+    ).toEqual(["address-ethereum", "address-polygon"]);
+  });
+
+  it("exposes an open-address-detail intent on each row", () => {
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-ethereum",
+          currencyId: "ethereum",
+          label: "Ethereum",
+        }),
+      ],
+    });
+
+    const address = contact.addresses[0];
+
+    expect(address).toBeDefined();
+    expect(createPopulatedContactDetailViewModel(contact, currencyPort).addressRows).toEqual([
+      {
+        addressId: "address-ethereum",
+        label: "Ethereum",
+        address: address!.address,
+        currencyId: "ethereum",
+        intent: createContactDetailAddressRowIntent(contact.id, address!.id),
+      },
+    ]);
+  });
+});
+
+describe("createContactDetailAddressRowIntent", () => {
+  it("creates an open-address-detail intent for the selected row", () => {
+    const contact = mockMeContact({
+      addresses: [mockContactAddress({ id: "address-me-ethereum" })],
+    });
+    const address = contact.addresses[0];
+
+    expect(address).toBeDefined();
+    expect(createContactDetailAddressRowIntent(contact.id, address!.id)).toEqual({
+      type: "open-address-detail",
+      contactId: contact.id,
+      addressId: "address-me-ethereum",
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -1,4 +1,30 @@
-import type { Contact } from "@domain/entity-contact";
+import type {
+  Contact,
+  ContactAddress,
+  ContactAddressId,
+  ContactId,
+} from "@domain/entity-contact";
+
+export type ContactDetailAddressRowIntent = Readonly<{
+  type: "open-address-detail";
+  contactId: ContactId;
+  addressId: ContactAddressId;
+}>;
+
+export type ContactDetailAddressRow = Readonly<{
+  addressId: ContactAddressId;
+  label: ContactAddress["label"];
+  address: ContactAddress["address"];
+  currencyId: ContactAddress["currencyId"];
+  intent: ContactDetailAddressRowIntent;
+}>;
+
+export type PopulatedContactDetailViewModel = Readonly<{
+  displayMode: "populated";
+  contact: Contact;
+  addressCount: number;
+  addressRows: readonly ContactDetailAddressRow[];
+}>;
 
 export type ContactDetailLabels = Readonly<{
   addAddress: string;

--- a/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.ts
+++ b/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.ts
@@ -1,0 +1,28 @@
+import {
+  selectContactById,
+  type ContactId,
+} from "@domain/entity-contact";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import type { ContactAddressCurrencyPort } from "./model/ports";
+import { createPopulatedContactDetailViewModel } from "./model/viewModel";
+import type { PopulatedContactDetailViewModel } from "./types";
+
+type ContactsStateRoot = Parameters<typeof selectContactById>[0];
+
+export function usePopulatedContactDetail(
+  contactId: ContactId,
+  currencyPort: ContactAddressCurrencyPort,
+): PopulatedContactDetailViewModel | undefined {
+  const contact = useSelector((state: ContactsStateRoot) =>
+    selectContactById(state, contactId),
+  );
+
+  return useMemo(() => {
+    if (contact === undefined || contact.addresses.length === 0) {
+      return undefined;
+    }
+
+    return createPopulatedContactDetailViewModel(contact, currencyPort);
+  }, [contact, currencyPort]);
+}

--- a/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.web.test.tsx
@@ -1,0 +1,91 @@
+import { createElement, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { ContactIdSchema, contactsSlice } from "@domain/entity-contact";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./model/ports";
+import { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+
+const currencyPort: ContactAddressCurrencyPort = {
+  resolveNetworkId: currencyId => {
+    if (currencyId === getCryptoCurrencyById("ethereum").id) {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("polygon").id) {
+      return getCryptoCurrencyById("polygon").id;
+    }
+
+    return undefined;
+  },
+};
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+describe("usePopulatedContactDetail", () => {
+  it("should return populated detail state when the contact has addresses", () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => usePopulatedContactDetail(contact.id, currencyPort),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toMatchObject({
+      displayMode: "populated",
+      contact,
+      addressCount: 1,
+    });
+  });
+
+  it("should return undefined when the contact has no addresses", () => {
+    const contact = mockContact();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => usePopulatedContactDetail(contact.id, currencyPort),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should return undefined when the contact does not exist", () => {
+    const Wrapper = makeWrapper([mockMeContact()]);
+    const { result } = renderHook(
+      () => usePopulatedContactDetail(ContactIdSchema.parse("contact-missing"), currencyPort),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should expose address rows ordered by network", () => {
+    const contact = mockContactWithMultipleAddresses();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => usePopulatedContactDetail(contact.id, currencyPort),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current?.addressRows.map(row => row.addressId)).toEqual([
+      "address-ethereum",
+      "address-polygon",
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Add shared populated contact detail state in @features/flow-contacts for contacts that already have saved addresses.
- Introduce a pure view-model builder and usePopulatedContactDetail hook that order address rows by production network order, expose addressCount, and attach open-address-detail intents per row.
- Define ContactAddressCurrencyPort for app wiring to resolve parent network ids (aligned with the future @features/platform-contacts contract).


### 🔗 Context

[LIVE-33939](https://ledgerhq.atlassian.net/browse/LIVE-33939)


[LIVE-33939]: https://ledgerhq.atlassian.net/browse/LIVE-33939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ