### PR TITLE
[LWDM] fix(cal): defer CAL_SERVICE_URL lookup to call site

### DIFF
--- a/.changeset/cal-defer-env-lookup.md
+++ b/.changeset/cal-defer-env-lookup.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/ledger-cal-service": patch
+---
+
+Defer CAL_SERVICE_URL env lookup to call site to avoid module-scope side effects.

--- a/libs/ledger-services/cal/src/partners/index.ts
+++ b/libs/ledger-services/cal/src/partners/index.ts
@@ -2,8 +2,6 @@ import { getEnv } from "@ledgerhq/live-env";
 import network from "@ledgerhq/live-network";
 import { AdditionalProviderConfig, SWAP_DATA_CDN } from "./default";
 
-const CAL_BASE_URL = getEnv("CAL_SERVICE_URL");
-
 export type PartnerType = {
   continuesInProviderLiveApp: boolean;
   displayName: string;
@@ -75,9 +73,10 @@ export async function getProvidersData({
   partnerSignatureEnv?: "test" | "prod";
   ledgerSignatureEnv?: "test" | "prod";
 }): Promise<Record<string, ExchangeProvider>> {
+  const baseUrl = getEnv("CAL_SERVICE_URL");
   const { data: providersData } = await network<ProvidersDataResponse>({
     method: "GET",
-    url: `${CAL_BASE_URL}/v1/partners`,
+    url: `${baseUrl}/v1/partners`,
     params: {
       output: "name,public_key,public_key_curve,service_app_version,descriptor,partner_id,env",
       service_name: type,


### PR DESCRIPTION
### 📝 Description

Moves the module-scope `getEnv("CAL_SERVICE_URL")` constant in `libs/ledger-services/cal/src/partners/index.ts` to inside the `getProvidersData` function body.

```diff
-const CAL_BASE_URL = getEnv("CAL_SERVICE_URL");
 export type PartnerType = { ... }
 
 export async function getProvidersData(...) {
+  const baseUrl = getEnv("CAL_SERVICE_URL");
   const { data: providersData } = await network({
     url: `${baseUrl}/v1/partners`,
```

Module-scope `getEnv()` calls break when `injectDefinitions()` is required before use (introduced by the `feat/live-env-inject-definitions-v2` PR). Deferring the lookup to call time fixes the import-time crash.

### 🔗 Context

- **JIRA / GitHub issue**: N/A — preparatory fix for #19748
- **ADR**: N/A

> [!IMPORTANT]
> This PR targets `feat/shared-env-import-migration` (#20038). It should be merged after that PR lands on `develop`.