### PR TITLE
[LWD] feat(LIVE-32915): add native Error classes for wallet-xp packages

### DIFF
--- a/apps/ledger-live-desktop/src/errors.ts
+++ b/apps/ledger-live-desktop/src/errors.ts
@@ -1,0 +1,50 @@
+export class NoDBPathGiven extends Error {
+  override name = "NoDBPathGiven";
+  constructor(message?: string) {
+    super(message || "NoDBPathGiven");
+  }
+}
+
+export class DBWrongPassword extends Error {
+  override name = "DBWrongPassword";
+  constructor(message?: string) {
+    super(message || "DBWrongPassword");
+  }
+}
+
+export class DBNotReset extends Error {
+  override name = "DBNotReset";
+  constructor(message?: string) {
+    super(message || "DBNotReset");
+  }
+}
+
+export class AccountNameRequiredError extends Error {
+  override name = "AccountNameRequired";
+  constructor(message?: string) {
+    super(message || "AccountNameRequired");
+  }
+}
+
+export class UpdateFetchFileFail extends Error {
+  override name = "UpdateFetchFileFail";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateFetchFileFail");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UpdateIncorrectHash extends Error {
+  override name = "UpdateIncorrectHash";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateIncorrectHash");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UpdateIncorrectSig extends Error {
+  override name = "UpdateIncorrectSig";
+  constructor(message?: string) {
+    super(message || "UpdateIncorrectSig");
+  }
+}

--- a/knip.json
+++ b/knip.json
@@ -50,7 +50,8 @@
         ".storybook/electronStub.js",
         ".storybook/fsStub.js",
         ".storybook/settingsMock.ts",
-        "src/renderer/mockServiceWorker.js"
+        "src/renderer/mockServiceWorker.js",
+        "src/errors.ts"
       ],
       "ignoreDependencies": [
         "prop-types",


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to `apps/ledger-live-desktop` as part of the `@ledgerhq/errors` sunset (LIVE-32915).

- `apps/ledger-live-desktop/src/errors.ts` — 7 desktop-specific error classes (`NoDBPathGiven`, `DBWrongPassword`, `UpdateFetchFileFail`, etc.)

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35091