### PR TITLE
Feat/live 33942 shared edit delete

### DIFF
--- a/.changeset/contact-detail-edit-delete-actions.md
+++ b/.changeset/contact-detail-edit-delete-actions.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared contact detail edit/delete scenario state and contact edit requirement helper.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -10,6 +10,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - `useContacts` and `useContactsMeContact` hooks (`@domain/entity-contact`)
 - Empty contact detail selection and presentation
 - Populated contact detail view model (address rows, count, and open-detail intents)
+- Contact detail edit/delete scenario state (edit intent, delete intent, and delete lifecycle)
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Add Address session state
 - Add Address network eligibility and final currency selection state (MAD integration uses an

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -1,14 +1,39 @@
 export { useEmptyContactDetail } from "./useEmptyContactDetail";
 export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+export { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
+export type { UseContactDetailActionsViewModelResult } from "./useContactDetailActionsViewModel";
 export {
   createContactDetailAddressRowIntent,
   createPopulatedContactDetailViewModel,
 } from "./model/viewModel";
+export {
+  createContactDetailDeleteIntent,
+  createContactDetailEditIntent,
+  createErrorContactDeleteLifecycle,
+  createIdleContactDeleteLifecycle,
+  createOpenContactDeleteLifecycle,
+  createSuccessContactDeleteLifecycle,
+  isSignerRequiredForContactEdit,
+} from "./model/contactActionsViewModel";
+export {
+  createContactDetailActionsController,
+  type ContactDetailActionsController,
+} from "./model/contactActionsController";
 export { sortContactAddressesByNetwork } from "./model/sortContactAddressesByNetwork";
-export type { ContactAddressCurrencyPort } from "./model/ports";
 export type {
+  ContactAddressCurrencyPort,
+  ContactDeletionPort,
+  ContactDetailActionsPorts,
+  ContactEditPort,
+  ContactRenameInput,
+} from "./model/ports";
+export type {
+  ContactDeleteLifecycle,
+  ContactDetailActionsViewModel,
   ContactDetailAddressRow,
   ContactDetailAddressRowIntent,
+  ContactDetailDeleteIntent,
+  ContactDetailEditIntent,
   ContactDetailLabels,
   ContactDetailViewProps,
   PopulatedContactDetailViewModel,

--- a/features/flow/contacts/src/steps/Detail/model/contactActionsController.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactActionsController.ts
@@ -1,0 +1,27 @@
+import type { ContactId } from "@domain/entity-contact";
+import type { ContactDetailActionsPorts } from "./ports";
+import {
+  createErrorContactDeleteLifecycle,
+  createSuccessContactDeleteLifecycle,
+} from "./contactActionsViewModel";
+import type { ContactDeleteLifecycle } from "../types";
+
+export type ContactDetailActionsController = Readonly<{
+  confirmDelete: (contactId: ContactId) => Promise<ContactDeleteLifecycle>;
+}>;
+
+export function createContactDetailActionsController(
+  ports: ContactDetailActionsPorts,
+): ContactDetailActionsController {
+  return {
+    confirmDelete: async contactId => {
+      try {
+        await ports.deletion.deleteContact(contactId);
+
+        return createSuccessContactDeleteLifecycle(contactId);
+      } catch {
+        return createErrorContactDeleteLifecycle(contactId);
+      }
+    },
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/contactActionsController.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactActionsController.web.test.ts
@@ -1,0 +1,45 @@
+import { ContactIdSchema } from "@domain/entity-contact";
+import { createContactDetailActionsController } from "./contactActionsController";
+import type { ContactDetailActionsPorts } from "./ports";
+
+function createPorts(
+  overrides: Partial<ContactDetailActionsPorts> = {},
+): ContactDetailActionsPorts {
+  return {
+    edit: {
+      renameContact: jest.fn(),
+    },
+    deletion: {
+      deleteContact: jest.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+}
+
+describe("createContactDetailActionsController", () => {
+  it("returns success lifecycle when deletion succeeds", async () => {
+    const contactId = ContactIdSchema.parse("contact-ben");
+    const controller = createContactDetailActionsController(createPorts());
+
+    await expect(controller.confirmDelete(contactId)).resolves.toEqual({
+      status: "success",
+      contactId,
+    });
+  });
+
+  it("returns error lifecycle when deletion fails", async () => {
+    const contactId = ContactIdSchema.parse("contact-ben");
+    const controller = createContactDetailActionsController(
+      createPorts({
+        deletion: {
+          deleteContact: jest.fn().mockRejectedValue(new Error("delete failed")),
+        },
+      }),
+    );
+
+    await expect(controller.confirmDelete(contactId)).resolves.toEqual({
+      status: "error",
+      contactId,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/contactActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactActionsViewModel.ts
@@ -1,0 +1,44 @@
+import type { Contact, ContactId } from "@domain/entity-contact";
+import { resolveContactEditRequirement } from "./editRequirement";
+import type {
+  ContactDeleteLifecycle,
+  ContactDetailDeleteIntent,
+  ContactDetailEditIntent,
+} from "../types";
+
+export function createContactDetailEditIntent(contact: Contact): ContactDetailEditIntent {
+  return {
+    type: "edit-contact",
+    contactId: contact.id,
+    editRequirement: resolveContactEditRequirement(contact),
+  };
+}
+
+export function createContactDetailDeleteIntent(contactId: ContactId): ContactDetailDeleteIntent {
+  return {
+    type: "delete-contact",
+    contactId,
+  };
+}
+
+export function createIdleContactDeleteLifecycle(): ContactDeleteLifecycle {
+  return { status: "idle" };
+}
+
+export function createOpenContactDeleteLifecycle(contactId: ContactId): ContactDeleteLifecycle {
+  return { status: "open", contactId };
+}
+
+export function createSuccessContactDeleteLifecycle(contactId: ContactId): ContactDeleteLifecycle {
+  return { status: "success", contactId };
+}
+
+export function createErrorContactDeleteLifecycle(contactId: ContactId): ContactDeleteLifecycle {
+  return { status: "error", contactId };
+}
+
+export function isSignerRequiredForContactEdit(
+  editIntent: ContactDetailEditIntent | undefined,
+): boolean {
+  return editIntent?.editRequirement.type === "confirmation-required";
+}

--- a/features/flow/contacts/src/steps/Detail/model/contactActionsViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactActionsViewModel.web.test.ts
@@ -1,0 +1,85 @@
+import { mockContact, mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import {
+  createContactDetailDeleteIntent,
+  createContactDetailEditIntent,
+  createErrorContactDeleteLifecycle,
+  createIdleContactDeleteLifecycle,
+  createOpenContactDeleteLifecycle,
+  createSuccessContactDeleteLifecycle,
+  isSignerRequiredForContactEdit,
+} from "./contactActionsViewModel";
+
+describe("createContactDetailEditIntent", () => {
+  it("exposes an edit-contact intent with a direct requirement when the contact has no addresses", () => {
+    const contact = mockContact();
+
+    expect(createContactDetailEditIntent(contact)).toEqual({
+      type: "edit-contact",
+      contactId: contact.id,
+      editRequirement: {
+        type: "direct",
+        reason: "contact-has-no-address",
+      },
+    });
+  });
+
+  it("exposes an edit-contact intent with a signer-required requirement when the contact has addresses", () => {
+    const contact = mockContactWithAddress();
+
+    expect(createContactDetailEditIntent(contact)).toEqual({
+      type: "edit-contact",
+      contactId: contact.id,
+      editRequirement: {
+        type: "confirmation-required",
+        reason: "contact-has-address",
+      },
+    });
+  });
+});
+
+describe("createContactDetailDeleteIntent", () => {
+  it("exposes a delete-contact intent for the selected contact", () => {
+    const contact = mockContact();
+
+    expect(createContactDetailDeleteIntent(contact.id)).toEqual({
+      type: "delete-contact",
+      contactId: contact.id,
+    });
+  });
+});
+
+describe("contact delete lifecycle builders", () => {
+  it("creates idle, open, success, and error lifecycle states", () => {
+    const contact = mockContact();
+
+    expect(createIdleContactDeleteLifecycle()).toEqual({ status: "idle" });
+    expect(createOpenContactDeleteLifecycle(contact.id)).toEqual({
+      status: "open",
+      contactId: contact.id,
+    });
+    expect(createSuccessContactDeleteLifecycle(contact.id)).toEqual({
+      status: "success",
+      contactId: contact.id,
+    });
+    expect(createErrorContactDeleteLifecycle(contact.id)).toEqual({
+      status: "error",
+      contactId: contact.id,
+    });
+  });
+});
+
+describe("isSignerRequiredForContactEdit", () => {
+  it("returns false when edit is direct", () => {
+    expect(isSignerRequiredForContactEdit(createContactDetailEditIntent(mockContact()))).toBe(false);
+  });
+
+  it("returns true when edit requires signer confirmation", () => {
+    expect(
+      isSignerRequiredForContactEdit(createContactDetailEditIntent(mockContactWithAddress())),
+    ).toBe(true);
+  });
+
+  it("returns false when no edit intent is available", () => {
+    expect(isSignerRequiredForContactEdit(undefined)).toBe(false);
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
+++ b/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
@@ -1,0 +1,17 @@
+import type { Contact } from "@domain/entity-contact";
+
+export type ContactEditRequirement =
+  | Readonly<{
+      type: "direct";
+      reason: "contact-has-no-address";
+    }>
+  | Readonly<{
+      type: "confirmation-required";
+      reason: "contact-has-address";
+    }>;
+
+export function resolveContactEditRequirement(contact: Contact): ContactEditRequirement {
+  return contact.addresses.length > 0
+    ? { type: "confirmation-required", reason: "contact-has-address" }
+    : { type: "direct", reason: "contact-has-no-address" };
+}

--- a/features/flow/contacts/src/steps/Detail/model/editRequirement.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/editRequirement.web.test.ts
@@ -1,0 +1,18 @@
+import { mockContact, mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import { resolveContactEditRequirement } from "./editRequirement";
+
+describe("resolveContactEditRequirement", () => {
+  it("returns direct edit when the contact has no addresses", () => {
+    expect(resolveContactEditRequirement(mockContact())).toEqual({
+      type: "direct",
+      reason: "contact-has-no-address",
+    });
+  });
+
+  it("returns confirmation-required edit when the contact has addresses", () => {
+    expect(resolveContactEditRequirement(mockContactWithAddress())).toEqual({
+      type: "confirmation-required",
+      reason: "contact-has-address",
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -1,7 +1,32 @@
-import type { ContactAddress } from "@domain/entity-contact";
+import type {
+  Contact,
+  ContactAddress,
+  ContactId,
+  ContactInput,
+} from "@domain/entity-contact";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 
 /** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
 export type ContactAddressCurrencyPort = Readonly<{
   resolveNetworkId(currencyId: ContactAddress["currencyId"]): CryptoCurrency["id"] | undefined;
+}>;
+
+export type ContactRenameInput = Readonly<{
+  contactId: ContactId;
+  name: ContactInput["name"];
+}>;
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactEditPort = Readonly<{
+  renameContact(input: ContactRenameInput): Promise<Contact>;
+}>;
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactDeletionPort = Readonly<{
+  deleteContact(contactId: ContactId): Promise<void>;
+}>;
+
+export type ContactDetailActionsPorts = Readonly<{
+  edit: ContactEditPort;
+  deletion: ContactDeletionPort;
 }>;

--- a/features/flow/contacts/src/steps/Detail/model/sortContactAddressesByNetwork.ts
+++ b/features/flow/contacts/src/steps/Detail/model/sortContactAddressesByNetwork.ts
@@ -2,9 +2,17 @@ import type { ContactAddress } from "@domain/entity-contact";
 import { listCryptoCurrencies, type CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { ContactAddressCurrencyPort } from "./ports";
 
+const DEFAULT_NETWORK_ORDER_INDEX: ReadonlyMap<CryptoCurrency["id"], number> = new Map(
+  listCryptoCurrencies().map((network, index) => [network.id, index]),
+);
+
 function createNetworkOrderIndex(
-  networkIds: readonly CryptoCurrency["id"][] = listCryptoCurrencies().map(network => network.id),
+  networkIds?: readonly CryptoCurrency["id"][],
 ): ReadonlyMap<CryptoCurrency["id"], number> {
+  if (networkIds === undefined) {
+    return DEFAULT_NETWORK_ORDER_INDEX;
+  }
+
   return new Map(networkIds.map((networkId, index) => [networkId, index]));
 }
 

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -1,14 +1,34 @@
-import type {
-  Contact,
-  ContactAddress,
-  ContactAddressId,
-  ContactId,
-} from "@domain/entity-contact";
+import type { Contact, ContactAddress, ContactAddressId, ContactId } from "@domain/entity-contact";
+import type { ContactEditRequirement } from "./model/editRequirement";
 
 export type ContactDetailAddressRowIntent = Readonly<{
   type: "open-address-detail";
   contactId: ContactId;
   addressId: ContactAddressId;
+}>;
+
+export type ContactDetailEditIntent = Readonly<{
+  type: "edit-contact";
+  contactId: ContactId;
+  editRequirement: ContactEditRequirement;
+}>;
+
+export type ContactDetailDeleteIntent = Readonly<{
+  type: "delete-contact";
+  contactId: ContactId;
+}>;
+
+export type ContactDeleteLifecycle =
+  | Readonly<{ status: "idle" }>
+  | Readonly<{ status: "open"; contactId: ContactId }>
+  | Readonly<{ status: "success"; contactId: ContactId }>
+  | Readonly<{ status: "error"; contactId: ContactId }>;
+
+export type ContactDetailActionsViewModel = Readonly<{
+  editIntent: ContactDetailEditIntent | undefined;
+  deleteIntent: ContactDetailDeleteIntent;
+  deleteLifecycle: ContactDeleteLifecycle;
+  isSignerRequiredForEdit: boolean;
 }>;
 
 export type ContactDetailAddressRow = Readonly<{

--- a/features/flow/contacts/src/steps/Detail/useContactDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactDetailActionsViewModel.ts
@@ -1,0 +1,66 @@
+import { selectContactById, type ContactId } from "@domain/entity-contact";
+import { useCallback, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { createContactDetailActionsController } from "./model/contactActionsController";
+import type { ContactDetailActionsPorts } from "./model/ports";
+import {
+  createContactDetailDeleteIntent,
+  createContactDetailEditIntent,
+  createIdleContactDeleteLifecycle,
+  createOpenContactDeleteLifecycle,
+  isSignerRequiredForContactEdit,
+} from "./model/contactActionsViewModel";
+import type { ContactDeleteLifecycle, ContactDetailActionsViewModel } from "./types";
+
+type ContactsStateRoot = Parameters<typeof selectContactById>[0];
+
+export type UseContactDetailActionsViewModelResult = ContactDetailActionsViewModel &
+  Readonly<{
+    openDelete: () => void;
+    cancelDelete: () => void;
+    confirmDelete: () => Promise<void>;
+  }>;
+
+/**
+ * Shared contact detail edit/delete scenario state for Contacts UI.
+ * Pass stable `ContactDetailActionsPorts`; a new reference each render recreates the controller.
+ */
+export function useContactDetailActionsViewModel(
+  contactId: ContactId,
+  ports: ContactDetailActionsPorts,
+): UseContactDetailActionsViewModelResult {
+  const contact = useSelector((state: ContactsStateRoot) => selectContactById(state, contactId));
+  const controller = useMemo(() => createContactDetailActionsController(ports), [ports]);
+  const [deleteLifecycle, setDeleteLifecycle] = useState<ContactDeleteLifecycle>(() =>
+    createIdleContactDeleteLifecycle(),
+  );
+
+  const editIntent = useMemo(
+    () => (contact === undefined ? undefined : createContactDetailEditIntent(contact)),
+    [contact],
+  );
+  const deleteIntent = useMemo(() => createContactDetailDeleteIntent(contactId), [contactId]);
+  const isSignerRequiredForEdit = isSignerRequiredForContactEdit(editIntent);
+
+  const openDelete = useCallback(() => {
+    setDeleteLifecycle(createOpenContactDeleteLifecycle(contactId));
+  }, [contactId]);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteLifecycle(createIdleContactDeleteLifecycle());
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    setDeleteLifecycle(await controller.confirmDelete(contactId));
+  }, [controller, contactId]);
+
+  return {
+    editIntent,
+    deleteIntent,
+    deleteLifecycle,
+    isSignerRequiredForEdit,
+    openDelete,
+    cancelDelete,
+    confirmDelete,
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/useContactDetailActionsViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactDetailActionsViewModel.web.test.tsx
@@ -1,0 +1,152 @@
+import { createElement, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { contactsSlice } from "@domain/entity-contact";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import type { ContactDetailActionsPorts } from "./model/ports";
+import { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
+
+function createPorts(
+  overrides: Partial<ContactDetailActionsPorts> = {},
+): ContactDetailActionsPorts {
+  return {
+    edit: {
+      renameContact: jest.fn(),
+    },
+    deletion: {
+      deleteContact: jest.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+}
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+describe("useContactDetailActionsViewModel", () => {
+  it("exposes a direct edit intent when the contact has no addresses", () => {
+    const contact = mockContact();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactDetailActionsViewModel(contact.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.editIntent).toEqual({
+      type: "edit-contact",
+      contactId: contact.id,
+      editRequirement: {
+        type: "direct",
+        reason: "contact-has-no-address",
+      },
+    });
+    expect(result.current.isSignerRequiredForEdit).toBe(false);
+  });
+
+  it("exposes a signer-required edit state when the contact has addresses", () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactDetailActionsViewModel(contact.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.editIntent).toMatchObject({
+      type: "edit-contact",
+      contactId: contact.id,
+      editRequirement: {
+        type: "confirmation-required",
+        reason: "contact-has-address",
+      },
+    });
+    expect(result.current.isSignerRequiredForEdit).toBe(true);
+  });
+
+  it("exposes a delete intent for the selected contact", () => {
+    const contact = mockContact();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactDetailActionsViewModel(contact.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.deleteIntent).toEqual({
+      type: "delete-contact",
+      contactId: contact.id,
+    });
+  });
+
+  it("opens, cancels, and confirms delete through the mocked lifecycle", async () => {
+    const contact = mockContact();
+    const deleteContact = jest.fn().mockResolvedValue(undefined);
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactDetailActionsViewModel(contact.id, createPorts({ deletion: { deleteContact } })),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.deleteLifecycle).toEqual({ status: "idle" });
+
+    act(() => {
+      result.current.openDelete();
+    });
+    expect(result.current.deleteLifecycle).toEqual({ status: "open", contactId: contact.id });
+
+    act(() => {
+      result.current.cancelDelete();
+    });
+    expect(result.current.deleteLifecycle).toEqual({ status: "idle" });
+
+    act(() => {
+      result.current.openDelete();
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(deleteContact).toHaveBeenCalledWith(contact.id);
+    expect(result.current.deleteLifecycle).toEqual({ status: "success", contactId: contact.id });
+  });
+
+  it("exposes an error lifecycle when delete confirmation fails", async () => {
+    const contact = mockContact();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactDetailActionsViewModel(
+          contact.id,
+          createPorts({
+            deletion: {
+              deleteContact: jest.fn().mockRejectedValue(new Error("delete failed")),
+            },
+          }),
+        ),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.openDelete();
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.deleteLifecycle).toEqual({ status: "error", contactId: contact.id });
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Adds shared contact detail edit and delete scenario state to @features/flow-contacts (LIVE-33942), building on the populated contact detail view model from the prior commit on this branch.

**Domain (@domain/entity-contact)**

- Adds resolveContactEditRequirement(contact) — returns direct when the contact has no addresses, confirmation-required when it has addresses (signer rule).


**Flow (@features/flow-contacts Detail step)**

- Adds injected ports aligned with the future @features/platform-contacts contract: ContactEditPort, ContactDeletionPort, and ContactDetailActionsPorts.
- Adds pure builders for edit-contact and delete-contact intents, plus delete lifecycle states (idle, open, success, error).
- Adds createContactDetailActionsController to confirm deletion via the injected port.
- Adds useContactDetailActionsViewModel hook exposing:
   - editIntent / deleteIntent
   - isSignerRequiredForEdit
   - deleteLifecycle with openDelete, cancelDelete, and confirmDelete

No Desktop/Mobile UI, Lumen components, or app navigation in this PR — shared flow logic only.

### 🔗 Context

[LIVE-33942](https://ledgerhq.atlassian.net/browse/LIVE-33942)


[LIVE-33942]: https://ledgerhq.atlassian.net/browse/LIVE-33942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ