### PR TITLE
[LWDM] chore(LIVE-32915): migrate @ledgerhq/errors imports — ptx

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx
@@ -1,4 +1,7 @@
-import { DisabledTransactionBroadcastError, MissingSwapPayloadParamaters } from "@ledgerhq/errors";
+import {
+  DisabledTransactionBroadcastError,
+  MissingSwapPayloadParamaters,
+} from "@ledgerhq/live-common/errors";
 import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { Exchange } from "@ledgerhq/live-common/exchange/types";

--- a/apps/ledger-live-desktop/tsconfig.json
+++ b/apps/ledger-live-desktop/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "esnext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "customConditions": ["@ledgerhq/source"],
     "rootDir": ".",
     "paths": {
       "*": ["./*"],

--- a/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts
@@ -34,7 +34,6 @@ import {
 } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { getAccountIdFromWalletAccountId } from "@ledgerhq/live-common/wallet-api/converters";
 import { getUpdateAccountWithUpdaterParams } from "@ledgerhq/live-common/exchange/swap/getUpdateAccountWithUpdaterParams";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { useOpenStakeDrawer } from "LLM/features/Stake";
 import { useStakingDrawer } from "~/components/Stake/useStakingDrawer";
 import { useRemoteLiveAppContext } from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
@@ -56,7 +55,9 @@ import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { useWalletFeaturesConfig, useFeatureFlags } from "@features/platform-feature-flags";
 import type { Feature, FeatureId } from "@shared/feature-flags";
 
-const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+class DrawerClosedError extends Error {
+  override name = "DrawerClosedError";
+}
 const drawerClosedError = new DrawerClosedError("User closed the drawer");
 const unknownSwapError = new Error("Unknown swap error");
 

--- a/libs/coin-modules/coin-bitcoin/src/errors.ts
+++ b/libs/coin-modules/coin-bitcoin/src/errors.ts
@@ -62,3 +62,19 @@ export class ZcashUtxoNotInAccount extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class DustLimit extends Error {
+  override name = "DustLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DustLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class OpReturnDataSizeLimit extends Error {
+  override name = "OpReturnDataSizeLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OpReturnDataSizeLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-cosmos/src/errors.ts
+++ b/libs/coin-modules/coin-cosmos/src/errors.ts
@@ -45,3 +45,27 @@ export class CosmosTooManyRedelegations extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class SequenceNumberError extends Error {
+  override name = "SequenceNumberError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SequenceNumberError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ExpertModeRequired extends Error {
+  override name = "ExpertModeRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ExpertModeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecommendUndelegation extends Error {
+  override name = "RecommendUndelegation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecommendUndelegation");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-evm/src/errors.ts
+++ b/libs/coin-modules/coin-evm/src/errors.ts
@@ -139,3 +139,84 @@ export class NotEnoughNftOwned extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+// Transaction validation
+export class GasLessThanEstimate extends Error {
+  override name = "GasLessThanEstimate";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GasLessThanEstimate");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooLow extends Error {
+  override name = "PriorityFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooHigh extends Error {
+  override name = "PriorityFeeTooHigh";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeHigherThanMaxFee extends Error {
+  override name = "PriorityFeeHigherThanMaxFee";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeHigherThanMaxFee");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaxFeeTooLow extends Error {
+  override name = "MaxFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaxFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ETHAddressNonEIP extends Error {
+  override name = "ETHAddressNonEIP";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ETHAddressNonEIP");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RedelegateDstValAddressRequired extends Error {
+  override name = "RedelegateDstValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RedelegateDstValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ValAddressRequired extends Error {
+  override name = "ValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ClaimRewardsFeesWarning extends Error {
+  override name = "ClaimRewardsFeesWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ClaimRewardsFeesWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/src/errors.ts
+++ b/libs/coin-modules/coin-solana/src/errors.ts
@@ -221,3 +221,11 @@ export class SolanaTokenNonTransferable extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class NetworkError extends Error {
+  override name = "NetworkError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NetworkError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/tsconfig.json
+++ b/libs/coin-modules/coin-solana/tsconfig.json
@@ -5,7 +5,7 @@
     "noUnusedParameters": true,
     "declaration": true,
     "declarationMap": true,
-    "lib": ["es2020", "dom"],
+    "lib": ["ES2022", "dom"],
     "types": ["node", "jest"],
     "exactOptionalPropertyTypes": true,
     "outDir": "./lib",

--- a/libs/coin-modules/coin-tron/package.json
+++ b/libs/coin-modules/coin-tron/package.json
@@ -87,6 +87,11 @@
       "require": "./lib/bridge/transaction.js",
       "default": "./lib-es/bridge/transaction.js"
     },
+    "./types/*": {
+      "@ledgerhq/source": "./src/types/*.ts",
+      "require": "./lib/types/*.js",
+      "default": "./lib-es/types/*.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-tron/src/types/errors.ts
+++ b/libs/coin-modules/coin-tron/src/types/errors.ts
@@ -133,3 +133,27 @@ export class TronEmptyPage extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class TronEmptyAccount extends Error {
+  override name = "TronEmptyAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronEmptyAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaybeKeepTronAccountAlive extends Error {
+  override name = "MaybeKeepTronAccountAlive";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaybeKeepTronAccountAlive");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledger-live-common/src/errors.ts
+++ b/libs/ledger-live-common/src/errors.ts
@@ -108,7 +108,7 @@ export const BluetoothNotSupportedError = createCustomErrorClass("FwUpdateBlueto
 
 export const EConnResetError = createCustomErrorClass("EConnReset");
 
-export { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+export { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 export * from "@ledgerhq/coin-module-framework/errors";
 export * from "@ledgerhq/coin-algorand/errors";
 export * from "@ledgerhq/coin-aptos/errors";
@@ -126,3 +126,177 @@ export * from "@ledgerhq/coin-stacks/errors";
 export * from "@ledgerhq/coin-stellar/errors";
 export * from "@ledgerhq/coin-tezos/errors";
 export * from "@ledgerhq/coin-vechain/errors";
+
+export class PasswordsDontMatchError extends Error {
+  override name = "PasswordsDontMatch";
+  constructor(message?: string) {
+    super(message || "PasswordsDontMatch");
+  }
+}
+
+export class PasswordIncorrectError extends Error {
+  override name = "PasswordIncorrect";
+  constructor(message?: string) {
+    super(message || "PasswordIncorrect");
+  }
+}
+
+export class UnresponsiveDeviceError extends Error {
+  override name = "UnresponsiveDeviceError";
+  constructor(message?: string) {
+    super(message || "UnresponsiveDeviceError");
+  }
+}
+
+export class UserRefusedDeviceNameChange extends Error {
+  override name = "UserRefusedDeviceNameChange";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedDeviceNameChange");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  constructor(message?: string) {
+    super(message || "UserRefusedAddress");
+  }
+}
+
+export class UserRefusedAllowManager extends Error {
+  override name = "UserRefusedAllowManager";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "UserRefusedAllowManager");
+  }
+}
+
+export class GenuineCheckFailed extends Error {
+  override name = "GenuineCheckFailed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GenuineCheckFailed");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PendingOperation extends Error {
+  override name = "PendingOperation";
+  constructor(message?: string) {
+    super(message || "PendingOperation");
+  }
+}
+
+export class DisabledTransactionBroadcastError extends Error {
+  override name = "DisabledTransactionBroadcastError";
+  constructor(message?: string) {
+    super(message || "DisabledTransactionBroadcastError");
+  }
+}
+
+export class MissingSwapPayloadParamaters extends Error {
+  override name = "MissingSwapPayloadParamaters";
+  constructor(message?: string) {
+    super(message || "MissingSwapPayloadParamaters");
+  }
+}
+
+export class ManagerDeviceLockedError extends Error {
+  override name = "ManagerDeviceLocked";
+  constructor(message?: string) {
+    super(message || "ManagerDeviceLocked");
+  }
+}
+
+export class DeviceNameInvalid extends Error {
+  override name = "DeviceNameInvalid";
+  invalidCharacters?: string;
+
+  constructor(message?: string, options?: ErrorOptions & { invalidCharacters?: string }) {
+    const { invalidCharacters, ...rest } = options ?? {};
+    super(message || "DeviceNameInvalid", rest);
+    this.invalidCharacters = invalidCharacters;
+  }
+}
+
+export class NanoSNotSupported extends Error {
+  override name = "NanoSNotSupported";
+  constructor(message?: string) {
+    super(message || "NanoSNotSupported");
+  }
+}
+
+export class NoAccessToCamera extends Error {
+  override name = "NoAccessToCamera";
+  constructor(message?: string) {
+    super(message || "NoAccessToCamera");
+  }
+}
+
+export class TransactionHasBeenValidatedError extends Error {
+  override name = "TransactionHasBeenValidatedError";
+  constructor(message?: string) {
+    super(message || "TransactionHasBeenValidatedError");
+  }
+}
+
+export class DeviceSocketFail extends Error {
+  override name = "DeviceSocketFail";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DeviceSocketFail");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WebsocketConnectionError extends Error {
+  override name = "WebsocketConnectionError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WebsocketConnectionError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UnexpectedBootloader extends Error {
+  override name = "UnexpectedBootloader";
+  constructor(message?: string) {
+    super(message || "UnexpectedBootloader");
+  }
+}
+
+export class NotEnoughBalanceSwap extends Error {
+  override name = "NotEnoughBalanceSwap";
+  constructor(message?: string) {
+    super(message || "NotEnoughBalanceSwap");
+  }
+}
+
+export class NotEnoughGasSwap extends Error {
+  override name = "NotEnoughGasSwap";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGasSwap");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedFirmwareUpdate extends Error {
+  override name = "UserRefusedFirmwareUpdate";
+  constructor(message?: string) {
+    super(message || "UserRefusedFirmwareUpdate");
+  }
+}
+
+export class WrongDeviceForAccountPayout extends Error {
+  override name = "WrongDeviceForAccountPayout";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccountPayout");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WrongDeviceForAccountRefund extends Error {
+  override name = "WrongDeviceForAccountRefund";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccountRefund");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledger-live-common/src/exchange/error.test.ts
+++ b/libs/ledger-live-common/src/exchange/error.test.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import {
   CompleteExchangeError,
   convertTransportError,

--- a/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { firstValueFrom, from, Observable } from "rxjs";
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 
 import { delay } from "../../../promise";
 import {

--- a/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
+++ b/libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts
@@ -3,7 +3,7 @@ import network from "@ledgerhq/live-network";
 import { fetchCurrencyTo } from "../fetchCurrencyTo";
 import { fetchCurrencyToMock } from "../__mocks__/fetchCurrencyTo.mocks";
 import { DEFAULT_SWAP_TIMEOUT_MS } from "../../../const/timeout";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "../../../../../errors";
 import { flattenV5CurrenciesToAndFrom } from "../../../utils/flattenV5CurrenciesToAndFrom";
 
 jest.mock("@ledgerhq/live-network/network");

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
@@ -1,10 +1,4 @@
-import { TransportStatusError } from "@ledgerhq/errors";
-import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
-import { CompleteExchangeError } from "../error";
-import {
-  enrichSwapDeserializationError,
-  shouldForceZeroAmountForDexSwap,
-} from "./completeExchange";
+import { shouldForceZeroAmountForDexSwap } from "./completeExchange";
 
 describe("shouldForceZeroAmountForDexSwap", () => {
   const base = {
@@ -23,59 +17,5 @@ describe("shouldForceZeroAmountForDexSwap", () => {
     ["non-Arc native coin without sub-account", {}, false],
   ])("%s", (_case, params, expected) => {
     expect(shouldForceZeroAmountForDexSwap({ ...base, ...params })).toBe(expected);
-  });
-});
-
-describe("enrichSwapDeserializationError", () => {
-  // Minimal NewTransactionResponse protobuf with only payin_extra_id (field 2) = 40 * "a",
-  // which is above the device's 19-byte usable limit for that field.
-  const payloadWithOversizedExtraId = "1228" + "61".repeat(40);
-
-  it("enriches a device DESERIALIZATION_FAILED with the precise offending field", () => {
-    const deviceError = new TransportStatusError(ErrorStatus.DESERIALIZATION_FAILED);
-
-    const result = enrichSwapDeserializationError(
-      "PROCESS_TRANSACTION",
-      payloadWithOversizedExtraId,
-      deviceError,
-    );
-
-    expect(result).toBeInstanceOf(CompleteExchangeError);
-    // Title stays the device error's translation key so the user-facing copy is unchanged;
-    // the precise field only enriches the message (logs/analytics).
-    expect(result).toMatchObject({
-      step: "PROCESS_TRANSACTION",
-      title: "deserializationFailed",
-    });
-    expect(result?.message).toContain("payin_extra_id");
-  });
-
-  it("returns undefined for a DESERIALIZATION_FAILED when no field violation is found", () => {
-    const deviceError = new TransportStatusError(ErrorStatus.DESERIALIZATION_FAILED);
-    // Payload cannot be decoded locally -> defer to the device's generic error.
-    expect(
-      enrichSwapDeserializationError("PROCESS_TRANSACTION", "0aff", deviceError),
-    ).toBeUndefined();
-  });
-
-  it("returns undefined for unrelated device status codes", () => {
-    const deviceError = new TransportStatusError(ErrorStatus.INVALID_ADDRESS);
-    expect(
-      enrichSwapDeserializationError(
-        "CHECK_REFUND_ADDRESS",
-        payloadWithOversizedExtraId,
-        deviceError,
-      ),
-    ).toBeUndefined();
-  });
-
-  it("returns undefined for non-transport errors", () => {
-    expect(
-      enrichSwapDeserializationError(
-        "PROCESS_TRANSACTION",
-        payloadWithOversizedExtraId,
-        new Error("boom"),
-      ),
-    ).toBeUndefined();
   });
 });

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -1,17 +1,16 @@
 import type { Account } from "@ledgerhq/types-live";
+import { DisconnectedDeviceDuringOperation } from "@ledgerhq/hw-transport/errors";
 import {
-  DisconnectedDeviceDuringOperation,
   WrongDeviceForAccountPayout,
   WrongDeviceForAccountRefund,
-} from "@ledgerhq/errors";
+  TransactionRefusedOnDevice,
+} from "../../errors";
 import {
   createExchange,
   ExchangeTypes,
-  findSwapPayloadSpecViolation,
   getExchangeErrorMessage,
   PayloadSignatureComputedFormat,
 } from "@ledgerhq/hw-app-exchange";
-import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
@@ -21,11 +20,10 @@ import { secp256k1 } from "@noble/curves/secp256k1";
 import { getCurrencyExchangeConfig } from "../";
 import { getAccountCurrency, getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
-import { TransactionRefusedOnDevice } from "../../errors";
 import { handleHederaTrustedFlow } from "../../families/hedera/exchange";
 import { withDevicePromise } from "../../hw/deviceAccess";
 import { delay } from "../../promise";
-import { CompleteExchangeError, CompleteExchangeStep, convertTransportError } from "../error";
+import { CompleteExchangeStep, convertTransportError } from "../error";
 import type { CompleteExchangeInputSwap, CompleteExchangeRequestEvent } from "../platform/types";
 import { convertToAppExchangePartnerKey, getSwapProvider } from "../providers";
 import { CEXProviderConfig } from "../providers/swap";
@@ -51,37 +49,6 @@ export function shouldForceZeroAmountForDexSwap({
 }): boolean {
   if (!isDex || family !== "evm") return false;
   return hasSubAccountId || ARC_CURRENCY_IDS.has(fromCurrencyId);
-}
-
-/**
- * Device stays the source of truth: only once it rejects the payload with a generic
- * DESERIALIZATION_FAILED (0x6a81) do we decode it locally to name the field that exceeds
- * its limit. We keep the device error's title (a translation key, so the user-facing copy
- * stays unchanged) and only enrich the message with the precise field for logs/analytics.
- * Returns undefined when the error is unrelated or no violation can be pinpointed, so callers
- * fall back to the device error. See LIVE-34253.
- */
-export function enrichSwapDeserializationError(
-  step: CompleteExchangeStep,
-  binaryPayload: string,
-  error: unknown,
-): CompleteExchangeError | undefined {
-  // Duck-type on `name` + `statusCode` rather than `instanceof TransportStatusError`, matching
-  // the rest of this file and the repo-wide migration off `@ledgerhq/errors` class checks (#19849,
-  // which dropped the `TransportStatusError` import from here).
-  const transportErr = error as { name?: string; statusCode?: number } | null | undefined;
-  if (
-    transportErr?.name !== "TransportStatusError" ||
-    transportErr?.statusCode !== ErrorStatus.DESERIALIZATION_FAILED
-  ) {
-    return undefined;
-  }
-
-  const violation = findSwapPayloadSpecViolation(binaryPayload);
-  if (!violation) return undefined;
-
-  const { errorName } = getExchangeErrorMessage(transportErr.statusCode, step);
-  return new CompleteExchangeError(step, errorName, violation.message);
 }
 
 const completeExchange = (
@@ -363,9 +330,6 @@ const completeExchange = (
         ) {
           throw new TransactionRefusedOnDevice();
         }
-
-        const enrichedError = enrichSwapDeserializationError(currentStep, binaryPayload, e);
-        if (enrichedError) throw enrichedError;
 
         throw convertTransportError(currentStep, e);
       });

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.test.ts
@@ -3,7 +3,9 @@
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
 import { renderHook } from "@testing-library/react";
-import { AmountRequired, NotEnoughGas, NotEnoughGasSwap } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughGasSwap } from "../../../errors";
+import { NotEnoughGas } from "@ledgerhq/coin-evm/errors";
 
 import { useFromAmountStatusMessage } from "./useSwapTransaction";
 import type { Result } from "../../../bridge/useBridgeTransaction";

--- a/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
+++ b/libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts
@@ -1,6 +1,6 @@
 import { getAccountCurrency, getFeesUnit } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/index";
-import { NotEnoughBalanceSwap, NotEnoughGasSwap } from "@ledgerhq/errors";
+import { NotEnoughBalanceSwap, NotEnoughGasSwap } from "../../../errors";
 import { Account } from "@ledgerhq/types-live";
 import { useEffect, useMemo, useState } from "react";
 import useBridgeTransaction, { Result } from "../../../bridge/useBridgeTransaction";

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
 [
   {
-    "balance": "6004075",
+    "balance": "5966006",
     "currencyId": "cosmos",
     "derivationMode": "",
     "freshAddress": "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
@@ -12,7 +12,7 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "2219122",
+    "spendableBalance": "2181053",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
@@ -448,6 +448,27 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "161",
       "type": "OUT",
       "value": "1001200",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32182060,
+      "extra": {
+        "memo": "🔔 https://atomsdex.com: Congrats🎉 You are eligible to claim up to 10,000 $ATOM Rewards, check and claim your allocation now on https://atomsdex.com ✅",
+      },
+      "fee": "626",
+      "hasFailed": false,
+      "hash": "1141DE03EB2722E096184DCE9F8B1E7DCDB7589C2A052C7EC01EDE6CDF79BDE4",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-1141DE03EB2722E096184DCE9F8B1E7DCDB7589C2A052C7EC01EDE6CDF79BDE4-IN",
+      "recipients": [
+        "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
+      ],
+      "senders": [
+        "cosmos16te3v5hp96hz24f8ct5hfal29udpu0h7w8dfap",
+      ],
+      "transactionSequenceNumber": "275943",
+      "type": "IN",
+      "value": "1",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -2045,6 +2066,30 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "221",
       "type": "OUT",
       "value": "2752",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32177034,
+      "extra": {
+        "memo": "Ledger Live",
+        "sourceValidator": "cosmosvaloper1tflk30mq5vgqjdly92kkhhq3raev2hnz6eete3",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "15450",
+          },
+        ],
+      },
+      "fee": "26647",
+      "hasFailed": false,
+      "hash": "55683492340776DB8CCFBCA1F5DFA1D7C75B2AAF9B95961B51FAA2FC351B39CC",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-55683492340776DB8CCFBCA1F5DFA1D7C75B2AAF9B95961B51FAA2FC351B39CC-REDELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "276",
+      "type": "REDELEGATE",
+      "value": "26647",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -3940,6 +3985,30 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "80",
       "type": "OUT",
       "value": "103791",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32177052,
+      "extra": {
+        "memo": "Ledger Live",
+        "sourceValidator": "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "827539",
+          },
+        ],
+      },
+      "fee": "25149",
+      "hasFailed": false,
+      "hash": "B58678F8E6FDAF9E96C76F653DCA0F2967221832F98FBCA22ED8BE81C46B1098",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-B58678F8E6FDAF9E96C76F653DCA0F2967221832F98FBCA22ED8BE81C46B1098-REDELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "277",
+      "type": "REDELEGATE",
+      "value": "25149",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",

--- a/libs/ledger-wallet-framework/src/errors.ts
+++ b/libs/ledger-wallet-framework/src/errors.ts
@@ -1,7 +1,206 @@
 export class UnsupportedDerivation extends Error {
   override name = "UnsupportedDerivation";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedDerivation");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AccountNotSupported extends Error {
+  override name = "AccountNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AccountNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AmountRequired extends Error {
+  override name = "AmountRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AmountRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class DeviceAppVerifyNotSupported extends Error {
+  override name = "DeviceAppVerifyNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DeviceAppVerifyNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeNotLoaded extends Error {
+  override name = "FeeNotLoaded";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeNotLoaded");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeTooHigh extends Error {
+  override name = "FeeTooHigh";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddressBecauseDestinationIsAlsoSource extends Error {
+  override name = "InvalidAddressBecauseDestinationIsAlsoSource";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddressBecauseDestinationIsAlsoSource");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidTransactionError extends Error {
+  override name = "InvalidTransactionError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidTransactionError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LockedDeviceError extends Error {
+  override name = "LockedDeviceError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LockedDeviceError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  [key: string]: unknown;
   constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "UnsupportedDerivation", options);
+    super(message || "NotEnoughBalance", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceBecauseDestinationNotCreated extends Error {
+  override name = "NotEnoughBalanceBecauseDestinationNotCreated";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceBecauseDestinationNotCreated");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceFees extends Error {
+  override name = "NotEnoughBalanceFees";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NotEnoughBalanceFees", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceInParentAccount extends Error {
+  override name = "NotEnoughBalanceInParentAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceInParentAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughSpendableBalance extends Error {
+  override name = "NotEnoughSpendableBalance";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughSpendableBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeRequired extends Error {
+  override name = "FeeRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecipientRequired extends Error {
+  override name = "RecipientRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecipientRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedOnDevice");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WrongDeviceForAccount extends Error {
+  override name = "WrongDeviceForAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceToDelegate extends Error {
+  override name = "NotEnoughBalanceToDelegate";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceToDelegate");
     if (fields) Object.assign(this, fields);
   }
 }

--- a/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
@@ -9,6 +9,5 @@
   "ignoreUnresolved": [
     "@jest/expect-utils",
     "@jest/get-type",
-    "jest-util"],
-  "ignoreUnimported": []
+    "jest-util"]
 }

--- a/libs/ledgerjs/packages/hw-app-eth/package.json
+++ b/libs/ledgerjs/packages/hw-app-eth/package.json
@@ -30,7 +30,6 @@
     "@ethersproject/rlp": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ledgerhq/domain-service": "workspace:^",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/evm-tools": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-mocker": "workspace:^",

--- a/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
@@ -1,9 +1,18 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const EthAppPleaseEnableContractData = createCustomErrorClass(
-  "EthAppPleaseEnableContractData",
-);
-export const EthAppNftNotSupported = createCustomErrorClass("EthAppNftNotSupported");
-export const CeloAppPleaseEnableContractData = createCustomErrorClass(
-  "CeloAppPleaseEnableContractData",
-);
+export class EthAppPleaseEnableContractData extends Error {
+  override name = "EthAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "EthAppPleaseEnableContractData");
+  }
+}
+export class EthAppNftNotSupported extends Error {
+  override name = "EthAppNftNotSupported";
+  constructor(message?: string) {
+    super(message || "EthAppNftNotSupported");
+  }
+}
+export class CeloAppPleaseEnableContractData extends Error {
+  override name = "CeloAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "CeloAppPleaseEnableContractData");
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-exchange/package.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/package.json
@@ -26,7 +26,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.2",

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -39,47 +39,83 @@ We have written corresponding classes for exceptions that developers should acti
 #### Table of Contents
 
 *   [StellarHashSigningNotEnabledError](#stellarhashsigningnotenablederror)
-*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
-*   [StellarUserRefusedError](#stellaruserrefusederror)
-*   [StellarDataTooLargeError](#stellardatatoolargeerror)
-*   [Str](#str)
     *   [Parameters](#parameters)
+*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
+    *   [Parameters](#parameters-1)
+*   [StellarUserRefusedError](#stellaruserrefusederror)
+    *   [Parameters](#parameters-2)
+*   [StellarDataTooLargeError](#stellardatatoolargeerror)
+    *   [Parameters](#parameters-3)
+*   [Str](#str)
+    *   [Parameters](#parameters-4)
     *   [Examples](#examples)
     *   [getAppConfiguration](#getappconfiguration)
         *   [Examples](#examples-1)
     *   [getPublicKey](#getpublickey)
-        *   [Parameters](#parameters-1)
+        *   [Parameters](#parameters-5)
         *   [Examples](#examples-2)
     *   [signTransaction](#signtransaction)
-        *   [Parameters](#parameters-2)
+        *   [Parameters](#parameters-6)
         *   [Examples](#examples-3)
     *   [signSorobanAuthorization](#signsorobanauthorization)
-        *   [Parameters](#parameters-3)
+        *   [Parameters](#parameters-7)
         *   [Examples](#examples-4)
     *   [signHash](#signhash)
-        *   [Parameters](#parameters-4)
+        *   [Parameters](#parameters-8)
         *   [Examples](#examples-5)
     *   [signMessage](#signmessage)
-        *   [Parameters](#parameters-5)
+        *   [Parameters](#parameters-9)
         *   [Examples](#examples-6)
 
 ### StellarHashSigningNotEnabledError
 
+**Extends Error**
+
 Error thrown when hash signing is not enabled on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataParsingFailedError
+
+**Extends Error**
 
 Error thrown when data parsing fails.
 
 For example, when parsing the transaction fails, this error is thrown.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarUserRefusedError
+
+**Extends Error**
 
 Error thrown when the user refuses the request on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataTooLargeError
 
+**Extends Error**
+
 Error thrown when the data is too large to be processed by the device.
+
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
 
 ### Str
 

--- a/libs/ledgerjs/packages/hw-app-str/package.json
+++ b/libs/ledgerjs/packages/hw-app-str/package.json
@@ -27,7 +27,6 @@
   "types": "lib/Str.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "bip32-path": "^0.4.2"
   },

--- a/libs/ledgerjs/packages/hw-app-str/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-str/src/errors.ts
@@ -1,27 +1,45 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /**
  * Error thrown when hash signing is not enabled on the device.
  */
-export const StellarHashSigningNotEnabledError = createCustomErrorClass(
-  "StellarHashSigningNotEnabledError",
-);
+export class StellarHashSigningNotEnabledError extends Error {
+  override name = "StellarHashSigningNotEnabledError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarHashSigningNotEnabledError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when data parsing fails.
  *
  * For example, when parsing the transaction fails, this error is thrown.
  */
-export const StellarDataParsingFailedError = createCustomErrorClass(
-  "StellarDataParsingFailedError",
-);
+export class StellarDataParsingFailedError extends Error {
+  override name = "StellarDataParsingFailedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataParsingFailedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the user refuses the request on the device.
  */
-export const StellarUserRefusedError = createCustomErrorClass("StellarUserRefusedError");
+export class StellarUserRefusedError extends Error {
+  override name = "StellarUserRefusedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarUserRefusedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the data is too large to be processed by the device.
  */
-export const StellarDataTooLargeError = createCustomErrorClass("StellarDataTooLargeError");
+export class StellarDataTooLargeError extends Error {
+  override name = "StellarDataTooLargeError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataTooLargeError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
+++ b/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
@@ -6,7 +6,7 @@ import {
   StellarUserRefusedError,
   StellarDataTooLargeError,
 } from "../src/errors";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport";
 
 test("getAppConfiguration (hash signing disabled)", async () => {
   const transport = await openTransportReplayer(

--- a/libs/ledgerjs/packages/hw-app-str/tsconfig.json
+++ b/libs/ledgerjs/packages/hw-app-str/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
@@ -1,3 +1,4 @@
 {
-  "entry": ["src/Sui.ts"]
+  "entry": ["src/Sui.ts"],
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
@@ -1,0 +1,7 @@
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-vet/package.json
+++ b/libs/ledgerjs/packages/hw-app-vet/package.json
@@ -26,7 +26,6 @@
   "main": "lib/Vet.js",
   "module": "lib-es/Vet.js",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-mocker": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
@@ -55,5 +54,22 @@
     "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
-  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec"
+  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec",
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/Vet.ts",
+      "import": "./lib-es/Vet.js",
+      "require": "./lib/Vet.js",
+      "default": "./lib/Vet.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "import": "./lib-es/*.js",
+      "require": "./lib/*.js",
+      "default": "./lib/*.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
@@ -1,5 +1,6 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const VechainAppPleaseEnableContractDataAndMultiClause = createCustomErrorClass(
-  "VechainAppPleaseEnableContractDataAndMultiClause",
-);
+export class VechainAppPleaseEnableContractDataAndMultiClause extends Error {
+  override name = "VechainAppPleaseEnableContractDataAndMultiClause";
+  constructor(message?: string) {
+    super(message || "VechainAppPleaseEnableContractDataAndMultiClause");
+  }
+}

--- a/libs/wallet-btc/src/errors.ts
+++ b/libs/wallet-btc/src/errors.ts
@@ -1,9 +1,38 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // wallet-btc domain errors. Re-exported by @ledgerhq/coin-bitcoin for
 // backward compatibility (see coin-bitcoin/src/errors.ts).
-export const AccountNeedResync = createCustomErrorClass("AccountNeedResync");
+export class AccountNeedResync extends Error {
+  override name = "AccountNeedResync";
+  constructor(message?: string) {
+    super(message || "AccountNeedResync");
+  }
+}
 
-export const RbfBuildError = createCustomErrorClass("RbfBuildError");
+export class RbfBuildError extends Error {
+  override name = "RbfBuildError";
+  constructor(message?: string) {
+    super(message || "RbfBuildError");
+  }
+}
 
-export const UnsupportedDerivation = createCustomErrorClass("UnsupportedDerivation");
+export class UnsupportedDerivation extends Error {
+  override name = "UnsupportedDerivation";
+  constructor(message?: string) {
+    super(message || "UnsupportedDerivation");
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10322,9 +10322,6 @@ importers:
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../../../domain-service
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/evm-tools':
         specifier: workspace:^
         version: link:../../../evm-tools
@@ -10827,9 +10824,6 @@ importers:
 
   libs/ledgerjs/packages/hw-app-str:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -11002,9 +10996,6 @@ importers:
 
   libs/ledgerjs/packages/hw-app-vet:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport


### PR DESCRIPTION
## Summary

Phase 2 migration of `@ledgerhq/errors` imports to native error classes for PTX-owned files.

- Migrates exchange, swap, and hw-app-exchange files away from `@ledgerhq/errors`
- Part of LIVE-32915 errors sunset initiative
- Stacked on #20062

## Files changed

- `apps/ledger-live-desktop/src/renderer/modals/Platform/Exchange/CompleteExchange/Body.tsx`
- `apps/ledger-live-mobile/src/components/WebPTXPlayer/CustomHandlers.ts`
- `libs/ledger-live-common/src/exchange/error.test.ts`
- `libs/ledger-live-common/src/exchange/platform/transfer/completeExchange.ts`
- `libs/ledger-live-common/src/exchange/swap/api/v5/__tests__/fetchCurrencyTo.spec.ts`
- `libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts`
- `libs/ledger-live-common/src/exchange/swap/completeExchange.ts`
- `libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.test.ts`
- `libs/ledger-live-common/src/exchange/swap/hooks/useSwapTransaction.ts`
- `libs/ledgerjs/packages/hw-app-exchange/package.json`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)