### PR TITLE
[LWDM] refactor(currencies): drop dead @ledgerhq/cryptoassets store injection (LIVE-35038)

### DIFF
--- a/.changeset/drop-dead-cryptoassets-currency-injection.md
+++ b/.changeset/drop-dead-cryptoassets-currency-injection.md
@@ -1,0 +1,11 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-cli": minor
+"@ledgerhq/web-tools": minor
+"@ledgerhq/coin-bitcoin": minor
+"@ledgerhq/wallet-btc": minor
+"@ledgerhq/live-countervalues": minor
+---
+
+Remove the now-dead `@ledgerhq/cryptoassets` currency/fiat store injection from the app bootstraps. Nothing reads the legacy currency/fiat accessors anymore (the runtime source of truth is the domain-backed wallet-framework currency resolver), so `setCryptoCurrenciesStore` / `setFiatCurrenciesStore` injected a store no consumer queried. Drop the calls, drop the `@ledgerhq/cryptoassets` dependency from the apps, and remove the remaining stale references to the package in comments.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -32,7 +32,6 @@
     "@domain/api-currency-token": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:^",
     "@features/platform-currencies": "workspace:^",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport-node-speculos": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",

--- a/apps/cli/src/live-common-setup-base.ts
+++ b/apps/cli/src/live-common-setup-base.ts
@@ -5,10 +5,7 @@ import { registerAllCoins } from "@ledgerhq/live-common/coin-modules/load-all-co
 import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import BigNumber from "bignumber.js";
-import { setCryptoCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
-  CRYPTO_CURRENCIES_REGISTRY,
-  CRYPTO_CURRENCY_ALIASES,
   getCryptoCurrencyById,
   findCryptoCurrencyById,
   findCryptoCurrencyByScheme,
@@ -18,7 +15,6 @@ import {
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 
 // The domain registry is the runtime source of truth for currency data.
-setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
 setCurrenciesResolver({
   getCryptoCurrencyById,
   findCryptoCurrencyById,

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -100,7 +100,6 @@
     "@domain/api-altcoins-sentiment": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/domain-service": "workspace:^",

--- a/apps/ledger-live-desktop/src/live-common-setup-base.ts
+++ b/apps/ledger-live-desktop/src/live-common-setup-base.ts
@@ -2,23 +2,17 @@ import os from "os";
 import { setEnv, getEnv } from "@shared/env";
 import { bridgeEnvToNetworkState } from "@ledgerhq/live-common/network/setup";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
-import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
-  CRYPTO_CURRENCIES_REGISTRY,
-  CRYPTO_CURRENCY_ALIASES,
   getCryptoCurrencyById,
   findCryptoCurrencyById,
   findCryptoCurrencyByScheme,
   listCryptoCurrencies,
   hasCryptoCurrencyId,
 } from "@domain/entity-currency-crypto";
-import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 import BigNumber from "bignumber.js";
 
-// The domain registries are the runtime source of truth for currency data.
-setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
-setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
+// The domain registry is the runtime source of truth for currency data.
 setCurrenciesResolver({
   getCryptoCurrencyById,
   findCryptoCurrencyById,

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -121,7 +121,6 @@
     "@domain/entity-pay-card": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",

--- a/apps/ledger-live-mobile/src/live-common-setup.ts
+++ b/apps/ledger-live-mobile/src/live-common-setup.ts
@@ -11,25 +11,19 @@ import { Platform } from "react-native";
 import { setSecp256k1Instance } from "@ledgerhq/live-common/families/bitcoin/logic";
 import { setGlobalOnBridgeError } from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { liveBlindSigningReporter } from "@ledgerhq/live-dmk-shared";
-import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import {
-  CRYPTO_CURRENCIES_REGISTRY,
-  CRYPTO_CURRENCY_ALIASES,
   getCryptoCurrencyById,
   findCryptoCurrencyById,
   findCryptoCurrencyByScheme,
   listCryptoCurrencies,
   hasCryptoCurrencyId,
 } from "@domain/entity-currency-crypto";
-import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 import "./experimental";
 import logger, { ConsoleLogger } from "./logger";
 import BigNumber from "bignumber.js";
 
-// The domain registries are the runtime source of truth for currency data.
-setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
-setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
+// The domain registry is the runtime source of truth for currency data.
 setCurrenciesResolver({
   getCryptoCurrencyById,
   findCryptoCurrencyById,

--- a/apps/web-tools/package.json
+++ b/apps/web-tools/package.json
@@ -38,7 +38,6 @@
     "@codemirror/view": "^6.39.5",
     "@domain/entity-currency-fiat": "workspace:^",
     "@ledgerhq/coin-module-framework": "catalog:",
-    "@ledgerhq/cryptoassets": "workspace:^",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-transport-kit-web-hid": "catalog:",

--- a/apps/web-tools/src/live-common-setup.ts
+++ b/apps/web-tools/src/live-common-setup.ts
@@ -4,25 +4,19 @@ import { setWalletAPIVersion } from "@ledgerhq/live-common/wallet-api/version";
 import { WALLET_API_VERSION } from "@ledgerhq/live-common/wallet-api/constants";
 import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
 import { liveConfig } from "@ledgerhq/live-common/config/sharedConfig";
-import { setCryptoCurrenciesStore, setFiatCurrenciesStore } from "@ledgerhq/cryptoassets";
 import { buildCryptoAssetsStore } from "@features/platform-currencies";
 import { store } from "./store";
 import {
-  CRYPTO_CURRENCIES_REGISTRY,
-  CRYPTO_CURRENCY_ALIASES,
   getCryptoCurrencyById,
   findCryptoCurrencyById,
   findCryptoCurrencyByScheme,
   listCryptoCurrencies,
   hasCryptoCurrencyId,
 } from "@domain/entity-currency-crypto";
-import { FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
 import { setCurrenciesResolver } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { setCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 
-// The domain registries are the runtime source of truth for currency data.
-setCryptoCurrenciesStore(Object.values(CRYPTO_CURRENCIES_REGISTRY), CRYPTO_CURRENCY_ALIASES);
-setFiatCurrenciesStore(Object.values(FIAT_CURRENCIES_REGISTRY));
+// The domain registry is the runtime source of truth for currency data.
 setCurrenciesResolver({
   getCryptoCurrencyById,
   findCryptoCurrencyById,

--- a/domain/entity/currency-crypto/src/legacy/accessors.ts
+++ b/domain/entity/currency-crypto/src/legacy/accessors.ts
@@ -63,8 +63,8 @@ export function findCryptoCurrencyByScheme(scheme: string | undefined): CryptoCu
  * when unknown.
  *
  * When two non-testnet currencies share a ticker, the one whose `keywords` list contains that
- * ticker (case-insensitive) wins. This matches the tiebreak introduced in and applied
- * by `registerCurrencyInStore` in `@ledgerhq/cryptoassets`.
+ * ticker (case-insensitive) wins. This matches the tiebreak previously applied by the
+ * legacy currency registry.
  *
  * @deprecated Tickers are not globally unique — the result can be ambiguous. Prefer
  * {@link findCryptoCurrencyById} when the currency id is available.

--- a/domain/entity/currency-crypto/src/registry.ts
+++ b/domain/entity/currency-crypto/src/registry.ts
@@ -22,10 +22,9 @@ export const CRYPTO_CURRENCIES_REGISTRY: Record<string, CryptoCurrency> = Object
 export const CRYPTO_CURRENCIES_IDS = Object.values(CRYPTO_CURRENCIES_REGISTRY).map(c => c.id);
 
 /**
- * Legacy alias keys from `@ledgerhq/cryptoassets` whose source-literal key differs from the
- * currency `.id` (the bundled map exposes both keys). Passed to `setCryptoCurrenciesStore` next to
- * the registry so `getCryptoCurrencyById` keeps resolving these aliases after injection. Maps the
- * alias key to its canonical id.
+ * Legacy alias keys whose source-literal key differs from the currency `.id` (some ids are exposed
+ * under an alternate historical key). The accessors resolve these so `getCryptoCurrencyById` keeps
+ * working for the alias keys. Maps the alias key to its canonical id.
  */
 export const CRYPTO_CURRENCY_ALIASES: Record<string, string> = {
   osmosis: "osmo",

--- a/features/platform/currencies/src/hooks/useTokensData.ts
+++ b/features/platform/currencies/src/hooks/useTokensData.ts
@@ -9,8 +9,8 @@ import {
  * Paginated CAL token list. Joins the RTK-Query infinite-query pages into a single
  * `{ tokens, pagination }` and exposes a `loadNext` when more pages are available.
  *
- * Relocated from `@ledgerhq/cryptoassets/cal-client/hooks`; wraps the `@domain/api-currency-token`
- * infinite query (this hook lives in `@features/platform-currencies`).
+ * Wraps the `@domain/api-currency-token` infinite query (this hook lives in
+ * `@features/platform-currencies`).
  */
 export function useTokensData(params: GetTokensDataParams) {
   const {

--- a/libs/coin-modules/coin-bitcoin/src/walletBtcCurrency.ts
+++ b/libs/coin-modules/coin-bitcoin/src/walletBtcCurrency.ts
@@ -6,7 +6,7 @@ import type { WalletBtcCurrency } from "@ledgerhq/wallet-btc/crypto/types";
 /**
  * Resolve a wallet-btc currency descriptor from a Ledger CryptoCurrency.
  *
- * wallet-btc is dependency-inverted: it no longer reads @ledgerhq/cryptoassets or
+ * wallet-btc is dependency-inverted: it no longer reads the currency registry or
  * @ledgerhq/live-env. coin-bitcoin (which legitimately depends on both) resolves the
  * explorer id and endpoint here and injects them into wallet-btc.
  */

--- a/libs/ledger-live-common/src/wallet-api/Exchange/quotes/format/types.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/quotes/format/types.ts
@@ -6,9 +6,9 @@ export type { FormattedNumber, FormattedQuoteValues };
 
 /**
  * Minimal per-currency metadata required by {@link formatQuote}. Deliberately
- * narrower than `CryptoCurrency` / `TokenCurrency` from
- * `@ledgerhq/cryptoassets` so the helper stays a pure function and can be
- * driven from fixtures without wallet-wide resolvers in tests.
+ * narrower than the full `CryptoCurrency` / `TokenCurrency` shapes so the
+ * helper stays a pure function and can be driven from fixtures without
+ * wallet-wide resolvers in tests.
  *
  * - `id` is the Ledger currency id (e.g. `"ethereum"`, `"ethereum/erc20/usd__coin"`).
  *   Used as the key into {@link FormatQuoteInput.spotPrices}.
@@ -26,8 +26,7 @@ export type CurrencyMeta = {
 /**
  * User's preferred counter-value fiat. Deliberately flat so callers can
  * resolve it once (via `findFiatCurrencyByTicker` + `units[0]`) and pass it
- * down; keeping the helper decoupled from `@ledgerhq/cryptoassets` makes
- * parity testing trivial.
+ * down; keeping the helper self-contained makes parity testing trivial.
  */
 export type FiatMeta = {
   ticker: string;

--- a/libs/live-countervalues/src/tests/currencies.ts
+++ b/libs/live-countervalues/src/tests/currencies.ts
@@ -1,7 +1,7 @@
 import { CoinType } from "@ledgerhq/types-cryptoassets";
 import type { CryptoCurrency, FiatCurrency } from "@ledgerhq/types-cryptoassets";
 
-// Minimal currency fixtures so tests don't depend on @ledgerhq/cryptoassets.
+// Minimal currency fixtures so tests don't pull the full currency registry.
 // Only the fields consumed by the countervalues logic and the account mocks are populated.
 
 const bitcoin: CryptoCurrency = {

--- a/libs/wallet-btc/src/__tests__/fixtures/common.fixtures.ts
+++ b/libs/wallet-btc/src/__tests__/fixtures/common.fixtures.ts
@@ -16,7 +16,7 @@ export const mockCrypto = {
 } as unknown as jest.Mocked<ICrypto>;
 
 // Test helper: build a wallet-btc currency descriptor (replaces getCryptoCurrencyById
-// wallet-btc is dependency-inverted (no @ledgerhq/cryptoassets), so tests inject the
+// wallet-btc is dependency-inverted (no currency-registry dependency), so tests inject the
 // explorer id explicitly. Map the currencies exercised here to their Ledger explorer code.
 const EXPLORER_IDS: Record<string, string> = {
   bitcoin: "btc",

--- a/libs/wallet-btc/src/explorer/baseUrl.ts
+++ b/libs/wallet-btc/src/explorer/baseUrl.ts
@@ -7,7 +7,7 @@ const EXPLORER_VERSION = "v4";
  *
  * The explorer id and endpoint are provided by the consumer through
  * `WalletBtcCurrency` (dependency inversion): wallet-btc no longer reads the
- * Ledger currency registry (@ledgerhq/cryptoassets) or the env (@ledgerhq/live-env).
+ * Ledger currency registry or the env (@ledgerhq/live-env).
  * The caller resolves the endpoint (e.g. from the EXPLORER / EXPLORER_REGTEST env)
  * and the explorer id, and passes them in.
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,9 +703,6 @@ importers:
       '@features/platform-currencies':
         specifier: workspace:^
         version: link:../../features/platform/currencies
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../../libs/ledgerjs/packages/errors
@@ -928,9 +925,6 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent
@@ -1665,9 +1659,6 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-rnative@0.1.50(06d7b9f801a4015982648e5aa5515f70))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent
@@ -2599,9 +2590,6 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/cryptoassets':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/cryptoassets
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)


### PR DESCRIPTION
## What

Removes the now-dead `@ledgerhq/cryptoassets` currency/fiat store injection from the app bootstraps, drops the dependency from the apps, and cleans up the remaining stale references to the package in comments / JSDoc.

## Why

After the value migration, nothing in-app reads the legacy `@ledgerhq/cryptoassets` currency/fiat accessors (`getCryptoCurrencyById`, `getFiatCurrencyByTicker`, …) anymore — the runtime source of truth is the domain-backed wallet-framework currency resolver (`setCurrenciesResolver`). So `setCryptoCurrenciesStore` / `setFiatCurrenciesStore` injected the domain registry into a store **no consumer queried** — dead code.

## Changes

- Remove `setCryptoCurrenciesStore` / `setFiatCurrenciesStore` calls + imports from `apps/cli`, `apps/ledger-live-desktop`, `apps/ledger-live-mobile`, `apps/web-tools` (the `setCurrenciesResolver` framework injection — the live path — is untouched).
- Drop `@ledgerhq/cryptoassets` from those apps' `package.json`.
- Reword the remaining inline-comment / JSDoc mentions of `@ledgerhq/cryptoassets` (`domain/*`, `@features/platform-currencies`, `@ledgerhq/live-common`, `@ledgerhq/coin-bitcoin`, `@ledgerhq/live-countervalues`, `@ledgerhq/wallet-btc`).

## Out of scope

- The parity tests inside `@ledgerhq/cryptoassets` (dual-maintenance guard — retired with the package drop).
- `@ledgerhq/cryptoassets-evm-signatures` (a different package).

## Verification

- Repo-wide `pnpm nx run-many -t typecheck` green (104 projects).
- `@ledgerhq/cryptoassets` (value) now has **zero in-repo consumers** — 0 `package.json` deps, 0 source imports of any subpath (`/state`, `/abandonseed`, `cal-client`, …).
- `pnpm install --frozen-lockfile` clean.