### PR TITLE
[LWDM] Fix(LIVE-34676): aleo self transfer label

### DIFF
--- a/.changeset/yellow-zebras-type.md
+++ b/.changeset/yellow-zebras-type.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+changes to self transfer label for Aleo

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/SelfTransferModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/SelfTransferModal.integ.test.tsx
@@ -89,7 +89,7 @@ describe("SelfTransferModal", () => {
   it("renders the self transfer modal with a CONVERT_PUBLIC_TO_PRIVATE transaction by default", async () => {
     render(<SelfTransferModal stepId="recipient" />, { initialState: openedModalState() });
 
-    expect(screen.getByText("Self transfer")).toBeInTheDocument();
+    expect(screen.getByText("Convert")).toBeInTheDocument();
 
     await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
     const [, transaction] = prepareTransactionSpy.mock.calls[0];

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/SelfTransferModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/SelfTransferModal.integ.test.tsx
@@ -89,7 +89,7 @@ describe("SelfTransferModal", () => {
   it("renders the self transfer modal with a CONVERT_PUBLIC_TO_PRIVATE transaction by default", async () => {
     render(<SelfTransferModal stepId="recipient" />, { initialState: openedModalState() });
 
-    expect(screen.getByText("Convert")).toBeInTheDocument();
+    expect(screen.getByText("Convert")).toBeVisible();
 
     await waitFor(() => expect(prepareTransactionSpy).toHaveBeenCalled());
     const [, transaction] = prepareTransactionSpy.mock.calls[0];

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9107,10 +9107,10 @@
       }
     },
     "selfTransfer": {
-      "headerAction": "Self transfer",
+      "headerAction": "Convert",
       "headerActionTooltip": "You don't have any funds to perform a self transfer",
       "modal": {
-        "title": "Self transfer",
+        "title": "Convert",
         "stepRecipient": {
           "selectLabel": "Transfer from"
         }

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10160,7 +10160,7 @@
       }
     },
     "accountActions": {
-      "publicToPrivate": "Self transfer"
+      "publicToPrivate": "Convert"
     },
     "send": {
       "balanceSelection": {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Renames the Aleo self-transfer action label from "Self transfer" to "Convert" in both desktop and mobile
- Desktop: updates aleo.selfTransfer.headerAction and the modal title in static/i18n/en/app.json
- Mobile: updates aleo.accountActions.publicToPrivate in src/locales/en/common.json
- Updates the desktop integration test assertion to match the new label

### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34676](https://ledgerhq.atlassian.net/browse/LIVE-34676)

<img width="530" height="259" alt="image" src="https://github.com/user-attachments/assets/71fa86a6-13f8-4f34-979e-c205ca9d6dd4" />
