### PR TITLE
[LWDM] feat(LIVE-32915): add native Error classes for coin-hedera

### DIFF
--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -69,6 +69,11 @@
       "require": "./lib/types/index.js",
       "default": "./lib-es/types/index.js"
     },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-hedera/src/errors.ts
+++ b/libs/coin-modules/coin-hedera/src/errors.ts
@@ -77,3 +77,11 @@ export class HederaMemoExceededSizeError extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class ClaimRewardsFeesWarning extends Error {
+  override name = "ClaimRewardsFeesWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ClaimRewardsFeesWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to `@ledgerhq/coin-hedera` as part of the `@ledgerhq/errors` sunset (LIVE-32915).

Replaces `createCustomErrorClass` with `class extends Error` in `src/errors.ts`. Adds explicit `./errors` subpath to `package.json` exports so consumers can import from `@ledgerhq/coin-hedera/errors`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35090