### PR TITLE
[LWDM] chore(lumen): bump packages to 0.1.49 and migrate TableCellContent (LIVE-35029)

### DIFF
--- a/.changeset/lumen-bump-0-1-49.md
+++ b/.changeset/lumen-bump-0-1-49.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Bump Lumen design-system packages to latest (design-core 0.1.23, ui-react 0.1.49, ui-rnative 0.1.52, ui-react-visualization 0.1.28, ui-rnative-visualization 0.1.29) and migrate the desktop tables to the new `TableCellContent` compound API (`TableCellItem` / `TableCellContent` / `TableCellContentTitle` / `TableCellContentDescription` / `TableCellContentRow`). Also round the market-list currency image fallback to match the crypto-icon shape.

--- a/.changeset/lumen-bump-0-1-49.md
+++ b/.changeset/lumen-bump-0-1-49.md
@@ -3,4 +3,9 @@
 "live-mobile": minor
 ---
 
-Bump Lumen design-system packages to latest (design-core 0.1.23, ui-react 0.1.49, ui-rnative 0.1.52, ui-react-visualization 0.1.28, ui-rnative-visualization 0.1.29) and migrate the desktop tables to the new `TableCellContent` compound API (`TableCellItem` / `TableCellContent` / `TableCellContentTitle` / `TableCellContentDescription` / `TableCellContentRow`). Also round the market-list currency image fallback to match the crypto-icon shape.
+Bump Lumen design-system packages to latest (design-core 0.1.23, ui-react 0.1.49, ui-rnative 0.1.52, ui-react-visualization 0.1.28, ui-rnative-visualization 0.1.29).
+
+- Migrate the desktop tables to the new `TableCellContent` compound API (`TableCellItem` / `TableCellContent` / `TableCellContentTitle` / `TableCellContentDescription` / `TableCellContentRow`).
+- Migrate the interactive My Wallet avatar to the new `AvatarButton` component on both apps, and fix the vertical centering of the desktop top-bar trigger.
+- Use the currency image fallback (`MediaImage`, circular) in the market list so it matches the crypto-icon shape.
+- Simplify `getDotIndicatorProps` avatar sizing now that the helper is typed for the full avatar size range.

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/BalanceCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/BalanceCell/BalanceCellView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import { TruncatedText } from "LLD/components/TruncatedText";
 
 type BalanceCellViewProps = {
@@ -8,8 +8,11 @@ type BalanceCellViewProps = {
 };
 
 export const BalanceCellView = ({ formattedBalance, className }: BalanceCellViewProps) => (
-  <TableCellContent
-    align="end"
-    title={<TruncatedText text={formattedBalance} className={className} />}
-  />
+  <TableCellItem align="end">
+    <TableCellContent>
+      <TableCellContentTitle>
+        <TruncatedText text={formattedBalance} className={className} />
+      </TableCellContentTitle>
+    </TableCellContent>
+  </TableCellItem>
 );

--- a/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/CounterValueCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/Cells/CounterValueCell/CounterValueCellView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 
 type CounterValueCellViewProps = {
   readonly formattedCounterValue: string;
@@ -10,10 +10,15 @@ export const CounterValueCellView = ({
   formattedCounterValue,
   className,
 }: CounterValueCellViewProps) => (
-  <TableCellContent
-    align="end"
-    title={
-      className ? <span className={className}>{formattedCounterValue}</span> : formattedCounterValue
-    }
-  />
+  <TableCellItem align="end">
+    <TableCellContent>
+      <TableCellContentTitle>
+        {className ? (
+          <span className={className}>{formattedCounterValue}</span>
+        ) : (
+          formattedCounterValue
+        )}
+      </TableCellContentTitle>
+    </TableCellContent>
+  </TableCellItem>
 );

--- a/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Analytics/hooks/useAllocationTable.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from "react";
-import { TableCellContent, useLumenDataTable } from "@ledgerhq/lumen-ui-react";
+import {
+  TableCellItem,
+  TableCellContent,
+  TableCellContentTitle,
+  TableCellContentDescription,
+  useLumenDataTable,
+} from "@ledgerhq/lumen-ui-react";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
@@ -25,21 +31,25 @@ export const useAllocationTable = (items: AllocationTableItem[]) => {
         header: t("analytics.allocation.columns.name"),
         enableSorting: false,
         cell: ({ row }) => (
-          <TableCellContent
-            leadingContent={
-              shouldDisplayAggregatedAssets ? (
-                <CryptoIcon
-                  ledgerId={row.original.currency.id}
-                  ticker={row.original.currency.ticker}
-                  size={getValidCryptoIconSize(32)}
-                />
-              ) : (
-                <CryptoCurrencyIcon currency={row.original.currency} size={32} />
-              )
-            }
-            title={<TruncatedText text={row.original.currency.name} />}
-            description={row.original.currency.ticker}
-          />
+          <TableCellItem>
+            {shouldDisplayAggregatedAssets ? (
+              <CryptoIcon
+                ledgerId={row.original.currency.id}
+                ticker={row.original.currency.ticker}
+                size={getValidCryptoIconSize(32)}
+              />
+            ) : (
+              <CryptoCurrencyIcon currency={row.original.currency} size={32} />
+            )}
+            <TableCellContent>
+              <TableCellContentTitle>
+                <TruncatedText text={row.original.currency.name} />
+              </TableCellContentTitle>
+              <TableCellContentDescription>
+                {row.original.currency.ticker}
+              </TableCellContentDescription>
+            </TableCellContent>
+          </TableCellItem>
         ),
       },
       {
@@ -70,10 +80,13 @@ export const useAllocationTable = (items: AllocationTableItem[]) => {
             maximumFractionDigits: 2,
           });
           return (
-            <TableCellContent
-              align="end"
-              title={<span className="text-muted">{formatted}%</span>}
-            />
+            <TableCellItem align="end">
+              <TableCellContent>
+                <TableCellContentTitle>
+                  <span className="text-muted">{formatted}%</span>
+                </TableCellContentTitle>
+              </TableCellContent>
+            </TableCellItem>
           );
         },
         meta: { align: "end" },

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/PriceCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/PriceCell/PriceCellView.tsx
@@ -1,10 +1,14 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 
 type PriceCellViewProps = {
   readonly formattedPrice: string;
 };
 
 export const PriceCellView = ({ formattedPrice }: PriceCellViewProps) => (
-  <TableCellContent align="end" title={formattedPrice} />
+  <TableCellItem align="end">
+    <TableCellContent>
+      <TableCellContentTitle>{formattedPrice}</TableCellContentTitle>
+    </TableCellContent>
+  </TableCellItem>
 );

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/TrendCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/components/Cells/TrendCell/TrendCellView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 
 type TrendCellViewProps = {
   readonly formattedTrend: string;
@@ -7,5 +7,11 @@ type TrendCellViewProps = {
 };
 
 export const TrendCellView = ({ formattedTrend, colorClass }: TrendCellViewProps) => (
-  <TableCellContent align="end" title={<span className={colorClass}>{formattedTrend}</span>} />
+  <TableCellItem align="end">
+    <TableCellContent>
+      <TableCellContentTitle>
+        <span className={colorClass}>{formattedTrend}</span>
+      </TableCellContentTitle>
+    </TableCellContent>
+  </TableCellItem>
 );

--- a/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Assets/hooks/useTable.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo } from "react";
 import {
+  TableCellItem,
   TableCellContent,
+  TableCellContentTitle,
+  TableCellContentDescription,
   TableInfoIcon,
   useLumenDataTable,
   Tooltip,
@@ -52,22 +55,25 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
             `${row.original.currency.name}-${row.original.currency.id}`,
           );
           return (
-            <TableCellContent
-              data-testid={`w40-asset-row-${assetTestId}`}
-              leadingContent={
-                row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
-                  <CryptoIcon
-                    ledgerId={row.original.currency.id}
-                    ticker={row.original.currency.ticker}
-                    size={getValidCryptoIconSize(32)}
-                  />
-                ) : (
-                  <CryptoCurrencyIcon currency={row.original.currency} size={32} />
-                )
-              }
-              title={<TruncatedText text={row.original.currency.name} />}
-              description={row.original.currency.ticker}
-            />
+            <TableCellItem data-testid={`w40-asset-row-${assetTestId}`}>
+              {row.original.isPlaceholder || shouldDisplayAggregatedAssets ? (
+                <CryptoIcon
+                  ledgerId={row.original.currency.id}
+                  ticker={row.original.currency.ticker}
+                  size={getValidCryptoIconSize(32)}
+                />
+              ) : (
+                <CryptoCurrencyIcon currency={row.original.currency} size={32} />
+              )}
+              <TableCellContent>
+                <TableCellContentTitle>
+                  <TruncatedText text={row.original.currency.name} />
+                </TableCellContentTitle>
+                <TableCellContentDescription>
+                  {row.original.currency.ticker}
+                </TableCellContentDescription>
+              </TableCellContent>
+            </TableCellItem>
           );
         },
       },
@@ -99,7 +105,11 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
           );
           return row.original.isPlaceholder ? (
             <div data-testid={`w40-asset-row-value-${assetValueTestId}`}>
-              <TableCellContent align="end" title={emptyFiatValue} />
+              <TableCellItem align="end">
+                <TableCellContent>
+                  <TableCellContentTitle>{emptyFiatValue}</TableCellContentTitle>
+                </TableCellContent>
+              </TableCellItem>
             </div>
           ) : (
             <div data-testid={`w40-asset-row-value-${assetValueTestId}`}>
@@ -115,7 +125,13 @@ export const useTable = (assets: AssetTableItem[], options?: UseAssetTableOption
         enableSorting: false,
         cell: ({ row }) =>
           row.original.isPlaceholder ? (
-            <TableCellContent align="end" title={<span className="text-muted">0.00%</span>} />
+            <TableCellItem align="end">
+              <TableCellContent>
+                <TableCellContentTitle>
+                  <span className="text-muted">0.00%</span>
+                </TableCellContentTitle>
+              </TableCellContent>
+            </TableCellItem>
           ) : (
             <TrendCell trend={row.original.trend} />
           ),

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAddressCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { getCryptoAccountAddress } from "LLD/features/CryptoAddresses/utils/getCryptoAccountAddress";
@@ -12,5 +12,11 @@ type AccountAddressCellProps = {
 export function AccountAddressCell({ account, lookupParentAccount }: AccountAddressCellProps) {
   const address = getCryptoAccountAddress(account, lookupParentAccount);
   const formatted = formatAddress(address, { prefixLength: 5, suffixLength: 5 });
-  return <TableCellContent title={formatted} />;
+  return (
+    <TableCellItem>
+      <TableCellContent>
+        <TableCellContentTitle>{formatted}</TableCellContentTitle>
+      </TableCellContent>
+    </TableCellItem>
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAssetsCellView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountAssetsCellView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import type { CryptoIconSize } from "LLD/components/SquaredCryptoIcon";
 import { IconStack } from "LLD/components/IconStack";
 import type { AccountAssetCurrency } from "LLD/features/CryptoAddresses/utils/getAccountAssetsCurrencies";
@@ -17,22 +17,23 @@ export function AccountAssetsCellView({
   tooltipContent,
 }: AccountAssetsCellViewProps) {
   return (
-    <TableCellContent
-      align="end"
-      title={
-        <IconStack
-          size={iconSize}
-          borderRadius="50%"
-          testID="account-assets-cell"
-          items={items}
-          getItemKey={currency => currency.id}
-          renderItem={currency => (
-            <CryptoIcon ledgerId={currency.id} ticker={currency.ticker} size={iconSize} />
-          )}
-          getTooltipContent={() => tooltipContent}
-          overflowTestID="account-assets-overflow"
-        />
-      }
-    />
+    <TableCellItem align="end">
+      <TableCellContent>
+        <TableCellContentTitle>
+          <IconStack
+            size={iconSize}
+            borderRadius="50%"
+            testID="account-assets-cell"
+            items={items}
+            getItemKey={currency => currency.id}
+            renderItem={currency => (
+              <CryptoIcon ledgerId={currency.id} ticker={currency.ticker} size={iconSize} />
+            )}
+            getTooltipContent={() => tooltipContent}
+            overflowTestID="account-assets-overflow"
+          />
+        </TableCellContentTitle>
+      </TableCellContent>
+    </TableCellItem>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AccountNameCell.tsx
@@ -1,5 +1,10 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import {
+  TableCellItem,
+  TableCellContent,
+  TableCellContentTitle,
+  TableCellContentDescription,
+} from "@ledgerhq/lumen-ui-react";
 import type { AccountLike } from "@ledgerhq/types-live";
 import { getAccountCurrency } from "@ledgerhq/live-common/account/helpers";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
@@ -12,10 +17,12 @@ type AccountNameCellProps = {
 export function AccountNameCell({ account, displayName }: AccountNameCellProps) {
   const currency = getAccountCurrency(account);
   return (
-    <TableCellContent
-      leadingContent={<CryptoCurrencyIcon currency={currency} size={32} />}
-      title={displayName}
-      description={currency.ticker}
-    />
+    <TableCellItem>
+      <CryptoCurrencyIcon currency={currency} size={32} />
+      <TableCellContent>
+        <TableCellContentTitle>{displayName}</TableCellContentTitle>
+        <TableCellContentDescription>{currency.ticker}</TableCellContentDescription>
+      </TableCellContent>
+    </TableCellItem>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountNameCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import type { Account } from "@ledgerhq/types-live";
 import { SquaredCryptoIcon } from "LLD/components/SquaredCryptoIcon";
 
@@ -13,15 +13,15 @@ export function AggregatedAccountNameCell({
   displayName,
 }: AggregatedAccountNameCellProps) {
   return (
-    <TableCellContent
-      leadingContent={
-        <SquaredCryptoIcon
-          ledgerId={account.currency.id}
-          ticker={account.currency.ticker}
-          size={32}
-        />
-      }
-      title={displayName}
-    />
+    <TableCellItem>
+      <SquaredCryptoIcon
+        ledgerId={account.currency.id}
+        ticker={account.currency.ticker}
+        size={32}
+      />
+      <TableCellContent>
+        <TableCellContentTitle>{displayName}</TableCellContentTitle>
+      </TableCellContent>
+    </TableCellItem>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/Table/Cell/AggregatedAccountValueCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TableCellContent } from "@ledgerhq/lumen-ui-react";
+import { TableCellItem, TableCellContent, TableCellContentTitle } from "@ledgerhq/lumen-ui-react";
 import { BigNumber } from "bignumber.js";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
 import { useSelector } from "LLD/hooks/redux";
@@ -26,5 +26,11 @@ export function AggregatedAccountValueCell({
     discreet,
   });
 
-  return <TableCellContent align="end" title={formattedValue} />;
+  return (
+    <TableCellItem align="end">
+      <TableCellContent>
+        <TableCellContentTitle>{formattedValue}</TableCellContentTitle>
+      </TableCellContent>
+    </TableCellItem>
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/components/OperationRow.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, memo } from "react";
-import { DotIndicator, TableRow, TableCell, TableCellContent } from "@ledgerhq/lumen-ui-react";
+import {
+  DotIndicator,
+  TableRow,
+  TableCell,
+  TableCellItem,
+  TableCellContent,
+  TableCellContentTitle,
+} from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
@@ -48,50 +55,51 @@ function OperationRow({ row, onRowClick }: OperationRowProps) {
   return (
     <TableRow clickable onClick={handleClick} data-testid={`history-operation-row-${operation.id}`}>
       <TableCell data-testid="history-operation-type">
-        <TableCellContent
-          leadingContent={
-            cryptoCurrency ? (
-              <TransactionalIcon
-                operationType={operation.type}
-                isPending={item.isPending}
-                hasFailed={operation.hasFailed}
-                currency={cryptoCurrency}
-                mediaSize={40}
-                network={
-                  !shouldDisplayAggregatedAssets && isToken
-                    ? cryptoCurrency.parentCurrencyId
-                    : undefined
-                }
-              />
-            ) : undefined
-          }
-          title={
-            <div className="inline-flex items-center gap-12">
-              {typeLabel}
-              {isUnread && (
-                <DotIndicator appearance="base" size="lg" data-testid="unread-indicator" />
-              )}
-            </div>
-          }
-        />
+        <TableCellItem>
+          {cryptoCurrency ? (
+            <TransactionalIcon
+              operationType={operation.type}
+              isPending={item.isPending}
+              hasFailed={operation.hasFailed}
+              currency={cryptoCurrency}
+              mediaSize={40}
+              network={
+                !shouldDisplayAggregatedAssets && isToken
+                  ? cryptoCurrency.parentCurrencyId
+                  : undefined
+              }
+            />
+          ) : null}
+          <TableCellContent>
+            <TableCellContentTitle>
+              <div className="inline-flex items-center gap-12">
+                {typeLabel}
+                {isUnread && (
+                  <DotIndicator appearance="base" size="lg" data-testid="unread-indicator" />
+                )}
+              </div>
+            </TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
       <TableCell align="end" data-testid="history-operation-address">
-        <TableCellContent
-          align="end"
-          title={
-            <div className="inline-flex items-center gap-4">
-              <OperationCounterpartyLabel item={item} prefix={addressPrefix} />
-              {iconCurrency && (
-                <SquaredCryptoIcon
-                  ledgerId={iconCurrency.id}
-                  ticker={iconCurrency.ticker}
-                  size={20}
-                  network={iconNetwork}
-                />
-              )}
-            </div>
-          }
-        />
+        <TableCellItem align="end">
+          <TableCellContent>
+            <TableCellContentTitle>
+              <div className="inline-flex items-center gap-4">
+                <OperationCounterpartyLabel item={item} prefix={addressPrefix} />
+                {iconCurrency && (
+                  <SquaredCryptoIcon
+                    ledgerId={iconCurrency.id}
+                    ticker={iconCurrency.ticker}
+                    size={20}
+                    network={iconNetwork}
+                  />
+                )}
+              </div>
+            </TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
       <TableCell align="end" data-testid="history-operation-amount">
         <BalanceCell

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/MarketRowView.tsx
@@ -1,6 +1,17 @@
 import React, { memo } from "react";
 import { TFunction } from "i18next";
-import { TableRow, TableCell, TableCellContent, Trend, Tag } from "@ledgerhq/lumen-ui-react";
+import {
+  TableRow,
+  TableCell,
+  TableCellItem,
+  TableCellContent,
+  TableCellContentTitle,
+  TableCellContentDescription,
+  TableCellContentRow,
+  Trend,
+  Tag,
+  MediaImage,
+} from "@ledgerhq/lumen-ui-react";
 import { CryptoIcon } from "@ledgerhq/crypto-icons";
 import { MarketCurrencyData } from "@ledgerhq/live-common/market/utils/types";
 import { TruncatedText } from "LLD/components/TruncatedText";
@@ -51,37 +62,54 @@ export const MarketRowView = memo<MarketRowViewProps>(function MarketRowView({
       style={{ ...style, gridTemplateColumns: MARKET_TABLE_GRID_TEMPLATE }}
     >
       <TableCell className={`${MARKET_CELL_CLASSNAME} min-w-0 [&>div]:min-w-0`}>
-        <TableCellContent
-          className="overflow-hidden"
-          leadingContent={
-            currency.ledgerIds.length > 0 ? (
-              <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
-            ) : (
-              <img width="32px" height="32px" src={currency.image} alt={currency.name} />
-            )
-          }
-          title={<TruncatedText text={currency.name} />}
-          description={
-            <span className="flex items-center gap-6">
-              {ticker}
+        <TableCellItem className="overflow-hidden">
+          {currency.ledgerIds.length > 0 ? (
+            <CryptoIcon ledgerId={currency.ledgerIds[0]} ticker={currency.ticker} size={32} />
+          ) : (
+            <MediaImage
+              src={currency.image}
+              alt={currency.name}
+              shape="circle"
+              size={32}
+              fallback={currency.name}
+            />
+          )}
+          <TableCellContent>
+            <TableCellContentTitle>
+              <TruncatedText text={currency.name} />
+            </TableCellContentTitle>
+            <TableCellContentRow>
+              <TableCellContentDescription>{ticker}</TableCellContentDescription>
               {currency.marketcapRank ? (
                 <Tag size="sm" appearance="gray" label={`#${currency.marketcapRank}`} />
               ) : null}
-            </span>
-          }
-        />
+            </TableCellContentRow>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-coin-price">
-        <TableCellContent align="end" title={formattedPrice} />
+        <TableCellItem align="end">
+          <TableCellContent>
+            <TableCellContentTitle>{formattedPrice}</TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-volume">
-        <TableCellContent align="end" title={formattedVolume} />
+        <TableCellItem align="end">
+          <TableCellContent>
+            <TableCellContentTitle>{formattedVolume}</TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-cap">
-        <TableCellContent align="end" title={formattedMarketCap} />
+        <TableCellItem align="end">
+          <TableCellContent>
+            <TableCellContentTitle>{formattedMarketCap}</TableCellContentTitle>
+          </TableCellContent>
+        </TableCellItem>
       </TableCell>
 
       <TableCell align="end" className={MARKET_CELL_CLASSNAME} data-testid="market-price-change">

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/MarketRowView.test.tsx
@@ -63,7 +63,7 @@ describe("MarketRowView", () => {
   it("should render the image fallback when ledgerIds is empty", () => {
     const currency = { ...mockCurrency, ledgerIds: [] };
     renderRow(createProps({ currency }));
-    expect(screen.getByAltText("Bitcoin")).toBeVisible();
+    expect(screen.getByRole("img", { name: "Bitcoin" })).toBeVisible();
   });
 
   it("should render '-' when priceChangePercentage is undefined", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/useMarketRowViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/__tests__/useMarketRowViewModel.test.ts
@@ -57,7 +57,6 @@ function renderViewModel(
         size: 56,
         start: 112,
         currency: bitcoinCurrency,
-        counterCurrency: "usd",
         locale: "en",
         range: "24h",
         isStarred: false,

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
@@ -31,7 +31,6 @@ export function useMarketRowViewModel({
   size,
   start,
   currency,
-  counterCurrency,
   locale,
   range,
   isStarred,

--- a/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Market/components/MarketRow/useMarketRowViewModel.ts
@@ -20,7 +20,6 @@ type UseMarketRowViewModelProps = {
   size: number;
   start: number;
   currency: MarketCurrencyData;
-  counterCurrency?: string;
   locale: string;
   range?: string;
   isStarred: boolean;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/ContextMenuTrigger.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import { PopoverTrigger } from "@ledgerhq/lumen-ui-react";
+import { PopoverTrigger, type PopoverTriggerProps } from "@ledgerhq/lumen-ui-react";
 import { useTranslation } from "react-i18next";
 import { UserAvatar } from "./UserAvatar";
+
+type TriggerRenderProps = Parameters<
+  Extract<PopoverTriggerProps["render"], (...args: never[]) => unknown>
+>[0];
 
 export function ContextMenuTrigger() {
   const { t } = useTranslation();
@@ -9,13 +13,9 @@ export function ContextMenuTrigger() {
 
   return (
     <PopoverTrigger
-      render={
-        <button aria-label={label} className="cursor-pointer items-center justify-center">
-          <span className="inline-flex">
-            <UserAvatar showNotification size="sm" />
-          </span>
-        </button>
-      }
+      render={(props: TriggerRenderProps) => (
+        <UserAvatar interactive showNotification size="sm" aria-label={label} {...props} />
+      )}
     />
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/UserAvatarView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Avatar, DotIndicator, getDotIndicatorProps } from "@ledgerhq/lumen-ui-react";
+import { Avatar, AvatarButton, DotIndicator, getDotIndicatorProps } from "@ledgerhq/lumen-ui-react";
 import { MY_WALLET_AVATAR_USER_URL } from "./constants";
 import { UserAvatarViewProps } from "./types";
 
@@ -8,6 +8,8 @@ export function UserAvatarView({
   showNotification,
   unseenCount,
   size = "md",
+  interactive = false,
+  ...buttonProps
 }: UserAvatarViewProps) {
   const { t } = useTranslation();
 
@@ -16,9 +18,19 @@ export function UserAvatarView({
       ? t("myWallet.avatar.labelWithNotifications", { count: unseenCount })
       : t("myWallet.avatar.label");
 
-  const dotIndicatorProps = getDotIndicatorProps("avatar", size === "sm" ? "sm" : "md");
+  const dotIndicatorProps = getDotIndicatorProps("avatar", size);
 
-  const avatar = (
+  const avatar = interactive ? (
+    <AvatarButton
+      className="flex"
+      size={size}
+      src={MY_WALLET_AVATAR_USER_URL}
+      alt={ariaLabel}
+      data-testid="my-wallet-avatar"
+      appearance="thick"
+      {...buttonProps}
+    />
+  ) : (
     <Avatar
       size={size}
       src={MY_WALLET_AVATAR_USER_URL}

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/types.ts
@@ -1,8 +1,17 @@
+import { ComponentPropsWithRef } from "react";
 import { AvatarProps } from "@ledgerhq/lumen-ui-react";
-export type UserAvatarViewProps = {
+
+type UserAvatarButtonProps = Omit<ComponentPropsWithRef<"button">, "children">;
+
+export type UserAvatarProps = {
+  showNotification?: boolean;
+  unseenCount?: number;
+  size?: AvatarProps["size"];
+  /** When true, renders an interactive `AvatarButton` and forwards the button props below. */
+  interactive?: boolean;
+} & UserAvatarButtonProps;
+
+export type UserAvatarViewProps = Omit<UserAvatarProps, "showNotification" | "unseenCount"> & {
   showNotification: boolean;
   unseenCount: number;
-  size?: AvatarProps["size"];
 };
-
-export type UserAvatarProps = Partial<UserAvatarViewProps>;

--- a/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/MyWallet/components/UserAvatar/useUserAvatarViewModel.ts
@@ -4,7 +4,7 @@ import type { UserAvatarProps, UserAvatarViewProps } from "./types";
 export function useUserAvatarViewModel({
   showNotification,
   unseenCount,
-  size,
+  ...rest
 }: UserAvatarProps): UserAvatarViewProps {
   const { totalNotifCount } = useNotificationIndicator();
 
@@ -12,8 +12,8 @@ export function useUserAvatarViewModel({
   const resolvedCount = unseenCount ?? totalNotifCount;
 
   return {
+    ...rest,
     showNotification: resolvedShow,
     unseenCount: resolvedShow ? resolvedCount : 0,
-    size,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/TopBar/components/MyWalletTopBarAction.tsx
@@ -1,33 +1,17 @@
 import React from "react";
 import { UserAvatar } from "LLM/components/UserAvatar";
-import { Pressable } from "@ledgerhq/lumen-ui-rnative";
-import { Platform } from "react-native";
-import { LumenViewStyle } from "@ledgerhq/lumen-ui-rnative/styles";
 
 type Props = {
   onPress: () => void;
   showNotification: boolean;
 };
 
-export function MyWalletTopBarAction({ onPress, showNotification }: Readonly<Props>) {
-  const isAndroid = Platform.OS === "android";
-  const backgroundColor: LumenViewStyle["backgroundColor"] = isAndroid
-    ? "muted"
-    : "mutedTransparent";
-
-  const pressedBackgroundColor: LumenViewStyle["backgroundColor"] = isAndroid
-    ? "mutedPressed"
-    : "mutedTransparentPressed";
-
-  return (
-    <Pressable onPress={onPress} testID="topbar-mywallet" accessibilityLabel="My Wallet">
-      {({ pressed }) => (
-        <UserAvatar
-          size="md"
-          lx={{ backgroundColor: pressed ? pressedBackgroundColor : backgroundColor }}
-          showNotification={showNotification}
-        />
-      )}
-    </Pressable>
-  );
-}
+export const MyWalletTopBarAction = ({ onPress, showNotification }: Readonly<Props>) => (
+  <UserAvatar
+    size="md"
+    onPress={onPress}
+    showNotification={showNotification}
+    testID="topbar-mywallet"
+    accessibilityLabel="My Wallet"
+  />
+);

--- a/apps/ledger-live-mobile/src/mvvm/components/UserAvatar/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/components/UserAvatar/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Avatar,
+  AvatarButton,
   DotIndicator,
   getDotIndicatorProps,
   type AvatarProps,
@@ -11,19 +12,35 @@ type Props = {
   size?: AvatarProps["size"];
   lx?: AvatarProps["lx"];
   showNotification?: boolean;
+  /** When provided, renders an interactive `AvatarButton` instead of a plain `Avatar`. */
+  onPress?: () => void;
+  testID?: string;
+  accessibilityLabel?: string;
 };
 
-export function UserAvatar({ size = "lg", lx, showNotification }: Readonly<Props>) {
-  const dotIndicatorProps = getDotIndicatorProps("avatar", size === "sm" ? "sm" : "md");
+export function UserAvatar({
+  size = "lg",
+  lx,
+  showNotification,
+  onPress,
+  testID = "my-wallet-avatar",
+  accessibilityLabel,
+}: Readonly<Props>) {
+  const dotIndicatorProps = getDotIndicatorProps("avatar", size);
 
-  const avatar = (
-    <Avatar
+  const avatar = onPress ? (
+    <AvatarButton
       size={size}
       src={USER_AVATAR_URL}
       alt="My wallet avatar"
-      testID="my-wallet-avatar"
+      onPress={onPress}
       lx={lx}
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
+      appearance="thick"
     />
+  ) : (
+    <Avatar size={size} src={USER_AVATAR_URL} alt="My wallet avatar" testID={testID} lx={lx} />
   );
 
   return showNotification ? <DotIndicator {...dotIndicatorProps}>{avatar}</DotIndicator> : avatar;

--- a/features/flow/contacts/src/steps/List/components/ContactsList/ListItems/ContactsMeListItem.native.tsx
+++ b/features/flow/contacts/src/steps/List/components/ContactsList/ListItems/ContactsMeListItem.native.tsx
@@ -30,7 +30,7 @@ export function ContactsMeListItem({
       lx={{ marginHorizontal: "-s8" }}
     >
       <ListItemLeading>
-        <Avatar size="sm" appearance="gray" src={avatarSrc} alt={contact.name} />
+        <Avatar size="sm" src={avatarSrc} alt={contact.name} />
         <ListItemContent>
           <ListItemTitle>{contact.name}</ListItemTitle>
           <ListItemDescription>{addressCountLabel}</ListItemDescription>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,20 +64,20 @@ catalogs:
       specifier: 1.2.4
       version: 1.2.4
     '@ledgerhq/lumen-design-core':
-      specifier: 0.1.21
-      version: 0.1.21
+      specifier: 0.1.23
+      version: 0.1.23
     '@ledgerhq/lumen-ui-react':
-      specifier: 0.1.47
-      version: 0.1.47
+      specifier: 0.1.49
+      version: 0.1.49
     '@ledgerhq/lumen-ui-react-visualization':
-      specifier: 0.1.26
-      version: 0.1.26
+      specifier: 0.1.28
+      version: 0.1.28
     '@ledgerhq/lumen-ui-rnative':
-      specifier: 0.1.50
-      version: 0.1.50
+      specifier: 0.1.52
+      version: 0.1.52
     '@ledgerhq/lumen-ui-rnative-visualization':
-      specifier: 0.1.27
-      version: 0.1.27
+      specifier: 0.1.29
+      version: 0.1.29
     '@ledgerhq/speculos-device-controller':
       specifier: 0.3.0
       version: 0.3.0
@@ -624,7 +624,7 @@ importers:
         version: link:tools/create-release-hash
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/pnpm-utils':
         specifier: workspace:*
         version: link:tools/pnpm-utils
@@ -924,7 +924,7 @@ importers:
         version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent
@@ -993,13 +993,13 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-react-visualization':
         specifier: 'catalog:'
-        version: 0.1.26(174bda2d2155fc2b6f646ce954f9609c)
+        version: 0.1.28(f0c77ae05bd524e9f1fa27fe924480e3)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -1658,7 +1658,7 @@ importers:
         version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-rnative@0.1.50(06d7b9f801a4015982648e5aa5515f70))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-rnative@0.1.52(e185c177b115a51380796750601a5dcf))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent
@@ -1739,13 +1739,13 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(06d7b9f801a4015982648e5aa5515f70)
+        version: 0.1.52(e185c177b115a51380796750601a5dcf)
       '@ledgerhq/lumen-ui-rnative-visualization':
         specifier: 'catalog:'
-        version: 0.1.27(c628217d266e4cf7a3bbdb7fc7eec7d3)
+        version: 0.1.29(1873e0e78bbbbbbfe1a873f67e3af978)
       '@ledgerhq/native-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/native
@@ -2589,7 +2589,7 @@ importers:
         version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(bufferutil@4.1.0)(rxjs@7.8.2)(utf-8-validate@6.0.6)
@@ -2634,10 +2634,10 @@ importers:
         version: link:../../libs/ledgerjs/packages/logs
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@ledgerhq/react-ui':
         specifier: workspace:^
         version: link:../../libs/ui/packages/react
@@ -2928,13 +2928,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(10ef5eb9bf3f80c1151d90fb21ba7baa)
+        version: 0.1.52(270d3755349a23492d91ca093f57aa47)
       '@ledgerhq/lumen-utils-shared':
         specifier: 0.1.7
         version: 0.1.7(react@19.1.4)
@@ -3142,13 +3142,13 @@ importers:
         version: 30.2.0
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(78e809eb3da9e35712e775fd58df1ba6)
+        version: 0.1.49(841e1162e8eaf064c6808dfad901f501)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(2fea0ad8a9c36db7db456aad1ab3d04a)
+        version: 0.1.52(3d4e8367284189935a47ae5c345b5680)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -4167,16 +4167,16 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.50(905d4173dc541e653e891f9aa83e878c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.52(8f2c508bbb7b9fda5127db56feef203c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(905d4173dc541e653e891f9aa83e878c)
+        version: 0.1.52(8f2c508bbb7b9fda5127db56feef203c)
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2(react-redux@9.2.0(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -4292,13 +4292,13 @@ importers:
         version: link:../../platform/jest-config
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(78e809eb3da9e35712e775fd58df1ba6)
+        version: 0.1.49(841e1162e8eaf064c6808dfad901f501)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(16b445be534886c3e19f949290f0835e)
+        version: 0.1.52(91c747930584a0677dd1168d06727d8c)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -4425,10 +4425,10 @@ importers:
     devDependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4482,13 +4482,13 @@ importers:
         version: 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(905d4173dc541e653e891f9aa83e878c)
+        version: 0.1.52(8f2c508bbb7b9fda5127db56feef203c)
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
@@ -4720,13 +4720,13 @@ importers:
     dependencies:
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(@ledgerhq/lumen-design-core@0.1.21)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 0.1.52(@ledgerhq/lumen-design-core@0.1.23)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       clsx:
         specifier: 'catalog:'
         version: 2.1.1
@@ -12861,7 +12861,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-rnative@0.1.50(659878d439338b242d3f32d1bdf17e9b))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-rnative@0.1.52(0aebe1fc8d199b5f7709a0e48177e723))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: link:../icons
@@ -12925,10 +12925,10 @@ importers:
         version: 0.19.12
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.50(659878d439338b242d3f32d1bdf17e9b)
+        version: 0.1.52(0aebe1fc8d199b5f7709a0e48177e723)
       '@react-native-async-storage/async-storage':
         specifier: 2.1.2
         version: 2.1.2(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))
@@ -13189,7 +13189,7 @@ importers:
     dependencies:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@ledgerhq/icons-ui':
         specifier: workspace:^
         version: file:libs/ui/packages/icons(@types/react@19.0.14)(react@19.1.4)(styled-components@5.3.11(@babel/core@7.28.5)(react-dom@19.1.4(react@19.1.4))(react-is@17.0.2)(react@19.1.4))(styled-system@5.1.5)
@@ -13250,10 +13250,10 @@ importers:
         version: 7.28.5(@babel/core@7.28.5)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
-        version: 0.1.21
+        version: 0.1.23
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       '@radix-ui/react-checkbox':
         specifier: 'catalog:'
         version: 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -18509,25 +18509,25 @@ packages:
   '@ledgerhq/logs@6.16.0':
     resolution: {integrity: sha512-v/PLfb1dq1En35kkpbfRWp8jLYgbPUXxGhmd4pmvPSIe0nRGkNTomsZASmWQAv6pRonVGqHIBVlte7j1MBbOww==}
 
-  '@ledgerhq/lumen-design-core@0.1.21':
-    resolution: {integrity: sha512-kSAT5PdQRr/1h/TQSgB0NHQAKBohNJsRPRCoIlD1sazg7xYHBjcZZLnFOTQ2qvvpItCo8wNpB25rlQAZMMhUdQ==}
+  '@ledgerhq/lumen-design-core@0.1.23':
+    resolution: {integrity: sha512-DZ164hzEnHlxSu775g1OHWATxqCGSWSbsBIvGIJkvxjqSWo5iKyiHR4G3pNmcYPnfzNXeQJ8LMcQaAwZ1g8ZoA==}
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.26':
-    resolution: {integrity: sha512-roPL4K+nbKrKg/eRkXRIMMrB5lhBy4+MjN88XyWMl6Ykygq+iEFYFkBWzYJzHg6/ZErcRLkBOi0xcoVCpm/AmA==}
+  '@ledgerhq/lumen-ui-react-visualization@0.1.28':
+    resolution: {integrity: sha512-eSU7FqHnCKhyIlVzGfMrexpr+ZfwnLv2LJzaW3ElNFCxnl4SOxhX9PBpmv5va7fUsXrh1lPG9zOnW/XjBIvrXQ==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-react': 0.1.47
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-react': 0.1.49
       class-variance-authority: ^0.7.1
       clsx: ^2.1.1
       react: 19.1.4
       react-dom: 19.1.4
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-react@0.1.47':
-    resolution: {integrity: sha512-Ad4UTKUoMO3q1neRD3CyzczayZnbkTIdUaxlKBFQa6CM5DMHB481iRlAJjt+S4vNdHmNcWrBZymygeRC43d+nw==}
+  '@ledgerhq/lumen-ui-react@0.1.49':
+    resolution: {integrity: sha512-avOcoe4UK9gnYPFDaGglTuTZSA8m4dd4DhHzbOs2EGBvgfMgiRSTO9vhFQGL/R3FJ3kiXAwb3EoW+M0MrSUU0A==}
     peerDependencies:
       '@base-ui/react': ^1.3.0
-      '@ledgerhq/lumen-design-core': 0.1.21
+      '@ledgerhq/lumen-design-core': 0.1.23
       '@radix-ui/react-checkbox': ^1.3.2
       '@radix-ui/react-dialog': ^1.1.15
       '@radix-ui/react-slot': ^1.2.4
@@ -18540,11 +18540,11 @@ packages:
       react-dom: 19.1.4
       tailwind-merge: ^2.6.0
 
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.27':
-    resolution: {integrity: sha512-PKXo2a8v/NYVL3YZ5lP4L1lz0VPc9QJ8M/iyhNNLJtoRs9FmgzTzGWDfmf6Ok8guvIMp/mFKan9HRnOZzmER8g==}
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.29':
+    resolution: {integrity: sha512-CXD6aDw1xczG6eqMdlDWMCnPWDA75cl/YID1YfdE5B0/TNY2CLrIyZzOx/mkliE3xkYBOHhyPKGsrZY4QdRh/w==}
     peerDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-rnative': 0.1.50
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-rnative': 0.1.52
       '@types/react': ^19.0.0
       react: 19.1.4
       react-native: ~0.81.6
@@ -18553,11 +18553,11 @@ packages:
       react-native-svg: ^15.0.0
       react-native-worklets: '>=0.5.0'
 
-  '@ledgerhq/lumen-ui-rnative@0.1.50':
-    resolution: {integrity: sha512-03CrPEFz6FuJO5bW+zI632uvqFtATt1HmnCAb4qIvBAXMLAqEYAd/O6El51y1v5/epHkBXnRZKKf/8ukSRIPBQ==}
+  '@ledgerhq/lumen-ui-rnative@0.1.52':
+    resolution: {integrity: sha512-7NbVsWLzQXMMGoKvjoOLwmrzM3HE7Jam81WDsnDlzvTTrhq7PMSYcnNQs+2rpiPvdCsY1Gf3jRtFufPqvWkvtQ==}
     peerDependencies:
       '@gorhom/bottom-sheet': ^5.0.0
-      '@ledgerhq/lumen-design-core': 0.1.21
+      '@ledgerhq/lumen-design-core': 0.1.23
       '@sbaiahmed1/react-native-blur': ^4.5.5
       '@types/react': ^19.0.0
       expo: '>=54.0.0'
@@ -18568,13 +18568,13 @@ packages:
       react-native-safe-area-context: ^4.0.0 || ^5.0.0
       react-native-svg: ^15.0.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.7':
-    resolution: {integrity: sha512-G/eZXvir5wgmrTx8gkHU+oe+lGS9iIYXBZtb9IYJlJJ5JYN4h3GbrM/w0dCe9zCePqUCyAIztCOBVeltZDeXRA==}
+  '@ledgerhq/lumen-utils-shared@0.1.10':
+    resolution: {integrity: sha512-P1iJqN2YrIR2o0GaEkh370T+cVZVoUjehB0y6XPCHMdyPJYa0wmwSKLrGpKqkcR68jnw1lh2FdOaGSukh7UiIA==}
     peerDependencies:
       react: 19.1.4
 
-  '@ledgerhq/lumen-utils-shared@0.1.9':
-    resolution: {integrity: sha512-sUl/G4QVobXEOz5XyG82ad2UU7ajNAY5vkuX1wDvTLd2F3yiPaWCSH6/0A2/VE0afCtH9XNsg4D0KcH00L/T3A==}
+  '@ledgerhq/lumen-utils-shared@0.1.7':
+    resolution: {integrity: sha512-G/eZXvir5wgmrTx8gkHU+oe+lGS9iIYXBZtb9IYJlJJ5JYN4h3GbrM/w0dCe9zCePqUCyAIztCOBVeltZDeXRA==}
     peerDependencies:
       react: 19.1.4
 
@@ -25005,7 +25005,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -46718,40 +46718,40 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-react': 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-react': 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
       react-dom: 19.1.4(react@19.1.4)
 
-  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.50(905d4173dc541e653e891f9aa83e878c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.52(8f2c508bbb7b9fda5127db56feef203c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-react': 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/lumen-ui-rnative': 0.1.50(905d4173dc541e653e891f9aa83e878c)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-react': 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative': 0.1.52(8f2c508bbb7b9fda5127db56feef203c)
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
-  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-rnative@0.1.50(06d7b9f801a4015982648e5aa5515f70))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-rnative@0.1.52(0aebe1fc8d199b5f7709a0e48177e723))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
     optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-rnative': 0.1.50(06d7b9f801a4015982648e5aa5515f70)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-
-  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.21)(@ledgerhq/lumen-ui-rnative@0.1.50(659878d439338b242d3f32d1bdf17e9b))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)':
-    dependencies:
-      react: 19.1.4
-    optionalDependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-rnative': 0.1.50(659878d439338b242d3f32d1bdf17e9b)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-rnative': 0.1.52(0aebe1fc8d199b5f7709a0e48177e723)
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
+
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-rnative@0.1.52(e185c177b115a51380796750601a5dcf))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-rnative': 0.1.52(e185c177b115a51380796750601a5dcf)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   '@ledgerhq/device-management-kit@1.7.1':
     dependencies:
@@ -47000,16 +47000,16 @@ snapshots:
 
   '@ledgerhq/logs@6.16.0': {}
 
-  '@ledgerhq/lumen-design-core@0.1.21':
+  '@ledgerhq/lumen-design-core@0.1.23':
     dependencies:
       tailwindcss: 4.1.18
       tslib: 2.6.2
 
-  '@ledgerhq/lumen-ui-react-visualization@0.1.26(174bda2d2155fc2b6f646ce954f9609c)':
+  '@ledgerhq/lumen-ui-react-visualization@0.1.28(f0c77ae05bd524e9f1fa27fe924480e3)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-react': 0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-react': 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       d3-array: 3.2.4
@@ -47019,10 +47019,10 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       tailwind-merge: 3.4.0
 
-  '@ledgerhq/lumen-ui-react@0.1.47(78e809eb3da9e35712e775fd58df1ba6)':
+  '@ledgerhq/lumen-ui-react@0.1.49(841e1162e8eaf064c6808dfad901f501)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.1.4)
@@ -47039,10 +47039,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       '@radix-ui/react-checkbox': 1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.1.4)
@@ -47059,10 +47059,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       '@radix-ui/react-checkbox': 1.3.2(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.0.14)(react@19.1.4)
@@ -47079,10 +47079,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
+  '@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       clsx: 2.1.1
       i18next: 23.10.1
       react: 19.1.4
@@ -47092,10 +47092,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.47(@ledgerhq/lumen-design-core@0.1.21)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+  '@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       i18next: 23.10.1
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -47103,11 +47103,11 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-rnative-visualization@0.1.27(c628217d266e4cf7a3bbdb7fc7eec7d3)':
+  '@ledgerhq/lumen-ui-rnative-visualization@0.1.29(1873e0e78bbbbbbfe1a873f67e3af978)':
     dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-ui-rnative': 0.1.50(06d7b9f801a4015982648e5aa5515f70)
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-rnative': 0.1.52(e185c177b115a51380796750601a5dcf)
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       '@types/react': 19.0.14
       d3-array: 3.2.4
       d3-scale: 4.0.2
@@ -47119,11 +47119,103 @@ snapshots:
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-worklets: 0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
 
-  '@ledgerhq/lumen-ui-rnative@0.1.50(06d7b9f801a4015982648e5aa5515f70)':
+  '@ledgerhq/lumen-ui-rnative@0.1.52(0aebe1fc8d199b5f7709a0e48177e723)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      expo: 54.0.33(@babel/core@7.28.5)(@typescript/typescript6@6.0.2)(expo-modules-core@3.0.29)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(270d3755349a23492d91ca093f57aa47)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      expo-haptics: 15.0.8(expo-modules-core@3.0.29(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(3d4e8367284189935a47ae5c345b5680)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      expo-haptics: 15.0.8(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(8f2c508bbb7b9fda5127db56feef203c)':
+    dependencies:
+      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-native-reanimated: 4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(91c747930584a0677dd1168d06727d8c)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-native-reanimated: 4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(@ledgerhq/lumen-design-core@0.1.23)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(e185c177b115a51380796750601a5dcf)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(9ca1a6d7a3a1152060da488767ca355f)
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
       '@sbaiahmed1/react-native-blur': 4.5.5(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@types/react': 19.0.14
       expo: 54.0.33(01371b6b08adf68dcde9ab2ace4a34f9)
@@ -47138,105 +47230,13 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.50(10ef5eb9bf3f80c1151d90fb21ba7baa)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      expo-haptics: 15.0.8(expo-modules-core@3.0.29(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.50(16b445be534886c3e19f949290f0835e)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-      react-native-reanimated: 4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.50(2fea0ad8a9c36db7db456aad1ab3d04a)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      expo-haptics: 15.0.8(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.50(659878d439338b242d3f32d1bdf17e9b)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      expo: 54.0.33(@babel/core@7.28.5)(@typescript/typescript6@6.0.2)(expo-modules-core@3.0.29)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
-      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
-      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.50(905d4173dc541e653e891f9aa83e878c)':
-    dependencies:
-      '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-      react-native-reanimated: 4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-      react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-ui-rnative@0.1.50(@ledgerhq/lumen-design-core@0.1.21)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.21
-      '@ledgerhq/lumen-utils-shared': 0.1.9(react@19.1.4)
-      '@types/react': 19.0.14
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
-  '@ledgerhq/lumen-utils-shared@0.1.7(react@19.1.4)':
+  '@ledgerhq/lumen-utils-shared@0.1.10(react@19.1.4)':
     dependencies:
       clsx: 2.1.1
       react: 19.1.4
       tailwind-merge: 2.6.0
 
-  '@ledgerhq/lumen-utils-shared@0.1.9(react@19.1.4)':
+  '@ledgerhq/lumen-utils-shared@0.1.7(react@19.1.4)':
     dependencies:
       clsx: 2.1.1
       react: 19.1.4
@@ -66423,7 +66423,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66547,6 +66547,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,11 +36,11 @@ catalog:
   "@ledgerhq/signer-utils": 1.2.0
   "@ledgerhq/device-transport-kit-web-hid": 1.2.4
   "@ledgerhq/speculos-device-controller": 0.3.0
-  "@ledgerhq/lumen-design-core": 0.1.21
-  "@ledgerhq/lumen-ui-react": 0.1.47
-  "@ledgerhq/lumen-ui-rnative": 0.1.50
-  "@ledgerhq/lumen-ui-rnative-visualization": 0.1.27
-  "@ledgerhq/lumen-ui-react-visualization": 0.1.26
+  "@ledgerhq/lumen-design-core": 0.1.23
+  "@ledgerhq/lumen-ui-react": 0.1.49
+  "@ledgerhq/lumen-ui-rnative": 0.1.52
+  "@ledgerhq/lumen-ui-rnative-visualization": 0.1.29
+  "@ledgerhq/lumen-ui-react-visualization": 0.1.28
   "@ledgerhq/zcash-utils": 1.1.0
   # React Native
   react-native: 0.81.6


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Existing desktop + mobile suites for the impacted areas all pass (My Wallet top bar, Market, History, Assets, Analytics, CryptoAddresses, Portfolio, Contacts). Purely-visual tweaks (rings, circular fallback, centering) are not asserted by unit tests._
- [x] **Impact of the changes:**
  - **My Wallet avatar / top bar (both apps)** — now an interactive `AvatarButton`; on Desktop this also **fixes the vertical centering** of the top-bar trigger. Verify the popover/press still opens and the notification dot renders.
  - **Market** list rows — name/price/volume/market-cap cells, marketcap-rank tag, and the circular `MediaImage` currency-icon **fallback** (when no crypto-icon is available)
  - **Portfolio / Assets** table (Wallet 4.0) — name, price, balance, value, trend cells (+ placeholder rows)
  - **Analytics → Allocation** table — name, balance, value, distribution cells
  - **History / Operations** list — operation type + counterparty cells, unread dot
  - **Crypto Addresses / Accounts** table (asset detail) — account name, address, aggregated name/value and assets cells
  - **Contacts** list (mobile) — the "Me" list-item avatar (dropped the removed `appearance="gray"`)
  - General: this is a global Lumen bump — check for visual regressions on components consuming the design system (notably `Avatar`, which no longer renders a ring by default).

### 📝 Description

Bumps the Lumen design-system packages on both Ledger Wallet Desktop and Mobile to the latest versions, handles the breaking changes, and adopts the new components so the UI stays coherent.

| Package | From | To |
| --- | --- | --- |
| `@ledgerhq/lumen-design-core` | 0.1.21 | 0.1.23 |
| `@ledgerhq/lumen-ui-react` | 0.1.47 | 0.1.49 |
| `@ledgerhq/lumen-ui-rnative` | 0.1.50 | 0.1.52 |
| `@ledgerhq/lumen-ui-rnative-visualization` | 0.1.27 | 0.1.29 |
| `@ledgerhq/lumen-ui-react-visualization` | 0.1.26 | 0.1.28 |

**Breaking changes handled**

- **`TableCellContent` → compound API (react 0.1.48, desktop only).** Removed `title` / `description` / `leadingContent` / `align` props migrated across all 13 desktop table usages:

  ```tsx
  // Before
  <TableCellContent leadingContent={icon} title="Bitcoin" description="BTC" />

  // After
  <TableCellItem>
    {icon}
    <TableCellContent>
      <TableCellContentTitle>Bitcoin</TableCellContentTitle>
      <TableCellContentDescription>BTC</TableCellContentDescription>
    </TableCellContent>
  </TableCellItem>
  ```

- **`Avatar.appearance` semantics (BC2).** `appearance` no longer controls the background color — it now controls the ring width (`thin` / `thick`, none by default). Removed the stale `appearance="gray"` on the mobile Contacts "Me" avatar, and set explicit `thin`/`thick` rings on the interactive My Wallet avatar to keep the intended look.

**New-component adoption (UI coherence)**

- **Interactive avatar → `AvatarButton` (both apps).** `UserAvatar` now renders an `AvatarButton` when interactive. On Desktop, `ContextMenuTrigger` uses `PopoverTrigger`'s render-function form so the trigger behaviour lands on the button while the notification `DotIndicator` stays a non-interactive wrapper — and this removes the old hand-rolled `<button>` whose dead centering classes left the trigger **vertically off-centre** in the top bar. On Mobile, `MyWalletTopBarAction` drops its outer `Pressable` (the `AvatarButton` is the pressable).
- **`getDotIndicatorProps` simplification.** The helper is now typed for the full avatar size range, so the manual `size === "sm" ? "sm" : "md"` clamp is gone.
- **`MediaImage` (circular) market fallback.** The market-list currency-icon fallback now uses the Lumen `MediaImage` component with `shape="circle"`, matching the round crypto-icon.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35029](https://ledgerhq.atlassian.net/browse/LIVE-35029)

Table 

https://github.com/user-attachments/assets/cbc90658-ec73-42b0-89ec-a42ae1e80224

Avatar


https://github.com/user-attachments/assets/c48c4110-e88e-48b9-8be9-41d756fdd090


https://github.com/user-attachments/assets/2ef2c571-e1c1-4632-8afe-4177545415ed


---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-35029]: https://ledgerhq.atlassian.net/browse/LIVE-35029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ