### PR TITLE
[LWM] Remove newsfeedPage feature flag (LIVE-31511)

### DIFF
--- a/.changeset/remove-newsfeed-page-flag.md
+++ b/.changeset/remove-newsfeed-page-flag.md
@@ -1,0 +1,7 @@
+---
+"@shared/feature-flags": patch
+"@ledgerhq/types-live": patch
+"live-mobile": patch
+---
+
+Remove newsfeedPage feature flag (LIVE-31511)

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -8910,11 +8910,6 @@
       }
     }
   },
-  "newsfeed": {
-    "title": "Newsfeed",
-    "poweredByCryptopanic": "Powered by Cryptopanic",
-    "noPosts": "No posts available currently"
-  },
   "deviceConnect": {
     "title": "Connect device"
   },

--- a/libs/ledgerjs/packages/types-live/src/feature.ts
+++ b/libs/ledgerjs/packages/types-live/src/feature.ts
@@ -216,7 +216,6 @@ export type Features = CurrencyFeatures & {
   evmNativeStaking: Feature_EvmNativeStaking;
   editBitcoinTx: Feature_EditBitcoinTx;
   stakeAccountBanner: Feature_StakeAccountBanner;
-  newsfeedPage: Feature_NewsfeedPage;
   domainInputResolution: Feature_DomainInputResolution;
   discover: Feature_Discover;
   transactionsAlerts: Feature_TransactionsAlerts;
@@ -532,12 +531,6 @@ export type Feature_Storyly = Feature<{
   stories: {
     [key in StorylyInstanceID]: StorylyInstanceType;
   };
-}>;
-
-/** @deprecated Moved to `@shared/feature-flags`. Use `Features["newsfeedPage"]` from `@shared/feature-flags` instead. */
-export type Feature_NewsfeedPage = Feature<{
-  cryptopanicApiKey: string;
-  whitelistedLocales: string[];
 }>;
 
 /** @deprecated Moved to `@shared/feature-flags`. Use `Features["protectServicesMobile"]` from `@shared/feature-flags` instead. */

--- a/shared/feature-flags/src/flags/team-engagement/index.ts
+++ b/shared/feature-flags/src/flags/team-engagement/index.ts
@@ -19,7 +19,6 @@ export * from "./llmNanoSUpsellBanners";
 export * from "./llmOnboardingEnableSync";
 export * from "./lwmNotificationsOptIn";
 export * from "./lwmProductTour";
-export * from "./newsfeedPage";
 export * from "./npsRatingsPrompt";
 export * from "./onboardingWidget";
 export * from "./ratingsPrompt";

--- a/shared/feature-flags/src/flags/team-engagement/newsfeedPage.ts
+++ b/shared/feature-flags/src/flags/team-engagement/newsfeedPage.ts
@@ -1,7 +1,0 @@
-import { z } from "zod";
-import { flagWith } from "../../define";
-
-export const newsfeedPage = flagWith({
-  cryptopanicApiKey: z.string(),
-  whitelistedLocales: z.array(z.string()),
-});


### PR DESCRIPTION
## Summary

Removes the dead `newsfeedPage` feature flag and related scaffolding. The LWM newsfeed UI was removed in Sep 2025; no runtime usage of `useFeature("newsfeedPage")` remains.

- Delete `newsfeedPage` flag from `@shared/feature-flags`
- Remove deprecated `Feature_NewsfeedPage` from `@ledgerhq/types-live`
- Remove orphaned English `newsfeed` i18n keys from mobile

## Test plan

- [x] `@shared/feature-flags` typecheck
- [x] `@ledgerhq/types-live` build
- [ ] Remove `feature_newsfeed_page` from Firebase remote config post-merge

## Jira

[LIVE-31511](https://ledgerhq.atlassian.net/browse/LIVE-31511)

[LIVE-31511]: https://ledgerhq.atlassian.net/browse/LIVE-31511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ