### PR TITLE
[LWM] fix(LIVE-34563): keep tab navigator mounted for swap sub-screens

### DIFF
--- a/.changeset/swap-history-back-to-input-form.md
+++ b/.changeset/swap-history-back-to-input-form.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix Swap: pressing "<" from the History screen after a multi-step swap now returns to the initial input form. Opening a Swap sub-screen no longer replaces the Main navigator when the Swap tab is the focused route (which unmounted the tab navigator and left the back button unable to navigate), and the webview reset is re-applied when the Swap tab regains focus if the live app is still on the page it was asked to leave.

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/SwapLiveAppWallet40.tsx
@@ -1,4 +1,5 @@
 import React, { RefObject, useCallback, useMemo } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { StyleSheet, View } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
 import InfiniteLoader from "~/components/InfiniteLoader";
@@ -69,7 +70,12 @@ export function SwapLiveAppWallet40({
     defaultParams,
     webviewResetKey,
     resetWebview,
+    ensureWebviewReset,
   } = useSwapLiveAppState(params);
+
+  // A reset requested while this screen was covered (swap success, history redirect) is
+  // re-applied here if the live app came back on the page it was asked to leave.
+  useFocusEffect(ensureWebviewReset);
 
   const updateWallet40HeaderState = useSwapWallet40HeaderStateUpdater(webviewRef);
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -36,6 +36,22 @@ const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
 const mockGetParent = jest.fn();
 
+/** BaseNavigator with a transient swap screen (`routeName`) pushed over Main. */
+function mockBaseNavigatorFocusedOn(routeName: string) {
+  mockGetParent.mockReturnValue({
+    dispatch: mockParentDispatch,
+    getState: () => ({ index: 1, routes: [{ name: NavigatorName.Main }, { name: routeName }] }),
+  });
+}
+
+/** BaseNavigator sitting on Main, i.e. the user is on the Swap tab itself. */
+function mockBaseNavigatorOnSwapTab() {
+  mockGetParent.mockReturnValue({
+    dispatch: mockParentDispatch,
+    getState: () => ({ index: 0, routes: [{ name: NavigatorName.Main }] }),
+  });
+}
+
 const MOCK_EXCHANGE_PARAMS = {
   provider: "lifi",
   swapId: "swap-123",
@@ -90,8 +106,8 @@ describe("useSwapCustomHandlers", () => {
   }
 
   describe("navigateToSwapPendingOperation (via onCompleteResult)", () => {
-    it("dispatches StackActions.replace to parent when parent navigator is found", () => {
-      mockGetParent.mockReturnValue({ dispatch: mockParentDispatch });
+    it("dispatches StackActions.replace to parent when a transient swap screen is focused", () => {
+      mockBaseNavigatorFocusedOn(NavigatorName.PlatformExchange);
 
       render();
 
@@ -150,8 +166,22 @@ describe("useSwapCustomHandlers", () => {
       });
     });
 
+    it("pushes instead of replacing when the Swap tab (Main) is the focused base route", () => {
+      mockBaseNavigatorOnSwapTab();
+
+      render();
+
+      capturedOnCompleteResult(MOCK_EXCHANGE_PARAMS, "hash-abc");
+
+      expect(mockParentDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapPendingOperation,
+        params: expect.objectContaining({ isEmbeddedSwap: false }),
+      });
+    });
+
     it("calls resetWebview after navigation when parent is found", () => {
-      mockGetParent.mockReturnValue({ dispatch: mockParentDispatch });
+      mockBaseNavigatorFocusedOn(NavigatorName.PlatformExchange);
 
       render();
 
@@ -198,47 +228,64 @@ describe("useSwapCustomHandlers", () => {
   });
 
   describe("navigateToSwapHistory", () => {
-    it("navigates to SwapHistory when swapRedirectToHistory handler is called", () => {
+    function callHandler(request?: unknown) {
       const { result } = render();
-
       const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
       expect(typeof handler).toBe("function");
+      (handler as (request?: unknown) => void)(request);
+    }
 
-      (handler as () => void)();
+    it("pushes SwapHistory over the Swap tab instead of replacing Main", () => {
+      mockBaseNavigatorOnSwapTab();
+
+      callHandler();
+
+      expect(mockGetParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+      expect(mockParentDispatch).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
+        screen: ScreenName.SwapHistory,
+      });
+    });
+
+    it("replaces a transient swap screen when one is focused", () => {
+      mockBaseNavigatorFocusedOn(NavigatorName.SwapSubScreens);
+
+      callHandler();
+
+      expect(mockParentDispatch).toHaveBeenCalledWith(
+        StackActions.replace(NavigatorName.SwapSubScreens, {
+          screen: ScreenName.SwapHistory,
+        }),
+      );
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it("calls navigation.navigate when parent navigator is not found", () => {
+      mockGetParent.mockReturnValue(undefined);
+
+      callHandler();
 
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
         screen: ScreenName.SwapHistory,
       });
     });
 
-    it("resets the webview when swapRedirectToHistory handler is called", () => {
-      const { result } = render();
+    it("resets the webview so the Swap tab is not left on the page it redirected from", () => {
+      mockBaseNavigatorOnSwapTab();
 
-      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
-      expect(typeof handler).toBe("function");
-
-      (handler as () => void)();
+      callHandler();
 
       expect(mockResetWebview).toHaveBeenCalledTimes(1);
     });
 
     it("passes swapId to SwapHistory when swapRedirectToHistory handler is called with params", () => {
-      const { result } = render();
+      mockBaseNavigatorOnSwapTab();
 
-      const handler = (result.current as Record<string, unknown>)["custom.swapRedirectToHistory"];
-      expect(typeof handler).toBe("function");
-
-      (handler as (request: unknown) => void)({
-        params: {
-          swapId: "swap-123",
-        },
-      });
+      callHandler({ params: { swapId: "swap-123" } });
 
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
         screen: ScreenName.SwapHistory,
-        params: {
-          swapId: "swap-123",
-        },
+        params: { swapId: "swap-123" },
       });
     });
   });

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -4,16 +4,15 @@ import type { AccountLike } from "@ledgerhq/types-live";
 import {
   NavigationProp,
   NavigationState,
-  StackActions,
+  type NavigatorScreenParams,
   useNavigation,
 } from "@react-navigation/native";
-import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import BigNumber from "bignumber.js";
 import { useCallback } from "react";
 import { Dispatch } from "redux";
-import { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { SwapSubScreensNavigatorParamList } from "~/components/RootNavigator/types/SwapSubScreensNavigator";
 import { WebviewProps } from "~/components/Web3AppWebview/types";
-import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
+import { NavigatorName, ScreenName } from "~/const";
 import { sendSwapLiveAppReady } from "~/e2e/bridge/client";
 import { getFee } from "./getFee";
 import { getTransactionByHash } from "./getTransactionByHash";
@@ -21,17 +20,11 @@ import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import type { SwapHistoryParams } from "../../types";
+import { openSwapSubScreens, type SwapBaseNavigation } from "../../navigation/openSwapSubScreens";
 
 export type NavigationType = Omit<NavigationProp<ReactNavigation.RootParamList>, "getState"> & {
   getState(): NavigationState | undefined;
 };
-
-/** Navigation typed with {@link BASE_NAVIGATOR_ID} so `getParent(BASE_NAVIGATOR_ID)` is type-safe. */
-type SwapBaseNavigation = NativeStackNavigationProp<
-  BaseNavigatorStackParamList,
-  keyof BaseNavigatorStackParamList,
-  typeof BASE_NAVIGATOR_ID
->;
 
 export function useSwapCustomHandlers(
   manifest: WebviewProps["manifest"],
@@ -59,24 +52,10 @@ export function useSwapCustomHandlers(
         sponsored: exchangeParams.sponsored,
       };
 
-      // React Navigation v7 pushes a new screen even if one already exists lower
-      // in the stack. Dispatching replace to BaseNavigator gives SwapSubScreensNavigator
-      // a clean [SwapPendingOperation] stack with no SwapLoading beneath it, so
-      // any back gesture returns to SwapTab instead of revealing SwapLoading.
-      const baseNavigation = navigation.getParent(BASE_NAVIGATOR_ID);
-      if (baseNavigation) {
-        baseNavigation.dispatch(
-          StackActions.replace(NavigatorName.SwapSubScreens, {
-            screen: ScreenName.SwapPendingOperation,
-            params,
-          }),
-        );
-      } else {
-        navigation.navigate(NavigatorName.SwapSubScreens, {
-          screen: ScreenName.SwapPendingOperation,
-          params,
-        });
-      }
+      openSwapSubScreens({
+        navigation,
+        target: { screen: ScreenName.SwapPendingOperation, params },
+      });
 
       // Remount the webview to its initial URL while the user reads the success
       // screen so they see a clean swap form when they navigate back to SwapTab.
@@ -106,15 +85,19 @@ export function useSwapCustomHandlers(
 
   const navigateToSwapHistory = useCallback(
     ({ params }: { params?: SwapHistoryParams } = {}) => {
-      navigation.navigate(NavigatorName.SwapSubScreens, {
+      // Annotated so `screen` keeps its literal type: in an unannotated object literal
+      // TypeScript widens the enum member to `ScreenName`, which no longer satisfies
+      // the navigator's screen/params pairing.
+      const historyScreen: NavigatorScreenParams<SwapSubScreensNavigatorParamList> = {
         screen: ScreenName.SwapHistory,
         ...(params?.swapId ? { params: { swapId: params.swapId } } : {}),
-      });
+      };
 
-      // Remount the webview while the History screen is on top so that pressing
-      // "<" (which pops back to SwapTab) lands on a clean swap form instead of
-      // the multi-step success screen still mounted underneath. Mirrors
-      // navigateToSwapPendingOperation. See LIVE-34563.
+      openSwapSubScreens({ navigation, target: historyScreen });
+
+      // The live app stays mounted underneath on the page it redirected from, so remount
+      // it to its initial URL. The Swap tab is already blurred here, hence the reset is
+      // re-asserted on focus by useSwapLiveAppState.
       resetWebview();
     },
     [navigation, resetWebview],

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapLiveAppState.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/__tests__/useSwapLiveAppState.test.ts
@@ -118,6 +118,79 @@ describe("useSwapLiveAppState", () => {
     expect(result.current.webviewResetKey).toBe(2);
   });
 
+  describe("ensureWebviewReset", () => {
+    const SWAP_FORM_URL = "https://swap.live.app/";
+    const SUCCESS_URL = "https://swap.live.app/multi-step-transaction?transactionStatus=complete";
+
+    function renderOnUrl(url: string) {
+      const rendered = renderHook(() => useSwapLiveAppState(null));
+
+      act(() => {
+        rendered.result.current.setWebviewState({ ...initialWebviewState, url });
+      });
+
+      return rendered;
+    }
+
+    it("does nothing when no reset was requested", () => {
+      const { result } = renderOnUrl(SUCCESS_URL);
+
+      act(() => {
+        result.current.ensureWebviewReset();
+      });
+
+      expect(result.current.webviewResetKey).toBe(0);
+    });
+
+    it("resets again when the live app is still on the page the reset should have left", () => {
+      const { result } = renderOnUrl(SUCCESS_URL);
+
+      act(() => {
+        result.current.resetWebview();
+      });
+      expect(result.current.webviewResetKey).toBe(1);
+
+      act(() => {
+        result.current.ensureWebviewReset();
+      });
+
+      expect(result.current.webviewResetKey).toBe(2);
+    });
+
+    it("does not reset again once the webview reloaded to another URL", () => {
+      const { result } = renderOnUrl(SUCCESS_URL);
+
+      act(() => {
+        result.current.resetWebview();
+      });
+      act(() => {
+        result.current.setWebviewState({ ...initialWebviewState, url: SWAP_FORM_URL });
+      });
+
+      act(() => {
+        result.current.ensureWebviewReset();
+      });
+
+      expect(result.current.webviewResetKey).toBe(1);
+    });
+
+    it("only honours a pending reset once", () => {
+      const { result } = renderOnUrl(SUCCESS_URL);
+
+      act(() => {
+        result.current.resetWebview();
+      });
+      act(() => {
+        result.current.ensureWebviewReset();
+      });
+      act(() => {
+        result.current.ensureWebviewReset();
+      });
+
+      expect(result.current.webviewResetKey).toBe(2);
+    });
+  });
+
   it("should return null defaultParams when params are invalid", () => {
     const { result } = renderHook(() => useSwapLiveAppState(null));
     expect(result.current.defaultParams).toBeNull();

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/hooks/useSwapLiveAppState.ts
@@ -55,7 +55,7 @@ export function useSwapLiveAppState(params: unknown) {
   const { t } = useTranslation();
   const ptxSwapLiveAppMobile = useFeature("ptxSwapLiveAppMobile");
   const { isConnected } = useNetInfo();
-  const [webviewState, setWebviewState] = useState<WebviewState>(initialWebviewState);
+  const [webviewState, setWebviewStateInternal] = useState<WebviewState>(initialWebviewState);
   const isWebviewError = webviewState?.url.includes("/unknown-error");
 
   const webviewRef = useRef<WebviewAPI>(null);
@@ -63,7 +63,40 @@ export function useSwapLiveAppState(params: unknown) {
   // Incrementing this key remounts SwapWebviewContent, resetting the webview to
   // its initial URL regardless of where it has navigated internally.
   const [webviewResetKey, setWebviewResetKey] = useState(0);
-  const resetWebview = useCallback(() => setWebviewResetKey(k => k + 1), []);
+
+  // Latest webview URL, mirrored in a ref so ensureWebviewReset can read it without
+  // being re-created on every navigation inside the live app.
+  const webviewUrlRef = useRef(initialWebviewState.url);
+  // URL the live app was on when a reset was last requested, until that reset is
+  // confirmed to have taken effect.
+  const pendingResetFromUrlRef = useRef<string | null>(null);
+
+  const setWebviewState = useCallback((nextState: WebviewState) => {
+    webviewUrlRef.current = nextState.url;
+    setWebviewStateInternal(nextState);
+  }, []);
+
+  const resetWebview = useCallback(() => {
+    pendingResetFromUrlRef.current = webviewUrlRef.current;
+    setWebviewResetKey(k => k + 1);
+  }, []);
+
+  /**
+   * Both reset call sites navigate away in the same tick, so the remount is committed
+   * while the Swap tab is already covered by another screen — and a webview remounted
+   * off-screen does not reliably come back on its initial URL. Re-assert the reset when
+   * the tab is focused again, but only if the live app is still on the page we wanted
+   * gone, so the common case costs no extra reload.
+   */
+  const ensureWebviewReset = useCallback(() => {
+    const resetFromUrl = pendingResetFromUrlRef.current;
+    if (resetFromUrl === null) return;
+
+    pendingResetFromUrlRef.current = null;
+    if (webviewUrlRef.current !== resetFromUrl) return;
+
+    setWebviewResetKey(k => k + 1);
+  }, []);
 
   const swapLiveAppManifestID = ptxSwapLiveAppMobile?.params?.manifest_id ?? DEFAULT_MANIFEST_ID;
 
@@ -112,5 +145,6 @@ export function useSwapLiveAppState(params: unknown) {
     defaultParams,
     webviewResetKey,
     resetWebview,
+    ensureWebviewReset,
   };
 }

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/openSwapSubScreens.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/__tests__/openSwapSubScreens.test.ts
@@ -1,0 +1,84 @@
+import { StackActions } from "@react-navigation/native";
+import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
+import { openSwapSubScreens, type SwapSubScreensTarget } from "../openSwapSubScreens";
+
+const TARGET: SwapSubScreensTarget = { screen: ScreenName.SwapHistory };
+
+/** `baseRoutes` is the BaseNavigator stack, last route being the focused one. */
+function setup({ baseRoutes }: { baseRoutes?: string[] } = {}) {
+  const dispatch = jest.fn();
+  const navigate = jest.fn();
+  const getParent = jest.fn(() =>
+    baseRoutes
+      ? {
+          dispatch,
+          getState: () => ({
+            index: baseRoutes.length - 1,
+            routes: baseRoutes.map(name => ({ name })),
+          }),
+        }
+      : undefined,
+  );
+
+  const navigation = { navigate, getParent } as unknown as Parameters<
+    typeof openSwapSubScreens
+  >[0]["navigation"];
+
+  return { dispatch, navigate, getParent, navigation };
+}
+
+describe("openSwapSubScreens", () => {
+  it("replaces the focused route when it is a transient swap screen", () => {
+    const { dispatch, navigate, getParent, navigation } = setup({
+      baseRoutes: [NavigatorName.Main, NavigatorName.SwapSubScreens],
+    });
+
+    openSwapSubScreens({ navigation, target: TARGET });
+
+    expect(getParent).toHaveBeenCalledWith(BASE_NAVIGATOR_ID);
+    expect(dispatch).toHaveBeenCalledWith(
+      StackActions.replace(NavigatorName.SwapSubScreens, TARGET),
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("replaces the focused route when the device exchange flow is on top", () => {
+    const { dispatch, navigate, navigation } = setup({
+      baseRoutes: [NavigatorName.Main, NavigatorName.PlatformExchange],
+    });
+
+    openSwapSubScreens({ navigation, target: TARGET });
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("pushes when Main is focused, so the tab navigator stays mounted", () => {
+    const { dispatch, navigate, navigation } = setup({ baseRoutes: [NavigatorName.Main] });
+
+    openSwapSubScreens({ navigation, target: TARGET });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, TARGET);
+  });
+
+  it("pushes when an unrelated screen is focused rather than replacing it", () => {
+    const { dispatch, navigate, navigation } = setup({
+      baseRoutes: [NavigatorName.Main, NavigatorName.Accounts],
+    });
+
+    openSwapSubScreens({ navigation, target: TARGET });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, TARGET);
+  });
+
+  it("pushes when the base navigator cannot be resolved", () => {
+    const { dispatch, navigate, navigation } = setup();
+
+    openSwapSubScreens({ navigation, target: TARGET });
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, TARGET);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/Swap/navigation/openSwapSubScreens.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/navigation/openSwapSubScreens.ts
@@ -1,0 +1,56 @@
+import { StackActions, type NavigatorScreenParams } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import type { BaseNavigatorStackParamList } from "~/components/RootNavigator/types/BaseNavigator";
+import type { SwapSubScreensNavigatorParamList } from "~/components/RootNavigator/types/SwapSubScreensNavigator";
+import { BASE_NAVIGATOR_ID, NavigatorName } from "~/const";
+
+/** Navigation typed with {@link BASE_NAVIGATOR_ID} so `getParent(BASE_NAVIGATOR_ID)` is type-safe. */
+export type SwapBaseNavigation = NativeStackNavigationProp<
+  BaseNavigatorStackParamList,
+  keyof BaseNavigatorStackParamList,
+  typeof BASE_NAVIGATOR_ID
+>;
+
+export type SwapSubScreensTarget = NavigatorScreenParams<SwapSubScreensNavigatorParamList>;
+
+/**
+ * BaseNavigator routes that a Swap sub-screen supersedes, so they can be replaced
+ * instead of being left underneath: the loading drawer and the device exchange flow.
+ */
+const REPLACEABLE_BASE_ROUTES: ReadonlySet<string> = new Set([
+  NavigatorName.SwapSubScreens,
+  NavigatorName.PlatformExchange,
+]);
+
+/**
+ * Opens a Swap sub-screen (History, PendingOperation, …) on top of the Swap tab.
+ *
+ * `StackActions.replace` carries no `target`, so BaseNavigator applies it to whichever
+ * route is focused. That is what we want while a transient swap screen is on top: it is
+ * swapped for the sub-screen, leaving a clean `[Main, SwapSubScreens]` stack whose back
+ * action returns to the Swap tab. When the Swap tab itself is on top the focused route is
+ * `Main`, and replacing that unmounts the tab navigator, leaving BaseNavigator with a
+ * single route that can no longer handle the sub-screen's back action — so we push.
+ *
+ * Intended as the single entry point for Swap sub-screen navigation; the loading drawer
+ * and the custom error screen still navigate directly.
+ */
+export function openSwapSubScreens({
+  navigation,
+  target,
+}: {
+  navigation: Pick<SwapBaseNavigation, "navigate" | "getParent">;
+  target: SwapSubScreensTarget;
+}): void {
+  const baseNavigation = navigation.getParent(BASE_NAVIGATOR_ID);
+  const baseState = baseNavigation?.getState();
+  const focusedRouteName =
+    baseState === undefined ? undefined : baseState.routes[baseState.index]?.name;
+
+  if (baseNavigation && focusedRouteName && REPLACEABLE_BASE_ROUTES.has(focusedRouteName)) {
+    baseNavigation.dispatch(StackActions.replace(NavigatorName.SwapSubScreens, target));
+    return;
+  }
+
+  navigation.navigate(NavigatorName.SwapSubScreens, target);
+}


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- **#20110 fix/LIVE-34563-swap-history-replace-nav ← this PR**
- #20183 fix/LIVE-32926-multi-step-swap-status-drawer
<!-- stac-man:stack-end -->

Jira: [LIVE-34563](https://ledgerhq.atlassian.net/browse/LIVE-34563) — pressing "<" from Swap History after a multi-step swap shows the transaction success screen instead of the input form.

## Root cause

Two earlier attempts missed it, so the diagnosis is worth stating precisely.

`StackActions.replace` carries no `target`, and `navigation.dispatch()` only attaches `source` (`useNavigationCache.tsx:154`). `StackRouter`'s `REPLACE` branch therefore falls through to `index = state.index` — BaseNavigator replaces **whichever route is focused**, not the one the caller has in mind:

```ts
case 'REPLACE': {
  const index = action.target === state.key && action.source
    ? state.routes.findIndex(r => r.key === action.source)
    : state.index;   // ← taken, because target is undefined
```

The multi-step live app redirects to history straight from the Swap tab, where the focused base route is `Main`. The previous version of this PR replaced it — unmounting the entire tab navigator, webview included, and leaving BaseNavigator with a single route. `SwapHistoryBackButton` → `navigateBackToSwapTab` → `baseNavigation.goBack()` then had nothing to pop, producing `The action 'GO_BACK' was not handled by any navigator` and stranding the user on History with no tab bar.

The same footgun was latent in `navigateToSwapPendingOperation`: on the `custom.exchange.complete` path, `onResult` calls `navigation.pop()` (removing the device flow) *before* `onCompleteResult`, so `Main` is focused there too.

## Changes

- **`screens/Swap/navigation/openSwapSubScreens.ts`** (new) — single entry point for putting a Swap sub-screen on top of the Swap tab. Replaces the focused base route only when it is one the sub-screen supersedes (`SwapSubScreens`, `PlatformExchange`), and pushes otherwise. Both `navigateToSwapHistory` and `navigateToSwapPendingOperation` route through it, so the latent case is fixed too, and LIVE-28726's "no SwapLoading beneath PendingOperation" guarantee still holds.
- **`useSwapLiveAppState.ts`** — the "clean form on return" half, which the first attempt (#19899) did not achieve reliably. Both reset call sites navigate away in the same tick, so the remount is committed while the Swap tab is already covered. `resetWebview()` now records the URL it wants gone, and `ensureWebviewReset()` re-applies the reset when the tab regains focus **only if the live app is still on that page** — the happy path costs no extra reload, the failure path self-heals. Wired via `useFocusEffect` in `SwapLiveAppWallet40`.

## Companion live-app change

LedgerHQ/swap-live-app#1813 makes the multi-step page reset itself to the swap form once the history handoff resolves — the flash-free mechanism, shipping without an app release. It does **not** fix this ticket on its own (the wallet's `resetWebview()` tears the webview down in the same tick and decides what the user comes back to), so this PR is the one that closes LIVE-34563. Once #1813 is deployed and verified, a follow-up can drop `resetWebview()` from `navigateToSwapHistory` and let the live app own it — keeping it for the single-step path, where the redirect is fired automatically from `saveSwapHistory` and the live app does not reset itself.

## Test plan

- [x] `openSwapSubScreens` unit tests: replace vs push per focused base route, including a regression test for the `Main` case
- [x] `useSwapCustomHandlers`: both handlers push when the Swap tab is focused, replace when a transient swap screen is
- [x] `useSwapLiveAppState`: deferred reset re-applies when the live app is still on the stale page, no-ops otherwise, honoured once
- [x] `screens/Swap` suite (97), swap-flow integration suites, mobile typecheck, oxlint, oxfmt
- [x] Rebased on current `develop` with zero conflicts; GitHub reports the branch mergeable
- [ ] Manual: multi-step swap → "See details" → "<" → swap input form shown, tab bar intact, no `GO_BACK` warning
- [ ] Manual: single-step swap → automatic redirect to history → "<" → swap input form shown

## Follow-ups (not in this PR)

- [LIVE-34886](https://ledgerhq.atlassian.net/browse/LIVE-34886) — `navigate` reuses an existing route only when it is the *focused* one, so `navigateToSwapTab` called from any screen stacked above `Main` pushes a **second** `Main`, i.e. a second tab navigator with its own mounted Swap webview. `StackActions.popTo` looks like the better primitive than the `{ pop: true }` that was tried: it searches the whole stack and, when the route is absent, replaces the current route rather than pushing. Unaffected by this PR — `openSwapSubScreens` keys off the focused route either way.
- Routing the loading drawer and custom error screen through `openSwapSubScreens` too, so they stop stacking on each other. Left out here because it changes live device-flow navigation.


[LIVE-34563]: https://ledgerhq.atlassian.net/browse/LIVE-34563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34886]: https://ledgerhq.atlassian.net/browse/LIVE-34886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ