### PR TITLE
[LWDM] fix(jest): ensure injectDefinitions() runs in jest setups (live-env compat)

### DIFF
--- a/libs/coin-modules/coin-kaspa/jest.config.js
+++ b/libs/coin-modules/coin-kaspa/jest.config.js
@@ -26,26 +26,27 @@ module.exports = {
     "!src/__tests__/**/*.ts",
   ],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
-  coveragePathIgnorePatterns: ["src/test", "src/types", "src/index.ts"],
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],
   coveragePathIgnorePatterns: ["src/test", "src/types", "src/index.ts"],
-  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup", "@ledgerhq/disable-network-setup"],
   projects: [
     {
       ...sharedConfig,
       displayName: "unit",
       testPathIgnorePatterns: [...sharedConfig.testPathIgnorePatterns, "\\.msw\\.test\\.ts"],
-      setupFilesAfterEnv: ["@ledgerhq/disable-network-setup"],
+      setupFilesAfterEnv: [
+        "@ledgerhq/wallet-framework-test-setup",
+        "@ledgerhq/disable-network-setup",
+      ],
     },
     {
       ...sharedConfig,
       displayName: "msw",
       testMatch: ["**/*.msw.test.ts"],
-      setupFiles: ["./src/test/msw-setup.ts"],
+      setupFiles: ["@ledgerhq/wallet-framework-test-setup", "./src/test/msw-setup.ts"],
     },
   ],
 };

--- a/libs/ledger-wallet-framework/jest.config.js
+++ b/libs/ledger-wallet-framework/jest.config.js
@@ -19,8 +19,8 @@ module.exports = {
   // Loaded by relative path (not as a package dep) so the public framework carries no
   // package.json edge back to it — that edge is what nx flags as a cyclic dependency.
   setupFilesAfterEnv: [
-    "<rootDir>/src/setup.ts",
     "<rootDir>/../wallet-framework-test-setup/src/index.js",
+    "<rootDir>/src/setup.ts",
   ],
   testEnvironment: "node",
   moduleNameMapper: {

--- a/libs/wallet-btc/jest.config.js
+++ b/libs/wallet-btc/jest.config.js
@@ -28,5 +28,5 @@ module.exports = {
     ...(process.env.CI ? ["github-actions"] : []),
     ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
   ],
-  setupFilesAfterEnv: ["@ledgerhq/disable-network-setup"],
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup", "@ledgerhq/disable-network-setup"],
 };

--- a/libs/wallet-pnl/jest-env-setup.js
+++ b/libs/wallet-pnl/jest-env-setup.js
@@ -1,0 +1,1 @@
+require("@shared/env");

--- a/libs/wallet-pnl/jest.config.js
+++ b/libs/wallet-pnl/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
     ],
   },
   testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/jest-env-setup.js"],
   testPathIgnorePatterns: ["lib/", "lib-es/", "helpers/"],
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
   reporters: [

--- a/libs/wallet-pnl/package.json
+++ b/libs/wallet-pnl/package.json
@@ -36,6 +36,7 @@
     }
   },
   "devDependencies": {
+    "@shared/env": "workspace:*",
     "@types/node": "catalog:",
     "@types/jest": "catalog:",
     "@types/react": "catalog:",


### PR DESCRIPTION
> [!IMPORTANT]
> This PR depends on #20076 landing first. It will only work once `@shared/env` and `injectDefinitions()` exist.

### 📝 Description

Companion to #20076 (`@shared/env` / `injectDefinitions()` refactor).

Packages that call `getEnv()` in tests need `injectDefinitions(allDefinitions)` to run before those calls, otherwise the env registry is empty and tests fail or produce wrong results.

This PR wires up the bootstrapping in jest configs for the affected packages:

- **`libs/ledger-wallet-framework`** — reorders `setupFilesAfterEnv` so `wallet-framework-test-setup` (which calls `injectDefinitions`) runs first, before `src/setup.ts`.
- **`libs/wallet-btc`** — adds `@ledgerhq/wallet-framework-test-setup` to `setupFilesAfterEnv`.
- **`libs/coin-modules/coin-kaspa`** — adds `@ledgerhq/wallet-framework-test-setup` to both jest projects (`unit` and `msw`).
- **`libs/wallet-pnl`** (private package) — instead of depending on `wallet-framework-test-setup` (wrong abstraction), adds `@shared/env` as a devDep and a local `jest-env-setup.js` that simply `require("@shared/env")` to trigger `injectDefinitions`.

### 🔗 Context

- **JIRA / GitHub issue**: depends on #20076
- **ADR** (if any): n/a