### PR TITLE
fix(celo): handle epoch-processing block during voting (LIVE-32861)

### DIFF
--- a/.changeset/celo-vote-epoch-processing.md
+++ b/.changeset/celo-vote-epoch-processing.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/coin-celo": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Celo: show a clear "temporarily unavailable" message when voting is blocked during on-chain epoch processing, instead of a generic "RPC request failed" error

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6788,6 +6788,10 @@
     "CeloAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
+    "CeloEpochProcessingActive": {
+      "title": "This action is temporarily unavailable",
+      "description": "Celo is currently processing an epoch update. During this short on-chain window, staking actions such as voting, activating, revoking, locking, and unlocking are temporarily blocked by the network. Please try again once epoch processing is complete."
+    },
     "CeloGroupNotVotable": {
       "title": "This validator group cannot receive votes. It may be full or no longer eligible."
     },

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -6822,6 +6822,10 @@
     "CeloAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
+    "CeloEpochProcessingActive": {
+      "title": "This action is temporarily unavailable",
+      "description": "Celo is currently processing an epoch update. During this short on-chain window, staking actions such as voting, activating, revoking, locking, and unlocking are temporarily blocked by the network. Please try again once epoch processing is complete."
+    },
     "CeloGroupNotVotable": {
       "title": "This validator group cannot receive votes. It may be full or no longer eligible."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -179,6 +179,10 @@
     "CeloAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
+    "CeloEpochProcessingActive": {
+      "title": "This action is temporarily unavailable",
+      "description": "Celo is currently processing an epoch update. During this short on-chain window, staking actions such as voting, activating, revoking, locking, and unlocking are temporarily blocked by the network. Please try again once epoch processing is complete."
+    },
     "CeloGroupNotVotable": {
       "title": "This validator group cannot receive votes. It may be full or no longer eligible."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -199,6 +199,10 @@
     "CeloAllFundsWarning": {
       "title": "Ensure you have enough balance left for future transaction fees"
     },
+    "CeloEpochProcessingActive": {
+      "title": "This action is temporarily unavailable",
+      "description": "Celo is currently processing an epoch update. During this short on-chain window, staking actions such as voting, activating, revoking, locking, and unlocking are temporarily blocked by the network. Please try again once epoch processing is complete."
+    },
     "CeloGroupNotVotable": {
       "title": "This validator group cannot receive votes. It may be full or no longer eligible."
     },

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/buildTransaction.test.ts
@@ -10,7 +10,7 @@ import {
   tokenTransactionWithUsdcFeeFixture,
 } from "../../bridge/fixtures";
 import { ZERO_ADDRESS } from "../../constants";
-import { CeloGroupNotVoted } from "../../errors";
+import { CeloEpochProcessingActive, CeloGroupNotVoted } from "../../errors";
 
 const LOCKED_GOLD_ADDRESS = "0x0000000000000000000000000000000000001d00";
 const ELECTION_ADDRESS = "0x000000000000000000000000000000000000ce10";
@@ -314,6 +314,45 @@ describe("buildTransaction", () => {
       to: ELECTION_ADDRESS,
       data: expectedData,
     });
+  });
+
+  it("should throw CeloEpochProcessingActive when a vote reverts during epoch processing (LIVE-32861)", async () => {
+    estimateGasMock.mockRejectedValueOnce(
+      new Error("execution reverted: Contract is blocked from performing this action"),
+    );
+
+    await expect(
+      buildTransaction(
+        {
+          ...accountFixture,
+          spendableBalance: BigNumber(123),
+          celoResources: {
+            registrationStatus: false,
+            lockedBalance: BigNumber(0),
+            nonvotingLockedBalance: BigNumber(40),
+            pendingWithdrawals: null,
+            votes: null,
+            electionAddress: null,
+            lockedGoldAddress: null,
+            maxNumGroupsVotedFor: BigNumber(0),
+          },
+        },
+        { ...transactionFixture, mode: "vote", recipient: VALID_RECIPIENT },
+      ),
+    ).rejects.toThrow(CeloEpochProcessingActive);
+  });
+
+  it("should rethrow the raw error for a non-vote mode blocked during epoch processing", async () => {
+    estimateGasMock.mockRejectedValueOnce(
+      new Error("execution reverted: Contract is blocked from performing this action"),
+    );
+
+    await expect(
+      buildTransaction(
+        { ...accountFixture, spendableBalance: BigNumber(123) },
+        { ...transactionFixture, mode: "send" },
+      ),
+    ).rejects.toThrow("Contract is blocked from performing this action");
   });
 
   it("should build a revoke transaction", async () => {

--- a/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/bridge/getTransactionStatus.test.ts
@@ -19,9 +19,18 @@ jest.mock("../../bridge/preload", () => ({
   getCurrentCeloPreloadData: () => mockGetCurrentCeloPreloadData(),
 }));
 
+// readContract is dispatched by functionName: `isBlocked` (the epoch-processing
+// probe) defaults to false; every other read (e.g. getAccountNonvotingLockedGold)
+// returns a balance. Tests override mockReadContract to simulate a blocked epoch.
+const defaultReadContract = async ({ functionName }: { functionName?: string }) =>
+  functionName === "isBlocked" ? false : BigInt(100);
+const mockReadContract = jest.fn<Promise<unknown>, [{ functionName?: string }]>(
+  defaultReadContract,
+);
+
 jest.mock("../../network/client", () => ({
   getCeloClient: jest.fn(() => ({
-    readContract: jest.fn(async () => BigInt(100)),
+    readContract: (args: { functionName?: string }) => mockReadContract(args),
   })),
 }));
 
@@ -528,6 +537,75 @@ describe("getTransactionStatus", () => {
       const status = await getTransactionStatus(voteAccount, voteTransaction);
 
       expect(status.errors).not.toHaveProperty("recipient");
+    });
+  });
+
+  describe("vote mode - epoch processing block (LIVE-32861)", () => {
+    const voteAccount = {
+      ...accountFixture,
+      balance: BigNumber(10000000000000000),
+      spendableBalance: BigNumber(10000000000000000),
+      celoResources: {
+        ...accountFixture.celoResources,
+        nonvotingLockedBalance: BigNumber(100),
+      },
+    };
+    const voteTransaction = {
+      ...transactionFixture,
+      mode: "vote" as const,
+      recipient: "0x79D5A290D7ba4b99322d91b577589e8d0BF87072",
+      fees: BigNumber(2),
+      amount: BigNumber(50),
+    };
+
+    const blockedReadContract = async ({ functionName }: { functionName?: string }) =>
+      functionName === "isBlocked" ? true : BigInt(100);
+
+    beforeEach(() => {
+      // Recipient is eligible so the votable check stays quiet; the probe reset
+      // guards against a blocked implementation leaking from a previous test.
+      mockGetCurrentCeloPreloadData.mockReturnValue({
+        validatorGroups: [
+          { address: voteTransaction.recipient, name: "Eligible Group", votes: BigNumber(0) },
+        ],
+      });
+      mockReadContract.mockImplementation(defaultReadContract);
+    });
+
+    it("sets CeloEpochProcessingActive on amount when Election.isBlocked() is true", async () => {
+      mockReadContract.mockImplementation(blockedReadContract);
+
+      const status = await getTransactionStatus(voteAccount, voteTransaction);
+
+      expect(status.errors["amount"].name).toEqual("CeloEpochProcessingActive");
+    });
+
+    it("does not set CeloEpochProcessingActive when Election.isBlocked() is false", async () => {
+      const status = await getTransactionStatus(voteAccount, voteTransaction);
+
+      expect(status.errors).not.toHaveProperty("amount");
+    });
+
+    it("takes precedence over NotEnoughBalance when the epoch is blocked", async () => {
+      mockReadContract.mockImplementation(blockedReadContract);
+
+      const status = await getTransactionStatus(voteAccount, {
+        ...voteTransaction,
+        amount: BigNumber(100000), // exceeds the non-voting locked balance (100)
+      });
+
+      expect(status.errors["amount"].name).toEqual("CeloEpochProcessingActive");
+    });
+
+    it("does not block when the isBlocked() probe fails transiently", async () => {
+      mockReadContract.mockImplementation(async ({ functionName }: { functionName?: string }) => {
+        if (functionName === "isBlocked") throw new Error("network error");
+        return BigInt(100);
+      });
+
+      const status = await getTransactionStatus(voteAccount, voteTransaction);
+
+      expect(status.errors).not.toHaveProperty("amount");
     });
   });
 });

--- a/libs/coin-modules/coin-celo/src/__tests__/network/rpcErrors.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/network/rpcErrors.test.ts
@@ -42,14 +42,12 @@ describe("isEpochBlockRevert", () => {
     expect(isEpochBlockRevert(new Error(message))).toBe(true);
   });
 
-  it.each([
-    "execution reverted",
-    "vote cap exceeded",
-    "Group not eligible",
-    "request timed out",
-  ])("does not classify unrelated failure %p as an epoch block", message => {
-    expect(isEpochBlockRevert(new Error(message))).toBe(false);
-  });
+  it.each(["execution reverted", "vote cap exceeded", "Group not eligible", "request timed out"])(
+    "does not classify unrelated failure %p as an epoch block",
+    message => {
+      expect(isEpochBlockRevert(new Error(message))).toBe(false);
+    },
+  );
 
   it("handles non-Error values", () => {
     expect(isEpochBlockRevert("contract is blocked from performing this action")).toBe(true);

--- a/libs/coin-modules/coin-celo/src/__tests__/network/rpcErrors.test.ts
+++ b/libs/coin-modules/coin-celo/src/__tests__/network/rpcErrors.test.ts
@@ -1,4 +1,4 @@
-import { isRevertLike } from "../../network/rpcErrors";
+import { isEpochBlockRevert, isRevertLike } from "../../network/rpcErrors";
 
 describe("isRevertLike", () => {
   it.each([
@@ -30,5 +30,29 @@ describe("isRevertLike", () => {
   it("handles non-Error values", () => {
     expect(isRevertLike("plain reverted string")).toBe(true);
     expect(isRevertLike(undefined)).toBe(false);
+  });
+});
+
+describe("isEpochBlockRevert", () => {
+  it.each([
+    "Contract is blocked from performing this action",
+    "execution reverted: Contract is blocked from performing this action",
+    "CONTRACT IS BLOCKED FROM PERFORMING THIS ACTION",
+  ])("classifies the epoch-processing block %p as an epoch block", message => {
+    expect(isEpochBlockRevert(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    "execution reverted",
+    "vote cap exceeded",
+    "Group not eligible",
+    "request timed out",
+  ])("does not classify unrelated failure %p as an epoch block", message => {
+    expect(isEpochBlockRevert(new Error(message))).toBe(false);
+  });
+
+  it("handles non-Error values", () => {
+    expect(isEpochBlockRevert("contract is blocked from performing this action")).toBe(true);
+    expect(isEpochBlockRevert(undefined)).toBe(false);
   });
 });

--- a/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/buildTransaction.ts
@@ -7,10 +7,11 @@ import {
   getStableTokenRegistryName,
   MAX_FEES_THRESHOLD_MULTIPLIER,
 } from "../constants";
-import { CeloGroupNotVoted } from "../errors";
+import { CeloEpochProcessingActive, CeloGroupNotVoted } from "../errors";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
 import { celoEstimateGas, getCeloClient } from "../network/client";
 import { getRegistryAddressFor } from "../network/registry";
+import { isEpochBlockRevert } from "../network/rpcErrors";
 import { voteSignerAccount } from "../network/sdk";
 import { getVoteNeighbors } from "../network/voteNeighbors";
 import type { CeloAccount, CeloTransactionRequest, Transaction } from "../types";
@@ -290,13 +291,25 @@ const buildTransaction = async (
       break;
   }
 
-  const estimatedGas = await celoEstimateGas({
-    from: celoTransaction.from,
-    ...(celoTransaction.to !== undefined && { to: celoTransaction.to }),
-    ...(celoTransaction.data !== undefined && { data: celoTransaction.data }),
-    ...(celoTransaction.value !== undefined && { value: BigInt(celoTransaction.value) }),
-    ...(celoTransaction.feeCurrency && { feeCurrency: celoTransaction.feeCurrency }),
-  });
+  let estimatedGas: bigint;
+  try {
+    estimatedGas = await celoEstimateGas({
+      from: celoTransaction.from,
+      ...(celoTransaction.to !== undefined && { to: celoTransaction.to }),
+      ...(celoTransaction.data !== undefined && { data: celoTransaction.data }),
+      ...(celoTransaction.value !== undefined && { value: BigInt(celoTransaction.value) }),
+      ...(celoTransaction.feeCurrency && { feeCurrency: celoTransaction.feeCurrency }),
+    });
+  } catch (error) {
+    // Safety net for the sign step: if a vote is submitted during the epoch
+    // processing window (the proactive isBlocked() check in getTransactionStatus
+    // races and lets it through), surface the friendly error instead of a raw
+    // "RPC request failed". See CeloEpochProcessingActive.
+    if (transaction.mode === "vote" && isEpochBlockRevert(error)) {
+      throw new CeloEpochProcessingActive();
+    }
+    throw error;
+  }
 
   const gas = Math.ceil(Number(estimatedGas) * MAX_FEES_THRESHOLD_MULTIPLIER).toString();
   const [chainId, nonce] = await Promise.all([

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -1,4 +1,4 @@
-import { lockedGoldABI } from "@celo/abis";
+import { electionABI, lockedGoldABI } from "@celo/abis";
 import { isAddress } from "viem";
 import {
   AmountRequired,
@@ -12,7 +12,7 @@ import {
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
-import { CeloAllFundsWarning, CeloGroupNotVotable } from "../errors";
+import { CeloAllFundsWarning, CeloEpochProcessingActive, CeloGroupNotVotable } from "../errors";
 import { getPendingStakingOperationAmounts, getVote } from "../logic";
 import { getCeloClient } from "../network/client";
 import { getRegistryAddressFor } from "../network/registry";
@@ -167,6 +167,29 @@ export const getTransactionStatus: AccountBridge<
       )
     ) {
       errors.recipient = new CeloGroupNotVotable();
+    }
+  }
+
+  // During the Celo epoch-processing window the EpochManager blocks `Election.vote`
+  // (onlyWhenNotBlocked), so on-chain estimation/broadcast reverts with an opaque
+  // "RPC request failed". Probe the same isBlocked() condition the modifier checks
+  // and surface a clear, actionable error before the user can sign. Set on `amount`
+  // so it takes precedence over the balance checks above and disables Continue.
+  // A transient probe failure is swallowed — the sign-step guard in buildTransaction
+  // remains the safety net.
+  if (transaction.mode === "vote") {
+    try {
+      const electionAddress = await getRegistryAddressFor("Election");
+      const blocked = await client.readContract({
+        address: electionAddress,
+        abi: electionABI,
+        functionName: "isBlocked",
+      });
+      if (blocked) {
+        errors.amount = new CeloEpochProcessingActive();
+      }
+    } catch {
+      // ignore — do not block on a failed probe
     }
   }
 

--- a/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/getTransactionStatus.ts
@@ -9,6 +9,7 @@ import {
   NotEnoughBalanceFees,
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
+import { log } from "@ledgerhq/logs";
 import { findSubAccountById } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { AccountBridge } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
@@ -188,8 +189,10 @@ export const getTransactionStatus: AccountBridge<
       if (blocked) {
         errors.amount = new CeloEpochProcessingActive();
       }
-    } catch {
-      // ignore — do not block on a failed probe
+    } catch (error) {
+      // Do not block on a failed probe, but log it so a wrong registry address
+      // or a decoding failure doesn't get swallowed silently.
+      log("celo/getTransactionStatus", "isBlocked probe failed", { error });
     }
   }
 

--- a/libs/coin-modules/coin-celo/src/errors.ts
+++ b/libs/coin-modules/coin-celo/src/errors.ts
@@ -21,3 +21,21 @@ export class CeloGroupNotVoted extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/**
+ * Raised when a Celo staking action is temporarily blocked by the network.
+ *
+ * Since the Celo L1→L2 migration, epoch processing runs on-chain in a short
+ * window during which the `EpochManager` blocks staking mutations. Any function
+ * carrying the `onlyWhenNotBlocked` modifier (e.g. `Election.vote`) reverts with
+ * "Contract is blocked from performing this action" until processing completes.
+ * This is a transient on-chain state, not a defect — retrying after the window
+ * closes succeeds.
+ */
+export class CeloEpochProcessingActive extends Error {
+  override name = "CeloEpochProcessingActive";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "CeloEpochProcessingActive");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-celo/src/network/rpcErrors.ts
+++ b/libs/coin-modules/coin-celo/src/network/rpcErrors.ts
@@ -21,3 +21,23 @@ export const isRevertLike = (error: unknown): boolean => {
     message.includes("invalid opcode")
   );
 };
+
+/**
+ * Stable substring of the revert reason emitted by Celo's
+ * `Blockable.onlyWhenNotBlocked` modifier while the `EpochManager` is processing
+ * an epoch. The full reason is "Contract is blocked from performing this action";
+ * matching the "contract is blocked" prefix tolerates provider-side truncation.
+ * `Election.vote` (and other blockable staking mutations) revert with it while
+ * that window is open.
+ */
+export const EPOCH_BLOCK_REVERT = "contract is blocked";
+
+/**
+ * True when an error is the transient "epoch processing" block (see
+ * {@link EPOCH_BLOCK_REVERT}) rather than a generic revert. Lets the bridge map
+ * it to a dedicated, user-friendly error instead of an opaque RPC failure.
+ */
+export const isEpochBlockRevert = (error: unknown): boolean => {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return message.includes(EPOCH_BLOCK_REVERT);
+};


### PR DESCRIPTION
## ✅ Checklist

- [ ] Tests
- [x] Bug fix
- [ ] Breaking change

## 📝 Description

Fixes **LIVE-32861** — Celo vote flow failed with an opaque **"RPC request Failed"**, blocking users from voting.

### Root cause
Since the Celo **L1→L2 migration**, epoch processing runs on-chain in a short recurring window (`startNextEpochProcess()` → `finishNextEpochProcess()`). During that window the `EpochManager` acts as a `Blocker`, and `Election.vote()` (via the `onlyWhenNotBlocked` modifier) reverts with `Contract is blocked from performing this action`. Our `eth_estimateGas` reverted and, because nothing classified it, surfaced as a generic RPC failure at the signing step.

This is a **transient on-chain state, not a defect** — the same vote succeeds once the window closes. The fix is a UX one: detect the block and show a specific, actionable message (wording approved by Product).

### Changes
- **coin-celo**
  - New `CeloEpochProcessingActive` error + `isEpochBlockRevert()` classifier for the block revert.
  - `getTransactionStatus` (primary): for `vote`, probe `Election.isBlocked()` — the same condition the on-chain modifier checks — and set an inline `amount` error, disabling **Continue** and showing the message *before* signing. A transient probe failure is swallowed so it never false-blocks.
  - `buildTransaction` (safety net, vote-only): map the block revert to `CeloEpochProcessingActive` instead of the raw RPC error, covering the race where the block starts after the status check.
- **i18n (en)**: added `errors.CeloEpochProcessingActive` (title + description) to LLD `app.json` and LLM `common.json`.
- **Tests**: `isEpochBlockRevert` cases; `getTransactionStatus` blocked / not-blocked / precedence-over-NotEnoughBalance / transient-probe; `buildTransaction` vote-block classification + non-vote passthrough.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-32861](https://ledgerhq.atlassian.net/browse/LIVE-32861)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
