### PR TITLE
chore: add commitlint commit-msg hook

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -17,7 +17,7 @@ hooks {
     ["commit-msg"] {
         steps {
             ["commitlint"] {
-                check = "pnpm commitlint --edit {{commit_msg_file}}"
+                check = "pnpm commitlint --edit {{ commit_msg_file }}"
             }
         }
     }

--- a/hk.pkl
+++ b/hk.pkl
@@ -14,4 +14,11 @@ hooks {
             }
         }
     }
+    ["commit-msg"] {
+        steps {
+            ["commitlint"] {
+                check = "pnpm commitlint --edit {{commit_msg_file}}"
+            }
+        }
+    }
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required — this only modifies `hk.pkl` (local git-hook config); no published package is affected.
- [ ] **Covered by automatic tests.** _Not applicable: this is local git-hook configuration, not runtime code. commitlint already runs in CI via `.github/workflows/commitlint.yml`; this hook surfaces the same check locally, before push._
- [x] **Impact of the changes:**
  - No end-user or app runtime impact — developer tooling only.
  - Committing with a non-Conventional message (e.g. `wip`) should be **rejected** by the new hook.
  - Committing with a valid Conventional Commit (e.g. `chore: x`) should **pass**.
  - Existing `pre-commit` steps (`oxfmt`, `gitleaks`) should still run and remain unaffected.

### 📝 Description

Adds a `commit-msg` git hook to `hk.pkl` that runs commitlint on every commit:

```pkl
["commit-msg"] {
    steps {
        ["commitlint"] {
            check = "pnpm commitlint --edit {{commit_msg_file}}"
        }
    }
}
```

**Problem:** Commit messages are currently only validated in CI (`.github/workflows/commitlint.yml`). Non-conforming messages aren't caught until after push, forcing an amend/force-push cycle.

**Solution:** Add a local `commit-msg` hook (managed by [`hk`](https://github.com/jdx/hk)) that runs `pnpm commitlint --edit` against the message being written, so Conventional Commit violations are caught at commit time — consistent with the existing `pre-commit` hooks (`oxfmt`, `gitleaks`) and with CI.

### ❓ Context

- **JIRA or GitHub link**: _N/A — no associated ticket._

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
