### PR TITLE
[LWD] chore(translations): update desktop translations for v4.13.0 release

### DIFF
--- a/apps/ledger-live-desktop/static/i18n/de/app.json
+++ b/apps/ledger-live-desktop/static/i18n/de/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™ unterstützt das Swappen von Monad nicht",
       "monad_description" : "Zum Swappen von Monad musst du ein anderes kompatibles Ledger-Gerät verwenden, z. B. Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ oder Ledger Stax™.",
       "zcash_title" : "Ledger Nano S™ unterstützt das Swappen von Zcash nicht",
-      "zcash_description" : "Zum Swappen von Zcash musst du ein anderes kompatibles Ledger-Gerät verwenden, z. B. einen Ledger Nano S Plus™, einen Ledger Nano X™, einen Ledger Flex™ oder einen Ledger Stax™."
+      "zcash_description" : "Zum Swappen von Zcash musst du ein anderes kompatibles Ledger-Gerät verwenden, z. B. einen Ledger Nano S Plus™, einen Ledger Nano X™, einen Ledger Flex™ oder einen Ledger Stax™.",
+      "aleo_title" : "Ledger Nano S™ unterstützt das Swappen von Aleo nicht",
+      "aleo_description" : "Zum Swappen von Aleo kannst du jedes sonstige kompatible Ledger-Gerät nutzen, z. B. Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ oder Ledger Stax™."
     },
     "providers" : {
       "title" : "Wähle einen Anbieter für das Swappen von Kryptowährungen",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Gebührenbetrag ({{unit}})",
     "gasLimit" : "Gaslimit ({{unit}})",
     "feesPaid" : "Gebühren, die an das Netzwerk entrichtet werden, um deine Transaktion durchzuführen",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Du verwendest {{energy}} Energie und {{bandwidth}} Bandbreite, um die Netzwerkgebühr zu bezahlen."
+      },
+      "insufficient" : {
+        "description" : "Du hast nicht genügend Energie und Bandbreite, um diesen Transfer zu decken. Der Fehlbetrag wird durch das Verbrennen von TRX gedeckt."
+      }
+    },
     "insufficientBalanceFees" : "Unzureichender Saldo zur Deckung der Netzwerkgebühren",
     "amountToSend" : "Zu sendender Betrag in ({{currency}})",
     "coinToSend" : "Zu sendender Coin",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Erneut delegieren",
         "redelegateDisabledTooltip" : "Du kannst für <0>{{days}}</0> wieder redelegieren.",
         "redelegateMaxDisabledTooltip" : "Du kannst nicht mehr als <0>7</0> Validatoren auf einmal redelegieren",
-        "undelegateDisabledTooltip" : "Du kannst die Delegierung nicht für mehr als <0>7</0> Validatoren gleichzeitig aufheben",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "Du kannst die Delegierung nicht für mehr als <0>7</0> Validatoren gleichzeitig aufheben",
+          "zero_gravity" : "Du benötigst mindestens 1 Gwei an delegierten Anteilen, um zu undelegieren."
+        },
         "undelegateActivatingTooltip" : "Du kannst ein Staking, das noch aktiviert wird, nicht undelegieren.",
         "reward" : "Prämien beanspruchen",
         "activeTooltip" : "Delegierte Beträge generieren Prämien",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Betrag"
+              "title" : "Betrag",
+              "visibilityDelay" : "Es kann bis zu {{numberOfMinutes}} Minuten dauern, bis diese Delegierung in deiner Delegierungsübersicht angezeigt wird."
             },
             "validator" : {
               "title" : "Validatoren",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Einzahlen",
+      "OUT" : "Abheben"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Kommagetrennte Familien für benutzerdefinierte Multi-Familien-Tests.",
         "customFamiliesPlaceholder" : "EVM, Stellar, Aptos",
         "applyFamilies" : "Anwenden",
-        "resetOverride" : "Überschreiben zurücksetzen"
+        "contactsData" : "Kontaktdaten",
+        "loadPopulatedContacts" : "Befüllte Kontakte laden",
+        "resetContacts" : "Kontakte zurücksetzen",
+        "resetOverride" : "Überschreiben zurücksetzen",
+        "featureIntroduction" : {
+          "title" : "Funktioneneinführung",
+          "label" : "Einführung in die „Kontakte anzeigen“-Funktion",
+          "dismissed" : "Ausgeblendet – aktivieren, um die Einführung unter „Kontakte“ erneut anzuzeigen.",
+          "willShow" : "Wird unter „Kontakte“ angezeigt, bis die Meldung verworfen wird."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Crypto Assets List (CAL)",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "Das Empfängerkonto hat sich nicht für den gewählten ASA entschieden."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Memo ist zu lang.",
+      "description" : "Algorand-Memos dürfen 1.024 Byte nicht überschreiten. Bitte kürze dein Memo."
     },
     "AmountRequired" : {
       "title" : "Erforderlicher Betrag"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Mehr anzeigen. Weniger tippen. Spare {{discount}}%",
-      "subtitle" : "Genieße einen größeren Bildschirm, eine smartere Transaktionsprüfung, erweiterten Schutz und exklusive {{discount}}% Rabatt."
+      "subtitle" : "Genieße einen größeren Bildschirm, eine smartere Transaktionsprüfung, erweiterten Schutz und exklusive {{discount}}% Rabatt.",
+      "cta" : "Touchscreen Signer entdecken"
     },
     "optedOut" : {
-      "title" : "Betrug erkennen. Jedes Detail ansehen",
-      "subtitle" : "Alles übersichtlich auf einem Touchscreen-Signer prüfen und Betrug dank fortschrittlicher Sicherheitsprüfungen erkennen."
-    },
-    "cta" : "Touchscreen Signer entdecken"
+      "title" : "Betrug vor dem Signieren erkennen",
+      "subtitle" : "Erfahre mehr über fortschrittliche Sicherheitsfunktionen, die eine Bedrohungserkennung in Echtzeit ermöglichen.",
+      "cta" : "Weitere Informationen"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Kontakte",
     "addContact" : "Kontakt hinzufügen",
     "searchPlaceholder" : "Kontakt suchen",
+    "searchNoResults" : "Kein Kontakt gefunden",
     "me" : {
       "name" : "Ich",
       "addressCount_zero" : "0 Adresse",
       "addressCount_one" : "{{count}} Adresse",
       "addressCount_other" : "{{count}} Adressen"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Deine Kontakte sind mit deinem Ledger Ende-zu-Ende verschlüsselt und werden mit deinen Geräten synchronisiert – nur du kannst sie entsperren.",
+      "dismiss" : "Verstanden"
+    },
+    "featureIntroduction" : {
+      "title" : "Wir stellen vor: Kontakte",
+      "description" : "Dein Adressbuch für Krypto – speichere an einem Ort die Wallets, an die du sendest.",
+      "primaryAction" : "Kontakte ausprobieren",
+      "secondaryAction" : "Vielleicht später",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Adressen einmalig speichern",
+          "description" : "Speichere an einem Ort die Wallets, an die du sendest."
+        },
+        "sendToRightAddress" : {
+          "title" : "An die richtige Adresse senden",
+          "description" : "Guthaben erreicht immer die richtige Wallet."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Privat auf all deinen Geräten",
+          "description" : "Ende-zu-Ende-verschlüsselt mit Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/es/app.json
+++ b/apps/ledger-live-desktop/static/i18n/es/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "No es posible usar el Ledger Nano S™ para permutar Monad",
       "monad_description" : "Para permutar Monad, usa cualquier otro dispositivo Ledger compatible, como el Ledger Nano S Plus™, el Ledger Nano X™, el Ledger Flex™ o el Ledger Stax™.",
       "zcash_title" : "No es posible usar el Ledger Nano S™ para permutar Zcash",
-      "zcash_description" : "Para permutar Zcash, usa cualquier otro dispositivo Ledger compatible, como el Ledger Nano S Plus™, el Ledger Nano X™, el Ledger Flex™ o el Ledger Stax™."
+      "zcash_description" : "Para permutar Zcash, usa cualquier otro dispositivo Ledger compatible, como el Ledger Nano S Plus™, el Ledger Nano X™, el Ledger Flex™ o el Ledger Stax™.",
+      "aleo_title" : "No es posible utilizar el Ledger Nano S™ para permutar Aleo",
+      "aleo_description" : "Para permutar Aleo, usa cualquier otro dispositivo Ledger compatible, como el Ledger Nano S Plus™, el Ledger Nano X™, el Ledger Flex™ o el Ledger Stax™."
     },
     "providers" : {
       "title" : "Elige un proveedor para permutar cripto",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Monto de la tarifa ({{unit}})",
     "gasLimit" : "Limite de gas ({{unit}})",
     "feesPaid" : "Tarifa abonada a la red para procesar tu transacción",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Usarás {{energy}} de energía y {{bandwidth}} de ancho de banda para pagar las tarifas de red."
+      },
+      "insufficient" : {
+        "description" : "No tienes suficiente energía y ancho de banda para cubrir esta transferencia. La diferencia se cubrirá quemando TRX."
+      }
+    },
     "insufficientBalanceFees" : "Saldo insuficiente para cubrir las tarifas de red.",
     "amountToSend" : "Monto a enviar en ({{currency}})",
     "coinToSend" : "Monedas a enviar",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Redelegar",
         "redelegateDisabledTooltip" : "Puedes volver a delegar <0>{{days}}</0>",
         "redelegateMaxDisabledTooltip" : "No puedes redelegar más de <0>7</0> validadores a la vez.",
-        "undelegateDisabledTooltip" : "No puedes desdelegar más de <0>7</0> validadores a la vez.",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "No puedes desdelegar más de <0>7</0> validadores a la vez.",
+          "zero_gravity" : "Necesitas al menos 1 gwei de participaciones delegadas para desdelegar"
+        },
         "undelegateActivatingTooltip" : "No puedes desdelegar una participación que sigue activándose",
         "reward" : "Reclamar recompensas",
         "activeTooltip" : "Los importes delegados generan recompensas",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Importe"
+              "title" : "Importe",
+              "visibilityDelay" : "Esta delegación puede tardar hasta {{numberOfMinutes}} minutos en aparecer en tu panel de delegación."
             },
             "validator" : {
               "title" : "Validadores",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Depositar",
+      "OUT" : "Retirar"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Familias separadas por comas para pruebas multifamilia personalizadas.",
         "customFamiliesPlaceholder" : "evm, stellar, aptos",
         "applyFamilies" : "Aplicar",
-        "resetOverride" : "Restablecer forzado"
+        "contactsData" : "Datos de contactos",
+        "loadPopulatedContacts" : "Cargar contactos completados",
+        "resetContacts" : "Restablecer contactos",
+        "resetOverride" : "Restablecer forzado",
+        "featureIntroduction" : {
+          "title" : "Introducción a las funcionalidades",
+          "label" : "Introducción a la funcionalidad Mostrar Contactos",
+          "dismissed" : "Descartado — Actívalo para volver a mostrar la introducción en Contactos.",
+          "willShow" : "Se mostrará en Contactos hasta que se descarte."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Lista de activos cripto",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "La cuenta de recepción no ha adherido al ASA seleccionado."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "El Memo es demasiado largo.",
+      "description" : "Los memos de Algorand no pueden superar los 1024 bytes. Por favor, acorta tu memo."
     },
     "AmountRequired" : {
       "title" : "Importe requerido"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Más datos. Menos toques. Ahorra un {{discount}}%",
-      "subtitle" : "Disfruta de una pantalla más grande, una revisión de transacciones más inteligente, protección mejorada y un descuento exclusivo del {{discount}}%."
+      "subtitle" : "Disfruta de una pantalla más grande, una revisión de transacciones más inteligente, protección mejorada y un descuento exclusivo del {{discount}}%.",
+      "cta" : "Explora los signers táctiles"
     },
     "optedOut" : {
-      "title" : "Detecta estafas. Visualiza cada detalle",
-      "subtitle" : "Revisa con claridad en un signer con pantalla táctil y detecta estafas con controles de seguridad avanzados."
-    },
-    "cta" : "Explora los signers táctiles"
+      "title" : "Detecta estafas antes de firmar",
+      "subtitle" : "Más información sobre las características de seguridad avanzadas que permiten detectar amenazas en tiempo real.",
+      "cta" : "Más información"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Contactos",
     "addContact" : "Agregar contacto",
     "searchPlaceholder" : "Buscar contacto",
+    "searchNoResults" : "No se encontró ningún contacto",
     "me" : {
       "name" : "Yo",
       "addressCount_zero" : "0 direcciones",
       "addressCount_one" : "{{count}} dirección",
       "addressCount_other" : "{{count}} direcciones"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Tus contactos están cifrados de extremo a extremo con tu Ledger y sincronizados en todos tus dispositivos; solo tú puedes desbloquearlos.",
+      "dismiss" : "Entendido"
+    },
+    "featureIntroduction" : {
+      "title" : "Presentamos Contactos",
+      "description" : "Tu agenda de direcciones cripto — Guarda las wallets a las que envías activos en un mismo lugar.",
+      "primaryAction" : "Prueba Contactos",
+      "secondaryAction" : "Quizás más tarde",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Guarda las direcciones una sola vez",
+          "description" : "Mantén las direcciones a las que envías en un solo lugar."
+        },
+        "sendToRightAddress" : {
+          "title" : "Envía a la dirección correcta",
+          "description" : "Los fondos siempre llegan a la wallet correcta."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Privado en todos tus dispositivos",
+          "description" : "Cifrado de extremo a extremo con Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/fr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/fr/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Le Ledger Nano S™ ne prend pas en charge l’échange de Monad",
       "monad_description" : "Pour échanger des Monad, utilisez un autre appareil Ledger compatible, tel que le Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™.",
       "zcash_title" : "Le Ledger Nano S™ ne prend pas en charge l’échange de Zcash",
-      "zcash_description" : "Pour échanger des Zcash, utilisez un autre appareil Ledger compatible, tel que le Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™."
+      "zcash_description" : "Pour échanger des Zcash, utilisez un autre appareil Ledger compatible, tel que le Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™.",
+      "aleo_title" : "Le Ledger Nano S™ ne prend pas en charge l’échange d’Aleo",
+      "aleo_description" : "Pour échanger des Aleo, utilisez un autre appareil Ledger compatible, tel que le Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™."
     },
     "providers" : {
       "title" : "Choisir un prestataire pour le Swap",
@@ -2402,7 +2404,7 @@
       "options" : {
         "fromBank" : {
           "title" : "Via un virement bancaire",
-          "description" : "Recevez des stablecoins en réalisant un virement depuis votre banque."
+          "description" : "Recevez des stablecoins par virement bancaire."
         },
         "fromCrypto" : {
           "title" : "Via une adresse crypto"
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Montant des frais ({{unit}})",
     "gasLimit" : "Limite de gaz ({{unit}})",
     "feesPaid" : "Frais payés au réseau pour le traitement de votre transaction",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Vous utiliserez {{energy}} en énergie et {{bandwidth}} en bande passante pour payer les frais de réseau."
+      },
+      "insufficient" : {
+        "description" : "Vous n’avez pas assez d’énergie et de bande passante pour couvrir ce transfert. Le montant manquant sera couvert en utilisant (brûlant) des TRX."
+      }
+    },
     "insufficientBalanceFees" : "Solde insuffisant pour couvrir les frais de réseau",
     "amountToSend" : "Montant à envoyer ({{currency}})",
     "coinToSend" : "Crypto à envoyer",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Modifier",
         "redelegateDisabledTooltip" : "Vous pouvez redéléguer dans <0>{{days}}</0>.",
         "redelegateMaxDisabledTooltip" : "Vous ne pouvez pas redéléguer à plus de <0>7</0> validateurs à la fois.",
-        "undelegateDisabledTooltip" : "Vous ne pouvez pas arrêter la délégation de plus de <0>7</0> validateurs à la fois.",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "Vous ne pouvez pas arrêter la délégation de plus de <0>7</0> validateurs à la fois.",
+          "zero_gravity" : "Vous devez avoir au moins 1 gwei de parts déléguées pour arrêter la délégation"
+        },
         "undelegateActivatingTooltip" : "Impossible d’arrêter la délégation lorsque le staking est en cours d’activation.",
         "reward" : "Demander les récompenses",
         "activeTooltip" : "Les montants délégués génèrent des récompenses.",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Montant"
+              "title" : "Montant",
+              "visibilityDelay" : "Retrouvez cette délégation sur votre tableau de bord d’ici {{numberOfMinutes}} minutes."
             },
             "validator" : {
               "title" : "Validateurs",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Dépôt",
+      "OUT" : "Retrait"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Familles séparées par des virgules pour des tests multifamilles personnalisés.",
         "customFamiliesPlaceholder" : "EVM, Stellar, Aptos",
         "applyFamilies" : "Appliquer",
-        "resetOverride" : "Réinitialiser"
+        "contactsData" : "Données des contacts",
+        "loadPopulatedContacts" : "Charger des contacts complets",
+        "resetContacts" : "Réinitialiser les contacts",
+        "resetOverride" : "Réinitialiser",
+        "featureIntroduction" : {
+          "title" : "Présentation",
+          "label" : "Afficher la présentation des Contacts.",
+          "dismissed" : "Désactivé : réactivez pour réafficher la présentation des Contacts.",
+          "willShow" : "S’affichera dans Contacts jusqu’à sa fermeture."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Liste de crypto-actifs (CAL)",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "Le compte bénéficiaire n’a pas activé l’ASA sélectionné."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Mémo trop long",
+      "description" : "Les mémos Algorand ne peuvent pas dépasser 1 024 bytes. Veuillez raccourcir votre mémo."
     },
     "AmountRequired" : {
       "title" : "Montant requis"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Voyez plus grand. Économisez {{discount}}%.",
-      "subtitle" : "Profitez d’un écran plus grand, d’une vérification des transactions automatisée, d’une protection renforcée et d’une réduction exclusive de {{discount}}%."
+      "subtitle" : "Profitez d’un écran plus grand, d’une vérification des transactions automatisée, d’une protection renforcée et d’une réduction exclusive de {{discount}}%.",
+      "cta" : "Explorer les signers tactiles"
     },
     "optedOut" : {
-      "title" : "Repérez les pièges d’un coup d’œil",
-      "subtitle" : "Vérifiez les détails de vos transactions sur un écran tactile et repérez les escroqueries grâce à des contrôles de sécurité avancés."
-    },
-    "cta" : "Explorer les signers tactiles"
+      "title" : "Détection des escroqueries",
+      "subtitle" : "Ces fonctionnalités de sécurité avancées permettent de détecter les menaces en temps réel.",
+      "cta" : "En savoir plus"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Contacts",
     "addContact" : "Ajouter un contact",
     "searchPlaceholder" : "Rechercher un contact",
+    "searchNoResults" : "Aucun contact trouvé",
     "me" : {
       "name" : "Moi",
       "addressCount_zero" : "0 adresse",
       "addressCount_one" : "{{count}} adresse",
       "addressCount_other" : "{{count}} adresses"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Vos contacts sont chiffrés de bout en bout avec votre appareil Ledger et synchronisés sur vos appareils. Vous seul(e) pouvez y accéder.",
+      "dismiss" : "Compris"
+    },
+    "featureIntroduction" : {
+      "title" : "Découvrez les contacts",
+      "description" : "Votre répertoire crypto : enregistrez les wallets vers lesquels vous transférez des actifs, en un seul endroit.",
+      "primaryAction" : "Explorer",
+      "secondaryAction" : "Plus tard",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Enregistrez vos adresses",
+          "description" : "Conservez un répertoire de vos adresses."
+        },
+        "sendToRightAddress" : {
+          "title" : "Envoyez à la bonne adresse",
+          "description" : "Transférez vos actifs vers le bon wallet."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Confidentialité multi-appareils",
+          "description" : "Chiffré de bout en bout avec Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/ja/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ja/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™はMonadのスワップに対応していません",
       "monad_description" : "Monadをスワップするには、Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™、Ledger Stax™など、対応する他のLedgerデバイスをご使用ください。",
       "zcash_title" : "Ledger Nano S™はZcashのスワップに対応していません",
-      "zcash_description" : "Zcashをスワップするには、Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™、Ledger Stax™など、対応する他のLedgerデバイスをご使用ください。"
+      "zcash_description" : "Zcashをスワップするには、Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™、Ledger Stax™など、対応する他のLedgerデバイスをご使用ください。",
+      "aleo_title" : "Ledger Nano S™は、Aleoのスワップに対応していません",
+      "aleo_description" : "Aleoをスワップするには、Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™、またはLedger Stax™など、他の対応するLedgerデバイスをご使用ください。"
     },
     "providers" : {
       "title" : "暗号資産のスワップに利用するプロバイダーを選択",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "手数料金額 ({{unit}})",
     "gasLimit" : "ガス制限（{{unit}}）",
     "feesPaid" : "トランザクションを処理するためにネットワークへ支払われる手数料です",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "ネットワーク手数料の支払いには、{{energy}}のエネルギーと{{bandwidth}}のバンド幅を使用します。"
+      },
+      "insufficient" : {
+        "description" : "この送金を行うのに十分なエネルギーとバンド幅がありません。不足分はTRXをバーンすることで補われます。"
+      }
+    },
     "insufficientBalanceFees" : "ネットワーク手数料をカバーするための残高が不足しています",
     "amountToSend" : "送金金額 ({{currency}})",
     "coinToSend" : "送付するコイン",
@@ -4339,7 +4349,10 @@
         "redelegate" : "再デリゲート",
         "redelegateDisabledTooltip" : "再デリゲートは、<0>{{days}}</0>後に可能です",
         "redelegateMaxDisabledTooltip" : "一度に<0>7</0>件以上のバリデーターを再デリゲートすることはできません。",
-        "undelegateDisabledTooltip" : "一度に<0>7</0>件以上のバリデーターのデリゲートを解除することはできません。",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "一度に<0>7</0>件以上のバリデーターのデリゲートを解除することはできません。",
+          "zero_gravity" : "デリゲート解除するには、デリゲートされたシェアが1 Gwei以上必要です。"
+        },
         "undelegateActivatingTooltip" : "アクティベート中のステーキングはデリゲート解除できません",
         "reward" : "報酬獲得を申請",
         "activeTooltip" : "デリゲートして報酬を得る",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "数量"
+              "title" : "数量",
+              "visibilityDelay" : "このデリゲーションがデリゲーションボードに反映されるまでに、最大{{numberOfMinutes}}分かかる場合があります。"
             },
             "validator" : {
               "title" : "バリデーター",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "入金",
+      "OUT" : "出金"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "カスタムマルチファミリーテスト用のカンマ区切りファミリー。",
         "customFamiliesPlaceholder" : "evm、stellar、aptos",
         "applyFamilies" : "適用",
-        "resetOverride" : "上書きをリセット"
+        "contactsData" : "連絡先データ",
+        "loadPopulatedContacts" : "入力済みの連絡先を読み込む",
+        "resetContacts" : "連絡先をリセット",
+        "resetOverride" : "上書きをリセット",
+        "featureIntroduction" : {
+          "title" : "新機能の紹介",
+          "label" : "連絡先の登録機能の紹介を表示",
+          "dismissed" : "非表示 — オンにすると、連絡先の案内通知を再び表示します。",
+          "willShow" : "非表示にするまで「連絡先」に表示されます。"
+        }
       },
       "cryptoAssetsList" : {
         "title" : "暗号資産リスト",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "送付先アカウントは、選択したASAをオプトインしていません。"
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "メモが長すぎます。",
+      "description" : "Algorandのメモは1024バイトを超えることはできません。メモを短くしてください。"
     },
     "AmountRequired" : {
       "title" : "数量は必須です。"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "詳細を表示。数回のタップで取引。{{discount}}％OFF",
-      "subtitle" : "大画面、スマートなトランザクション、強化された保護を{{discount}}％OFFでお楽しみください。"
+      "subtitle" : "大画面、スマートなトランザクション、強化された保護を{{discount}}％OFFでお楽しみください。",
+      "cta" : "タッチスクリーン搭載の署名用デバイスを詳しく見る"
     },
     "optedOut" : {
-      "title" : "詐欺を見抜く。すべての詳細を確認する",
-      "subtitle" : "タッチスクリーン搭載の署名用デバイスで詳細を明確に確認し、高度なセキュリティチェックで詐欺を検知しましょう。"
-    },
-    "cta" : "タッチスクリーン搭載の署名用デバイスを詳しく見る"
+      "title" : "署名前に詐欺を見抜く",
+      "subtitle" : "リアルタイムの脅威検出を可能にする、高度なセキュリティ機能についての詳細をご確認ください。",
+      "cta" : "詳細をチェック"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "お問い合せ",
     "addContact" : "連絡先を追加",
     "searchPlaceholder" : "連絡先を検索",
+    "searchNoResults" : "連絡先が見つかりません",
     "me" : {
       "name" : "自分",
       "addressCount_zero" : "0アドレス",
       "addressCount_one" : "{{count}}アドレス",
       "addressCount_other" : "{{count}}アドレス"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "連絡先はLedgerによってエンドツーエンドで暗号化され、デバイス間で同期されます。これをロック解除できるのはあなただけです。",
+      "dismiss" : "了解"
+    },
+    "featureIntroduction" : {
+      "title" : "連絡先の登録機能のご紹介",
+      "description" : "暗号資産用のアドレス帳 — 送信先のウォレットをすべて1か所に保存。",
+      "primaryAction" : "連絡先の登録機能を試す",
+      "secondaryAction" : "後で",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "アドレスを一度保存するだけ",
+          "description" : "送信先のアドレスを1か所で管理。"
+        },
+        "sendToRightAddress" : {
+          "title" : "正しいアドレスに送信",
+          "description" : "資金は常に正しいウォレットに届きます。"
+        },
+        "privateAcrossDevices" : {
+          "title" : "デバイス間でプライバシーを保護",
+          "description" : "Ledger Syncによりエンドツーエンドで暗号化。"
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/ko/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ko/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™는 모나드(Monad) 스왑을 지원하지 않습니다.",
       "monad_description" : "모나드를 스왑하려면 Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ 또는 Ledger Stax™와 같은 호환 가능한 다른 Ledger 장치를 사용하세요.",
       "zcash_title" : "Ledger Nano S™는 Zcash 스왑을 지원하지 않습니다.",
-      "zcash_description" : "Zcash를 스왑하려면 Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ 또는 Ledger Stax™와 같은 호환 가능한 다른 Ledger 장치를 사용하세요."
+      "zcash_description" : "Zcash를 스왑하려면 Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ 또는 Ledger Stax™와 같은 호환 가능한 다른 Ledger 장치를 사용하세요.",
+      "aleo_title" : "Ledger Nano S™는 Aleo 스왑을 지원하지 않습니다.",
+      "aleo_description" : "Aleo를 스왑하려면 Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ 또는 Ledger Stax™와 같은 다른 호환 Ledger 장치를 사용하세요."
     },
     "providers" : {
       "title" : "암호화폐를 스왑할 공급자를 선택하세요",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "수수료({{unit}})",
     "gasLimit" : "가스 한도({{unit}})",
     "feesPaid" : "네트워크에 지불하는 트랜잭션 처리 수수료",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "네트워크 수수료로 에너지({{energy}})와 대역폭({{bandwidth}})이 사용됩니다."
+      },
+      "insufficient" : {
+        "description" : "이번 전송을 처리하기에 에너지와 대역폭이 충분하지 않습니다. 부족분은 TRX를 소각하여 충당됩니다."
+      }
+    },
     "insufficientBalanceFees" : "네트워크 수수료를 지불할 잔액이 부족합니다",
     "amountToSend" : "보낼 수량({{currency}})",
     "coinToSend" : "보낼 코인",
@@ -4339,7 +4349,10 @@
         "redelegate" : "재위임",
         "redelegateDisabledTooltip" : "<0>{{days}}</0>에 재위임할 수 있습니다",
         "redelegateMaxDisabledTooltip" : "한 번에 <0>7</0>명 이상의 검증인을 재위임할 수 없습니다",
-        "undelegateDisabledTooltip" : "한 번에 <0>7</0>명 이상의 검증인을 위임 해제할 수 없습니다",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "한 번에 위임 해제할 수 있는 검증인 수는 최대 <0>7</0>명입니다.",
+          "zero_gravity" : "위임된 지분이 최소 1 Gwei 이상이어야 위임을 해제를 할 수 있습니다."
+        },
         "undelegateActivatingTooltip" : "아직 활성화 단계의 스테이킹 자산은 위임을 취소할 수 없습니다.",
         "reward" : "보상 수령",
         "activeTooltip" : "위임된 수량에서 보상이 생성됩니다",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "수량"
+              "title" : "수량",
+              "visibilityDelay" : "이 위임 내역이 위임 보드에 표시되기까지 최대 {{numberOfMinutes}}분이 소요될 수 있습니다."
             },
             "validator" : {
               "title" : "검증인",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "입금",
+      "OUT" : "출금"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "사용자 지정 다중 패밀리 테스트를 위해 쉼표로 구분된 주소 체계",
         "customFamiliesPlaceholder" : "evm, stellar, aptos",
         "applyFamilies" : "적용",
-        "resetOverride" : "오버라이드 리셋"
+        "contactsData" : "연락처 데이터",
+        "loadPopulatedContacts" : "등록된 연락처 불러오기",
+        "resetContacts" : "연락처 초기화",
+        "resetOverride" : "오버라이드 리셋",
+        "featureIntroduction" : {
+          "title" : "기능 소개",
+          "label" : "연락처 기능 소개 보기",
+          "dismissed" : "해제 — 연락처에서 소개 화면을 다시 보려면 이 설정을 켜세요.",
+          "willShow" : "닫기 전까지 연락처에 표시됩니다."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "암호화폐 목록",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "선택한 ASA에서 수령인 계정을 선택하지 않았습니다."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "메모 길이 초과",
+      "description" : "Algorand 메모는 1,024바이트를 초과할 수 없습니다. 메모 길이를 줄여주세요."
     },
     "AmountRequired" : {
       "title" : "필요 금액"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "더 다양하게, 더 간편하게, {{discount}}% 할인까지",
-      "subtitle" : "더 커진 화면, 더 스마트해진 트랜잭션 검토, 강화된 보안은 물론 {{discount}}% 할인 혜택까지."
+      "subtitle" : "더 커진 화면, 더 스마트해진 트랜잭션 검토, 강화된 보안은 물론 {{discount}}% 할인 혜택까지.",
+      "cta" : "자세히 알아보기"
     },
     "optedOut" : {
-      "title" : "스캠 감지, 모든 정보 확인",
-      "subtitle" : "터치스크린 사이너에서 모든 정보를 꼼꼼히 확인하고, 고급 보안 점검 기능으로 스캠을 식별하세요."
-    },
-    "cta" : "터치스크린 사이너 둘러보기"
+      "title" : "서명 전 스캠 감지",
+      "subtitle" : "실시간 위협 감지를 지원하는 고급 보안 기능에 대해 자세히 알아보세요.",
+      "cta" : "자세히 알아보기"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "연락처",
     "addContact" : "연락처 추가",
     "searchPlaceholder" : "연락처 검색",
+    "searchNoResults" : "검색된 연락처가 없습니다",
     "me" : {
       "name" : "나",
       "addressCount_zero" : "주소 0개",
       "addressCount_one" : "주소 {{count}}개",
       "addressCount_other" : "주소 {{count}}개"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "연락처는 Ledger 장치를 통해 종단간 암호화되어 모든 장치에 동기화되며, 오직 사용자 본인만 잠금을 해제할 수 있습니다.",
+      "dismiss" : "확인"
+    },
+    "featureIntroduction" : {
+      "title" : "연락처 기능 소개",
+      "description" : "암호화폐 주소록 — 송금할 지갑 주소를 한곳에 모두 저장하세요.",
+      "primaryAction" : "연락처 기능 사용해 보기",
+      "secondaryAction" : "다음에 결정하기",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "주소를 한 번만 저장하세요",
+          "description" : "송금할 주소를 한 곳에서 보관하고 관리하세요."
+        },
+        "sendToRightAddress" : {
+          "title" : "정확한 주소로 송금하기",
+          "description" : "자산이 매번 올바른 지갑으로 전송됩니다."
+        },
+        "privateAcrossDevices" : {
+          "title" : "모든 장치에서 비공개로 유지",
+          "description" : "Ledger Sync를 통해 엔드투엔드로 암호화를 지원합니다."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
+++ b/apps/ledger-live-desktop/static/i18n/pt-BR/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "A Ledger Nano S™ não é compatível com a troca de Monad",
       "monad_description" : "Para trocar Monad, use qualquer outro dispositivo Ledger compatível, como a Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™.",
       "zcash_title" : "A Ledger Nano™ S não é compatível com a troca de Zcash",
-      "zcash_description" : "Para trocar Zcash, use qualquer outro dispositivo Ledger compatível, como a Ledger Nano™ S Plus, Ledger Nano™ X, Ledger Flex™ ou Ledger Stax™."
+      "zcash_description" : "Para trocar Zcash, use qualquer outro dispositivo Ledger compatível, como a Ledger Nano™ S Plus, Ledger Nano™ X, Ledger Flex™ ou Ledger Stax™.",
+      "aleo_title" : "A Ledger Nano S™ não é compatível com a troca de Aleo",
+      "aleo_description" : "Para trocar Aleo, use qualquer outro dispositivo Ledger compatível, como a Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ ou Ledger Stax™."
     },
     "providers" : {
       "title" : "Escolha um provedor para trocar cripto",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Quantia da taxa ({{unit}})",
     "gasLimit" : "Limite de gás ({{unit}})",
     "feesPaid" : "Taxas pagas à rede para processar sua transação",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Você usará {{energy}} de energia e {{bandwidth}} de largura de banda para pagar a taxa de rede."
+      },
+      "insufficient" : {
+        "description" : "Você não tem energia ou largura de banda suficiente para cobrir esta transferência. O valor faltante será coberto pela queima de TRX."
+      }
+    },
     "insufficientBalanceFees" : "Saldo insuficiente para cobrir as taxas de rede",
     "amountToSend" : "Quantia a enviar em ({{currency}})",
     "coinToSend" : "Moeda a enviar",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Redelegar",
         "redelegateDisabledTooltip" : "Você pode delegar novamente em <0>{{days}}</0>",
         "redelegateMaxDisabledTooltip" : "Você não pode redelegar a mais de <0>7</0> validadores por vez",
-        "undelegateDisabledTooltip" : "Você não pode desdelegar mais de <0>7</0> validadores por vez",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "Você não pode desdelegar mais de <0>7</0> validadores por vez",
+          "zero_gravity" : "Você precisa de pelo menos 1 Gwei de cotas delegadas para desdelegar"
+        },
         "undelegateActivatingTooltip" : "Você não pode desdelegar uma aplicação ainda em ativação.",
         "reward" : "Resgatar Recompensas",
         "activeTooltip" : "Quantias delegadas geram recompensas",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Quantia"
+              "title" : "Quantia",
+              "visibilityDelay" : "Pode levar até {{numberOfMinutes}} minutos para que esta delegação apareça em seu painel de delegação."
             },
             "validator" : {
               "title" : "Validadores",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Depositar",
+      "OUT" : "Sacar"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Famílias separadas por vírgula, usadas em testes personalizados com várias famílias.",
         "customFamiliesPlaceholder" : "evm, stellar, aptos",
         "applyFamilies" : "Aplicar",
-        "resetOverride" : "Redefinir sobreposição"
+        "contactsData" : "Dados dos contatos",
+        "loadPopulatedContacts" : "Carregar contatos preenchidos",
+        "resetContacts" : "Redefinir contatos",
+        "resetOverride" : "Redefinir sobreposição",
+        "featureIntroduction" : {
+          "title" : "Introdução de Recursos",
+          "label" : "Introdução ao recurso Mostrar Contatos",
+          "dismissed" : "Dispensado — ative para exibir a introdução novamente em Contatos.",
+          "willShow" : "Será exibido em Contatos até ser dispensado."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Lista de Criptoativos",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "A conta do destinatário não aderiu ao ASA selecionado."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "O memo é muito longo.",
+      "description" : "Os memos da Algorand não podem exceder 1024 bytes. Escreva um memo mais curto."
     },
     "AmountRequired" : {
       "title" : "Quantia Necessária"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Veja mais. Clique menos. Economize {{discount}}%",
-      "subtitle" : "Aproveite uma tela maior, um jeito de rever transações mais inteligente, mais proteção e {{discount}}% de desconto exclusivo."
+      "subtitle" : "Aproveite uma tela maior, um jeito de rever transações mais inteligente, mais proteção e {{discount}}% de desconto exclusivo.",
+      "cta" : "Explore autenticadores com tela touch"
     },
     "optedOut" : {
-      "title" : "Identifique golpes. Veja cada detalhe",
-      "subtitle" : "Revise tudo com clareza em um autenticador com tela touch e detecte golpes com verificações de segurança avançadas."
-    },
-    "cta" : "Explore autenticadores com tela touch"
+      "title" : "Detecte golpes antes de assinar",
+      "subtitle" : "Saiba mais sobre recursos de segurança avançados que permitem detectar ameaças em tempo real.",
+      "cta" : "Saiba mais"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Contatos",
     "addContact" : "Adicionar contato",
     "searchPlaceholder" : "Buscar contato",
+    "searchNoResults" : "Nenhum contato encontrado",
     "me" : {
       "name" : "Eu",
       "addressCount_zero" : "0 endereço",
       "addressCount_one" : "{{count}} endereço",
       "addressCount_other" : "{{count}} endereços"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Seus contatos são criptografados de ponta a ponta com sua Ledger e sincronizados entre seus dispositivos, apenas você pode desbloqueá-los.",
+      "dismiss" : "Entendi"
+    },
+    "featureIntroduction" : {
+      "title" : "Apresentando Contatos",
+      "description" : "Sua agenda de endereços para cripto — salve as carteiras para as quais envia, tudo em um só lugar.",
+      "primaryAction" : "Experimente os contatos",
+      "secondaryAction" : "Talvez mais tarde",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Salve endereços uma vez",
+          "description" : "Mantenha os endereços para os quais envia em um só lugar."
+        },
+        "sendToRightAddress" : {
+          "title" : "Envie para o endereço correto",
+          "description" : "Os fundos chegam sempre à carteira correta."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Privada em todos os seus dispositivos",
+          "description" : "Criptografada de ponta a ponta com o Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/ru/app.json
+++ b/apps/ledger-live-desktop/static/i18n/ru/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™ не поддерживает обмен Monad",
       "monad_description" : "Для обмена Monad используйте совместимые устройства Ledger. Это Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ и Ledger Stax™.",
       "zcash_title" : "Ledger Nano S™ не поддерживает обмен Zcash",
-      "zcash_description" : "Для обмена Zcash используйте совместимые устройства Ledger. Это Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ и Ledger Stax™."
+      "zcash_description" : "Для обмена Zcash используйте совместимые устройства Ledger. Это Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ и Ledger Stax™.",
+      "aleo_title" : "Ledger Nano S™ не поддерживает обмен Aleo",
+      "aleo_description" : "Используйте другие совместимые устройства Ledger для обмена Aleo. Это Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ и Ledger Stax™."
     },
     "providers" : {
       "title" : "Выберите поставщика услуг по обмену криптовалюты",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Сумма комиссии ({{unit}})",
     "gasLimit" : "Лимит Газа ({{unit}})",
     "feesPaid" : "Комиссия сети за обработку вашей транзакции",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Для оплаты комиссии сети потребуется {{energy}} Energy и {{bandwidth}} Bandwidth."
+      },
+      "insufficient" : {
+        "description" : "У вас недостаточно Energy и Bandwidth для этого перевода. Недостаток будет покрыт за счёт сжигания TRX."
+      }
+    },
     "insufficientBalanceFees" : "Недостаточный баланс для покрытия комиссии сети",
     "amountToSend" : "Сумма к отправке в ({{currency}})",
     "coinToSend" : "Монета для отправки",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Переделегировать",
         "redelegateDisabledTooltip" : "Вы можете переделегировать через <0>{{days}}</0> дн",
         "redelegateMaxDisabledTooltip" : "Вы не можете перевыбрать более <0>7</0> валидаторов за раз",
-        "undelegateDisabledTooltip" : "Вы не можете перевыбрать более <0>7</0> валидаторов за раз",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "Вы не можете перевыбрать более <0>7</0> валидаторов за раз",
+          "zero_gravity" : "Чтобы отозвать, вам нужно как минимум 1 Gwei делегированных долей"
+        },
         "undelegateActivatingTooltip" : "Вы не можете отозвать стейк, который ещё активируется.",
         "reward" : "Запросить вознаграждение",
         "activeTooltip" : "Делегирование приносит вознаграждения",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Количество"
+              "title" : "Количество",
+              "visibilityDelay" : "Может пройти до {{numberOfMinutes}} мин., прежде чем это делегирование появится на вашей панели делегирования."
             },
             "validator" : {
               "title" : "Валидаторы",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Пополнение",
+      "OUT" : "Вывод"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Семейства, разделённые запятыми, для пользовательского тестирования нескольких семейств.",
         "customFamiliesPlaceholder" : "evm, stellar, aptos",
         "applyFamilies" : "Применить",
-        "resetOverride" : "Сбросить переопределения"
+        "contactsData" : "Данные контактов",
+        "loadPopulatedContacts" : "Загрузить заполненные контакты",
+        "resetContacts" : "Сбросить контакты",
+        "resetOverride" : "Сбросить переопределения",
+        "featureIntroduction" : {
+          "title" : "Презентация функции",
+          "label" : "Показывать презентацию функции «Контакты»",
+          "dismissed" : "Отключено — включите, чтобы ещё раз показать презентацию о функции «Контакты».",
+          "willShow" : "Будет отображаться в разделе «Контакты», пока вы его не скроете её."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Список криптоактивов",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "В указанном ASA не выбран счёт получателя."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Слишком длинное Memo",
+      "description" : "Memo в Algorand не могут превышать 1024 байта. Пожалуйста, сократите примечание Memo."
     },
     "AmountRequired" : {
       "title" : "Укажите сумму"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Обзора больше. Действий меньше. Скидка {{discount}}%",
-      "subtitle" : "Оцените увеличенный экран, удобную Проверку транзакций, усиленную защиту и эксклюзивную скидку {{discount}}%."
+      "subtitle" : "Оцените увеличенный экран, удобную Проверку транзакций, усиленную защиту и эксклюзивную скидку {{discount}}%.",
+      "cta" : "Изучить сенсорные устройства"
     },
     "optedOut" : {
-      "title" : "Распознавайте скам. Исследуйте каждую деталь",
-      "subtitle" : "Проверяйте всë на сенсорном устройстве подписи и выявляйте скам благодаря передовым функциям проверки безопасности."
-    },
-    "cta" : "Изучить сенсорные устройства подписи"
+      "title" : "Распознайте скам до подписания",
+      "subtitle" : "Узнайте больше о продвинутых функциях безопасности, которые позволяют обнаруживать угрозы в реальном времени.",
+      "cta" : "Подробнее"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Контакты",
     "addContact" : "Добавить контакт",
     "searchPlaceholder" : "Поиск контакта...",
+    "searchNoResults" : "Контакт не найден",
     "me" : {
       "name" : "Я",
       "addressCount_zero" : "0 адресов",
       "addressCount_one" : "{{count}} адрес",
       "addressCount_other" : "Адресов: {{count}}"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Ваши контакты защищены сквозным шифрованием устройством Ledger и синхронизируются между вашими устройствами — только вы можете разблокировать их.",
+      "dismiss" : "Понятно"
+    },
+    "featureIntroduction" : {
+      "title" : "Представляем «Контакты»",
+      "description" : "Ваша адресная книга для криптовалюты — сохраняйте криптокошельки для отправки средств. Удобно и универсально.",
+      "primaryAction" : "Попробовать",
+      "secondaryAction" : "Не сейчас",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Сохраняйте адреса",
+          "description" : "Удобно храните все адреса для отправки средств."
+        },
+        "sendToRightAddress" : {
+          "title" : "Отправляйте на правильные адреса",
+          "description" : "Средства всегда поступят на нужный криптокошелёк."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Конфиденциальность на всех устройствах",
+          "description" : "Сквозное шифрование благодаря Ledger Sync."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/th/app.json
+++ b/apps/ledger-live-desktop/static/i18n/th/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™ ไม่รองรับการสวอป Monad",
       "monad_description" : "หากต้องการสวอป Monad ให้ใช้อุปกรณ์ Ledger ที่รองรับรุ่นอื่น ๆ เช่น Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ หรือ Ledger Stax™",
       "zcash_title" : "Ledger Nano S™ ไม่รองรับการสวอป Zcash",
-      "zcash_description" : "เพื่อสวอป Zcash ให้ทำธุรกรรมผ่านอุปกรณ์ Ledger รุ่นอื่น ๆ ที่ใช้ได้ เช่น Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ หรือ Ledger Stax™"
+      "zcash_description" : "เพื่อสวอป Zcash ให้ทำธุรกรรมผ่านอุปกรณ์ Ledger รุ่นอื่น ๆ ที่ใช้ได้ เช่น Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ หรือ Ledger Stax™",
+      "aleo_title" : "Ledger Nano S™ ไม่รองรับการสวอป Aleo",
+      "aleo_description" : "ในการสวอป Aleo ให้ทำธุรกรรมผ่านอุปกรณ์ Ledger รุ่นอื่นที่ใช้ได้ เช่น Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ หรือ Ledger Stax™"
     },
     "providers" : {
       "title" : "เลือกผู้ให้บริการเพื่อ Swap คริปโต",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "ยอดค่าธรรมเนียม {{unit}}",
     "gasLimit" : "ปริมาณแก๊สสูงสุด ({{unit}}",
     "feesPaid" : "ค่าธรรมเนียมที่ต้องชำระให้กับเครือข่ายเพื่อทำธุรกรรมของคุณ",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "คุณจะใช้ {{energy}} Energy และ {{bandwidth}} Bandwidth ในการจ่ายค่าธรรมเนียมเครือข่าย"
+      },
+      "insufficient" : {
+        "description" : "คุณมี Energy และ Bandwidth ไม่เพียงพอสำหรับการทำธุรกรรมโอนนี้ ส่วนที่ขาดจะถูกชดเชยโดยการจ่ายด้วย TRX"
+      }
+    },
     "insufficientBalanceFees" : "ยอดคงเหลือไม่เพียงพอสำหรับค่าธรรมเนียมเครือข่าย",
     "amountToSend" : "จำนวนที่จะส่งใน {{currency}}",
     "coinToSend" : "เหรียญที่จะส่ง",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Redelegate",
         "redelegateDisabledTooltip" : "คุณสามารถมอบหมายใหม่ได้ในอีก <0>{{days}}</0> วัน",
         "redelegateMaxDisabledTooltip" : "คุณไม่สามารถ Redelegate ได้มากกว่า <0>7</0> ผู้ตรวจสอบต่อครั้ง",
-        "undelegateDisabledTooltip" : "คุณไม่สามารถ Redelegate ได้มากกว่า <0>7</0> ผู้ตรวจสอบต่อครั้ง",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "คุณไม่สามารถ Redelegate ได้มากกว่า <0>7</0> ผู้ตรวจสอบต่อครั้ง",
+          "zero_gravity" : "คุณต้องมีอย่างน้อย 1 Gwei เพื่อยกเลิกการมอบหมาย"
+        },
         "undelegateActivatingTooltip" : "คุณไม่สามารถยกเลิกการมอบหมายสเตคที่ยังอยู่ในระหว่างการเปิดใช้งานได้",
         "reward" : "เคลม Reward",
         "activeTooltip" : "จำนวนที่ Delegate จะส่งผลต่อจำนวน Reward ที่ได้",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "จำนวน"
+              "title" : "จำนวน",
+              "visibilityDelay" : "อาจใช้เวลาสูงสุดถึง {{numberOfMinutes}} นาทีก่อนที่จะเห็นการ Delegate นี้บนบอร์ดการ Delegate ของคุณ"
             },
             "validator" : {
               "title" : "ผู้ตรวจสอบ",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "ฝาก",
+      "OUT" : "ถอน"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "ใส่เครื่องหมายจุลภาค (,) คั่นเพื่อทดสอบที่อยู่คริปโตหลายเครือข่ายแบบกำหนดเอง",
         "customFamiliesPlaceholder" : "evm, stellar, aptos",
         "applyFamilies" : "ใช้งาน",
-        "resetOverride" : "รีเซ็ตการเขียนทับ"
+        "contactsData" : "ข้อมูลรายชื่อ",
+        "loadPopulatedContacts" : "โหลดรายชื่อที่มีอยู่",
+        "resetContacts" : "รีเซ็ตรายชื่อ",
+        "resetOverride" : "รีเซ็ตการเขียนทับ",
+        "featureIntroduction" : {
+          "title" : "แนะนำฟีเจอร์",
+          "label" : "แสดงบทแนะนำฟีเจอร์รายชื่อ",
+          "dismissed" : "ยกเลิกแล้ว เปิดใช้งานเพื่อแสดงบทแนะนำในหน้ารายชื่ออีกครั้ง",
+          "willShow" : "จะแสดงในรายชื่อจนกว่าจะกดปิด"
+        }
       },
       "cryptoAssetsList" : {
         "title" : "รายการสินทรัพย์คริปโต",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "บัญชีผู้รับยังไม่ได้เลือกเข้าร่วม ASA ที่เลือก"
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Memo ยาวเกินไป",
+      "description" : "Memo ของ Algorand ต้องไม่เกิน 1024 ไบต์ โปรดย่อ Memo ให้สั้นลง"
     },
     "AmountRequired" : {
       "title" : "ต้องระบุจำนวน"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "ดูเพิ่มเติม ใช้งานคล่องตัวขึ้น รับส่วนลดถึง {{discount}}%",
-      "subtitle" : "เพลิดเพลินกับหน้าจอที่ใหญ่ขึ้น, การตรวจสอบธุรกรรมที่ฉลาดขึ้น, การปกป้องที่ดียิ่งขึ้น และรับส่วนลดเพิ่ม {{discount}}%"
+      "subtitle" : "เพลิดเพลินกับหน้าจอที่ใหญ่ขึ้น, การตรวจสอบธุรกรรมที่ฉลาดขึ้น, การปกป้องที่ดียิ่งขึ้น และรับส่วนลดเพิ่ม {{discount}}%",
+      "cta" : "ดูอุปกรณ์ลงนามหน้าจอสัมผัส"
     },
     "optedOut" : {
-      "title" : "ตรวจจับสแกมได้ทันที ดูได้ทุกรายละเอียด",
-      "subtitle" : "ตรวจสอบได้ชัดเจนบนอุปกรณ์ลงนามหน้าจอสัมผัส และตรวจจับสแกมด้วยการตรวจสอบความปลอดภัยขั้นสูง"
-    },
-    "cta" : "ดูอุปกรณ์ลงนามหน้าจอสัมผัส"
+      "title" : "ตรวจพบสแกมก่อนลงนาม",
+      "subtitle" : "เรียนรู้เพิ่มเติมเกี่ยวกับฟีเจอร์ความปลอดภัยขั้นสูงที่ช่วยตรวจจับภัยคุกคามแบบเรียลไทม์",
+      "cta" : "เรียนรู้เพิ่มเติม"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "รายชื่อ",
     "addContact" : "เพิ่มรายชื่อ",
     "searchPlaceholder" : "ค้นหารายชื่อ",
+    "searchNoResults" : "ไม่พบรายชื่อ",
     "me" : {
       "name" : "ที่อยู่ของฉัน",
       "addressCount_zero" : "0 ที่อยู่คริปโต",
       "addressCount_one" : "{{count}} ที่อยู่",
       "addressCount_other" : "{{count}} ที่อยู่"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "รายชื่อติดต่อของคุณได้รับการเข้ารหัสแบบต้นทางถึงปลายทาง (End-to-End Encrypted) ด้วย Ledger ของคุณ และซิงค์กับอุปกรณ์ต่าง ๆ ของคุณ โดยมีเพียงคุณเท่านั้นที่สามารถปลดล็อกได้",
+      "dismiss" : "เข้าใจแล้ว"
+    },
+    "featureIntroduction" : {
+      "title" : "ขอแนะนำรายชื่อ",
+      "description" : "สมุดที่อยู่คริปโตของคุณ บันทึกวอลเล็ตที่คุณส่งไปหาทั้งหมดไว้ในที่เดียว",
+      "primaryAction" : "ลองใช้รายชื่อ",
+      "secondaryAction" : "ไว้ทีหลัง",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "บันทึกที่อยู่คริปโตเพียงครั้งเดียว",
+          "description" : "เก็บที่อยู่คริปโตที่คุณส่งไปหาไว้ในที่เดียว"
+        },
+        "sendToRightAddress" : {
+          "title" : "ส่งไปยังที่อยู่คริปโตที่ถูกต้อง",
+          "description" : "เงินทุนส่งถึงวอลเล็ตที่ถูกต้องทุกครั้ง"
+        },
+        "privateAcrossDevices" : {
+          "title" : "เป็นส่วนตัวในทุกอุปกรณ์ของคุณ",
+          "description" : "ได้รับการเข้ารหัสแบบครบวงจรด้วยฟีเจอร์ Ledger Sync"
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/tr/app.json
+++ b/apps/ledger-live-desktop/static/i18n/tr/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™, Monad takasını desteklemez",
       "monad_description" : "Monad takas etmek için Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ veya Ledger Stax™ gibi başka bir uyumlu Ledger cihazını kullanın.",
       "zcash_title" : "Ledger Nano S™, Zcash takasını desteklemez",
-      "zcash_description" : "Zcash takas etmek için Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ veya Ledger Stax™ gibi başka bir uyumlu Ledger cihazını kullanın."
+      "zcash_description" : "Zcash takas etmek için Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ veya Ledger Stax™ gibi başka bir uyumlu Ledger cihazını kullanın.",
+      "aleo_title" : "Ledger Nano S™, Aleo takasını desteklemez",
+      "aleo_description" : "Aleo takas etmek için Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ veya Ledger Stax™ gibi diğer herhangi bir uyumlu Ledger cihazını kullanın."
     },
     "providers" : {
       "title" : "Kripto takası işlemleri için bir sağlayıcı seçin",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "Ücret tutarı ({{unit}})",
     "gasLimit" : "Gas limiti ({{unit}})",
     "feesPaid" : "İşleminizi başlatabilmek için ağa ödenen ücretler",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "Ağ ücretini ödemek için {{energy}} enerji ve {{bandwidth}} bant genişliği kullanacaksınız."
+      },
+      "insufficient" : {
+        "description" : "Bu transferi karşılamak için yeterli enerji ve bant genişliğiniz yok. Eksik tutar TRX yakılarak karşılanacak."
+      }
+    },
     "insufficientBalanceFees" : "Ağ ücretlerini karşılayacak kadar bakiye mevcut değil.",
     "amountToSend" : "({{currency}}) olarak gönderilecek tutar",
     "coinToSend" : "Gönderilecek coin",
@@ -4339,7 +4349,10 @@
         "redelegate" : "Yetki devret",
         "redelegateDisabledTooltip" : "Yetkiyi yeniden devretmek için <0>{{days}}</0> gün beklemelisiniz",
         "redelegateMaxDisabledTooltip" : "Bir seferde en fazla <0>7</0> doğrulayıcıya yeniden yetki devredebilirsiniz.",
-        "undelegateDisabledTooltip" : "Bir seferde en fazla <0>7</0> doğrulayıcının yetkisini iptal edebilirsiniz.",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "Bir seferde en fazla <0>7</0> doğrulayıcının yetkisini iptal edebilirsiniz.",
+          "zero_gravity" : "Yetki devrini sonlandırmak için en az 1 Gwei değerinde yetkisi devredilmiş payınız olmalıdır."
+        },
         "undelegateActivatingTooltip" : "Etkinleşmekte olan bir stake'in yetki devrini sonlandıramazsınız",
         "reward" : "Ödüllerinizi alın",
         "activeTooltip" : "Yetkisi devredilen tutar ödül üretiyor",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "Miktar"
+              "title" : "Miktar",
+              "visibilityDelay" : "Bu yetki devrini yetki devri panonuzda görmeniz {{numberOfMinutes}} dakika kadar sürebilir."
             },
             "validator" : {
               "title" : "Doğrulayıcılar",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "Yatır",
+      "OUT" : "Çek"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "Özel çoklu format testi için virgülle ayrılmış formatlar.",
         "customFamiliesPlaceholder" : "EVM, Stellar, Aptos",
         "applyFamilies" : "Uygula",
-        "resetOverride" : "Uygulamayı sıfırla"
+        "contactsData" : "Kişi verileri",
+        "loadPopulatedContacts" : "Örnek kişileri yükle",
+        "resetContacts" : "Kişileri sıfırla",
+        "resetOverride" : "Uygulamayı sıfırla",
+        "featureIntroduction" : {
+          "title" : "Özellik tanıtımı",
+          "label" : "Kişileri Göster özellikleri tanıtımı",
+          "dismissed" : "Kapatıldı: Tanıtımı Kişiler bölümünde tekrar göstermek için açın.",
+          "willShow" : "Kapatılana kadar Kişiler bölümünde gösterilir."
+        }
       },
       "cryptoAssetsList" : {
         "title" : "Kripto Varlık Listesi",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "Alıcı hesap, seçili ASA'yı onaylamadı."
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Memo çok uzun",
+      "description" : "Algorand memo'ları 1024 baytı aşamaz. Lütfen memo'nuzu kısaltın."
     },
     "AmountRequired" : {
       "title" : "Gerekli tutar"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "Daha fazla görün. Daha az dokunun. %{{discount}} tasarruf",
-      "subtitle" : "Daha büyük ekranın, daha akıllı işlem incelemelerinin, gelişmiş korumanın ve özel %{{discount}} indirimin keyfini çıkarın."
+      "subtitle" : "Daha büyük ekranın, daha akıllı işlem incelemelerinin, gelişmiş korumanın ve özel %{{discount}} indirimin keyfini çıkarın.",
+      "cta" : "Dokunmatik ekranlı imzalayıcıları keşfedin"
     },
     "optedOut" : {
-      "title" : "Dolandırıcılık girişimlerini tespit edin. Tüm ayrıntıları görün",
-      "subtitle" : "İşlem detaylarını dokunmatik ekranlı bir imzalayıcıda net bir şekilde inceleyin ve gelişmiş güvenlik kontrolleriyle dolandırıcılıkları tespit edin."
-    },
-    "cta" : "Dokunmatik ekranlı imzalayıcıları keşfedin"
+      "title" : "Dolandırıcılıkları imzalamadan önce fark edin",
+      "subtitle" : "Gerçek zamanlı tehdit tespiti sağlayan gelişmiş güvenlik özellikleri hakkında daha fazla bilgi edinin.",
+      "cta" : "Daha fazla bilgi"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "Kişiler",
     "addContact" : "Kişi ekle",
     "searchPlaceholder" : "Kişi ara",
+    "searchNoResults" : "Kişi bulunamadı",
     "me" : {
       "name" : "Ben",
       "addressCount_zero" : "0 adres",
       "addressCount_one" : "{{count}} adres",
       "addressCount_other" : "{{count}} adres"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "Kişileriniz, Ledger cihazınız ile uçtan uca şifrelenir ve cihazlarınız arasında senkronize edilir; bunların kilidini yalnızca siz açabilirsiniz.",
+      "dismiss" : "Anladım"
+    },
+    "featureIntroduction" : {
+      "title" : "Karşınızda Kişiler",
+      "description" : "Kripto adres defteriniz: Gönderim yaptığınız cüzdanları kaydedin, hepsi tek bir yerde.",
+      "primaryAction" : "Kişileri deneyin",
+      "secondaryAction" : "Belki sonra",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "Adresleri bir kez kaydedin",
+          "description" : "Gönderim yaptığınız adresleri tek bir yerde tutun."
+        },
+        "sendToRightAddress" : {
+          "title" : "Doğru adrese gönderin",
+          "description" : "Fonlar her seferinde doğru cüzdana ulaşır."
+        },
+        "privateAcrossDevices" : {
+          "title" : "Tüm cihazlarınızda gizli kalır",
+          "description" : "Ledger Sync ile uçtan uca şifrelenir."
+        }
+      }
     }
   },
   "assetDetails" : {

--- a/apps/ledger-live-desktop/static/i18n/zh/app.json
+++ b/apps/ledger-live-desktop/static/i18n/zh/app.json
@@ -538,7 +538,9 @@
       "monad_title" : "Ledger Nano S™ 不支持互换 Monad",
       "monad_description" : "要互换 Monad，请使用其他兼容的 Ledger 设备，例如 Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™ 或 Ledger Stax™。",
       "zcash_title" : "Ledger Nano S™ 不支持互换 Zcash",
-      "zcash_description" : "要互换 Zcash，请使用其他兼容的 Ledger 设备，例如 Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™ 或 Ledger Stax™。"
+      "zcash_description" : "要互换 Zcash，请使用其他兼容的 Ledger 设备，例如 Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™ 或 Ledger Stax™。",
+      "aleo_title" : "Ledger Nano S™ 不支持互换 Aleo",
+      "aleo_description" : "要互换 Aleo，请使用任何其他兼容的 Ledger 设备，例如 Ledger Nano S Plus™、Ledger Nano X™、Ledger Flex™ 或 Ledger Stax™。"
     },
     "providers" : {
       "title" : "选择一个供应方来互换加密货币",
@@ -2596,6 +2598,14 @@
     "feesAmount" : "费用数额 ({{unit}})",
     "gasLimit" : "Gas 限值 ({{unit}})",
     "feesPaid" : "支付给网络用于处理交易的费用",
+    "tronFees" : {
+      "sufficient" : {
+        "description" : "您将使用 {{energy}} 能量和 {{bandwidth}} 带宽来支付网络费用。"
+      },
+      "insufficient" : {
+        "description" : "您的能量和带宽不足，无法完成此转账。差额将通过销毁波场币 (TRX) 来补足。"
+      }
+    },
     "insufficientBalanceFees" : "余额不足以支付网络费用",
     "amountToSend" : "发送数额为 ({{currency}})",
     "coinToSend" : "发送币种",
@@ -4339,7 +4349,10 @@
         "redelegate" : "重新委托",
         "redelegateDisabledTooltip" : "您可以再次重新委托 <0>{{days}}</0>",
         "redelegateMaxDisabledTooltip" : "每次重新委托的验证者不能多于 <0>7</0> 个",
-        "undelegateDisabledTooltip" : "每次取消委托的验证者不能多于 <0>7</0> 个",
+        "undelegateDisabledTooltip" : {
+          "sei_evm" : "每次取消委托的验证者不能多于 <0>7</0> 个",
+          "zero_gravity" : "您至少需要 1 Gwei 的已委托份额才能解除委托"
+        },
         "undelegateActivatingTooltip" : "您无法解除委托仍在激活中的质押",
         "reward" : "申领奖励",
         "activeTooltip" : "已委托的数额会生成奖励",
@@ -4363,7 +4376,8 @@
               }
             },
             "amount" : {
-              "title" : "数额"
+              "title" : "数额",
+              "visibilityDelay" : "最多可能需要 {{numberOfMinutes}} 分钟，此委托才会显示在您的委托面板上。"
             },
             "validator" : {
               "title" : "验证者",
@@ -4732,6 +4746,12 @@
           }
         }
       }
+    }
+  },
+  "hypercore" : {
+    "operationTypes" : {
+      "IN" : "存入",
+      "OUT" : "提取"
     }
   },
   "tezos" : {
@@ -5232,7 +5252,16 @@
         "customFamiliesHint" : "用于自定义多系列测试的以逗号分隔的系列。",
         "customFamiliesPlaceholder" : "以太坊虚拟机 (EVM)、恒星币、阿普托斯币",
         "applyFamilies" : "应用",
-        "resetOverride" : "重置覆盖"
+        "contactsData" : "联系人数据",
+        "loadPopulatedContacts" : "加载现有联系人",
+        "resetContacts" : "重置联系人",
+        "resetOverride" : "重置覆盖",
+        "featureIntroduction" : {
+          "title" : "功能介绍",
+          "label" : "显示联系人功能介绍",
+          "dismissed" : "已忽略 — 开启后将在联系人页面再次显示介绍。",
+          "willShow" : "将在联系人页面持续显示，直到您关闭为止。"
+        }
       },
       "cryptoAssetsList" : {
         "title" : "加密资产列表",
@@ -6714,6 +6743,10 @@
     },
     "AlgorandASANotOptInInRecipient" : {
       "title" : "收币人账户没有选择加入所选的 ASA。"
+    },
+    "AlgorandMemoExceededSizeError" : {
+      "title" : "Memo 备注太长。",
+      "description" : "Algorand Memo 备注不能超过 1024 字节。请缩短您的 Memo 备注。"
     },
     "AmountRequired" : {
       "title" : "所需数额"
@@ -8622,13 +8655,14 @@
   "largeScreenUpsellModal" : {
     "optedIn" : {
       "title" : "查看更多。减少点击。节省 {{discount}}%",
-      "subtitle" : "尽享更大的屏幕、更智能的交易审核、更强的保护，以及专属的 {{discount}}% 优惠。"
+      "subtitle" : "尽享更大的屏幕、更智能的交易审核、更强的保护，以及专属的 {{discount}}% 优惠。",
+      "cta" : "探索触摸屏签署设备"
     },
     "optedOut" : {
-      "title" : "识别骗局。查看所有详情",
-      "subtitle" : "在触摸屏签署设备上清晰审核，并通过高级安全检查发现骗局。"
-    },
-    "cta" : "探索触摸屏签署设备"
+      "title" : "签署之前，识破骗局",
+      "subtitle" : "详细了解支持实时威胁检测的高级安全功能。",
+      "cta" : "了解更多"
+    }
   },
   "modularAssetDrawer" : {
     "addAccounts" : {
@@ -9272,11 +9306,36 @@
     "title" : "联系人",
     "addContact" : "添加联系人",
     "searchPlaceholder" : "搜索联系人",
+    "searchNoResults" : "未找到联系人",
     "me" : {
       "name" : "我",
       "addressCount_zero" : "0 个地址",
       "addressCount_one" : "{{count}} 个地址",
       "addressCount_other" : "{{count}} 个地址"
+    },
+    "ledgerSyncIntroduction" : {
+      "description" : "您的联系人信息通过您的 Ledger 进行端到端加密，并在您的设备之间进行同步，只有您自己可以解锁。",
+      "dismiss" : "知道了"
+    },
+    "featureIntroduction" : {
+      "title" : "认识「联系人」功能",
+      "description" : "您的加密货币地址簿——将常用的转账钱包地址集中保存在一处。",
+      "primaryAction" : "试用联系人",
+      "secondaryAction" : "以后再说",
+      "highlights" : {
+        "saveAddresses" : {
+          "title" : "地址只需保存一次",
+          "description" : "将常用转账地址集中保存在一处。"
+        },
+        "sendToRightAddress" : {
+          "title" : "转账至正确地址",
+          "description" : "资金每次都能到达正确的钱包。"
+        },
+        "privateAcrossDevices" : {
+          "title" : "跨设备私密同步",
+          "description" : "通过 Ledger Sync 账户同步功能进行端到端加密。"
+        }
+      }
     }
   },
   "assetDetails" : {


### PR DESCRIPTION
## Summary

- Replaces 10 locale translation files for LLD Desktop (`de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `ru`, `th`, `tr`, `zh`)
- All files sourced from the v4.13.0 translation export
- Arabic (`ar`) was not included in the translation export and is unchanged

## Review notes

Pre-push review: REVIEW OUTCOME: pass

- All 10 locales have matching key counts with English (5426 keys)
- All new keys and `{{…}}` placeholders verified consistent with English
- Pre-existing gap: `ru/app.json` has a missing `{{count}}` placeholder in `polkadot.nominate.steps.validators.notValidatorsRemoved` (not introduced by this PR)
- Pre-existing gap: `ar/app.json` is not included in this update (no Arabic file provided in the translation export)