### PR TITLE
[LWD] fix(datadog): scrub wallet addresses and account IDs from RUM events (LIVE-34926)

### DIFF
--- a/.changeset/LIVE-34926-scrub-datadog-rum.md
+++ b/.changeset/LIVE-34926-scrub-datadog-rum.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Scrub wallet addresses and account IDs from Datadog RUM events

--- a/apps/ledger-live-desktop/src/datadog/config.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.test.ts
@@ -124,6 +124,48 @@ describe("datadog config", () => {
       expect(stack).toContain("https://app.asar/.webpack/renderer.bundle.js:1447:337795");
       expect(stack).not.toContain("file://");
     });
+
+    it("scrubs wallet address from resource.url", () => {
+      const beforeSend = buildBeforeSend(() => true);
+      const event = {
+        resource: {
+          url: "https://api.ledger.com/blockchain/v4/eth/address/0x9aa99c23f67c81701c772b106b4f83f6e858dd2e/txs",
+        },
+      };
+      beforeSend(event, undefined);
+      expect((event.resource as Record<string, unknown>).url).toBe(
+        "https://api.ledger.com/blockchain/v4/eth/address/[redacted]/txs",
+      );
+    });
+
+    it("scrubs wallet address from action.target.name", () => {
+      const beforeSend = buildBeforeSend(() => true);
+      const event = {
+        action: {
+          target: {
+            name: 'click on { "xpub": "xpub6C8aARQ2jRGKeZsDxLWMZfS8oVnrFGw1b61Pzeiub4H98DRSXdBJ65ctCYoJ1vUjLvFzcFvt2znVZvASmxm9M", "index": 0 }',
+          },
+        },
+      };
+      beforeSend(event, undefined);
+      expect(
+        ((event.action as Record<string, unknown>).target as Record<string, unknown>).name,
+      ).toBe('click on { "xpub": "[redacted]", "index": 0 }');
+    });
+
+    it("scrubs account ID from view.url_hash", () => {
+      const beforeSend = buildBeforeSend(() => true);
+      const event = {
+        view: {
+          url_hash:
+            "/account/js:2:bitcoin:xpub6DEHKg8fgKcb5iYGPLtpBYD9gm7nvym3wwhHVnH3TtogvJGTcApj71K8iTpL7CzdZWAxwyjkZEFUrnLK24zKqgj3EVH7Vg1CD1ujibwiHuy:segwit",
+        },
+      };
+      beforeSend(event, undefined);
+      expect((event.view as Record<string, unknown>).url_hash).toBe(
+        "/account/js:2:bitcoin:[redacted]:segwit",
+      );
+    });
   });
 
   describe("rewriteAsarUrls", () => {

--- a/apps/ledger-live-desktop/src/datadog/config.ts
+++ b/apps/ledger-live-desktop/src/datadog/config.ts
@@ -1,4 +1,5 @@
 import anonymizer from "~/datadog/anonymizer";
+import { scrubResourceUrl, scrubViewUrlHash, scrubActionTargetName } from "./scrubRum";
 import { shouldIgnoreErrorMessage } from "./ignoreErrors";
 
 export type ShouldSendCallback = () => boolean;
@@ -65,6 +66,22 @@ export function buildBeforeSend(shouldSend: ShouldSendCallback) {
       rewriteAsarUrlsRecursive(ev, new Set());
     } catch (e) {
       console.warn("Datadog: asar URL rewrite failed (best-effort):", e);
+    }
+
+    const resource = ev.resource as Record<string, unknown> | undefined;
+    if (resource && typeof resource.url === "string") {
+      resource.url = scrubResourceUrl(resource.url);
+    }
+
+    const action = ev.action as Record<string, unknown> | undefined;
+    const target = action?.target as Record<string, unknown> | undefined;
+    if (target && typeof target.name === "string") {
+      target.name = scrubActionTargetName(target.name);
+    }
+
+    const view = ev.view as Record<string, unknown> | undefined;
+    if (view && typeof view.url_hash === "string") {
+      view.url_hash = scrubViewUrlHash(view.url_hash);
     }
 
     return true;

--- a/apps/ledger-live-desktop/src/datadog/scrubRum.test.ts
+++ b/apps/ledger-live-desktop/src/datadog/scrubRum.test.ts
@@ -1,0 +1,113 @@
+import { scrubResourceUrl, scrubViewUrlHash, scrubActionTargetName } from "./scrubRum";
+
+describe("scrubResourceUrl", () => {
+  describe("address path segment", () => {
+    it("redacts the address segment after /address/", () => {
+      expect(scrubResourceUrl("https://api.ledger.com/blockchain/v4/eth/address/0xFoo/txs")).toBe(
+        "https://api.ledger.com/blockchain/v4/eth/address/[redacted]/txs",
+      );
+    });
+
+    it("is case-insensitive on the /address/ prefix", () => {
+      expect(
+        scrubResourceUrl("https://api.ledger.com/blockchain/v4/btc/Address/xpubFoo/utxo"),
+      ).toBe("https://api.ledger.com/blockchain/v4/btc/Address/[redacted]/utxo");
+    });
+
+    it("redacts the address segment after /addresses/ (plural)", () => {
+      expect(scrubResourceUrl("https://api.ledger.com/addresses/0xFoo/balance")).toBe(
+        "https://api.ledger.com/addresses/[redacted]/balance",
+      );
+    });
+
+    it("leaves URLs without /address/ unchanged", () => {
+      const url = "https://api.ledger.com/blockchain/v4/eth/fees";
+      expect(scrubResourceUrl(url)).toBe(url);
+    });
+  });
+
+  describe("reverse-resolve path segment", () => {
+    it("redacts the address segment after /reverse-resolve/", () => {
+      expect(scrubResourceUrl("https://api.ledger.com/ens/reverse-resolve/0xFoo")).toBe(
+        "https://api.ledger.com/ens/reverse-resolve/[redacted]",
+      );
+    });
+
+    it("is case-insensitive on the /reverse-resolve/ prefix", () => {
+      expect(scrubResourceUrl("https://api.ledger.com/ens/Reverse-Resolve/0xFoo")).toBe(
+        "https://api.ledger.com/ens/Reverse-Resolve/[redacted]",
+      );
+    });
+  });
+
+  describe("query param account ID", () => {
+    it("scrubs a URL-encoded account ID in a query param", () => {
+      expect(
+        scrubResourceUrl(
+          "https://crypto-assets-service.api.ledger.com/v1/tokens?id=js%3A2%3Abitcoin%3AxpubFoo%3Asegwit",
+        ),
+      ).toBe(
+        "https://crypto-assets-service.api.ledger.com/v1/tokens?id=js%3A2%3Abitcoin%3A%5Bredacted%5D%3Asegwit",
+      );
+    });
+
+    it("leaves non-account-id query params unchanged", () => {
+      const url = "https://api.ledger.com/v1/tokens?currency=bitcoin&limit=10";
+      expect(scrubResourceUrl(url)).toBe(url);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns an invalid URL as-is", () => {
+      expect(scrubResourceUrl("not a url")).toBe("not a url");
+    });
+
+    it("handles a URL with both a path leak and a query param leak", () => {
+      expect(
+        scrubResourceUrl(
+          "https://api.ledger.com/blockchain/v4/eth/address/0xFoo/txs?accountId=js%3A2%3Aethereum%3A0xFoo%3A",
+        ),
+      ).toBe(
+        "https://api.ledger.com/blockchain/v4/eth/address/[redacted]/txs?accountId=js%3A2%3Aethereum%3A%5Bredacted%5D%3A",
+      );
+    });
+  });
+});
+
+describe("scrubViewUrlHash", () => {
+  it("scrubs the account ID from a hash-router account route", () => {
+    expect(scrubViewUrlHash("/account/js:2:bitcoin:xpubFoo:segwit")).toBe(
+      "/account/js:2:bitcoin:[redacted]:segwit",
+    );
+  });
+
+  it("leaves a hash without an account ID unchanged", () => {
+    expect(scrubViewUrlHash("/cryptos")).toBe("/cryptos");
+  });
+
+  it("leaves the portfolio route unchanged", () => {
+    expect(scrubViewUrlHash("/")).toBe("/");
+  });
+});
+
+describe("scrubActionTargetName", () => {
+  it('redacts an EVM address in a "xpub" JSON key-value', () => {
+    expect(scrubActionTargetName('click on { "xpub": "0xFoo", "index": 0 }')).toBe(
+      'click on { "xpub": "[redacted]", "index": 0 }',
+    );
+  });
+
+  it('redacts a Bitcoin xpub in a "xpub" JSON key-value', () => {
+    expect(scrubActionTargetName('click on { "xpub": "xpubFoo", "index": 0 }')).toBe(
+      'click on { "xpub": "[redacted]", "index": 0 }',
+    );
+  });
+
+  it("handles whitespace variations around the colon", () => {
+    expect(scrubActionTargetName('"xpub" : "xpubFoo"')).toBe('"xpub": "[redacted]"');
+  });
+
+  it("leaves action names without a xpub field unchanged", () => {
+    expect(scrubActionTargetName("click on portfolio tab")).toBe("click on portfolio tab");
+  });
+});

--- a/apps/ledger-live-desktop/src/datadog/scrubRum.ts
+++ b/apps/ledger-live-desktop/src/datadog/scrubRum.ts
@@ -1,0 +1,74 @@
+import { scrubAccountId } from "~/renderer/helpers/scrubAccountId";
+
+/**
+ * Redacts the segment following `/address/` or `/addresses/` in a URL pathname.
+ * Ledger coin module APIs embed the wallet address at this path position,
+ * e.g. `.../blockchain/v4/eth/address/0xeF…/txs` or `.../addresses/${addr}/balance`.
+ */
+function scrubAddressPathSegment(pathname: string): string {
+  return pathname.replace(/(\/address(?:es)?\/)([^/]+)/gi, "$1[redacted]");
+}
+
+/**
+ * Redacts the segment following `/reverse-resolve/` in a URL pathname.
+ * ENS lookup endpoints use this path shape: `.../ens/reverse-resolve/0xeF…`
+ */
+function scrubReverseResolveSegment(pathname: string): string {
+  return pathname.replace(/(\/reverse-resolve\/)([^/]+)/gi, "$1[redacted]");
+}
+
+/**
+ * Scrubs account IDs from URL query parameters.
+ * Some Ledger API requests pass the full account ID URL-encoded in a query param,
+ * e.g. `?id=js%3A2%3Abitcoin%3Axpub6…%3Anative_segwit`. Each value is decoded
+ * and passed through `scrubAccountId` before being re-encoded.
+ */
+function scrubQueryParams(searchParams: URLSearchParams): URLSearchParams {
+  const scrubbed = new URLSearchParams();
+  for (const [key, value] of searchParams) {
+    scrubbed.set(key, scrubAccountId(value));
+  }
+  return scrubbed;
+}
+
+/**
+ * Scrubs wallet addresses from Datadog RUM resource.url.
+ *
+ * Three confirmed leak patterns in Ledger API request URLs:
+ * - `/address/{address}/…` — coin module path (all chains)
+ * - `/reverse-resolve/{address}` — ENS lookup endpoint
+ * - `?{key}=js%3A2%3A…` — full account ID URL-encoded in a query param
+ */
+export function scrubResourceUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+  parsed.pathname = scrubReverseResolveSegment(scrubAddressPathSegment(parsed.pathname));
+  parsed.search = scrubQueryParams(parsed.searchParams).toString();
+  return parsed.toString();
+}
+
+/**
+ * Scrubs wallet addresses from Datadog RUM view.url_hash.
+ *
+ * The hash fragment holds the React Router route, which on account pages is
+ * /account/js:2:{chain}:{address}:{derivation} — the full account ID.
+ * Present on every event type (view, action, resource, error).
+ */
+export function scrubViewUrlHash(hash: string): string {
+  return scrubAccountId(hash);
+}
+
+/**
+ * Scrubs wallet addresses from Datadog RUM action.target.name.
+ *
+ * The Browser SDK captures the visible text of clicked elements; account data
+ * serialized as JSON produces strings like: {"xpub":"xpub6C8aARQ2…","index":0,…}
+ * The "xpub" key holds the address for all chain types (EVM stores the 0x address there).
+ */
+export function scrubActionTargetName(name: string): string {
+  return name.replace(/"xpub"\s*:\s*"[^"]*"/g, '"xpub": "[redacted]"');
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

  Wallet addresses and account IDs were leaking into Datadog RUM through three confirmed vectors:

  - **`resource.url`**: Ledger API calls embed addresses in path segments (`/address/{addr}/…`,
  `/reverse-resolve/{addr}`) and account IDs URL-encoded in query parameters.
  - **`view.url_hash`**: The React Router hash contains the full account ID on account pages (e.g. 
  `/account/js:2:bitcoin:xpub6…:segwit`).
  - **`action.target.name`**: The Browser SDK captures visible text of clicked elements; account data serialized as JSON
  exposes the `xpub` field.

  A new `scrubRum.ts` module provides three scrubbing functions (`scrubResourceUrl`, `scrubViewUrlHash`, 
  `scrubActionTargetName`) wired into the Datadog `beforeSend` hook in `config.ts`. Sensitive values are replaced with 
  `[redacted]`.


This pr tries to remove as much ids as possible in datadog rum without removing tracking.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34926](https://ledgerhq.atlassian.net/browse/LIVE-34926)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34926]: https://ledgerhq.atlassian.net/browse/LIVE-34926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ