### PR TITLE
[LWDM] feat(LIVE-32915): add native Error classes for blockchain-support

### DIFF
--- a/libs/coin-modules/coin-aptos/package.json
+++ b/libs/coin-modules/coin-aptos/package.json
@@ -80,6 +80,11 @@
       "require": "./lib/utils/index.js",
       "default": "./lib-es/utils/index.js"
     },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-aptos/src/errors.ts
+++ b/libs/coin-modules/coin-aptos/src/errors.ts
@@ -21,3 +21,43 @@ export class TransactionExpiredError extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class NotEnoughToStake extends Error {
+  override name = "NotEnoughToStake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughToStake");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughToUnstake extends Error {
+  override name = "NotEnoughToUnstake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughToUnstake");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughToRestake extends Error {
+  override name = "NotEnoughToRestake";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughToRestake");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UnstakeNotEnoughStakedBalanceLeft extends Error {
+  override name = "UnstakeNotEnoughStakedBalanceLeft";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnstakeNotEnoughStakedBalanceLeft");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RestakeNotEnoughStakedBalanceLeft extends Error {
+  override name = "RestakeNotEnoughStakedBalanceLeft";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RestakeNotEnoughStakedBalanceLeft");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-kaspa/package.json
+++ b/libs/coin-modules/coin-kaspa/package.json
@@ -78,6 +78,11 @@
       "require": "./lib/transaction/*.js",
       "default": "./lib-es/transaction/*.js"
     },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-kaspa/src/errors.ts
+++ b/libs/coin-modules/coin-kaspa/src/errors.ts
@@ -14,3 +14,11 @@ export class MissingCoinConfig extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class DustLimit extends Error {
+  override name = "DustLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DustLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-mina/.unimportedrc.json
+++ b/libs/coin-modules/coin-mina/.unimportedrc.json
@@ -15,6 +15,7 @@
     "**/*.test.{js,jsx,ts,tsx}"
   ],
   "ignoreUnimported": [
+    "src/errors.ts",
     "src/test/fixtures.ts",
     "src/test/helpers/msw-fixtures.ts",
     "src/test/helpers/msw-setup.ts",

--- a/libs/coin-modules/coin-mina/package.json
+++ b/libs/coin-modules/coin-mina/package.json
@@ -98,6 +98,11 @@
       "require": "./lib/types/index.js",
       "default": "./lib-es/types/index.js"
     },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-mina/src/errors.ts
+++ b/libs/coin-modules/coin-mina/src/errors.ts
@@ -1,0 +1,7 @@
+export class LedgerAPI5xx extends Error {
+  override name = "LedgerAPI5xx";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LedgerAPI5xx");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-stacks/.unimportedrc.json
+++ b/libs/coin-modules/coin-stacks/.unimportedrc.json
@@ -23,6 +23,7 @@
     "jest-message-util"
   ],
   "ignoreUnimported": [
+    "src/errors.ts",
     "src/network/index.ts",
     "src/signer/signMessage.ts",
     "src/supportedFeatures.ts"

--- a/libs/coin-modules/coin-stacks/package.json
+++ b/libs/coin-modules/coin-stacks/package.json
@@ -76,6 +76,11 @@
       "require": "./lib/types/index.js",
       "default": "./lib-es/types/index.js"
     },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-stacks/src/errors.ts
+++ b/libs/coin-modules/coin-stacks/src/errors.ts
@@ -5,3 +5,11 @@ export class StacksMemoTooLong extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class InvalidNonce extends Error {
+  override name = "InvalidNonce";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidNonce");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to `@ledgerhq/blockchain-support` packages as part of the `@ledgerhq/errors` sunset (LIVE-32915).

- `coin-aptos/src/errors.ts` — added staking error classes
- `coin-kaspa/src/errors.ts` — added `DustLimit`
- `coin-mina/src/errors.ts` — new file with `LedgerAPI5xx`
- `coin-stacks/src/errors.ts` — added `InvalidNonce`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35094