### PR TITLE
[LWDM] feat(LIVE-32915): add native Error classes for coin-integration

### DIFF
--- a/libs/coin-modules/coin-bitcoin/src/errors.ts
+++ b/libs/coin-modules/coin-bitcoin/src/errors.ts
@@ -62,3 +62,19 @@ export class ZcashUtxoNotInAccount extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class DustLimit extends Error {
+  override name = "DustLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DustLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class OpReturnDataSizeLimit extends Error {
+  override name = "OpReturnDataSizeLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OpReturnDataSizeLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-cosmos/src/errors.ts
+++ b/libs/coin-modules/coin-cosmos/src/errors.ts
@@ -45,3 +45,27 @@ export class CosmosTooManyRedelegations extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class SequenceNumberError extends Error {
+  override name = "SequenceNumberError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SequenceNumberError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ExpertModeRequired extends Error {
+  override name = "ExpertModeRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ExpertModeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecommendUndelegation extends Error {
+  override name = "RecommendUndelegation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecommendUndelegation");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-evm/src/errors.ts
+++ b/libs/coin-modules/coin-evm/src/errors.ts
@@ -139,3 +139,76 @@ export class NotEnoughNftOwned extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+// Transaction validation
+export class GasLessThanEstimate extends Error {
+  override name = "GasLessThanEstimate";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GasLessThanEstimate");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooLow extends Error {
+  override name = "PriorityFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooHigh extends Error {
+  override name = "PriorityFeeTooHigh";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeHigherThanMaxFee extends Error {
+  override name = "PriorityFeeHigherThanMaxFee";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeHigherThanMaxFee");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaxFeeTooLow extends Error {
+  override name = "MaxFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaxFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ETHAddressNonEIP extends Error {
+  override name = "ETHAddressNonEIP";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ETHAddressNonEIP");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RedelegateDstValAddressRequired extends Error {
+  override name = "RedelegateDstValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RedelegateDstValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ValAddressRequired extends Error {
+  override name = "ValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/src/errors.ts
+++ b/libs/coin-modules/coin-solana/src/errors.ts
@@ -221,3 +221,11 @@ export class SolanaTokenNonTransferable extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class NetworkError extends Error {
+  override name = "NetworkError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NetworkError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/tsconfig.json
+++ b/libs/coin-modules/coin-solana/tsconfig.json
@@ -5,7 +5,7 @@
     "noUnusedParameters": true,
     "declaration": true,
     "declarationMap": true,
-    "lib": ["es2020", "dom"],
+    "lib": ["ES2022", "dom"],
     "types": ["node", "jest"],
     "exactOptionalPropertyTypes": true,
     "outDir": "./lib",

--- a/libs/coin-modules/coin-tron/package.json
+++ b/libs/coin-modules/coin-tron/package.json
@@ -87,6 +87,11 @@
       "require": "./lib/bridge/transaction.js",
       "default": "./lib-es/bridge/transaction.js"
     },
+    "./types/*": {
+      "@ledgerhq/source": "./src/types/*.ts",
+      "require": "./lib/types/*.js",
+      "default": "./lib-es/types/*.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-tron/src/types/errors.ts
+++ b/libs/coin-modules/coin-tron/src/types/errors.ts
@@ -133,3 +133,27 @@ export class TronEmptyPage extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class TronEmptyAccount extends Error {
+  override name = "TronEmptyAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronEmptyAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaybeKeepTronAccountAlive extends Error {
+  override name = "MaybeKeepTronAccountAlive";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaybeKeepTronAccountAlive");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledger-wallet-framework/src/errors.ts
+++ b/libs/ledger-wallet-framework/src/errors.ts
@@ -1,7 +1,206 @@
 export class UnsupportedDerivation extends Error {
   override name = "UnsupportedDerivation";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedDerivation");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AccountNotSupported extends Error {
+  override name = "AccountNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AccountNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AmountRequired extends Error {
+  override name = "AmountRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AmountRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class DeviceAppVerifyNotSupported extends Error {
+  override name = "DeviceAppVerifyNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DeviceAppVerifyNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeNotLoaded extends Error {
+  override name = "FeeNotLoaded";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeNotLoaded");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeTooHigh extends Error {
+  override name = "FeeTooHigh";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddressBecauseDestinationIsAlsoSource extends Error {
+  override name = "InvalidAddressBecauseDestinationIsAlsoSource";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddressBecauseDestinationIsAlsoSource");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidTransactionError extends Error {
+  override name = "InvalidTransactionError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidTransactionError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LockedDeviceError extends Error {
+  override name = "LockedDeviceError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LockedDeviceError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  [key: string]: unknown;
   constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "UnsupportedDerivation", options);
+    super(message || "NotEnoughBalance", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceBecauseDestinationNotCreated extends Error {
+  override name = "NotEnoughBalanceBecauseDestinationNotCreated";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceBecauseDestinationNotCreated");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceFees extends Error {
+  override name = "NotEnoughBalanceFees";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NotEnoughBalanceFees", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceInParentAccount extends Error {
+  override name = "NotEnoughBalanceInParentAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceInParentAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughSpendableBalance extends Error {
+  override name = "NotEnoughSpendableBalance";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughSpendableBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeRequired extends Error {
+  override name = "FeeRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecipientRequired extends Error {
+  override name = "RecipientRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecipientRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedOnDevice");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WrongDeviceForAccount extends Error {
+  override name = "WrongDeviceForAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceToDelegate extends Error {
+  override name = "NotEnoughBalanceToDelegate";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceToDelegate");
     if (fields) Object.assign(this, fields);
   }
 }

--- a/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
@@ -10,5 +10,5 @@
     "@jest/expect-utils",
     "@jest/get-type",
     "jest-util"],
-  "ignoreUnimported": []
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
@@ -1,9 +1,18 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const EthAppPleaseEnableContractData = createCustomErrorClass(
-  "EthAppPleaseEnableContractData",
-);
-export const EthAppNftNotSupported = createCustomErrorClass("EthAppNftNotSupported");
-export const CeloAppPleaseEnableContractData = createCustomErrorClass(
-  "CeloAppPleaseEnableContractData",
-);
+export class EthAppPleaseEnableContractData extends Error {
+  override name = "EthAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "EthAppPleaseEnableContractData");
+  }
+}
+export class EthAppNftNotSupported extends Error {
+  override name = "EthAppNftNotSupported";
+  constructor(message?: string) {
+    super(message || "EthAppNftNotSupported");
+  }
+}
+export class CeloAppPleaseEnableContractData extends Error {
+  override name = "CeloAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "CeloAppPleaseEnableContractData");
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-str/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-str/.unimportedrc.json
@@ -1,4 +1,5 @@
 {
   "entry": ["src/Str.ts"],
-  "ignoreUnused": ["jest-sonar"]
+  "ignoreUnused": ["jest-sonar"],
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -39,47 +39,83 @@ We have written corresponding classes for exceptions that developers should acti
 #### Table of Contents
 
 *   [StellarHashSigningNotEnabledError](#stellarhashsigningnotenablederror)
-*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
-*   [StellarUserRefusedError](#stellaruserrefusederror)
-*   [StellarDataTooLargeError](#stellardatatoolargeerror)
-*   [Str](#str)
     *   [Parameters](#parameters)
+*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
+    *   [Parameters](#parameters-1)
+*   [StellarUserRefusedError](#stellaruserrefusederror)
+    *   [Parameters](#parameters-2)
+*   [StellarDataTooLargeError](#stellardatatoolargeerror)
+    *   [Parameters](#parameters-3)
+*   [Str](#str)
+    *   [Parameters](#parameters-4)
     *   [Examples](#examples)
     *   [getAppConfiguration](#getappconfiguration)
         *   [Examples](#examples-1)
     *   [getPublicKey](#getpublickey)
-        *   [Parameters](#parameters-1)
+        *   [Parameters](#parameters-5)
         *   [Examples](#examples-2)
     *   [signTransaction](#signtransaction)
-        *   [Parameters](#parameters-2)
+        *   [Parameters](#parameters-6)
         *   [Examples](#examples-3)
     *   [signSorobanAuthorization](#signsorobanauthorization)
-        *   [Parameters](#parameters-3)
+        *   [Parameters](#parameters-7)
         *   [Examples](#examples-4)
     *   [signHash](#signhash)
-        *   [Parameters](#parameters-4)
+        *   [Parameters](#parameters-8)
         *   [Examples](#examples-5)
     *   [signMessage](#signmessage)
-        *   [Parameters](#parameters-5)
+        *   [Parameters](#parameters-9)
         *   [Examples](#examples-6)
 
 ### StellarHashSigningNotEnabledError
 
+**Extends Error**
+
 Error thrown when hash signing is not enabled on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataParsingFailedError
+
+**Extends Error**
 
 Error thrown when data parsing fails.
 
 For example, when parsing the transaction fails, this error is thrown.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarUserRefusedError
+
+**Extends Error**
 
 Error thrown when the user refuses the request on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataTooLargeError
 
+**Extends Error**
+
 Error thrown when the data is too large to be processed by the device.
+
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
 
 ### Str
 

--- a/libs/ledgerjs/packages/hw-app-str/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-str/src/errors.ts
@@ -1,27 +1,45 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /**
  * Error thrown when hash signing is not enabled on the device.
  */
-export const StellarHashSigningNotEnabledError = createCustomErrorClass(
-  "StellarHashSigningNotEnabledError",
-);
+export class StellarHashSigningNotEnabledError extends Error {
+  override name = "StellarHashSigningNotEnabledError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarHashSigningNotEnabledError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when data parsing fails.
  *
  * For example, when parsing the transaction fails, this error is thrown.
  */
-export const StellarDataParsingFailedError = createCustomErrorClass(
-  "StellarDataParsingFailedError",
-);
+export class StellarDataParsingFailedError extends Error {
+  override name = "StellarDataParsingFailedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataParsingFailedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the user refuses the request on the device.
  */
-export const StellarUserRefusedError = createCustomErrorClass("StellarUserRefusedError");
+export class StellarUserRefusedError extends Error {
+  override name = "StellarUserRefusedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarUserRefusedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the data is too large to be processed by the device.
  */
-export const StellarDataTooLargeError = createCustomErrorClass("StellarDataTooLargeError");
+export class StellarDataTooLargeError extends Error {
+  override name = "StellarDataTooLargeError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataTooLargeError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-str/tsconfig.json
+++ b/libs/ledgerjs/packages/hw-app-str/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
@@ -1,3 +1,4 @@
 {
-  "entry": ["src/Sui.ts"]
+  "entry": ["src/Sui.ts"],
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
@@ -1,0 +1,7 @@
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-vet/package.json
+++ b/libs/ledgerjs/packages/hw-app-vet/package.json
@@ -55,5 +55,22 @@
     "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
-  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec"
+  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec",
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/Vet.ts",
+      "import": "./lib-es/Vet.js",
+      "require": "./lib/Vet.js",
+      "default": "./lib/Vet.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "import": "./lib-es/*.js",
+      "require": "./lib/*.js",
+      "default": "./lib/*.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
@@ -1,5 +1,6 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const VechainAppPleaseEnableContractDataAndMultiClause = createCustomErrorClass(
-  "VechainAppPleaseEnableContractDataAndMultiClause",
-);
+export class VechainAppPleaseEnableContractDataAndMultiClause extends Error {
+  override name = "VechainAppPleaseEnableContractDataAndMultiClause";
+  constructor(message?: string) {
+    super(message || "VechainAppPleaseEnableContractDataAndMultiClause");
+  }
+}

--- a/libs/wallet-btc/src/errors.ts
+++ b/libs/wallet-btc/src/errors.ts
@@ -1,9 +1,38 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // wallet-btc domain errors. Re-exported by @ledgerhq/coin-bitcoin for
 // backward compatibility (see coin-bitcoin/src/errors.ts).
-export const AccountNeedResync = createCustomErrorClass("AccountNeedResync");
+export class AccountNeedResync extends Error {
+  override name = "AccountNeedResync";
+  constructor(message?: string) {
+    super(message || "AccountNeedResync");
+  }
+}
 
-export const RbfBuildError = createCustomErrorClass("RbfBuildError");
+export class RbfBuildError extends Error {
+  override name = "RbfBuildError";
+  constructor(message?: string) {
+    super(message || "RbfBuildError");
+  }
+}
 
-export const UnsupportedDerivation = createCustomErrorClass("UnsupportedDerivation");
+export class UnsupportedDerivation extends Error {
+  override name = "UnsupportedDerivation";
+  constructor(message?: string) {
+    super(message || "UnsupportedDerivation");
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **Phase 1 of 2** — This PR introduces native `Error` subclasses without changing import sites in consuming code. The migration of imports from `@ledgerhq/errors` to the new package-specific paths will happen in a follow-up step. Native and legacy classes coexist during the transition.

### 📝 Description

Adds native `Error` class definitions to `@ledgerhq/coin-integration` packages as part of the `@ledgerhq/errors` sunset (LIVE-32915).

- `ledger-wallet-framework/src/errors.ts` — 22 native classes (`UserRefusedOnDevice`, `NotEnoughBalance`, `FeeNotLoaded`, etc.)
- `coin-algorand`, `coin-bitcoin`, `coin-cosmos`, `coin-evm`, `coin-solana`, `coin-tron/types` — expanded with new error classes
- `hw-app-eth`, `hw-app-str`, `hw-app-sui` (new), `hw-app-vet` — replaced `createCustomErrorClass`
- `wallet-btc/src/errors.ts` — replaced with native classes

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915]
- **ADR** (if any): N/A

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ