### PR TITLE
[LWDM] chore(fiat): drop id field from @domain/entity-currency-fiat

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/hooks/__tests__/fixtures.ts
@@ -1,6 +1,5 @@
 import type { Portfolio, PortfolioRange } from "@ledgerhq/types-live";
 import type { SyncPhase } from "@ledgerhq/live-common/bridge/react/useSyncLifecycle";
-import { FiatCurrencySchema } from "@domain/entity-currency-fiat";
 
 // --- Sync source mock functions ---
 
@@ -29,7 +28,6 @@ const dayRange: PortfolioRange = "day";
 
 export const mockCounterValue = {
   type: "FiatCurrency" as const,
-  id: FiatCurrencySchema.shape.id.parse("usd"),
   ticker: "USD",
   name: "US Dollar",
   units: [{ name: "US Dollar", code: "$", magnitude: 2, showAllDigits: true, prefixCode: true }],

--- a/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/changeCurrency.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Market/__integrations__/changeCurrency.integration.test.tsx
@@ -2,8 +2,6 @@ import * as React from "react";
 import { screen, renderWithReactQuery } from "@tests/test-renderer";
 import { MarketPages } from "./shared";
 import { State, supportedCountervaluesData } from "~/reducers/types";
-import { FiatCurrencySchema } from "@domain/entity-currency-fiat";
-
 const SUPPORTED_CURRENCIES = [
   {
     currency: {
@@ -12,7 +10,6 @@ const SUPPORTED_CURRENCIES = [
       ticker: "EUR",
       type: "FiatCurrency",
       units: [],
-      id: FiatCurrencySchema.shape.id.parse("eur"),
     },
     label: "Euro - EUR",
     ticker: "EUR",
@@ -25,7 +22,6 @@ const SUPPORTED_CURRENCIES = [
       ticker: "USD",
       type: "FiatCurrency",
       units: [],
-      id: FiatCurrencySchema.shape.id.parse("usd"),
     },
     label: "US Dollar - USD",
     ticker: "USD",

--- a/domain/api/currency-fiat/src/converter.ts
+++ b/domain/api/currency-fiat/src/converter.ts
@@ -20,9 +20,9 @@ export function resolveSupportedFiats(tickers: string[]): FiatCurrency[] {
     if (OFAC_FIAT_TICKERS.has(upper)) continue;
 
     const currency = findFiatCurrencyByTicker(upper);
-    if (!currency || seen.has(currency.id)) continue;
+    if (!currency || seen.has(currency.ticker)) continue;
 
-    seen.add(currency.id);
+    seen.add(currency.ticker);
     resolved.push(currency);
   }
 

--- a/domain/entity/currency-fiat/package.json
+++ b/domain/entity/currency-fiat/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
-    "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/domain/entity/currency-fiat/src/constants.test.ts
+++ b/domain/entity/currency-fiat/src/constants.test.ts
@@ -1,7 +1,7 @@
 import * as currencies from "./currencies";
 import {
   FIAT_CURRENCIES_REGISTRY,
-  FIAT_CURRENCIES_IDS,
+  FIAT_CURRENCIES_TICKERS,
   FIAT_CURRENCIES_BY_TICKER,
 } from "./constants";
 
@@ -10,32 +10,32 @@ describe("FIAT_CURRENCIES_REGISTRY", () => {
     expect(Object.keys(FIAT_CURRENCIES_REGISTRY).length).toBeGreaterThan(0);
   });
 
-  it("has no duplicate ids across currency files", () => {
+  it("has no duplicate tickers across currency files", () => {
     const seen = new Map<string, string>();
     for (const [varName, currency] of Object.entries(currencies)) {
-      const existing = seen.get(currency.id);
+      const existing = seen.get(currency.ticker);
       expect(existing).toBeUndefined();
-      seen.set(currency.id, varName);
+      seen.set(currency.ticker, varName);
     }
   });
 
-  it("every entry is keyed by its own id", () => {
+  it("every entry is keyed by its own ticker", () => {
     for (const [key, currency] of Object.entries(FIAT_CURRENCIES_REGISTRY)) {
-      expect(currency.id).toBe(key);
+      expect(currency.ticker).toBe(key);
     }
   });
 
-  it("every entry has type FiatCurrency and a non-empty id", () => {
+  it("every entry has type FiatCurrency and a non-empty ticker", () => {
     for (const currency of Object.values(FIAT_CURRENCIES_REGISTRY)) {
       expect(currency.type).toBe("FiatCurrency");
-      expect(currency.id.length).toBeGreaterThan(0);
+      expect(currency.ticker.length).toBeGreaterThan(0);
     }
   });
 });
 
-describe("FIAT_CURRENCIES_IDS", () => {
+describe("FIAT_CURRENCIES_TICKERS", () => {
   it("length matches registry", () => {
-    expect(FIAT_CURRENCIES_IDS.length).toBe(Object.keys(FIAT_CURRENCIES_REGISTRY).length);
+    expect(FIAT_CURRENCIES_TICKERS.length).toBe(Object.keys(FIAT_CURRENCIES_REGISTRY).length);
   });
 });
 

--- a/domain/entity/currency-fiat/src/constants.ts
+++ b/domain/entity/currency-fiat/src/constants.ts
@@ -2,16 +2,16 @@ import * as currencies from "./currencies";
 import type { FiatCurrency } from "./schema";
 
 /**
- * Pre-built registry of all known fiat currencies, keyed by currency id.
+ * Pre-built registry of all known fiat currencies, keyed by ISO 4217 ticker (e.g. `"USD"`).
  */
 export const FIAT_CURRENCIES_REGISTRY: Record<string, FiatCurrency> = Object.fromEntries(
   Object.values(currencies)
     .filter((c): c is FiatCurrency => Boolean(c))
-    .map(c => [c.id, c]),
+    .map(c => [c.ticker, c]),
 );
 
-/** All known fiat currency ids as a constant array. */
-export const FIAT_CURRENCIES_IDS = Object.values(FIAT_CURRENCIES_REGISTRY).map(c => c.id);
+/** All known fiat currency ISO 4217 tickers as a constant array. */
+export const FIAT_CURRENCIES_TICKERS = Object.values(FIAT_CURRENCIES_REGISTRY).map(c => c.ticker);
 
 /**
  * Registry of all known fiat currencies, keyed by ISO 4217 ticker (e.g. `"USD"`).

--- a/domain/entity/currency-fiat/src/currencies/aed.ts
+++ b/domain/entity/currency-fiat/src/currencies/aed.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const aed = fiat({
   type: "FiatCurrency",
-  id: "aed",
   ticker: "AED",
   name: "Emirati Dirham",
   symbol: "د.إ.",

--- a/domain/entity/currency-fiat/src/currencies/afn.ts
+++ b/domain/entity/currency-fiat/src/currencies/afn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const afn = fiat({
   type: "FiatCurrency",
-  id: "afn",
   ticker: "AFN",
   name: "Afghan Afghani",
   symbol: "؋",

--- a/domain/entity/currency-fiat/src/currencies/all.ts
+++ b/domain/entity/currency-fiat/src/currencies/all.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const all = fiat({
   type: "FiatCurrency",
-  id: "all",
   ticker: "ALL",
   name: "Albanian Lek",
   symbol: "Lek",

--- a/domain/entity/currency-fiat/src/currencies/amd.ts
+++ b/domain/entity/currency-fiat/src/currencies/amd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const amd = fiat({
   type: "FiatCurrency",
-  id: "amd",
   ticker: "AMD",
   name: "Armenian Dram",
   symbol: "֏",

--- a/domain/entity/currency-fiat/src/currencies/ang.ts
+++ b/domain/entity/currency-fiat/src/currencies/ang.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ang = fiat({
   type: "FiatCurrency",
-  id: "ang",
   ticker: "ANG",
   name: "Netherlands Antillean Guilder",
   symbol: "ƒ",

--- a/domain/entity/currency-fiat/src/currencies/aoa.ts
+++ b/domain/entity/currency-fiat/src/currencies/aoa.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const aoa = fiat({
   type: "FiatCurrency",
-  id: "aoa",
   ticker: "AOA",
   name: "Angolan Kwanza",
   symbol: "Kz",

--- a/domain/entity/currency-fiat/src/currencies/ars.ts
+++ b/domain/entity/currency-fiat/src/currencies/ars.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ars = fiat({
   type: "FiatCurrency",
-  id: "ars",
   ticker: "ARS",
   name: "Argentine Peso",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/aud.ts
+++ b/domain/entity/currency-fiat/src/currencies/aud.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const aud = fiat({
   type: "FiatCurrency",
-  id: "aud",
   ticker: "AUD",
   name: "Australian Dollar",
   symbol: "AU$",

--- a/domain/entity/currency-fiat/src/currencies/awg.ts
+++ b/domain/entity/currency-fiat/src/currencies/awg.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const awg = fiat({
   type: "FiatCurrency",
-  id: "awg",
   ticker: "AWG",
   name: "Aruban Florin",
   symbol: "ƒ",

--- a/domain/entity/currency-fiat/src/currencies/azn.ts
+++ b/domain/entity/currency-fiat/src/currencies/azn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const azn = fiat({
   type: "FiatCurrency",
-  id: "azn",
   ticker: "AZN",
   name: "Azerbaijani Manat",
   symbol: "₼",

--- a/domain/entity/currency-fiat/src/currencies/bam.ts
+++ b/domain/entity/currency-fiat/src/currencies/bam.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bam = fiat({
   type: "FiatCurrency",
-  id: "bam",
   ticker: "BAM",
   name: "Bosnia-Herzegovina Convertible Mark",
   symbol: "КМ",

--- a/domain/entity/currency-fiat/src/currencies/bbd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bbd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bbd = fiat({
   type: "FiatCurrency",
-  id: "bbd",
   ticker: "BBD",
   name: "Barbadian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/bdt.ts
+++ b/domain/entity/currency-fiat/src/currencies/bdt.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bdt = fiat({
   type: "FiatCurrency",
-  id: "bdt",
   ticker: "BDT",
   name: "Bangladeshi Taka",
   symbol: "৳",

--- a/domain/entity/currency-fiat/src/currencies/bgn.ts
+++ b/domain/entity/currency-fiat/src/currencies/bgn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bgn = fiat({
   type: "FiatCurrency",
-  id: "bgn",
   ticker: "BGN",
   name: "Bulgarian Lev",
   symbol: "лв.",

--- a/domain/entity/currency-fiat/src/currencies/bhd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bhd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bhd = fiat({
   type: "FiatCurrency",
-  id: "bhd",
   ticker: "BHD",
   name: "Bahraini Dinar",
   symbol: "د.ب.",

--- a/domain/entity/currency-fiat/src/currencies/bif.ts
+++ b/domain/entity/currency-fiat/src/currencies/bif.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bif = fiat({
   type: "FiatCurrency",
-  id: "bif",
   ticker: "BIF",
   name: "Burundian Franc",
   symbol: "FBu",

--- a/domain/entity/currency-fiat/src/currencies/bmd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bmd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bmd = fiat({
   type: "FiatCurrency",
-  id: "bmd",
   ticker: "BMD",
   name: "Bermudian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/bnd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bnd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bnd = fiat({
   type: "FiatCurrency",
-  id: "bnd",
   ticker: "BND",
   name: "Brunei Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/bob.ts
+++ b/domain/entity/currency-fiat/src/currencies/bob.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bob = fiat({
   type: "FiatCurrency",
-  id: "bob",
   ticker: "BOB",
   name: "Bolivian Boliviano",
   symbol: "Bs",

--- a/domain/entity/currency-fiat/src/currencies/brl.ts
+++ b/domain/entity/currency-fiat/src/currencies/brl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const brl = fiat({
   type: "FiatCurrency",
-  id: "brl",
   ticker: "BRL",
   name: "Brazilian Real",
   symbol: "R$",

--- a/domain/entity/currency-fiat/src/currencies/bsd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bsd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bsd = fiat({
   type: "FiatCurrency",
-  id: "bsd",
   ticker: "BSD",
   name: "Bahamian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/btc.ts
+++ b/domain/entity/currency-fiat/src/currencies/btc.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const btc = fiat({
   type: "FiatCurrency",
-  id: "btc",
   ticker: "BTC",
   name: "Bitcoin",
   symbol: "₿",

--- a/domain/entity/currency-fiat/src/currencies/btn.ts
+++ b/domain/entity/currency-fiat/src/currencies/btn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const btn = fiat({
   type: "FiatCurrency",
-  id: "btn",
   ticker: "BTN",
   name: "Bhutanese Ngultrum",
   symbol: "Nu.",

--- a/domain/entity/currency-fiat/src/currencies/bwp.ts
+++ b/domain/entity/currency-fiat/src/currencies/bwp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bwp = fiat({
   type: "FiatCurrency",
-  id: "bwp",
   ticker: "BWP",
   name: "Botswana Pula",
   symbol: "P",

--- a/domain/entity/currency-fiat/src/currencies/byn.ts
+++ b/domain/entity/currency-fiat/src/currencies/byn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const byn = fiat({
   type: "FiatCurrency",
-  id: "byn",
   ticker: "BYN",
   name: "Belarusian Ruble",
   symbol: "р.",

--- a/domain/entity/currency-fiat/src/currencies/byr.ts
+++ b/domain/entity/currency-fiat/src/currencies/byr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const byr = fiat({
   type: "FiatCurrency",
-  id: "byr",
   ticker: "BYR",
   name: "Belarusian Ruble (pre-2016)",
   symbol: "р.",

--- a/domain/entity/currency-fiat/src/currencies/bzd.ts
+++ b/domain/entity/currency-fiat/src/currencies/bzd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const bzd = fiat({
   type: "FiatCurrency",
-  id: "bzd",
   ticker: "BZD",
   name: "Belize Dollar",
   symbol: "BZ$",

--- a/domain/entity/currency-fiat/src/currencies/cad.ts
+++ b/domain/entity/currency-fiat/src/currencies/cad.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cad = fiat({
   type: "FiatCurrency",
-  id: "cad",
   ticker: "CAD",
   name: "Canadian Dollar",
   symbol: "CA$",

--- a/domain/entity/currency-fiat/src/currencies/cdf.ts
+++ b/domain/entity/currency-fiat/src/currencies/cdf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cdf = fiat({
   type: "FiatCurrency",
-  id: "cdf",
   ticker: "CDF",
   name: "Congolese Franc",
   symbol: "FC",

--- a/domain/entity/currency-fiat/src/currencies/chf.ts
+++ b/domain/entity/currency-fiat/src/currencies/chf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const chf = fiat({
   type: "FiatCurrency",
-  id: "chf",
   ticker: "CHF",
   name: "Swiss Franc",
   symbol: "CHF",

--- a/domain/entity/currency-fiat/src/currencies/clp.ts
+++ b/domain/entity/currency-fiat/src/currencies/clp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const clp = fiat({
   type: "FiatCurrency",
-  id: "clp",
   ticker: "CLP",
   name: "Chilean Peso",
   symbol: "CLP$",

--- a/domain/entity/currency-fiat/src/currencies/cny.ts
+++ b/domain/entity/currency-fiat/src/currencies/cny.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cny = fiat({
   type: "FiatCurrency",
-  id: "cny",
   ticker: "CNY",
   name: "Chinese Yuan Renminbi",
   symbol: "¥",

--- a/domain/entity/currency-fiat/src/currencies/cop.ts
+++ b/domain/entity/currency-fiat/src/currencies/cop.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cop = fiat({
   type: "FiatCurrency",
-  id: "cop",
   ticker: "COP",
   name: "Colombian Peso",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/crc.ts
+++ b/domain/entity/currency-fiat/src/currencies/crc.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const crc = fiat({
   type: "FiatCurrency",
-  id: "crc",
   ticker: "CRC",
   name: "Costa Rican Colón",
   symbol: "₡",

--- a/domain/entity/currency-fiat/src/currencies/cuc.ts
+++ b/domain/entity/currency-fiat/src/currencies/cuc.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cuc = fiat({
   type: "FiatCurrency",
-  id: "cuc",
   ticker: "CUC",
   name: "Cuban Convertible Peso",
   symbol: "CUC",

--- a/domain/entity/currency-fiat/src/currencies/cup.ts
+++ b/domain/entity/currency-fiat/src/currencies/cup.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cup = fiat({
   type: "FiatCurrency",
-  id: "cup",
   ticker: "CUP",
   name: "Cuban Peso",
   symbol: "$MN",

--- a/domain/entity/currency-fiat/src/currencies/cve.ts
+++ b/domain/entity/currency-fiat/src/currencies/cve.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const cve = fiat({
   type: "FiatCurrency",
-  id: "cve",
   ticker: "CVE",
   name: "Cape Verdean Escudo",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/czk.ts
+++ b/domain/entity/currency-fiat/src/currencies/czk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const czk = fiat({
   type: "FiatCurrency",
-  id: "czk",
   ticker: "CZK",
   name: "Czech Koruna",
   symbol: "Kč",

--- a/domain/entity/currency-fiat/src/currencies/djf.ts
+++ b/domain/entity/currency-fiat/src/currencies/djf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const djf = fiat({
   type: "FiatCurrency",
-  id: "djf",
   ticker: "DJF",
   name: "Djiboutian Franc",
   symbol: "Fdj",

--- a/domain/entity/currency-fiat/src/currencies/dkk.ts
+++ b/domain/entity/currency-fiat/src/currencies/dkk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const dkk = fiat({
   type: "FiatCurrency",
-  id: "dkk",
   ticker: "DKK",
   name: "Danish Krone",
   symbol: "kr.",

--- a/domain/entity/currency-fiat/src/currencies/dop.ts
+++ b/domain/entity/currency-fiat/src/currencies/dop.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const dop = fiat({
   type: "FiatCurrency",
-  id: "dop",
   ticker: "DOP",
   name: "Dominican Peso",
   symbol: "RD$",

--- a/domain/entity/currency-fiat/src/currencies/dzd.ts
+++ b/domain/entity/currency-fiat/src/currencies/dzd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const dzd = fiat({
   type: "FiatCurrency",
-  id: "dzd",
   ticker: "DZD",
   name: "Algerian Dinar",
   symbol: "د.ج.‏",

--- a/domain/entity/currency-fiat/src/currencies/egp.ts
+++ b/domain/entity/currency-fiat/src/currencies/egp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const egp = fiat({
   type: "FiatCurrency",
-  id: "egp",
   ticker: "EGP",
   name: "Egyptian Pound",
   symbol: "ج.م.‏",

--- a/domain/entity/currency-fiat/src/currencies/ern.ts
+++ b/domain/entity/currency-fiat/src/currencies/ern.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ern = fiat({
   type: "FiatCurrency",
-  id: "ern",
   ticker: "ERN",
   name: "Eritrean Nakfa",
   symbol: "Nfk",

--- a/domain/entity/currency-fiat/src/currencies/etb.ts
+++ b/domain/entity/currency-fiat/src/currencies/etb.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const etb = fiat({
   type: "FiatCurrency",
-  id: "etb",
   ticker: "ETB",
   name: "Ethiopian Birr",
   symbol: "ETB",

--- a/domain/entity/currency-fiat/src/currencies/eur.ts
+++ b/domain/entity/currency-fiat/src/currencies/eur.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const eur = fiat({
   type: "FiatCurrency",
-  id: "eur",
   ticker: "EUR",
   name: "Euro",
   symbol: "€",

--- a/domain/entity/currency-fiat/src/currencies/fjd.ts
+++ b/domain/entity/currency-fiat/src/currencies/fjd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const fjd = fiat({
   type: "FiatCurrency",
-  id: "fjd",
   ticker: "FJD",
   name: "Fijian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/fkp.ts
+++ b/domain/entity/currency-fiat/src/currencies/fkp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const fkp = fiat({
   type: "FiatCurrency",
-  id: "fkp",
   ticker: "FKP",
   name: "Falkland Islands Pound",
   symbol: "£",

--- a/domain/entity/currency-fiat/src/currencies/gbp.ts
+++ b/domain/entity/currency-fiat/src/currencies/gbp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gbp = fiat({
   type: "FiatCurrency",
-  id: "gbp",
   ticker: "GBP",
   name: "British Pound",
   symbol: "£",

--- a/domain/entity/currency-fiat/src/currencies/gel.ts
+++ b/domain/entity/currency-fiat/src/currencies/gel.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gel = fiat({
   type: "FiatCurrency",
-  id: "gel",
   ticker: "GEL",
   name: "Georgian Lari",
   symbol: "GEL",

--- a/domain/entity/currency-fiat/src/currencies/ghs.ts
+++ b/domain/entity/currency-fiat/src/currencies/ghs.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ghs = fiat({
   type: "FiatCurrency",
-  id: "ghs",
   ticker: "GHS",
   name: "Ghanaian Cedi",
   symbol: "₵",

--- a/domain/entity/currency-fiat/src/currencies/gip.ts
+++ b/domain/entity/currency-fiat/src/currencies/gip.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gip = fiat({
   type: "FiatCurrency",
-  id: "gip",
   ticker: "GIP",
   name: "Gibraltar Pound",
   symbol: "£",

--- a/domain/entity/currency-fiat/src/currencies/gmd.ts
+++ b/domain/entity/currency-fiat/src/currencies/gmd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gmd = fiat({
   type: "FiatCurrency",
-  id: "gmd",
   ticker: "GMD",
   name: "Gambian Dalasi",
   symbol: "D",

--- a/domain/entity/currency-fiat/src/currencies/gnf.ts
+++ b/domain/entity/currency-fiat/src/currencies/gnf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gnf = fiat({
   type: "FiatCurrency",
-  id: "gnf",
   ticker: "GNF",
   name: "Guinean Franc",
   symbol: "FG",

--- a/domain/entity/currency-fiat/src/currencies/gtq.ts
+++ b/domain/entity/currency-fiat/src/currencies/gtq.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gtq = fiat({
   type: "FiatCurrency",
-  id: "gtq",
   ticker: "GTQ",
   name: "Guatemalan Quetzal",
   symbol: "Q",

--- a/domain/entity/currency-fiat/src/currencies/gyd.ts
+++ b/domain/entity/currency-fiat/src/currencies/gyd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const gyd = fiat({
   type: "FiatCurrency",
-  id: "gyd",
   ticker: "GYD",
   name: "Guyanese Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/hkd.ts
+++ b/domain/entity/currency-fiat/src/currencies/hkd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const hkd = fiat({
   type: "FiatCurrency",
-  id: "hkd",
   ticker: "HKD",
   name: "Hong Kong Dollar",
   symbol: "HK$",

--- a/domain/entity/currency-fiat/src/currencies/hnl.ts
+++ b/domain/entity/currency-fiat/src/currencies/hnl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const hnl = fiat({
   type: "FiatCurrency",
-  id: "hnl",
   ticker: "HNL",
   name: "Honduran Lempira",
   symbol: "L.",

--- a/domain/entity/currency-fiat/src/currencies/hrk.ts
+++ b/domain/entity/currency-fiat/src/currencies/hrk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const hrk = fiat({
   type: "FiatCurrency",
-  id: "hrk",
   ticker: "HRK",
   name: "Croatian Kuna",
   symbol: "kn",

--- a/domain/entity/currency-fiat/src/currencies/htg.ts
+++ b/domain/entity/currency-fiat/src/currencies/htg.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const htg = fiat({
   type: "FiatCurrency",
-  id: "htg",
   ticker: "HTG",
   name: "Haitian Gourde",
   symbol: "G",

--- a/domain/entity/currency-fiat/src/currencies/huf.ts
+++ b/domain/entity/currency-fiat/src/currencies/huf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const huf = fiat({
   type: "FiatCurrency",
-  id: "huf",
   ticker: "HUF",
   name: "Hungarian Forint",
   symbol: "Ft",

--- a/domain/entity/currency-fiat/src/currencies/idr.ts
+++ b/domain/entity/currency-fiat/src/currencies/idr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const idr = fiat({
   type: "FiatCurrency",
-  id: "idr",
   ticker: "IDR",
   name: "Indonesian Rupiah",
   symbol: "Rp",

--- a/domain/entity/currency-fiat/src/currencies/ils.ts
+++ b/domain/entity/currency-fiat/src/currencies/ils.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ils = fiat({
   type: "FiatCurrency",
-  id: "ils",
   ticker: "ILS",
   name: "Israeli Shekel",
   symbol: "₪",

--- a/domain/entity/currency-fiat/src/currencies/inr.ts
+++ b/domain/entity/currency-fiat/src/currencies/inr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const inr = fiat({
   type: "FiatCurrency",
-  id: "inr",
   ticker: "INR",
   name: "Indian Rupee",
   symbol: "₹",

--- a/domain/entity/currency-fiat/src/currencies/iqd.ts
+++ b/domain/entity/currency-fiat/src/currencies/iqd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const iqd = fiat({
   type: "FiatCurrency",
-  id: "iqd",
   ticker: "IQD",
   name: "Iraqi Dinar",
   symbol: "د.ع.‏",

--- a/domain/entity/currency-fiat/src/currencies/irr.ts
+++ b/domain/entity/currency-fiat/src/currencies/irr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const irr = fiat({
   type: "FiatCurrency",
-  id: "irr",
   ticker: "IRR",
   name: "Iranian Rial",
   symbol: "﷼",

--- a/domain/entity/currency-fiat/src/currencies/isk.ts
+++ b/domain/entity/currency-fiat/src/currencies/isk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const isk = fiat({
   type: "FiatCurrency",
-  id: "isk",
   ticker: "ISK",
   name: "Iceland Krona",
   symbol: "kr.",

--- a/domain/entity/currency-fiat/src/currencies/jmd.ts
+++ b/domain/entity/currency-fiat/src/currencies/jmd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const jmd = fiat({
   type: "FiatCurrency",
-  id: "jmd",
   ticker: "JMD",
   name: "Jamaican Dollar",
   symbol: "J$",

--- a/domain/entity/currency-fiat/src/currencies/jod.ts
+++ b/domain/entity/currency-fiat/src/currencies/jod.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const jod = fiat({
   type: "FiatCurrency",
-  id: "jod",
   ticker: "JOD",
   name: "Jordanian Dinar",
   symbol: "د.ا.‏",

--- a/domain/entity/currency-fiat/src/currencies/jpy.ts
+++ b/domain/entity/currency-fiat/src/currencies/jpy.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const jpy = fiat({
   type: "FiatCurrency",
-  id: "jpy",
   ticker: "JPY",
   name: "Japanese Yen",
   symbol: "¥",

--- a/domain/entity/currency-fiat/src/currencies/kes.ts
+++ b/domain/entity/currency-fiat/src/currencies/kes.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kes = fiat({
   type: "FiatCurrency",
-  id: "kes",
   ticker: "KES",
   name: "Kenyan Shilling",
   symbol: "KSh",

--- a/domain/entity/currency-fiat/src/currencies/kgs.ts
+++ b/domain/entity/currency-fiat/src/currencies/kgs.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kgs = fiat({
   type: "FiatCurrency",
-  id: "kgs",
   ticker: "KGS",
   name: "Kyrgyzstani Som",
   symbol: "сом",

--- a/domain/entity/currency-fiat/src/currencies/khr.ts
+++ b/domain/entity/currency-fiat/src/currencies/khr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const khr = fiat({
   type: "FiatCurrency",
-  id: "khr",
   ticker: "KHR",
   name: "Cambodian Riel",
   symbol: "៛",

--- a/domain/entity/currency-fiat/src/currencies/kmf.ts
+++ b/domain/entity/currency-fiat/src/currencies/kmf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kmf = fiat({
   type: "FiatCurrency",
-  id: "kmf",
   ticker: "KMF",
   name: "Comorian Franc",
   symbol: "CF",

--- a/domain/entity/currency-fiat/src/currencies/kpw.ts
+++ b/domain/entity/currency-fiat/src/currencies/kpw.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kpw = fiat({
   type: "FiatCurrency",
-  id: "kpw",
   ticker: "KPW",
   name: "North Korean Won",
   symbol: "₩",

--- a/domain/entity/currency-fiat/src/currencies/krw.ts
+++ b/domain/entity/currency-fiat/src/currencies/krw.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const krw = fiat({
   type: "FiatCurrency",
-  id: "krw",
   ticker: "KRW",
   name: "South Korean Won",
   symbol: "₩",

--- a/domain/entity/currency-fiat/src/currencies/kwd.ts
+++ b/domain/entity/currency-fiat/src/currencies/kwd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kwd = fiat({
   type: "FiatCurrency",
-  id: "kwd",
   ticker: "KWD",
   name: "Kuwaiti Dinar",
   symbol: "د.ك.‏",

--- a/domain/entity/currency-fiat/src/currencies/kyd.ts
+++ b/domain/entity/currency-fiat/src/currencies/kyd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kyd = fiat({
   type: "FiatCurrency",
-  id: "kyd",
   ticker: "KYD",
   name: "Cayman Islands Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/kzt.ts
+++ b/domain/entity/currency-fiat/src/currencies/kzt.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const kzt = fiat({
   type: "FiatCurrency",
-  id: "kzt",
   ticker: "KZT",
   name: "Kazakhstani Tenge",
   symbol: "₸",

--- a/domain/entity/currency-fiat/src/currencies/lak.ts
+++ b/domain/entity/currency-fiat/src/currencies/lak.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lak = fiat({
   type: "FiatCurrency",
-  id: "lak",
   ticker: "LAK",
   name: "Lao Kip",
   symbol: "₭",

--- a/domain/entity/currency-fiat/src/currencies/lbp.ts
+++ b/domain/entity/currency-fiat/src/currencies/lbp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lbp = fiat({
   type: "FiatCurrency",
-  id: "lbp",
   ticker: "LBP",
   name: "Lebanese Pound",
   symbol: "ل.ل.‏",

--- a/domain/entity/currency-fiat/src/currencies/lkr.ts
+++ b/domain/entity/currency-fiat/src/currencies/lkr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lkr = fiat({
   type: "FiatCurrency",
-  id: "lkr",
   ticker: "LKR",
   name: "Sri Lankan Rupee",
   symbol: "₨",

--- a/domain/entity/currency-fiat/src/currencies/lrd.ts
+++ b/domain/entity/currency-fiat/src/currencies/lrd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lrd = fiat({
   type: "FiatCurrency",
-  id: "lrd",
   ticker: "LRD",
   name: "Liberian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/lsl.ts
+++ b/domain/entity/currency-fiat/src/currencies/lsl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lsl = fiat({
   type: "FiatCurrency",
-  id: "lsl",
   ticker: "LSL",
   name: "Lesotho Loti",
   symbol: "M",

--- a/domain/entity/currency-fiat/src/currencies/lyd.ts
+++ b/domain/entity/currency-fiat/src/currencies/lyd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const lyd = fiat({
   type: "FiatCurrency",
-  id: "lyd",
   ticker: "LYD",
   name: "Libyan Dinar",
   symbol: "د.ل.‏",

--- a/domain/entity/currency-fiat/src/currencies/mad.ts
+++ b/domain/entity/currency-fiat/src/currencies/mad.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mad = fiat({
   type: "FiatCurrency",
-  id: "mad",
   ticker: "MAD",
   name: "Moroccan Dirham",
   symbol: "د.م.‏",

--- a/domain/entity/currency-fiat/src/currencies/mdl.ts
+++ b/domain/entity/currency-fiat/src/currencies/mdl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mdl = fiat({
   type: "FiatCurrency",
-  id: "mdl",
   ticker: "MDL",
   name: "Moldovan Leu",
   symbol: "lei",

--- a/domain/entity/currency-fiat/src/currencies/mga.ts
+++ b/domain/entity/currency-fiat/src/currencies/mga.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mga = fiat({
   type: "FiatCurrency",
-  id: "mga",
   ticker: "MGA",
   name: "Malagasy Ariary",
   symbol: "Ar",

--- a/domain/entity/currency-fiat/src/currencies/mkd.ts
+++ b/domain/entity/currency-fiat/src/currencies/mkd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mkd = fiat({
   type: "FiatCurrency",
-  id: "mkd",
   ticker: "MKD",
   name: "Macedonian Denar",
   symbol: "ден.",

--- a/domain/entity/currency-fiat/src/currencies/mmk.ts
+++ b/domain/entity/currency-fiat/src/currencies/mmk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mmk = fiat({
   type: "FiatCurrency",
-  id: "mmk",
   ticker: "MMK",
   name: "Myanmar Kyat",
   symbol: "K",

--- a/domain/entity/currency-fiat/src/currencies/mnt.ts
+++ b/domain/entity/currency-fiat/src/currencies/mnt.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mnt = fiat({
   type: "FiatCurrency",
-  id: "mnt",
   ticker: "MNT",
   name: "Mongolian Tugrik",
   symbol: "₮",

--- a/domain/entity/currency-fiat/src/currencies/mop.ts
+++ b/domain/entity/currency-fiat/src/currencies/mop.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mop = fiat({
   type: "FiatCurrency",
-  id: "mop",
   ticker: "MOP",
   name: "Macanese Pataca",
   symbol: "MOP$",

--- a/domain/entity/currency-fiat/src/currencies/mro.ts
+++ b/domain/entity/currency-fiat/src/currencies/mro.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mro = fiat({
   type: "FiatCurrency",
-  id: "mro",
   ticker: "MRO",
   name: "Mauritanian Ouguiya",
   symbol: "UM",

--- a/domain/entity/currency-fiat/src/currencies/mtl.ts
+++ b/domain/entity/currency-fiat/src/currencies/mtl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mtl = fiat({
   type: "FiatCurrency",
-  id: "mtl",
   ticker: "MTL",
   name: "Maltese Lira",
   symbol: "₤",

--- a/domain/entity/currency-fiat/src/currencies/mur.ts
+++ b/domain/entity/currency-fiat/src/currencies/mur.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mur = fiat({
   type: "FiatCurrency",
-  id: "mur",
   ticker: "MUR",
   name: "Mauritian Rupee",
   symbol: "₨",

--- a/domain/entity/currency-fiat/src/currencies/mvr.ts
+++ b/domain/entity/currency-fiat/src/currencies/mvr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mvr = fiat({
   type: "FiatCurrency",
-  id: "mvr",
   ticker: "MVR",
   name: "Maldivian Rufiyaa",
   symbol: "MVR",

--- a/domain/entity/currency-fiat/src/currencies/mwk.ts
+++ b/domain/entity/currency-fiat/src/currencies/mwk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mwk = fiat({
   type: "FiatCurrency",
-  id: "mwk",
   ticker: "MWK",
   name: "Malawian Kwacha",
   symbol: "MK",

--- a/domain/entity/currency-fiat/src/currencies/mxn.ts
+++ b/domain/entity/currency-fiat/src/currencies/mxn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mxn = fiat({
   type: "FiatCurrency",
-  id: "mxn",
   ticker: "MXN",
   name: "Mexican Peso",
   symbol: "Mex$",

--- a/domain/entity/currency-fiat/src/currencies/myr.ts
+++ b/domain/entity/currency-fiat/src/currencies/myr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const myr = fiat({
   type: "FiatCurrency",
-  id: "myr",
   ticker: "MYR",
   name: "Malaysian Ringgit",
   symbol: "RM",

--- a/domain/entity/currency-fiat/src/currencies/mzn.ts
+++ b/domain/entity/currency-fiat/src/currencies/mzn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const mzn = fiat({
   type: "FiatCurrency",
-  id: "mzn",
   ticker: "MZN",
   name: "Mozambican Metical",
   symbol: "MT",

--- a/domain/entity/currency-fiat/src/currencies/nad.ts
+++ b/domain/entity/currency-fiat/src/currencies/nad.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const nad = fiat({
   type: "FiatCurrency",
-  id: "nad",
   ticker: "NAD",
   name: "Namibian Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/ngn.ts
+++ b/domain/entity/currency-fiat/src/currencies/ngn.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ngn = fiat({
   type: "FiatCurrency",
-  id: "ngn",
   ticker: "NGN",
   name: "Nigerian Naira",
   symbol: "₦",

--- a/domain/entity/currency-fiat/src/currencies/nio.ts
+++ b/domain/entity/currency-fiat/src/currencies/nio.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const nio = fiat({
   type: "FiatCurrency",
-  id: "nio",
   ticker: "NIO",
   name: "Nicaraguan Córdoba",
   symbol: "C$",

--- a/domain/entity/currency-fiat/src/currencies/nok.ts
+++ b/domain/entity/currency-fiat/src/currencies/nok.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const nok = fiat({
   type: "FiatCurrency",
-  id: "nok",
   ticker: "NOK",
   name: "Norwegian Krone",
   symbol: "kr",

--- a/domain/entity/currency-fiat/src/currencies/npr.ts
+++ b/domain/entity/currency-fiat/src/currencies/npr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const npr = fiat({
   type: "FiatCurrency",
-  id: "npr",
   ticker: "NPR",
   name: "Nepalese Rupee",
   symbol: "₨",

--- a/domain/entity/currency-fiat/src/currencies/nzd.ts
+++ b/domain/entity/currency-fiat/src/currencies/nzd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const nzd = fiat({
   type: "FiatCurrency",
-  id: "nzd",
   ticker: "NZD",
   name: "New Zealand Dollar",
   symbol: "NZ$",

--- a/domain/entity/currency-fiat/src/currencies/omr.ts
+++ b/domain/entity/currency-fiat/src/currencies/omr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const omr = fiat({
   type: "FiatCurrency",
-  id: "omr",
   ticker: "OMR",
   name: "Omani Rial",
   symbol: "﷼",

--- a/domain/entity/currency-fiat/src/currencies/pab.ts
+++ b/domain/entity/currency-fiat/src/currencies/pab.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pab = fiat({
   type: "FiatCurrency",
-  id: "pab",
   ticker: "PAB",
   name: "Panamanian Balboa",
   symbol: "B/.",

--- a/domain/entity/currency-fiat/src/currencies/pen.ts
+++ b/domain/entity/currency-fiat/src/currencies/pen.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pen = fiat({
   type: "FiatCurrency",
-  id: "pen",
   ticker: "PEN",
   name: "Peruvian Sol",
   symbol: "S/.",

--- a/domain/entity/currency-fiat/src/currencies/pgk.ts
+++ b/domain/entity/currency-fiat/src/currencies/pgk.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pgk = fiat({
   type: "FiatCurrency",
-  id: "pgk",
   ticker: "PGK",
   name: "Papua New Guinean Kina",
   symbol: "K",

--- a/domain/entity/currency-fiat/src/currencies/php.ts
+++ b/domain/entity/currency-fiat/src/currencies/php.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const php = fiat({
   type: "FiatCurrency",
-  id: "php",
   ticker: "PHP",
   name: "Philippine Peso",
   symbol: "₱",

--- a/domain/entity/currency-fiat/src/currencies/pkr.ts
+++ b/domain/entity/currency-fiat/src/currencies/pkr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pkr = fiat({
   type: "FiatCurrency",
-  id: "pkr",
   ticker: "PKR",
   name: "Pakistani Rupee",
   symbol: "₨",

--- a/domain/entity/currency-fiat/src/currencies/pln.ts
+++ b/domain/entity/currency-fiat/src/currencies/pln.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pln = fiat({
   type: "FiatCurrency",
-  id: "pln",
   ticker: "PLN",
   name: "Polish Złoty",
   symbol: "zł",

--- a/domain/entity/currency-fiat/src/currencies/pyg.ts
+++ b/domain/entity/currency-fiat/src/currencies/pyg.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const pyg = fiat({
   type: "FiatCurrency",
-  id: "pyg",
   ticker: "PYG",
   name: "Paraguayan Guarani",
   symbol: "₲",

--- a/domain/entity/currency-fiat/src/currencies/qar.ts
+++ b/domain/entity/currency-fiat/src/currencies/qar.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const qar = fiat({
   type: "FiatCurrency",
-  id: "qar",
   ticker: "QAR",
   name: "Qatari Riyal",
   symbol: "﷼",

--- a/domain/entity/currency-fiat/src/currencies/ron.ts
+++ b/domain/entity/currency-fiat/src/currencies/ron.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ron = fiat({
   type: "FiatCurrency",
-  id: "ron",
   ticker: "RON",
   name: "Romanian Leu",
   symbol: "L",

--- a/domain/entity/currency-fiat/src/currencies/rsd.ts
+++ b/domain/entity/currency-fiat/src/currencies/rsd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const rsd = fiat({
   type: "FiatCurrency",
-  id: "rsd",
   ticker: "RSD",
   name: "Serbian Dinar",
   symbol: "Дин.",

--- a/domain/entity/currency-fiat/src/currencies/rub.ts
+++ b/domain/entity/currency-fiat/src/currencies/rub.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const rub = fiat({
   type: "FiatCurrency",
-  id: "rub",
   ticker: "RUB",
   name: "Russian Rouble",
   symbol: "₽",

--- a/domain/entity/currency-fiat/src/currencies/rwf.ts
+++ b/domain/entity/currency-fiat/src/currencies/rwf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const rwf = fiat({
   type: "FiatCurrency",
-  id: "rwf",
   ticker: "RWF",
   name: "Rwandan Franc",
   symbol: "RWF",

--- a/domain/entity/currency-fiat/src/currencies/sar.ts
+++ b/domain/entity/currency-fiat/src/currencies/sar.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sar = fiat({
   type: "FiatCurrency",
-  id: "sar",
   ticker: "SAR",
   name: "Saudi Riyal",
   symbol: "﷼",

--- a/domain/entity/currency-fiat/src/currencies/sbd.ts
+++ b/domain/entity/currency-fiat/src/currencies/sbd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sbd = fiat({
   type: "FiatCurrency",
-  id: "sbd",
   ticker: "SBD",
   name: "Solomon Islands Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/scr.ts
+++ b/domain/entity/currency-fiat/src/currencies/scr.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const scr = fiat({
   type: "FiatCurrency",
-  id: "scr",
   ticker: "SCR",
   name: "Seychellois Rupee",
   symbol: "₨",

--- a/domain/entity/currency-fiat/src/currencies/sdd.ts
+++ b/domain/entity/currency-fiat/src/currencies/sdd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sdd = fiat({
   type: "FiatCurrency",
-  id: "sdd",
   ticker: "SDD",
   name: "Sudanese Dinar (1992-2007)",
   symbol: "LSd",

--- a/domain/entity/currency-fiat/src/currencies/sdg.ts
+++ b/domain/entity/currency-fiat/src/currencies/sdg.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sdg = fiat({
   type: "FiatCurrency",
-  id: "sdg",
   ticker: "SDG",
   name: "Sudanese Pound",
   symbol: "£‏",

--- a/domain/entity/currency-fiat/src/currencies/sek.ts
+++ b/domain/entity/currency-fiat/src/currencies/sek.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sek = fiat({
   type: "FiatCurrency",
-  id: "sek",
   ticker: "SEK",
   name: "Swedish Krona",
   symbol: "kr",

--- a/domain/entity/currency-fiat/src/currencies/sgd.ts
+++ b/domain/entity/currency-fiat/src/currencies/sgd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sgd = fiat({
   type: "FiatCurrency",
-  id: "sgd",
   ticker: "SGD",
   name: "Singapore Dollar",
   symbol: "S$",

--- a/domain/entity/currency-fiat/src/currencies/shp.ts
+++ b/domain/entity/currency-fiat/src/currencies/shp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const shp = fiat({
   type: "FiatCurrency",
-  id: "shp",
   ticker: "SHP",
   name: "Saint Helena Pound",
   symbol: "£",

--- a/domain/entity/currency-fiat/src/currencies/sll.ts
+++ b/domain/entity/currency-fiat/src/currencies/sll.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sll = fiat({
   type: "FiatCurrency",
-  id: "sll",
   ticker: "SLL",
   name: "Sierra Leonean Leone",
   symbol: "Le",

--- a/domain/entity/currency-fiat/src/currencies/sos.ts
+++ b/domain/entity/currency-fiat/src/currencies/sos.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const sos = fiat({
   type: "FiatCurrency",
-  id: "sos",
   ticker: "SOS",
   name: "Somali Shilling",
   symbol: "S",

--- a/domain/entity/currency-fiat/src/currencies/srd.ts
+++ b/domain/entity/currency-fiat/src/currencies/srd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const srd = fiat({
   type: "FiatCurrency",
-  id: "srd",
   ticker: "SRD",
   name: "Surinamese Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/std.ts
+++ b/domain/entity/currency-fiat/src/currencies/std.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const std = fiat({
   type: "FiatCurrency",
-  id: "std",
   ticker: "STD",
   name: "São Tomé and Príncipe Dobra",
   symbol: "Db",

--- a/domain/entity/currency-fiat/src/currencies/svc.ts
+++ b/domain/entity/currency-fiat/src/currencies/svc.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const svc = fiat({
   type: "FiatCurrency",
-  id: "svc",
   ticker: "SVC",
   name: "Salvadoran Colón",
   symbol: "₡",

--- a/domain/entity/currency-fiat/src/currencies/syp.ts
+++ b/domain/entity/currency-fiat/src/currencies/syp.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const syp = fiat({
   type: "FiatCurrency",
-  id: "syp",
   ticker: "SYP",
   name: "Syrian Pound",
   symbol: "£",

--- a/domain/entity/currency-fiat/src/currencies/szl.ts
+++ b/domain/entity/currency-fiat/src/currencies/szl.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const szl = fiat({
   type: "FiatCurrency",
-  id: "szl",
   ticker: "SZL",
   name: "Swazi Lilangeni",
   symbol: "E",

--- a/domain/entity/currency-fiat/src/currencies/thb.ts
+++ b/domain/entity/currency-fiat/src/currencies/thb.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const thb = fiat({
   type: "FiatCurrency",
-  id: "thb",
   ticker: "THB",
   name: "Thai Baht",
   symbol: "฿",

--- a/domain/entity/currency-fiat/src/currencies/tjs.ts
+++ b/domain/entity/currency-fiat/src/currencies/tjs.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const tjs = fiat({
   type: "FiatCurrency",
-  id: "tjs",
   ticker: "TJS",
   name: "Tajikistani Somoni",
   symbol: "TJS",

--- a/domain/entity/currency-fiat/src/currencies/tmt.ts
+++ b/domain/entity/currency-fiat/src/currencies/tmt.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const tmt = fiat({
   type: "FiatCurrency",
-  id: "tmt",
   ticker: "TMT",
   name: "Turkmenistani Manat",
   symbol: "m",

--- a/domain/entity/currency-fiat/src/currencies/tnd.ts
+++ b/domain/entity/currency-fiat/src/currencies/tnd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const tnd = fiat({
   type: "FiatCurrency",
-  id: "tnd",
   ticker: "TND",
   name: "Tunisian Dinar",
   symbol: "د.ت.‏",

--- a/domain/entity/currency-fiat/src/currencies/top.ts
+++ b/domain/entity/currency-fiat/src/currencies/top.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const top = fiat({
   type: "FiatCurrency",
-  id: "top",
   ticker: "TOP",
   name: "Tongan Pa'anga",
   symbol: "T$",

--- a/domain/entity/currency-fiat/src/currencies/try.ts
+++ b/domain/entity/currency-fiat/src/currencies/try.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const try_ = fiat({
   type: "FiatCurrency",
-  id: "try",
   ticker: "TRY",
   name: "Turkish Lira",
   symbol: "₺",

--- a/domain/entity/currency-fiat/src/currencies/ttd.ts
+++ b/domain/entity/currency-fiat/src/currencies/ttd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ttd = fiat({
   type: "FiatCurrency",
-  id: "ttd",
   ticker: "TTD",
   name: "Trinidad and Tobago Dollar",
   symbol: "TT$",

--- a/domain/entity/currency-fiat/src/currencies/tvd.ts
+++ b/domain/entity/currency-fiat/src/currencies/tvd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const tvd = fiat({
   type: "FiatCurrency",
-  id: "tvd",
   ticker: "TVD",
   name: "Tuvaluan Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/twd.ts
+++ b/domain/entity/currency-fiat/src/currencies/twd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const twd = fiat({
   type: "FiatCurrency",
-  id: "twd",
   ticker: "TWD",
   name: "New Taiwan Dollar",
   symbol: "NT$",

--- a/domain/entity/currency-fiat/src/currencies/tzs.ts
+++ b/domain/entity/currency-fiat/src/currencies/tzs.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const tzs = fiat({
   type: "FiatCurrency",
-  id: "tzs",
   ticker: "TZS",
   name: "Tanzanian Shilling",
   symbol: "TSh",

--- a/domain/entity/currency-fiat/src/currencies/uah.ts
+++ b/domain/entity/currency-fiat/src/currencies/uah.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const uah = fiat({
   type: "FiatCurrency",
-  id: "uah",
   ticker: "UAH",
   name: "Ukrainian Hryvnia",
   symbol: "₴",

--- a/domain/entity/currency-fiat/src/currencies/ugx.ts
+++ b/domain/entity/currency-fiat/src/currencies/ugx.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const ugx = fiat({
   type: "FiatCurrency",
-  id: "ugx",
   ticker: "UGX",
   name: "Ugandan Shilling",
   symbol: "USh",

--- a/domain/entity/currency-fiat/src/currencies/usd.ts
+++ b/domain/entity/currency-fiat/src/currencies/usd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const usd = fiat({
   type: "FiatCurrency",
-  id: "usd",
   ticker: "USD",
   name: "US Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/uyu.ts
+++ b/domain/entity/currency-fiat/src/currencies/uyu.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const uyu = fiat({
   type: "FiatCurrency",
-  id: "uyu",
   ticker: "UYU",
   name: "Uruguayan Peso",
   symbol: "$U",

--- a/domain/entity/currency-fiat/src/currencies/uzs.ts
+++ b/domain/entity/currency-fiat/src/currencies/uzs.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const uzs = fiat({
   type: "FiatCurrency",
-  id: "uzs",
   ticker: "UZS",
   name: "Uzbekistani Som",
   symbol: "сўм",

--- a/domain/entity/currency-fiat/src/currencies/veb.ts
+++ b/domain/entity/currency-fiat/src/currencies/veb.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const veb = fiat({
   type: "FiatCurrency",
-  id: "veb",
   ticker: "VEB",
   name: "Venezuelan Bolívar (1871–2008)",
   symbol: "Bs.",

--- a/domain/entity/currency-fiat/src/currencies/vef.ts
+++ b/domain/entity/currency-fiat/src/currencies/vef.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const vef = fiat({
   type: "FiatCurrency",
-  id: "vef",
   ticker: "VEF",
   name: "Venezuelan Bolívar (2008–2018)",
   symbol: "Bs. F.",

--- a/domain/entity/currency-fiat/src/currencies/vnd.ts
+++ b/domain/entity/currency-fiat/src/currencies/vnd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const vnd = fiat({
   type: "FiatCurrency",
-  id: "vnd",
   ticker: "VND",
   name: "Vietnamese Dong",
   symbol: "₫",

--- a/domain/entity/currency-fiat/src/currencies/vuv.ts
+++ b/domain/entity/currency-fiat/src/currencies/vuv.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const vuv = fiat({
   type: "FiatCurrency",
-  id: "vuv",
   ticker: "VUV",
   name: "Vanuatu Vatu",
   symbol: "VT",

--- a/domain/entity/currency-fiat/src/currencies/won.ts
+++ b/domain/entity/currency-fiat/src/currencies/won.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const won = fiat({
   type: "FiatCurrency",
-  id: "won",
   ticker: "WON",
   name: "North Korean Won",
   symbol: "₩",

--- a/domain/entity/currency-fiat/src/currencies/wst.ts
+++ b/domain/entity/currency-fiat/src/currencies/wst.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const wst = fiat({
   type: "FiatCurrency",
-  id: "wst",
   ticker: "WST",
   name: "Samoan Tala",
   symbol: "WS$",

--- a/domain/entity/currency-fiat/src/currencies/xaf.ts
+++ b/domain/entity/currency-fiat/src/currencies/xaf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const xaf = fiat({
   type: "FiatCurrency",
-  id: "xaf",
   ticker: "XAF",
   name: "Central African CFA Franc",
   symbol: "F",

--- a/domain/entity/currency-fiat/src/currencies/xbt.ts
+++ b/domain/entity/currency-fiat/src/currencies/xbt.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const xbt = fiat({
   type: "FiatCurrency",
-  id: "xbt",
   ticker: "XBT",
   name: "Bitcoin",
   symbol: "Ƀ",

--- a/domain/entity/currency-fiat/src/currencies/xcd.ts
+++ b/domain/entity/currency-fiat/src/currencies/xcd.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const xcd = fiat({
   type: "FiatCurrency",
-  id: "xcd",
   ticker: "XCD",
   name: "East Caribbean Dollar",
   symbol: "$",

--- a/domain/entity/currency-fiat/src/currencies/xof.ts
+++ b/domain/entity/currency-fiat/src/currencies/xof.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const xof = fiat({
   type: "FiatCurrency",
-  id: "xof",
   ticker: "XOF",
   name: "West African CFA Franc",
   symbol: "F",

--- a/domain/entity/currency-fiat/src/currencies/xpf.ts
+++ b/domain/entity/currency-fiat/src/currencies/xpf.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const xpf = fiat({
   type: "FiatCurrency",
-  id: "xpf",
   ticker: "XPF",
   name: "CFP Franc",
   symbol: "F",

--- a/domain/entity/currency-fiat/src/currencies/yer.ts
+++ b/domain/entity/currency-fiat/src/currencies/yer.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const yer = fiat({
   type: "FiatCurrency",
-  id: "yer",
   ticker: "YER",
   name: "Yemeni Rial",
   symbol: "﷼",

--- a/domain/entity/currency-fiat/src/currencies/zar.ts
+++ b/domain/entity/currency-fiat/src/currencies/zar.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const zar = fiat({
   type: "FiatCurrency",
-  id: "zar",
   ticker: "ZAR",
   name: "South African Rand",
   symbol: "R",

--- a/domain/entity/currency-fiat/src/currencies/zmw.ts
+++ b/domain/entity/currency-fiat/src/currencies/zmw.ts
@@ -2,7 +2,6 @@ import { fiat } from "../define";
 
 export const zmw = fiat({
   type: "FiatCurrency",
-  id: "zmw",
   ticker: "ZMW",
   name: "Zambian Kwacha",
   symbol: "ZK",

--- a/domain/entity/currency-fiat/src/define.ts
+++ b/domain/entity/currency-fiat/src/define.ts
@@ -9,7 +9,6 @@ import { FiatCurrencySchema, type FiatCurrency } from "./schema";
  * ```ts
  * export const usd = fiat({
  *   type: "FiatCurrency",
- *   id: "usd",
  *   name: "US Dollar",
  *   ticker: "USD",
  *   symbol: "$",

--- a/domain/entity/currency-fiat/src/schema.mock.ts
+++ b/domain/entity/currency-fiat/src/schema.mock.ts
@@ -1,4 +1,3 @@
-import { FiatCurrencyIdSchema } from "@shared/schema-primitives";
 import type { FiatCurrency } from "./schema";
 
 /**
@@ -8,7 +7,6 @@ import type { FiatCurrency } from "./schema";
 export function mockFiatCurrency(overrides?: Partial<FiatCurrency>): FiatCurrency {
   return {
     type: "FiatCurrency",
-    id: FiatCurrencyIdSchema.parse("usd"),
     name: "US Dollar",
     ticker: "USD",
     symbol: "$",

--- a/domain/entity/currency-fiat/src/schema.test.ts
+++ b/domain/entity/currency-fiat/src/schema.test.ts
@@ -4,8 +4,8 @@ import { mockFiatCurrency } from "./schema.mock";
 describe("FiatCurrencySchema", () => {
   it("parses a valid fiat currency from mock factory", () => {
     const result = FiatCurrencySchema.parse(mockFiatCurrency());
-    expect(result.id).toBe("usd");
     expect(result.type).toBe("FiatCurrency");
+    expect(result.ticker).toBe("USD");
   });
 
   it("requires at least one unit", () => {
@@ -35,7 +35,6 @@ describe("FiatCurrencySchema", () => {
   it("optional fields default to undefined", () => {
     const result = FiatCurrencySchema.parse({
       type: "FiatCurrency",
-      id: "eur",
       name: "Euro",
       ticker: "EUR",
       units: [{ name: "Euro", code: "EUR", magnitude: 2 }],

--- a/domain/entity/currency-fiat/src/schema.ts
+++ b/domain/entity/currency-fiat/src/schema.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { FiatCurrencyIdSchema } from "@shared/schema-primitives";
 import { UnitSchema } from "@domain/entity-currency-unit";
 
 /**
@@ -13,8 +12,6 @@ import { UnitSchema } from "@domain/entity-currency-unit";
 export const FiatCurrencySchema = z.object({
   /** Discriminant for the currency union — always `"FiatCurrency"`. */
   type: z.literal("FiatCurrency"),
-  /** Unique opaque id (e.g. `"usd"`, `"eur"`). */
-  id: FiatCurrencyIdSchema,
   /** Human-readable display name (e.g. `"US Dollar"`). */
   name: z.string(),
   /** ISO 4217 ticker (e.g. `"USD"`, `"EUR"`). */

--- a/domain/entity/currency-fiat/src/utils.test.ts
+++ b/domain/entity/currency-fiat/src/utils.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("findFiatCurrencyByTicker", () => {
   it("resolves a known ticker", () => {
-    expect(findFiatCurrencyByTicker("USD")?.id).toBe("usd");
+    expect(findFiatCurrencyByTicker("USD")?.ticker).toBe("USD");
   });
 
   it("returns undefined for an unknown ticker", () => {
@@ -22,7 +22,6 @@ describe("findFiatCurrencyByTicker", () => {
 describe("getFiatCurrencyByTicker", () => {
   it("resolves a known ticker to its registry object", () => {
     const usd = getFiatCurrencyByTicker("USD");
-    expect(usd.id).toBe("usd");
     expect(usd.ticker).toBe("USD");
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3725,9 +3725,6 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
-      '@shared/schema-primitives':
-        specifier: workspace:*
-        version: link:../../../shared/schema-primitives
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## Summary

[LIVE-35057](https://ledgerhq.atlassian.net/browse/LIVE-35057)

- \`FiatCurrency\` in the legacy \`@ledgerhq/types-cryptoassets\` had no \`id\` field
- The \`id: FiatCurrencyIdSchema\` field added in the domain had zero external consumers — nothing outside the fiat package itself accessed \`fiat.id\` or imported \`FiatCurrencyId\`/\`FiatCurrencyIdSchema\`
- Removes the field from schema, mock, define JSDoc example, and all 164 currency data files
- \`FIAT_CURRENCIES_REGISTRY\` now keyed by \`ticker\` (was: lowercased id, which equalled \`ticker.toLowerCase()\`)
- \`FIAT_CURRENCIES_IDS\` renamed to \`FIAT_CURRENCIES_TICKERS\` (no external callers)

## Test plan

- [x] \`pnpm nx run @domain/entity-currency-fiat:typecheck\` passes
- [x] \`pnpm nx run @domain/entity-currency-fiat:coverage\` passes (42/42 tests)
- [x] No fiat-related errors in \`live-mobile:typecheck\` or \`ledger-live-desktop:typecheck\`

[LIVE-35057]: https://ledgerhq.atlassian.net/browse/LIVE-35057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ