### PR TITLE
refactor(currencies): remove specialized re-exports from @domain/entity-currency (LIVE-34763)

### DIFF
--- a/.changeset/drop-aggregate-currency-reexports.md
+++ b/.changeset/drop-aggregate-currency-reexports.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-currency": minor
+---
+
+Remove the specialized re-exports from `@domain/entity-currency`; it now exposes only the cross-package unions (`Currency`/`CurrencySchema`, `CryptoOrTokenCurrency`/`CryptoOrTokenCurrencySchema`). Import specialized types (`CryptoCurrency`, `TokenCurrency`, `FiatCurrency`, `Unit`) directly from their own `@domain/entity-currency-*` package.

--- a/domain/entity/currency/README.md
+++ b/domain/entity/currency/README.md
@@ -3,30 +3,29 @@
 > [!NOTE]
 > **Status: STABLE** — Production-ready; API is considered stable.
 
-Currency union types and single entry-point for all currency entity packages.
+Cross-package currency **union types**. Specialized entity types live in their own packages.
 
 ## Responsibility
 
 - Export **`CryptoOrTokenCurrency`** — discriminated union of `CryptoCurrency | TokenCurrency`
 - Export **`Currency`** — discriminated union of `CryptoCurrency | TokenCurrency | FiatCurrency`
-- Re-export everything from the three currency entity packages and `@domain/entity-currency-unit`
 
-This package owns no schemas of its own. It is a pure aggregation layer.
+This package owns no schemas of its own and exposes **only** the cross-package unions. Import
+specialized types (`CryptoCurrency`, `TokenCurrency`, `FiatCurrency`, `Unit`) directly from their
+own `@domain/entity-currency-*` package — the aggregate does not re-export them.
 
 ## Usage
 
 ```ts
-// Union types
+// Unions — from the aggregate
 import { type Currency, type CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { CurrencySchema, CryptoOrTokenCurrencySchema } from "@domain/entity-currency";
 
-// Everything from the sub-packages is also re-exported here
-import {
-  type CryptoCurrency, CRYPTO_CURRENCIES_REGISTRY,
-  type TokenCurrency, token,
-  type FiatCurrency, FIAT_CURRENCIES_REGISTRY,
-  type Unit,
-} from "@domain/entity-currency";
+// Specialized types — each from its own package
+import { type CryptoCurrency, CRYPTO_CURRENCIES_REGISTRY } from "@domain/entity-currency-crypto";
+import { type TokenCurrency, token } from "@domain/entity-currency-token";
+import { type FiatCurrency, FIAT_CURRENCIES_REGISTRY } from "@domain/entity-currency-fiat";
+import { type Unit } from "@domain/entity-currency-unit";
 ```
 
 ## Union types
@@ -50,12 +49,13 @@ Use `CryptoOrTokenCurrency` when working with on-chain balances or addresses. Us
 
 ## Dependencies
 
-| Package | Re-exports |
+The unions are composed from the specialized entity schemas:
+
+| Package | Union member |
 |---|---|
-| `@domain/entity-currency-unit` | `Unit`, `UnitSchema` |
-| `@domain/entity-currency-crypto` | `CryptoCurrency`, `CRYPTO_CURRENCIES_REGISTRY`, `currency()`, … |
-| `@domain/entity-currency-token` | `TokenCurrency`, `token()`, … |
-| `@domain/entity-currency-fiat` | `FiatCurrency`, `FIAT_CURRENCIES_REGISTRY`, `fiat()`, … |
+| `@domain/entity-currency-crypto` | `CryptoCurrencySchema` |
+| `@domain/entity-currency-token` | `TokenCurrencySchema` |
+| `@domain/entity-currency-fiat` | `FiatCurrencySchema` |
 
 ## Testing
 

--- a/domain/entity/currency/package.json
+++ b/domain/entity/currency/package.json
@@ -2,7 +2,7 @@
   "name": "@domain/entity-currency",
   "version": "0.2.1",
   "private": true,
-  "description": "Currency union types (Currency, CryptoOrTokenCurrency) and re-exports from all currency entity packages",
+  "description": "Currency union types (Currency, CryptoOrTokenCurrency) composed from the currency entity packages",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
@@ -21,7 +21,6 @@
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-fiat": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
-    "@domain/entity-currency-unit": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/domain/entity/currency/src/index.ts
+++ b/domain/entity/currency/src/index.ts
@@ -3,12 +3,6 @@ import { CryptoCurrencySchema } from "@domain/entity-currency-crypto";
 import { TokenCurrencySchema } from "@domain/entity-currency-token";
 import { FiatCurrencySchema } from "@domain/entity-currency-fiat";
 
-// Re-export everything from the three currency entity packages and unit
-export * from "@domain/entity-currency-unit";
-export * from "@domain/entity-currency-crypto";
-export * from "@domain/entity-currency-token";
-export * from "@domain/entity-currency-fiat";
-
 /**
  * Discriminated union of {@link CryptoCurrency} and {@link TokenCurrency}.
  * Use when handling on-chain currencies (no fiat).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3660,9 +3660,6 @@ importers:
       '@domain/entity-currency-token':
         specifier: workspace:*
         version: link:../currency-token
-      '@domain/entity-currency-unit':
-        specifier: workspace:*
-        version: link:../currency-unit
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## What

`domain/entity/currency/src/index.ts` re-exported everything from the specialized entity packages (`unit` / `crypto` / `token` / `fiat`) via `export *`. This removes those re-exports so **`@domain/entity-currency` exposes only the cross-package unions**: `Currency` / `CurrencySchema` and `CryptoOrTokenCurrency` / `CryptoOrTokenCurrencySchema`.

## Why

The `export *` barrel gave every specialized type two import paths (`@domain/entity-currency` **and** its own package) — a barrel smell that knip flags and that blurs the dependency graph. The aggregate should exist **only** for the cross-package unions.

Import convention going forward:
- **Specialized** types ← their own package: `CryptoCurrency` ← `@domain/entity-currency-crypto`, `TokenCurrency` ← `@domain/entity-currency-token`, `FiatCurrency` ← `@domain/entity-currency-fiat`, `Unit` ← `@domain/entity-currency-unit`.
- **Unions** ← `@domain/entity-currency` only.

## Changes

- Remove the four `export *` re-exports from `src/index.ts` (kept the union imports + definitions).
- Drop the now-unused `@domain/entity-currency-unit` dependency (it was only referenced by the removed `export *`).
- Update the README and package description to the unions-only convention.

## No repointing needed

This ticket is described as the *final* step, after all consumers stop importing specialized symbols via the aggregate. On `develop` the aggregate already has **zero in-repo consumers**: no `package.json` depends on it and no file imports `@domain/entity-currency`. So the removal is fully self-contained — nothing to repoint. Once the re-exports are gone, importing a specialized symbol through the aggregate is a compile error, so the optional `no-restricted-imports` guard is redundant and left out.

## Verification

- `@domain/entity-currency` unit tests green (unions still parse crypto/token/fiat correctly).
- Global `nx run-many -t typecheck` green across all projects.
- `pnpm install --frozen-lockfile` consistent; lockfile diff is the single removed importer entry.