### PR TITLE
fix(ledger-wallet-framework): add explicit string type in map callback

### DIFF
--- a/libs/ledger-wallet-framework/src/operation.ts
+++ b/libs/ledger-wallet-framework/src/operation.ts
@@ -267,7 +267,7 @@ export const isAddressPoisoningOperation = (
   // Fallback to environment variable if no families are provided to be retro-compatible
   const impactedFamilies = getEnv("ADDRESS_POISONING_FAMILIES")
     .split(",")
-    .map(s => s.trim());
+    .map((s: string) => s.trim());
 
   return impactedFamilies.includes(family);
 };


### PR DESCRIPTION
### 📝 Description

In context of live-env decoupling, the getEnv will return "unknown" and in context of  `isAddressPoisoningOperation`, the `.map()` callback lacked an explicit parameter type:

```ts
// before
.map(s => s.trim())

// after
.map((s: string) => s.trim())
```

### 🔗 Context

- **JIRA / GitHub issue**: N/A — standalone typecheck fix extracted from feat/live-env-inject-definitions-v2-fresh
- **ADR** (if any): N/A