### PR TITLE
[LWDM] feat(LIVE-32915): add native Error classes for partner-hoodies

### DIFF
--- a/libs/coin-modules/coin-canton/.unimportedrc.json
+++ b/libs/coin-modules/coin-canton/.unimportedrc.json
@@ -23,6 +23,7 @@
     "@ledgerhq/types-cryptoassets"
   ],
   "ignoreUnimported": [
+    "src/errors.ts",
     "src/network/gateway.ts",
     "src/network/mock-network.ts",
     "src/network/types.ts",

--- a/libs/coin-modules/coin-canton/src/errors.ts
+++ b/libs/coin-modules/coin-canton/src/errors.ts
@@ -1,0 +1,7 @@
+export class LockedDeviceError extends Error {
+  override name = "LockedDeviceError";
+  statusCode?: number;
+  constructor(message?: string) {
+    super(message ?? "LockedDeviceError");
+  }
+}

--- a/libs/coin-modules/coin-cardano/src/errors.ts
+++ b/libs/coin-modules/coin-cardano/src/errors.ts
@@ -73,3 +73,19 @@ export class CardanoMemoExceededSizeError extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class AccountAwaitingSendPendingOperations extends Error {
+  override name = "AccountAwaitingSendPendingOperations";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "AccountAwaitingSendPendingOperations");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ValAddressRequired extends Error {
+  override name = "ValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-concordium/.unimportedrc.json
+++ b/libs/coin-modules/coin-concordium/.unimportedrc.json
@@ -19,6 +19,7 @@
     "jest-message-util"
   ],
   "ignoreUnimported": [
+    "src/errors.ts",
     "src/test/concordiumTestUtils.ts",
     "src/test/fixtures.ts",
     "src/test/testHelpers.ts",

--- a/libs/coin-modules/coin-concordium/src/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/errors.ts
@@ -1,0 +1,7 @@
+export class LockedDeviceError extends Error {
+  override name = "LockedDeviceError";
+  statusCode?: number;
+  constructor(message?: string) {
+    super(message ?? "LockedDeviceError");
+  }
+}

--- a/libs/coin-modules/coin-concordium/src/types/errors.ts
+++ b/libs/coin-modules/coin-concordium/src/types/errors.ts
@@ -1,9 +1,63 @@
-export { ConcordiumMemoTooLong, ConcordiumInsufficientFunds } from "@ledgerhq/errors";
+export class ConcordiumMemoTooLong extends Error {
+  override name = "ConcordiumMemoTooLong";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumMemoTooLong");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumInsufficientFunds extends Error {
+  override name = "ConcordiumInsufficientFunds";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumInsufficientFunds");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumTrustedMetadataServiceError extends Error {
+  override name = "ConcordiumTrustedMetadataServiceError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumTrustedMetadataServiceError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumSessionExpiredError extends Error {
+  override name = "ConcordiumSessionExpiredError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumSessionExpiredError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumPairingExpiredError extends Error {
+  override name = "ConcordiumPairingExpiredError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumPairingExpiredError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumAddressVerificationFailedError extends Error {
+  override name = "ConcordiumAddressVerificationFailedError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumAddressVerificationFailedError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ConcordiumInvalidMaxFeeError extends Error {
+  override name = "ConcordiumInvalidMaxFeeError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message ?? "ConcordiumInvalidMaxFeeError");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 export class SimulationError extends Error {
   override name = "SimulationError";
   constructor(message?: string, fields?: Record<string, unknown>) {
-    super(message || "SimulationError");
+    super(message ?? "SimulationError");
     if (fields) Object.assign(this, fields);
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to partner-coin packages as part of the `@ledgerhq/errors` sunset (LIVE-32915).

- `coin-canton/src/errors.ts` — new file
- `coin-cardano/src/errors.ts` — updated with additional classes
- `coin-concordium/src/errors.ts` — new file
- `coin-concordium/src/types/errors.ts` — updated with native class definitions

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35093