### PR TITLE
feat(contacts): add shared contact address detail view model

### DIFF
--- a/.changeset/flow-contacts-address-detail.md
+++ b/.changeset/flow-contacts-address-detail.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"@domain/entity-contact": minor
+---
+
+Add shared contact address detail view model with selected address payload, QR payload string, and not-found state.

--- a/domain/entity/contact/src/selectors.test.ts
+++ b/domain/entity/contact/src/selectors.test.ts
@@ -1,8 +1,17 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { contactsSlice, setContacts } from "./slice";
-import { mockContact, mockMeContact } from "./schema.mock";
-import { ContactIdSchema } from "./schema";
-import { selectContactById, selectContacts, selectMeContact } from "./selectors";
+import {
+  mockContact,
+  mockContactWithAddress,
+  mockMeContact,
+} from "./schema.mock";
+import { ContactAddressIdSchema, ContactIdSchema } from "./schema";
+import {
+  selectContactAddressById,
+  selectContactById,
+  selectContacts,
+  selectMeContact,
+} from "./selectors";
 
 function makeStore() {
   return configureStore({
@@ -35,6 +44,32 @@ describe("Contacts selectors", () => {
     expect(selectContactById(store.getState(), ben.id)).toEqual(ben);
     expect(
       selectContactById(store.getState(), ContactIdSchema.parse("contact-missing")),
+    ).toBeUndefined();
+  });
+
+  it("selects a contact address by contact and address id", () => {
+    const store = makeStore();
+    const contact = mockContactWithAddress();
+    store.dispatch(setContacts([mockMeContact(), contact]));
+    const address = contact.addresses[0];
+
+    expect(address).toBeDefined();
+    expect(
+      selectContactAddressById(store.getState(), contact.id, address!.id),
+    ).toEqual(address);
+    expect(
+      selectContactAddressById(
+        store.getState(),
+        contact.id,
+        ContactAddressIdSchema.parse("address-missing"),
+      ),
+    ).toBeUndefined();
+    expect(
+      selectContactAddressById(
+        store.getState(),
+        ContactIdSchema.parse("contact-missing"),
+        address!.id,
+      ),
     ).toBeUndefined();
   });
 });

--- a/domain/entity/contact/src/selectors.ts
+++ b/domain/entity/contact/src/selectors.ts
@@ -1,4 +1,4 @@
-import type { Contact, ContactId, ContactsState } from "./types";
+import type { Contact, ContactAddress, ContactAddressId, ContactId, ContactsState } from "./types";
 
 type ContactsStateRoot = {
   contacts: ContactsState;
@@ -17,4 +17,12 @@ export function selectContactById(
   contactId: ContactId,
 ): Contact | undefined {
   return selectContacts(state).find(contact => contact.id === contactId);
+}
+
+export function selectContactAddressById(
+  state: ContactsStateRoot,
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactAddress | undefined {
+  return selectContactById(state, contactId)?.addresses.find(address => address.id === addressId);
 }

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -11,6 +11,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Empty contact detail selection and presentation
 - Populated contact detail view model (address rows, count, and open-detail intents)
 - Contact detail edit/delete scenario state (edit intent, delete intent, and delete lifecycle)
+- Contact address detail view model (selected address payload, QR payload string, and not-found state)
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Add Address session state from currency selection to address entry
 - Add Address network eligibility and final currency selection state (MAD integration uses an
@@ -84,9 +85,9 @@ src/
 │   │   ├── useContactsFeatureIntroductionState.ts / resolver.ts / ports.ts / constants.ts / types.ts
 │   │   ├── internals/useSingleFireDismiss.ts
 │   │   └── index.ts / web.ts / native.ts
-│   └── Detail/                          # Contact detail empty state (web + native)
-│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / types.ts
-│       ├── model/                       # resolveContactDetailEmptyStateCopy / address ordering + populated detail view-model builders
+│   └── Detail/                          # Contact detail (web + native)
+│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / useContactAddressDetail.ts / types.ts
+│       ├── model/                       # empty + populated + address detail view-model builders
 │       ├── components/                  # Header, EmptyState, Avatar (web + native)
 │       └── index.ts / web.ts / native.ts
 ├── components/                          # Cross-step shared UI

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -2,6 +2,7 @@ export { useEmptyContactDetail } from "./useEmptyContactDetail";
 export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
 export { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
 export type { UseContactDetailActionsViewModelResult } from "./useContactDetailActionsViewModel";
+export { useContactAddressDetail } from "./useContactAddressDetail";
 export {
   createContactDetailAddressRowIntent,
   createPopulatedContactDetailViewModel,
@@ -19,15 +20,20 @@ export {
   createContactDetailActionsController,
   type ContactDetailActionsController,
 } from "./model/contactActionsController";
+export { createContactAddressDetailViewModel } from "./model/addressDetailViewModel";
 export { sortContactAddressesByNetwork } from "./model/sortContactAddressesByNetwork";
 export type {
   ContactAddressCurrencyPort,
+  ContactAddressDetailPort,
   ContactDeletionPort,
   ContactDetailActionsPorts,
   ContactEditPort,
   ContactRenameInput,
 } from "./model/ports";
 export type {
+  ContactAddressDetailAsset,
+  ContactAddressDetailNetwork,
+  ContactAddressDetailViewModel,
   ContactDeleteLifecycle,
   ContactDetailActionsViewModel,
   ContactDetailAddressRow,

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailViewModel.ts
@@ -1,0 +1,21 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import type { ContactAddressDetailPort } from "./ports";
+import type { ContactAddressDetailViewModel } from "../types";
+
+export function createContactAddressDetailViewModel(
+  contactAddress: ContactAddress | undefined,
+  port: ContactAddressDetailPort,
+): ContactAddressDetailViewModel {
+  if (contactAddress === undefined) {
+    return { displayMode: "not-found" };
+  }
+
+  return {
+    displayMode: "found",
+    address: contactAddress.address,
+    label: contactAddress.label,
+    network: port.resolveNetwork(contactAddress.currencyId),
+    asset: port.resolveAsset(contactAddress.currencyId),
+    qrPayload: port.resolveQrPayload(contactAddress),
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailViewModel.web.test.ts
@@ -1,0 +1,51 @@
+import { mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressDetailPort } from "./ports";
+import { createContactAddressDetailViewModel } from "./addressDetailViewModel";
+
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const addressDetailPort: ContactAddressDetailPort = {
+  resolveNetwork: () => ({
+    id: ethereum.id,
+    name: ethereum.name,
+  }),
+  resolveAsset: () => ({
+    currencyId: ethereum.id,
+    name: ethereum.name,
+    ticker: ethereum.ticker,
+  }),
+  resolveQrPayload: contactAddress => contactAddress.address,
+};
+
+describe("createContactAddressDetailViewModel", () => {
+  it("exposes the selected address payload", () => {
+    const contactAddress = mockContactAddress();
+    const port: ContactAddressDetailPort = {
+      ...addressDetailPort,
+      resolveQrPayload: () => "qr:0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    };
+
+    expect(createContactAddressDetailViewModel(contactAddress, port)).toEqual({
+      displayMode: "found",
+      address: contactAddress.address,
+      label: contactAddress.label,
+      network: {
+        id: ethereum.id,
+        name: ethereum.name,
+      },
+      asset: {
+        currencyId: ethereum.id,
+        name: ethereum.name,
+        ticker: ethereum.ticker,
+      },
+      qrPayload: "qr:0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    });
+  });
+
+  it("returns not-found when the address does not exist", () => {
+    expect(createContactAddressDetailViewModel(undefined, addressDetailPort)).toEqual({
+      displayMode: "not-found",
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -5,6 +5,7 @@ import type {
   ContactInput,
 } from "@domain/entity-contact";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactAddressDetailAsset, ContactAddressDetailNetwork } from "../types";
 
 /** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
 export type ContactAddressCurrencyPort = Readonly<{
@@ -29,4 +30,11 @@ export type ContactDeletionPort = Readonly<{
 export type ContactDetailActionsPorts = Readonly<{
   edit: ContactEditPort;
   deletion: ContactDeletionPort;
+}>;
+
+/** Injected by app wiring; aligns with the future @features/platform-contacts contract. */
+export type ContactAddressDetailPort = Readonly<{
+  resolveNetwork(currencyId: ContactAddress["currencyId"]): ContactAddressDetailNetwork;
+  resolveAsset(currencyId: ContactAddress["currencyId"]): ContactAddressDetailAsset;
+  resolveQrPayload(contactAddress: ContactAddress): string;
 }>;

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -1,4 +1,5 @@
 import type { Contact, ContactAddress, ContactAddressId, ContactId } from "@domain/entity-contact";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { ContactEditRequirement } from "./model/editRequirement";
 
 export type ContactDetailAddressRowIntent = Readonly<{
@@ -65,3 +66,25 @@ export type ContactDetailViewProps = Readonly<{
   onAddAddress: () => void;
   onOpenLedgerWalletAddresses?: () => void;
 }>;
+
+export type ContactAddressDetailAsset = Readonly<{
+  currencyId: ContactAddress["currencyId"];
+  name: string;
+  ticker: string;
+}>;
+
+export type ContactAddressDetailNetwork = Readonly<{
+  id: CryptoCurrency["id"];
+  name: string;
+}>;
+
+export type ContactAddressDetailViewModel =
+  | Readonly<{ displayMode: "not-found" }>
+  | Readonly<{
+      displayMode: "found";
+      address: ContactAddress["address"];
+      label: ContactAddress["label"];
+      network: ContactAddressDetailNetwork;
+      asset: ContactAddressDetailAsset;
+      qrPayload: string;
+    }>;

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetail.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetail.ts
@@ -1,0 +1,27 @@
+import {
+  selectContactAddressById,
+  type ContactAddressId,
+  type ContactId,
+} from "@domain/entity-contact";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import type { ContactAddressDetailPort } from "./model/ports";
+import { createContactAddressDetailViewModel } from "./model/addressDetailViewModel";
+import type { ContactAddressDetailViewModel } from "./types";
+
+type ContactsStateRoot = Parameters<typeof selectContactAddressById>[0];
+
+export function useContactAddressDetail(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+  port: ContactAddressDetailPort,
+): ContactAddressDetailViewModel {
+  const contactAddress = useSelector((state: ContactsStateRoot) =>
+    selectContactAddressById(state, contactId, addressId),
+  );
+
+  return useMemo(
+    () => createContactAddressDetailViewModel(contactAddress, port),
+    [contactAddress, port],
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetail.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetail.web.test.tsx
@@ -1,0 +1,94 @@
+import { createElement, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import {
+  ContactAddressIdSchema,
+  ContactIdSchema,
+  contactsSlice,
+} from "@domain/entity-contact";
+import { mockContactWithAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressDetailPort } from "./model/ports";
+import { useContactAddressDetail } from "./useContactAddressDetail";
+
+const ethereum = getCryptoCurrencyById("ethereum");
+
+const addressDetailPort: ContactAddressDetailPort = {
+  resolveNetwork: () => ({
+    id: ethereum.id,
+    name: ethereum.name,
+  }),
+  resolveAsset: () => ({
+    currencyId: ethereum.id,
+    name: ethereum.name,
+    ticker: ethereum.ticker,
+  }),
+  resolveQrPayload: contactAddress => contactAddress.address,
+};
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+describe("useContactAddressDetail", () => {
+  it("should expose the selected address payload", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0];
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+
+    expect(address).toBeDefined();
+
+    const { result } = renderHook(
+      () => useContactAddressDetail(contact.id, address!.id, addressDetailPort),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toMatchObject({
+      displayMode: "found",
+      address: address!.address,
+      label: address!.label,
+      qrPayload: address!.address,
+    });
+  });
+
+  it("should return not-found when the address does not exist", () => {
+    const contact = mockContactWithAddress();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetail(
+          contact.id,
+          ContactAddressIdSchema.parse("address-missing"),
+          addressDetailPort,
+        ),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toEqual({ displayMode: "not-found" });
+  });
+
+  it("should return not-found when the contact does not exist", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0];
+    const Wrapper = makeWrapper([mockMeContact()]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetail(
+          ContactIdSchema.parse("contact-missing"),
+          address!.id,
+          addressDetailPort,
+        ),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current).toEqual({ displayMode: "not-found" });
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

## Summary

Adds shared state for viewing a saved contact address in `@features/flow-contacts`, building on the populated contact detail work from #20041.

- **`@domain/entity-contact`**: new `selectContactAddressById` selector to look up a saved address by `contactId` + `addressId`
- **`@features/flow-contacts`**: address detail view model under `steps/Detail/`:
  - `useContactAddressDetail` hook
  - `createContactAddressDetailViewModel` pure builder
  - `ContactAddressDetailPort` for app wiring to resolve network, asset, and QR payload (no QR library in shared logic)
- **Found state** exposes `address`, `label`, `network`, `asset`, and `qrPayload`
- **Not-found state** when the contact or address is missing from Redux

No Desktop/Mobile UI, Lumen, or navigation changes — shared logic only.


### 🔗 Context

[LIVE-33945](https://ledgerhq.atlassian.net/browse/LIVE-33945)


[LIVE-33945]: https://ledgerhq.atlassian.net/browse/LIVE-33945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ