### PR TITLE
[LWDM] chore(LIVE-32915): migrate @ledgerhq/errors imports — ledger-third-party-leads

### DIFF
--- a/apps/ledger-live-desktop/tsconfig.json
+++ b/apps/ledger-live-desktop/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "esnext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "customConditions": ["@ledgerhq/source"],
     "rootDir": ".",
     "paths": {
       "*": ["./*"],

--- a/libs/coin-modules/coin-aleo/.unimportedrc.json
+++ b/libs/coin-modules/coin-aleo/.unimportedrc.json
@@ -27,6 +27,7 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",
-    "@ledgerhq/live-env"
+    "@ledgerhq/live-env",
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-aleo/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aleo/src/api/index.test.ts
@@ -1,9 +1,9 @@
+import { InvalidParameterError } from "@ledgerhq/errors";
 import type {
   BalanceOptions,
   MemoNotSupported,
   TransactionIntent,
 } from "@ledgerhq/coin-module-framework/api/types";
-import { InvalidParameterError } from "@ledgerhq/errors";
 import { getMockedConfig } from "../__tests__/fixtures/config.fixture";
 import { getMockedCoinFrameworkOperation } from "../__tests__/fixtures/operation.fixture";
 import coinConfig from "../config";

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.test.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   getMockedAccount,
   getMockedTokenAccount,

--- a/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aleo/src/bridge/getTransactionStatus.ts
@@ -5,7 +5,7 @@ import {
   NotEnoughBalance,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import type {

--- a/libs/coin-modules/coin-aleo/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/network/utils.test.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 import { AleoApiConfigurationResetError } from "../errors";
 import {
   EXPLORER_TRANSFER_TYPES,

--- a/libs/coin-modules/coin-aptos/.unimportedrc.json
+++ b/libs/coin-modules/coin-aptos/.unimportedrc.json
@@ -16,7 +16,8 @@
     "@ledgerhq/devices",
     "@ledgerhq/types-cryptoassets",
     "invariant",
-    "got"
+    "got",
+    "@ledgerhq/errors"
   ],
   "ignoreUnimported": [
     "src/bridge/bridge.fixture.ts",

--- a/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-aptos/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -5,11 +5,9 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   NotEnoughBalanceFees,
-  NotEnoughToRestake,
-  NotEnoughToStake,
-  NotEnoughToUnstake,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotEnoughToRestake, NotEnoughToStake, NotEnoughToUnstake } from "../../errors";
 import BigNumber from "bignumber.js";
 import {
   createFixtureAccount,

--- a/libs/coin-modules/coin-aptos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-aptos/src/api/index.test.ts
@@ -1,5 +1,5 @@
-import { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { InvalidParameterError } from "@ledgerhq/errors";
+import { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { createApi } from ".";
 import type { AptosConfig as AptosConfigApi } from "../config";
 

--- a/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-aptos/src/bridge/getTransactionStatus.ts
@@ -1,18 +1,20 @@
 import { AccountAddress } from "@aptos-labs/ts-sdk";
 import {
   NotEnoughBalance,
-  NotEnoughToStake,
-  UnstakeNotEnoughStakedBalanceLeft,
-  RestakeNotEnoughStakedBalanceLeft,
-  NotEnoughToRestake,
-  NotEnoughToUnstake,
   RecipientRequired,
   InvalidAddress,
   FeeNotLoaded,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalanceFees,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
+  NotEnoughToStake,
+  NotEnoughToUnstake,
+  NotEnoughToRestake,
+  UnstakeNotEnoughStakedBalanceLeft,
+  RestakeNotEnoughStakedBalanceLeft,
+} from "../errors";
 import { TokenAccount } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-bitcoin/src/errors.ts
+++ b/libs/coin-modules/coin-bitcoin/src/errors.ts
@@ -62,3 +62,19 @@ export class ZcashUtxoNotInAccount extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class DustLimit extends Error {
+  override name = "DustLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DustLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class OpReturnDataSizeLimit extends Error {
+  override name = "OpReturnDataSizeLimit";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "OpReturnDataSizeLimit");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-canton/package.json
+++ b/libs/coin-modules/coin-canton/package.json
@@ -52,10 +52,18 @@
         "lib/signer/*",
         "lib/test/*",
         "lib/types/*"
+      ],
+      "errors": [
+        "./src/errors.ts"
       ]
     }
   },
   "exports": {
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./lib/*": "./lib/*.js",
     "./lib-es/*": "./lib-es/*.js",
     "./api": {

--- a/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughSpendableBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import coinConfig from "../config";
 import * as gateway from "../network/gateway";

--- a/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/getTransactionStatus.ts
@@ -9,7 +9,7 @@ import {
   NotEnoughBalanceInParentAccount,
   NotEnoughSpendableBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { isRecipientValid } from "../common-logic/utils";

--- a/libs/coin-modules/coin-canton/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/onboard.ts
@@ -1,4 +1,5 @@
-import { UserRefusedOnDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { LockedDeviceError } from "../errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";

--- a/libs/coin-modules/coin-canton/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-canton/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";

--- a/libs/coin-modules/coin-canton/src/network/gateway.test.ts
+++ b/libs/coin-modules/coin-canton/src/network/gateway.test.ts
@@ -1,6 +1,6 @@
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import coinConfig from "../config";
 import {
   createMockCantonCurrency,

--- a/libs/coin-modules/coin-canton/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-canton/src/test/bridgeDatasetTest.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/accountId";
 import { DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-cardano/.unimportedrc.json
+++ b/libs/coin-modules/coin-cardano/.unimportedrc.json
@@ -33,6 +33,9 @@
   "ignoreUnresolved": [
     "@jest/expect-utils",
     "@jest/get-type",
-    "jest-util"],
-  "ignoreUnused": []
+    "jest-util"
+  ],
+  "ignoreUnused": [
+    "@ledgerhq/errors"
+  ]
 }

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/delegate.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/delegate.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import { buildTransaction } from "../buildTransaction";
 import {

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/getTransactionStatus.ts
@@ -1,16 +1,16 @@
-import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
+import {
+  AccountAwaitingSendPendingOperations,
+  CardanoFeeHigh,
+  CardanoFeeTooHigh,
+  CardanoMemoExceededSizeError,
+  CardanoNotEnoughFunds,
+} from "../errors";
 import { AddressesSanctionedError } from "@ledgerhq/ledger-wallet-framework/sanction/errors";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import coinConfig from "../config";
-import {
-  CardanoNotEnoughFunds,
-  CardanoFeeTooHigh,
-  CardanoFeeHigh,
-  CardanoMemoExceededSizeError,
-} from "../errors";
 import { validateMemo } from "../logic/validateMemo";
 import type { CardanoAccount, CardanoOutput, Transaction, TransactionStatus } from "../types";
 import { getTransactionStatusByTransactionMode } from "./handler";

--- a/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
+++ b/libs/coin-modules/coin-cardano/src/getTransactionStatus/send.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import { BigNumber } from "bignumber.js";
 import { decodeTokenAssetId, decodeTokenCurrencyId } from "../buildSubAccounts";

--- a/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-cardano/src/logic/validateIntent.ts
@@ -15,14 +15,13 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-  ValAddressRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { utils as TyphonUtils } from "@stricahq/typhonjs";
 import BigNumber from "bignumber.js";
 import { fetchNetworkInfo } from "../api/getNetworkInfo";
 import { CARDANO_MAX_SUPPLY } from "../constants";
-import { CardanoMemoExceededSizeError, CardanoMinAmountError } from "../errors";
+import { CardanoMemoExceededSizeError, CardanoMinAmountError, ValAddressRequired } from "../errors";
 import { getPaymentCredentialKeyHash, isTestnet, isTokenAsset, isValidAddress } from "../logic";
 import { validateMemo } from "./validateMemo";
 

--- a/libs/coin-modules/coin-cardano/src/signOperation.ts
+++ b/libs/coin-modules/coin-cardano/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge, SignOperationEvent } from "@ledgerhq/types-live";
 import { Bip32PublicKey } from "@stricahq/bip32ed25519";

--- a/libs/coin-modules/coin-casper/.unimportedrc.json
+++ b/libs/coin-modules/coin-casper/.unimportedrc.json
@@ -23,7 +23,9 @@
     "jest-message-util",
     "@ledgerhq/types-cryptoassets"
   ],
-  "ignoreUnused": [],
+  "ignoreUnused": [
+    "@ledgerhq/errors"
+  ],
   "ignoreUnimported": [
     "src/hw-signMessage.ts",
     "src/supportedFeatures.ts"

--- a/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/bridgeHelpers/txn.ts
@@ -1,5 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { log } from "@ledgerhq/logs";
 import { Unit } from "@ledgerhq/ledger-wallet-framework/types";

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.test.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import {
   CASPER_MINIMUM_VALID_AMOUNT_MOTES,

--- a/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-casper/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-casper/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { AmountRequired, InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  AmountRequired,
+  InvalidAddress,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getEstimatedFees } from "../bridge/bridgeHelpers/fee";

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/scanResilience.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/scanResilience.test.ts
@@ -1,4 +1,4 @@
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "@ledgerhq/ledger-wallet-framework/errors";
 import { buildResilientIterateResult, isUpdateYourAppError } from "../../bridge/scanResilience";
 
 describe("isUpdateYourAppError", () => {

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import type { SignOperationEvent } from "@ledgerhq/types-live";
 import { accountFixture, transactionFixture } from "../../bridge/fixtures";

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -8,7 +8,7 @@ import {
   NotEnoughBalance,
   NotEnoughBalanceFees,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";

--- a/libs/coin-modules/coin-celo/src/bridge/scanResilience.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/scanResilience.ts
@@ -1,7 +1,7 @@
 import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import type { IterateResultBuilder } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { runDerivationScheme } from "@ledgerhq/ledger-wallet-framework/derivation";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "@ledgerhq/ledger-wallet-framework/errors";
 
 /**
  * The signer's "can't authorize this path" signal. The signer owns the

--- a/libs/coin-modules/coin-celo/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/signOperation.ts
@@ -1,5 +1,5 @@
 import { CeloSignature } from "../signer/signer";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, AccountBridge, DeviceId, SignOperationEvent } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-celo/src/datasets/celo.scanAccounts.1.ts
+++ b/libs/coin-modules/coin-celo/src/datasets/celo.scanAccounts.1.ts
@@ -3,7 +3,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountRaw, CurrenciesData, TransactionStatusCommon } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import TransactionModule from "../bridge/transaction";

--- a/libs/coin-modules/coin-concordium/package.json
+++ b/libs/coin-modules/coin-concordium/package.json
@@ -73,10 +73,18 @@
         "lib/signer/*",
         "lib/test/*",
         "lib/types/*"
+      ],
+      "errors": [
+        "./src/errors.ts"
       ]
     }
   },
   "exports": {
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
+    },
     "./lib/*": "./lib/*.js",
     "./lib-es/*": "./lib-es/*.js",
     "./api": {
@@ -173,8 +181,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/coin-module-framework": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/concordium-core": "workspace:^",
+    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
@@ -189,6 +197,7 @@
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",

--- a/libs/coin-modules/coin-concordium/src/api/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.test.ts
@@ -1,5 +1,5 @@
-import { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { InvalidParameterError } from "@ledgerhq/errors";
+import { BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
 import { TESTNET_COIN_CONFIG, VALID_ADDRESS } from "../test/fixtures";
 import { createApi } from ".";
 

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.test.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { MAX_MEMO_LENGTH } from "@ledgerhq/concordium-core";
 import {

--- a/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { MAX_MEMO_LENGTH, AccountAddress } from "@ledgerhq/concordium-core";

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.integ.test.ts
@@ -1,4 +1,4 @@
-import { ConcordiumSessionExpiredError } from "@ledgerhq/errors";
+import { ConcordiumSessionExpiredError } from "../types";
 import { firstValueFrom, toArray } from "rxjs";
 import coinConfig from "../config";
 import { submitCredential } from "../network/proxyClient";

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.test.ts
@@ -1,9 +1,6 @@
-import {
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-  TransportStatusError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { LockedDeviceError, TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ConcordiumSessionExpiredError } from "../types";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountOnboardStatus, ConcordiumPairingStatus } from "../types";
 import {

--- a/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/onboard.ts
@@ -1,10 +1,7 @@
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import {
-  ConcordiumPairingExpiredError,
-  ConcordiumSessionExpiredError,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { LockedDeviceError } from "../errors";
+import { ConcordiumPairingExpiredError, ConcordiumSessionExpiredError } from "../types/errors";
 import { log } from "@ledgerhq/logs";
 import type { Account } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { firstValueFrom, toArray } from "rxjs";
 import { AccountAddress } from "@ledgerhq/concordium-core";

--- a/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-concordium/src/bridge/signOperation.ts
@@ -1,6 +1,6 @@
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { AccountBridge, Operation } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { Observable } from "rxjs";

--- a/libs/coin-modules/coin-concordium/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-concordium/src/test/bridgeDatasetTest.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { DatasetTest } from "@ledgerhq/types-live";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import { fromTransactionRaw } from "../bridge/transaction";
 import { Transaction } from "../types";
 

--- a/libs/coin-modules/coin-cosmos/src/errors.ts
+++ b/libs/coin-modules/coin-cosmos/src/errors.ts
@@ -45,3 +45,27 @@ export class CosmosTooManyRedelegations extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class SequenceNumberError extends Error {
+  override name = "SequenceNumberError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "SequenceNumberError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ExpertModeRequired extends Error {
+  override name = "ExpertModeRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ExpertModeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecommendUndelegation extends Error {
+  override name = "RecommendUndelegation";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecommendUndelegation");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-evm/src/errors.ts
+++ b/libs/coin-modules/coin-evm/src/errors.ts
@@ -139,3 +139,84 @@ export class NotEnoughNftOwned extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+// Transaction validation
+export class GasLessThanEstimate extends Error {
+  override name = "GasLessThanEstimate";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GasLessThanEstimate");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooLow extends Error {
+  override name = "PriorityFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeTooHigh extends Error {
+  override name = "PriorityFeeTooHigh";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PriorityFeeHigherThanMaxFee extends Error {
+  override name = "PriorityFeeHigherThanMaxFee";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "PriorityFeeHigherThanMaxFee");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaxFeeTooLow extends Error {
+  override name = "MaxFeeTooLow";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaxFeeTooLow");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ETHAddressNonEIP extends Error {
+  override name = "ETHAddressNonEIP";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ETHAddressNonEIP");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RedelegateDstValAddressRequired extends Error {
+  override name = "RedelegateDstValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RedelegateDstValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ValAddressRequired extends Error {
+  override name = "ValAddressRequired";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ValAddressRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class ClaimRewardsFeesWarning extends Error {
+  override name = "ClaimRewardsFeesWarning";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "ClaimRewardsFeesWarning");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-filecoin/.unimportedrc.json
+++ b/libs/coin-modules/coin-filecoin/.unimportedrc.json
@@ -9,7 +9,8 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/cryptoassets",
-    "@ledgerhq/devices"
+    "@ledgerhq/devices",
+    "@ledgerhq/errors"
   ],
   "ignoreUnimported": [
     "src/bridge/deviceTransactionConfig.ts",

--- a/libs/coin-modules/coin-filecoin/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/estimateMaxSpendable.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddress,
   NotEnoughBalanceInParentAccount,
   NotEnoughSpendableBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-filecoin/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getAddress, getSubAccount } from "../common-logic";

--- a/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-filecoin/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
 import { Account, AccountBridge, Operation } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
+++ b/libs/coin-modules/coin-filecoin/src/erc20/tokenAccounts.ts
@@ -1,5 +1,5 @@
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { RecipientRequired } from "@ledgerhq/errors";
+import { RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   emptyHistoryCache,
   encodeTokenAccountId,

--- a/libs/coin-modules/coin-filecoin/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-filecoin/src/logic/validateIntent.ts
@@ -10,7 +10,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isRecipientValidForTokenTransfer, validateAddress } from "../network/addresses";
 
 function validateRecipient(

--- a/libs/coin-modules/coin-filecoin/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-filecoin/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { InvalidAddress, NotEnoughBalance, AmountRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  NotEnoughBalance,
+  AmountRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-hedera/.unimportedrc.json
+++ b/libs/coin-modules/coin-hedera/.unimportedrc.json
@@ -30,6 +30,7 @@
   "ignoreUnused": [
     "@ledgerhq/devices",
     "lodash",
-    "rxjs"
+    "rxjs",
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-hedera/src/api/index.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.test.ts
@@ -1,5 +1,5 @@
-import { BalanceOptions, TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import { InvalidParameterError } from "@ledgerhq/errors";
+import { BalanceOptions, TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
 import BigNumber from "bignumber.js";
 import coinConfig from "../config";
 import { HARDCODED_BLOCK_HEIGHT, HEDERA_OPERATION_TYPES } from "../constants";

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -3,9 +3,9 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   NotEnoughBalance,
-  ClaimRewardsFeesWarning,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { ClaimRewardsFeesWarning } from "../errors";
 import * as accountHelpers from "@ledgerhq/ledger-wallet-framework/account";
 import BigNumber from "bignumber.js";
 import { HEDERA_TRANSACTION_MODES } from "../constants";

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.ts
@@ -3,24 +3,24 @@ import {
   NotEnoughBalance,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import {
   ClaimRewardsFeesWarning,
-} from "@ledgerhq/errors";
+  HederaInsufficientFundsForAssociation,
+  HederaInvalidStakingNodeIdError,
+  HederaMemoExceededSizeError,
+  HederaNoStakingRewardsError,
+  HederaRecipientEvmAddressVerificationRequired,
+  HederaRecipientTokenAssociationRequired,
+  HederaRecipientTokenAssociationUnverified,
+  HederaRedundantStakingNodeIdError,
+} from "../errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account";
 import { getEnv } from "@ledgerhq/live-env";
 import type { Account, AccountBridge, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import invariant from "invariant";
 import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
-import {
-  HederaInsufficientFundsForAssociation,
-  HederaRecipientTokenAssociationRequired,
-  HederaRecipientTokenAssociationUnverified,
-  HederaRecipientEvmAddressVerificationRequired,
-  HederaInvalidStakingNodeIdError,
-  HederaRedundantStakingNodeIdError,
-  HederaNoStakingRewardsError,
-  HederaMemoExceededSizeError,
-} from "../errors";
 import { estimateFees } from "../logic/estimateFees";
 import {
   isTokenAssociateTransaction,

--- a/libs/coin-modules/coin-hedera/src/bridge/receive.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/receive.ts
@@ -1,4 +1,4 @@
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { isSegwitDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account, AccountBridge, DerivationMode } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import BigNumber from "bignumber.js";
 import hederaCoinConfig from "../config";
 import { HederaAddAccountError } from "../errors";

--- a/libs/coin-modules/coin-hedera/src/network/api.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/api.test.ts
@@ -1,4 +1,4 @@
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import network from "@ledgerhq/live-network";
 import BigNumber from "bignumber.js";
 import { resolveConfig } from "../logic/utils";

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -1,4 +1,4 @@
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getEnv } from "@ledgerhq/live-env";
 import BigNumber from "bignumber.js";
 import { HederaRecipientInvalidChecksum } from "../errors";

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -1,7 +1,7 @@
 import invariant from "invariant";
 import { AccountId, TransactionId } from "@hashgraph/sdk";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import cvsApi from "@ledgerhq/live-countervalues/api/index";
 import { getEnv } from "@ledgerhq/live-env";
 import { makeLRUCache, seconds } from "@ledgerhq/live-network/cache";

--- a/libs/coin-modules/coin-hedera/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-hedera/src/test/bridgeDatasetTest.ts
@@ -3,7 +3,7 @@ import {
   NotEnoughBalance,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import { HEDERA_TRANSACTION_MODES } from "../constants";
 import { fromTransactionRaw } from "../transaction";

--- a/libs/coin-modules/coin-internet_computer/.unimportedrc.json
+++ b/libs/coin-modules/coin-internet_computer/.unimportedrc.json
@@ -51,5 +51,8 @@
   ],
   "ignoreUnimported": [
     "src/supportedFeatures.ts"
+  ],
+  "ignoreUnused": [
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-internet_computer/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { validateAddress } from "../logic/validation";
 import BigNumber from "bignumber.js";

--- a/libs/coin-modules/coin-internet_computer/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-internet_computer/src/test/bridgeDatasetTest.ts
@@ -1,4 +1,8 @@
-import { AmountRequired, InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  AmountRequired,
+  InvalidAddress,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { getEstimatedFees } from "../bridge/bridgeHelpers/fee";

--- a/libs/coin-modules/coin-kaspa/.unimportedrc.json
+++ b/libs/coin-modules/coin-kaspa/.unimportedrc.json
@@ -92,6 +92,7 @@
     "lodash",
     "lru-cache",
     "prando",
-    "rxjs"
+    "rxjs",
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-kaspa/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-kaspa/src/bridge/getTransactionStatus.ts
@@ -1,13 +1,13 @@
 import {
   AmountRequired,
-  DustLimit,
   FeeNotLoaded,
   FeeRequired,
   FeeTooHigh,
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "../errors";
 import { makeLRUCache, minutes } from "@ledgerhq/live-network/cache";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-kaspa/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-kaspa/src/logic/validateIntent.ts
@@ -11,7 +11,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isValidKaspaAddress } from "./kaspaAddresses";
 
 // Fees are flagged "too high" once they exceed 1/RATIO of the sent amount (i.e. 10%),

--- a/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, Operation } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import * as logicValidateMemo from "../logic/validateMemo";

--- a/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   FeeNotLoaded,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { isValidAddress, getMaxAmount, getTotalSpent } from "../logic/utils";

--- a/libs/coin-modules/coin-mina/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { BigNumber } from "bignumber.js";
 import { firstValueFrom } from "rxjs";

--- a/libs/coin-modules/coin-mina/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-mina/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { FeeNotLoaded, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { encodeOperationId } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type {

--- a/libs/coin-modules/coin-mina/src/network/index.test.ts
+++ b/libs/coin-modules/coin-mina/src/network/index.test.ts
@@ -3,7 +3,7 @@ jest.mock("@ledgerhq/logs");
 jest.mock("../config");
 
 import { DeepPartial } from "@ledgerhq/coin-module-framework/test/utils";
-import { LedgerAPI5xx } from "@ledgerhq/errors";
+import { LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 import network from "@ledgerhq/live-network";
 import { getCoinConfig } from "../config";
 import {

--- a/libs/coin-modules/coin-mina/src/signer/getAddress.test.ts
+++ b/libs/coin-modules/coin-mina/src/signer/getAddress.test.ts
@@ -1,5 +1,5 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { DerivationMode } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-mina/src/signer/getAddress.ts
+++ b/libs/coin-modules/coin-mina/src/signer/getAddress.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { GetAddressOptions } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";

--- a/libs/coin-modules/coin-mina/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-mina/src/test/bridgeDatasetTest.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-near/.unimportedrc.json
+++ b/libs/coin-modules/coin-near/.unimportedrc.json
@@ -21,5 +21,8 @@
     "src/api/node.mock.ts",
     "src/test/bridge.dataset.ts",
     "src/supportedFeatures.ts"
+  ],
+  "ignoreUnused": [
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-near/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-near/src/getTransactionStatus.ts
@@ -7,7 +7,7 @@ import {
   FeeNotLoaded,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { fetchAccountDetails } from "./api";

--- a/libs/coin-modules/coin-near/src/signOperation.ts
+++ b/libs/coin-modules/coin-near/src/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";

--- a/libs/coin-modules/coin-near/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-near/src/test/bridge.dataset.ts
@@ -1,4 +1,7 @@
-import { InvalidAddressBecauseDestinationIsAlsoSource, NotEnoughBalance } from "@ledgerhq/errors";
+import {
+  InvalidAddressBecauseDestinationIsAlsoSource,
+  NotEnoughBalance,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { DatasetTest, CurrenciesData } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import {

--- a/libs/coin-modules/coin-solana/src/errors.ts
+++ b/libs/coin-modules/coin-solana/src/errors.ts
@@ -221,3 +221,11 @@ export class SolanaTokenNonTransferable extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class NetworkError extends Error {
+  override name = "NetworkError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NetworkError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-solana/tsconfig.json
+++ b/libs/coin-modules/coin-solana/tsconfig.json
@@ -5,7 +5,7 @@
     "noUnusedParameters": true,
     "declaration": true,
     "declarationMap": true,
-    "lib": ["es2020", "dom"],
+    "lib": ["ES2022", "dom"],
     "types": ["node", "jest"],
     "exactOptionalPropertyTypes": true,
     "outDir": "./lib",

--- a/libs/coin-modules/coin-stacks/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/getTransactionStatus.ts
@@ -5,7 +5,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { StacksMemoTooLong } from "../errors";

--- a/libs/coin-modules/coin-stacks/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-stacks/src/bridge/signOperation.ts
@@ -1,4 +1,5 @@
-import { FeeNotLoaded, InvalidAddress, InvalidNonce } from "@ledgerhq/errors";
+import { InvalidNonce } from "../errors";
+import { FeeNotLoaded, InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { AccountBridge } from "@ledgerhq/types-live";
 import invariant from "invariant";

--- a/libs/coin-modules/coin-stacks/src/test/bridgeDatasetTest.ts
+++ b/libs/coin-modules/coin-stacks/src/test/bridgeDatasetTest.ts
@@ -3,7 +3,7 @@ import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CurrenciesData } from "@ledgerhq/types-live";
 import type { DatasetTest } from "@ledgerhq/types-live";
 import { AnchorMode } from "@stacks/transactions";

--- a/libs/coin-modules/coin-sui/.unimportedrc.json
+++ b/libs/coin-modules/coin-sui/.unimportedrc.json
@@ -32,6 +32,7 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/live-env",
-    "@ledgerhq/types-cryptoassets"
+    "@ledgerhq/types-cryptoassets",
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-sui/src/api/index.test.ts
+++ b/libs/coin-modules/coin-sui/src/api/index.test.ts
@@ -1,5 +1,5 @@
-import { BalanceOptions, Page, Reward, Stake } from "@ledgerhq/coin-module-framework/api/types";
 import { InvalidParameterError } from "@ledgerhq/errors";
+import { BalanceOptions, Page, Reward, Stake } from "@ledgerhq/coin-module-framework/api/types";
 import type { SuiCoinConfig } from "../config";
 import * as logic from "../logic";
 import { createApi } from "./index";

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.test.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
   FeeNotLoaded,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 
 import BigNumber from "bignumber.js";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";

--- a/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/getTransactionStatus.ts
@@ -7,7 +7,7 @@ import {
   FeeNotLoaded,
   FeeTooHigh,
   InvalidAddress,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { isValidSuiAddress } from "@mysten/sui/utils";

--- a/libs/coin-modules/coin-sui/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/prepareTransaction.test.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { DEFAULT_COIN_TYPE } from "../network/sdk";
 import { createFixtureAccount, createFixtureTransaction } from "../types/bridge.fixture";

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.test.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { LedgerSigner } from "@mysten/signers/ledger";
 import { messageWithIntent as mockMessageWithIntent } from "@mysten/sui/cryptography";

--- a/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-sui/src/bridge/signOperation.ts
@@ -1,4 +1,4 @@
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { AccountBridge } from "@ledgerhq/types-live";
 import { LedgerSigner } from "@mysten/signers/ledger";

--- a/libs/coin-modules/coin-sui/src/logic/mapDryRunError.test.ts
+++ b/libs/coin-modules/coin-sui/src/logic/mapDryRunError.test.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import { mapDryRunError } from "./mapDryRunError";
 
 describe("mapDryRunError", () => {

--- a/libs/coin-modules/coin-sui/src/logic/mapDryRunError.ts
+++ b/libs/coin-modules/coin-sui/src/logic/mapDryRunError.ts
@@ -1,4 +1,4 @@
-import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalance, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 
 type ErrorMatcher = {
   pattern: RegExp;

--- a/libs/coin-modules/coin-sui/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-sui/src/network/sdk.test.ts
@@ -1,5 +1,5 @@
 import assert, { fail } from "assert";
-import { NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import { SuiJsonRpcClient } from "@mysten/sui/jsonRpc";
 import type {
   BalanceChange,

--- a/libs/coin-modules/coin-sui/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-sui/src/test/bridge.dataset.ts
@@ -2,7 +2,7 @@ import {
   RecipientRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountRaw, CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromTransactionRaw } from "../bridge/transaction";

--- a/libs/coin-modules/coin-tezos/.unimportedrc.json
+++ b/libs/coin-modules/coin-tezos/.unimportedrc.json
@@ -1,5 +1,9 @@
 {
-  "ignoreUnresolved": ["@jest/expect-utils", "@jest/get-type", "jest-util"],
+  "ignoreUnresolved": [
+    "@jest/expect-utils",
+    "@jest/get-type",
+    "jest-util"
+  ],
   "entry": [
     "src/api/index.ts",
     "src/index.ts",
@@ -15,7 +19,11 @@
     "src/logic/validateAddress.ts",
     "src/logic/positionUid.ts"
   ],
-  "ignoreUnimported": ["src/supportedFeatures.ts"],
+  "ignoreUnimported": [
+    "src/supportedFeatures.ts"
+  ],
   "ignore": [],
-  "ignoreUnused": []
+  "ignoreUnused": [
+    "@ledgerhq/errors"
+  ]
 }

--- a/libs/coin-modules/coin-tezos/package.json
+++ b/libs/coin-modules/coin-tezos/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@ledgerhq/coin-module-framework": "catalog:",
     "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "@taquito/ledger-signer": "^23.0.0-RC.0",

--- a/libs/coin-modules/coin-tezos/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tezos/src/api/index.test.ts
@@ -1,6 +1,6 @@
+import { InvalidParameterError } from "@ledgerhq/errors";
 import type { BalanceOptions, Operation } from "@ledgerhq/coin-module-framework/api/types";
 import { TransactionIntent } from "@ledgerhq/coin-module-framework/api/types";
-import { InvalidParameterError } from "@ledgerhq/errors";
 import type { APIAccount } from "../network/types";
 import networkApi from "../network/tzkt";
 import { createApi } from "./index";

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.test.ts
@@ -6,7 +6,7 @@ import {
   AmountRequired,
   NotEnoughBalance,
   NotEnoughBalanceToDelegate,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import coinConfig from "../config";
 import {
   InvalidAddressBecauseAlreadyDelegated,

--- a/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-tezos/src/logic/validateIntent.ts
@@ -9,7 +9,7 @@ import {
   NotEnoughBalanceToDelegate,
   AmountRequired,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { validateAddress, ValidationResult } from "@taquito/utils";
 import api from "../network/tzkt";
 import type { APIAccount } from "../network/types";

--- a/libs/coin-modules/coin-ton/.unimportedrc.json
+++ b/libs/coin-modules/coin-ton/.unimportedrc.json
@@ -1,5 +1,9 @@
 {
-  "ignoreUnresolved": ["@jest/expect-utils", "@jest/get-type", "jest-util"],
+  "ignoreUnresolved": [
+    "@jest/expect-utils",
+    "@jest/get-type",
+    "jest-util"
+  ],
   "entry": [
     "src/bridge/js.ts",
     "src/errors.ts",
@@ -14,5 +18,10 @@
     "src/test/bridge.dataset.ts",
     "src/supportedFeatures.ts"
   ],
-  "ignoreUnused": ["msw", "@ledgerhq/types-cryptoassets", "@ledgerhq/live-env"]
+  "ignoreUnused": [
+    "msw",
+    "@ledgerhq/types-cryptoassets",
+    "@ledgerhq/live-env",
+    "@ledgerhq/errors"
+  ]
 }

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
 import { TonCommentInvalid, TonExcessFee } from "../../errors";
 import getTransactionStatus from "../../getTransactionStatus";

--- a/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { isTokenAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { toNano } from "@ton/core";

--- a/libs/coin-modules/coin-ton/src/test/bridge.dataset.ts
+++ b/libs/coin-modules/coin-ton/src/test/bridge.dataset.ts
@@ -1,4 +1,4 @@
-import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { CurrenciesData, DatasetTest } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { TonCommentInvalid } from "../errors";

--- a/libs/coin-modules/coin-tron/package.json
+++ b/libs/coin-modules/coin-tron/package.json
@@ -87,6 +87,11 @@
       "require": "./lib/bridge/transaction.js",
       "default": "./lib-es/bridge/transaction.js"
     },
+    "./types/*": {
+      "@ledgerhq/source": "./src/types/*.ts",
+      "require": "./lib/types/*.js",
+      "default": "./lib-es/types/*.js"
+    },
     "./*": {
       "@ledgerhq/source": "./src/*.ts",
       "require": "./lib/*.js",

--- a/libs/coin-modules/coin-tron/src/types/errors.ts
+++ b/libs/coin-modules/coin-tron/src/types/errors.ts
@@ -133,3 +133,27 @@ export class TronEmptyPage extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+export class TronEmptyAccount extends Error {
+  override name = "TronEmptyAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronEmptyAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class MaybeKeepTronAccountAlive extends Error {
+  override name = "MaybeKeepTronAccountAlive";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "MaybeKeepTronAccountAlive");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-vechain/.unimportedrc.json
+++ b/libs/coin-modules/coin-vechain/.unimportedrc.json
@@ -79,6 +79,7 @@
     "eip55",
     "invariant",
     "lodash",
-    "rxjs"
+    "rxjs",
+    "@ledgerhq/errors"
   ]
 }

--- a/libs/coin-modules/coin-vechain/package.json
+++ b/libs/coin-modules/coin-vechain/package.json
@@ -109,13 +109,13 @@
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/live-network": "workspace:^",
+    "@vechain/sdk-core": "2.0.0",
+    "@vechain/sdk-network": "2.0.0",
     "bignumber.js": "^9.1.2",
     "eip55": "^2.1.1",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@vechain/sdk-core": "2.0.0",
-    "@vechain/sdk-network": "2.0.0"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.test.ts
@@ -10,7 +10,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { NotEnoughVTHO } from "../errors";
 
 // Mock dependencies

--- a/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-vechain/src/bridge/getTransactionStatus.ts
@@ -6,7 +6,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { calculateTransactionInfo, parseAddress } from "../common-logic";
 import type { Transaction } from "../types";

--- a/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
+++ b/libs/coin-modules/coin-vechain/src/network/sdk.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import type { Operation } from "@ledgerhq/types-live";
-import { LedgerAPI4xx } from "@ledgerhq/errors";
+import { LedgerAPI4xx } from "@ledgerhq/live-network/errors";
 import {
   getAccount,
   getBlockRef,

--- a/libs/ledger-live-common/src/errors.ts
+++ b/libs/ledger-live-common/src/errors.ts
@@ -108,7 +108,7 @@ export const BluetoothNotSupportedError = createCustomErrorClass("FwUpdateBlueto
 
 export const EConnResetError = createCustomErrorClass("EConnReset");
 
-export { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+export { NetworkDown, LedgerAPI4xx, LedgerAPI5xx } from "@ledgerhq/live-network/errors";
 export * from "@ledgerhq/coin-module-framework/errors";
 export * from "@ledgerhq/coin-algorand/errors";
 export * from "@ledgerhq/coin-aptos/errors";
@@ -126,3 +126,177 @@ export * from "@ledgerhq/coin-stacks/errors";
 export * from "@ledgerhq/coin-stellar/errors";
 export * from "@ledgerhq/coin-tezos/errors";
 export * from "@ledgerhq/coin-vechain/errors";
+
+export class PasswordsDontMatchError extends Error {
+  override name = "PasswordsDontMatch";
+  constructor(message?: string) {
+    super(message || "PasswordsDontMatch");
+  }
+}
+
+export class PasswordIncorrectError extends Error {
+  override name = "PasswordIncorrect";
+  constructor(message?: string) {
+    super(message || "PasswordIncorrect");
+  }
+}
+
+export class UnresponsiveDeviceError extends Error {
+  override name = "UnresponsiveDeviceError";
+  constructor(message?: string) {
+    super(message || "UnresponsiveDeviceError");
+  }
+}
+
+export class UserRefusedDeviceNameChange extends Error {
+  override name = "UserRefusedDeviceNameChange";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedDeviceNameChange");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  constructor(message?: string) {
+    super(message || "UserRefusedAddress");
+  }
+}
+
+export class UserRefusedAllowManager extends Error {
+  override name = "UserRefusedAllowManager";
+  [key: string]: unknown;
+  constructor(message?: string) {
+    super(message || "UserRefusedAllowManager");
+  }
+}
+
+export class GenuineCheckFailed extends Error {
+  override name = "GenuineCheckFailed";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "GenuineCheckFailed");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class PendingOperation extends Error {
+  override name = "PendingOperation";
+  constructor(message?: string) {
+    super(message || "PendingOperation");
+  }
+}
+
+export class DisabledTransactionBroadcastError extends Error {
+  override name = "DisabledTransactionBroadcastError";
+  constructor(message?: string) {
+    super(message || "DisabledTransactionBroadcastError");
+  }
+}
+
+export class MissingSwapPayloadParamaters extends Error {
+  override name = "MissingSwapPayloadParamaters";
+  constructor(message?: string) {
+    super(message || "MissingSwapPayloadParamaters");
+  }
+}
+
+export class ManagerDeviceLockedError extends Error {
+  override name = "ManagerDeviceLocked";
+  constructor(message?: string) {
+    super(message || "ManagerDeviceLocked");
+  }
+}
+
+export class DeviceNameInvalid extends Error {
+  override name = "DeviceNameInvalid";
+  invalidCharacters?: string;
+
+  constructor(message?: string, options?: ErrorOptions & { invalidCharacters?: string }) {
+    const { invalidCharacters, ...rest } = options ?? {};
+    super(message || "DeviceNameInvalid", rest);
+    this.invalidCharacters = invalidCharacters;
+  }
+}
+
+export class NanoSNotSupported extends Error {
+  override name = "NanoSNotSupported";
+  constructor(message?: string) {
+    super(message || "NanoSNotSupported");
+  }
+}
+
+export class NoAccessToCamera extends Error {
+  override name = "NoAccessToCamera";
+  constructor(message?: string) {
+    super(message || "NoAccessToCamera");
+  }
+}
+
+export class TransactionHasBeenValidatedError extends Error {
+  override name = "TransactionHasBeenValidatedError";
+  constructor(message?: string) {
+    super(message || "TransactionHasBeenValidatedError");
+  }
+}
+
+export class DeviceSocketFail extends Error {
+  override name = "DeviceSocketFail";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DeviceSocketFail");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WebsocketConnectionError extends Error {
+  override name = "WebsocketConnectionError";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WebsocketConnectionError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UnexpectedBootloader extends Error {
+  override name = "UnexpectedBootloader";
+  constructor(message?: string) {
+    super(message || "UnexpectedBootloader");
+  }
+}
+
+export class NotEnoughBalanceSwap extends Error {
+  override name = "NotEnoughBalanceSwap";
+  constructor(message?: string) {
+    super(message || "NotEnoughBalanceSwap");
+  }
+}
+
+export class NotEnoughGasSwap extends Error {
+  override name = "NotEnoughGasSwap";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGasSwap");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedFirmwareUpdate extends Error {
+  override name = "UserRefusedFirmwareUpdate";
+  constructor(message?: string) {
+    super(message || "UserRefusedFirmwareUpdate");
+  }
+}
+
+export class WrongDeviceForAccountPayout extends Error {
+  override name = "WrongDeviceForAccountPayout";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccountPayout");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WrongDeviceForAccountRefund extends Error {
+  override name = "WrongDeviceForAccountRefund";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccountRefund");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/cosmos.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
 [
   {
-    "balance": "6004075",
+    "balance": "5966006",
     "currencyId": "cosmos",
     "derivationMode": "",
     "freshAddress": "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
@@ -12,7 +12,7 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
-    "spendableBalance": "2219122",
+    "spendableBalance": "2181053",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,
@@ -448,6 +448,27 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "161",
       "type": "OUT",
       "value": "1001200",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32182060,
+      "extra": {
+        "memo": "🔔 https://atomsdex.com: Congrats🎉 You are eligible to claim up to 10,000 $ATOM Rewards, check and claim your allocation now on https://atomsdex.com ✅",
+      },
+      "fee": "626",
+      "hasFailed": false,
+      "hash": "1141DE03EB2722E096184DCE9F8B1E7DCDB7589C2A052C7EC01EDE6CDF79BDE4",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-1141DE03EB2722E096184DCE9F8B1E7DCDB7589C2A052C7EC01EDE6CDF79BDE4-IN",
+      "recipients": [
+        "cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl",
+      ],
+      "senders": [
+        "cosmos16te3v5hp96hz24f8ct5hfal29udpu0h7w8dfap",
+      ],
+      "transactionSequenceNumber": "275943",
+      "type": "IN",
+      "value": "1",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -2045,6 +2066,30 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "221",
       "type": "OUT",
       "value": "2752",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32177034,
+      "extra": {
+        "memo": "Ledger Live",
+        "sourceValidator": "cosmosvaloper1tflk30mq5vgqjdly92kkhhq3raev2hnz6eete3",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "15450",
+          },
+        ],
+      },
+      "fee": "26647",
+      "hasFailed": false,
+      "hash": "55683492340776DB8CCFBCA1F5DFA1D7C75B2AAF9B95961B51FAA2FC351B39CC",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-55683492340776DB8CCFBCA1F5DFA1D7C75B2AAF9B95961B51FAA2FC351B39CC-REDELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "276",
+      "type": "REDELEGATE",
+      "value": "26647",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
@@ -3940,6 +3985,30 @@ exports[`cosmos currency bridge scanAccounts cosmos seed 1 2`] = `
       "transactionSequenceNumber": "80",
       "type": "OUT",
       "value": "103791",
+    },
+    {
+      "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",
+      "blockHash": null,
+      "blockHeight": 32177052,
+      "extra": {
+        "memo": "Ledger Live",
+        "sourceValidator": "cosmosvaloper1c4k24jzduc365kywrsvf5ujz4ya6mwympnc4en",
+        "validators": [
+          {
+            "address": "cosmosvaloper10wljxpl03053h9690apmyeakly3ylhejrucvtm",
+            "amount": "827539",
+          },
+        ],
+      },
+      "fee": "25149",
+      "hasFailed": false,
+      "hash": "B58678F8E6FDAF9E96C76F653DCA0F2967221832F98FBCA22ED8BE81C46B1098",
+      "id": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:-B58678F8E6FDAF9E96C76F653DCA0F2967221832F98FBCA22ED8BE81C46B1098-REDELEGATE",
+      "recipients": [],
+      "senders": [],
+      "transactionSequenceNumber": "277",
+      "type": "REDELEGATE",
+      "value": "25149",
     },
     {
       "accountId": "js:2:cosmos:cosmos1g84934jpu3v5de5yqukkkhxmcvsw3u2ajxvpdl:",

--- a/libs/ledger-wallet-framework/src/errors.ts
+++ b/libs/ledger-wallet-framework/src/errors.ts
@@ -1,7 +1,206 @@
 export class UnsupportedDerivation extends Error {
   override name = "UnsupportedDerivation";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UnsupportedDerivation");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AccountNotSupported extends Error {
+  override name = "AccountNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AccountNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class AmountRequired extends Error {
+  override name = "AmountRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "AmountRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class DeviceAppVerifyNotSupported extends Error {
+  override name = "DeviceAppVerifyNotSupported";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "DeviceAppVerifyNotSupported");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeNotLoaded extends Error {
+  override name = "FeeNotLoaded";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeNotLoaded");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeTooHigh extends Error {
+  override name = "FeeTooHigh";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeTooHigh");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidAddressBecauseDestinationIsAlsoSource extends Error {
+  override name = "InvalidAddressBecauseDestinationIsAlsoSource";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddressBecauseDestinationIsAlsoSource");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class InvalidTransactionError extends Error {
+  override name = "InvalidTransactionError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidTransactionError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class LockedDeviceError extends Error {
+  override name = "LockedDeviceError";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "LockedDeviceError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  [key: string]: unknown;
   constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
-    super(message || "UnsupportedDerivation", options);
+    super(message || "NotEnoughBalance", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceBecauseDestinationNotCreated extends Error {
+  override name = "NotEnoughBalanceBecauseDestinationNotCreated";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceBecauseDestinationNotCreated");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceFees extends Error {
+  override name = "NotEnoughBalanceFees";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "NotEnoughBalanceFees", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceInParentAccount extends Error {
+  override name = "NotEnoughBalanceInParentAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceInParentAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughSpendableBalance extends Error {
+  override name = "NotEnoughSpendableBalance";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughSpendableBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class FeeRequired extends Error {
+  override name = "FeeRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "FeeRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughGas extends Error {
+  override name = "NotEnoughGas";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughGas");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class RecipientRequired extends Error {
+  override name = "RecipientRequired";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecipientRequired");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedAddress extends Error {
+  override name = "UserRefusedAddress";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UserRefusedOnDevice extends Error {
+  override name = "UserRefusedOnDevice";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UserRefusedOnDevice");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class WrongDeviceForAccount extends Error {
+  override name = "WrongDeviceForAccount";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "WrongDeviceForAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalanceToDelegate extends Error {
+  override name = "NotEnoughBalanceToDelegate";
+  [key: string]: unknown;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalanceToDelegate");
     if (fields) Object.assign(this, fields);
   }
 }

--- a/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-eth/.unimportedrc.json
@@ -9,6 +9,5 @@
   "ignoreUnresolved": [
     "@jest/expect-utils",
     "@jest/get-type",
-    "jest-util"],
-  "ignoreUnimported": []
+    "jest-util"]
 }

--- a/libs/ledgerjs/packages/hw-app-eth/package.json
+++ b/libs/ledgerjs/packages/hw-app-eth/package.json
@@ -30,7 +30,6 @@
     "@ethersproject/rlp": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",
     "@ledgerhq/domain-service": "workspace:^",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/evm-tools": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-mocker": "workspace:^",

--- a/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-eth/src/errors.ts
@@ -1,9 +1,18 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const EthAppPleaseEnableContractData = createCustomErrorClass(
-  "EthAppPleaseEnableContractData",
-);
-export const EthAppNftNotSupported = createCustomErrorClass("EthAppNftNotSupported");
-export const CeloAppPleaseEnableContractData = createCustomErrorClass(
-  "CeloAppPleaseEnableContractData",
-);
+export class EthAppPleaseEnableContractData extends Error {
+  override name = "EthAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "EthAppPleaseEnableContractData");
+  }
+}
+export class EthAppNftNotSupported extends Error {
+  override name = "EthAppNftNotSupported";
+  constructor(message?: string) {
+    super(message || "EthAppNftNotSupported");
+  }
+}
+export class CeloAppPleaseEnableContractData extends Error {
+  override name = "CeloAppPleaseEnableContractData";
+  constructor(message?: string) {
+    super(message || "CeloAppPleaseEnableContractData");
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-str/README.md
+++ b/libs/ledgerjs/packages/hw-app-str/README.md
@@ -39,47 +39,83 @@ We have written corresponding classes for exceptions that developers should acti
 #### Table of Contents
 
 *   [StellarHashSigningNotEnabledError](#stellarhashsigningnotenablederror)
-*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
-*   [StellarUserRefusedError](#stellaruserrefusederror)
-*   [StellarDataTooLargeError](#stellardatatoolargeerror)
-*   [Str](#str)
     *   [Parameters](#parameters)
+*   [StellarDataParsingFailedError](#stellardataparsingfailederror)
+    *   [Parameters](#parameters-1)
+*   [StellarUserRefusedError](#stellaruserrefusederror)
+    *   [Parameters](#parameters-2)
+*   [StellarDataTooLargeError](#stellardatatoolargeerror)
+    *   [Parameters](#parameters-3)
+*   [Str](#str)
+    *   [Parameters](#parameters-4)
     *   [Examples](#examples)
     *   [getAppConfiguration](#getappconfiguration)
         *   [Examples](#examples-1)
     *   [getPublicKey](#getpublickey)
-        *   [Parameters](#parameters-1)
+        *   [Parameters](#parameters-5)
         *   [Examples](#examples-2)
     *   [signTransaction](#signtransaction)
-        *   [Parameters](#parameters-2)
+        *   [Parameters](#parameters-6)
         *   [Examples](#examples-3)
     *   [signSorobanAuthorization](#signsorobanauthorization)
-        *   [Parameters](#parameters-3)
+        *   [Parameters](#parameters-7)
         *   [Examples](#examples-4)
     *   [signHash](#signhash)
-        *   [Parameters](#parameters-4)
+        *   [Parameters](#parameters-8)
         *   [Examples](#examples-5)
     *   [signMessage](#signmessage)
-        *   [Parameters](#parameters-5)
+        *   [Parameters](#parameters-9)
         *   [Examples](#examples-6)
 
 ### StellarHashSigningNotEnabledError
 
+**Extends Error**
+
 Error thrown when hash signing is not enabled on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataParsingFailedError
+
+**Extends Error**
 
 Error thrown when data parsing fails.
 
 For example, when parsing the transaction fails, this error is thrown.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarUserRefusedError
+
+**Extends Error**
 
 Error thrown when the user refuses the request on the device.
 
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
+
 ### StellarDataTooLargeError
 
+**Extends Error**
+
 Error thrown when the data is too large to be processed by the device.
+
+#### Parameters
+
+*   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?**&#x20;
+*   `fields` **Record<[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), any>?**&#x20;
+*   `options` **ErrorOptions?**&#x20;
 
 ### Str
 

--- a/libs/ledgerjs/packages/hw-app-str/package.json
+++ b/libs/ledgerjs/packages/hw-app-str/package.json
@@ -27,7 +27,6 @@
   "types": "lib/Str.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "bip32-path": "^0.4.2"
   },

--- a/libs/ledgerjs/packages/hw-app-str/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-str/src/errors.ts
@@ -1,27 +1,45 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 /**
  * Error thrown when hash signing is not enabled on the device.
  */
-export const StellarHashSigningNotEnabledError = createCustomErrorClass(
-  "StellarHashSigningNotEnabledError",
-);
+export class StellarHashSigningNotEnabledError extends Error {
+  override name = "StellarHashSigningNotEnabledError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarHashSigningNotEnabledError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when data parsing fails.
  *
  * For example, when parsing the transaction fails, this error is thrown.
  */
-export const StellarDataParsingFailedError = createCustomErrorClass(
-  "StellarDataParsingFailedError",
-);
+export class StellarDataParsingFailedError extends Error {
+  override name = "StellarDataParsingFailedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataParsingFailedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the user refuses the request on the device.
  */
-export const StellarUserRefusedError = createCustomErrorClass("StellarUserRefusedError");
+export class StellarUserRefusedError extends Error {
+  override name = "StellarUserRefusedError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarUserRefusedError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 /**
  * Error thrown when the data is too large to be processed by the device.
  */
-export const StellarDataTooLargeError = createCustomErrorClass("StellarDataTooLargeError");
+export class StellarDataTooLargeError extends Error {
+  override name = "StellarDataTooLargeError";
+  constructor(message?: string, fields?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message || "StellarDataTooLargeError", options);
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
+++ b/libs/ledgerjs/packages/hw-app-str/tests/Str.test.ts
@@ -6,7 +6,7 @@ import {
   StellarUserRefusedError,
   StellarDataTooLargeError,
 } from "../src/errors";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport";
 
 test("getAppConfiguration (hash signing disabled)", async () => {
   const transport = await openTransportReplayer(

--- a/libs/ledgerjs/packages/hw-app-str/tsconfig.json
+++ b/libs/ledgerjs/packages/hw-app-str/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
     "outDir": "lib",
     "rootDir": "src"
   },

--- a/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-sui/.unimportedrc.json
@@ -1,3 +1,4 @@
 {
-  "entry": ["src/Sui.ts"]
+  "entry": ["src/Sui.ts"],
+  "ignoreUnimported": ["src/errors.ts"]
 }

--- a/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-sui/src/errors.ts
@@ -1,0 +1,7 @@
+export class UpdateYourApp extends Error {
+  override name = "UpdateYourApp";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "UpdateYourApp");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/ledgerjs/packages/hw-app-vet/package.json
+++ b/libs/ledgerjs/packages/hw-app-vet/package.json
@@ -26,7 +26,6 @@
   "main": "lib/Vet.js",
   "module": "lib-es/Vet.js",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-mocker": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
@@ -55,5 +54,22 @@
     "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
-  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec"
+  "gitHead": "dd0dea64b58e5a9125c8a422dcffd29e5ef6abec",
+  "exports": {
+    ".": {
+      "@ledgerhq/source": "./src/Vet.ts",
+      "import": "./lib-es/Vet.js",
+      "require": "./lib/Vet.js",
+      "default": "./lib/Vet.js"
+    },
+    "./lib-es/*": "./lib-es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./*": {
+      "@ledgerhq/source": "./src/*.ts",
+      "import": "./lib-es/*.js",
+      "require": "./lib/*.js",
+      "default": "./lib/*.js"
+    },
+    "./package.json": "./package.json"
+  }
 }

--- a/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/src/errors.ts
@@ -1,5 +1,6 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const VechainAppPleaseEnableContractDataAndMultiClause = createCustomErrorClass(
-  "VechainAppPleaseEnableContractDataAndMultiClause",
-);
+export class VechainAppPleaseEnableContractDataAndMultiClause extends Error {
+  override name = "VechainAppPleaseEnableContractDataAndMultiClause";
+  constructor(message?: string) {
+    super(message || "VechainAppPleaseEnableContractDataAndMultiClause");
+  }
+}

--- a/libs/wallet-btc/src/errors.ts
+++ b/libs/wallet-btc/src/errors.ts
@@ -1,9 +1,38 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
 // wallet-btc domain errors. Re-exported by @ledgerhq/coin-bitcoin for
 // backward compatibility (see coin-bitcoin/src/errors.ts).
-export const AccountNeedResync = createCustomErrorClass("AccountNeedResync");
+export class AccountNeedResync extends Error {
+  override name = "AccountNeedResync";
+  constructor(message?: string) {
+    super(message || "AccountNeedResync");
+  }
+}
 
-export const RbfBuildError = createCustomErrorClass("RbfBuildError");
+export class RbfBuildError extends Error {
+  override name = "RbfBuildError";
+  constructor(message?: string) {
+    super(message || "RbfBuildError");
+  }
+}
 
-export const UnsupportedDerivation = createCustomErrorClass("UnsupportedDerivation");
+export class UnsupportedDerivation extends Error {
+  override name = "UnsupportedDerivation";
+  constructor(message?: string) {
+    super(message || "UnsupportedDerivation");
+  }
+}
+
+export class InvalidAddress extends Error {
+  override name = "InvalidAddress";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "InvalidAddress");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+export class NotEnoughBalance extends Error {
+  override name = "NotEnoughBalance";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "NotEnoughBalance");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10322,9 +10322,6 @@ importers:
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../../../domain-service
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/evm-tools':
         specifier: workspace:^
         version: link:../../../evm-tools
@@ -10827,9 +10824,6 @@ importers:
 
   libs/ledgerjs/packages/hw-app-str:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -11002,9 +10996,6 @@ importers:
 
   libs/ledgerjs/packages/hw-app-vet:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport


### PR DESCRIPTION
## Summary

Part of the [@ledgerhq/errors sunset (LIVE-32915)](https://ledgerhq.atlassian.net/browse/LIVE-32915) initiative.

This PR migrates all `@ledgerhq/errors` import sites for packages owned by **@ledgerhq/ledger-third-party-leads**.

- Stacked on #20062 (`feat/LIVE-32915-errors-coin-integration`)
- Owned by: @ledgerhq/ledger-third-party-leads

## Packages affected

- coin-aleo
- coin-aptos
- coin-canton
- coin-cardano
- coin-casper
- coin-celo
- coin-concordium
- coin-filecoin
- coin-hedera
- coin-internet_computer
- coin-kaspa
- coin-mina
- coin-near
- coin-stacks
- coin-sui
- coin-tezos
- coin-ton
- coin-vechain

## Test plan

- [ ] CI passes on this branch
- [ ] Parent PR #20062 merges cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)