### PR TITLE
test(mobile): fix TMS link placement for SEI EVM delegate test

### DIFF
--- a/e2e/mobile/specs/delegate/delegateSEI.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateSEI.spec.ts
@@ -15,10 +15,9 @@ const tmsLinks: string[] = ["B2CQA-5740"];
 const tags = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@sei_evm", "@family-evm"];
 
 setTeamOwner(Team.COIN_INTEGRATION);
+tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+tags.forEach(tag => $Tag(tag));
 describe("Delegate", () => {
-  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
-  tags.forEach(tag => $Tag(tag));
-
   beforeAll(async () => {
     await app.init({
       speculosApp: AppInfos.SEI,


### PR DESCRIPTION
## Summary
- Moves `$TmsLink` and `$Tag` calls outside of `describe()` block to correctly associate them with the test suite in Allure
- Previously TMS link was not visible in Allure report because `$TmsLink("B2CQA-5740")` was called inside `describe()` — reporter ignores metadata registered at that phase
- Aligns with the pattern used in all other delegate tests (see `delegate.ts`)

## Test plan
- [ ] Verify in Allure report that test `Delegate on SEI Network (EVM)` has a clickable TMS link to B2CQA-5740