### PR TITLE
fix(live-common): import @shared/env in test setup for env bootstrap

### DIFF
--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -415,7 +415,6 @@
   "devDependencies": {
     "@features/platform-currencies": "workspace:^",
     "@ledgerhq/device-react": "workspace:^",
-    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/types-cryptoassets": "workspace:^",
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",

--- a/libs/ledger-live-common/src/__tests__/test-helpers/setup-registry.ts
+++ b/libs/ledger-live-common/src/__tests__/test-helpers/setup-registry.ts
@@ -1,3 +1,4 @@
+import "@shared/env";
 import { registerAllCoins } from "../../coin-modules/load-all-coins";
 
 registerAllCoins();

--- a/libs/ledger-live-common/src/env.test.ts
+++ b/libs/ledger-live-common/src/env.test.ts
@@ -1,6 +1,6 @@
-import { getEnv } from "@ledgerhq/live-env";
+import { getEnv } from "@shared/env";
 
-// @ts-expect-error – @ledgerhq/live-env is typed in PR1; becomes type-lossy in PR2
+// @ts-expect-error – "yolo" is not a valid env key
 getEnv("yolo");
 
 test("typecheck env", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9448,9 +9448,6 @@ importers:
       '@ledgerhq/device-react':
         specifier: workspace:^
         version: link:../device-react
-      '@ledgerhq/live-env':
-        specifier: workspace:^
-        version: link:../env
       '@ledgerhq/types-cryptoassets':
         specifier: workspace:^
         version: link:../ledgerjs/packages/types-cryptoassets
@@ -25005,7 +25002,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on #20076 landing first. It will not be mergeable until `@shared/env` and `injectDefinitions()` exist on `develop`.

### 📝 Description

Companion to #20076 (feat: decouple live-env from definitions).

That PR adds `injectDefinitions()` to `@ledgerhq/live-env` and introduces `@shared/env`, a workspace-private package that auto-calls `injectDefinitions(allDefinitions)` at import time.

`ledger-live-common` already depends on `@shared/env` for runtime code, but its test helper (`setup-registry.ts`) loaded coin modules before `injectDefinitions()` had been called, causing `getEnv()` to fail in tests with the new API.

**Changes:**
- `setup-registry.ts`: adds `import "@shared/env"` as the first import so `allDefinitions` are injected before any coin module registers
- `env.test.ts`: updates the import from `@ledgerhq/live-env` to `@shared/env` (the in-monorepo facade)
- `package.json`: removes the now-redundant `@ledgerhq/live-env` devDependency (superseded by `@shared/env`)

### 🔗 Context

- **JIRA / GitHub issue**: #20076
- **ADR** (if any): N/A