### PR TITLE
[LWDM] fix(gam): stop modal cascade and add braze logging (LIVE-34438)

### DIFF
--- a/.changeset/fix-gam-cascade-braze-logging.md
+++ b/.changeset/fix-gam-cascade-braze-logging.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Fix Generic Awareness Modal cascade on mobile and add Braze content card logging on mobile and desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/GenericAwarenessModalView.tsx
@@ -16,6 +16,7 @@ import useGenericAwarenessModalCarouselViewModel, {
 import useGenericAwarenessModalPromptViewModel, {
   type GenericAwarenessModalPromptViewModel,
 } from "./hooks/useGenericAwarenessModalPromptViewModel";
+import { useGenericAwarenessModalBrazeLogging } from "./hooks/useGenericAwarenessModalBrazeLogging";
 import CarouselContent from "./components/CarouselContent";
 import FeatureIntroContent from "./components/FeatureIntroContent";
 import PromptContent from "./components/PromptContent";
@@ -69,9 +70,25 @@ const GenericAwarenessModalView = ({
   contentCard,
 }: GenericAwarenessModalViewProps) => {
   const hasStoredContentCards = useSelector(selectGenericAwarenessModalHasStoredContentCards);
-  const carouselViewModel = useGenericAwarenessModalCarouselViewModel(contentCard, isOpen);
-  const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(contentCard, isOpen);
-  const promptViewModel = useGenericAwarenessModalPromptViewModel(contentCard, isOpen);
+  const { logClick, logDismiss } = useGenericAwarenessModalBrazeLogging(contentCard?.id, isOpen);
+  const carouselViewModel = useGenericAwarenessModalCarouselViewModel(
+    contentCard,
+    isOpen,
+    logClick,
+    logDismiss,
+  );
+  const featureIntroViewModel = useGenericAwarenessModalFeatureIntroViewModel(
+    contentCard,
+    isOpen,
+    logClick,
+    logDismiss,
+  );
+  const promptViewModel = useGenericAwarenessModalPromptViewModel(
+    contentCard,
+    isOpen,
+    logClick,
+    logDismiss,
+  );
 
   useEffect(() => {
     if (isOpen && !contentCard && hasStoredContentCards) {

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import type { Card as BrazeCard } from "@braze/web-sdk";
 import { fireEvent, render, screen, waitFor } from "tests/testSetup";
+import type { State } from "~/renderer/reducers";
 import { track, trackPage } from "~/renderer/analytics/segment";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import GenericAwarenessModalView from "../GenericAwarenessModalView";
@@ -20,6 +22,14 @@ import {
   createGenericAwarenessModalTestState,
   renderOpenAwarenessModalView,
 } from "../testUtils/modalTestUtils";
+
+const mockLogContentCardImpressions = jest.fn();
+
+jest.mock("@braze/web-sdk", () => ({
+  logContentCardImpressions: (...args: unknown[]) => mockLogContentCardImpressions(...args),
+  logContentCardClick: jest.fn(),
+  logCardDismissal: jest.fn(),
+}));
 
 jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
   closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
@@ -59,6 +69,29 @@ describe("GenericAwarenessModalView", () => {
 
       expect(onClose).not.toHaveBeenCalled();
     });
+  });
+
+  it("should log one Braze impression when the modal opens", () => {
+    renderOpenAwarenessModalView(carouselCampaignCard, {
+      initialState: createGenericAwarenessModalTestState({
+        dynamicContent: {
+          desktopCards: [
+            { id: CAROUSEL_CAMPAIGN_ID, title: "Carousel card" } as unknown as BrazeCard,
+          ],
+          portfolioCards: [],
+          bottomPortfolioCards: [],
+          actionCards: [],
+          notificationsCards: [],
+        },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: false,
+          dismissedContentCards: {},
+        } as State["settings"],
+      }),
+    });
+
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(1);
   });
 
   it("should render feature intro, track the page, and hide carousel controls", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/CarouselContent.tsx
@@ -67,7 +67,7 @@ export type CarouselContentProps = {
   onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
   onSlideChange: (index: number) => void;
   onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
-  onClose: () => void;
+  onCompleteClose: () => void;
 };
 
 function CarouselContentProgress() {
@@ -83,12 +83,12 @@ function CarouselContentFooter({
   slides,
   onSlidePrimaryClick,
   onContinueClick,
-  onClose,
+  onCompleteClose,
 }: Readonly<{
   slides: GenericAwarenessModalCarouselSlide[];
   onSlidePrimaryClick: (slide: GenericAwarenessModalCarouselSlide) => void;
   onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
-  onClose: () => void;
+  onCompleteClose: () => void;
 }>) {
   const { t } = useTranslation();
   const { currentIndex, totalSlides, goToNext } = useSlidesContext();
@@ -105,11 +105,11 @@ function CarouselContentFooter({
   const handleContinue = useCallback(() => {
     onContinueClick(currentIndex, isLastSlide);
     if (isLastSlide) {
-      onClose();
+      onCompleteClose();
     } else {
       goToNext();
     }
-  }, [currentIndex, goToNext, isLastSlide, onClose, onContinueClick]);
+  }, [currentIndex, goToNext, isLastSlide, onCompleteClose, onContinueClick]);
 
   const handlePrimary = useCallback(() => {
     if (currentSlide) {
@@ -148,7 +148,7 @@ export default function CarouselContent({
   onSlidePrimaryClick,
   onSlideChange,
   onContinueClick,
-  onClose,
+  onCompleteClose,
 }: Readonly<CarouselContentProps>) {
   return (
     <Slides initialSlideIndex={0} onSlideChange={onSlideChange}>
@@ -167,7 +167,7 @@ export default function CarouselContent({
           slides={slides}
           onSlidePrimaryClick={onSlidePrimaryClick}
           onContinueClick={onContinueClick}
-          onClose={onClose}
+          onCompleteClose={onCompleteClose}
         />
       </Slides.Footer>
     </Slides>

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/components/__tests__/CarouselContent.test.tsx
@@ -32,7 +32,7 @@ const defaultProps: CarouselContentProps = {
   onSlidePrimaryClick: jest.fn(),
   onSlideChange: jest.fn(),
   onContinueClick: jest.fn(),
-  onClose: jest.fn(),
+  onCompleteClose: jest.fn(),
 };
 
 jest.mock("~/renderer/hooks/useTheme");
@@ -143,7 +143,7 @@ describe("CarouselContent", () => {
 
     expect(onContinueClick).toHaveBeenCalledWith(0, false);
     expect(onSlideChange).toHaveBeenCalledWith(1);
-    expect(defaultProps.onClose).not.toHaveBeenCalled();
+    expect(defaultProps.onCompleteClose).not.toHaveBeenCalled();
   });
 
   it("should invoke onSlidePrimaryClick with the current slide", async () => {
@@ -167,31 +167,31 @@ describe("CarouselContent", () => {
     expect(onSlidePrimaryClick).toHaveBeenCalledWith(slides[1]);
   });
 
-  it("should call onContinueClick with last slide flag and onClose when Close is clicked", async () => {
+  it("should call onContinueClick with last slide flag and onCompleteClose when Close is clicked", async () => {
     const onContinueClick = jest.fn();
-    const onClose = jest.fn();
+    const onCompleteClose = jest.fn();
     const onSlidePrimaryClick = jest.fn();
-    const { user } = renderCarousel({ onContinueClick, onClose, onSlidePrimaryClick });
+    const { user } = renderCarousel({ onContinueClick, onCompleteClose, onSlidePrimaryClick });
 
     await advanceCarouselSlide(user, "First slide title");
 
     await user.click(screen.getByRole("button", { name: "Close" }));
 
     expect(onContinueClick).toHaveBeenCalledWith(1, true);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onCompleteClose).toHaveBeenCalledTimes(1);
     expect(onSlidePrimaryClick).not.toHaveBeenCalled();
   });
 
-  it("should call onContinueClick and onClose when Continue is clicked on a single-slide carousel", async () => {
+  it("should call onContinueClick and onCompleteClose when Continue is clicked on a single-slide carousel", async () => {
     const onContinueClick = jest.fn();
-    const onClose = jest.fn();
-    const { user } = renderCarousel({ slides: [slides[0]], onContinueClick, onClose });
+    const onCompleteClose = jest.fn();
+    const { user } = renderCarousel({ slides: [slides[0]], onContinueClick, onCompleteClose });
 
     expect(screen.getByRole("button", { name: "Close" })).toBeVisible();
 
     await user.click(screen.getByTestId("generic-awareness-modal-continue-button"));
 
     expect(onContinueClick).toHaveBeenCalledWith(0, true);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onCompleteClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalBrazeLogging.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalBrazeLogging.test.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import type { Card as BrazeCard } from "@braze/web-sdk";
+import createStore from "~/state-manager/configureStore";
+import type { State } from "~/renderer/reducers";
+import { useGenericAwarenessModalBrazeLogging } from "../useGenericAwarenessModalBrazeLogging";
+
+const mockLogContentCardImpressions = jest.fn();
+const mockLogContentCardClick = jest.fn();
+const mockLogCardDismissal = jest.fn();
+
+jest.mock("@braze/web-sdk", () => ({
+  logContentCardImpressions: (...args: unknown[]) => mockLogContentCardImpressions(...args),
+  logContentCardClick: (...args: unknown[]) => mockLogContentCardClick(...args),
+  logCardDismissal: (...args: unknown[]) => mockLogCardDismissal(...args),
+}));
+
+const CARD_ID = "awareness-modal-card";
+
+const brazeCard = { id: CARD_ID, title: "Awareness modal" } as unknown as BrazeCard;
+
+const createTestState = (overrides: Partial<State> = {}): State =>
+  ({
+    dynamicContent: {
+      desktopCards: [brazeCard],
+      portfolioCards: [],
+      bottomPortfolioCards: [],
+      actionCards: [],
+      notificationsCards: [],
+    },
+    settings: {
+      shareAnalytics: true,
+      sharePersonalizedRecommandations: false,
+    },
+    ...overrides,
+  }) as State;
+
+type HookProps = {
+  contentCardId: string | undefined;
+  isOpen: boolean;
+  stateOverrides?: Partial<State>;
+};
+
+const renderBrazeLoggingHook = ({ contentCardId, isOpen, stateOverrides = {} }: HookProps) => {
+  const store = createStore({ state: createTestState(stateOverrides) });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return renderHook(
+    ({ contentCardId: cardId, isOpen: open }) => useGenericAwarenessModalBrazeLogging(cardId, open),
+    {
+      wrapper,
+      initialProps: { contentCardId, isOpen },
+    },
+  );
+};
+
+describe("useGenericAwarenessModalBrazeLogging", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should log one Braze impression per open and not repeat on rerender", () => {
+    const { rerender } = renderBrazeLoggingHook({ contentCardId: CARD_ID, isOpen: true });
+
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(1);
+    expect(mockLogContentCardImpressions).toHaveBeenCalledWith([brazeCard]);
+
+    rerender({ contentCardId: CARD_ID, isOpen: true });
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reset impression dedup when isOpen toggles off and log again on reopen", () => {
+    const { rerender } = renderBrazeLoggingHook({ contentCardId: CARD_ID, isOpen: true });
+
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(1);
+
+    rerender({ contentCardId: CARD_ID, isOpen: false });
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(1);
+
+    rerender({ contentCardId: CARD_ID, isOpen: true });
+    expect(mockLogContentCardImpressions).toHaveBeenCalledTimes(2);
+  });
+
+  it("should skip impression logging when analytics tracking is disabled", () => {
+    renderBrazeLoggingHook({
+      contentCardId: CARD_ID,
+      isOpen: true,
+      stateOverrides: {
+        settings: {
+          shareAnalytics: false,
+          sharePersonalizedRecommandations: false,
+        } as State["settings"],
+      },
+    });
+
+    expect(mockLogContentCardImpressions).not.toHaveBeenCalled();
+  });
+
+  it("should log click and dismiss when tracking is enabled", () => {
+    const { result } = renderBrazeLoggingHook({ contentCardId: CARD_ID, isOpen: true });
+
+    act(() => {
+      result.current.logClick();
+      result.current.logDismiss();
+    });
+
+    expect(mockLogContentCardClick).toHaveBeenCalledWith(brazeCard);
+    expect(mockLogCardDismissal).toHaveBeenCalledWith(brazeCard);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalCarouselViewModel.test.tsx
@@ -1,20 +1,32 @@
 import { act } from "tests/testSetup";
+import { openURL } from "~/renderer/linking";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import { appStartFeatureIntroCard, carouselCampaignCard } from "../../testUtils/fixtures";
 import useGenericAwarenessModalCarouselViewModel from "../useGenericAwarenessModalCarouselViewModel";
 import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
+
+const mockLogClick = jest.fn();
+const mockLogDismiss = jest.fn();
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
 
 jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
   closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
 }));
 
 describe("useGenericAwarenessModalCarouselViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it.each([
     ["undefined content card", undefined],
     ["non-carousel content card", appStartFeatureIntroCard],
   ] as const)("should return empty slides for %s", (_label, contentCard) => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(contentCard, false),
+      useGenericAwarenessModalCarouselViewModel(contentCard, false, mockLogClick, mockLogDismiss),
     );
 
     expect(result.current.slides).toEqual([]);
@@ -22,23 +34,55 @@ describe("useGenericAwarenessModalCarouselViewModel", () => {
 
   it("should expose carousel slides from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard, true),
+      useGenericAwarenessModalCarouselViewModel(
+        carouselCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.slides).toEqual(carouselCampaignCard.data);
   });
 
-  it("should close dialog when onClose is called", () => {
+  it("should close dialog and log Braze dismiss when onCompleteClose is called", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalCarouselViewModel(carouselCampaignCard, true),
+      useGenericAwarenessModalCarouselViewModel(
+        carouselCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     act(() => {
-      result.current.onClose();
+      result.current.onCompleteClose();
     });
 
+    expect(mockLogDismiss).toHaveBeenCalledTimes(1);
+    expect(mockLogClick).not.toHaveBeenCalled();
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalledWith({
       dismissAppStart: true,
     });
+  });
+
+  it("should log Braze click when onSlidePrimaryClick is called", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalCarouselViewModel(
+        carouselCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
+    );
+    const slide = carouselCampaignCard.data[0];
+
+    act(() => {
+      result.current.onSlidePrimaryClick(slide);
+    });
+
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).not.toHaveBeenCalled();
+    expect(openURL).toHaveBeenCalledWith(slide.primaryButtonLink);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalFeatureIntroViewModel.test.tsx
@@ -1,11 +1,27 @@
+import { act } from "tests/testSetup";
 import { appStartFeatureIntroCard, carouselCampaignCard } from "../../testUtils/fixtures";
 import useGenericAwarenessModalFeatureIntroViewModel from "../useGenericAwarenessModalFeatureIntroViewModel";
 import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
 
+const mockLogClick = jest.fn();
+const mockLogDismiss = jest.fn();
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
+}));
+
+jest.mock("LLD/features/GenericAwarenessModal/genericAwarenessModalDialog", () => ({
+  closeGenericAwarenessModalDialog: jest.fn(() => jest.fn()),
+}));
+
 describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("should return empty content when content card is undefined", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(undefined, false),
+      useGenericAwarenessModalFeatureIntroViewModel(undefined, false, mockLogClick, mockLogDismiss),
     );
 
     expect(result.current).toEqual({
@@ -27,7 +43,12 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
 
   it("should return empty content when content card is not feature intro", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(carouselCampaignCard, false),
+      useGenericAwarenessModalFeatureIntroViewModel(
+        carouselCampaignCard,
+        false,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.title).toBe("");
@@ -36,7 +57,12 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
 
   it("should map feature intro content from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(appStartFeatureIntroCard, true),
+      useGenericAwarenessModalFeatureIntroViewModel(
+        appStartFeatureIntroCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.title).toBe("Connect a Ledger device");
@@ -55,9 +81,37 @@ describe("useGenericAwarenessModalFeatureIntroViewModel", () => {
     };
 
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalFeatureIntroViewModel(cardWithInvalidIcon, true),
+      useGenericAwarenessModalFeatureIntroViewModel(
+        cardWithInvalidIcon,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.items[0]?.icon).toBe("LedgerLogo");
+  });
+
+  it("should log Braze click on primary click and dismiss on header close", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalFeatureIntroViewModel(
+        appStartFeatureIntroCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
+    );
+
+    act(() => {
+      result.current.onPrimaryClick();
+    });
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.onHeaderClose();
+    });
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/__tests__/useGenericAwarenessModalPromptViewModel.test.tsx
@@ -7,6 +7,9 @@ import { carouselCampaignCard, promptCampaignCard } from "../../testUtils/fixtur
 import useGenericAwarenessModalPromptViewModel from "../useGenericAwarenessModalPromptViewModel";
 import { renderHookWithStore } from "../testHelpers/renderHookWithStore";
 
+const mockLogClick = jest.fn();
+const mockLogDismiss = jest.fn();
+
 jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
@@ -22,7 +25,7 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should return empty content when content card is undefined", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(undefined, false),
+      useGenericAwarenessModalPromptViewModel(undefined, false, mockLogClick, mockLogDismiss),
     );
 
     expect(result.current).toEqual({
@@ -43,7 +46,12 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should return empty content when content card is not prompt", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(carouselCampaignCard, false),
+      useGenericAwarenessModalPromptViewModel(
+        carouselCampaignCard,
+        false,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.title).toBe("");
@@ -52,7 +60,12 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should map prompt content from the content card", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
+      useGenericAwarenessModalPromptViewModel(
+        promptCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     expect(result.current.title).toBe("Stay in control");
@@ -64,7 +77,14 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
   });
 
   it("should track page view when open with a prompt card", () => {
-    renderHookWithStore(() => useGenericAwarenessModalPromptViewModel(promptCampaignCard, true));
+    renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(
+        promptCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
+    );
 
     expect(trackPage).toHaveBeenCalledWith(
       PAGE_TRACKING_AWARENESS_MODAL_PROMPT,
@@ -77,7 +97,12 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should track primary click, open the link, and close dialog", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
+      useGenericAwarenessModalPromptViewModel(
+        promptCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     act(() => {
@@ -100,7 +125,12 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
 
   it("should track secondary click, open the link, and dismiss app start when closing", () => {
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(promptCampaignCard, true),
+      useGenericAwarenessModalPromptViewModel(
+        promptCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     act(() => {
@@ -127,7 +157,12 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
       primaryButtonLink: "",
     };
     const { result } = renderHookWithStore(() =>
-      useGenericAwarenessModalPromptViewModel(cardWithEmptyPrimaryLink, true),
+      useGenericAwarenessModalPromptViewModel(
+        cardWithEmptyPrimaryLink,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
     );
 
     act(() => {
@@ -146,5 +181,28 @@ describe("useGenericAwarenessModalPromptViewModel", () => {
     expect(jest.mocked(closeGenericAwarenessModalDialog)).toHaveBeenCalledWith({
       dismissAppStart: true,
     });
+  });
+
+  it("should log Braze click on primary click and dismiss on header close", () => {
+    const { result } = renderHookWithStore(() =>
+      useGenericAwarenessModalPromptViewModel(
+        promptCampaignCard,
+        true,
+        mockLogClick,
+        mockLogDismiss,
+      ),
+    );
+
+    act(() => {
+      result.current.onPrimaryClick();
+    });
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.onHeaderClose();
+    });
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import * as braze from "@braze/web-sdk";
+import { useSelector } from "LLD/hooks/redux";
+import { desktopContentCardSelector } from "~/renderer/reducers/dynamicContent";
+import { trackingEnabledSelector } from "~/renderer/reducers/settings";
+
+export function useGenericAwarenessModalBrazeLogging(
+  contentCardId: string | undefined,
+  isOpen: boolean,
+) {
+  const desktopCards = useSelector(desktopContentCardSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
+  const hasLoggedImpressionRef = useRef(false);
+
+  const brazeCard = useMemo(
+    () => (contentCardId ? desktopCards.find(card => card.id === contentCardId) : undefined),
+    [contentCardId, desktopCards],
+  );
+
+  useEffect(() => {
+    if (!isOpen || !brazeCard) {
+      hasLoggedImpressionRef.current = false;
+      return;
+    }
+
+    if (hasLoggedImpressionRef.current) {
+      return;
+    }
+
+    hasLoggedImpressionRef.current = true;
+    if (isTrackedUser) {
+      braze.logContentCardImpressions([brazeCard]);
+    }
+  }, [brazeCard, isOpen, isTrackedUser]);
+
+  const logClick = useCallback(() => {
+    if (isTrackedUser && brazeCard) {
+      braze.logContentCardClick(brazeCard);
+    }
+  }, [brazeCard, isTrackedUser]);
+
+  const logDismiss = useCallback(() => {
+    if (isTrackedUser && brazeCard) {
+      braze.logCardDismissal(brazeCard);
+    }
+  }, [brazeCard, isTrackedUser]);
+
+  return { logClick, logDismiss };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalCarouselViewModel.ts
@@ -29,12 +29,14 @@ export interface GenericAwarenessModalCarouselViewModel {
   onContinueClick: (slideIndex: number, isLastSlide: boolean) => void;
   onHeaderClose: () => void;
   onDismiss: () => void;
-  onClose: () => void;
+  onCompleteClose: () => void;
 }
 
 const useGenericAwarenessModalCarouselViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
+  logDismiss: () => void,
 ): GenericAwarenessModalCarouselViewModel => {
   const dispatch = useDispatch();
   const currentIndexRef = useRef(0);
@@ -96,9 +98,10 @@ const useGenericAwarenessModalCarouselViewModel = (
       if (actionLink) {
         openURL(actionLink);
       }
+      logClick();
       closeDialog({ dismissAppStart: true });
     },
-    [closeDialog, getContext],
+    [closeDialog, getContext, logClick],
   );
 
   const onContinueClick = useCallback(
@@ -124,20 +127,23 @@ const useGenericAwarenessModalCarouselViewModel = (
     if (context) {
       trackCarouselCloseClick(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   const onDismiss = useCallback(() => {
     const context = getContext(currentIndexRef.current);
     if (context) {
       trackCarouselDismissed(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   const onCompleteClose = useCallback(() => {
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog]);
+  }, [closeDialog, logDismiss]);
 
   return useMemo(
     () => ({
@@ -147,7 +153,7 @@ const useGenericAwarenessModalCarouselViewModel = (
       onContinueClick,
       onHeaderClose,
       onDismiss,
-      onClose: onCompleteClose,
+      onCompleteClose,
     }),
     [
       carousel?.data,

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalFeatureIntroViewModel.ts
@@ -21,7 +21,6 @@ import {
   trackFeatureIntroSecondaryClick,
 } from "../analytics/featureIntroAnalytics";
 import type { FeatureIntroContentItem, LumenSymbolName } from "../components/FeatureIntroContent";
-
 export interface GenericAwarenessModalFeatureIntroViewModel {
   title: string;
   subtitle: string;
@@ -53,6 +52,8 @@ const mapFeatureIntroItems = (
 const useGenericAwarenessModalFeatureIntroViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
+  logDismiss: () => void,
 ): GenericAwarenessModalFeatureIntroViewModel => {
   const dispatch = useDispatch();
   const hasTrackedOpenRef = useRef(false);
@@ -101,8 +102,9 @@ const useGenericAwarenessModalFeatureIntroViewModel = (
         openURL(actionLink);
       }
     }
+    logClick();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, featureIntro, getContext]);
+  }, [closeDialog, featureIntro, getContext, logClick]);
 
   const onSecondaryClick = useCallback(() => {
     const context = getContext();
@@ -117,24 +119,27 @@ const useGenericAwarenessModalFeatureIntroViewModel = (
         openURL(actionLink);
       }
     }
+    logClick();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, featureIntro, getContext]);
+  }, [closeDialog, featureIntro, getContext, logClick]);
 
   const onHeaderClose = useCallback(() => {
     const context = getContext();
     if (context) {
       trackFeatureIntroCloseClick(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   const onDismiss = useCallback(() => {
     const context = getContext();
     if (context) {
       trackFeatureIntroDismissed(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   return useMemo(
     () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalPromptViewModel.ts
@@ -19,7 +19,6 @@ import {
   trackPromptPrimaryClick,
   trackPromptSecondaryClick,
 } from "../analytics/promptAnalytics";
-
 export interface GenericAwarenessModalPromptViewModel {
   title: string;
   subtitle: string;
@@ -38,6 +37,8 @@ export interface GenericAwarenessModalPromptViewModel {
 const useGenericAwarenessModalPromptViewModel = (
   contentCard: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
+  logDismiss: () => void,
 ): GenericAwarenessModalPromptViewModel => {
   const dispatch = useDispatch();
   const hasTrackedOpenRef = useRef(false);
@@ -82,8 +83,9 @@ const useGenericAwarenessModalPromptViewModel = (
         openURL(actionLink);
       }
     }
+    logClick();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext, prompt]);
+  }, [closeDialog, getContext, logClick, prompt]);
 
   const onSecondaryClick = useCallback(() => {
     const context = getContext();
@@ -94,24 +96,27 @@ const useGenericAwarenessModalPromptViewModel = (
         openURL(actionLink);
       }
     }
+    logClick();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext, prompt]);
+  }, [closeDialog, getContext, logClick, prompt]);
 
   const onHeaderClose = useCallback(() => {
     const context = getContext();
     if (context) {
       trackPromptCloseClick(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   const onDismiss = useCallback(() => {
     const context = getContext();
     if (context) {
       trackPromptDismissed(context);
     }
+    logDismiss();
     closeDialog({ dismissAppStart: true });
-  }, [closeDialog, getContext]);
+  }, [closeDialog, getContext, logDismiss]);
 
   return useMemo(
     () => ({

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -96,6 +96,8 @@ Object.defineProperty(window, "matchMedia", {
 
 jest.mock("@ledgerhq/react-ui/assets/fonts", () => ({}));
 
+jest.mock("@braze/web-sdk", () => require("tests/mocks/brazeWebSdk").getBrazeWebSdkJestMock());
+
 class WorkerMock {
   constructor(stringUrl) {
     this.url = stringUrl;

--- a/apps/ledger-live-mobile/src/mvvm/components/FeatureIntroLayout/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/FeatureIntroLayout/index.tsx
@@ -54,12 +54,12 @@ export function FeatureIntroLayout({ onClose, viewModel }: FeatureIntroLayoutPro
       } catch {
         // TODO: track("malformed_url")
       } finally {
-        requestAnimationFrame(onClose);
+        requestAnimationFrame(() => onClose({ logDismiss: false }));
       }
       return;
     }
 
-    onClose();
+    onClose({ logDismiss: false });
   };
 
   return (

--- a/apps/ledger-live-mobile/src/mvvm/components/FeatureIntroLayout/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/components/FeatureIntroLayout/types.ts
@@ -7,6 +7,6 @@ export type FeatureIntroViewModel = Readonly<{
 }>;
 
 export type FeatureIntroLayoutProps = Readonly<{
-  onClose: () => void;
+  onClose: (options?: { logDismiss?: boolean }) => void;
   viewModel: FeatureIntroViewModel;
 }>;

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselFooterButton.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselFooterButton.tsx
@@ -10,10 +10,11 @@ import {
   resolveCarouselNavigationButtonLabel,
   type GenericAwarenessModalCarouselSlide,
 } from "@ledgerhq/live-common/genericAwarenessModal";
+import type { GenericAwarenessModalCloseHandler } from "../screens/useGenericAwarenessModalDrawerViewModel";
 
 type CarouselFooterButtonProps = Readonly<{
   slides: GenericAwarenessModalCarouselSlide[];
-  onClose: () => void;
+  onClose: GenericAwarenessModalCloseHandler;
   onNavigationPress: (slideIndex: number, button: string, isLastSlide: boolean) => void;
   onPrimaryPress: (slideIndex: number) => void;
   onMalformedUrl: (slideIndex: number) => void;
@@ -80,7 +81,7 @@ export function CarouselFooterButton({
     onPrimaryPress(slideIndex);
 
     if (!actionLink) {
-      onClose();
+      onClose({ logDismiss: false });
       return;
     }
 
@@ -89,7 +90,7 @@ export function CarouselFooterButton({
     try {
       await Linking.openURL(actionLink);
       if (!isExternalLink) {
-        requestAnimationFrame(onClose);
+        requestAnimationFrame(() => onClose({ logDismiss: false }));
       }
     } catch {
       onMalformedUrl(slideIndex);

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselLayout.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/CarouselLayout.tsx
@@ -6,10 +6,13 @@ import Animated from "react-native-reanimated";
 import { CarouselFooterButton } from "./CarouselFooterButton";
 import { CarouselProgressIndicator } from "./CarouselProgressIndicator";
 import { CarouselSlideItem } from "./CarouselSlideItem";
-import type { CarouselViewModel } from "../screens/useGenericAwarenessModalDrawerViewModel";
+import type {
+  CarouselViewModel,
+  GenericAwarenessModalCloseHandler,
+} from "../screens/useGenericAwarenessModalDrawerViewModel";
 
 type CarouselLayoutProps = Readonly<{
-  onClose: () => void;
+  onClose: GenericAwarenessModalCloseHandler;
   viewModel: CarouselViewModel;
 }>;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/GenericAwarenessModalDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/GenericAwarenessModalDrawer.tsx
@@ -12,12 +12,13 @@ import {
 } from "@ledgerhq/live-common/genericAwarenessModal";
 import type {
   CarouselViewModel,
+  GenericAwarenessModalCloseHandler,
   PromptViewModel,
 } from "../screens/useGenericAwarenessModalDrawerViewModel";
 
 type GenericAwarenessModalDrawerViewProps = Readonly<{
   isOpen: boolean;
-  onClose: () => void;
+  onClose: GenericAwarenessModalCloseHandler;
   data: GenericAwarenessModalContentCard | undefined;
   bottomInset: number;
   featureIntroViewModel: FeatureIntroViewModel | undefined;

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/PromptLayout.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/components/PromptLayout.tsx
@@ -8,10 +8,13 @@ import { Linking, StyleSheet } from "react-native";
 import FastImage from "react-native-fast-image";
 import { useTranslation } from "~/context/Locale";
 import { useThemedAwarenessModalImage } from "../hooks/useThemedAwarenessModalImage";
-import type { PromptViewModel } from "../screens/useGenericAwarenessModalDrawerViewModel";
+import type {
+  GenericAwarenessModalCloseHandler,
+  PromptViewModel,
+} from "../screens/useGenericAwarenessModalDrawerViewModel";
 
 type PromptLayoutProps = Readonly<{
-  onClose: () => void;
+  onClose: GenericAwarenessModalCloseHandler;
   viewModel: PromptViewModel;
 }>;
 
@@ -33,7 +36,7 @@ export function PromptLayout({ onClose, viewModel }: PromptLayoutProps) {
     viewModel.onPrimaryPress();
 
     if (!actionLink) {
-      onClose();
+      onClose({ logDismiss: false });
       return;
     }
 
@@ -42,7 +45,7 @@ export function PromptLayout({ onClose, viewModel }: PromptLayoutProps) {
     try {
       await Linking.openURL(actionLink);
       if (!isExternalLink) {
-        requestAnimationFrame(onClose);
+        requestAnimationFrame(() => onClose({ logDismiss: false }));
       }
     } catch {
       viewModel.onMalformedUrl();

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from "@tests/test-renderer";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
+import { useGenericAwarenessModalBrazeLogging } from "./useGenericAwarenessModalBrazeLogging";
+
+const mockLogImpressionCard = jest.fn();
+const mockLogClickCard = jest.fn();
+const mockLogDismissCard = jest.fn();
+
+jest.mock("~/dynamicContent/useDynamicContent", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseDynamicContent = useDynamicContent as jest.MockedFunction<typeof useDynamicContent>;
+
+describe("useGenericAwarenessModalBrazeLogging", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDynamicContent.mockReturnValue({
+      logImpressionCard: mockLogImpressionCard,
+      logClickCard: mockLogClickCard,
+      logDismissCard: mockLogDismissCard,
+    } as unknown as ReturnType<typeof useDynamicContent>);
+  });
+
+  it("should log one impression per open and not repeat on rerender", () => {
+    let isOpen = true;
+    const { rerender } = renderHook(() => useGenericAwarenessModalBrazeLogging("card-1", isOpen));
+
+    expect(mockLogImpressionCard).toHaveBeenCalledTimes(1);
+    expect(mockLogImpressionCard).toHaveBeenCalledWith("card-1");
+
+    rerender(undefined);
+    expect(mockLogImpressionCard).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reset impression dedup when isOpen toggles off and log again on reopen", () => {
+    let isOpen = true;
+    const { rerender } = renderHook(() => useGenericAwarenessModalBrazeLogging("card-1", isOpen));
+
+    expect(mockLogImpressionCard).toHaveBeenCalledTimes(1);
+
+    isOpen = false;
+    rerender(undefined);
+    expect(mockLogImpressionCard).toHaveBeenCalledTimes(1);
+
+    isOpen = true;
+    rerender(undefined);
+    expect(mockLogImpressionCard).toHaveBeenCalledTimes(2);
+  });
+
+  it("should log click and dismiss for the content card id", () => {
+    const { result } = renderHook(() => useGenericAwarenessModalBrazeLogging("card-1", true));
+
+    act(() => {
+      result.current.logClick();
+      result.current.logDismiss();
+    });
+
+    expect(mockLogClickCard).toHaveBeenCalledWith("card-1");
+    expect(mockLogDismissCard).toHaveBeenCalledWith("card-1");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/hooks/useGenericAwarenessModalBrazeLogging.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from "react";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
+
+export function useGenericAwarenessModalBrazeLogging(
+  contentCardId: string | undefined,
+  isOpen: boolean,
+) {
+  const { logImpressionCard, logClickCard, logDismissCard } = useDynamicContent();
+  const hasLoggedImpressionRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen || !contentCardId) {
+      hasLoggedImpressionRef.current = false;
+      return;
+    }
+
+    if (hasLoggedImpressionRef.current) {
+      return;
+    }
+
+    hasLoggedImpressionRef.current = true;
+    logImpressionCard(contentCardId);
+  }, [contentCardId, isOpen, logImpressionCard]);
+
+  const logClick = useCallback(() => {
+    if (contentCardId) {
+      logClickCard(contentCardId);
+    }
+  }, [contentCardId, logClickCard]);
+
+  const logDismiss = useCallback(() => {
+    if (contentCardId) {
+      logDismissCard(contentCardId);
+    }
+  }, [contentCardId, logDismissCard]);
+
+  return { logClick, logDismiss };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { promptMockData } from "../mockData";
+import { useGenericAwarenessModalDrawerViewModel } from "./useGenericAwarenessModalDrawerViewModel";
+
+const mockDispatch = jest.fn();
+const mockLogClick = jest.fn();
+const mockLogDismiss = jest.fn();
+
+jest.mock("~/context/hooks", () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: () => ({ enabled: true }),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ bottom: 0, top: 0, left: 0, right: 0 }),
+}));
+
+jest.mock("./useGenericAwarenessModalLogic", () => ({
+  useGenericAwarenessModalLogic: () => ({ shouldMarkAsRead: false }),
+}));
+
+jest.mock("../hooks/useGenericAwarenessModalBrazeLogging", () => ({
+  useGenericAwarenessModalBrazeLogging: () => ({
+    logClick: mockLogClick,
+    logDismiss: mockLogDismiss,
+  }),
+}));
+
+jest.mock("~/reducers/genericAwarenessModal", () => ({
+  selectIsGenericAwarenessModalOpen: () => true,
+  selectGenericAwarenessModalCampaignId: () => promptMockData.id,
+  selectGenericAwarenessModalContentCards: () => [promptMockData],
+  selectCurrentGenericAwarenessModalContentCard: () => promptMockData,
+  closeGenericAwarenessModalDrawer: jest.fn(() => ({ type: "CLOSE_GENERIC_AWARENESS_MODAL" })),
+  markGenericAwarenessModalContentCardAsRead: jest.fn((payload: { id: string }) => ({
+    type: "MARK_GENERIC_AWARENESS_MODAL_READ",
+    payload,
+  })),
+}));
+
+describe("useGenericAwarenessModalDrawerViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should log a Braze dismiss when the drawer is closed", () => {
+    const { result } = renderHook(() => useGenericAwarenessModalDrawerViewModel());
+
+    act(() => {
+      result.current.onClose();
+    });
+
+    expect(mockLogDismiss).toHaveBeenCalledTimes(1);
+    expect(mockLogClick).not.toHaveBeenCalled();
+  });
+
+  it("should not log a Braze dismiss when closing after a CTA click", () => {
+    const { result } = renderHook(() => useGenericAwarenessModalDrawerViewModel());
+
+    act(() => {
+      result.current.promptViewModel?.onPrimaryPress();
+      result.current.onClose({ logDismiss: false });
+    });
+
+    expect(mockLogClick).toHaveBeenCalledTimes(1);
+    expect(mockLogDismiss).not.toHaveBeenCalled();
+  });
+
+  it("should not log a Braze click when the prompt close button is pressed", () => {
+    const { result } = renderHook(() => useGenericAwarenessModalDrawerViewModel());
+
+    act(() => {
+      result.current.promptViewModel?.onClosePress();
+      result.current.onClose();
+    });
+
+    expect(mockLogClick).not.toHaveBeenCalled();
+    expect(mockLogDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalDrawerViewModel.ts
@@ -20,6 +20,7 @@ import {
 } from "~/reducers/genericAwarenessModal";
 import { useGenericAwarenessModalLogic } from "./useGenericAwarenessModalLogic";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
+import { useGenericAwarenessModalBrazeLogging } from "../hooks/useGenericAwarenessModalBrazeLogging";
 import {
   trackGenericAwarenessModalButtonClicked,
   trackGenericAwarenessModalCarouselStepViewed,
@@ -46,9 +47,18 @@ export type PromptViewModel = Readonly<{
   onMalformedUrl: () => void;
 }>;
 
+export type GenericAwarenessModalCloseOptions = Readonly<{
+  logDismiss?: boolean;
+}>;
+
+export type GenericAwarenessModalCloseHandler = (
+  options?: GenericAwarenessModalCloseOptions,
+) => void;
+
 function useFeatureIntroViewModel(
   data: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
 ): FeatureIntroViewModel | undefined {
   const displayedFeatureIntroIdRef = useRef<string | undefined>(undefined);
 
@@ -76,7 +86,8 @@ function useFeatureIntroViewModel(
       ctaPosition: "primary",
       link: data.primaryButtonLink,
     });
-  }, [data]);
+    logClick();
+  }, [data, logClick]);
 
   const onSecondaryPress = useCallback(() => {
     if (data?.layout !== GenericAwarenessModalLayout.FeatureIntro) {
@@ -87,7 +98,8 @@ function useFeatureIntroViewModel(
       ctaPosition: "secondary",
       link: data.secondaryButtonLink,
     });
-  }, [data]);
+    logClick();
+  }, [data, logClick]);
 
   return useMemo(() => {
     if (data?.layout !== GenericAwarenessModalLayout.FeatureIntro) {
@@ -105,6 +117,7 @@ function useFeatureIntroViewModel(
 function useCarouselViewModel(
   data: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
 ): CarouselViewModel | undefined {
   const currentSlideIndexRef = useRef(0);
 
@@ -142,8 +155,9 @@ function useCarouselViewModel(
         ctaPosition: "primary",
         slideIndex,
       });
+      logClick();
     },
-    [data],
+    [data, logClick],
   );
 
   const onPrimaryPress = useCallback(
@@ -162,8 +176,9 @@ function useCarouselViewModel(
         slideIndex,
         link: slide.primaryButtonLink,
       });
+      logClick();
     },
-    [data],
+    [data, logClick],
   );
 
   const onMalformedUrl = useCallback(
@@ -203,6 +218,7 @@ function useCarouselViewModel(
 function usePromptViewModel(
   data: GenericAwarenessModalContentCard | undefined,
   isOpen: boolean,
+  logClick: () => void,
 ): PromptViewModel | undefined {
   const displayedPromptIdRef = useRef<string | undefined>(undefined);
 
@@ -240,7 +256,8 @@ function usePromptViewModel(
       ctaPosition: "secondary",
       link: data.primaryButtonLink,
     });
-  }, [data]);
+    logClick();
+  }, [data, logClick]);
 
   const onMalformedUrl = useCallback(() => {
     if (data?.layout !== GenericAwarenessModalLayout.Prompt) {
@@ -289,22 +306,31 @@ export function useGenericAwarenessModalDrawerViewModel() {
     },
   );
 
-  const featureIntroViewModel = useFeatureIntroViewModel(data, isOpen);
-  const carouselViewModel = useCarouselViewModel(data, isOpen);
-  const promptViewModel = usePromptViewModel(data, isOpen);
+  const { logClick, logDismiss } = useGenericAwarenessModalBrazeLogging(data?.id, isOpen);
 
-  const onClose = useCallback(() => {
-    if (data) {
-      trackGenericAwarenessModalDismissed(data, carouselViewModel?.getCurrentSlideIndex());
-    }
+  const featureIntroViewModel = useFeatureIntroViewModel(data, isOpen, logClick);
+  const carouselViewModel = useCarouselViewModel(data, isOpen, logClick);
+  const promptViewModel = usePromptViewModel(data, isOpen, logClick);
 
-    if (data && shouldMarkAsRead) {
-      dispatch(setDismissedContentCard({ [data.id]: Date.now() }));
-      dispatch(markGenericAwarenessModalContentCardAsRead({ id: data.id }));
-    }
+  const onClose: GenericAwarenessModalCloseHandler = useCallback(
+    (options?: GenericAwarenessModalCloseOptions) => {
+      if (options?.logDismiss !== false) {
+        logDismiss();
+      }
 
-    dispatch(closeGenericAwarenessModalDrawer());
-  }, [carouselViewModel, data, dispatch, shouldMarkAsRead]);
+      if (data) {
+        trackGenericAwarenessModalDismissed(data, carouselViewModel?.getCurrentSlideIndex());
+      }
+
+      if (data && shouldMarkAsRead) {
+        dispatch(setDismissedContentCard({ [data.id]: Date.now() }));
+        dispatch(markGenericAwarenessModalContentCardAsRead({ id: data.id }));
+      }
+
+      dispatch(closeGenericAwarenessModalDrawer());
+    },
+    [carouselViewModel, data, dispatch, logDismiss, shouldMarkAsRead],
+  );
 
   return {
     isOpen,

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.test.tsx
@@ -97,4 +97,77 @@ describe("useGenericAwarenessModalLogic", () => {
 
     expect(open).not.toHaveBeenCalled();
   });
+
+  it("should not auto-open a second app-start card after dismissing the first one in the same session", async () => {
+    const secondAppStartContentCard = {
+      ...featureIntroMockData,
+      id: "app_start-feature-intro-2",
+    };
+    const open = jest.fn();
+    const props = {
+      cards: [appStartContentCard, secondAppStartContentCard],
+      isOpen: false,
+    };
+
+    const { rerender } = renderHook(() =>
+      useGenericAwarenessModalLogic(
+        { cards: props.cards },
+        {
+          enabled: true,
+          isOpen: props.isOpen,
+          open,
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(open).toHaveBeenCalledWith(appStartContentCard.id);
+    });
+
+    props.cards = [secondAppStartContentCard];
+    props.isOpen = false;
+    rerender(undefined);
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should auto-open again after the hook remounts in the same session", async () => {
+    const open = jest.fn();
+
+    const { unmount } = renderHook(() =>
+      useGenericAwarenessModalLogic(
+        { cards: [appStartContentCard] },
+        {
+          enabled: true,
+          isOpen: false,
+          open,
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(open).toHaveBeenCalledWith(appStartContentCard.id);
+    });
+
+    unmount();
+
+    renderHook(() =>
+      useGenericAwarenessModalLogic(
+        { cards: [appStartContentCard] },
+        {
+          enabled: true,
+          isOpen: false,
+          open,
+        },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(open).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import {
   isGenericAwarenessModalContentCardReady,
@@ -42,6 +42,9 @@ export function useGenericAwarenessModalLogic(
   { campaignId, cards }: GenericAwarenessModalLogicInput,
   { enabled, isOpen, open }: GenericAwarenessModalLogicContext,
 ) {
+  // Resets when this hook remounts (e.g. nav stack pop+push); auto-open may fire again once per mount.
+  const hasAutoOpenedAppStartThisSessionRef = useRef(false);
+
   const cardToOpen = useMemo(
     () => getGenericAwarenessModalCardToOpen({ campaignId, cards }),
     [campaignId, cards],
@@ -51,8 +54,17 @@ export function useGenericAwarenessModalLogic(
     useCallback(() => {
       if (!enabled || isOpen || !cardToOpen) return;
 
+      const isAutoAppStart = !campaignId && isGenericAwarenessModalAppStartId(cardToOpen.id);
+      if (isAutoAppStart && hasAutoOpenedAppStartThisSessionRef.current) {
+        return;
+      }
+
+      if (isAutoAppStart) {
+        hasAutoOpenedAppStartThisSessionRef.current = true;
+      }
+
       open(cardToOpen.id);
-    }, [cardToOpen, enabled, isOpen, open]),
+    }, [campaignId, cardToOpen, enabled, isOpen, open]),
   );
 
   return {


### PR DESCRIPTION
## Summary

Fixes [LIVE-34438](https://ledgerhq.atlassian.net/browse/LIVE-34438) — two Generic Awareness Modal (GAM) issues reported via [PROD-12532](https://ledgerhq.atlassian.net/browse/PROD-12532):

- **Mobile modal cascade:** Dismissing an auto-opened `app_start` GAM immediately opened the next eligible card in the same session. Root cause: `useFocusEffect` in `useGenericAwarenessModalLogic` re-ran when the dismissed card was removed from Redux, selecting the next card and calling `open()` again. Desktop already had a session guard in `useGenericAwarenessModalAppStart`; mobile did not.
- **Missing Braze logs:** GAM fired Segment analytics only. Impression, click, and dismiss events were not sent to Braze on either platform.

This PR adds a `useRef` session guard on mobile (mirroring desktop behavior) and wires Braze content-card logging into GAM on both mobile and desktop.

## Changes

### Mobile — stop modal cascade
- Added `hasAutoOpenedAppStartThisSessionRef` in `useGenericAwarenessModalLogic` to allow only one auto-opened `app_start` card per session.
- Deeplink-driven opens (`campaignId` set) are unchanged.

### Mobile — Braze logging
- New `useGenericAwarenessModalBrazeLogging` hook (via `useDynamicContent`).
- Wired into `useGenericAwarenessModalDrawerViewModel`: impression on open, click on CTA presses, dismiss on close.

### Desktop — Braze logging
- New `useGenericAwarenessModalBrazeLogging` hook (via `@braze/web-sdk` + `desktopContentCardSelector`, respecting `trackingEnabledSelector`).
- Wired into feature intro, prompt, and carousel view models: impression on open, click on CTA, dismiss on close/dismiss gestures.

## Test plan

- [x] `pnpm mobile test:jest "src/mvvm/features/GenericAwarenessModal/screens/useGenericAwarenessModalLogic.test.tsx"` — includes new cascade-prevention test
- [x] `pnpm mobile test:jest "src/mvvm/features/GenericAwarenessModal/__integrations__/GenericAwarenessModal.integration.test.tsx"` — 10/10 pass
- [x] Desktop GAM view model tests (blocked locally by missing `@ledgerhq/react-ui/assets/fonts` in jest setup — pre-existing env issue)
- [ ] Manual mobile: launch app with multiple `app_start` GAM cards → dismiss first → confirm second does **not** auto-open in same session
- [ ] Manual mobile: deeplink to a specific GAM campaign → confirm it still opens regardless of session guard
- [ ] Manual mobile + desktop: open GAM → verify Braze impression logged
- [ ] Manual mobile + desktop: tap CTA → verify Braze click logged
- [ ] Manual mobile + desktop: dismiss GAM → verify Braze dismiss logged

[LIVE-34438]: https://ledgerhq.atlassian.net/browse/LIVE-34438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROD-12532]: https://ledgerhq.atlassian.net/browse/PROD-12532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ