### PR TITLE
[LWDM] chore(LIVE-32915): migrate @ledgerhq/errors imports — wallet-xp

### DIFF
--- a/apps/ledger-live-desktop/src/errors.ts
+++ b/apps/ledger-live-desktop/src/errors.ts
@@ -1,0 +1,7 @@
+export class AccountNameRequiredError extends Error {
+  override name = "AccountNameRequiredError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AccountNameRequiredError");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -2,7 +2,7 @@ import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";

--- a/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { TokenCurrency, CryptoCurrency } from "@ledgerhq/types-cryptoassets";
 import ErrorBanner from "./ErrorBanner";
 import { useFilteredServiceStatus } from "@ledgerhq/live-common/notifications/ServiceStatusProvider/index";
@@ -7,7 +6,14 @@ type Props = {
   currencies: Array<CryptoCurrency | TokenCurrency>;
   hideStatusIncidents?: boolean;
 };
-const ServiceStatusWarning = createCustomErrorClass("ServiceStatusWarning");
+class ServiceStatusWarning extends Error {
+  override name = "ServiceStatusWarning";
+  description?: string;
+  constructor(message?: string, options?: ErrorOptions & { description?: string }) {
+    super(message, options);
+    this.description = options?.description;
+  }
+}
 const CurrencyDownStatusAlert = ({ currencies, hideStatusIncidents }: Props) => {
   const errors: Error[] = [];
 

--- a/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { setEncryptionKey, isEncryptionKeyCorrect, hasBeenDecrypted } from "~/renderer/storage";
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import { useHardReset } from "~/renderer/reset";

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -31,7 +31,6 @@ import { ExchangeType } from "@ledgerhq/live-common/wallet-api/Exchange/server";
 import { getIncompatibleCurrencyKeys } from "@ledgerhq/live-common/exchange/swap/index";
 import { Exchange, isExchangeSwap } from "@ledgerhq/live-common/exchange/types";
 import { HardwareUpdate, renderLoading } from "./DeviceAction/rendering";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { HOOKS_TRACKING_LOCATIONS } from "../analytics/hooks/variables";
 import { getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
@@ -66,7 +65,9 @@ export function isStartExchangeData(data: unknown): data is StartExchangeData {
   return "exchangeType" in data;
 }
 
-const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+class DrawerClosedError extends Error {
+  override name = "DrawerClosedError";
+}
 
 export const LiveAppDrawer = () => {
   const [dismissDisclaimerChecked, setDismissDisclaimerChecked] = useState<boolean>(false);

--- a/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import jsQR from "jsqr";
 import styled from "styled-components";
-import { NoAccessToCamera } from "@ledgerhq/errors";
+import { NoAccessToCamera } from "@ledgerhq/live-common/errors";
 import logger from "~/renderer/logger";
 import IconCameraError from "~/renderer/icons/CameraError";
 import IconCross from "~/renderer/icons/Cross";

--- a/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { catchError, throwError } from "rxjs";
-import { GenuineCheckFailed } from "@ledgerhq/errors";
+import { GenuineCheckFailed } from "@ledgerhq/live-common/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import connectManager from "@ledgerhq/live-common/hw/connectManager";
@@ -118,7 +118,7 @@ export function useGenuineCheckAction(): Action<ManagerRequest, ManagerState, Ma
           if (isCounterfeitError(error)) return throwError(() => error);
           if (isDeviceNotOnboardedError(error)) return throwError(() => error);
 
-          return throwError(() => new GenuineCheckFailed("", undefined, { cause: error }));
+          return throwError(() => new GenuineCheckFailed("", { cause: error }));
         }),
       );
     return createManagerAction(task);

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -1,8 +1,8 @@
-import { getEnv } from "@shared/env";
 import { createRoot } from "react-dom/client";
 import React from "react";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { getEnv } from "@shared/env";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import "../config/configInit";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";

--- a/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { closeModal } from "~/renderer/actions/modals";
@@ -10,7 +10,7 @@ import InputPassword from "~/renderer/components/InputPassword";
 import Label from "~/renderer/components/Label";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const DisablePasswordModal = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from "react";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { TFunction } from "i18next";
 import Box from "~/renderer/components/Box";
 import InputPassword from "~/renderer/components/InputPassword";

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -10,7 +10,7 @@ import PasswordForm from "./PasswordForm";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const PasswordModal = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import type { Account } from "@ledgerhq/types-live";
 import { validateNameEdition } from "@ledgerhq/live-wallet/accountName";
 import { setAccountName as actionSetAccountName } from "@ledgerhq/live-wallet/store";
-import { AccountNameRequiredError } from "@ledgerhq/errors";
+import { AccountNameRequiredError } from "~/errors";
 import { getEnv } from "@shared/env";
 import { urls } from "~/config/urls";
 import { setDataModal } from "~/renderer/actions/modals";

--- a/apps/ledger-live-desktop/src/support/os.ts
+++ b/apps/ledger-live-desktop/src/support/os.ts
@@ -1,8 +1,6 @@
 import os from "os";
 import semverSatisfies from "semver/functions/satisfies";
 import { getEnv } from "@shared/env";
-import { createCustomErrorClass } from "@ledgerhq/errors";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
 
 type OperatingSystemOutdatedInfos = {
   type: string;
@@ -10,10 +8,13 @@ type OperatingSystemOutdatedInfos = {
   criteria: string;
 };
 
-export const OperatingSystemOutdated = createCustomErrorClass<
-  OperatingSystemOutdatedInfos,
-  LedgerErrorConstructor<OperatingSystemOutdatedInfos>
->("OperatingSystemOutdated");
+export class OperatingSystemOutdated extends Error {
+  override name = "OperatingSystemOutdated";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 export type SupportStatus =
   | {

--- a/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
+++ b/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from "react";
 import { AppState, Platform, Vibration } from "react-native";
 import type { Privacy } from "~/reducers/types";
 import * as Keychain from "react-native-keychain";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { VIBRATION_PATTERN_ERROR } from "~/utils/constants";
 
 interface UsePrivacyInitializationProps {

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -10,7 +10,7 @@ import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
 import "./config/configInit";

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -13,7 +13,7 @@ import type {
   BroadcastConfig,
 } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
   addPendingOperation,

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -1,6 +1,6 @@
 import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { BluetoothRequired } from "@ledgerhq/errors";
+import { BluetoothRequired } from "@ledgerhq/hw-transport/errors";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
 import { findMatchingNewDevice } from "@ledgerhq/live-dmk-mobile";
 import { act, renderHook } from "@tests/test-renderer";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@tests/test-renderer";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { SignedOperation } from "@ledgerhq/types-live";
 import { createIntent } from "@ledgerhq/device-intent";
 import { buildDeviceInitializationInput } from "LLM/components/DeviceIntentExecutor";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { createIntent } from "@ledgerhq/device-intent";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
@@ -3,7 +3,7 @@ import { Text } from "react-native";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { useAddMember } from "../hooks/useAddMember";
 import { SceneKind } from "../hooks/useFollowInstructionDrawer";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { track } from "~/analytics";
 import { AnalyticsEvents } from "../Analytics/enums";

--- a/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { Box } from "@ledgerhq/native-ui";
 import HeaderErrorTitle from "~/components/HeaderErrorTitle";
 import { useNetInfo } from "@react-native-community/netinfo";
-import { NetworkDown } from "@ledgerhq/errors";
+import { NetworkDown } from "@ledgerhq/live-common/errors";
 
 type ErrorBannerProps = {
   error: Error;

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -21,7 +21,7 @@ import { BleSaveDeviceNamePayload } from "~/actions/types";
 import { useRenameDeviceAction } from "~/hooks/deviceActions";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useToastsActions } from "~/actions/toast";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 
 const mapDispatchToProps = {
   saveBleDeviceName,

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -8,7 +8,7 @@ import {
 import { Flex } from "@ledgerhq/native-ui";
 import { getAccountSpendableBalance, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { ScreenName, NavigatorName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
@@ -3,7 +3,7 @@ import { Platform, Vibration } from "react-native";
 import * as Keychain from "react-native-keychain";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 
 import { CompositeScreenProps } from "@react-navigation/native";
 import { setPrivacy } from "~/actions/settings";

--- a/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useState } from "react";
 import * as Keychain from "react-native-keychain";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { Vibration } from "react-native";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";

--- a/apps/ledger-live-mobile/src/types/error.ts
+++ b/apps/ledger-live-mobile/src/types/error.ts
@@ -1,6 +1,3 @@
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-
-export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>> & {
-  name?: string;
+export type LedgerError = Error & {
   managerAppName?: string;
 };


### PR DESCRIPTION
## Summary

Migrate `@ledgerhq/errors` import sites for packages owned by **@ledgerhq/wallet-xp** (25 files across `apps/ledger-live-desktop` and `apps/ledger-live-mobile`).

Stacked on: feat/LIVE-32915-errors-coin-integration (PR #20062)

## Context

Part of the phased deprecation of `@ledgerhq/errors` (LIVE-32915). Each team gets their own PR to review and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Jira: https://ledgerhq.atlassian.net/browse/LIVE-35096