### PR TITLE
[LWDM] feat(post-onboarding): remove custom lock screen step

### DIFF
--- a/.changeset/calm-locks-fade.md
+++ b/.changeset/calm-locks-fade.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Remove Custom Lock Screen step from the post-onboarding widget.

--- a/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/FinishOnboarding/FinishOnboardingDialog/hooks/utils.ts
@@ -1,7 +1,6 @@
 import {
   LedgerDevices,
   Lightbulb,
-  PictureImage,
   Plus,
   Refresh,
   ShieldLock,
@@ -23,8 +22,6 @@ export function getLumenSymbolForActionId(id: PostOnboardingActionId): FinishFlo
   switch (id) {
     case PostOnboardingActionId.assetsTransfer:
       return Plus as FinishFlowLumenSymbol;
-    case PostOnboardingActionId.customImage:
-      return PictureImage as FinishFlowLumenSymbol;
     case PostOnboardingActionId.discoverWallet:
       return Lightbulb as FinishFlowLumenSymbol;
     case PostOnboardingActionId.deviceOnboarded:
@@ -46,7 +43,6 @@ const ACTION_ID_TO_DIALOG_GROUP: Readonly<Partial<Record<PostOnboardingActionId,
   [PostOnboardingActionId.deviceOnboarded]: "deviceOnboarded",
   [PostOnboardingActionId.assetsTransfer]: "assetsTransfer",
   [PostOnboardingActionId.syncAccounts]: "syncAccounts",
-  [PostOnboardingActionId.customImage]: "customImage",
   [PostOnboardingActionId.discoverWallet]: "discoverWallet",
   [PostOnboardingActionId.recover]: "recover",
 };
@@ -55,11 +51,9 @@ const ACTION_ID_TO_DIALOG_GROUP: Readonly<Partial<Record<PostOnboardingActionId,
 const DIALOG_GROUPS_WITH_DESCRIPTION: ReadonlySet<string> = new Set([
   "assetsTransfer",
   "syncAccounts",
-  "customImage",
   "discoverWallet",
   "recover",
 ]);
-
 type ActionWithI18nKeys = PostOnboardingAction & PostOnboardingActionState;
 
 /**

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/index.tsx
@@ -7,7 +7,6 @@ import {
 import { Icons } from "@ledgerhq/react-ui";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import PostOnboardingMockAction from "~/renderer/components/PostOnboardingHub/PostOnboardingMockAction";
-import CustomImage from "~/renderer/screens/customImage";
 import { getStoreValue } from "~/renderer/store";
 import { LedgerRecoverSubscriptionStateEnum } from "~/types/recoverSubscriptionState";
 import { openProductTour } from "LLD/features/ProductTour/Drawer/productTourDialog";
@@ -79,25 +78,6 @@ const recover: PostOnboardingAction = {
     ),
 };
 
-const customImage: PostOnboardingAction = {
-  id: PostOnboardingActionId.customImage,
-  Icon: Icons.PictureImage,
-  title: "customImage.postOnboarding.title",
-  titleCompleted: "customImage.postOnboarding.title",
-  description: "customImage.postOnboarding.description",
-  actionCompletedPopupLabel: "customImage.postOnboarding.actionCompletedPopupLabel",
-  startAction: ({ deviceModelId }: StartActionArgs) =>
-    setDrawer(
-      CustomImage,
-      {
-        isFromPostOnboardingEntryPoint: true,
-        deviceModelId: deviceModelId || null,
-      },
-      { forceDisableFocusTrap: true },
-    ),
-  buttonLabelForAnalyticsEvent: "Set lock screen picture",
-};
-
 const discoverWallet: PostOnboardingAction = {
   id: PostOnboardingActionId.discoverWallet,
   featureFlagId: "lwdProductTour",
@@ -146,17 +126,6 @@ const migrateAssetsMock: PostOnboardingAction = {
     setDrawer(PostOnboardingMockAction, { id: PostOnboardingActionId.migrateAssetsMock }),
 };
 
-const customImageMock: PostOnboardingAction = {
-  id: PostOnboardingActionId.customImageMock,
-  Icon: Icons.PictureImage,
-  title: "customImage.postOnboarding.title",
-  titleCompleted: "customImage.postOnboarding.title",
-  description: "customImage.postOnboarding.description",
-  actionCompletedPopupLabel: "customImage.postOnboarding.actionCompletedPopupLabel",
-  startAction: () =>
-    setDrawer(PostOnboardingMockAction, { id: PostOnboardingActionId.customImageMock }),
-};
-
 const assetsTransferMock: PostOnboardingAction = {
   id: PostOnboardingActionId.assetsTransferMock,
   Icon: Icons.Lock,
@@ -197,13 +166,11 @@ const postOnboardingActions: { [id in PostOnboardingActionId]?: PostOnboardingAc
   assetsTransfer,
   buyCrypto,
   syncAccounts,
-  customImage,
   discoverWallet,
   recover,
   // Mocks for desktop development and tests
   assetsTransferMock,
   buyCryptoMock,
-  customImageMock,
   claimMock,
   personalizeMock,
   migrateAssetsMock,
@@ -221,11 +188,10 @@ const staxPostOnboardingActionsMock: PostOnboardingAction[] = [
 const europaPostOnboardingActionsMock: PostOnboardingAction[] = [
   assetsTransferMock,
   buyCryptoMock,
-  customImageMock,
   recoverMock,
 ];
 
-const apexPostOnboardingActionsMock: PostOnboardingAction[] = [customImageMock, recoverMock];
+const apexPostOnboardingActionsMock: PostOnboardingAction[] = [recoverMock];
 
 export function getPostOnboardingAction(
   id: PostOnboardingActionId,
@@ -240,21 +206,18 @@ export function getPostOnboardingActionsForDevice(
   switch (deviceModelId) {
     case DeviceModelId.stax:
       if (mock) return staxPostOnboardingActionsMock;
-      return [assetsTransfer, buyCrypto, syncAccounts, customImage, discoverWallet, recover];
+      return [assetsTransfer, buyCrypto, syncAccounts, discoverWallet, recover];
     case DeviceModelId.europa:
       if (mock) return europaPostOnboardingActionsMock;
-      return [assetsTransfer, buyCrypto, syncAccounts, customImage, discoverWallet, recover];
+      return [assetsTransfer, buyCrypto, syncAccounts, discoverWallet, recover];
     case DeviceModelId.apex:
       if (mock) return apexPostOnboardingActionsMock;
-      return [assetsTransfer, buyCrypto, syncAccounts, customImage, discoverWallet, recover];
+      return [assetsTransfer, buyCrypto, syncAccounts, discoverWallet, recover];
     case DeviceModelId.nanoS:
-      // Post-onboarding actions for Nano S (no custom lock screen step).
       return [assetsTransfer, buyCrypto];
     case DeviceModelId.nanoSP:
-      // Post-onboarding actions for Nano S Plus (no custom lock screen step).
       return [assetsTransfer, buyCrypto, syncAccounts, discoverWallet];
     case DeviceModelId.nanoX:
-      // Post-onboarding actions for Nano X (no custom lock screen step).
       return [assetsTransfer, buyCrypto, syncAccounts, discoverWallet];
     default:
       return [];

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -1388,10 +1388,6 @@
           "title": "Sync your wallet",
           "description": "Keep your crypto accounts synced"
         },
-        "customImage": {
-          "title": "Customize the lock screen",
-          "description": "Display your favorite digital art or photo as your device’s lock screen."
-        },
         "discoverWallet": {
           "title": "Discover what your wallet can do",
           "description": "Dive into your wallet’s features"
@@ -8318,11 +8314,6 @@
         "confirmRestorePicture": "Tap on “Keep“ to\nconfirm your lock screen picture",
         "doThisLater": "Maybe later"
       }
-    },
-    "postOnboarding": {
-      "title": "Customize the lock screen",
-      "description": "Display your favorite digital art or photo as your device’s lock screen.",
-      "actionCompletedPopupLabel": "Device personalized"
     },
     "customImageSet": "Lock screen customized",
     "finishCTA": "Close"

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8826,10 +8826,6 @@
           "title": "Sync your wallet",
           "description": "Keep your crypto accounts synced"
         },
-        "customImage": {
-          "title": "Customize the lock screen",
-          "description": "Display your favorite digital art or photo as your device’s lock screen."
-        },
         "recover": {
           "title": "Finish securing your backup",
           "description": "Complete activating Ledger Recover"
@@ -8857,10 +8853,6 @@
         "titleCompleted": "Crypto bought",
         "description": "Choose from 500+ coins and tokens.",
         "popupLabel": "Crypto bought"
-      },
-      "customImage": {
-        "titleCompleted": "Lock screen customized",
-        "popupLabel": "Lock screen customized successfully"
       },
       "recover": {
         "titleCompleted": "Backup secured",

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/getPostOnboardingActionsForDevice.test.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/getPostOnboardingActionsForDevice.test.ts
@@ -29,9 +29,26 @@ describe("getPostOnboardingActionsForDevice", () => {
     },
   );
 
+  it.each([DeviceModelId.stax, DeviceModelId.europa, DeviceModelId.apex])(
+    "should not include customImage for %s in real and mock lists",
+    deviceModelId => {
+      const actions = getPostOnboardingActionsForDevice(deviceModelId);
+      const mockActions = getPostOnboardingActionsForDevice(deviceModelId, true);
+
+      expect(actions.some(action => action.id === PostOnboardingActionId.customImage)).toBe(false);
+      expect(mockActions.some(action => action.id === PostOnboardingActionId.customImageMock)).toBe(
+        false,
+      );
+    },
+  );
+
   it("should return discoverWallet from getPostOnboardingAction", () => {
     expect(getPostOnboardingAction(PostOnboardingActionId.discoverWallet)?.id).toBe(
       PostOnboardingActionId.discoverWallet,
     );
+  });
+
+  it("should not return customImage from getPostOnboardingAction", () => {
+    expect(getPostOnboardingAction(PostOnboardingActionId.customImage)).toBeUndefined();
   });
 });

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/actions.tsx
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/actions.tsx
@@ -46,27 +46,6 @@ export const buyCryptoAction: PostOnboardingAction = {
   ],
 };
 
-export const customImageAction: PostOnboardingAction = {
-  id: PostOnboardingActionId.customImage,
-  Icon: Icons.PictureImage,
-  title: "postOnboarding.drawer.actions.customImage.title",
-  titleCompleted: "postOnboarding.actions.customImage.titleCompleted",
-  description: "postOnboarding.drawer.actions.customImage.description",
-  actionCompletedPopupLabel: "postOnboarding.actions.customImage.titleCompleted",
-  buttonLabelForAnalyticsEvent: "Set lock screen picture",
-  getNavigationParams: ({ deviceModelId, referral }) => [
-    NavigatorName.CustomImage,
-    {
-      screen: ScreenName.CustomImageStep0Welcome,
-      params: {
-        device: null,
-        deviceModelId,
-        ...(referral ? { referral } : {}),
-      },
-    },
-  ],
-};
-
 export const syncAccountsAction: PostOnboardingAction = {
   id: PostOnboardingActionId.syncAccounts,
   featureFlagId: "llmLedgerSyncEntryPoints",

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/index.tsx
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/index.tsx
@@ -3,14 +3,12 @@ import { PostOnboardingAction, PostOnboardingActionId } from "@ledgerhq/types-li
 import {
   assetsTransferMock,
   buyCryptoMock,
-  customImageMock,
   syncAccountsMock,
   recoverMock,
   discoverWalletMock,
 } from "./mockActions";
 import {
   assetsTransferAction,
-  customImageAction,
   buyCryptoAction,
   syncAccountsAction,
   recoverAction,
@@ -23,11 +21,9 @@ import {
 const postOnboardingActions: { [id in PostOnboardingActionId]?: PostOnboardingAction } = {
   assetsTransferMock,
   buyCryptoMock,
-  customImageMock,
   syncAccountsMock,
   recoverMock,
   discoverWalletMock,
-  customImage: customImageAction,
   assetsTransfer: assetsTransferAction,
   buyCrypto: buyCryptoAction,
   syncAccounts: syncAccountsAction,
@@ -42,7 +38,6 @@ const staxPostOnboardingActionsMock: PostOnboardingAction[] = [
   assetsTransferMock,
   syncAccountsMock,
   discoverWalletMock,
-  customImageMock,
   recoverMock,
 ];
 
@@ -50,7 +45,6 @@ const staxPostOnboardingActions: PostOnboardingAction[] = [
   assetsTransferAction,
   syncAccountsAction,
   discoverWalletAction,
-  customImageAction,
   recoverAction,
 ];
 
@@ -61,7 +55,6 @@ const europaPostOnboardingActionsMock: PostOnboardingAction[] = [
   assetsTransferMock,
   syncAccountsMock,
   discoverWalletMock,
-  customImageMock,
   recoverMock,
 ];
 
@@ -69,7 +62,6 @@ const europaPostOnboardingActions: PostOnboardingAction[] = [
   assetsTransferAction,
   syncAccountsAction,
   discoverWalletAction,
-  customImageAction,
   recoverAction,
 ];
 
@@ -80,7 +72,6 @@ const apexPostOnboardingActionsMock: PostOnboardingAction[] = [
   assetsTransferMock,
   syncAccountsMock,
   discoverWalletMock,
-  customImageMock,
   recoverMock,
 ];
 
@@ -88,7 +79,6 @@ const apexPostOnboardingActions: PostOnboardingAction[] = [
   assetsTransferAction,
   syncAccountsAction,
   discoverWalletAction,
-  customImageAction,
   recoverAction,
 ];
 
@@ -109,13 +99,11 @@ export function getPostOnboardingActionsForDevice(
 ): PostOnboardingAction[] {
   switch (deviceModelId) {
     case DeviceModelId.nanoS:
-      // Post-onboarding actions for Nano S (no custom lock screen or sync step).
+      // Post-onboarding actions for Nano S (no sync step).
       return [assetsTransferAction, discoverWalletAction];
     case DeviceModelId.nanoSP:
-      // Post-onboarding actions for Nano S Plus (no custom lock screen step).
       return [assetsTransferAction, syncAccountsAction, discoverWalletAction];
     case DeviceModelId.nanoX:
-      // Post-onboarding actions for Nano X (no custom lock screen step).
       return [assetsTransferAction, syncAccountsAction, discoverWalletAction];
     case DeviceModelId.stax:
       if (mock) return staxPostOnboardingActionsMock;

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/mockActions.ts
@@ -45,25 +45,6 @@ export const buyCryptoMock: PostOnboardingAction = {
   },
 };
 
-export const customImageMock: PostOnboardingAction = {
-  id: PostOnboardingActionId.customImageMock,
-  Icon: Icons.PictureImage,
-  title: "postOnboarding.drawer.actions.customImage.title",
-  titleCompleted: "postOnboarding.actions.customImage.titleCompleted",
-  description: "postOnboarding.drawer.actions.customImage.description",
-  actionCompletedPopupLabel: "postOnboarding.actions.customImage.popupLabel",
-  getNavigationParams: () => [
-    NavigatorName.PostOnboarding,
-    {
-      screen: ScreenName.PostOnboardingMockActionScreen,
-      params: {
-        id: PostOnboardingActionId.customImageMock,
-        title: PostOnboardingActionId.customImageMock,
-      },
-    },
-  ],
-};
-
 export const syncAccountsMock: PostOnboardingAction = {
   id: PostOnboardingActionId.syncAccountsMock,
   Icon: Icons.Refresh,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Remove the Custom Lock Screen (`customImage`) step from the post-onboarding widget on mobile and desktop
- Step count updates automatically; existing sessions with a persisted `customImage` action no longer show it

https://github.com/user-attachments/assets/3d3b7bdd-0169-4167-9e57-83d4c6745d3a


<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34386]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34386]: https://ledgerhq.atlassian.net/browse/LIVE-34386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ