### PR TITLE
[LWD] fix(desktop-mas): use global max build number for CFBundleVersion

### DIFF
--- a/apps/ledger-live-desktop/fastlane/Fastfile
+++ b/apps/ledger-live-desktop/fastlane/Fastfile
@@ -109,7 +109,6 @@ platform :mac do
     version = trim_version_number(package["version"])
     latest = latest_testflight_build_number(
       app_identifier: ENV["APP_IDENTIFIER"],
-      version: version,
       platform: "osx",
       initial_build_number: 0
     )


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Previous versions of the MAS build were manually set using the buildVersion as the build number, rather than an incremental build number causing package validation to fail.

This change makes the initial starting build number non version-specific meaning that the current build number of 4.6.1 will be cast to integer and +1 applied, giving a valid build number that exceeds the previous build number
