### PR TITLE
[LWDM] fix: integ test reject message on broadcast

### DIFF
--- a/libs/coin-modules/coin-ton/src/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-ton/src/broadcast.integ.test.ts
@@ -41,7 +41,7 @@ describe("Broadcast", () => {
     const base64 = Buffer.from(cell.toBoc()).toString("base64");
 
     await expect(broadcast({ signedOperation: { signature: base64 } } as any)).rejects.toThrow(
-      /Failed to unpack account state/,
+      /Failed to unpack account state|external import fees exceed account balance/,
     );
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

 broadcast.integ.test.ts hits the real TON node and asserts the rejection message matches /Failed to unpack account state/. The test deliberately broadcasts from a fresh random wallet (undeployed, zero balance), expecting the node to reject it. The node changed its rejection wording for this case to external message was not accepted: ... external import fees exceed account balance — same underlying condition (empty, non-existent account), different string — so the regex no longer matched and the test failed.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
