### PR TITLE
[LWDM] Test(LIVE-34469): hedera unit tests with better cov (part 1)

### DIFF
--- a/libs/coin-modules/coin-hedera/src/api/index.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.test.ts
@@ -40,7 +40,7 @@ const mockListOperationsV2 = jest.mocked(logic.listOperationsV2);
 
 describe("createApi", () => {
   let api: ReturnType<typeof createApi>;
-  const mockConfig = { ...getMockedConfig() };
+  const mockConfig = getMockedConfig();
   const mockCurrency = getMockedCurrency();
 
   beforeEach(() => {
@@ -125,6 +125,12 @@ describe("createApi", () => {
     });
   });
 
+  describe("call", () => {
+    it("should throw 'call is not supported'", async () => {
+      await expect(api.call({})).rejects.toThrow("call is not supported");
+    });
+  });
+
   describe("craftRawTransaction", () => {
     it("should throw when called", () => {
       expect(() => api.craftRawTransaction("tx", "sender", "pubkey", 1n)).toThrow(
@@ -145,6 +151,7 @@ describe("createApi", () => {
       const result = await api.estimateFees(txIntent);
 
       expect(result).toEqual({ value: BigInt("5000") });
+      expect(mockEstimateFees).toHaveBeenCalledTimes(1);
       expect(mockEstimateFees).toHaveBeenCalledWith(
         expect.objectContaining({ operationType: "CRYPTOTRANSFER" }),
       );
@@ -160,6 +167,7 @@ describe("createApi", () => {
       const result = await api.estimateFees(txIntent);
 
       expect(result).toEqual({ value: BigInt("9000") });
+      expect(mockEstimateFees).toHaveBeenCalledTimes(1);
       expect(mockEstimateFees).toHaveBeenCalledWith(
         expect.objectContaining({
           operationType: HEDERA_OPERATION_TYPES.ContractCall,
@@ -440,6 +448,29 @@ describe("createApi", () => {
 
       expect(result.items[0].id).toEqual(order === "desc" ? newId : oldId);
       expect(result.items[1].id).toEqual(order === "desc" ? oldId : newId);
+    });
+
+    it("should pass ERC20 contract addresses as tokenEvmAddresses to listOperationsV2", async () => {
+      mockGetERC20BalancesForAccountV2.mockResolvedValue([
+        {
+          contractAddress: "0xDeAdBeEf000000000000000000000000000ABCDE",
+          balance: new BigNumber(500),
+        },
+      ]);
+      mockListOperationsV2.mockResolvedValue({
+        coinOperations: [],
+        tokenOperations: [],
+        nextCursor: null,
+      });
+
+      await api.listOperations(mockAddress, mockOptions);
+
+      expect(mockListOperationsV2).toHaveBeenCalledTimes(1);
+      expect(mockListOperationsV2).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenEvmAddresses: expect.arrayContaining(["0xdeadbeef000000000000000000000000000abcde"]),
+        }),
+      );
     });
 
     it("should fall back to date sort when consensusTimestamp is missing", async () => {

--- a/libs/coin-modules/coin-hedera/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/broadcast.test.ts
@@ -1,0 +1,99 @@
+import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
+import { broadcast as logicBroadcast } from "../logic/broadcast";
+import * as logicUtils from "../logic/utils";
+import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { getMockedOperation } from "../test/fixtures/operation.fixture";
+import { broadcast } from "./broadcast";
+
+jest.mock("../logic/broadcast");
+jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
+  patchOperationWithHash: jest.fn((op: unknown) => op),
+}));
+jest.mock("../logic/utils", () => ({
+  ...jest.requireActual("../logic/utils"),
+  base64ToUrlSafeBase64: jest.fn((v: string) => `urlsafe-${v}`),
+  isValidExtra: jest.fn(() => true),
+  formatTransactionId: jest.fn(() => "formatted-tx-id"),
+}));
+jest.mock("./utils", () => ({
+  ...jest.requireActual("./utils"),
+  patchOperationWithExtra: jest.fn((op: unknown, extra: unknown) => ({ ...(op as object), extra })),
+}));
+
+const mockTransactionResponse = {
+  transactionHash: new Uint8Array([1, 2, 3]),
+  transactionId: { toString: () => "0.0.1234@1234.5678" },
+} as unknown as Awaited<ReturnType<typeof logicBroadcast>>;
+
+describe("broadcast", () => {
+  const mockAccount = getMockedAccount();
+  const mockOperation = getMockedOperation({ extra: { consensusTimestamp: "1.2.3" } });
+  const mockSignedOperation = {
+    signature: "base64-signature",
+    operation: mockOperation,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(logicBroadcast).mockResolvedValue(mockTransactionResponse);
+  });
+
+  it("calls logicBroadcast with account currencyId and the signature", async () => {
+    await broadcast({ signedOperation: mockSignedOperation as never, account: mockAccount });
+
+    expect(logicBroadcast).toHaveBeenCalledTimes(1);
+    expect(logicBroadcast).toHaveBeenCalledWith({
+      configOrCurrencyId: mockAccount.currency.id,
+      txWithSignature: mockSignedOperation.signature,
+    });
+  });
+
+  it("patches the operation with a base64url-encoded hash from the response", async () => {
+    await broadcast({ signedOperation: mockSignedOperation as never, account: mockAccount });
+
+    expect(patchOperationWithHash).toHaveBeenCalledTimes(1);
+    expect(patchOperationWithHash).toHaveBeenCalledWith(
+      mockOperation,
+      expect.stringContaining("urlsafe-"),
+    );
+  });
+
+  it("includes the formatted transactionId in the operation extra", async () => {
+    const result = await broadcast({
+      signedOperation: mockSignedOperation as never,
+      account: mockAccount,
+    });
+
+    expect(result).toMatchObject({
+      extra: expect.objectContaining({ transactionId: "formatted-tx-id" }),
+    });
+  });
+
+  it("merges existing valid extra with the new transactionId", async () => {
+    const result = await broadcast({
+      signedOperation: mockSignedOperation as never,
+      account: mockAccount,
+    });
+
+    expect(result).toMatchObject({
+      extra: expect.objectContaining({
+        transactionId: "formatted-tx-id",
+        consensusTimestamp: "1.2.3",
+      }),
+    });
+  });
+
+  it("does not spread operation.extra when isValidExtra returns false", async () => {
+    jest.mocked(logicUtils.isValidExtra).mockReturnValueOnce(false);
+
+    const result = await broadcast({
+      signedOperation: mockSignedOperation as never,
+      account: mockAccount,
+    });
+
+    expect(result).toMatchObject({
+      extra: { transactionId: "formatted-tx-id" },
+    });
+    expect((result.extra as Record<string, unknown>).consensusTimestamp).toBeUndefined();
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/buildOptimisticOperation.test.ts
@@ -54,15 +54,18 @@ describe("buildOptimisticOperation", () => {
     expect(op.recipients).toContain("0.0.5678");
   });
 
-  it("builds optimistic operation for HTS token", async () => {
-    const mockedTokenCurrency = getMockedHTSTokenCurrency();
+  it.each([
+    ["HTS", getMockedHTSTokenCurrency, new BigNumber(2000)],
+    ["ERC20", getMockedERC20TokenCurrency, new BigNumber(2500)],
+  ] as const)("builds optimistic operation for %s token", async (_, getMockedCurrency, maxFee) => {
+    const mockedTokenCurrency = getMockedCurrency();
     const tokenAccount = getMockedTokenAccount(mockedTokenCurrency);
     const parentAccount = getMockedAccount({ subAccounts: [tokenAccount] });
     const mockedTransaction = getMockedTransaction({
       subAccountId: tokenAccount.id,
       amount: new BigNumber(123),
       recipient: "0.0.9999",
-      maxFee: new BigNumber(2000),
+      maxFee,
     });
 
     const op = await buildOptimisticOperation({
@@ -72,41 +75,41 @@ describe("buildOptimisticOperation", () => {
     const subOp = (op.subOperations ?? [])[0];
 
     expect(op.type).toBe("FEES");
-    expect(op.value).toEqual(mockedTransaction.maxFee);
+    expect(op.value).toEqual(maxFee);
     expect(op.subOperations).toHaveLength(1);
     expect(subOp.type).toBe("OUT");
     expect(subOp.value).toEqual(new BigNumber(123));
-    expect(subOp.fee).toEqual(mockedTransaction.maxFee);
+    expect(subOp.fee).toEqual(maxFee);
     expect(subOp.accountId).toBe(tokenAccount.id);
     expect(subOp.recipients).toContain("0.0.9999");
   });
 
-  it("builds optimistic operation for ERC20 token", async () => {
-    const mockedTokenCurrency = getMockedERC20TokenCurrency();
-    const tokenAccount = getMockedTokenAccount(mockedTokenCurrency);
-    const parentAccount = getMockedAccount({ subAccounts: [tokenAccount] });
-    const mockedTransaction = getMockedTransaction({
-      subAccountId: tokenAccount.id,
-      amount: new BigNumber(123),
-      recipient: "0.0.9999",
-      maxFee: new BigNumber(2500),
-    });
+  it.each([
+    ["HTS", getMockedHTSTokenCurrency, "HTS transfer with memo"],
+    ["ERC20", getMockedERC20TokenCurrency, "ERC20 transfer with memo"],
+  ] as const)(
+    "includes memo in %s token sub-operation extra when memo is set",
+    async (_, getMockedCurrency, memo) => {
+      const mockedTokenCurrency = getMockedCurrency();
+      const tokenAccount = getMockedTokenAccount(mockedTokenCurrency);
+      const parentAccount = getMockedAccount({ subAccounts: [tokenAccount] });
+      const mockedTransaction = getMockedTransaction({
+        subAccountId: tokenAccount.id,
+        amount: new BigNumber(50),
+        recipient: "0.0.9999",
+        maxFee: new BigNumber(1000),
+        memo,
+      });
 
-    const op = await buildOptimisticOperation({
-      account: parentAccount,
-      transaction: mockedTransaction,
-    });
-    const subOp = (op.subOperations ?? [])[0];
+      const op = await buildOptimisticOperation({
+        account: parentAccount,
+        transaction: mockedTransaction,
+      });
 
-    expect(op.type).toBe("FEES");
-    expect(op.value).toEqual(mockedTransaction.maxFee);
-    expect(op.subOperations).toHaveLength(1);
-    expect(subOp.type).toBe("OUT");
-    expect(subOp.value).toEqual(new BigNumber(123));
-    expect(subOp.fee).toEqual(mockedTransaction.maxFee);
-    expect(subOp.accountId).toBe(tokenAccount.id);
-    expect(subOp.recipients).toContain("0.0.9999");
-  });
+      const subOp = (op.subOperations ?? [])[0];
+      expect(subOp.extra).toEqual({ memo });
+    },
+  );
 
   it("builds optimistic operation for delegate transaction", async () => {
     const mockedAccount = getMockedAccount();

--- a/libs/coin-modules/coin-hedera/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/estimateMaxSpendable.test.ts
@@ -1,0 +1,66 @@
+import BigNumber from "bignumber.js";
+import { HEDERA_OPERATION_TYPES } from "../constants";
+import { estimateFees } from "../logic/estimateFees";
+import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
+import { getMockedHTSTokenCurrency } from "../test/fixtures/currency.fixture";
+import { estimateMaxSpendable } from "./estimateMaxSpendable";
+
+jest.mock("../logic/estimateFees");
+
+describe("estimateMaxSpendable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the token balance directly for token accounts, without calling estimateFees", async () => {
+    const tokenCurrency = getMockedHTSTokenCurrency();
+    const mainAccount = getMockedAccount();
+    const tokenAccount = getMockedTokenAccount(tokenCurrency);
+
+    const result = await estimateMaxSpendable({
+      account: tokenAccount,
+      parentAccount: mainAccount,
+    });
+
+    expect(result).toEqual(tokenAccount.balance);
+    expect(estimateFees).not.toHaveBeenCalled();
+  });
+
+  it("returns balance minus estimated fees for a main HBAR account", async () => {
+    const account = getMockedAccount({ balance: new BigNumber(1_000) });
+    jest
+      .mocked(estimateFees)
+      .mockResolvedValue({ tinybars: new BigNumber(100), gas: new BigNumber(0) });
+
+    const result = await estimateMaxSpendable({ account });
+
+    expect(result).toEqual(new BigNumber(900));
+    expect(estimateFees).toHaveBeenCalledTimes(1);
+    expect(estimateFees).toHaveBeenCalledWith({
+      currencyId: account.currency.id,
+      operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
+    });
+  });
+
+  it("returns zero when account balance is less than the estimated fee", async () => {
+    const account = getMockedAccount({ balance: new BigNumber(50) });
+    jest
+      .mocked(estimateFees)
+      .mockResolvedValue({ tinybars: new BigNumber(100), gas: new BigNumber(0) });
+
+    const result = await estimateMaxSpendable({ account });
+
+    expect(result).toEqual(new BigNumber(0));
+  });
+
+  it("returns zero when balance exactly equals the estimated fee", async () => {
+    const account = getMockedAccount({ balance: new BigNumber(100) });
+    jest
+      .mocked(estimateFees)
+      .mockResolvedValue({ tinybars: new BigNumber(100), gas: new BigNumber(0) });
+
+    const result = await estimateMaxSpendable({ account });
+
+    expect(result).toEqual(new BigNumber(0));
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/getTransactionStatus.test.ts
@@ -159,6 +159,22 @@ describe("getTransactionStatus", () => {
     expect(result.amount).toEqual(new BigNumber(200));
   });
 
+  it("token associate transaction uses BigNumber(0) when usdRate is null", async () => {
+    mockGetCurrencyToUSDRate.mockResolvedValueOnce(null);
+    const mockedTokenCurrency = getMockedHTSTokenCurrency();
+    const mockedAccount = getMockedAccount({ balance: new BigNumber(0) });
+    const mockedTransaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+      properties: { token: mockedTokenCurrency },
+    });
+
+    const result = await getTransactionStatus(mockedAccount, mockedTransaction);
+
+    expect(result.errors.insufficientAssociateBalance).toBeInstanceOf(
+      HederaInsufficientFundsForAssociation,
+    );
+  });
+
   it("token associate transaction with sufficient USD worth completes successfully", async () => {
     const mockedTokenCurrency = getMockedHTSTokenCurrency();
     const mockedAccount = getMockedAccount();
@@ -176,6 +192,21 @@ describe("getTransactionStatus", () => {
     expect(result.warnings).toEqual({});
     expect(result.totalSpent).toEqual(mockedEstimatedFee.tinybars);
     expect(result.estimatedFees).toEqual(mockedEstimatedFee.tinybars);
+  });
+
+  it("token associate transaction skips association check when token is already associated", async () => {
+    const mockedTokenCurrency = getMockedHTSTokenCurrency();
+    const tokenAccount = getMockedTokenAccount(mockedTokenCurrency);
+    const mockedAccount = getMockedAccount({ subAccounts: [tokenAccount] });
+    const mockedTransaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+      properties: { token: mockedTokenCurrency },
+    });
+
+    const result = await getTransactionStatus(mockedAccount, mockedTransaction);
+
+    expect(result.errors.insufficientAssociateBalance).toBeUndefined();
+    expect(result.errors).toEqual({});
   });
 
   it("recipient with checksum is supported", async () => {
@@ -389,6 +420,53 @@ describe("getTransactionStatus", () => {
     expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
   });
 
+  it("adds error when main account balance cannot cover fees during HTS token transfer", async () => {
+    const tokenCurrency = getMockedHTSTokenCurrency();
+    const tokenAccount = getMockedTokenAccount(tokenCurrency, { balance: new BigNumber(1000) });
+    const account = getMockedAccount({ balance: new BigNumber(0), subAccounts: [tokenAccount] });
+    const transaction = getMockedTransaction({
+      subAccountId: tokenAccount.id,
+      recipient: validRecipientAddress,
+      amount: new BigNumber(100),
+    });
+    mockEstimateFees.mockResolvedValueOnce({ tinybars: new BigNumber(500) });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+  });
+
+  it("adds error during ERC20 token transfer with insufficient sub-account balance", async () => {
+    const tokenCurrency = getMockedERC20TokenCurrency();
+    const tokenAccount = getMockedTokenAccount(tokenCurrency, { balance: new BigNumber(0) });
+    const account = getMockedAccount({ balance: new BigNumber(1000), subAccounts: [tokenAccount] });
+    const transaction = getMockedTransaction({
+      subAccountId: tokenAccount.id,
+      recipient: validRecipientAddress,
+      amount: new BigNumber(100),
+    });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+  });
+
+  it("adds error when main account balance cannot cover fees during ERC20 token transfer", async () => {
+    const tokenCurrency = getMockedERC20TokenCurrency();
+    const tokenAccount = getMockedTokenAccount(tokenCurrency, { balance: new BigNumber(1000) });
+    const account = getMockedAccount({ balance: new BigNumber(0), subAccounts: [tokenAccount] });
+    const transaction = getMockedTransaction({
+      subAccountId: tokenAccount.id,
+      recipient: validRecipientAddress,
+      amount: new BigNumber(100),
+    });
+    mockEstimateFees.mockResolvedValueOnce({ tinybars: new BigNumber(500) });
+
+    const result = await getTransactionStatus(account, transaction);
+
+    expect(result.errors.amount).toBeInstanceOf(NotEnoughBalance);
+  });
+
   it("adds error if amount is zero and useAllAmount is false", async () => {
     const mockedAccount = getMockedAccount();
     const mockedTransaction = getMockedTransaction({
@@ -440,18 +518,18 @@ describe("getTransactionStatus", () => {
     expect(result.errors.stakingNodeId).toBeInstanceOf(HederaInvalidStakingNodeIdError);
   });
 
+  const hederaResourcesDelegatedToNode1 = {
+    maxAutomaticTokenAssociations: 0,
+    isAutoTokenAssociationEnabled: false,
+    delegation: {
+      nodeId: 1,
+      pendingReward: new BigNumber(0),
+      delegated: new BigNumber(1000),
+    },
+  };
+
   it("adds error for delegation to already delegated node", async () => {
-    const account = getMockedAccount({
-      hederaResources: {
-        maxAutomaticTokenAssociations: 0,
-        isAutoTokenAssociationEnabled: false,
-        delegation: {
-          nodeId: 1,
-          pendingReward: new BigNumber(0),
-          delegated: new BigNumber(1000),
-        },
-      },
-    });
+    const account = getMockedAccount({ hederaResources: hederaResourcesDelegatedToNode1 });
     const transaction = getMockedTransaction({
       mode: HEDERA_TRANSACTION_MODES.Delegate,
       properties: { stakingNodeId: 1 },
@@ -495,17 +573,7 @@ describe("getTransactionStatus", () => {
   });
 
   it("adds error when claiming rewards with no rewards available", async () => {
-    const account = getMockedAccount({
-      hederaResources: {
-        maxAutomaticTokenAssociations: 0,
-        isAutoTokenAssociationEnabled: false,
-        delegation: {
-          nodeId: 1,
-          pendingReward: new BigNumber(0),
-          delegated: new BigNumber(1000),
-        },
-      },
-    });
+    const account = getMockedAccount({ hederaResources: hederaResourcesDelegatedToNode1 });
     const transaction = getMockedTransaction({
       mode: HEDERA_TRANSACTION_MODES.ClaimRewards,
     });

--- a/libs/coin-modules/coin-hedera/src/bridge/index.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/index.test.ts
@@ -1,0 +1,41 @@
+import { HEDERA_DUMMY_ADDRESS } from "../constants";
+import { createBridges } from "./index";
+
+jest.mock("../config");
+jest.mock("../preload", () => ({
+  preload: jest.fn(),
+  hydrate: jest.fn(),
+  getPreloadStrategy: jest.fn(),
+}));
+jest.mock("../signer/index", () => jest.fn(() => jest.fn()));
+jest.mock("./signOperation", () => ({ buildSignOperation: jest.fn(() => jest.fn()) }));
+jest.mock("./synchronisation", () => ({
+  getAccountShape: jest.fn(),
+  buildIterateResult: jest.fn(),
+}));
+jest.mock("@ledgerhq/ledger-wallet-framework/bridge/jsHelpers", () => ({
+  getSerializedAddressParameters: jest.fn(),
+  makeScanAccounts: jest.fn(() => jest.fn()),
+  makeSync: jest.fn(() => jest.fn()),
+  updateTransaction: jest.fn(),
+}));
+jest.mock("@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper", () =>
+  jest.fn(() => jest.fn()),
+);
+
+describe("createBridges", () => {
+  const signerContext = jest.fn();
+  const coinConfig = jest.fn(() => ({})) as never;
+
+  it("accountBridge.signRawOperation throws an error", () => {
+    const { accountBridge } = createBridges(signerContext, coinConfig);
+    expect(() => accountBridge.signRawOperation?.(undefined as never)).toThrow(
+      "signRawOperation is not supported",
+    );
+  });
+
+  it("accountBridge.getEstimationRecipient returns HEDERA_DUMMY_ADDRESS", () => {
+    const { accountBridge } = createBridges(signerContext, coinConfig);
+    expect(accountBridge.getEstimationRecipient?.(undefined as never)).toBe(HEDERA_DUMMY_ADDRESS);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integ.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/js-estimateMaxSpendable.integ.test.ts
@@ -25,7 +25,7 @@ describe("js-estimateMaxSpendable", () => {
     estimatedFees = { crypto };
   });
 
-  test("estimateMaxSpendable returns balance minus fee", async () => {
+  it("estimateMaxSpendable returns balance minus fee", async () => {
     const mockedAccount = getMockedAccount();
 
     const result = await bridge.accountBridge.estimateMaxSpendable({
@@ -37,7 +37,7 @@ describe("js-estimateMaxSpendable", () => {
     expect(result).toEqual(expected);
   });
 
-  test("estimateMaxSpendable returns 0 if balance < estimated fees", async () => {
+  it("estimateMaxSpendable returns 0 if balance < estimated fees", async () => {
     const mockedAccount = getMockedAccount({ balance: estimatedFees.crypto.tinybars.minus(1) });
 
     const result = await bridge.accountBridge.estimateMaxSpendable({
@@ -47,7 +47,7 @@ describe("js-estimateMaxSpendable", () => {
     expect(result).toEqual(new BigNumber(0));
   });
 
-  test("estimateMaxSpendable returns token balance for token account", async () => {
+  it("estimateMaxSpendable returns token balance for token account", async () => {
     const mockedTokenCurrency = getMockedHTSTokenCurrency();
     const mockedTokenAccount = getMockedTokenAccount(mockedTokenCurrency);
     const mockedAccount = getMockedAccount({ subAccounts: [mockedTokenAccount] });

--- a/libs/coin-modules/coin-hedera/src/bridge/js-transaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/js-transaction.test.ts
@@ -17,14 +17,14 @@ describe("js-transaction", () => {
     bridge = createBridges(signer, mockCoinConfig);
   });
 
-  test("createTransaction", () => {
+  it("createTransaction", () => {
     const data = mockedTransaction;
     const result = bridge.accountBridge.createTransaction(mockedAccount);
 
     expect(result).toEqual(data);
   });
 
-  test("updateTransaction", () => {
+  it("updateTransaction", () => {
     const patch: Partial<Transaction> = {
       amount: new BigNumber(5),
       recipient: "0.0.3",
@@ -36,7 +36,7 @@ describe("js-transaction", () => {
     expect(result).toEqual(data);
   });
 
-  test("prepareTransaction", async () => {
+  it("prepareTransaction", async () => {
     const data = mockedTransaction;
     const result = await bridge.accountBridge.prepareTransaction(mockedAccount, mockedTransaction);
 

--- a/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/prepareTransaction.test.ts
@@ -1,5 +1,9 @@
 import BigNumber from "bignumber.js";
-import { HEDERA_OPERATION_TYPES, HEDERA_TRANSACTION_MODES } from "../constants";
+import {
+  HEDERA_OPERATION_TYPES,
+  HEDERA_TRANSACTION_MODES,
+  MAP_STAKING_MODE_TO_MEMO,
+} from "../constants";
 import { estimateFees } from "../logic/estimateFees";
 import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
 import {
@@ -9,6 +13,13 @@ import {
 import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
 import type { EstimateFeesResult } from "../types";
 import { prepareTransaction } from "./prepareTransaction";
+
+jest.mock("@ledgerhq/live-env", () => ({
+  getEnv: jest.fn((key: string) => {
+    if (key === "HEDERA_CLAIM_REWARDS_RECIPIENT_ACCOUNT_ID") return "0.0.98";
+    return "";
+  }),
+}));
 
 jest.mock("../logic/estimateFees");
 
@@ -59,6 +70,7 @@ describe("prepareTransaction", () => {
 
     await prepareTransaction(accountWithToken, transaction);
 
+    expect(estimateFees).toHaveBeenCalledTimes(1);
     expect(estimateFees).toHaveBeenCalledWith({
       configOrCurrencyId: accountWithToken.currency.id,
       operationType: HEDERA_OPERATION_TYPES.ContractCall,
@@ -104,6 +116,7 @@ describe("prepareTransaction", () => {
 
     await prepareTransaction(accountWithToken, transaction);
 
+    expect(estimateFees).toHaveBeenCalledTimes(1);
     expect(estimateFees).toHaveBeenCalledWith({
       currencyId: accountWithToken.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenTransfer,
@@ -121,6 +134,7 @@ describe("prepareTransaction", () => {
 
     await prepareTransaction(mockAccount, transaction);
 
+    expect(estimateFees).toHaveBeenCalledTimes(1);
     expect(estimateFees).toHaveBeenCalledWith({
       currencyId: mockAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.TokenAssociate,
@@ -136,9 +150,48 @@ describe("prepareTransaction", () => {
 
     await prepareTransaction(mockAccount, transaction);
 
+    expect(estimateFees).toHaveBeenCalledTimes(1);
     expect(estimateFees).toHaveBeenCalledWith({
       currencyId: mockAccount.currency.id,
       operationType: HEDERA_OPERATION_TYPES.CryptoTransfer,
     });
+  });
+
+  it("should use CryptoUpdate operation type for staking transactions", async () => {
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Delegate,
+      properties: { stakingNodeId: 3 },
+    });
+
+    await prepareTransaction(mockAccount, transaction);
+
+    expect(estimateFees).toHaveBeenCalledTimes(1);
+    expect(estimateFees).toHaveBeenCalledWith({
+      currencyId: mockAccount.currency.id,
+      operationType: HEDERA_OPERATION_TYPES.CryptoUpdate,
+    });
+  });
+
+  it("should set memo from MAP_STAKING_MODE_TO_MEMO for staking transactions", async () => {
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Delegate,
+      properties: { stakingNodeId: 3 },
+    });
+
+    const result = await prepareTransaction(mockAccount, transaction);
+
+    expect(result.memo).toBe(MAP_STAKING_MODE_TO_MEMO[HEDERA_TRANSACTION_MODES.Delegate]);
+  });
+
+  it("should set recipient to reward account and amount to 1 for ClaimRewards", async () => {
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.ClaimRewards,
+    });
+
+    const result = await prepareTransaction(mockAccount, transaction);
+
+    expect(result.recipient).toBe("0.0.98");
+    expect(result.amount).toEqual(new BigNumber(1));
+    expect(result.memo).toBe(MAP_STAKING_MODE_TO_MEMO[HEDERA_TRANSACTION_MODES.ClaimRewards]);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/receive.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/receive.test.ts
@@ -1,4 +1,4 @@
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
 import { receive } from "./receive";
 

--- a/libs/coin-modules/coin-hedera/src/bridge/receive.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/receive.test.ts
@@ -1,0 +1,92 @@
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { receive } from "./receive";
+
+const PUBLIC_KEY = "03a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3";
+
+const buildGetAddress = (returnedPublicKey: string, rejectWith?: Error) =>
+  jest.fn().mockImplementation(
+    rejectWith !== undefined
+      ? () => Promise.reject(rejectWith)
+      : () =>
+          Promise.resolve({
+            publicKey: returnedPublicKey,
+            address: returnedPublicKey,
+            path: "44'/3030'/0'/0'/0'",
+          }),
+  );
+
+type ObservableResult = { events: unknown[]; error?: unknown };
+
+const collectObservable = (
+  obs: ReturnType<ReturnType<typeof receive>>,
+): Promise<ObservableResult> =>
+  new Promise(resolve => {
+    const events: unknown[] = [];
+    obs.subscribe({
+      next: v => events.push(v),
+      complete: () => resolve({ events }),
+      error: err => resolve({ events, error: err }),
+    });
+  });
+
+describe("receive", () => {
+  const account = getMockedAccount({
+    seedIdentifier: PUBLIC_KEY,
+    freshAddress: "0.0.12345",
+    freshAddressPath: "44'/3030'/0'/0'/0'",
+  });
+
+  it("emits the account freshAddress and completes when publicKey matches seedIdentifier", async () => {
+    const getAddress = buildGetAddress(PUBLIC_KEY);
+    const receiveFn = receive(getAddress);
+
+    const { events, error } = await collectObservable(receiveFn(account, { deviceId: "device-1" }));
+
+    expect(error).toBeUndefined();
+    expect(events).toEqual([
+      {
+        address: account.freshAddress,
+        path: account.freshAddressPath,
+        publicKey: PUBLIC_KEY,
+      },
+    ]);
+  });
+
+  it("errors with WrongDeviceForAccount when the returned publicKey does not match seedIdentifier", async () => {
+    const getAddress = buildGetAddress("different-public-key");
+    const receiveFn = receive(getAddress);
+
+    const { events, error } = await collectObservable(receiveFn(account, { deviceId: "device-1" }));
+
+    expect(error).toBeInstanceOf(WrongDeviceForAccount);
+    expect(events).toEqual([]);
+  });
+
+  it("propagates getAddress errors to the Observable", async () => {
+    const thrown = new Error("device disconnected");
+    const getAddress = buildGetAddress("", thrown);
+    const receiveFn = receive(getAddress);
+
+    const { events, error } = await collectObservable(receiveFn(account, { deviceId: "device-1" }));
+
+    expect(error).toBe(thrown);
+    expect(events).toEqual([]);
+  });
+
+  it("calls getAddress with the correct derivation parameters", async () => {
+    const getAddress = buildGetAddress(PUBLIC_KEY);
+    const receiveFn = receive(getAddress);
+
+    await collectObservable(receiveFn(account, { deviceId: "my-device" }));
+
+    expect(getAddress).toHaveBeenCalledTimes(1);
+    expect(getAddress).toHaveBeenCalledWith(
+      "my-device",
+      expect.objectContaining({
+        path: account.freshAddressPath,
+        currency: account.currency,
+      }),
+    );
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/bridge/receive.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/receive.ts
@@ -1,4 +1,4 @@
-import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import { isSegwitDerivationMode } from "@ledgerhq/ledger-wallet-framework/derivation";
 import type { Account, AccountBridge, DerivationMode } from "@ledgerhq/types-live";

--- a/libs/coin-modules/coin-hedera/src/bridge/serialization.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/serialization.test.ts
@@ -1,9 +1,16 @@
+import BigNumber from "bignumber.js";
 import {
   getMockedAccount,
   getMockedAccountRaw,
   mockHederaResources,
   mockHederaResourcesRaw,
 } from "../test/fixtures/account.fixture";
+import type {
+  HederaAccount,
+  HederaAccountRaw,
+  HederaResources,
+  HederaResourcesRaw,
+} from "../types";
 import {
   assignFromAccountRaw,
   assignToAccountRaw,
@@ -15,25 +22,94 @@ const mockedAccount = getMockedAccount();
 const mockedAccountRaw = getMockedAccountRaw();
 
 describe("serialization", () => {
-  test("toHederaResourcesRaw should convert HederaResources to HederaResourcesRaw", () => {
+  it("toHederaResourcesRaw should convert HederaResources to HederaResourcesRaw (null delegation)", () => {
     const result = toHederaResourcesRaw(mockHederaResources);
     expect(result).toEqual(mockHederaResourcesRaw);
   });
 
-  test("fromHederaResourcesRaw should convert HederaResourcesRaw to HederaResources", () => {
+  it("toHederaResourcesRaw should convert HederaResources to HederaResourcesRaw (truthy delegation)", () => {
+    const resources: HederaResources = {
+      maxAutomaticTokenAssociations: 10,
+      isAutoTokenAssociationEnabled: true,
+      delegation: {
+        nodeId: 3,
+        delegated: new BigNumber(500000),
+        pendingReward: new BigNumber(1000),
+      },
+    };
+
+    const result = toHederaResourcesRaw(resources);
+
+    expect(result).toEqual({
+      maxAutomaticTokenAssociations: 10,
+      isAutoTokenAssociationEnabled: true,
+      delegation: {
+        nodeId: 3,
+        delegated: "500000",
+        pendingReward: "1000",
+      },
+    });
+  });
+
+  it("fromHederaResourcesRaw should convert HederaResourcesRaw to HederaResources (null delegation)", () => {
     const result = fromHederaResourcesRaw(mockHederaResourcesRaw);
     expect(result).toEqual(mockHederaResources);
   });
 
-  test("assignToAccountRaw should assign HederaResources to AccountRaw", () => {
+  it("fromHederaResourcesRaw should convert HederaResourcesRaw to HederaResources (truthy delegation)", () => {
+    const rawResources: HederaResourcesRaw = {
+      maxAutomaticTokenAssociations: 5,
+      isAutoTokenAssociationEnabled: true,
+      delegation: {
+        nodeId: 7,
+        delegated: "200000",
+        pendingReward: "500",
+      },
+    };
+
+    const result = fromHederaResourcesRaw(rawResources);
+
+    expect(result).toEqual({
+      maxAutomaticTokenAssociations: 5,
+      isAutoTokenAssociationEnabled: true,
+      delegation: {
+        nodeId: 7,
+        delegated: new BigNumber(200000),
+        pendingReward: new BigNumber(500),
+      },
+    });
+  });
+
+  it("assignToAccountRaw should assign HederaResources to AccountRaw when hederaResources exists", () => {
     assignToAccountRaw(mockedAccount, mockedAccountRaw);
     expect(typeof mockedAccountRaw.hederaResources).toBe("object");
     expect(mockedAccountRaw.hederaResources).not.toBeNull();
   });
 
-  test("assignFromAccountRaw should assign HederaResourcesRaw to Account", () => {
+  it("assignToAccountRaw should not set hederaResources when account has none", () => {
+    const accountWithoutResources = { ...mockedAccount } as HederaAccount;
+    delete (accountWithoutResources as Partial<HederaAccount>).hederaResources;
+    const rawTarget = {} as HederaAccountRaw;
+
+    assignToAccountRaw(accountWithoutResources, rawTarget);
+
+    expect(rawTarget.hederaResources).toBeUndefined();
+  });
+
+  it("assignFromAccountRaw should assign HederaResourcesRaw to Account when hederaResources exists", () => {
     assignFromAccountRaw(mockedAccountRaw, mockedAccount);
     expect(typeof mockedAccountRaw.hederaResources).toBe("object");
     expect(mockedAccountRaw.hederaResources).not.toBeNull();
+  });
+
+  it("assignFromAccountRaw should not set hederaResources when accountRaw has none", () => {
+    const rawWithoutResources = { ...mockedAccountRaw } as HederaAccountRaw;
+    delete (rawWithoutResources as Partial<HederaAccountRaw>).hederaResources;
+    const accountTarget = { ...mockedAccount } as HederaAccount;
+    delete (accountTarget as Partial<HederaAccount>).hederaResources;
+
+    assignFromAccountRaw(rawWithoutResources, accountTarget);
+
+    expect(accountTarget.hederaResources).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/signOperation.test.ts
@@ -1,7 +1,14 @@
+import BigNumber from "bignumber.js";
 import { craftTransaction } from "../logic/craftTransaction";
 import { combine } from "../logic/combine";
-import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { getMockedAccount, getMockedTokenAccount } from "../test/fixtures/account.fixture";
+import {
+  getMockedERC20TokenCurrency,
+  getMockedHTSTokenCurrency,
+} from "../test/fixtures/currency.fixture";
 import { getMockedTransaction } from "../test/fixtures/transaction.fixture";
+import { HEDERA_TRANSACTION_MODES } from "../constants";
+import * as logicUtils from "../logic/utils";
 import { buildSignOperation } from "./signOperation";
 
 jest.mock("../logic/craftTransaction", () => ({
@@ -21,9 +28,30 @@ jest.mock("../logic/utils", () => ({
   isStakingTransaction: jest.fn(() => false),
 }));
 
+const buildSignerContext = () =>
+  jest.fn(async (_deviceId: string, fn: (signer: unknown) => Promise<string>) => {
+    const signer = { signTransaction: jest.fn(async () => new Uint8Array([9, 9, 9])) };
+    return await fn(signer);
+  });
+
+const runSignOperation = (
+  account: ReturnType<typeof getMockedAccount>,
+  transaction: ReturnType<typeof getMockedTransaction>,
+) =>
+  new Promise<void>((resolve, reject) => {
+    const signerContext = buildSignerContext();
+    const signOperation = buildSignOperation(signerContext as never);
+    signOperation({ account, transaction, deviceId: "test-device" }).subscribe({
+      complete: () => resolve(),
+      error: (err: unknown) => reject(err),
+    });
+  });
+
 describe("signOperation", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(logicUtils.isTokenAssociateTransaction).mockReturnValue(false);
+    jest.mocked(logicUtils.isStakingTransaction).mockReturnValue(false);
   });
 
   it("passes hedera coin config to craftTransaction", async () => {
@@ -60,5 +88,159 @@ describe("signOperation", () => {
       configOrCurrencyId: account.currency.id,
     });
     expect(combine).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds HTS token asset when subAccount has tokenType hts", async () => {
+    const htsToken = getMockedHTSTokenCurrency();
+    const tokenAccount = getMockedTokenAccount(htsToken, { id: "ta-hts" });
+    const account = getMockedAccount({ subAccounts: [tokenAccount] });
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Send,
+      subAccountId: tokenAccount.id,
+    });
+
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    await runSignOperation(account, transaction);
+
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txIntent: expect.objectContaining({
+          asset: expect.objectContaining({
+            type: "hts",
+            assetReference: htsToken.contractAddress,
+            assetOwner: account.freshAddress,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("builds ERC20 token asset with gasLimit data when subAccount has tokenType erc20", async () => {
+    const erc20Token = getMockedERC20TokenCurrency();
+    const tokenAccount = getMockedTokenAccount(erc20Token, { id: "ta-erc20" });
+    const account = getMockedAccount({ subAccounts: [tokenAccount] });
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Send,
+      subAccountId: tokenAccount.id,
+    });
+
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    await runSignOperation(account, transaction);
+
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txIntent: expect.objectContaining({
+          asset: expect.objectContaining({
+            type: "erc20",
+            assetReference: erc20Token.contractAddress,
+            assetOwner: account.freshAddress,
+          }),
+          data: expect.objectContaining({ type: "erc20", gasLimit: expect.anything() }),
+        }),
+      }),
+    );
+  });
+
+  it("builds staking asset with stakingNodeId data when isStakingTransaction returns true", async () => {
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.Delegate,
+      properties: { stakingNodeId: 7 },
+    });
+
+    jest.mocked(logicUtils.isStakingTransaction).mockReturnValue(true as never);
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    await runSignOperation(account, transaction);
+
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txIntent: expect.objectContaining({
+          asset: { type: "native" },
+          data: expect.objectContaining({ type: "staking", stakingNodeId: 7 }),
+        }),
+      }),
+    );
+  });
+
+  it("builds TokenAssociate asset when isTokenAssociateTransaction returns true", async () => {
+    const htsToken = getMockedHTSTokenCurrency();
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction({
+      mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+      assetReference: htsToken.contractAddress,
+      assetOwner: account.freshAddress,
+      properties: { token: htsToken },
+    });
+
+    jest.mocked(logicUtils.isTokenAssociateTransaction).mockReturnValue(true as never);
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    await runSignOperation(account, transaction);
+
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txIntent: expect.objectContaining({
+          type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+          asset: expect.objectContaining({ assetReference: htsToken.contractAddress }),
+        }),
+      }),
+    );
+  });
+
+  it("passes customFees to craftTransaction when transaction.maxFee is set", async () => {
+    const account = getMockedAccount();
+    const maxFee = new BigNumber(5000);
+    const transaction = getMockedTransaction({ maxFee });
+
+    jest
+      .mocked(craftTransaction)
+      .mockResolvedValue({ tx: {} as never, serializedTx: "serialized-tx" });
+    jest.mocked(combine).mockReturnValue("combined-signature");
+
+    await runSignOperation(account, transaction);
+
+    expect(craftTransaction).toHaveBeenCalledTimes(1);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customFees: { value: BigInt(maxFee.toString()) },
+      }),
+    );
+  });
+
+  it("propagates signerContext errors to the Observable", async () => {
+    const account = getMockedAccount();
+    const transaction = getMockedTransaction();
+    const thrown = new Error("device disconnected");
+
+    const signerContext = jest.fn(() => Promise.reject(thrown));
+    const signOperation = buildSignOperation(signerContext as never);
+
+    const error = await new Promise<unknown>(resolve => {
+      signOperation({ account, transaction, deviceId: "test-device" }).subscribe({
+        complete: () => resolve(undefined),
+        error: err => resolve(err),
+      });
+    });
+
+    expect(error).toBe(thrown);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
@@ -6,10 +6,11 @@ import * as logic from "../logic";
 import { apiClient } from "../network/api";
 import * as networkUtils from "../network/utils";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
-import { getMockedCurrency } from "../test/fixtures/currency.fixture";
+import { getMockedCurrency, getMockedERC20TokenCurrency } from "../test/fixtures/currency.fixture";
 import { getMockedMirrorAccount } from "../test/fixtures/mirror.fixture";
 import type { HederaAccount } from "../types";
-import { getAccountShape } from "./synchronisation";
+import { getAccountShape, buildIterateResult } from "./synchronisation";
+import * as bridgeUtils from "./utils";
 
 jest.mock("../config");
 jest.mock("../network/api");
@@ -19,6 +20,10 @@ jest.mock("@ledgerhq/ledger-wallet-framework/account", () => ({
   ...jest.requireActual("@ledgerhq/ledger-wallet-framework/account"),
   getSyncHash: jest.fn(),
   encodeAccountId: jest.fn(),
+}));
+jest.mock("./utils", () => ({
+  ...jest.requireActual("./utils"),
+  buildCalTokenMap: jest.fn(),
 }));
 
 const mockEncodeAccountId = jest.mocked(coinFrameworkAccount.encodeAccountId);
@@ -30,7 +35,7 @@ const mockGetAccountTokens = jest.mocked(apiClient.getAccountTokens);
 const mockListOperationsV2 = jest.mocked(logic.listOperationsV2);
 const mockGetERC20BalancesForAccountV2 = jest.mocked(networkUtils.getERC20BalancesForAccountV2);
 
-const mockConfig = { ...getMockedConfig() };
+const mockConfig = getMockedConfig();
 const mockCurrency = getMockedCurrency();
 const mockMirrorAccount = getMockedMirrorAccount();
 const mockAddress = mockMirrorAccount.account;
@@ -45,6 +50,8 @@ const mockInfo: AccountShapeInfo<HederaAccount> = {
   index: 0,
   derivationPath: "44/3030",
 };
+
+const mockBuildCalTokenMap = jest.mocked(bridgeUtils.buildCalTokenMap);
 
 describe("getAccountShape", () => {
   beforeEach(() => {
@@ -62,6 +69,7 @@ describe("getAccountShape", () => {
       tokenOperations: [],
       nextCursor: null,
     });
+    mockBuildCalTokenMap.mockResolvedValue(new Map());
   });
 
   it("should call listOperationsV2 and getERC20BalancesForAccountV2", async () => {
@@ -115,6 +123,47 @@ describe("getAccountShape", () => {
     );
   });
 
+  it("passes ERC20 token contractAddresses to listOperationsV2 tokenEvmAddresses", async () => {
+    const erc20Token = getMockedERC20TokenCurrency();
+    const erc20Address = erc20Token.contractAddress.toLowerCase();
+    mockBuildCalTokenMap.mockResolvedValueOnce(new Map([[erc20Address, erc20Token as never]]));
+
+    await getAccountShape(mockInfo, { paginationConfig: {} });
+
+    expect(logic.listOperationsV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenEvmAddresses: expect.arrayContaining([erc20Address]),
+      }),
+    );
+  });
+
+  it("uses ?? [] fallback when initialAccount pendingOperations is undefined", async () => {
+    mockGetSyncHash.mockResolvedValue(mockSyncHash);
+    // @ts-expect-error - partial account for testing ?? [] branch
+    const initialAccount = {
+      syncHash: mockSyncHash,
+      operations: undefined,
+      pendingOperations: undefined,
+    } as Account;
+
+    const result = await getAccountShape({ ...mockInfo, initialAccount }, { paginationConfig: {} });
+
+    expect(result.operations).toEqual([]);
+  });
+
+  it("populates delegation when staked_node_id is a number", async () => {
+    mockGetAccount.mockResolvedValue(
+      getMockedMirrorAccount({ staked_node_id: 5, pending_reward: 1000 }),
+    );
+
+    const result = await getAccountShape(mockInfo, { paginationConfig: {} });
+
+    const hederaResources = (result as { hederaResources?: unknown }).hederaResources as {
+      delegation: unknown;
+    } | null;
+    expect(hederaResources?.delegation).toMatchObject({ nodeId: 5 });
+  });
+
   it("should NOT pass cursor when syncHash has changed", async () => {
     mockGetSyncHash.mockResolvedValue("new-synchash");
     // @ts-expect-error - no other fields are needed for this test
@@ -129,6 +178,83 @@ describe("getAccountShape", () => {
     expect(logic.listOperationsV2).toHaveBeenCalledTimes(1);
     expect(logic.listOperationsV2).toHaveBeenCalledWith(
       expect.not.objectContaining({ cursor: expect.any(String) }),
+    );
+  });
+});
+
+describe("buildIterateResult", () => {
+  const mockGetAccountsForPublicKey = jest.mocked(apiClient.getAccountsForPublicKey);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns address result for an index within bounds", async () => {
+    mockGetAccountsForPublicKey.mockResolvedValue([
+      { account: "0.0.1234" },
+      { account: "0.0.5678" },
+    ] as never);
+
+    const iterateFn = await buildIterateResult({ result: { publicKey: "pubkey" } } as never);
+    const result = await iterateFn({
+      currency: mockCurrency,
+      derivationMode: "" as const,
+      index: 0,
+    } as never);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        address: "0.0.1234",
+        publicKey: "0.0.1234",
+      }),
+    );
+  });
+
+  it("returns result for the second account when index is 1", async () => {
+    mockGetAccountsForPublicKey.mockResolvedValue([
+      { account: "0.0.1234" },
+      { account: "0.0.5678" },
+    ] as never);
+
+    const iterateFn = await buildIterateResult({ result: { publicKey: "pubkey" } } as never);
+    const result = await iterateFn({
+      currency: mockCurrency,
+      derivationMode: "" as const,
+      index: 1,
+    } as never);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        address: "0.0.5678",
+        publicKey: "0.0.5678",
+      }),
+    );
+  });
+
+  it("returns null when index is out of bounds", async () => {
+    mockGetAccountsForPublicKey.mockResolvedValue([{ account: "0.0.1234" }] as never);
+
+    const iterateFn = await buildIterateResult({ result: { publicKey: "pubkey" } } as never);
+    const result = await iterateFn({
+      currency: mockCurrency,
+      derivationMode: "" as const,
+      index: 5,
+    } as never);
+
+    expect(result).toBeNull();
+  });
+
+  it("calls getAccountsForPublicKey with the rootResult publicKey", async () => {
+    mockGetAccountsForPublicKey.mockResolvedValue([] as never);
+
+    const iterateFn = await buildIterateResult({
+      result: { publicKey: "root-public-key" },
+    } as never);
+    await iterateFn({ currency: mockCurrency, derivationMode: "" as const, index: 0 } as never);
+
+    expect(mockGetAccountsForPublicKey).toHaveBeenCalledTimes(1);
+    expect(mockGetAccountsForPublicKey).toHaveBeenCalledWith(
+      expect.objectContaining({ publicKey: "root-public-key" }),
     );
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/transaction.test.ts
@@ -1,9 +1,12 @@
 import BigNumber from "bignumber.js";
+import { HEDERA_TRANSACTION_MODES } from "../constants";
 import { getMockedAccount } from "../test/fixtures/account.fixture";
+import { getMockedHTSTokenCurrency } from "../test/fixtures/currency.fixture";
 import {
   getMockedTransaction,
   getMockedTransactionRaw,
 } from "../test/fixtures/transaction.fixture";
+import type { Transaction, TransactionRaw } from "../types";
 import { formatTransaction, fromTransactionRaw, toTransactionRaw } from "../transaction";
 
 describe("transaction", () => {
@@ -17,7 +20,7 @@ describe("transaction", () => {
     recipient: "0.0.3",
   });
 
-  test("formatTransaction", () => {
+  it("formatTransaction", () => {
     const result = formatTransaction(mockedTransaction, mockedAccount);
     const nonBreakingSpace = String.fromCharCode(160);
     const string = `SEND 1${nonBreakingSpace}HBAR\nTO 0.0.3`;
@@ -25,17 +28,162 @@ describe("transaction", () => {
     expect(result).toEqual(string);
   });
 
-  test("fromTransactionRaw", () => {
+  it("fromTransactionRaw", () => {
     const result = fromTransactionRaw(mockedTransactionRaw);
     const data = mockedTransaction;
 
     expect(result).toEqual(data);
   });
 
-  test("toTransactionRaw", () => {
+  it("toTransactionRaw", () => {
     const result = toTransactionRaw(mockedTransaction);
     const data = mockedTransactionRaw;
 
     expect(result).toEqual(data);
+  });
+});
+
+describe("fromTransactionRaw — maxFee and gasLimit branches", () => {
+  it("fromTransactionRaw includes maxFee when present in raw", () => {
+    const raw = getMockedTransactionRaw({ maxFee: "5000" });
+    const result = fromTransactionRaw(raw);
+    expect(result.maxFee).toEqual(new BigNumber(5000));
+  });
+
+  it("fromTransactionRaw includes gasLimit when present in raw", () => {
+    const raw = { ...getMockedTransactionRaw(), gasLimit: "100000" } as TransactionRaw;
+    const result = fromTransactionRaw(raw);
+    expect((result as Record<string, unknown>).gasLimit).toEqual(new BigNumber(100000));
+  });
+
+  it("toTransactionRaw includes maxFee when present in transaction", () => {
+    const tx = getMockedTransaction({ maxFee: new BigNumber(5000) });
+    const raw = toTransactionRaw(tx);
+    expect(raw.maxFee).toBe("5000");
+  });
+
+  it("toTransactionRaw includes gasLimit when present in transaction", () => {
+    const tx = { ...getMockedTransaction(), gasLimit: new BigNumber(100000) } as Transaction;
+    const raw = toTransactionRaw(tx);
+    expect((raw as Record<string, unknown>).gasLimit).toBe("100000");
+  });
+});
+
+describe("fromTransactionRaw — all modes", () => {
+  const token = getMockedHTSTokenCurrency();
+
+  it("TokenAssociate mode preserves assetReference, assetOwner and properties", () => {
+    const raw = {
+      ...getMockedTransactionRaw(),
+      mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+      assetReference: token.contractAddress,
+      assetOwner: "0.0.12345",
+      properties: { token },
+    } as TransactionRaw;
+
+    const result = fromTransactionRaw(raw);
+
+    expect(result.mode).toBe(HEDERA_TRANSACTION_MODES.TokenAssociate);
+    expect(
+      (result as Extract<Transaction, { mode: typeof HEDERA_TRANSACTION_MODES.TokenAssociate }>)
+        .assetReference,
+    ).toBe(token.contractAddress);
+    expect(
+      (result as Extract<Transaction, { mode: typeof HEDERA_TRANSACTION_MODES.TokenAssociate }>)
+        .assetOwner,
+    ).toBe("0.0.12345");
+    expect(
+      (result as Extract<Transaction, { mode: typeof HEDERA_TRANSACTION_MODES.TokenAssociate }>)
+        .properties,
+    ).toEqual({ token });
+  });
+
+  it.each([
+    HEDERA_TRANSACTION_MODES.Delegate,
+    HEDERA_TRANSACTION_MODES.Undelegate,
+    HEDERA_TRANSACTION_MODES.Redelegate,
+  ])("%s mode preserves properties.stakingNodeId", mode => {
+    const raw = {
+      ...getMockedTransactionRaw(),
+      mode,
+      properties: { stakingNodeId: 3 },
+    } as TransactionRaw;
+
+    const result = fromTransactionRaw(raw);
+
+    expect(result.mode).toBe(mode);
+    expect(
+      (result as Extract<Transaction, { mode: typeof HEDERA_TRANSACTION_MODES.Delegate }>)
+        .properties,
+    ).toEqual({ stakingNodeId: 3 });
+  });
+
+  it("ClaimRewards mode round-trips without extra fields", () => {
+    const raw = {
+      ...getMockedTransactionRaw(),
+      mode: HEDERA_TRANSACTION_MODES.ClaimRewards,
+    } as TransactionRaw;
+
+    const result = fromTransactionRaw(raw);
+
+    expect(result.mode).toBe(HEDERA_TRANSACTION_MODES.ClaimRewards);
+  });
+});
+
+describe("toTransactionRaw — all modes", () => {
+  const token = getMockedHTSTokenCurrency();
+
+  it("TokenAssociate mode preserves assetReference, assetOwner and properties", () => {
+    const tx = {
+      ...getMockedTransaction(),
+      mode: HEDERA_TRANSACTION_MODES.TokenAssociate,
+      assetReference: token.contractAddress,
+      assetOwner: "0.0.12345",
+      properties: { token },
+    } as Transaction;
+
+    const raw = toTransactionRaw(tx);
+
+    expect(raw.mode).toBe(HEDERA_TRANSACTION_MODES.TokenAssociate);
+    expect(
+      (raw as Extract<TransactionRaw, { mode: typeof HEDERA_TRANSACTION_MODES.TokenAssociate }>)
+        .assetReference,
+    ).toBe(token.contractAddress);
+    expect(
+      (raw as Extract<TransactionRaw, { mode: typeof HEDERA_TRANSACTION_MODES.TokenAssociate }>)
+        .assetOwner,
+    ).toBe("0.0.12345");
+  });
+
+  it.each([
+    HEDERA_TRANSACTION_MODES.Delegate,
+    HEDERA_TRANSACTION_MODES.Undelegate,
+    HEDERA_TRANSACTION_MODES.Redelegate,
+  ])("%s mode preserves properties.stakingNodeId", mode => {
+    const tx = {
+      ...getMockedTransaction(),
+      mode,
+      properties: { stakingNodeId: 5 },
+    } as Transaction;
+
+    const raw = toTransactionRaw(tx);
+
+    expect(raw.mode).toBe(mode);
+    expect(
+      (raw as Extract<TransactionRaw, { mode: typeof HEDERA_TRANSACTION_MODES.Delegate }>)
+        .properties,
+    ).toEqual({ stakingNodeId: 5 });
+  });
+
+  it("ClaimRewards mode serialises without extra fields", () => {
+    const tx = {
+      ...getMockedTransaction(),
+      mode: HEDERA_TRANSACTION_MODES.ClaimRewards,
+    } as Transaction;
+
+    const raw = toTransactionRaw(tx);
+
+    expect(raw.mode).toBe(HEDERA_TRANSACTION_MODES.ClaimRewards);
+    expect((raw as Record<string, unknown>).properties).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
@@ -13,6 +13,7 @@ import type { HederaOperationExtra } from "../types";
 import {
   applyPendingExtras,
   buildCalTokenMap,
+  getSubAccounts,
   mergeSubAccounts,
   patchOperationWithExtra,
   prepareOperations,
@@ -44,8 +45,7 @@ describe("bridge utils", () => {
 
       const result = await prepareOperations([mockedCoinOperation], [mockedTokenOperation]);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].subOperations).toEqual([mockedTokenOperation]);
+      expect(result).toEqual([expect.objectContaining({ subOperations: [mockedTokenOperation] })]);
     });
 
     it("creates NONE coin operation as parent if no coin op with matching hash exists", async () => {
@@ -134,11 +134,14 @@ describe("bridge utils", () => {
 
       const result = applyPendingExtras([mockedOperation1], [mockedPendingOperation1]);
 
-      expect(result).toHaveLength(1);
-      expect(result[0].extra).toEqual({
-        ...mockedOperation1.extra,
-        ...mockedPendingOperation1.extra,
-      });
+      expect(result).toEqual([
+        expect.objectContaining({
+          extra: {
+            ...mockedOperation1.extra,
+            ...mockedPendingOperation1.extra,
+          },
+        }),
+      ]);
     });
 
     it("returns original operation if no matching pending is found", () => {
@@ -149,8 +152,7 @@ describe("bridge utils", () => {
       const mockedPendingOperation = getMockedOperation({ hash: "op1", extra: pendingExtra });
 
       const result = applyPendingExtras([mockedOperation], [mockedPendingOperation]);
-      expect(result).toHaveLength(1);
-      expect(result[0].extra).toEqual(mockedOperation.extra);
+      expect(result).toEqual([expect.objectContaining({ extra: mockedOperation.extra })]);
     });
   });
 
@@ -367,8 +369,122 @@ describe("bridge utils", () => {
       const patched = patchOperationWithExtra(mockedOperation, extra);
 
       expect(patched.extra).toEqual(extra);
-      expect(patched.subOperations).toHaveLength(1);
-      expect(patched.subOperations?.[0].extra).toEqual(extra);
+      expect(patched.subOperations).toEqual([expect.objectContaining({ extra })]);
     });
+
+    it("adds extra to nested nft operations", () => {
+      const nftOp = getMockedOperation({ hash: "nft1", extra: {} });
+      const mockedOperation = getMockedOperation({
+        hash: "parent",
+        extra: {},
+        nftOperations: [nftOp],
+      });
+      const extra: HederaOperationExtra = { consensusTimestamp: "99999" };
+
+      const patched = patchOperationWithExtra(mockedOperation, extra);
+
+      expect(patched.nftOperations).toEqual([expect.objectContaining({ extra })]);
+    });
+
+    it("handles operations with no subOperations or nftOperations gracefully", () => {
+      const mockedOperation = getMockedOperation({ hash: "bare", extra: {} });
+      const extra: HederaOperationExtra = { transactionId: "tx-123" };
+
+      const patched = patchOperationWithExtra(mockedOperation, extra);
+
+      expect(patched.extra).toEqual(extra);
+      expect(patched.subOperations).toEqual([]);
+      expect(patched.nftOperations).toEqual([]);
+    });
+  });
+});
+
+describe("getSubAccounts", () => {
+  const ledgerAccountId = "js:2:hedera:0.0.12345:hederaBip44";
+
+  it("returns an empty array when all inputs are empty", async () => {
+    const result = await getSubAccounts({
+      ledgerAccountId,
+      latestTokenOperations: [],
+      mirrorTokens: [],
+      erc20Tokens: [],
+      calTokenByAddress: new Map(),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips mirror tokens whose token_id is not in calTokenByAddress", async () => {
+    const mirrorToken = getMockedMirrorToken({ token_id: "0.0.9999", balance: 100 });
+
+    const result = await getSubAccounts({
+      ledgerAccountId,
+      latestTokenOperations: [],
+      mirrorTokens: [mirrorToken],
+      erc20Tokens: [],
+      calTokenByAddress: new Map(),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips ERC20 tokens with zero balance and no operations", async () => {
+    const erc20Token = getMockedERC20TokenCurrency({ contractAddress: "0xdeadbeef" });
+    const calTokenByAddress = new Map([[erc20Token.contractAddress, erc20Token]]);
+
+    const result = await getSubAccounts({
+      ledgerAccountId,
+      latestTokenOperations: [],
+      mirrorTokens: [],
+      erc20Tokens: [{ contractAddress: erc20Token.contractAddress, balance: new BigNumber(0) }],
+      calTokenByAddress,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("creates a sub account for an HTS mirror token with a positive balance", async () => {
+    const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+    const mirrorToken = getMockedMirrorToken({ token_id: "0.0.1001", balance: 500 });
+    const calTokenByAddress = new Map([[htsToken.contractAddress, htsToken]]);
+
+    const result = await getSubAccounts({
+      ledgerAccountId,
+      latestTokenOperations: [],
+      mirrorTokens: [mirrorToken],
+      erc20Tokens: [],
+      calTokenByAddress,
+    });
+
+    expect(result).toMatchObject([
+      {
+        type: "TokenAccount",
+        token: htsToken,
+        balance: new BigNumber(500),
+        spendableBalance: new BigNumber(500),
+        operations: [],
+      },
+    ]);
+  });
+
+  it("creates a sub account for an ERC20 token with a positive balance", async () => {
+    const erc20Token = getMockedERC20TokenCurrency({ contractAddress: "0xaabbcc" });
+    const calTokenByAddress = new Map([[erc20Token.contractAddress, erc20Token]]);
+
+    const result = await getSubAccounts({
+      ledgerAccountId,
+      latestTokenOperations: [],
+      mirrorTokens: [],
+      erc20Tokens: [{ contractAddress: erc20Token.contractAddress, balance: new BigNumber(250) }],
+      calTokenByAddress,
+    });
+
+    expect(result).toMatchObject([
+      {
+        type: "TokenAccount",
+        token: erc20Token,
+        balance: new BigNumber(250),
+      },
+    ]);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/deviceTransactionConfig.test.ts
+++ b/libs/coin-modules/coin-hedera/src/deviceTransactionConfig.test.ts
@@ -146,6 +146,29 @@ describe("getDeviceTransactionConfig", () => {
         },
       ]);
     });
+
+    it("should not include fees field when estimated fees are zero for staking transaction", async () => {
+      const transaction = getMockedTransaction({
+        mode: HEDERA_TRANSACTION_MODES.ClaimRewards,
+        amount: new BigNumber(0),
+      });
+
+      const status = createMockStatus(new BigNumber(0));
+
+      const fields = await getDeviceTransactionConfig({
+        account: mockAccount,
+        transaction,
+        status,
+      });
+
+      expect(fields).toEqual([
+        {
+          type: "text",
+          label: "Method",
+          value: "Claim Rewards",
+        },
+      ]);
+    });
   });
 
   describe("token associate transactions", () => {

--- a/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/craftTransaction.test.ts
@@ -30,7 +30,7 @@ const mockToEVMAddress = jest.mocked(toEVMAddress);
 const mockSerializeTransaction = jest.mocked(serializeTransaction);
 
 describe("craftTransaction", () => {
-  const mockConfig = { ...getMockedConfig(), useNetworkTimestamp: false };
+  const mockConfig = getMockedConfig();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -370,6 +370,197 @@ describe("craftTransaction", () => {
 
     expect(mockGetLatestBlock).toHaveBeenCalledTimes(1);
     expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
+  });
+
+  it("should craft a delegate staking transaction", async () => {
+    const txIntent = {
+      intentType: "transaction",
+      type: HEDERA_TRANSACTION_MODES.Delegate,
+      amount: BigInt(0),
+      recipient: "",
+      sender: "0.0.54321",
+      asset: { type: "native" },
+      memo: {
+        kind: "text",
+        type: "string",
+        value: "Delegate staking",
+      },
+      data: {
+        type: "staking",
+        stakingNodeId: 5,
+      },
+    } satisfies TransactionIntent<HederaMemo, HederaTxData>;
+
+    const result = await craftTransaction({ configOrCurrencyId: mockConfig, txIntent });
+
+    expect(result.tx).toBeInstanceOf(sdk.AccountUpdateTransaction);
+    invariant(
+      result.tx instanceof sdk.AccountUpdateTransaction,
+      "AccountUpdateTransaction type guard",
+    );
+    expect(result.tx.stakedNodeId).toEqual(sdk.Long.fromNumber(5));
+    expect(serializeTransaction).toHaveBeenCalled();
+  });
+
+  it("should craft an undelegate transaction (stakingNodeId=null clears staked node)", async () => {
+    const txIntent = {
+      intentType: "transaction",
+      type: HEDERA_TRANSACTION_MODES.Undelegate,
+      amount: BigInt(0),
+      recipient: "",
+      sender: "0.0.54321",
+      asset: { type: "native" },
+      memo: {
+        kind: "text",
+        type: "string",
+        value: "Undelegate staking",
+      },
+      data: {
+        type: "staking",
+        stakingNodeId: null,
+      },
+    } satisfies TransactionIntent<HederaMemo, HederaTxData>;
+
+    const result = await craftTransaction({ configOrCurrencyId: mockConfig, txIntent });
+
+    expect(result.tx).toBeInstanceOf(sdk.AccountUpdateTransaction);
+    expect(serializeTransaction).toHaveBeenCalled();
+  });
+
+  it("should use DEFAULT_GAS_LIMIT when ERC20 txIntent has no data field", async () => {
+    mockToEVMAddress.mockResolvedValue("0x0000000000000000000000000000000000003039");
+
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        amount: BigInt(1000),
+        recipient: "0.0.12345",
+        sender: "0.0.54321",
+        asset: { type: "erc20", assetReference: "0x39ceba2b467fa987546000eb5d1373acf1f3a2e1" },
+        memo: { kind: "text", type: "string", value: "ERC20 no data" },
+      },
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
+  });
+
+  it("should use undefined stakingNodeId when staking txIntent has no data field", async () => {
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Delegate,
+        amount: BigInt(0),
+        recipient: "",
+        sender: "0.0.54321",
+        asset: { type: "native" },
+        memo: { kind: "text", type: "string", value: "No staking data" },
+      },
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.AccountUpdateTransaction);
+  });
+
+  it("should apply custom fees to delegate staking transaction", async () => {
+    const customFees: FeeEstimation = { value: BigInt(60000) };
+
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Delegate,
+        amount: BigInt(0),
+        recipient: "",
+        sender: "0.0.54321",
+        asset: { type: "native" },
+        memo: { kind: "text", type: "string", value: "Delegate with fee" },
+        data: { type: "staking", stakingNodeId: 3 },
+      },
+      customFees,
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.AccountUpdateTransaction);
+    invariant(
+      result.tx instanceof sdk.AccountUpdateTransaction,
+      "AccountUpdateTransaction type guard",
+    );
+    expect(result.tx.maxTransactionFee).toEqual(sdk.Hbar.fromTinybars(customFees.value.toString()));
+  });
+
+  it("should apply custom fees to HTS token transfer", async () => {
+    const customFees: FeeEstimation = { value: BigInt(75000) };
+
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        amount: BigInt(1000),
+        recipient: "0.0.12345",
+        sender: "0.0.54321",
+        asset: { type: "hts", assetReference: "0.0.7890" },
+        memo: { kind: "text", type: "string", value: "HTS with fee" },
+      },
+      customFees,
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.TransferTransaction);
+    invariant(result.tx instanceof sdk.TransferTransaction, "TransferTransaction type guard");
+    expect(result.tx.maxTransactionFee).toEqual(sdk.Hbar.fromTinybars(customFees.value.toString()));
+  });
+
+  it("should apply custom fees to ERC20 token transfer", async () => {
+    mockToEVMAddress.mockResolvedValue("0x0000000000000000000000000000000000003039");
+    const customFees: FeeEstimation = { value: BigInt(90000) };
+
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        amount: BigInt(1000),
+        recipient: "0.0.12345",
+        sender: "0.0.54321",
+        asset: { type: "erc20", assetReference: "0x39ceba2b467fa987546000eb5d1373acf1f3a2e1" },
+        memo: { kind: "text", type: "string", value: "ERC20 with fee" },
+        data: { type: "erc20", gasLimit: BigInt(100000) },
+      },
+      customFees,
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.ContractExecuteTransaction);
+    invariant(
+      result.tx instanceof sdk.ContractExecuteTransaction,
+      "ContractExecuteTransaction type guard",
+    );
+    expect(result.tx.maxTransactionFee).toEqual(sdk.Hbar.fromTinybars(customFees.value.toString()));
+  });
+
+  it("should apply custom fees to token associate transaction", async () => {
+    const customFees: FeeEstimation = { value: BigInt(55000) };
+
+    const result = await craftTransaction({
+      configOrCurrencyId: mockConfig,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.TokenAssociate,
+        amount: BigInt(0),
+        recipient: "",
+        sender: "0.0.54321",
+        asset: { type: "hts", assetReference: "0.0.7890" },
+        memo: { kind: "text", type: "string", value: "Associate with fee" },
+      },
+      customFees,
+    });
+
+    expect(result.tx).toBeInstanceOf(sdk.TokenAssociateTransaction);
+    invariant(
+      result.tx instanceof sdk.TokenAssociateTransaction,
+      "TokenAssociateTransaction type guard",
+    );
+    expect(result.tx.maxTransactionFee).toEqual(sdk.Hbar.fromTinybars(customFees.value.toString()));
   });
 
   it("should use mirror timestamp when system clock is skewed", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/estimateFees.test.ts
@@ -245,6 +245,83 @@ describe("getEstimatedFees", () => {
     });
   });
 
+  it("returns zero tinybars early when asset has no assetReference (native asset for ContractCall)", async () => {
+    const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
+      operationType: HEDERA_OPERATION_TYPES.ContractCall,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        sender: senderAddress,
+        recipient: recipientAddress,
+        amount: BigInt(1000000),
+        asset: { type: "native" },
+      },
+    });
+
+    expect(result).toMatchObject({ tinybars: new BigNumber(0) });
+    expect(apiClient.getNetworkFees).not.toHaveBeenCalled();
+  });
+
+  it("uses DEFAULT_GAS_PRICE_TINYBARS when ContractCall fee type is absent from network fees", async () => {
+    const estimatedGasLimit = new BigNumber(50000);
+    const transferAmount = BigInt(1000000);
+
+    (apiClient.getAccount as jest.Mock).mockImplementation(({ address }) => ({
+      address,
+      evm_address: "0x0000000000000000000000000000000000012345",
+    }));
+    (apiClient.getNetworkFees as jest.Mock).mockResolvedValueOnce({ fees: [] });
+    (apiClient.estimateContractCallGas as jest.Mock).mockResolvedValueOnce(estimatedGasLimit);
+
+    const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
+      operationType: HEDERA_OPERATION_TYPES.ContractCall,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        sender: senderAddress,
+        recipient: recipientAddress,
+        amount: transferAmount,
+        asset: { type: "erc20", assetReference: mockedTokenCurrencyERC20.contractAddress },
+      },
+    });
+
+    const expectedGas = estimatedGasLimit
+      .multipliedBy(ESTIMATED_GAS_SAFETY_RATE)
+      .integerValue(BigNumber.ROUND_CEIL);
+    const expectedTinybars = expectedGas
+      .multipliedBy(DEFAULT_GAS_PRICE_TINYBARS)
+      .integerValue(BigNumber.ROUND_CEIL);
+
+    expect(result).toMatchObject({ tinybars: expectedTinybars, gas: expectedGas });
+  });
+
+  it("returns zero tinybars early when EVM address cannot be resolved (no evm_address on account)", async () => {
+    const transferAmount = BigInt(1000000);
+
+    (apiClient.getAccount as jest.Mock).mockResolvedValue({ account: senderAddress });
+
+    const result = await estimateFees({
+      configOrCurrencyId: mockedAccount.currency.id,
+      operationType: HEDERA_OPERATION_TYPES.ContractCall,
+      txIntent: {
+        intentType: "transaction",
+        type: HEDERA_TRANSACTION_MODES.Send,
+        sender: senderAddress,
+        recipient: recipientAddress,
+        amount: transferAmount,
+        asset: {
+          type: "erc20",
+          assetReference: mockedTokenCurrencyERC20.contractAddress,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ tinybars: new BigNumber(0) });
+    expect(apiClient.getNetworkFees).not.toHaveBeenCalled();
+  });
+
   it("falls back to default estimate on cvs api failure", async () => {
     (cvsApi.fetchLatest as jest.Mock).mockRejectedValueOnce(new Error("Network error"));
 

--- a/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBalance.test.ts
@@ -145,21 +145,22 @@ describe("getBalance", () => {
       nodeId: mockMirrorAccount.staked_node_id,
     });
     expect(apiClient.getNodes).not.toHaveBeenCalled();
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      asset: { type: "native" },
-      value: BigInt(mockMirrorAccount.balance.balance),
-      stake: {
-        uid: address,
-        address,
+    expect(result).toMatchObject([
+      {
         asset: { type: "native" },
-        state: "active",
-        amount: BigInt(mockMirrorAccount.balance.balance + mockMirrorAccount.pending_reward),
-        amountDeposited: BigInt(mockMirrorAccount.balance.balance),
-        amountRewarded: BigInt(mockMirrorAccount.pending_reward),
-        delegate: mockMirrorNode.node_account_id,
+        value: BigInt(mockMirrorAccount.balance.balance),
+        stake: {
+          uid: address,
+          address,
+          asset: { type: "native" },
+          state: "active",
+          amount: BigInt(mockMirrorAccount.balance.balance + mockMirrorAccount.pending_reward),
+          amountDeposited: BigInt(mockMirrorAccount.balance.balance),
+          amountRewarded: BigInt(mockMirrorAccount.pending_reward),
+          delegate: mockMirrorNode.node_account_id,
+        },
       },
-    });
+    ]);
   });
 
   it("should return all token balances without CAL filtering", async () => {

--- a/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getBlock.v2.test.ts
@@ -82,7 +82,9 @@ describe("getBlockV2", () => {
 
     await getBlockV2({ configOrCurrencyId, height: 42 });
 
+    expect(getDateRangeFromBlockHeight).toHaveBeenCalledTimes(1);
     expect(getDateRangeFromBlockHeight).toHaveBeenCalledWith(42);
+    expect(getBlockInfo).toHaveBeenCalledTimes(1);
     expect(getBlockInfo).toHaveBeenCalledWith(42);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledTimes(1);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalledWith({
@@ -896,6 +898,7 @@ describe("getBlockV2", () => {
       info: mockBlockInfo,
       transactions: [],
     });
+    expect(getBlockInfo).toHaveBeenCalledTimes(1);
     expect(getBlockInfo).toHaveBeenCalledWith(100);
     expect(apiClient.getTransactionsByTimestampRange).toHaveBeenCalled();
   });

--- a/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/getStakes.test.ts
@@ -140,6 +140,7 @@ describe("getStakes", () => {
 
     const result = await getStakes({ configOrCurrencyId: mockCurrency.id, address: mockAddress });
 
+    expect(mockGetNode).toHaveBeenCalledTimes(1);
     expect(mockGetNode).toHaveBeenCalledWith({
       configOrCurrencyId: mockCurrency.id,
       nodeId,

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -51,7 +51,7 @@ jest.mock("./utils", () => ({
 
 describe("listOperationsV2", () => {
   const mockCurrency = getMockedCurrency();
-  const mockMirrorAccount = getMockedMirrorAccount({ account: "0.0.12345" });
+  const mockMirrorAccount = getMockedMirrorAccount();
   const mockSyntheticBlock: SyntheticBlock = {
     blockHeight: 1000000,
     blockHash: "0x100000",
@@ -166,7 +166,6 @@ describe("listOperationsV2", () => {
     });
 
     expect(result.tokenOperations).toEqual([]);
-    expect(result.coinOperations).toHaveLength(1);
     expect(result.coinOperations).toMatchObject([
       {
         type: "OUT",
@@ -1324,7 +1323,7 @@ describe("listOperationsV2", () => {
       useSyntheticBlocks: false,
     });
 
-    expect(result.coinOperations).toHaveLength(0);
+    expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toHaveLength(1);
     expect(result.tokenOperations[0].type).toBe("OUT");
   });
@@ -1364,8 +1363,7 @@ describe("listOperationsV2", () => {
       useSyntheticBlocks: false,
     });
 
-    expect(result.coinOperations).toHaveLength(1);
-    expect(result.coinOperations[0].hash).toBe("encoded-hash1");
+    expect(result.coinOperations).toEqual([expect.objectContaining({ hash: "encoded-hash1" })]);
   });
 
   it("should use synthetic blocks when useSyntheticBlocks is true", async () => {
@@ -1718,7 +1716,38 @@ describe("listOperationsV2", () => {
       useSyntheticBlocks: false,
     });
 
-    expect(result.coinOperations).toHaveLength(1);
-    expect(result.coinOperations[0].recipients).toEqual([nodeAccountId]);
+    expect(result.coinOperations).toEqual([
+      expect.objectContaining({ recipients: [nodeAccountId] }),
+    ]);
+  });
+
+  it("should return no coin operations for a mirror tx with empty transfers", async () => {
+    const mockTransaction = getMockedMirrorTransaction({
+      token_transfers: [],
+      staking_reward_transfers: [],
+      transfers: [],
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+    (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(null);
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toEqual([]);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../test/fixtures/currency.fixture";
 import { getMockedMirrorTransaction } from "../test/fixtures/mirror.fixture";
 import { getMockedOperation } from "../test/fixtures/operation.fixture";
+import { getMockedValidator } from "../test/fixtures/validator.fixture";
 import type {
   HederaAccount,
   HederaMemo,
@@ -80,6 +81,8 @@ import {
   toTimestamp,
   createStakingRewardOperationHash,
   resolveConfig,
+  base64ToUrlSafeBase64,
+  getHederaTransactionBodyBytes,
 } from "./utils";
 
 jest.mock("../config");
@@ -803,17 +806,11 @@ describe("logic utils", () => {
   });
 
   describe("filterValidatorBySearchTerm", () => {
-    const mockValidator: HederaValidator = {
+    const mockValidator = getMockedValidator({
       nodeId: 123,
       name: "Validator Test",
       address: "0.0.456",
-      addressChecksum: "abcde",
-      minStake: new BigNumber(0),
-      maxStake: new BigNumber(0),
-      activeStake: new BigNumber(0),
-      activeStakePercentage: new BigNumber(0),
-      overstaked: false,
-    };
+    });
 
     it("should match by nodeId", () => {
       expect(filterValidatorBySearchTerm(mockValidator, "123")).toBe(true);
@@ -1426,6 +1423,50 @@ describe("logic utils", () => {
       });
 
       expect(() => resolveConfig("hedera")).toThrow("No config for currency: hedera");
+    });
+  });
+
+  describe("base64ToUrlSafeBase64", () => {
+    it("replaces / with _ and + with -", () => {
+      expect(base64ToUrlSafeBase64("ab/cd+ef")).toBe("ab_cd-ef");
+    });
+
+    it("leaves strings without / or + unchanged", () => {
+      expect(base64ToUrlSafeBase64("abcdef1234")).toBe("abcdef1234");
+    });
+
+    it("replaces multiple occurrences", () => {
+      expect(base64ToUrlSafeBase64("a/b/c+d+e")).toBe("a_b_c-d-e");
+    });
+  });
+
+  describe("getHederaTransactionBodyBytes", () => {
+    it("returns bodyBytes from the first signed transaction", () => {
+      const bodyBytes = new Uint8Array([1, 2, 3]);
+      const mockTx = {
+        _signedTransactions: { get: jest.fn().mockReturnValue({ bodyBytes }) },
+      };
+      const result = getHederaTransactionBodyBytes(mockTx as never);
+      expect(result).toBe(bodyBytes);
+      expect(mockTx._signedTransactions.get).toHaveBeenCalledWith(0);
+    });
+
+    it("throws invariant when bodyBytes are missing", () => {
+      const mockTx = {
+        _signedTransactions: { get: jest.fn().mockReturnValue({ bodyBytes: undefined }) },
+      };
+      expect(() => getHederaTransactionBodyBytes(mockTx as never)).toThrow(
+        "hedera: tx body bytes are missing",
+      );
+    });
+
+    it("throws invariant when signed transaction entry is missing", () => {
+      const mockTx = {
+        _signedTransactions: { get: jest.fn().mockReturnValue(undefined) },
+      };
+      expect(() => getHederaTransactionBodyBytes(mockTx as never)).toThrow(
+        "hedera: tx body bytes are missing",
+      );
     });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/hgraph.test.ts
@@ -2,7 +2,7 @@ import network from "@ledgerhq/live-network";
 import BigNumber from "bignumber.js";
 import { resolveConfig } from "../logic/utils";
 import { getMockedConfig } from "../test/fixtures/config.fixture";
-import { getMockResponse } from "../test/fixtures/network.fixture";
+import { getMockResponse } from "../test/fixtures/common.fixture";
 import { hgraphClient } from "./hgraph";
 
 jest.mock("@ledgerhq/live-network");
@@ -334,6 +334,87 @@ describe("hgraphClient", () => {
 
       const query = getRequestData(0).query;
       expect(query).toContain("order_by: { consensus_timestamp: desc }");
+    });
+
+    it("uses _gt pagination direction when fetchAllPages is false and order is asc with timestamp", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: [] },
+        }),
+      );
+
+      await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        timestamp: "1234.000000000",
+        order: "asc",
+        fetchAllPages: false,
+      });
+
+      const query = getRequestData(0).query;
+      expect(query).toContain("consensus_timestamp: { _gt: $cursor }");
+    });
+
+    it("uses _lt pagination direction when fetchAllPages is false and order is desc with timestamp", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: [] },
+        }),
+      );
+
+      await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        timestamp: "1234.000000000",
+        order: "desc",
+        fetchAllPages: false,
+      });
+
+      const query = getRequestData(0).query;
+      expect(query).toContain("consensus_timestamp: { _lt: $cursor }");
+    });
+
+    it("throws with empty message when error object has no message", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          errors: [{}],
+        }),
+      );
+
+      await expect(
+        hgraphClient.getERC20Transfers({
+          configOrCurrencyId: mockConfig,
+          address: "0.0.1234",
+          tokenEvmAddresses: ["0xabc123"],
+          fetchAllPages: true,
+        }),
+      ).rejects.toThrow("hedera: failed to fetch ERC20 transfers from Hgraph: ");
+    });
+
+    it("splices transfers to limit when fetchAllPages is false and page exceeds limit", async () => {
+      const mockTransfers = [
+        { consensus_timestamp: "1000000000000000000", transaction_hash: "0xhash1" },
+        { consensus_timestamp: "1100000000000000000", transaction_hash: "0xhash2" },
+      ];
+
+      mockedNetwork.mockResolvedValueOnce(
+        getMockResponse({
+          data: { erc_token_transfer: mockTransfers },
+        }),
+      );
+
+      const result = await hgraphClient.getERC20Transfers({
+        configOrCurrencyId: mockConfig,
+        address: "0.0.1234",
+        tokenEvmAddresses: ["0xabc123"],
+        limit: 1,
+        fetchAllPages: false,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].consensus_timestamp).toBe("1000000000000000000");
     });
 
     it("should throw error when API returns errors", async () => {

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -44,7 +44,7 @@ describe("network utils", () => {
   const mockCurrency = getMockedCurrency();
 
   beforeAll(() => {
-    hederaCoinConfig.setCoinConfig(getMockedConfig);
+    hederaCoinConfig.setCoinConfig(() => getMockedConfig());
   });
 
   beforeEach(() => {

--- a/libs/coin-modules/coin-hedera/src/preload-data.test.ts
+++ b/libs/coin-modules/coin-hedera/src/preload-data.test.ts
@@ -28,7 +28,7 @@ describe("preload-data", () => {
       setHederaPreloadData(testData, hedera);
 
       expect(getCurrentHederaPreloadData(hedera).validators).toHaveLength(1);
-      expect(getCurrentHederaPreloadData(hederaTestnet).validators).toHaveLength(0);
+      expect(getCurrentHederaPreloadData(hederaTestnet).validators).toEqual([]);
     });
 
     it("should throw for unsupported currency", () => {

--- a/libs/coin-modules/coin-hedera/src/preload.test.ts
+++ b/libs/coin-modules/coin-hedera/src/preload.test.ts
@@ -1,11 +1,120 @@
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import BigNumber from "bignumber.js";
-import { hydrate } from "./preload";
+import { getPreloadStrategy, hydrate, preload } from "./preload";
+import { apiClient } from "./network/api";
 import { setHederaPreloadData } from "./preload-data";
 
 jest.mock("./preload-data", () => ({
   setHederaPreloadData: jest.fn(),
 }));
+
+jest.mock("./network/api");
+
+describe("getPreloadStrategy", () => {
+  it("returns preloadMaxAge of 15 minutes in milliseconds", () => {
+    const strategy = getPreloadStrategy();
+    expect(strategy.preloadMaxAge).toBe(15 * 60 * 1000);
+  });
+});
+
+describe("preload", () => {
+  const currency = getCryptoCurrencyById("hedera");
+  const mockGetNodes = jest.mocked(apiClient.getNodes);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should call getNodes with fetchAllPages=true and call setHederaPreloadData with mapped validators", async () => {
+    mockGetNodes.mockResolvedValue({
+      nodes: [
+        {
+          node_id: 0,
+          node_account_id: "0.0.3",
+          description: "Hedera | 0 | Hosted by Hedera",
+          min_stake: 1000,
+          max_stake: 100000,
+          stake: 50000,
+          stake_rewarded: 30000,
+          reward_rate_start: 0,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    const result = await preload(currency);
+
+    expect(mockGetNodes).toHaveBeenCalledTimes(1);
+    expect(mockGetNodes).toHaveBeenCalledWith({
+      configOrCurrencyId: currency.id,
+      fetchAllPages: true,
+    });
+    expect(setHederaPreloadData).toHaveBeenCalledTimes(1);
+    expect(result.validators).toHaveLength(1);
+    expect(result.validators[0]).toMatchObject({
+      nodeId: 0,
+      address: "0.0.3",
+      minStake: new BigNumber(1000),
+      maxStake: new BigNumber(100000),
+      activeStake: new BigNumber(30000),
+      overstaked: false,
+    });
+  });
+
+  it("should set activeStakePercentage to 0 when maxStake is 0", async () => {
+    mockGetNodes.mockResolvedValue({
+      nodes: [
+        {
+          node_id: 1,
+          node_account_id: "0.0.4",
+          description: "Hedera | 1 | Hosted by Hashpack",
+          min_stake: 0,
+          max_stake: 0,
+          stake: 0,
+          stake_rewarded: 0,
+          reward_rate_start: 0,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    const result = await preload(currency);
+
+    expect(result.validators[0].activeStakePercentage).toEqual(new BigNumber(0));
+  });
+
+  it("should mark validator as overstaked when activeStake >= maxStake", async () => {
+    mockGetNodes.mockResolvedValue({
+      nodes: [
+        {
+          node_id: 2,
+          node_account_id: "0.0.5",
+          description: "Hedera | 2 | Overstaked node",
+          min_stake: 0,
+          max_stake: 1000,
+          stake: 2000,
+          stake_rewarded: 1000,
+          reward_rate_start: 0,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    const result = await preload(currency);
+
+    expect(result.validators[0].overstaked).toBe(true);
+  });
+
+  it("should return empty validators array when nodes list is empty", async () => {
+    mockGetNodes.mockResolvedValue({ nodes: [], nextCursor: null });
+
+    const result = await preload(currency);
+
+    expect(result.validators).toEqual([]);
+    expect(setHederaPreloadData).toHaveBeenCalledTimes(1);
+    expect(setHederaPreloadData).toHaveBeenCalledWith({ validators: [] }, currency);
+  });
+});
 
 describe("hydrate", () => {
   const currency = getCryptoCurrencyById("hedera");
@@ -18,9 +127,16 @@ describe("hydrate", () => {
     "should hydrate empty validators list if data is corrupted (%p value)",
     value => {
       hydrate(value, currency);
+      expect(setHederaPreloadData).toHaveBeenCalledTimes(1);
       expect(setHederaPreloadData).toHaveBeenCalledWith({ validators: [] }, currency);
     },
   );
+
+  it("should hydrate empty validators when validators field is not an array", () => {
+    hydrate({ validators: "not-an-array" }, currency);
+    expect(setHederaPreloadData).toHaveBeenCalledTimes(1);
+    expect(setHederaPreloadData).toHaveBeenCalledWith({ validators: [] }, currency);
+  });
 
   it("should hydrate valid validators list", () => {
     hydrate(
@@ -42,6 +158,7 @@ describe("hydrate", () => {
       currency,
     );
 
+    expect(setHederaPreloadData).toHaveBeenCalledTimes(1);
     expect(setHederaPreloadData).toHaveBeenCalledWith(
       {
         validators: [

--- a/libs/coin-modules/coin-hedera/src/signer/getAddress.test.ts
+++ b/libs/coin-modules/coin-hedera/src/signer/getAddress.test.ts
@@ -1,0 +1,45 @@
+import resolver from "./getAddress";
+
+describe("getAddress resolver", () => {
+  it("returns a function that calls signerContext with the path and returns address/publicKey", async () => {
+    const publicKey = "somePublicKey";
+    const path = "44/3030/0/0/0";
+    const deviceId = "device-1";
+
+    const signerContext = jest.fn(
+      async (_deviceId: string, fn: (signer: unknown) => Promise<string>) => {
+        const signer = { getPublicKey: jest.fn().mockResolvedValue(publicKey) };
+        return fn(signer);
+      },
+    );
+
+    const getAddressFn = resolver(signerContext as never);
+    const result = await getAddressFn(deviceId, { path } as never);
+
+    expect(signerContext).toHaveBeenCalledTimes(1);
+    expect(signerContext).toHaveBeenCalledWith(deviceId, expect.any(Function));
+    expect(result).toEqual({
+      path,
+      address: publicKey,
+      publicKey,
+    });
+  });
+
+  it("passes the derivation path to signer.getPublicKey", async () => {
+    const path = "44/3030/1/0/0";
+    const deviceId = "device-2";
+    const getPublicKey = jest.fn().mockResolvedValue("anotherKey");
+
+    const signerContext = jest.fn(
+      async (_deviceId: string, fn: (signer: unknown) => Promise<string>) => {
+        return fn({ getPublicKey });
+      },
+    );
+
+    const getAddressFn = resolver(signerContext as never);
+    await getAddressFn(deviceId, { path } as never);
+
+    expect(getPublicKey).toHaveBeenCalledTimes(1);
+    expect(getPublicKey).toHaveBeenCalledWith(path);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/supportedFeatures.test.ts
+++ b/libs/coin-modules/coin-hedera/src/supportedFeatures.test.ts
@@ -2,7 +2,8 @@ import { supportedFeatures } from "./supportedFeatures";
 
 describe("supportedFeatures", () => {
   it("exports blockchain_txs as a non-empty array", () => {
-    expect(supportedFeatures.blockchain_txs).toBeInstanceOf(Array);
-    expect(supportedFeatures.blockchain_txs.length).toBeGreaterThan(0);
+    const blockchainTxs = supportedFeatures.blockchain_txs ?? [];
+    expect(blockchainTxs).toBeInstanceOf(Array);
+    expect(blockchainTxs.length).toBeGreaterThan(0);
   });
 });

--- a/libs/coin-modules/coin-hedera/src/supportedFeatures.test.ts
+++ b/libs/coin-modules/coin-hedera/src/supportedFeatures.test.ts
@@ -1,0 +1,8 @@
+import { supportedFeatures } from "./supportedFeatures";
+
+describe("supportedFeatures", () => {
+  it("exports blockchain_txs as a non-empty array", () => {
+    expect(supportedFeatures.blockchain_txs).toBeInstanceOf(Array);
+    expect(supportedFeatures.blockchain_txs.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/config.fixture.ts
@@ -1,6 +1,6 @@
 import type { HederaCoinConfig } from "../../config";
 
-export const getMockedConfig = (): HederaCoinConfig => {
+export const getMockedConfig = (overrides?: Partial<HederaCoinConfig>): HederaCoinConfig => {
   return {
     status: { type: "active" },
     useNetworkTimestamp: false,
@@ -9,5 +9,6 @@ export const getMockedConfig = (): HederaCoinConfig => {
       hgraph: "https://hedera-indexer-mainnet.coin.ledger.com/v1/graphql",
       mirrorNode: "https://hedera.coin.ledger.com",
     },
+    ...overrides,
   };
 };

--- a/libs/coin-modules/coin-hedera/src/test/fixtures/validator.fixture.ts
+++ b/libs/coin-modules/coin-hedera/src/test/fixtures/validator.fixture.ts
@@ -1,0 +1,17 @@
+import BigNumber from "bignumber.js";
+import type { HederaValidator } from "../../types";
+
+export const getMockedValidator = (overrides?: Partial<HederaValidator>): HederaValidator => {
+  return {
+    nodeId: 1,
+    name: "Mock Validator",
+    address: "0.0.3",
+    addressChecksum: "abcde",
+    minStake: new BigNumber(0),
+    maxStake: new BigNumber(0),
+    activeStake: new BigNumber(0),
+    activeStakePercentage: new BigNumber(0),
+    overstaked: false,
+    ...overrides,
+  };
+};


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Extended unit test coverage for @ledgerhq/coin-hedera across all major layers of the bridge and logic stack
- Added new test files and significantly expanded existing ones: bridge/broadcast, bridge/receive, bridge/estimateMaxSpendable, bridge/signOperation, bridge/synchronisation, bridge/serialization, bridge/transaction, signer/getAddress, logic/craftTransaction, logic/estimateFees, network/hgraph, and more
- Added validator.fixture.ts and made getMockedConfig accept partial overrides for flexibility in test setup

Test quality improvements
- Replaced duplicated test blocks with it.each where HTS/ERC20 token cases differed only by currency factory
- Standardised test() → it() (and test.each → it.each) across all test files for consistency
- Simplified toHaveLength(0) → toEqual([]) and toHaveLength(1) + expect(x[0]).toEqual({...}) → toEqual([{...}]) / toMatchObject([{...}])
- Added toHaveBeenCalledTimes alongside every toHaveBeenCalledWith to prevent false positives from multiple invocations
- Replaced hardcoded value assertion in supportedFeatures.test.ts with a structural check (non-empty array) since TypeScript already enforces element type

<img width="561" height="50" alt="image" src="https://github.com/user-attachments/assets/1275512c-3aad-4eb5-8f24-42806fe1932e" />


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34469](https://ledgerhq.atlassian.net/browse/LIVE-34469)
