### PR TITLE
[LWDM] feat(contacts): select desktop address currency with MAD (LIVE-33913)

### DIFF
--- a/.changeset/bright-coins-select.md
+++ b/.changeset/bright-coins-select.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": minor
+"live-mobile": patch
+---
+
+Add contact address asset and network selection through the Modular Dialog, with shared asset
+filtering across Desktop and Mobile.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import type { ContactId } from "@domain/entity-contact";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { resolveEligibleAddressCurrencyIds } from "@features/flow-contacts";
 import {
   mockContact,
   mockMeContact,
   mockPopulatedContacts,
 } from "@domain/entity-contact/schema.mock";
-import { fireEvent, render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
+import { act, fireEvent, render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
 import { useContactsViewModel } from "LLD/features/Contacts/screens/Contacts/useContactsViewModel";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
@@ -69,7 +71,15 @@ function ContactsViewModelProbe({
   const stateLabel =
     viewModel.addAddressFlowState.status === "closed"
       ? "closed"
-      : `${viewModel.addAddressFlowState.status}:${viewModel.addAddressFlowState.selectedContactId}`;
+      : [
+          viewModel.addAddressFlowState.status,
+          viewModel.addAddressFlowState.selectedContactId,
+          "selectedCurrencyId" in viewModel.addAddressFlowState
+            ? viewModel.addAddressFlowState.selectedCurrencyId
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join(":");
 
   return (
     <>
@@ -411,6 +421,29 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
   });
 
+  it("should open MAD from the real Add Address CTA with the eligible network ids", async () => {
+    const { store, user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-me-row"));
+    await user.click(screen.getByTestId("contacts-detail-add-address"));
+
+    expect(store.getState().modularDialog.isOpen).toBe(true);
+    expect(store.getState().modularDialog.dialogParams?.networkIds).toEqual(
+      resolveEligibleAddressCurrencyIds(["evm"]),
+    );
+    expect(store.getState().modularDialog.dialogParams?.onAccountSelected).toBeUndefined();
+  });
+
   it("should expose the Add Address session started for Me", async () => {
     const { user } = render(
       <MemoryRouter initialEntries={["/contacts"]}>
@@ -455,6 +488,86 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
       "selectingCurrency:contact-ada",
     );
+  });
+
+  it("should enter the address step with the exact selected contact and currency", async () => {
+    const { store, user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={savedContactId} contactType="saved" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    act(() => {
+      store
+        .getState()
+        .modularDialog.dialogParams?.onAssetSelected?.(getCryptoCurrencyById("ethereum"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
+        "enteringAddress:contact-ada:ethereum",
+      );
+    });
+    expect(store.getState().modularDialog.isOpen).toBe(false);
+  });
+
+  it("should close the Add Address session when MAD is cancelled", async () => {
+    const { store, user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={meContactId} contactType="me" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    act(() => {
+      store.getState().modularDialog.dialogParams?.onClose?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+    });
+    expect(store.getState().modularDialog.isOpen).toBe(false);
+  });
+
+  it("should keep the Add Address session closed when no network is eligible", async () => {
+    const { store, user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <ContactsViewModelProbe contactId={meContactId} contactType="me" />
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: {
+          ...contactsPageInitialState(),
+          ...withFlagOverrides({
+            lwdContacts: {
+              enabled: true,
+              params: { newBadge: false, eligibleAddressFamilies: ["unknown"] },
+            },
+          }),
+        },
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open contact" }));
+    await user.click(screen.getByRole("button", { name: "Start Add Address" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+    });
+    expect(store.getState().modularDialog.isOpen).toBe(false);
   });
 
   it("should not render the detail state when a contact with addresses is selected", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -1,0 +1,43 @@
+import { renderHook } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useOpenCurrencyFlow } from "../../ModularDialog/hooks/useOpenCurrencyFlow";
+import { useContactsCurrencySelectionAdapter } from "./useContactsCurrencySelectionAdapter";
+
+jest.mock("../../ModularDialog/hooks/useOpenCurrencyFlow", () => ({
+  useOpenCurrencyFlow: jest.fn(),
+}));
+
+const openCurrencyFlow = jest.fn();
+
+describe("useContactsCurrencySelectionAdapter", () => {
+  const ethereumId = getCryptoCurrencyById("ethereum").id;
+  const bitcoinId = getCryptoCurrencyById("bitcoin").id;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useOpenCurrencyFlow).mockReturnValue({ openCurrencyFlow });
+  });
+
+  it("should pass the exact network ids and return the selected currency id", async () => {
+    openCurrencyFlow.mockResolvedValue(getCryptoCurrencyById("ethereum"));
+    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
+
+    await expect(result.current.selectCurrency([ethereumId, bitcoinId])).resolves.toBe(ethereumId);
+    expect(openCurrencyFlow).toHaveBeenCalledWith([ethereumId, bitcoinId]);
+  });
+
+  it("should return null when the selected currency id is invalid", async () => {
+    openCurrencyFlow.mockResolvedValue({ id: "" } as CryptoOrTokenCurrency);
+    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
+
+    await expect(result.current.selectCurrency([ethereumId])).resolves.toBeNull();
+  });
+
+  it("should return null when the selection is cancelled", async () => {
+    openCurrencyFlow.mockResolvedValue(null);
+    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
+
+    await expect(result.current.selectCurrency([ethereumId])).resolves.toBeNull();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import { ContactCurrencyIdSchema, type ContactAddress } from "@domain/entity-contact";
+import type { ContactsCurrencySelectionPort } from "@features/flow-contacts";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import {
+  type OpenCurrencyFlow,
+  useOpenCurrencyFlow,
+} from "../../ModularDialog/hooks/useOpenCurrencyFlow";
+
+function resolveContactCurrencyId(
+  currency: CryptoOrTokenCurrency | null,
+): ContactAddress["currencyId"] | null {
+  const parsedCurrencyId = ContactCurrencyIdSchema.safeParse(currency?.id);
+  return parsedCurrencyId.success ? parsedCurrencyId.data : null;
+}
+
+function createCurrencySelectionPort(
+  openCurrencyFlow: OpenCurrencyFlow,
+): ContactsCurrencySelectionPort {
+  return {
+    selectCurrency: async networkIds =>
+      resolveContactCurrencyId(await openCurrencyFlow(networkIds)),
+  };
+}
+
+export function useContactsCurrencySelectionAdapter(): ContactsCurrencySelectionPort {
+  const { openCurrencyFlow } = useOpenCurrencyFlow();
+
+  return useMemo(() => createCurrencySelectionPort(openCurrencyFlow), [openCurrencyFlow]);
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import type { Contact, ContactId } from "@domain/entity-contact";
 import {
   useEmptyContactDetail,
-  type AddAddressFlowViewModel,
   type ContactDetailLabels,
   type ContactDetailViewProps,
   type ContactsListViewProps,
@@ -12,7 +11,7 @@ import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/User
 
 export function useContactDetailPaneAdapter(
   contacts: readonly Contact[],
-  startAddAddress: AddAddressFlowViewModel["start"],
+  onAddAddress: (contactId: ContactId) => void,
 ): Readonly<{
   detail: ContactDetailViewProps | undefined;
   onOpenMe: ContactsListViewProps["onOpenMe"];
@@ -59,9 +58,9 @@ export function useContactDetailPaneAdapter(
       contact: selectedContact,
       labels,
       meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
-      onAddAddress: () => startAddAddress(selectedContact.id),
+      onAddAddress: () => onAddAddress(selectedContact.id),
     };
-  }, [labels, selectedContact, startAddAddress]);
+  }, [labels, onAddAddress, selectedContact]);
 
   return {
     detail,

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
+import type { ContactId } from "@domain/entity-contact";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   createContactsListViewModel,
   createContactsSearchViewModel,
   resolveContactsLedgerSyncIntroductionOpen,
+  useAddAddressCurrencySelectionViewModel,
   useAddAddressFlowViewModel,
   useContacts,
   useContactsFeatureIntroductionState,
@@ -17,6 +19,7 @@ import {
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
 import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
+import { useContactsCurrencySelectionAdapter } from "../../hooks/useContactsCurrencySelectionAdapter";
 import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 
 export type ContactsPageViewModel = Omit<ContactsListViewProps, "onAddContact"> &
@@ -31,11 +34,33 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
-  const { state: addAddressFlowState, start: startAddAddress } = useAddAddressFlowViewModel();
-  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(
-    contacts,
-    startAddAddress,
+  const currencySelection = useContactsCurrencySelectionAdapter();
+  const { selectCurrency } = useAddAddressCurrencySelectionViewModel({
+    platform: "desktop",
+    currencySelection,
+  });
+  const {
+    state: addAddressFlowState,
+    start: startAddAddress,
+    completeCurrencySelection,
+    close: closeAddAddress,
+  } = useAddAddressFlowViewModel();
+  const onAddAddress = useCallback(
+    (contactId: ContactId) => {
+      startAddAddress(contactId);
+      void selectCurrency()
+        .then(result => {
+          if (result.status === "selected") {
+            completeCurrencySelection(contactId, result.currencyId);
+          } else if (result.status === "cancelled" || result.status === "unavailable") {
+            closeAddAddress();
+          }
+        })
+        .catch(closeAddAddress);
+    },
+    [closeAddAddress, completeCurrencySelection, selectCurrency, startAddAddress],
   );
+  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(contacts, onAddAddress);
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const preference = useContactsFeatureIntroductionPreference();

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
@@ -1,7 +1,24 @@
-import { useModularDialogData } from "../useModularDialogData";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { LoadingStatus } from "@ledgerhq/live-common/deposit/type";
-import { renderHook, waitFor } from "tests/testSetup";
 import { expectedAssetsSorted } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
+import { renderHook, waitFor } from "tests/testSetup";
+import { useModularDialogData } from "../useModularDialogData";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => {
+  const actual = jest.requireActual<
+    typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
+  >("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+
+  return {
+    ...actual,
+    useAssetsData: jest.fn(actual.useAssetsData),
+  };
+});
+
+const mockedUseAssetsData = jest.mocked(useAssetsData);
+const actualUseAssetsData = jest.requireActual<
+  typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
+>("@ledgerhq/live-common/dada-client/hooks/useAssetsData").useAssetsData;
 
 describe("useModularDialogData", () => {
   it("should return the correct data structure", async () => {
@@ -46,5 +63,82 @@ describe("useModularDialogData", () => {
     expect(sortedCryptoCurrencies).toBeDefined();
     expect(Array.isArray(sortedCryptoCurrencies)).toBe(true);
     expect(sortedCryptoCurrencies[0].id).toBe("bitcoin");
+  });
+});
+
+describe("useModularDialogData filters", () => {
+  beforeEach(() => {
+    mockedUseAssetsData.mockClear();
+    mockedUseAssetsData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetchingNextPage: false,
+      isSuccess: true,
+      isError: false,
+      error: undefined,
+      errorInfo: {
+        hasError: false,
+        isNetworkError: false,
+        isApiError: false,
+        apiStatus: undefined,
+      },
+      loadNext: jest.fn(),
+      refetch: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    mockedUseAssetsData.mockImplementation(actualUseAssetsData);
+  });
+
+  it("should not forward network ids as exact DADA currency ids", () => {
+    renderHook(() => useModularDialogData(), {
+      initialState: {
+        modularDialog: {
+          searchedValue: undefined,
+          isDebuggingDuplicates: false,
+          flow: "",
+          source: "",
+          isOpen: true,
+          dialogParams: {
+            networkIds: ["ethereum"],
+            currencies: ["bitcoin"],
+            areCurrenciesFiltered: true,
+          },
+        },
+      },
+    });
+
+    expect(mockedUseAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currencyIds: undefined,
+        areCurrenciesFiltered: false,
+      }),
+    );
+  });
+
+  it("should preserve the existing exact currency filter", () => {
+    renderHook(() => useModularDialogData(), {
+      initialState: {
+        modularDialog: {
+          searchedValue: undefined,
+          isDebuggingDuplicates: false,
+          flow: "",
+          source: "",
+          isOpen: true,
+          dialogParams: {
+            currencies: ["bitcoin"],
+            areCurrenciesFiltered: true,
+          },
+        },
+      },
+    });
+
+    expect(mockedUseAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currencyIds: ["bitcoin"],
+        areCurrenciesFiltered: true,
+      }),
+    );
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useOpenCurrencyFlow.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from "tests/testSetup";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { useOpenCurrencyFlow } from "../useOpenCurrencyFlow";
+
+describe("useOpenCurrencyFlow", () => {
+  const ethereum = getCryptoCurrencyById("ethereum");
+  const bitcoin = getCryptoCurrencyById("bitcoin");
+
+  it("should open the terminal currency flow with the exact network ids", () => {
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+
+    void result.current.openCurrencyFlow([ethereum.id, bitcoin.id]);
+
+    expect(store.getState().modularDialog.dialogParams).toMatchObject({
+      networkIds: [ethereum.id, bitcoin.id],
+    });
+    expect(store.getState().modularDialog.dialogParams?.currencies).toBeUndefined();
+    expect(store.getState().modularDialog.dialogParams?.onAccountSelected).toBeUndefined();
+  });
+
+  it("should resolve the selected currency and close the dialog once", async () => {
+    const onResolved = jest.fn();
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+    const selection = result.current.openCurrencyFlow([ethereum.id]).then(onResolved);
+    const { onAssetSelected, onClose } = store.getState().modularDialog.dialogParams ?? {};
+
+    act(() => {
+      onAssetSelected?.(ethereum);
+      onClose?.();
+    });
+    await selection;
+
+    expect(onResolved).toHaveBeenCalledTimes(1);
+    expect(onResolved).toHaveBeenCalledWith(ethereum);
+    expect(store.getState().modularDialog.isOpen).toBe(false);
+  });
+
+  it("should resolve null when the dialog closes", async () => {
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+    const selection = result.current.openCurrencyFlow([ethereum.id]);
+
+    act(() => {
+      store.getState().modularDialog.dialogParams?.onClose?.();
+    });
+
+    await expect(selection).resolves.toBeNull();
+    expect(store.getState().modularDialog.isOpen).toBe(false);
+  });
+
+  it("should cancel its pending selection before opening another one", async () => {
+    const { result, store } = renderHook(() => useOpenCurrencyFlow());
+    const firstSelection = result.current.openCurrencyFlow([bitcoin.id]);
+    const firstOnAssetSelected = store.getState().modularDialog.dialogParams?.onAssetSelected;
+    const secondSelection = result.current.openCurrencyFlow([ethereum.id]);
+
+    await expect(firstSelection).resolves.toBeNull();
+
+    act(() => {
+      firstOnAssetSelected?.(bitcoin);
+    });
+
+    expect(store.getState().modularDialog.isOpen).toBe(true);
+    expect(store.getState().modularDialog.dialogParams?.networkIds).toEqual([ethereum.id]);
+
+    act(() => {
+      store.getState().modularDialog.dialogParams?.onAssetSelected?.(ethereum);
+    });
+
+    await expect(secondSelection).resolves.toBe(ethereum);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
@@ -5,12 +5,13 @@ import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssets
 import {
   modularDialogAreCurrenciesFilteredSelector,
   modularDialogCurrenciesSelector,
+  modularDialogNetworkIdsSelector,
   modularDialogUseCaseSelector,
   modularDialogSearchedSelector,
 } from "~/renderer/reducers/modularDialog";
 import { useSelector } from "LLD/hooks/redux";
 import { useFeature } from "@features/platform-feature-flags";
-import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
+import { buildAssetsSorted } from "@ledgerhq/live-common/modularDrawer/utils/buildAssetsSorted";
 import useEnv from "@features/platform-env";
 
 export function useModularDialogData() {
@@ -24,41 +25,31 @@ export function useModularDialogData() {
   const searchedValue = useSelector(modularDialogSearchedSelector);
 
   const currencyIds = useSelector(modularDialogCurrenciesSelector);
+  const networkIds = useSelector(modularDialogNetworkIdsSelector);
   const useCase = useSelector(modularDialogUseCaseSelector);
   const areCurrenciesFiltered = useSelector(modularDialogAreCurrenciesFilteredSelector);
 
   const { data, isLoading, isSuccess, error, errorInfo, loadNext, refetch } = useAssetsData({
     search: searchedValue,
-    currencyIds,
+    currencyIds: networkIds === undefined ? currencyIds : undefined,
     product: "lld",
     version: __APP_VERSION__,
     useCase,
-    areCurrenciesFiltered,
+    areCurrenciesFiltered: networkIds === undefined ? areCurrenciesFiltered : false,
     isStaging,
     includeTestNetworks: devMode,
   });
 
-  const assetsSorted: AssetData[] | undefined = useMemo(() => {
-    if (!data?.currenciesOrder.metaCurrencyIds) return undefined;
-
-    return data.currenciesOrder.metaCurrencyIds
-      .filter(currencyId => data.cryptoAssets[currencyId])
-      .map(currencyId => {
-        const firstNetworkId = Object.values(data.cryptoAssets[currencyId].assetsIds)[0];
-        return {
-          asset: {
-            ...data.cryptoAssets[currencyId],
-            id: firstNetworkId,
-            metaCurrencyId: currencyId,
-          },
-          networks: Object.values(data.cryptoAssets[currencyId].assetsIds)
-            .map(assetId => data.cryptoOrTokenCurrencies[assetId])
-            .filter(network => network !== undefined),
-          interestRates: data.interestRates?.[firstNetworkId],
-          market: data.markets?.[firstNetworkId],
-        };
-      });
-  }, [data]);
+  const assetsSorted = useMemo(
+    () =>
+      data
+        ? buildAssetsSorted(data, {
+            includeMetaCurrencyId: true,
+            networkIds,
+          })
+        : undefined,
+    [data, networkIds],
+  );
 
   const loadingStatus: LoadingStatus = getLoadingStatus({ isLoading, isSuccess, error });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useOpenCurrencyFlow.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import { useDispatch, useStore } from "LLD/hooks/redux";
+import { closeDialog, openDialog } from "~/renderer/reducers/modularDialog";
+
+type SettleCurrencySelection = (currency: CryptoOrTokenCurrency | null) => boolean;
+
+type PendingCurrencySelection = Readonly<{
+  requestId: object;
+  onAssetSelected: (currency: CryptoOrTokenCurrency) => void;
+  settle: SettleCurrencySelection;
+}>;
+
+export type OpenCurrencyFlow = (
+  networkIds: readonly CryptoCurrency["id"][],
+) => Promise<CryptoOrTokenCurrency | null>;
+
+export function useOpenCurrencyFlow(): Readonly<{ openCurrencyFlow: OpenCurrencyFlow }> {
+  const dispatch = useDispatch();
+  const store = useStore();
+  const pendingSelectionRef = useRef<PendingCurrencySelection | undefined>(undefined);
+
+  const openCurrencyFlow = useCallback<OpenCurrencyFlow>(
+    networkIds => {
+      pendingSelectionRef.current?.settle(null);
+
+      return new Promise(resolve => {
+        let isSettled = false;
+        const requestId = {};
+
+        const settle: SettleCurrencySelection = currency => {
+          if (isSettled) return false;
+
+          isSettled = true;
+          if (pendingSelectionRef.current?.requestId === requestId) {
+            pendingSelectionRef.current = undefined;
+          }
+          resolve(currency);
+          return true;
+        };
+        const onAssetSelected = (currency: CryptoOrTokenCurrency) => {
+          if (settle(currency)) {
+            dispatch(closeDialog());
+          }
+        };
+
+        pendingSelectionRef.current = { requestId, onAssetSelected, settle };
+
+        dispatch(
+          openDialog({
+            networkIds: [...networkIds],
+            onAssetSelected,
+            onClose: () => {
+              if (settle(null)) {
+                dispatch(closeDialog());
+              }
+            },
+          }),
+        );
+      });
+    },
+    [dispatch],
+  );
+
+  useEffect(
+    () => () => {
+      const pendingSelection = pendingSelectionRef.current;
+      if (!pendingSelection) return;
+
+      pendingSelection.settle(null);
+      if (
+        store.getState().modularDialog.dialogParams?.onAssetSelected ===
+        pendingSelection.onAssetSelected
+      ) {
+        dispatch(closeDialog());
+      }
+    },
+    [dispatch, store],
+  );
+
+  return { openCurrencyFlow };
+}

--- a/apps/ledger-live-desktop/src/renderer/reducers/modularDialog.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/modularDialog.ts
@@ -6,6 +6,7 @@ import type { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/w
 
 export interface ModularDialogParams {
   currencies?: string[];
+  networkIds?: readonly string[];
   dialogConfiguration?: EnhancedModularDrawerConfiguration;
   useCase?: string;
   uiUseCase?: string;
@@ -51,7 +52,10 @@ const modularDialogSlice = createSlice({
       state.source = action.payload;
     },
     openDialog: (state, action: PayloadAction<ModularDialogParams>) => {
-      state.dialogParams = action.payload;
+      state.dialogParams = {
+        ...action.payload,
+        networkIds: action.payload.networkIds ? [...action.payload.networkIds] : undefined,
+      };
       state.isOpen = true;
     },
     closeDialog: state => {
@@ -75,6 +79,8 @@ export const modularDialogConfigurationSelector = (state: State) =>
   state.modularDialog.dialogParams?.dialogConfiguration;
 export const modularDialogCurrenciesSelector = (state: State) =>
   state.modularDialog.dialogParams?.currencies;
+export const modularDialogNetworkIdsSelector = (state: State) =>
+  state.modularDialog.dialogParams?.networkIds;
 export const modularDialogUseCaseSelector = (state: State) =>
   state.modularDialog.dialogParams?.useCase;
 export const modularDialogUiUseCaseSelector = (state: State) =>

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
@@ -4,11 +4,9 @@ import { getLoadingStatus } from "@ledgerhq/live-common/modularDrawer/utils/getL
 import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import VersionNumber from "react-native-version-number";
 import { useFeature } from "@features/platform-feature-flags";
-import { AssetData } from "@ledgerhq/live-common/modularDrawer/utils/type";
+import { buildAssetsSorted } from "@ledgerhq/live-common/modularDrawer/utils/buildAssetsSorted";
 import { useAcceptedCurrency } from "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency";
 import useEnv from "@features/platform-env";
-
-type DadaAssetsData = NonNullable<ReturnType<typeof useAssetsData>["data"]>;
 
 interface AssetsProps {
   currencyIds?: string[];
@@ -16,38 +14,6 @@ interface AssetsProps {
   searchedValue?: string;
   useCase?: string;
   areCurrenciesFiltered?: boolean;
-}
-
-function buildAssetsSorted(data: DadaAssetsData, networkIds?: readonly string[]): AssetData[] {
-  const allowedNetworkIds = networkIds === undefined ? undefined : new Set(networkIds);
-
-  return data.currenciesOrder.metaCurrencyIds.flatMap(metaCurrencyId => {
-    const asset = data.cryptoAssets[metaCurrencyId];
-    if (!asset) return [];
-
-    const assetIdEntries = Object.entries(asset.assetsIds).filter(
-      ([networkId]) => allowedNetworkIds?.has(networkId) ?? true,
-    );
-    const networks = assetIdEntries.flatMap(([, assetId]) => {
-      const currency = data.cryptoOrTokenCurrencies[assetId];
-      return currency ? [currency] : [];
-    });
-    const firstCurrency = networks[0];
-    if (!firstCurrency) return [];
-
-    return [
-      {
-        asset: {
-          ...asset,
-          id: firstCurrency.id,
-          assetsIds: Object.fromEntries(assetIdEntries),
-        },
-        networks,
-        interestRates: data.interestRates?.[firstCurrency.id],
-        market: data.markets?.[firstCurrency.id],
-      },
-    ];
-  });
 }
 
 export function useAssets({
@@ -78,7 +44,7 @@ export function useAssets({
   });
 
   const assetsSorted = useMemo(
-    () => (data ? buildAssetsSorted(data, networkIds) : undefined),
+    () => (data ? buildAssetsSorted(data, { networkIds }) : undefined),
     [data, networkIds],
   );
 

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -349,6 +349,7 @@
     "src/wallet-api/ModularDrawer/utils.ts",
     "src/modularDrawer/hooks/useDetailedAccountsCore.ts",
     "src/modularDrawer/types/detailedAccount.ts",
+    "src/modularDrawer/utils/buildAssetsSorted.ts",
     "src/modularDrawer/utils/sortAccountsByFiatValue.ts",
     "src/modularDrawer/index.ts",
     "src/test-helpers/cryptoAssetsStore.ts",

--- a/libs/ledger-live-common/src/modularDrawer/utils/__tests__/buildAssetsSorted.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/__tests__/buildAssetsSorted.test.ts
@@ -1,0 +1,54 @@
+import {
+  mockAssetsData,
+  mockBitcoinAssetsData,
+  mockUsdcAssetsData,
+} from "../../../dada-client/__mocks__/assets.mock";
+import { buildAssetsSorted } from "../buildAssetsSorted";
+
+describe("buildAssetsSorted", () => {
+  it("filters native assets and tokens by their parent network", () => {
+    const ethereumTokens = buildAssetsSorted(mockAssetsData, {
+      includeMetaCurrencyId: true,
+      networkIds: ["ethereum"],
+    });
+    const usdc = buildAssetsSorted(mockUsdcAssetsData, {
+      includeMetaCurrencyId: true,
+      networkIds: ["ethereum"],
+    });
+    const bitcoin = buildAssetsSorted(mockBitcoinAssetsData, {
+      includeMetaCurrencyId: true,
+      networkIds: ["bitcoin"],
+    });
+
+    expect(ethereumTokens[0]?.asset).toMatchObject({
+      metaCurrencyId: "urn:crypto:meta-currency:injective_protocol",
+      assetsIds: { ethereum: "ethereum/erc20/injective_token" },
+    });
+    expect(ethereumTokens[0]?.networks).toEqual([
+      expect.objectContaining({ id: "ethereum/erc20/injective_token" }),
+    ]);
+    expect(usdc[0]?.asset.assetsIds).toEqual({
+      ethereum: "ethereum/erc20/usd_coin",
+    });
+    expect(bitcoin[0]?.networks).toEqual([expect.objectContaining({ id: "bitcoin" })]);
+  });
+
+  it("omits meta-currency identifiers by default", () => {
+    const assets = buildAssetsSorted(mockAssetsData, {
+      networkIds: ["ethereum"],
+    });
+
+    expect(assets.every(({ asset }) => asset.metaCurrencyId === undefined)).toBe(true);
+  });
+
+  it("preserves all asset networks without a network filter", () => {
+    const [injective] = buildAssetsSorted(mockAssetsData, {
+      includeMetaCurrencyId: true,
+    });
+
+    expect(injective?.asset.assetsIds).toEqual(
+      mockAssetsData.cryptoAssets["urn:crypto:meta-currency:injective_protocol"].assetsIds,
+    );
+    expect(injective?.networks).toHaveLength(3);
+  });
+});

--- a/libs/ledger-live-common/src/modularDrawer/utils/buildAssetsSorted.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/buildAssetsSorted.ts
@@ -1,0 +1,43 @@
+import type { AssetsData } from "../../dada-client/entities";
+import type { AssetData } from "./type";
+
+type BuildAssetsSortedOptions = Readonly<{
+  includeMetaCurrencyId?: boolean;
+  networkIds?: readonly string[];
+}>;
+
+export function buildAssetsSorted(
+  data: AssetsData,
+  { includeMetaCurrencyId = false, networkIds }: BuildAssetsSortedOptions = {},
+): AssetData[] {
+  const allowedNetworkIds = networkIds === undefined ? undefined : new Set(networkIds);
+
+  return data.currenciesOrder.metaCurrencyIds.flatMap(metaCurrencyId => {
+    const asset = data.cryptoAssets[metaCurrencyId];
+    if (!asset) return [];
+
+    const assetIdEntries = Object.entries(asset.assetsIds).filter(
+      ([networkId]) => allowedNetworkIds?.has(networkId) ?? true,
+    );
+    const networks = assetIdEntries.flatMap(([, assetId]) => {
+      const currency = data.cryptoOrTokenCurrencies[assetId];
+      return currency ? [currency] : [];
+    });
+    const firstCurrency = networks[0];
+    if (!firstCurrency) return [];
+
+    return [
+      {
+        asset: {
+          ...asset,
+          id: firstCurrency.id,
+          ...(includeMetaCurrencyId ? { metaCurrencyId } : {}),
+          assetsIds: Object.fromEntries(assetIdEntries),
+        },
+        networks,
+        interestRates: data.interestRates?.[firstCurrency.id],
+        market: data.markets?.[firstCurrency.id],
+      },
+    ];
+  });
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** 42 targeted Contacts and Modular Dialog tests cover network filtering, terminal selection, cancellation, replacement, and existing Account behavior.
- [x] **Impact of the changes:**
      Verify that Add Address opens MAD, EVM tokens such as USDC and USDT remain selectable, and selection stops before address entry.

### 📝 Description

Connects the Desktop Contacts Add Address CTA to the existing Modular Dialog terminal asset and network selection.

The shared Contacts flow provides eligible parent network IDs. Desktop keeps those IDs separate from DADA's exact currency filter, filters each asset by its parent network, and returns only the final native or token `currencyId` to the Contacts session. Selection advances the session to `enteringAddress`; cancellation or an unavailable selection closes it.

This PR does not add address-entry UI, Add Account or Device navigation, analytics, or translations. Network filtering intentionally matches the current Mobile client-side behavior; server-side `networkIds` filtering and automatic loading of filtered-empty pages remain follow-up work.

### 📸 Screenshots

https://github.com/user-attachments/assets/da4ba3c4-f82e-44d7-86dd-2d7c57fcb8f2

### 
❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33913

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
