### PR TITLE
[LWD] refactor(desktop): rename settings.sentryLogs to crashReporting

### DIFF
--- a/apps/ledger-live-desktop/src/datadog/renderer.ts
+++ b/apps/ledger-live-desktop/src/datadog/renderer.ts
@@ -60,7 +60,7 @@ export function isDatadogAvailable(): boolean {
 
 /**
  * Initialize Datadog RUM in the renderer process.
- * Call only when lldDatadog.enabled and sentryLogs (user opt-in) are true.
+ * Call only when lldDatadog.enabled and crashReporting (user opt-in) are true.
  */
 export async function initDatadog(
   shouldSend: () => boolean,

--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -59,9 +59,9 @@ export const setDiscreetMode = (discreetMode: boolean) =>
   saveSettings({
     discreetMode,
   });
-export const setSentryLogs = (sentryLogs: boolean) =>
+export const setCrashReporting = (crashReporting: boolean) =>
   saveSettings({
-    sentryLogs,
+    crashReporting,
   });
 export const setShareAnalytics = (shareAnalytics: boolean) =>
   saveSettings({

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.test.tsx
@@ -24,17 +24,17 @@ describe("ConnectEnvsToDatadog", () => {
 
   it("should render nothing (null)", () => {
     const { container } = render(<ConnectEnvsToDatadog />, {
-      initialState: { settings: { sentryLogs: false } },
+      initialState: { settings: { crashReporting: false } },
     });
     expect(container.firstChild).toBeNull();
   });
 
-  it("should not call initDatadog when sentryLogs is false", async () => {
+  it("should not call initDatadog when crashReporting is false", async () => {
     render(<ConnectEnvsToDatadog />, {
       initialState: {
         ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
         settings: {
-          sentryLogs: false,
+          crashReporting: false,
         },
       },
     });
@@ -42,12 +42,12 @@ describe("ConnectEnvsToDatadog", () => {
     expect(initDatadog).not.toHaveBeenCalled();
   });
 
-  it("should call initDatadog when lldDatadog.enabled, sentryLogs and isDatadogAvailable are true", async () => {
+  it("should call initDatadog when lldDatadog.enabled, crashReporting, and isDatadogAvailable are true", async () => {
     render(<ConnectEnvsToDatadog />, {
       initialState: {
         ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
         settings: {
-          sentryLogs: true,
+          crashReporting: true,
         },
       },
     });
@@ -64,7 +64,7 @@ describe("ConnectEnvsToDatadog", () => {
       initialState: {
         ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
         settings: {
-          sentryLogs: true,
+          crashReporting: true,
         },
       },
     });
@@ -77,7 +77,7 @@ describe("ConnectEnvsToDatadog", () => {
       initialState: {
         ...withFlagOverrides({ lldDatadog: { enabled: true, params: {} } }),
         settings: {
-          sentryLogs: true,
+          crashReporting: true,
         },
       },
     });
@@ -85,7 +85,7 @@ describe("ConnectEnvsToDatadog", () => {
     expect(initDatadog).toHaveBeenCalled();
     const shouldSend = initDatadog.mock.calls[0]![0] as () => boolean;
     expect(shouldSend()).toBe(true);
-    store.dispatch({ type: "SAVE_SETTINGS", payload: { sentryLogs: false } });
+    store.dispatch({ type: "SAVE_SETTINGS", payload: { crashReporting: false } });
     expect(shouldSend()).toBe(false);
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@shared/feature-flags";
 import { useFeature, useFeatureFlags } from "@features/platform-feature-flags";
 import { enabledExperimentalFeatures } from "~/renderer/experimental";
-import { sentryLogsSelector } from "~/renderer/reducers/settings";
+import { crashReportingSelector } from "~/renderer/reducers/settings";
 import { initDatadog, setTags, isDatadogAvailable } from "~/datadog/renderer";
 import { initDatadogLogs } from "~/datadog/logs";
 
@@ -37,19 +37,20 @@ export const ConnectEnvsToDatadog = () => {
   const store = useStore();
   const featureFlags = useFeatureFlags();
   const rawLldDatadog = useFeature("lldDatadog");
-  const sentryLogs = useSelector(sentryLogsSelector);
+  const crashReporting = useSelector(crashReportingSelector);
   const lldDatadog = isLldDatadogFeature(rawLldDatadog) ? rawLldDatadog : null;
   const [datadogInitialized, setDatadogInitialized] = useState(false);
   const initInFlightRef = useRef(false);
 
   useEffect(() => {
-    if (!lldDatadog?.enabled || !sentryLogs || !isDatadogAvailable() || datadogInitialized) return;
+    if (!lldDatadog?.enabled || !crashReporting || !isDatadogAvailable() || datadogInitialized)
+      return;
     if (initInFlightRef.current) return;
 
     let cancelled = false;
     initInFlightRef.current = true;
 
-    const shouldSend = () => sentryLogsSelector(store.getState());
+    const shouldSend = () => crashReportingSelector(store.getState());
     initDatadogLogs(shouldSend);
     initDatadog(
       shouldSend,
@@ -71,7 +72,7 @@ export const ConnectEnvsToDatadog = () => {
       cancelled = true;
       initInFlightRef.current = false;
     };
-  }, [store, lldDatadog, sentryLogs, datadogInitialized]);
+  }, [store, lldDatadog, crashReporting, datadogInitialized]);
 
   useEffect(() => {
     if (!lldDatadog?.enabled || !datadogInitialized) return;

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -191,6 +191,13 @@ async function init() {
   // supportedCounterValues is now derived at runtime from @domain/entity-currency-fiat — strip stale persisted copy.
   delete (settingsToLoad as Record<string, unknown>).supportedCounterValues;
 
+  // sentryLogs was renamed to crashReporting (LIVE-34932); migrate persisted value to avoid silent opt-in reset.
+  const legacySettings = settingsToLoad as Record<string, unknown>;
+  if (legacySettings.sentryLogs !== undefined && legacySettings.crashReporting === undefined) {
+    settingsToLoad.crashReporting = Boolean(legacySettings.sentryLogs);
+    delete legacySettings.sentryLogs;
+  }
+
   if (deepLinkUrl) {
     settingsToLoad.deepLinkUrl = deepLinkUrl;
   }

--- a/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/settings.ts
@@ -92,7 +92,7 @@ export type SettingsState = {
   shareAnalytics: boolean;
   sharePersonalizedRecommandations: boolean;
   analyticsConsentInfo: AnalyticsConsentInfo;
-  sentryLogs: boolean; // will be addressed by LIVE-34932
+  crashReporting: boolean;
   lastUsedVersion: string;
   dismissedBanners: string[];
   accountsViewMode: "card" | "list";
@@ -191,7 +191,7 @@ export const INITIAL_STATE: SettingsState = {
     privacyPolicyVersion: null,
   },
   hasSeenAnalyticsOptInPrompt: false,
-  sentryLogs: true,
+  crashReporting: true,
   lastUsedVersion: __APP_VERSION__,
   dismissedBanners: [],
   accountsViewMode: "list",
@@ -792,7 +792,7 @@ export const accountUnitSelector = (state: State, account: AccountLike): Unit =>
 export const preferredDeviceModelSelector = (state: State) => state.settings.preferredDeviceModel;
 export const sidebarCollapsedSelector = (state: State) => state.settings.sidebarCollapsed;
 export const accountsViewModeSelector = (state: State) => state.settings.accountsViewMode;
-export const sentryLogsSelector = (state: State) => state.settings.sentryLogs;
+export const crashReportingSelector = (state: State) => state.settings.crashReporting;
 export const autoLockTimeoutSelector = (state: State) => state.settings.autoLockTimeout;
 export const shareAnalyticsSelector = (state: State) => state.settings.shareAnalytics;
 export const sharePersonalizedRecommendationsSelector = (state: State) =>

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ReportBugsButton.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/General/ReportBugsButton.tsx
@@ -1,15 +1,15 @@
 import React, { useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { setSentryLogs } from "~/renderer/actions/settings";
-import { sentryLogsSelector } from "~/renderer/reducers/settings";
+import { setCrashReporting } from "~/renderer/actions/settings";
+import { crashReportingSelector } from "~/renderer/reducers/settings";
 import Track from "~/renderer/analytics/Track";
 import Switch from "~/renderer/components/Switch";
 const ReportBugsButton = () => {
   const dispatch = useDispatch();
-  const reportBugs = useSelector(sentryLogsSelector);
+  const reportBugs = useSelector(crashReportingSelector);
   const onChangeReportBugs = useCallback(
     (value: boolean) => {
-      dispatch(setSentryLogs(value));
+      dispatch(setCrashReporting(value));
     },
     [dispatch],
   );


### PR DESCRIPTION
### 📝 Description

Renames the `sentryLogs` settings field to `crashReporting` now that Sentry is removed (LIVE-20973). The field drives the Datadog crash-reporting opt-in gate.

A settings migration in `init.tsx` reads the legacy `sentryLogs` key from the persisted `app.json` and writes it as `crashReporting`, so existing opt-outs are preserved. The guard `crashReporting === undefined` ensures a downgrade/re-upgrade cycle can't silently restore a user's opt-out.

All test and e2e userdata fixtures updated in the same commit.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34932](https://ledgerhq.atlassian.net/browse/LIVE-34932)

[LIVE-34932]: https://ledgerhq.atlassian.net/browse/LIVE-34932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ