### PR TITLE
[LWM] fix(llm): migrate CryptoOrTokenCurrency to @domain/entity-currency

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { ContactCurrencyIdSchema, type ContactAddress } from "@domain/entity-contact";
 import type { ContactsCurrencySelectionPort } from "@features/flow-contacts";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { ScreenName } from "~/const";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/ModularDrawer.tsx
@@ -9,7 +9,7 @@ import QueuedDrawerBottomSheet from "LLM/components/QueuedDrawer/QueuedDrawerBot
 import QueuedDrawerGorhom from "LLM/components/QueuedDrawer/temp/QueuedDrawerGorhom";
 
 import { AccountLike } from "@ledgerhq/types-live";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useSelector } from "~/context/hooks";
 import {
   modularDrawerCompletionModeSelector,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
@@ -1,5 +1,5 @@
 import { AccountLike } from "@ledgerhq/types-live";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 
 export type AccountCallback = (account: AccountLike, parentAccount?: AccountLike) => void;
 export type CurrencyCallback = (currency: CryptoOrTokenCurrency | null) => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { shallowEqual } from "react-redux";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { AccountLike } from "@ledgerhq/types-live";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { openModularDrawer, closeModularDrawer } from "~/reducers/modularDrawer";
 import type { State } from "~/reducers/types";
 import { DrawerParams, DrawerRemoteParams } from "../types";

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -1,6 +1,6 @@
 import { AccountLike, Account } from "@ledgerhq/types-live";
 import { EnhancedModularDrawerConfiguration } from "@ledgerhq/live-common/wallet-api/ModularDrawer/types";
-import type { CryptoOrTokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 
 export enum ModularDrawerStep {
   Asset = "Asset",


### PR DESCRIPTION
## Summary

- 5 files in \`apps/ledger-live-mobile\` were importing \`CryptoOrTokenCurrency\` from \`@ledgerhq/types-cryptoassets\`, which was dropped from LLM in #20016
- These files were introduced by PRs merged after #20016 and missed the migration
- Fix: import from \`@domain/entity-currency\` — the designated package for union currency types (\`CryptoOrTokenCurrency\`, \`Currency\`, etc.)

## Files changed

- \`Contacts/hooks/useContactsCurrencySelectionAdapter.ts\`
- \`ModularDrawer/ModularDrawer.tsx\`
- \`ModularDrawer/hooks/useCallbackRegistry/types.ts\`
- \`ModularDrawer/hooks/useModularDrawerController.ts\`
- \`ModularDrawer/types.ts\`

## Test plan

- [ ] \`pnpm nx run ledger-live-mobile:typecheck\` passes