### PR TITLE
[LWD] fix(drawer): allow clicking dialog buttons when side drawer is opened 

### DIFF
--- a/.changeset/loud-ducks-listen.md
+++ b/.changeset/loud-ducks-listen.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Fix dialog buttons doing nothing while a side drawer is open, by releasing the drawer focus trap when a dialog opens

--- a/apps/ledger-live-desktop/src/renderer/components/SideDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/SideDrawer.tsx
@@ -6,6 +6,7 @@ import { Transition, TransitionStatus } from "react-transition-group";
 import { createFocusTrap, FocusTrap } from "focus-trap";
 import { createPortal } from "react-dom";
 import { modalsStateSelector } from "~/renderer/reducers/modals";
+import { selectIsAnyDialogOpen } from "~/renderer/reducers/dialogs";
 import { useDeviceBlocked } from "./DeviceAction/DeviceBlocker";
 import SideDrawerHeader from "./SideDrawerHeader";
 
@@ -156,7 +157,9 @@ export function SideDrawer({
   const shouldRestoreFocusOnCloseRef = useRef(shouldRestoreFocusOnClose);
   shouldRestoreFocusOnCloseRef.current = shouldRestoreFocusOnClose;
   const modalsState = useSelector(modalsStateSelector);
-  const shouldDisableFocusTrap = Object.values(modalsState).some(state => state?.isOpened);
+  const isAnyDialogOpen = useSelector(selectIsAnyDialogOpen);
+  const shouldDisableFocusTrap =
+    isAnyDialogOpen || Object.values(modalsState).some(state => state?.isOpened);
   const deactivateFocusTrap = useCallback(() => {
     focusTrap.current?.deactivate({ returnFocus: shouldRestoreFocusOnCloseRef.current });
     focusTrap.current = null;

--- a/apps/ledger-live-desktop/src/renderer/components/__tests__/SideDrawer.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/__tests__/SideDrawer.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
+import { render, screen } from "tests/testSetup";
+import { SideDrawer } from "~/renderer/components/SideDrawer";
+
+describe("SideDrawer", () => {
+  let modalsContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    modalsContainer = document.createElement("div");
+    modalsContainer.id = "modals";
+    document.body.appendChild(modalsContainer);
+  });
+
+  afterEach(() => modalsContainer.remove());
+
+  it("should let a dialog opened above the drawer receive clicks", async () => {
+    const onClose = jest.fn();
+    const { user } = render(
+      <>
+        <SideDrawer isOpen>
+          <button type="button">drawer button</button>
+        </SideDrawer>
+        <Dialog open>
+          <DialogContent>
+            <button type="button" onClick={onClose}>
+              dialog close
+            </button>
+          </DialogContent>
+        </Dialog>
+      </>,
+      { initialState: { dialogs: { FINISH_POST_ONBOARDING: true } } },
+    );
+
+    expect(screen.getByTestId("side-drawer-container")).toBeInTheDocument();
+
+    await user.click(await screen.findByRole("button", { name: "dialog close" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/reducers/dialogs.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/dialogs.ts
@@ -56,4 +56,7 @@ export const { openDialog, closeDialog } = dialogsSlice.actions;
 /** Select whether a specific dialog is currently open. */
 export const selectIsDialogOpen = (state: Pick<State, "dialogs">, id: DialogId) =>
   !!state.dialogs[id];
+
+export const selectIsAnyDialogOpen = (state: Pick<State, "dialogs">) =>
+  Object.values(state.dialogs).some(Boolean);
 export default dialogsSlice.reducer;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Post-onboarding dialog opened over the add-account drawer: the ✕ button must close it
  - Any dialog opened while a side drawer is visible (Product Tour, Release Notes, Buy Device)
  - Keyboard navigation inside drawers when no dialog is open: focus must still stay trapped

### 📝 Description

The ✕ button of the post-onboarding dialog did nothing when the dialog opened during the add-account flow. Clicking outside the dialog closed it, which is what made the report confusing.

The add-account flow runs in a `SideDrawer`, which activates a `focus-trap` while open. The trap listens for `click` on `document` in the capture phase and calls `preventDefault()` + `stopImmediatePropagation()` for any click outside the drawer container. Dialogs are portaled to `document.body`, so they count as outside and React never receives their clicks. Clicking outside still worked because Radix dismisses on `pointerdown`, which the trap does not intercept.

`SideDrawer` already released the trap for legacy modals. This adds the same handling for the `dialogs` slice, so it covers every dialog rather than the post-onboarding one alone.

<table>
<tr>
 <td><video src="https://github.com/user-attachments/assets/3b4e29a2-1efb-4f00-9c9b-e0ea65541c20"/>
 <td><video src="https://github.com/user-attachments/assets/dd6d2515-8244-43c0-8c0e-f8edec6d4d19" />
</table>

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34306](https://ledgerhq.atlassian.net/browse/LIVE-34306)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-34306]: https://ledgerhq.atlassian.net/browse/LIVE-34306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ