### PR TITLE
feat(devtools): add transport-panel package and sidebarFooter slot

### DIFF
--- a/.agents/skills/devtools-import-boundary/SKILL.md
+++ b/.agents/skills/devtools-import-boundary/SKILL.md
@@ -19,6 +19,7 @@ Every `@devtools/*` package is **self-contained**. The only permitted cross-pack
 | `@devtools/wire` | `@devtools/transport`, `@devtools/protocols` |
 | `@devtools/protocols` | `@devtools/transport` only |
 | `@devtools/relay` | `@devtools/transport` only |
+| `@devtools/transport-panel` | `@devtools/transport` only |
 | `@devtools/<tool>` | *none* |
 
 All other `@devtools/*` → `@devtools/*` imports are forbidden.

--- a/.changeset/gentle-birds-fly.md
+++ b/.changeset/gentle-birds-fly.md
@@ -1,0 +1,8 @@
+---
+"@devtools/transport": minor
+"@devtools/transport-panel": minor
+"@devtools/shell": minor
+"@ledgerhq/web-tools": minor
+---
+
+Add @devtools/transport-panel package with TransportPanel, TransportPanelContent, TransportDebug, HistoryLine and TransportStateIndicator components. Expose sidebarFooter slot in @devtools/shell sidebar. Add origin field to TransportState. Wire transport panel in web-tools dev-tools page.

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@devtools/shell": "workspace:*",
+    "@devtools/transport-panel": "workspace:*",
     "@devtools/wire": "workspace:*",
     "@devtools/protocols": "workspace:*",
     "@domain/api-currency-token": "workspace:*",

--- a/apps/web-tools/src/pages/dev-tools.tsx
+++ b/apps/web-tools/src/pages/dev-tools.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
 import { DevTools, type DevToolsConfig } from "@devtools/shell";
 import { useFeatureFlagsToolProps } from "@devtools/bindings";
+import { TransportPanel } from "@devtools/transport-panel";
 import { buildTransport, buildCopyStoreProtocol, combineProtocols } from "@devtools/wire";
 import { store } from "../store";
 import { sleepingListener } from "../store/sleepingListener";
@@ -21,11 +22,24 @@ export default function DevToolsPage() {
     () => [{ id: "feature-flags", config: featureFlagsProps }],
     [featureFlagsProps],
   );
+  const wireState = useSyncExternalStore(wire.subscribe, wire.getState, wire.getState);
 
   return (
     <ThemeProvider colorScheme="system">
       <div style={{ height: "100vh" }}>
-        <DevTools config={config} />
+        <DevTools
+          config={config}
+          sidebarFooter={
+            <TransportPanel
+              transport={wire.transport}
+              hubUrl={wireState.hubUrl}
+              setHubUrl={wire.setHubUrl}
+              role={wireState.role}
+              target={wireState.target}
+              setTarget={wire.setTarget}
+            />
+          }
+        />
       </div>
     </ThemeProvider>
   );

--- a/devtools/feature-flags/package.json
+++ b/devtools/feature-flags/package.json
@@ -51,7 +51,7 @@
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@ledgerhq/lumen-design-core": "catalog:",
-    "@ledgerhq/lumen-utils-shared": "0.1.7",
+    "@ledgerhq/lumen-utils-shared": "catalog:",
     "expo-file-system": "catalog:",
     "expo-modules-core": "catalog:",
     "expo-document-picker": "catalog:",

--- a/devtools/shell/package.json
+++ b/devtools/shell/package.json
@@ -105,6 +105,7 @@
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@ledgerhq/lumen-utils-shared": "catalog:",
     "@radix-ui/react-checkbox": "catalog:",
     "@radix-ui/react-dialog": "catalog:",
     "@radix-ui/react-dropdown-menu": "catalog:",

--- a/devtools/shell/src/DevTools/DevTools.types.ts
+++ b/devtools/shell/src/DevTools/DevTools.types.ts
@@ -1,6 +1,8 @@
+import { type ReactNode } from "react";
 import { type DevToolsConfig } from "@devtools/registry";
 
 /** Props common to every platform's DevTools entry. Platform entries extend this. */
 export interface DevToolsBaseProps {
   readonly config?: DevToolsConfig;
+  readonly sidebarFooter?: ReactNode;
 }

--- a/devtools/shell/src/DevTools/DevTools.web.tsx
+++ b/devtools/shell/src/DevTools/DevTools.web.tsx
@@ -16,6 +16,7 @@ function DevToolsView({
   onSelectTool,
   onClearTool,
   onClose,
+  sidebarFooter,
 }: DevToolsViewProps & { onClose?: () => void }) {
   return (
     <div data-testid="devtools" className="flex flex-col h-full bg-canvas text-base">
@@ -31,6 +32,7 @@ function DevToolsView({
           onSelectTool={onSelectTool}
           onHome={onClearTool}
           onClose={onClose}
+          sidebarFooter={sidebarFooter}
         />
 
         <Divider orientation="vertical" />
@@ -56,10 +58,10 @@ function DevToolsView({
   );
 }
 
-export const DevTools = ({ config = [], onClose }: DevToolsProps) => {
+export const DevTools = ({ config = [], onClose, sidebarFooter }: DevToolsProps) => {
   return (
     <DevToolsProvider value={config}>
-      <DevToolsView {...useDevToolsViewModel({ config })} onClose={onClose} />
+      <DevToolsView {...useDevToolsViewModel({ config, sidebarFooter })} onClose={onClose} />
     </DevToolsProvider>
   );
 };

--- a/devtools/shell/src/DevTools/useDevToolsViewModel.web.ts
+++ b/devtools/shell/src/DevTools/useDevToolsViewModel.web.ts
@@ -1,8 +1,10 @@
 import { useToolsFromConfig, useDevToolsStorage } from "../hooks";
 import type { Category, DevToolsConfig, Tool, ToolId } from "@devtools/registry";
+import type { ReactNode } from "react";
 
 interface DevToolsInput {
   config: DevToolsConfig;
+  sidebarFooter?: ReactNode;
 }
 
 export interface DevToolsViewProps {
@@ -11,9 +13,10 @@ export interface DevToolsViewProps {
   recentToolIds: ToolId[];
   onSelectTool: (id: ToolId) => void;
   onClearTool: () => void;
+  sidebarFooter?: ReactNode;
 }
 
-export function useDevToolsViewModel({ config }: DevToolsInput): DevToolsViewProps {
+export function useDevToolsViewModel({ config, sidebarFooter }: DevToolsInput): DevToolsViewProps {
   const { activeTool, setActiveToolId, clearActiveTool, categories } = useToolsFromConfig(
     config,
     "web",
@@ -26,5 +29,6 @@ export function useDevToolsViewModel({ config }: DevToolsInput): DevToolsViewPro
     recentToolIds,
     onSelectTool: setActiveToolId,
     onClearTool: clearActiveTool,
+    sidebarFooter,
   };
 }

--- a/devtools/shell/src/components/Sidebar/Sidebar.web.tsx
+++ b/devtools/shell/src/components/Sidebar/Sidebar.web.tsx
@@ -2,6 +2,7 @@ import { SearchInput } from "@ledgerhq/lumen-ui-react";
 import { ArrowLeft } from "@ledgerhq/lumen-ui-react/symbols";
 import { Category, ValueOf } from "@devtools/registry";
 import type { Tool, ToolId } from "@devtools/registry";
+import type { ReactNode } from "react";
 import { CategoryRow } from "../CategoryRow/CategoryRow";
 import { IconSquare } from "../IconSquare/IconSquare";
 import { useSidebarViewModel, type SidebarViewProps } from "./useSidebarViewModel";
@@ -18,6 +19,7 @@ function SidebarView({
   onSelectTool,
   onHome,
   onClose,
+  sidebarFooter,
 }: SidebarViewProps) {
   return (
     <nav
@@ -67,6 +69,7 @@ function SidebarView({
           />
         ))}
       </ul>
+      {sidebarFooter}
     </nav>
   );
 }
@@ -77,6 +80,7 @@ interface SidebarProps {
   onSelectTool: (id: ToolId) => void;
   onHome: () => void;
   onClose?: () => void;
+  sidebarFooter?: ReactNode;
 }
 
 export function Sidebar(props: SidebarProps) {

--- a/devtools/shell/src/components/Sidebar/useSidebarViewModel.web.ts
+++ b/devtools/shell/src/components/Sidebar/useSidebarViewModel.web.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { ChangeEventHandler } from "react";
+import type { ChangeEventHandler, ReactNode } from "react";
 import type { Category, Tool, ToolId } from "@devtools/registry";
 import { useAccordion } from "../../hooks";
 import type { IconComponent } from "../../categoryConfig";
@@ -12,6 +12,7 @@ interface SidebarInput {
   onSelectTool: (id: ToolId) => void;
   onHome: () => void;
   onClose?: () => void;
+  sidebarFooter?: ReactNode;
 }
 
 export interface SidebarViewProps {
@@ -26,6 +27,7 @@ export interface SidebarViewProps {
   onSelectTool: (id: ToolId) => void;
   onHome: () => void;
   onClose?: () => void;
+  sidebarFooter?: ReactNode;
 }
 
 export function useSidebarViewModel({
@@ -34,6 +36,7 @@ export function useSidebarViewModel({
   onSelectTool,
   onHome,
   onClose,
+  sidebarFooter,
 }: SidebarInput): SidebarViewProps {
   const [query, setQuery] = useState("");
 
@@ -65,5 +68,6 @@ export function useSidebarViewModel({
     onSelectTool,
     onHome,
     onClose,
+    sidebarFooter,
   };
 }

--- a/devtools/transport-panel/jest.config.js
+++ b/devtools/transport-panel/jest.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/src"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+          transform: {
+            react: {
+              runtime: "automatic",
+            },
+          },
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ["web.tsx", "web.ts", "tsx", "ts", "js", "jsx", "json", "node"],
+  testPathIgnorePatterns: ["\\.native\\.test\\."],
+  modulePaths: ["<rootDir>"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  transformIgnorePatterns: [
+    "node_modules/.pnpm/(?!(@ledgerhq\\+lumen-ui-react|@ledgerhq\\+lumen-design-core|@ledgerhq\\+lumen-utils-shared))",
+  ],
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/devtools/transport-panel/jest.setup.ts
+++ b/devtools/transport-panel/jest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/devtools/transport-panel/jest/mocks/transport.ts
+++ b/devtools/transport-panel/jest/mocks/transport.ts
@@ -1,0 +1,38 @@
+import type { Transport, TransportState, MessageMap } from "@devtools/transport";
+import type { TransportPanelProps } from "../../src/types";
+
+/**
+ * getState returns a single stable object reference — required for useSyncExternalStore,
+ * which compares snapshots with Object.is and loops if the reference changes every call.
+ */
+export function mockTransport(
+  stateOverrides?: Partial<TransportState<MessageMap>>,
+): Transport<MessageMap> {
+  const state: TransportState<MessageMap> = {
+    status: "open",
+    url: "ws://localhost",
+    origin: "local",
+    history: [],
+    ...stateOverrides,
+  };
+  return {
+    getState: () => state,
+    subscribe: jest.fn(() => jest.fn()),
+    setUrl: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    send: jest.fn(),
+  };
+}
+
+export function mockTransportPanelProps(
+  overrides?: Partial<TransportPanelProps>,
+): TransportPanelProps {
+  return {
+    transport: mockTransport(),
+    hubUrl: "ws://localhost",
+    setHubUrl: jest.fn(),
+    role: "host",
+    ...overrides,
+  };
+}

--- a/devtools/transport-panel/jest/render/index.tsx
+++ b/devtools/transport-panel/jest/render/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render as rtlRender, RenderOptions, RenderResult } from "@testing-library/react";
+import { ThemeProvider } from "@ledgerhq/lumen-ui-react";
+
+interface AllProvidersProps {
+  readonly children: React.ReactNode;
+}
+
+function AllProviders({ children }: AllProvidersProps) {
+  return <ThemeProvider colorScheme="dark">{children}</ThemeProvider>;
+}
+
+function render(ui: React.ReactElement, options?: Omit<RenderOptions, "wrapper">): RenderResult {
+  return rtlRender(ui, { wrapper: AllProviders, ...options });
+}
+
+export * from "@testing-library/react";
+export { render };

--- a/devtools/transport-panel/package.json
+++ b/devtools/transport-panel/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@devtools/transport-panel",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Ledger Live DevTools — transport status panel",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "sideEffects": false,
+  "scripts": {
+    "format": "oxfmt src jest",
+    "format:check": "oxfmt src jest --check",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json",
+    "test": "jest --config jest.config.js",
+    "test:watch": "jest --watch",
+    "coverage": "jest --config jest.config.js --coverage"
+  },
+  "dependencies": {
+    "@devtools/transport": "workspace:*"
+  },
+  "devDependencies": {
+    "@testing-library/react": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/user-event": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "@swc/jest": "catalog:",
+    "@swc/core": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "jest-sonar": "0.2.16",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-utils-shared": "catalog:",
+    "@radix-ui/react-dialog": "catalog:",
+    "@radix-ui/react-slot": "catalog:",
+    "@radix-ui/react-tooltip": "catalog:",
+    "@radix-ui/react-checkbox": "catalog:",
+    "@radix-ui/react-switch": "catalog:",
+    "@tanstack/react-table": "catalog:",
+    "class-variance-authority": "catalog:",
+    "clsx": "catalog:",
+    "tailwind-merge": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">=19",
+    "@ledgerhq/lumen-design-core": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@radix-ui/react-dialog": "catalog:",
+    "@radix-ui/react-tooltip": "catalog:",
+    "class-variance-authority": "catalog:",
+    "clsx": "catalog:",
+    "tailwind-merge": "catalog:"
+  }
+}

--- a/devtools/transport-panel/src/TransportPanel.web.test.tsx
+++ b/devtools/transport-panel/src/TransportPanel.web.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "jest/render";
+import { mockTransportPanelProps } from "jest/mocks/transport";
+import { TransportPanel } from "./TransportPanel.web";
+
+describe("TransportPanel", () => {
+  it("renders the current connection status from transport state", () => {
+    render(<TransportPanel {...mockTransportPanelProps()} />);
+    expect(screen.getByText("open")).toBeInTheDocument();
+  });
+
+  it("renders the role badge", () => {
+    render(<TransportPanel {...mockTransportPanelProps({ role: "tool" })} />);
+    expect(screen.getByText("tool")).toBeInTheDocument();
+  });
+
+  it("starts collapsed — panel content is not visible", () => {
+    render(<TransportPanel {...mockTransportPanelProps()} />);
+    expect(screen.queryByText("Hub URL")).not.toBeInTheDocument();
+  });
+
+  it("expands panel content when the header button is clicked", () => {
+    render(<TransportPanel {...mockTransportPanelProps()} />);
+    fireEvent.click(screen.getByRole("button", { name: /WS/i }));
+    expect(screen.getByText("Hub URL")).toBeInTheDocument();
+  });
+
+  it("collapses panel content when the header button is clicked a second time", () => {
+    render(<TransportPanel {...mockTransportPanelProps()} />);
+    fireEvent.click(screen.getByRole("button", { name: /WS/i }));
+    fireEvent.click(screen.getByRole("button", { name: /WS/i }));
+    expect(screen.queryByText("Hub URL")).not.toBeInTheDocument();
+  });
+});

--- a/devtools/transport-panel/src/TransportPanel.web.tsx
+++ b/devtools/transport-panel/src/TransportPanel.web.tsx
@@ -1,0 +1,38 @@
+import { Divider } from "@ledgerhq/lumen-ui-react";
+import { TransportStateIndicator } from "./components/TransportStateIndicator/TransportStateIndicator";
+import { useSyncExternalStore, useState } from "react";
+import { TransportPanelContent } from "./components/TransportPanelContent/TransportPanelContent.web";
+import { ChevronDown, ChevronUp } from "@ledgerhq/lumen-ui-react/symbols";
+import type { MessageMap } from "@devtools/transport";
+import type { TransportPanelProps } from "./types";
+
+export function TransportPanel<M extends MessageMap>(props: TransportPanelProps<M>) {
+  const { transport } = props;
+  const state = useSyncExternalStore(transport.subscribe, transport.getState, transport.getState);
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <div>
+      <Divider />
+      <div className="flex flex-col">
+        <button
+          type="button"
+          className="flex items-center justify-between px-2 transition-colors duration-150 hover:bg-muted-hover p-10"
+          aria-expanded={isExpanded}
+          onClick={() => setIsExpanded(prev => !prev)}
+        >
+          <div className="flex items-center gap-8">
+            <TransportStateIndicator transportState={state} />
+            <span className="body-3 text-muted">WS</span>
+            <span className="body-4 text-muted bg-muted rounded-full px-6 py-1">{props.role}</span>
+          </div>
+          {isExpanded ? (
+            <ChevronDown size={16} className="text-muted" />
+          ) : (
+            <ChevronUp size={16} className="text-muted" />
+          )}
+        </button>
+        {isExpanded && <TransportPanelContent transportConfig={props} />}
+      </div>
+    </div>
+  );
+}

--- a/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.test.tsx
+++ b/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from "jest/render";
+import type { Envelope, MessageMap } from "@devtools/transport";
+import { HistoryLine } from "./HistoryLine.web";
+
+const makeEnvelope = (overrides?: Partial<Envelope<MessageMap>>): Envelope<MessageMap> => ({
+  id: "abc-123",
+  seq: 1,
+  ts: 1000,
+  origin: "remote",
+  kind: "action",
+  payload: { foo: "bar" },
+  ...overrides,
+});
+
+describe("HistoryLine", () => {
+  it("starts collapsed and shows the one-liner summary", () => {
+    render(<HistoryLine envelope={makeEnvelope()} localOrigin="local" />);
+    expect(screen.getByText(/^#1 action/)).toBeInTheDocument();
+    expect(screen.queryByText(/"id":/)).not.toBeInTheDocument();
+  });
+
+  it("expands to show the full envelope JSON when clicked", () => {
+    render(<HistoryLine envelope={makeEnvelope()} localOrigin="local" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/"id":/)).toBeInTheDocument();
+    expect(screen.getByText(/"seq":/)).toBeInTheDocument();
+    expect(screen.getByText(/"kind":/)).toBeInTheDocument();
+  });
+
+  it("collapses back to the one-liner when clicked a second time", () => {
+    render(<HistoryLine envelope={makeEnvelope()} localOrigin="local" />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(screen.queryByText(/"id":/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^#1 action/)).toBeInTheDocument();
+  });
+
+  it("truncates the collapsed summary with '…' when the line exceeds 50 chars", () => {
+    const envelope = makeEnvelope({ payload: "x".repeat(200) });
+    render(<HistoryLine envelope={envelope} localOrigin="local" />);
+    const button = screen.getByRole("button");
+    expect(button.textContent).toContain("…");
+  });
+
+  it("shows the 'Output too big to display' sentinel when the payload JSON exceeds 500 chars in expanded view", () => {
+    const envelope = makeEnvelope({ payload: "x".repeat(600) });
+    render(<HistoryLine envelope={envelope} localOrigin="local" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/"Output too big to display"/)).toBeInTheDocument();
+  });
+
+  it("uses the accent colour on the arrow when the envelope was sent by the local origin", () => {
+    const envelope = makeEnvelope({ origin: "local" });
+    const { container } = render(<HistoryLine envelope={envelope} localOrigin="local" />);
+    expect(container.querySelector("svg")).toHaveClass("text-accent");
+  });
+
+  it("uses the muted colour on the arrow when the envelope was received from a remote origin", () => {
+    const envelope = makeEnvelope({ origin: "remote" });
+    const { container } = render(<HistoryLine envelope={envelope} localOrigin="local" />);
+    expect(container.querySelector("svg")).toHaveClass("text-muted");
+  });
+});

--- a/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.tsx
+++ b/devtools/transport-panel/src/components/HistoryLine/HistoryLine.web.tsx
@@ -1,0 +1,44 @@
+import type { Envelope, MessageMap } from "@devtools/transport";
+import { ArrowUp, ArrowDown } from "@ledgerhq/lumen-ui-react/symbols";
+import { useMemo, useState } from "react";
+
+const COLLAPSED_LIMIT = 50;
+const EXPANDED_LIMIT = 500;
+
+interface HistoryLineProps<M extends MessageMap> {
+  readonly envelope: Envelope<M>;
+  readonly localOrigin: string;
+}
+
+export function HistoryLine<M extends MessageMap>({ envelope, localOrigin }: HistoryLineProps<M>) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const isSent = envelope.origin === localOrigin;
+  const Arrow = isSent ? ArrowUp : ArrowDown;
+
+  const collapsed = `#${envelope.seq} ${String(envelope.kind)} ${envelope.id} ${JSON.stringify(envelope.payload)}`;
+  const collapsedText =
+    collapsed.length > COLLAPSED_LIMIT ? collapsed.slice(0, COLLAPSED_LIMIT) + "…" : collapsed;
+
+  const expandedText = useMemo(() => {
+    const payloadJson = JSON.stringify(envelope.payload, null, 2);
+    const payload =
+      payloadJson.length > EXPANDED_LIMIT ? "Output too big to display" : envelope.payload;
+    return JSON.stringify({ ...envelope, payload }, null, 2);
+  }, [envelope]);
+
+  return (
+    <button
+      type="button"
+      className="flex items-start gap-8 w-full text-left hover:bg-muted-hover rounded-sm p-4 transition-colors duration-150"
+      onClick={() => setIsExpanded(prev => !prev)}
+    >
+      <Arrow size={12} className={`shrink-0 mt-2 ${isSent ? "text-accent" : "text-muted"}`} />
+      {isExpanded ? (
+        <pre className="body-4 text-base whitespace-pre-wrap break-all">{expandedText}</pre>
+      ) : (
+        <span className="body-4 text-muted font-mono truncate">{collapsedText}</span>
+      )}
+    </button>
+  );
+}

--- a/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.test.tsx
+++ b/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from "jest/render";
+import { mockTransportPanelProps, mockTransport } from "jest/mocks/transport";
+import { TransportDebug } from "./TransportDebug.web";
+
+describe("TransportDebug", () => {
+  it("renders the dialog when open", () => {
+    render(<TransportDebug transportConfig={mockTransportPanelProps()} open />);
+    expect(screen.getByRole("dialog", { name: "Transport Debug" })).toBeInTheDocument();
+  });
+
+  it("renders one row per history entry", () => {
+    const config = mockTransportPanelProps({
+      transport: mockTransport({
+        history: [
+          { id: "e1", seq: 1, ts: 0, origin: "local", kind: "ping", payload: null },
+          { id: "e2", seq: 2, ts: 0, origin: "remote", kind: "pong", payload: null },
+        ],
+      }),
+    });
+    render(<TransportDebug transportConfig={config} open />);
+    expect(screen.getByText(/ping/)).toBeInTheDocument();
+    expect(screen.getByText(/pong/)).toBeInTheDocument();
+  });
+
+  it("always renders the Send button", () => {
+    render(<TransportDebug transportConfig={mockTransportPanelProps()} open />);
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
+  it("defaults the Kind field to 'debug'", () => {
+    render(<TransportDebug transportConfig={mockTransportPanelProps()} open />);
+    expect(screen.getByDisplayValue("debug")).toBeInTheDocument();
+  });
+
+  it("shows the error message when transport.send throws", () => {
+    const config = mockTransportPanelProps({
+      transport: {
+        ...mockTransport(),
+        send: jest.fn().mockImplementation(() => {
+          throw new Error("transport is not open");
+        }),
+      },
+    });
+    render(<TransportDebug transportConfig={config} open />);
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByText("transport is not open")).toBeInTheDocument();
+  });
+
+  it("clears the error message on a successful send", () => {
+    const send = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("transport is not open");
+      })
+      .mockImplementationOnce(() => {});
+    const config = mockTransportPanelProps({ transport: { ...mockTransport(), send } });
+    render(<TransportDebug transportConfig={config} open />);
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.getByText("transport is not open")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(screen.queryByText("transport is not open")).not.toBeInTheDocument();
+  });
+
+  it("calls transport.send with the current kind and message when Send is clicked", () => {
+    const send = jest.fn();
+    const config = mockTransportPanelProps({
+      transport: { ...mockTransport(), send },
+    });
+    render(<TransportDebug transportConfig={config} open />);
+
+    const [kindInput, messageInput] = screen.getAllByRole("textbox");
+    fireEvent.change(kindInput, { target: { value: "action" } });
+    fireEvent.change(messageInput, { target: { value: '{"x":1}' } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(send).toHaveBeenCalledWith("action", '{"x":1}');
+  });
+});

--- a/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.tsx
+++ b/devtools/transport-panel/src/components/TransportDebug/TransportDebug.web.tsx
@@ -1,0 +1,66 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogBody,
+  DialogFooter,
+  TextInput,
+  Button,
+} from "@ledgerhq/lumen-ui-react";
+import { useState } from "react";
+import { HistoryLine } from "../HistoryLine/HistoryLine.web";
+import type { MessageMap } from "@devtools/transport";
+import type { TransportPanelProps } from "../../types";
+
+export interface TransportDebugProps<M extends MessageMap> {
+  readonly transportConfig: TransportPanelProps<M>;
+  readonly open?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+export function TransportDebug<M extends MessageMap>({
+  transportConfig,
+  open,
+  onOpenChange,
+}: TransportDebugProps<M>) {
+  const [sendMessage, setSendMessage] = useState("");
+  const [kind, setKind] = useState("debug");
+  const [sendError, setSendError] = useState<string | null>(null);
+  const state = transportConfig.transport.getState();
+
+  function handleSend() {
+    try {
+      transportConfig.transport.send(kind as keyof M, sendMessage as M[keyof M]);
+      setSendError(null);
+    } catch (e) {
+      setSendError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} height="fixed">
+      <DialogContent>
+        <DialogHeader title="Transport Debug" description="Debug transport connection" />
+        <DialogBody className="flex flex-col gap-16">
+          <div className="flex flex-col gap-8 bg-canvas-muted p-16 rounded-md">
+            {state.history.map(entry => (
+              <HistoryLine key={entry.id} envelope={entry} localOrigin={state.origin} />
+            ))}
+          </div>
+        </DialogBody>
+        <DialogFooter className="flex flex-col gap-8 pt-32">
+          <div className="flex gap-16">
+            <TextInput label="Kind" value={kind} onChange={e => setKind(e.target.value)} />
+            <TextInput
+              label="Debug Input"
+              value={sendMessage}
+              onChange={e => setSendMessage(e.target.value)}
+            />
+            <Button onClick={handleSend}>Send</Button>
+          </div>
+          {sendError && <span className="body-4 text-error">{sendError}</span>}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.test.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from "jest/render";
+import { mockTransportPanelProps, mockTransport } from "jest/mocks/transport";
+import { TransportPanelContent } from "./TransportPanelContent.web";
+
+describe("TransportPanelContent", () => {
+  it("always renders the Hub URL field", () => {
+    render(<TransportPanelContent transportConfig={mockTransportPanelProps()} />);
+    expect(screen.getByText("Hub URL")).toBeInTheDocument();
+  });
+
+  it("renders the Target field when role is 'tool'", () => {
+    render(<TransportPanelContent transportConfig={mockTransportPanelProps({ role: "tool" })} />);
+    expect(screen.getByText("Target")).toBeInTheDocument();
+  });
+
+  it("hides the Target field when role is 'host'", () => {
+    render(<TransportPanelContent transportConfig={mockTransportPanelProps({ role: "host" })} />);
+    expect(screen.queryByText("Target")).not.toBeInTheDocument();
+  });
+
+  it("calls transport.setUrl with the current URL when Refresh is clicked", () => {
+    const setUrl = jest.fn();
+    const config = mockTransportPanelProps({
+      transport: { ...mockTransport({ url: "ws://localhost:8080" }), setUrl },
+    });
+    render(<TransportPanelContent transportConfig={config} />);
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(setUrl).toHaveBeenCalledWith("ws://localhost:8080");
+  });
+
+  it("opens the debug dialog when Repair is clicked", () => {
+    render(<TransportPanelContent transportConfig={mockTransportPanelProps()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Repair" }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.tsx
@@ -1,0 +1,70 @@
+import { IconButton, TextInput } from "@ledgerhq/lumen-ui-react";
+import { Refresh, Repair } from "@ledgerhq/lumen-ui-react/symbols";
+import { useState } from "react";
+import { TransportDebug } from "../TransportDebug/TransportDebug";
+import type { MessageMap } from "@devtools/transport";
+import type { TransportPanelProps } from "../../types";
+
+interface TransportPanelContentProps<M extends MessageMap> {
+  readonly transportConfig: TransportPanelProps<M>;
+}
+
+export function TransportPanelContent<M extends MessageMap>({
+  transportConfig,
+}: TransportPanelContentProps<M>) {
+  const { transport, target, setTarget, hubUrl, setHubUrl, role } = transportConfig;
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  return (
+    <div className="p-10 flex flex-col gap-8">
+      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-8 items-center">
+        {role === "tool" && (
+          <>
+            <label htmlFor="target" className="body-3 text-muted">
+              Target
+            </label>
+            <TextInput
+              id="target"
+              value={target ?? ""}
+              onChange={e => setTarget?.(e.target.value)}
+              containerClassName="!h-32 !px-8 !rounded-xs"
+              hideClearButton
+              style={{ fontSize: "12px" }}
+            />
+          </>
+        )}
+        <label htmlFor="hubUrl" className="body-3 text-muted">
+          Hub URL
+        </label>
+        <TextInput
+          id="hubUrl"
+          value={hubUrl}
+          onChange={e => setHubUrl(e.target.value)}
+          containerClassName="!h-32 !px-8 !rounded-xs"
+          hideClearButton
+          style={{ fontSize: "12px" }}
+        />
+      </div>
+      <div className="flex items-center justify-evenly gap-16">
+        <IconButton
+          aria-label="Refresh"
+          icon={Refresh}
+          onClick={() => {
+            transport.setUrl(transport.getState().url);
+          }}
+          size="xs"
+        />
+        <IconButton
+          aria-label="Repair"
+          icon={Repair}
+          onClick={() => setIsDialogOpen(true)}
+          size="xs"
+        />
+      </div>
+      <TransportDebug
+        transportConfig={transportConfig}
+        open={isDialogOpen}
+        onOpenChange={setIsDialogOpen}
+      />
+    </div>
+  );
+}

--- a/devtools/transport-panel/src/components/TransportStateIndicator/TransportStateIndicator.tsx
+++ b/devtools/transport-panel/src/components/TransportStateIndicator/TransportStateIndicator.tsx
@@ -1,0 +1,28 @@
+import type { MessageMap, ConnectionStatus, TransportState } from "@devtools/transport";
+import { cn } from "@ledgerhq/lumen-utils-shared";
+
+export interface TransportStateIndicatorProps<M extends MessageMap> {
+  readonly transportState: TransportState<M>;
+}
+
+const STATUS_COLOR: Record<ConnectionStatus, string> = {
+  idle: "text-muted bg-muted",
+  connecting: "text-warning bg-warning",
+  open: "text-success bg-success",
+  closed: "text-disabled bg-disabled",
+  error: "text-error bg-error",
+};
+
+export function TransportStateIndicator<M extends MessageMap>({
+  transportState,
+}: TransportStateIndicatorProps<M>) {
+  const status = transportState.status;
+  const color = STATUS_COLOR[status];
+
+  return (
+    <div className={cn(`flex items-center rounded-full px-8 py-2`, color)}>
+      <span className={cn(`size-10 rounded-full`, `${color}-strong`)} />
+      <span className={cn(`body-3 ml-8  px-4 py-2`)}>{status}</span>
+    </div>
+  );
+}

--- a/devtools/transport-panel/src/components/TransportStateIndicator/TransportStateIndicator.web.test.tsx
+++ b/devtools/transport-panel/src/components/TransportStateIndicator/TransportStateIndicator.web.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "jest/render";
+import type { TransportState, ConnectionStatus } from "@devtools/transport";
+import { TransportStateIndicator } from "./TransportStateIndicator";
+
+const makeState = (status: ConnectionStatus): TransportState<any> => ({
+  status,
+  url: "ws://localhost",
+  origin: "test",
+  history: [],
+});
+
+describe("TransportStateIndicator", () => {
+  it.each<ConnectionStatus>(["idle", "connecting", "open", "closed", "error"])(
+    'displays "%s" status text',
+    status => {
+      render(<TransportStateIndicator transportState={makeState(status)} />);
+      expect(screen.getByText(status)).toBeVisible();
+    },
+  );
+});

--- a/devtools/transport-panel/src/index.ts
+++ b/devtools/transport-panel/src/index.ts
@@ -1,0 +1,2 @@
+export { TransportPanel } from "./TransportPanel.web";
+export type { TransportPanelProps } from "./types";

--- a/devtools/transport-panel/src/types.ts
+++ b/devtools/transport-panel/src/types.ts
@@ -1,0 +1,10 @@
+import type { MessageMap, Transport, Role } from "@devtools/transport";
+
+export interface TransportPanelProps<M extends MessageMap = MessageMap> {
+  readonly transport: Transport<M>;
+  readonly hubUrl: string;
+  readonly setHubUrl: (url: string) => void;
+  readonly role: Role;
+  readonly target?: string;
+  readonly setTarget?: (url: string) => void;
+}

--- a/devtools/transport-panel/tsconfig.json
+++ b/devtools/transport-panel/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "jest/*": ["./jest/*"]
+    },
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" }
+  ]
+}

--- a/devtools/transport-panel/tsconfig.web.json
+++ b/devtools/transport-panel/tsconfig.web.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""]
+  },
+  "include": ["src/**/*", "jest.setup.ts", "jest/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/devtools/transport/src/createTransport.ts
+++ b/devtools/transport/src/createTransport.ts
@@ -25,6 +25,7 @@ export function createTransport<M extends MessageMap>(
   let socket: WebSocketLike | null = null;
   let status: ConnectionStatus = "idle";
   let url = config.url;
+  let origin = config.origin;
   let seq = 0;
   let lastError: Error | undefined;
   let history: ReadonlyArray<Envelope<M>> = [];
@@ -34,6 +35,7 @@ export function createTransport<M extends MessageMap>(
     return {
       status,
       url,
+      origin,
       history,
       lastError,
     };

--- a/devtools/transport/src/types.ts
+++ b/devtools/transport/src/types.ts
@@ -107,6 +107,7 @@ export type TransportConfig = {
 export type TransportState<M extends MessageMap> = {
   status: ConnectionStatus;
   url: string;
+  origin: string;
   history: ReadonlyArray<Envelope<M>>;
   lastError?: Error;
 };

--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "./feature-flags/" },
     { "path": "./registry" },
     { "path": "./transport" },
+    { "path": "./transport-panel" },
     { "path": "./protocols" }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ catalogs:
     '@ledgerhq/lumen-ui-rnative-visualization':
       specifier: 0.1.29
       version: 0.1.29
+    '@ledgerhq/lumen-utils-shared':
+      specifier: 0.1.7
+      version: 0.1.7
     '@ledgerhq/speculos-device-controller':
       specifier: 0.3.0
       version: 0.3.0
@@ -2566,6 +2569,9 @@ importers:
       '@devtools/shell':
         specifier: workspace:*
         version: link:../../devtools/shell
+      '@devtools/transport-panel':
+        specifier: workspace:*
+        version: link:../../devtools/transport-panel
       '@devtools/wire':
         specifier: workspace:*
         version: link:../../devtools/wire
@@ -2939,7 +2945,7 @@ importers:
         specifier: 'catalog:'
         version: 0.1.52(270d3755349a23492d91ca093f57aa47)
       '@ledgerhq/lumen-utils-shared':
-        specifier: 0.1.7
+        specifier: 'catalog:'
         version: 0.1.7(react@19.1.4)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
@@ -3152,6 +3158,9 @@ importers:
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
         version: 0.1.52(3d4e8367284189935a47ae5c345b5680)
+      '@ledgerhq/lumen-utils-shared':
+        specifier: 'catalog:'
+        version: 0.1.7(react@19.1.4)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -3284,6 +3293,91 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  devtools/transport-panel:
+    dependencies:
+      '@devtools/transport':
+        specifier: workspace:*
+        version: link:../transport
+    devDependencies:
+      '@ledgerhq/lumen-design-core':
+        specifier: 'catalog:'
+        version: 0.1.23
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+      '@ledgerhq/lumen-utils-shared':
+        specifier: 'catalog:'
+        version: 0.1.7(react@19.1.4)
+      '@radix-ui/react-checkbox':
+        specifier: 'catalog:'
+        version: 1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-dialog':
+        specifier: 'catalog:'
+        version: 1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.0.14)(react@19.1.4)
+      '@radix-ui/react-switch':
+        specifier: 'catalog:'
+        version: 1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-tooltip':
+        specifier: 'catalog:'
+        version: 1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@tanstack/react-table':
+        specifier: 'catalog:'
+        version: 8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      class-variance-authority:
+        specifier: 'catalog:'
+        version: 0.7.1
+      clsx:
+        specifier: 'catalog:'
+        version: 2.1.1
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      jest-sonar:
+        specifier: 0.2.16
+        version: 0.2.16
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      tailwind-merge:
+        specifier: 'catalog:'
+        version: 3.4.0
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -18257,11 +18351,6 @@ packages:
       '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
-
-  '@ledgerhq/coin-module-framework@4.0.0':
-    resolution: {integrity: sha512-V0kXnykw2M+J+EtWP7lB7qZLX/HSlbNBalQx7dxiNFPlCxNqUvjOZ6HkuCOZTEXA0Sk96svBFkrZVHGG4VOvHg==}
-    peerDependencies:
-      '@ledgerhq/errors': ^6.33.0
 
   '@ledgerhq/coin-module-framework@4.0.2':
     resolution: {integrity: sha512-uYbsVd6t5qzgSEyINEhfuruTO74wAEi+lpMvAPF67F9gWAsFC7109kxlG1AgRdIQmmW5cCMYaSMt69DrhN0BuQ==}
@@ -34109,7 +34198,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -46245,11 +46333,6 @@ snapshots:
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
 
-  '@ledgerhq/coin-module-framework@4.0.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)':
-    dependencies:
-      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
-      bignumber.js: 9.1.2
-
   '@ledgerhq/coin-module-framework@4.0.2':
     dependencies:
       bignumber.js: 9.1.2
@@ -46271,7 +46354,7 @@ snapshots:
 
   '@ledgerhq/coin-xrp@7.25.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 4.0.0(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+      '@ledgerhq/coin-module-framework': 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
@@ -46653,6 +46736,26 @@ snapshots:
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
       react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      tailwind-merge: 3.4.0
+    transitivePeerDependencies:
+      - react-native
+
+  '@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@radix-ui/react-checkbox': 1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.1.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@tanstack/react-table': 8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      i18next: 23.10.1
+      react: 19.1.4
+      react-dom: 19.1.4(react@19.1.4)
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       tailwind-merge: 3.4.0
     transitivePeerDependencies:
       - react-native
@@ -65568,7 +65671,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65692,54 +65795,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,6 +41,7 @@ catalog:
   "@ledgerhq/lumen-ui-rnative": 0.1.52
   "@ledgerhq/lumen-ui-rnative-visualization": 0.1.29
   "@ledgerhq/lumen-ui-react-visualization": 0.1.28
+  "@ledgerhq/lumen-utils-shared": "0.1.7"
   "@ledgerhq/zcash-utils": 1.1.0
   # React Native
   react-native: 0.81.6


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Introduces @devtools/transport-panel, a new self-contained package with all the WebSocket transport UI — TransportPanel, TransportPanelContent, TransportDebug, HistoryLine, and TransportStateIndicator.

Shell exposes a generic sidebarFooter slot so hosts can inject any sidebar content without coupling shell to transport types. @devtools/transport gains an origin field on TransportState. Web-tools wires the panel as sidebarFooter.

[
<img width="1604" height="947" alt="Screenshot 2026-07-28 at 16 18 54" src="https://github.com/user-attachments/assets/ec91c4ad-f7a1-4427-88b3-a846cbeb1860" />
<img width="1604" height="947" alt="Screenshot 2026-07-28 at 16 19 12" src="https://github.com/user-attachments/assets/4994ec98-bc40-4dcf-8313-97db89c9d725" />
<img width="1604" height="947" alt="Screenshot 2026-07-28 at 16 19 16" src="https://github.com/user-attachments/assets/7a35ef45-e23f-47bd-a9a2-e854e4bbaae5" />
<img width="1604" height="947" alt="Screenshot 2026-07-28 at 16 19 20" src="https://github.com/user-attachments/assets/57ab3b50-ab9d-453f-84dd-ad513e101be0" />
<img width="1604" height="947" alt="Screenshot 2026-07-28 at 16 19 23" src="https://github.com/user-attachments/assets/f2b3ab47-f844-4182-a7c0-e653506cdc83" />
](url)



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-29145](https://ledgerhq.atlassian.net/browse/LIVE-29145)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-29145]: https://ledgerhq.atlassian.net/browse/LIVE-29145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ