### PR TITLE
test(e2e): raise device review timeout for send tx validation

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -295,7 +295,6 @@ test.describe("e2e delegation - Celo", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await addBugLink(["NAPPS-1128"]);
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();
@@ -327,7 +326,6 @@ test.describe("e2e delegation - Celo", () => {
     },
     async ({ app }) => {
       await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-      await addBugLink(["NAPPS-1128"]);
       await app.mainNavigation.openTargetFromMainNavigation("accounts");
       await app.accounts.navigateToAccountByName(account.account.accountName);
       await app.account.startStakingFlowFromMainStakeButton();

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -71,6 +71,10 @@ const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = Math.ceil(
   SWAP_REVIEW_TRANSACTION_TIMEOUT_MS / SCREEN_POLL_INTERVAL_MS,
 );
 
+const SEND_REVIEW_TRANSACTION_TIMEOUT_MS = 120_000;
+const SEND_REVIEW_TRANSACTION_MAX_ATTEMPTS = Math.ceil(
+  SEND_REVIEW_TRANSACTION_TIMEOUT_MS / SCREEN_POLL_INTERVAL_MS,
+);
 export type Spec = {
   currency?: CryptoCurrency;
   appQuery: {
@@ -968,11 +972,14 @@ export async function signSendTransaction(tx: Transaction) {
   }
 }
 
-export async function getSendEvents(tx: Transaction): Promise<string[]> {
+export async function getSendEvents(
+  tx: Transaction,
+  verifyMaxAttempts: number = SEND_REVIEW_TRANSACTION_MAX_ATTEMPTS,
+): Promise<string[]> {
   const { sendVerifyLabel, sendConfirmLabel } = getDeviceLabels(
     tx.accountToDebit.currency.speculosApp,
   );
-  await waitFor(sendVerifyLabel);
+  await waitFor(sendVerifyLabel, verifyMaxAttempts);
   return await pressUntilTextFound(sendConfirmLabel);
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not required: changes are limited to the private `@ledgerhq/live-e2e-shared` E2E package and a desktop E2E spec — no publishable package behaviour changes._
- [x] **Covered by automatic tests.** _This is E2E test infrastructure._
- [x] **Impact of the changes:**
  - Desktop/mobile E2E send flows that verify a transaction on the Speculos device
  - Celo delegate desktop E2E spec

### 📝 Description

**Send transaction review timeout** — Sending can require many device APDU round-trips to load a transaction (e.g. fetching UTXO prevouts), so the device can stay on "Loading transaction" past the default ~30s review budget, causing flaky send E2E failures at the device-review step. This adds a dedicated `SEND_REVIEW_TRANSACTION_TIMEOUT_MS` (120s) budget and lets `getSendEvents` accept a `verifyMaxAttempts` override (defaulting to that budget), so `waitFor(sendVerifyLabel, …)` waits long enough for the transaction to finish loading on the device before confirming.

**Celo delegate cleanup** — Removes the stale `NAPPS-1128` bug link from the Celo delegation tests.

_Scope note: this branch previously also contained swap E2E stabilization changes; those were reverted so this PR is limited to the send transaction-review timeout and the delegate bug-link cleanup._

### ✅ Proof the fix works

Successful E2E run with this change: https://github.com/LedgerHQ/ledger-live/actions/runs/30360086594

### ❓ Context

- **JIRA or GitHub link**: _n/a — E2E send stabilization_

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

