### PR TITLE
feat(domain): reshare CryptoCurrencyId/TokenCurrencyId from domain packages

### DIFF
--- a/.changeset/domain-currency-id-reshare.md
+++ b/.changeset/domain-currency-id-reshare.md
@@ -1,0 +1,6 @@
+---
+"@domain/entity-currency-crypto": minor
+"@domain/entity-currency-token": minor
+---
+
+Re-export CryptoCurrencyId / CryptoCurrencyIdSchema from @domain/entity-currency-crypto and TokenCurrencyId / TokenCurrencyIdSchema from @domain/entity-currency-token

--- a/domain/entity/currency-crypto/src/index.ts
+++ b/domain/entity/currency-crypto/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./schema";
 export * from "./registry";
 export * from "./legacy/accessors";
+export type { CryptoCurrencyId } from "@shared/schema-primitives";
+export { CryptoCurrencyIdSchema } from "@shared/schema-primitives";

--- a/domain/entity/currency-token/src/index.ts
+++ b/domain/entity/currency-token/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./schema";
 export * from "./define";
+export type { TokenCurrencyId } from "@shared/schema-primitives";
+export { TokenCurrencyIdSchema } from "@shared/schema-primitives";


### PR DESCRIPTION
## Summary

- Re-export `CryptoCurrencyId` and `CryptoCurrencyIdSchema` from `@domain/entity-currency-crypto`
- Re-export `TokenCurrencyId` and `TokenCurrencyIdSchema` from `@domain/entity-currency-token`

Consumers can now import these branded ID types directly from the domain package that owns the entity, instead of reaching into `@shared/schema-primitives`.

## Test plan

- [ ] `pnpm nx run @domain/entity-currency-crypto:typecheck`
- [ ] `pnpm nx run @domain/entity-currency-token:typecheck`