### PR TITLE
[LWDM] feat(LIVE-32915): add native Error classes for live-devices

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -347,6 +347,11 @@ libs/live-dmk-desktop/                                             @ledgerhq/liv
 libs/live-dmk-shared/                                              @ledgerhq/live-devices
 libs/live-signer-evm/                                              @ledgerhq/live-devices
 libs/live-signer-solana/                                           @ledgerhq/live-devices
+libs/live-signer-aleo/                                             @ledgerhq/live-devices
+libs/live-signer-canton/                                           @ledgerhq/live-devices
+libs/live-signer-concordium/                                       @ledgerhq/live-devices
+libs/live-signer-zcash/                                            @ledgerhq/live-devices
+libs/ledgerjs/packages/hw-transport/                               @ledgerhq/live-devices
 libs/live-dmk-speculos/                                            @ledgerhq/live-devices
 apps/ledger-live-desktop/src/renderer/hooks/useDeeplinking/handlers/manager.handler.ts  @ledgerhq/live-devices
 

--- a/libs/device-core/src/errors.ts
+++ b/libs/device-core/src/errors.ts
@@ -1,31 +1,119 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // 0x5123
-export const AppNotFound = createCustomErrorClass("AppNotFound");
-export const InvalidContext = createCustomErrorClass("InvalidContext");
+export class AppNotFound extends Error {
+  override name = "AppNotFound";
+  constructor(message?: string) {
+    super(message || "AppNotFound");
+  }
+}
+export class InvalidContext extends Error {
+  override name = "InvalidContext";
+  constructor(message?: string) {
+    super(message || "InvalidContext");
+  }
+}
 // 0x670a
-export const InvalidAppNameLength = createCustomErrorClass("InvalidAppNameLength");
+export class InvalidAppNameLength extends Error {
+  override name = "InvalidAppNameLength";
+  constructor(message?: string) {
+    super(message || "InvalidAppNameLength");
+  }
+}
 // 0x5419
-export const GenerateAesKeyFailed = createCustomErrorClass("GenerateAesKeyFailed");
+export class GenerateAesKeyFailed extends Error {
+  override name = "GenerateAesKeyFailed";
+  constructor(message?: string) {
+    super(message || "GenerateAesKeyFailed");
+  }
+}
 // 0x541a
-export const InternalCryptoOperationFailed = createCustomErrorClass(
-  "InternalCryptoOperationFailed",
-);
+export class InternalCryptoOperationFailed extends Error {
+  override name = "InternalCryptoOperationFailed";
+  constructor(message?: string) {
+    super(message || "InternalCryptoOperationFailed");
+  }
+}
 // 0x541b
-export const InternalComputeAesCmacFailed = createCustomErrorClass("InternalComputeAesCmacFailed");
+export class InternalComputeAesCmacFailed extends Error {
+  override name = "InternalComputeAesCmacFailed";
+  constructor(message?: string) {
+    super(message || "InternalComputeAesCmacFailed");
+  }
+}
 // 0x541c
-export const EncryptAppStorageFailed = createCustomErrorClass("EncryptAppStorageFailed");
+export class EncryptAppStorageFailed extends Error {
+  override name = "EncryptAppStorageFailed";
+  constructor(message?: string) {
+    super(message || "EncryptAppStorageFailed");
+  }
+}
 // 0x5502
-export const PinNotSet = createCustomErrorClass("PinNotSet");
+export class PinNotSet extends Error {
+  override name = "PinNotSet";
+  constructor(message?: string) {
+    super(message || "PinNotSet");
+  }
+}
 // 0x684a
-export const InvalidBackupHeader = createCustomErrorClass("InvalidBackupHeader");
+export class InvalidBackupHeader extends Error {
+  override name = "InvalidBackupHeader";
+  constructor(message?: string) {
+    super(message || "InvalidBackupHeader");
+  }
+}
 // 0x6733
-export const InvalidBackupLength = createCustomErrorClass("InvalidBackupLength");
+export class InvalidBackupLength extends Error {
+  override name = "InvalidBackupLength";
+  constructor(message?: string) {
+    super(message || "InvalidBackupLength");
+  }
+}
 // 0x6642
-export const InvalidBackupState = createCustomErrorClass("InvalidBackupState");
+export class InvalidBackupState extends Error {
+  override name = "InvalidBackupState";
+  constructor(message?: string) {
+    super(message || "InvalidBackupState");
+  }
+}
 // 0x6643
-export const InvalidRestoreState = createCustomErrorClass("InvalidRestoreState");
+export class InvalidRestoreState extends Error {
+  override name = "InvalidRestoreState";
+  constructor(message?: string) {
+    super(message || "InvalidRestoreState");
+  }
+}
 // 0x6734
-export const InvalidChunkLength = createCustomErrorClass("InvalidChunkLength");
+export class InvalidChunkLength extends Error {
+  override name = "InvalidChunkLength";
+  constructor(message?: string) {
+    super(message || "InvalidChunkLength");
+  }
+}
 // 0x5501
-export const UserRefusedOnDevice = createCustomErrorClass("UserRefusedOnDevice");
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  constructor(message?: string) {
+    super(message || "UserRefusedOnDevice");
+  }
+}
+
+export class FirmwareNotRecognized extends Error {
+  override name = "FirmwareNotRecognized";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FirmwareNotRecognized");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NetworkDown extends Error {
+  override name = "NetworkDown";
+  constructor(message?: string) {
+    super(message || "NetworkDown");
+  }
+}
+
+export class UnknownMCU extends Error {
+  override name = "UnknownMCU";
+  constructor(message?: string) {
+    super(message || "UnknownMCU");
+  }
+}

--- a/libs/ledger-live-common/src/customImage/errors.ts
+++ b/libs/ledger-live-common/src/customImage/errors.ts
@@ -1,21 +1,69 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
+export class ImageLoadFromGalleryError extends Error {
+  override name = "ImageLoadFromGalleryError";
+  constructor(message?: string) {
+    super(message || "ImageLoadFromGalleryError");
+  }
+}
 
-export const ImageLoadFromGalleryError = createCustomErrorClass("ImageLoadFromGalleryError");
+export class ImageLoadFromFileError extends Error {
+  override name = "ImageLoadFromFileError";
+  constructor(message?: string) {
+    super(message || "ImageLoadFromFileError");
+  }
+}
 
-export const ImageLoadFromFileError = createCustomErrorClass("ImageLoadFromFileError");
+export class ImageIncorrectFileTypeError extends Error {
+  override name = "ImageIncorrectFileTypeError";
+  constructor(message?: string) {
+    super(message || "ImageIncorrectFileTypeError");
+  }
+}
 
-export const ImageIncorrectFileTypeError = createCustomErrorClass("ImageIncorrectFileTypeError");
+export class ImageDownloadError extends Error {
+  override name = "ImageDownloadError";
+  constructor(message?: string) {
+    super(message || "ImageDownloadError");
+  }
+}
 
-export const ImageDownloadError = createCustomErrorClass("ImageDownloadError");
+export class ImageTooLargeError extends Error {
+  override name = "ImageTooLargeError";
+  constructor(message?: string) {
+    super(message || "ImageTooLargeError");
+  }
+}
 
-export const ImageTooLargeError = createCustomErrorClass("ImageTooLargeError");
+export class ImageSizeLoadingError extends Error {
+  override name = "ImageSizeLoadingError";
+  constructor(message?: string) {
+    super(message || "ImageSizeLoadingError");
+  }
+}
 
-export const ImageSizeLoadingError = createCustomErrorClass("ImageSizeLoadingError");
+export class ImageCropError extends Error {
+  override name = "ImageCropError";
+  constructor(message?: string) {
+    super(message || "ImageCropError");
+  }
+}
 
-export const ImageCropError = createCustomErrorClass("ImageCropError");
+export class ImageResizeError extends Error {
+  override name = "ImageResizeError";
+  constructor(message?: string) {
+    super(message || "ImageResizeError");
+  }
+}
 
-export const ImageResizeError = createCustomErrorClass("ImageResizeError");
+export class ImagePreviewError extends Error {
+  override name = "ImagePreviewError";
+  constructor(message?: string) {
+    super(message || "ImagePreviewError");
+  }
+}
 
-export const ImagePreviewError = createCustomErrorClass("ImagePreviewError");
-
-export const ImageProcessingError = createCustomErrorClass("ImageProcessingError");
+export class ImageProcessingError extends Error {
+  override name = "ImageProcessingError";
+  constructor(message?: string) {
+    super(message || "ImageProcessingError");
+  }
+}

--- a/libs/ledgerjs/packages/hw-transport/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-transport/.unimportedrc.json
@@ -1,3 +1,4 @@
 {
-  "entry": ["src/Transport.ts"]
+  "entry": ["src/Transport.ts"],
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-transport/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/errors.ts
@@ -1,0 +1,250 @@
+export enum HwTransportErrorType {
+  Unknown = "Unknown",
+  LocationServicesDisabled = "LocationServicesDisabled",
+  LocationServicesUnauthorized = "LocationServicesUnauthorized",
+  BluetoothScanStartFailed = "BluetoothScanStartFailed",
+}
+
+export class HwTransportError extends Error {
+  [key: string]: unknown;
+  type: HwTransportErrorType;
+
+  constructor(type: HwTransportErrorType, message: string) {
+    super(message || "HwTransportError");
+    this.name = "HwTransportError";
+    this.type = type;
+    Object.setPrototypeOf(this, HwTransportError.prototype);
+  }
+}
+
+export class TransportError extends Error {
+  [key: string]: unknown;
+  id: string;
+  constructor(message: string, id: string) {
+    const name = "TransportError";
+    super(message || name);
+    this.name = name;
+    this.message = message;
+    this.stack = new Error(message).stack;
+    this.id = id;
+  }
+}
+
+export const StatusCodes = {
+  ACCESS_CONDITION_NOT_FULFILLED: 0x9804,
+  ALGORITHM_NOT_SUPPORTED: 0x9484,
+  CLA_NOT_SUPPORTED: 0x6e00,
+  CLA_NOT_SUPPORTED_BOOTLOADER: 0x6e01,
+  CODE_BLOCKED: 0x9840,
+  CODE_NOT_INITIALIZED: 0x9802,
+  COMMAND_INCOMPATIBLE_FILE_STRUCTURE: 0x6981,
+  CONDITIONS_OF_USE_NOT_SATISFIED: 0x6985,
+  CONTRADICTION_INVALIDATION: 0x9810,
+  CONTRADICTION_SECRET_CODE_STATUS: 0x9808,
+  DEVICE_IN_RECOVERY_MODE: 0x662f,
+  CUSTOM_IMAGE_EMPTY: 0x662e,
+  FILE_ALREADY_EXISTS: 0x6a89,
+  FILE_NOT_FOUND: 0x9404,
+  GP_AUTH_FAILED: 0x6300,
+  HALTED: 0x6faa,
+  INCONSISTENT_FILE: 0x9408,
+  INCORRECT_DATA: 0x6a80,
+  INCORRECT_LENGTH: 0x6700,
+  INCORRECT_P1_P2: 0x6b00,
+  INS_NOT_SUPPORTED: 0x6d00,
+  DEVICE_NOT_ONBOARDED: 0x6d07,
+  DEVICE_NOT_ONBOARDED_2: 0x6611,
+  INVALID_KCV: 0x9485,
+  INVALID_OFFSET: 0x9402,
+  LICENSING: 0x6f42,
+  LOCKED_DEVICE: 0x5515,
+  MAX_VALUE_REACHED: 0x9850,
+  MEMORY_PROBLEM: 0x9240,
+  MISSING_CRITICAL_PARAMETER: 0x6800,
+  NO_EF_SELECTED: 0x9400,
+  NOT_ENOUGH_MEMORY_SPACE: 0x6a84,
+  OK: 0x9000,
+  PIN_REMAINING_ATTEMPTS: 0x63c0,
+  REFERENCED_DATA_NOT_FOUND: 0x6a88,
+  SECURITY_STATUS_NOT_SATISFIED: 0x6982,
+  TECHNICAL_PROBLEM: 0x6f00,
+  UNKNOWN_APDU: 0x6d02,
+  USER_REFUSED_ON_DEVICE: 0x5501,
+  NOT_ENOUGH_SPACE: 0x5102,
+  APP_NOT_FOUND_OR_INVALID_CONTEXT: 0x5123,
+  INVALID_APP_NAME_LENGTH: 0x670a,
+  GEN_AES_KEY_FAILED: 0x5419,
+  INTERNAL_CRYPTO_OPERATION_FAILED: 0x541a,
+  INTERNAL_COMPUTE_AES_CMAC_FAILED: 0x541b,
+  ENCRYPT_APP_STORAGE_FAILED: 0x541c,
+  INVALID_BACKUP_STATE: 0x6642,
+  PIN_NOT_SET: 0x5502,
+  INVALID_BACKUP_LENGTH: 0x6733,
+  INVALID_RESTORE_STATE: 0x6643,
+  INVALID_CHUNK_LENGTH: 0x6734,
+  INVALID_BACKUP_HEADER: 0x684a,
+  SW_BAD_STATE: 0xb007,
+};
+
+export function getAltStatusMessage(code: number): string | undefined | null {
+  switch (code) {
+    case 0x6700:
+      return "Incorrect length";
+    case 0x6800:
+      return "Missing critical parameter";
+    case 0x6982:
+      return "Security not satisfied (dongle locked or have invalid access rights)";
+    case 0x6985:
+      return "Condition of use not satisfied (denied by the user?)";
+    case 0x6a80:
+      return "Invalid data received";
+    case 0x6b00:
+      return "Invalid parameter received";
+    case 0x5515:
+      return "Locked device";
+    case 0xb007:
+      return "Unexpected state on the device";
+  }
+  if (0x6f00 <= code && code <= 0x6fff) {
+    return "Internal error, please report";
+  }
+}
+
+export class TransportStatusError extends Error {
+  [key: string]: unknown;
+  statusCode: number;
+  statusText: string;
+
+  constructor(
+    statusCode: number,
+    { canBeMappedToChildError = true }: { canBeMappedToChildError?: boolean } = {},
+  ) {
+    const statusText =
+      Object.keys(StatusCodes).find(k => StatusCodes[k] === statusCode) || "UNKNOWN_ERROR";
+    const smsg = getAltStatusMessage(statusCode) || statusText;
+    const statusCodeStr = statusCode.toString(16);
+    const message = `Ledger device: ${smsg} (0x${statusCodeStr})`;
+
+    super(message || "TransportStatusError");
+    this.name = "TransportStatusError";
+
+    this.statusCode = statusCode;
+    this.statusText = statusText;
+
+    Object.setPrototypeOf(this, TransportStatusError.prototype);
+
+    if (canBeMappedToChildError && statusCode === StatusCodes.LOCKED_DEVICE) {
+      return new LockedDeviceError(message);
+    }
+  }
+}
+
+export class LockedDeviceError extends TransportStatusError {
+  constructor(message?: string) {
+    super(StatusCodes.LOCKED_DEVICE, { canBeMappedToChildError: false });
+    if (message) {
+      this.message = message;
+    }
+    this.name = "LockedDeviceError";
+    Object.setPrototypeOf(this, LockedDeviceError.prototype);
+  }
+}
+
+export class DeviceMangementKitError extends Error {
+  [key: string]: unknown;
+  constructor(name: string, message: string) {
+    super(message || "DeviceMangementKitError");
+    this.name = name;
+    Object.setPrototypeOf(this, DeviceMangementKitError.prototype);
+  }
+}
+
+export type TransportStatusErrorClassType = typeof TransportStatusError | typeof LockedDeviceError;
+
+export class BluetoothRequired extends Error {
+  override name = "BluetoothRequired";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "BluetoothRequired");
+  }
+}
+
+export class CantOpenDevice extends Error {
+  override name = "CantOpenDevice";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "CantOpenDevice");
+  }
+}
+
+export class DisconnectedDevice extends Error {
+  override name = "DisconnectedDevice";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "DisconnectedDevice");
+  }
+}
+
+export class DisconnectedDeviceDuringOperation extends Error {
+  override name = "DisconnectedDeviceDuringOperation";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "DisconnectedDeviceDuringOperation");
+  }
+}
+
+export class TransportOpenUserCancelled extends Error {
+  override name = "TransportOpenUserCancelled";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "TransportOpenUserCancelled");
+  }
+}
+
+export class TransportInterfaceNotAvailable extends Error {
+  override name = "TransportInterfaceNotAvailable";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "TransportInterfaceNotAvailable");
+  }
+}
+
+export class TransportRaceCondition extends Error {
+  override name = "TransportRaceCondition";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "TransportRaceCondition");
+  }
+}
+
+export class TransportWebUSBGestureRequired extends Error {
+  override name = "TransportWebUSBGestureRequired";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "TransportWebUSBGestureRequired");
+  }
+}
+
+export class TransportExchangeTimeoutError extends Error {
+  override name = "TransportExchangeTimeoutError";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "TransportExchangeTimeoutError");
+  }
+}
+
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "UserRefusedOnDevice");
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "UserRefusedAddress");
+  }
+}

--- a/libs/live-dmk-mobile/src/errors.ts
+++ b/libs/live-dmk-mobile/src/errors.ts
@@ -1,3 +1,19 @@
+export class PairingFailed extends Error {
+  override name = "PairingFailed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PairingFailed");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PeerRemovedPairing extends Error {
+  override name = "PeerRemovedPairing";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PeerRemovedPairing");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
 import {
   DeviceBusyError,
   DeviceDisconnectedWhileSendingError,

--- a/libs/live-signer-aleo/src/errors.ts
+++ b/libs/live-signer-aleo/src/errors.ts
@@ -1,0 +1,6 @@
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  constructor(message?: string) {
+    super(message || "UserRefusedOnDevice");
+  }
+}

--- a/libs/live-signer-canton/src/errors.ts
+++ b/libs/live-signer-canton/src/errors.ts
@@ -1,0 +1,7 @@
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/live-signer-concordium/src/errors.ts
+++ b/libs/live-signer-concordium/src/errors.ts
@@ -1,0 +1,6 @@
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  constructor(message?: string) {
+    super(message || "UserRefusedOnDevice");
+  }
+}

--- a/libs/live-signer-evm/src/errors.ts
+++ b/libs/live-signer-evm/src/errors.ts
@@ -1,5 +1,6 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const EthAppPleaseEnableContractData = createCustomErrorClass(
-  "EthAppPleaseEnableContractData",
-);
+export class EthAppPleaseEnableContractData extends Error {
+  override name = "EthAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "EthAppPleaseEnableContractData");
+  }
+}

--- a/libs/live-signer-solana/src/errors.ts
+++ b/libs/live-signer-solana/src/errors.ts
@@ -1,0 +1,14 @@
+export class LatestFirmwareVersionRequired extends Error {
+  override name = "LatestFirmwareVersionRequired";
+  constructor(message?: string) {
+    super(message || "LatestFirmwareVersionRequired");
+  }
+}
+
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/live-signer-zcash/src/errors.ts
+++ b/libs/live-signer-zcash/src/errors.ts
@@ -1,0 +1,6 @@
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  constructor(message?: string) {
+    super(message || "UserRefusedOnDevice");
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to `@ledgerhq/live-devices` packages as part of the `@ledgerhq/errors` sunset (LIVE-32915).

**Import Note:** `UserRefusedOnDevice` is duplicated on many live-signer-* because there is a lack of a generic "live-signer" framework I would say, and I think we can't afford that a `live-signer-*` depends on legacy `hw-transport`. So the imminent solution is to make each live-signer-* exposing its own UserRefusedOnDevice error as an interface. This solution is fine for now because we match error by `.name` now. But if you see this pattern eventually being a problem, there is a need to have a common framework library that factorize the live-signer-* needs 🙏  not the scope of this migration.

---

- `libs/ledgerjs/packages/hw-transport/src/errors.ts` — new file (`TransportStatusError`, `LockedDeviceError`, `CantOpenDevice`, `DisconnectedDevice`, etc.)
- `libs/device-core/src/errors.ts` — updated
- `libs/ledger-live-common/src/customImage/errors.ts` — updated
- `libs/live-dmk-mobile/src/errors.ts` — updated
- `libs/live-signer-evm/src/errors.ts` — updated
- `libs/live-signer-aleo/canton/concordium/solana/zcash/src/errors.ts` — new files

Also adds missing `CODEOWNERS` entries for `hw-transport`, `live-signer-aleo`, `live-signer-canton`, `live-signer-concordium`, `live-signer-zcash` → `@ledgerhq/live-devices`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35095