### PR TITLE
[LWM] fix(lwm): drop legacy ticker lookup on Large Mover (LIVE-34635)

### DIFF
--- a/.changeset/drop-large-mover-ticker-lookup.md
+++ b/.changeset/drop-large-mover-ticker-lookup.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"live-mobile": patch
+---
+
+Drop legacy ticker lookup from Large Mover landing page (LIVE-34635)

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/LandingPagesNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/LandingPagesNavigator.ts
@@ -10,9 +10,8 @@ export enum InitialRange {
 }
 
 export type LargeMoverLandingPageParams = {
-  currencyIds: string;
+  ledgerIds: string;
   initialRange?: InitialRange;
-  ledgerIds?: string;
 };
 
 export type LandingPagesNavigatorParamList = {

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/__integrations__/largeMoverLandingPage.integration.test.tsx
@@ -28,7 +28,7 @@ const mockRoute: RouteProp<LandingPagesNavigatorParamList, ScreenName.LargeMover
   key: "LargeMoverRouteKey",
   name: ScreenName.LargeMoverLandingPage,
   params: {
-    currencyIds: "BTC,ETH",
+    ledgerIds: "bitcoin,ethereum",
     initialRange: InitialRange.Day,
   },
 };
@@ -139,7 +139,7 @@ describe("LargeMoverLandingPage Integration Tests", () => {
     const multiCurrencyRoute = {
       ...mockRoute,
       params: {
-        currencyIds: "BTC,ETH",
+        ledgerIds: "bitcoin,ethereum",
         initialRange: InitialRange.Day,
       },
     };
@@ -263,7 +263,7 @@ describe("LargeMoverLandingPage Integration Tests", () => {
       <MockedLargeMoverLandingPage
         key={mockRoute.key}
         name={mockRoute.name}
-        params={{ currencyIds: "BTC", initialRange: InitialRange.Day }}
+        params={{ ledgerIds: "bitcoin", initialRange: InitialRange.Day }}
       />,
       {
         overrideInitialState: (state: State) => ({
@@ -307,7 +307,7 @@ describe("LargeMoverLandingPage Integration Tests", () => {
         <MockedLargeMoverLandingPage
           key={mockRoute.key}
           name={mockRoute.name}
-          params={{ currencyIds: "BTC", initialRange: InitialRange.Day }}
+          params={{ ledgerIds: "bitcoin", initialRange: InitialRange.Day }}
         />,
         {
           overrideInitialState: (state: State) => ({
@@ -345,7 +345,7 @@ describe("LargeMoverLandingPage Integration Tests", () => {
         <MockedLargeMoverLandingPage
           key={mockRoute.key}
           name={mockRoute.name}
-          params={{ currencyIds: "BTC", initialRange: InitialRange.Day }}
+          params={{ ledgerIds: "bitcoin", initialRange: InitialRange.Day }}
         />,
         {
           overrideInitialState: (state: State) => ({
@@ -371,7 +371,6 @@ describe("LargeMoverLandingPage Integration Tests", () => {
         key: "LargeMoverTokenRouteKey",
         name: ScreenName.LargeMoverLandingPage,
         params: {
-          currencyIds: "BTC",
           ledgerIds: "ethereum/erc20/usd__coin",
           initialRange: InitialRange.Day,
         },

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/__tests__/OverlayTutorial.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/components/__tests__/OverlayTutorial.test.tsx
@@ -28,14 +28,9 @@ jest.mock("~/logic/getWindowDimensions", () => () => ({ height: 1000 }));
 
 jest.mock("../../hooks/useLargeMover", () => ({
   useLargeMover: () => ({
-    currencies: [
-      {
-        id: mockCurrencyData.id,
-        data: mockCurrencyData,
-        isLoading: false,
-        isError: false,
-      },
-    ],
+    currencies: { cryptoOrTokenCurrencies: {} },
+    currenciesIds: ["bitcoin", "ethereum"],
+    chartIds: ["bitcoin", "ethereum"],
     loading: false,
     isError: false,
   }),
@@ -71,7 +66,7 @@ const mockRoute = {
   key: "LargeMoverRouteKey",
   name: ScreenName.LargeMoverLandingPage,
   params: {
-    currencyIds: "BTC,ETH",
+    ledgerIds: "bitcoin,ethereum",
     initialRange: InitialRange.Day,
   },
 } as RouteProp<LandingPagesNavigatorParamList, ScreenName.LargeMoverLandingPage>;

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/__tests__/useLargeMover.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/__tests__/useLargeMover.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from "@tests/test-renderer";
 import { useLargeMover } from "../useLargeMover";
 
-jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => ({
+jest.mock("@features/platform-aggregated-assets", () => ({
   useAssetsData: jest.fn(() => ({
     data: undefined,
     isLoading: false,

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/__tests__/useLargeMover.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/__tests__/useLargeMover.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from "@tests/test-renderer";
+import { useLargeMover } from "../useLargeMover";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => ({
+  useAssetsData: jest.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+}));
+
+jest.mock("../useLedgerMapping", () => ({
+  useMapLedgerIdsToCoinGeckoIds: jest.fn(() => ({
+    coinGeckoIds: ["bitcoin", "ethereum"],
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+describe("useLargeMover", () => {
+  it("parses comma-separated ledger ids", () => {
+    const { result } = renderHook(() =>
+      useLargeMover({ ledgerIds: "bitcoin, ethereum/erc20/usd__coin" }),
+    );
+
+    expect(result.current.currenciesIds).toEqual(["bitcoin", "ethereum/erc20/usd__coin"]);
+    expect(result.current.chartIds).toEqual(["bitcoin", "ethereum"]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/useLargeMover.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/useLargeMover.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useAssetsData } from "@features/platform-aggregated-assets";
 import VersionNumber from "react-native-version-number";
-import { parseLargeMoverLedgerIds } from "~/navigation/deeplinks/validation";
+import { parseLargeMoverLedgerIds } from "../utils/parseLargeMoverLedgerIds";
 import { useMapLedgerIdsToCoinGeckoIds } from "./useLedgerMapping";
 
 type UseLargeMoverProps = {

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/useLargeMover.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/hooks/useLargeMover.ts
@@ -1,23 +1,15 @@
 import { useMemo } from "react";
 import { useAssetsData } from "@features/platform-aggregated-assets";
 import VersionNumber from "react-native-version-number";
-import { getCurrencyIdsFromTickers } from "../utils";
+import { parseLargeMoverLedgerIds } from "~/navigation/deeplinks/validation";
 import { useMapLedgerIdsToCoinGeckoIds } from "./useLedgerMapping";
 
 type UseLargeMoverProps = {
-  currencyIds?: string;
-  ledgerIds?: string;
+  ledgerIds: string;
 };
 
-export const useLargeMover = ({ currencyIds, ledgerIds }: UseLargeMoverProps) => {
-  const currenciesIds = useMemo(() => {
-    if (ledgerIds) {
-      return ledgerIds.split(",");
-    } else {
-      const currencyIdsArray = currencyIds?.split(",") || [];
-      return getCurrencyIdsFromTickers(currencyIdsArray);
-    }
-  }, [currencyIds, ledgerIds]);
+export const useLargeMover = ({ ledgerIds }: UseLargeMoverProps) => {
+  const currenciesIds = useMemo(() => parseLargeMoverLedgerIds(ledgerIds), [ledgerIds]);
 
   const {
     coinGeckoIds: chartIds,

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/index.tsx
@@ -32,13 +32,12 @@ type LargeMoverLandingPageProps = StackNavigatorProps<
 >;
 
 export const LargeMoverLandingPage = ({ route }: LargeMoverLandingPageProps) => {
-  const { currencyIds, initialRange = "day", ledgerIds } = route.params;
+  const { ledgerIds, initialRange = "day" } = route.params;
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
 
   const [range, setRange] = useState<KeysPriceChange>(rangeMap[initialRange]);
 
   const { currencies, currenciesIds, chartIds, loading, isError } = useLargeMover({
-    currencyIds,
     ledgerIds,
   });
 
@@ -141,12 +140,7 @@ export const LargeMoverLandingPage = ({ route }: LargeMoverLandingPageProps) => 
     <>
       {showOverlay && !isLoading && <OverlayTutorial />}
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.neutral.c00, paddingTop: 40 }}>
-        <TrackScreen
-          name={PAGE_NAME}
-          initialRange={initialRange}
-          currencyIds={currencyIds}
-          ledgerIds={ledgerIds}
-        />
+        <TrackScreen name={PAGE_NAME} initialRange={initialRange} ledgerIds={ledgerIds} />
         <StickyHeader />
         <Flex paddingTop={25}>
           {isLoading ? (

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/index.tsx
@@ -1,6 +1,5 @@
 import i18next from "i18next";
 import { KeysPriceChange } from "@ledgerhq/live-common/market/utils/types";
-import { findCryptoCurrencyByTicker } from "@domain/entity-currency-crypto";
 
 function getTimeAgoCode(date: Date): string {
   const now = new Date();
@@ -41,11 +40,4 @@ const rangeMap: Record<string, KeysPriceChange> = {
   year: KeysPriceChange.year,
 };
 
-function getCurrencyIdsFromTickers(tickers: string[]): string[] {
-  return tickers.flatMap(ticker => {
-    const currency = findCryptoCurrencyByTicker(ticker);
-    return currency?.id ? [currency.id] : [];
-  });
-}
-
-export { getTimeAgoCode, getColors, rangeMap, getCurrencyIdsFromTickers };
+export { getTimeAgoCode, getColors, rangeMap };

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds.test.ts
@@ -1,0 +1,18 @@
+import { parseLargeMoverLedgerIds } from "./parseLargeMoverLedgerIds";
+
+describe("parseLargeMoverLedgerIds", () => {
+  it("should return ledger ids when they are already comma-separated and lowercase", () => {
+    expect(parseLargeMoverLedgerIds("bitcoin,ethereum")).toEqual(["bitcoin", "ethereum"]);
+  });
+
+  it("trims, lowercases and dedupes ledger ids", () => {
+    expect(parseLargeMoverLedgerIds(" Bitcoin, ethereum ,bitcoin ")).toEqual([
+      "bitcoin",
+      "ethereum",
+    ]);
+  });
+
+  it("filters out empty segments", () => {
+    expect(parseLargeMoverLedgerIds("btc,,eth")).toEqual(["btc", "eth"]);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds.ts
@@ -1,0 +1,7 @@
+export function parseLargeMoverLedgerIds(ledgerIds: string): string[] {
+  const ids = ledgerIds
+    .split(",")
+    .map(id => id.trim().toLowerCase())
+    .filter(Boolean);
+  return [...new Set(ids)];
+}

--- a/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
+++ b/apps/ledger-live-mobile/src/navigation/DeeplinksProvider.tsx
@@ -42,7 +42,6 @@ import {
   logSecurityEvent,
   EarnDeeplinkAction,
   validateEarnDepositScreen,
-  validateLargeMoverCurrencyIds,
   validateLargeMoverLedgerIds,
 } from "./deeplinks/validation";
 import { handleWallet40Deeplink } from "./deeplinks/handleWallet40Deeplink";
@@ -674,15 +673,9 @@ export const DeeplinksProvider = ({
 
           if (hostname === "landing-page-large-mover") {
             const validatedLedgerIds = validateLargeMoverLedgerIds(searchParams.get("ledgerIds"));
-            const validatedCurrencyIds = validateLargeMoverCurrencyIds(
-              searchParams.get("currencyIds"),
-            );
             if (validatedLedgerIds) {
-              url.searchParams.set("currencyIds", "");
+              url.searchParams.delete("currencyIds");
               url.searchParams.set("ledgerIds", validatedLedgerIds);
-            } else if (validatedCurrencyIds) {
-              url.searchParams.delete("ledgerIds");
-              url.searchParams.set("currencyIds", validatedCurrencyIds);
             } else {
               return handleMarketBannerDeeplink();
             }

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
@@ -1,54 +1,20 @@
 import {
-  validateLargeMoverCurrencyIds,
+  parseLargeMoverLedgerIds,
   validateLargeMoverLedgerIds,
   validateMarketAssetPath,
   validateMarketListCategory,
 } from "../validation";
 
-describe("validateLargeMoverCurrencyIds", () => {
-  it("should return null when currencyIds is null", () => {
-    const result = validateLargeMoverCurrencyIds(null);
-    expect(result).toBeNull();
+describe("parseLargeMoverLedgerIds", () => {
+  it("trims, lowercases and dedupes ledger ids", () => {
+    expect(parseLargeMoverLedgerIds(" Bitcoin, ethereum ,bitcoin ")).toEqual([
+      "bitcoin",
+      "ethereum",
+    ]);
   });
 
-  it("should return null when currencyIds is undefined", () => {
-    const result = validateLargeMoverCurrencyIds(null);
-    expect(result).toBeNull();
-  });
-
-  it("should return null when currencyIds is an empty string", () => {
-    const result = validateLargeMoverCurrencyIds("");
-    expect(result).toBeNull();
-  });
-
-  it("should return null when currencyIds is only whitespace", () => {
-    const result = validateLargeMoverCurrencyIds("   ");
-    expect(result).toBeNull();
-  });
-
-  it("should uppercase single currencyId", () => {
-    const result = validateLargeMoverCurrencyIds("btc");
-    expect(result).toBe("BTC");
-  });
-
-  it("should uppercase multiple currencyIds separated by commas", () => {
-    const result = validateLargeMoverCurrencyIds("btc,eth,xrp");
-    expect(result).toBe("BTC,ETH,XRP");
-  });
-
-  it("should uppercase and trim currencyIds with whitespace", () => {
-    const result = validateLargeMoverCurrencyIds("  btc,eth  ");
-    expect(result).toBe("BTC,ETH");
-  });
-
-  it("should handle already uppercase currencyIds", () => {
-    const result = validateLargeMoverCurrencyIds("BTC,ETH");
-    expect(result).toBe("BTC,ETH");
-  });
-
-  it("should handle mixed case currencyIds", () => {
-    const result = validateLargeMoverCurrencyIds("BtC,eTh,XrP");
-    expect(result).toBe("BTC,ETH,XRP");
+  it("filters out empty segments", () => {
+    expect(parseLargeMoverLedgerIds("btc,,eth")).toEqual(["btc", "eth"]);
   });
 });
 

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/__tests__/validation.test.ts
@@ -1,22 +1,8 @@
 import {
-  parseLargeMoverLedgerIds,
   validateLargeMoverLedgerIds,
   validateMarketAssetPath,
   validateMarketListCategory,
 } from "../validation";
-
-describe("parseLargeMoverLedgerIds", () => {
-  it("trims, lowercases and dedupes ledger ids", () => {
-    expect(parseLargeMoverLedgerIds(" Bitcoin, ethereum ,bitcoin ")).toEqual([
-      "bitcoin",
-      "ethereum",
-    ]);
-  });
-
-  it("filters out empty segments", () => {
-    expect(parseLargeMoverLedgerIds("btc,,eth")).toEqual(["btc", "eth"]);
-  });
-});
 
 describe("validateLargeMoverLedgerIds", () => {
   it("should return null when ledgerIds is null", () => {

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
@@ -231,23 +231,19 @@ export function validateEarnDepositScreen(
   };
 }
 
-export function validateLargeMoverCurrencyIds(currencyIds: string | null): string | null {
-  if (!currencyIds || currencyIds?.trim() === "") {
-    return null;
-  }
-
-  return currencyIds.trim().toUpperCase();
+export function parseLargeMoverLedgerIds(ledgerIds: string): string[] {
+  const ids = ledgerIds
+    .split(",")
+    .map(id => id.trim().toLowerCase())
+    .filter(Boolean);
+  return [...new Set(ids)];
 }
 
 export function validateLargeMoverLedgerIds(ledgerIds: string | null): string | null {
   if (!ledgerIds || ledgerIds.trim() === "") {
     return null;
   }
-  const ids = ledgerIds
-    .split(",")
-    .map(id => id.trim().toLowerCase())
-    .filter(Boolean);
-  const unique = [...new Set(ids)];
+  const unique = parseLargeMoverLedgerIds(ledgerIds);
   return unique.length ? unique.join(",") : null;
 }
 

--- a/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
+++ b/apps/ledger-live-mobile/src/navigation/deeplinks/validation.ts
@@ -9,6 +9,7 @@ import { DdRum, ErrorSource } from "@datadog/mobile-react-native";
 import { parseLedgerAssetPath, type LedgerAssetPath } from "@ledgerhq/asset-detail";
 import { validateUrl } from "@ledgerhq/live-common/wallet-api/validation/validateUrl";
 import { parseMarketListCategory } from "@ledgerhq/live-common/market/utils/category";
+import { parseLargeMoverLedgerIds } from "LLM/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds";
 import { isDatadogEnabled } from "../../datadog";
 import type { MarketListCategory, OptionMetadata } from "../../reducers/types";
 
@@ -229,14 +230,6 @@ export function validateEarnDepositScreen(
     cryptoAssetId: sanitizeString(cryptoAssetId || "", MAX_TITLE_LENGTH),
     accountId: sanitizeString(accountId || "", MAX_TITLE_LENGTH),
   };
-}
-
-export function parseLargeMoverLedgerIds(ledgerIds: string): string[] {
-  const ids = ledgerIds
-    .split(",")
-    .map(id => id.trim().toLowerCase())
-    .filter(Boolean);
-  return [...new Set(ids)];
 }
 
 export function validateLargeMoverLedgerIds(ledgerIds: string | null): string | null {

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/index.tsx
@@ -29,7 +29,6 @@ export default function Features() {
   const osUpdateBannerMode = useSelector(debugOsUpdateBannerModeSelector);
   const navigateToLargeMover = () => {
     navigation.navigate(ScreenName.LargeMoverLandingPage, {
-      currencyIds: "BTC,ETH,SOL",
       initialRange: InitialRange.Day,
       ledgerIds: "bitcoin,ethereum,solana,ethereum/erc20/usd__coin,ethereum/erc20/wrapped_bitcoin",
     });


### PR DESCRIPTION
## Summary
- Drops the last Large Mover ticker fallback (`currencyIds` / `getCurrencyIdsFromTickers`). Deeplinks and navigation now require `ledgerIds` (comma-separated Ledger currency ids, e.g. `bitcoin,ethereum`).
- Makes `ledgerIds` required on `LargeMoverLandingPageParams` and removes the misnamed `currencyIds` param.
- Moves `parseLargeMoverLedgerIds` into a side-effect-free screen util so `useLargeMover` no longer imports the deeplink validation module (Datadog / earn validators). `validateLargeMoverLedgerIds` still wraps that helper.
- Adds parser unit tests for a normal `bitcoin,ethereum` list, trim/lowercase/dedupe, and empty segments.
## Deeplink format
`ledgerlive://landing-page-large-mover?ledgerIds=bitcoin,ethereum`
Legacy `currencyIds=BTC,ETH` deeplinks fall back to the market banner (same as when both params are missing).
## Test plan
- [x] `pnpm mobile test:jest --watchman=false "src/mvvm/features/LandingPages/screens/LargeMoverLandingPage/utils/parseLargeMoverLedgerIds.test.ts"`
- [ ] `pnpm mobile test:jest --watchman=false "src/mvvm/features/LandingPages"`
- [ ] `pnpm mobile test:jest --watchman=false "src/navigation/deeplinks/__tests__/validation.test.ts"`
## Jira
[LIVE-34635](https://ledgerhq.atlassian.net/browse/LIVE-34635)

[LIVE-34635]: https://ledgerhq.atlassian.net/browse/LIVE-34635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ