### PR TITLE
[LWD] feat(contacts): add populated contact detail

### DIFF
--- a/.changeset/live-33940-populated-contact-detail.md
+++ b/.changeset/live-33940-populated-contact-detail.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Add populated contact detail with network-grouped address rows, crypto icons, and shared address detail dialog.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -8,7 +8,15 @@ import {
   mockMeContact,
   mockPopulatedContacts,
 } from "@domain/entity-contact/schema.mock";
-import { act, fireEvent, render, screen, withFlagOverrides, waitFor } from "tests/testSetup";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  within,
+  withFlagOverrides,
+  waitFor,
+} from "tests/testSetup";
 import ContactsScreen, { ContactsButton } from "LLD/features/Contacts";
 import { useContactsViewModel } from "LLD/features/Contacts/screens/Contacts/useContactsViewModel";
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
@@ -570,7 +578,7 @@ describe("Contacts integration", () => {
     expect(store.getState().modularDialog.isOpen).toBe(false);
   });
 
-  it("should not render the detail state when a contact with addresses is selected", async () => {
+  it("should render populated contact detail when a contact with addresses is selected", async () => {
     const { user } = render(
       <MemoryRouter initialEntries={["/contacts"]}>
         <Routes>
@@ -585,11 +593,62 @@ describe("Contacts integration", () => {
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
 
-    expect(screen.queryByTestId("contacts-detail-screen")).not.toBeInTheDocument();
-    expect(screen.getByTestId("contacts-detail-pane")).toBeEmptyDOMElement();
+    const detailScreen = screen.getByTestId("contacts-detail-screen");
+    expect(detailScreen).toBeVisible();
+    expect(within(detailScreen).getByText("2 addresses")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-address-list")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-network-group-ethereum")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-network-group-polygon")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-address-row-address-ethereum")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-address-row-address-polygon")).toBeInTheDocument();
   });
 
-  it("should clear the detail state when selecting a contact with addresses after an empty contact", async () => {
+  it("should open the address detail dialog when an address row is clicked", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+    await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
+
+    expect(screen.getByTestId("contacts-address-detail-dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-address-detail-full-address")).toHaveTextContent(
+      "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    );
+  });
+
+  it("should close the address detail dialog when switching contacts", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({ contacts: { contacts: mockPopulatedContacts() } }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+    await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
+
+    expect(screen.getByTestId("contacts-address-detail-dialog")).toBeVisible();
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ada"));
+
+    expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
+  });
+
+  it("should switch populated detail when selecting another contact with addresses", async () => {
     const { user } = render(
       <MemoryRouter initialEntries={["/contacts"]}>
         <Routes>
@@ -604,10 +663,13 @@ describe("Contacts integration", () => {
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ada"));
     expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    expect(screen.getByText("No saved addresses for Ada")).toBeInTheDocument();
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
 
-    expect(screen.queryByTestId("contacts-detail-screen")).not.toBeInTheDocument();
-    expect(screen.getByTestId("contacts-detail-pane")).toBeEmptyDOMElement();
+    const detailScreen = screen.getByTestId("contacts-detail-screen");
+    expect(detailScreen).toBeVisible();
+    expect(within(detailScreen).getByText("2 addresses")).toBeInTheDocument();
+    expect(screen.queryByText("No saved addresses for Ada")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsAddressCurrencyAdapter.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsAddressCurrencyAdapter.test.ts
@@ -1,0 +1,32 @@
+import { renderHook } from "@testing-library/react";
+import { mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { useContactsAddressCurrencyAdapter } from "./useContactsAddressCurrencyAdapter";
+
+describe("useContactsAddressCurrencyAdapter", () => {
+  it("returns the native currency id for known crypto currencies", () => {
+    const { result } = renderHook(() => useContactsAddressCurrencyAdapter());
+
+    expect(result.current.resolveNetworkId(getCryptoCurrencyById("ethereum").id)).toBe("ethereum");
+  });
+
+  it("resolves token parent networks for grouping", () => {
+    const { result } = renderHook(() => useContactsAddressCurrencyAdapter());
+
+    expect(
+      result.current.resolveNetworkId(
+        mockContactAddress({ currencyId: "ethereum/erc20/usd-coin" }).currencyId,
+      ),
+    ).toBe("ethereum");
+  });
+
+  it("returns undefined for unknown currency ids", () => {
+    const { result } = renderHook(() => useContactsAddressCurrencyAdapter());
+
+    expect(
+      result.current.resolveNetworkId(
+        mockContactAddress({ currencyId: "unknown-currency-id" }).currencyId,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsAddressCurrencyAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsAddressCurrencyAdapter.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import type { ContactAddress } from "@domain/entity-contact";
+import { findCryptoCurrencyById, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "@features/flow-contacts";
+
+function resolveNetworkId(
+  currencyId: ContactAddress["currencyId"],
+): CryptoCurrency["id"] | undefined {
+  const cryptoCurrency = findCryptoCurrencyById(currencyId);
+
+  if (cryptoCurrency) {
+    return cryptoCurrency.id;
+  }
+
+  const parentCurrencyId = currencyId.split("/")[0];
+  const parentCurrency = findCryptoCurrencyById(parentCurrencyId);
+
+  return parentCurrency?.id;
+}
+
+export function useContactsAddressCurrencyAdapter(): ContactAddressCurrencyPort {
+  return useMemo(
+    () => ({
+      resolveNetworkId,
+    }),
+    [],
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import {
+  ContactAddressDetailDialog,
   ContactsAddContactDialog,
   ContactsListView,
+  type ContactAddressDetailDialogProps,
   type ContactsAddContactDialogProps,
   type ContactsListViewProps,
 } from "@features/flow-contacts";
@@ -9,13 +11,19 @@ import {
 export type ContactsViewProps = ContactsListViewProps &
   Readonly<{
     addContactDialog: ContactsAddContactDialogProps;
+    addressDetailDialog: ContactAddressDetailDialogProps;
   }>;
 
-export function ContactsView({ addContactDialog, ...pageProps }: Readonly<ContactsViewProps>) {
+export function ContactsView({
+  addContactDialog,
+  addressDetailDialog,
+  ...pageProps
+}: Readonly<ContactsViewProps>) {
   return (
     <>
       <ContactsListView {...pageProps} />
       <ContactsAddContactDialog {...addContactDialog} />
+      <ContactAddressDetailDialog {...addressDetailDialog} />
     </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -1,25 +1,39 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { Contact, ContactId } from "@domain/entity-contact";
+import type { ContactId } from "@domain/entity-contact";
 import {
   useEmptyContactDetail,
+  usePopulatedContactDetail,
+  useContactAddressDetailDialog,
+  type ContactAddressDetailDialogLabels,
+  type ContactAddressDetailDialogProps,
   type ContactDetailLabels,
   type ContactDetailViewProps,
   type ContactsListViewProps,
 } from "@features/flow-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
+import { useContactsAddressCurrencyAdapter } from "../../hooks/useContactsAddressCurrencyAdapter";
 
 export function useContactDetailPaneAdapter(
-  contacts: readonly Contact[],
   onAddAddress: (contactId: ContactId) => void,
 ): Readonly<{
   detail: ContactDetailViewProps | undefined;
+  addressDetailDialog: ContactAddressDetailDialogProps;
   onOpenMe: ContactsListViewProps["onOpenMe"];
   onOpenContact: ContactsListViewProps["onOpenContact"];
 }> {
   const { t } = useTranslation();
+  const currencyPort = useContactsAddressCurrencyAdapter();
   const [detailContactId, setDetailContactId] = useState<ContactId | undefined>();
-  const selectedContact = useEmptyContactDetail(detailContactId);
+  const emptyContact = useEmptyContactDetail(detailContactId);
+  const populatedContactDetail = usePopulatedContactDetail(detailContactId, currencyPort);
+  const {
+    isOpen,
+    selection,
+    onAddressRowPress,
+    onClose: onCloseAddressDetail,
+    clearSelection,
+  } = useContactAddressDetailDialog(populatedContactDetail);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
@@ -31,40 +45,74 @@ export function useContactDetailPaneAdapter(
     }),
     [t],
   );
-  const onOpenMe = useCallback<ContactsListViewProps["onOpenMe"]>(contactId => {
-    setDetailContactId(contactId);
-  }, []);
-  const onOpenContact = useCallback<ContactsListViewProps["onOpenContact"]>(
-    contactId => {
-      const isEmptyContact = contacts.some(
-        contact => contact.id === contactId && contact.addresses.length === 0,
-      );
-
-      if (!isEmptyContact) {
-        setDetailContactId(undefined);
-        return;
-      }
-
+  const addressDetailDialogLabels = useMemo<ContactAddressDetailDialogLabels>(
+    () => ({
+      send: t("contacts.addressDetail.send"),
+      copy: t("contacts.addressDetail.copy"),
+      copied: t("contacts.addressDetail.copied"),
+      edit: t("contacts.addressDetail.edit"),
+      delete: t("contacts.addressDetail.delete"),
+      formatNetworkTag: networkName =>
+        t("contacts.addressDetail.networkTag", { name: networkName }),
+    }),
+    [t],
+  );
+  const openContact = useCallback(
+    (contactId: ContactId) => {
       setDetailContactId(contactId);
+      clearSelection();
     },
-    [contacts],
+    [clearSelection],
   );
   const detail = useMemo<ContactDetailViewProps | undefined>(() => {
-    if (!selectedContact) {
+    const baseDetail = {
+      labels,
+      meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
+    };
+
+    if (populatedContactDetail) {
+      return {
+        ...baseDetail,
+        contact: populatedContactDetail.contact,
+        onAddAddress: () => onAddAddress(populatedContactDetail.contact.id),
+        addressGroups: populatedContactDetail.addressGroups,
+        onAddressRowPress,
+      };
+    }
+
+    if (!emptyContact) {
       return undefined;
     }
 
     return {
-      contact: selectedContact,
-      labels,
-      meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
-      onAddAddress: () => onAddAddress(selectedContact.id),
+      ...baseDetail,
+      contact: emptyContact,
+      onAddAddress: () => onAddAddress(emptyContact.id),
     };
-  }, [labels, onAddAddress, selectedContact]);
+  }, [emptyContact, labels, onAddAddress, onAddressRowPress, populatedContactDetail]);
+  const addressDetailDialog = useMemo<ContactAddressDetailDialogProps>(
+    () => ({
+      isOpen,
+      contactName: populatedContactDetail?.contact.name ?? "",
+      row: selection?.row,
+      network: selection?.network,
+      labels: addressDetailDialogLabels,
+      onClose: onCloseAddressDetail,
+    }),
+    [
+      addressDetailDialogLabels,
+      isOpen,
+      onCloseAddressDetail,
+      populatedContactDetail?.contact.name,
+      selection?.network,
+      selection?.row,
+    ],
+  );
 
   return {
     detail,
-    onOpenMe,
-    onOpenContact,
+    addressDetailDialog,
+    onOpenMe: openContact,
+    onOpenContact: openContact,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -13,6 +13,7 @@ import {
   useContactsFeatureIntroductionState,
   useContactsMeContact,
   type AddAddressFlowState,
+  type ContactAddressDetailDialogProps,
   type ContactsLedgerSyncStatus,
   type ContactsListViewLabels,
   type ContactsListViewProps,
@@ -25,6 +26,7 @@ import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
 export type ContactsPageViewModel = Omit<ContactsListViewProps, "onAddContact"> &
   Readonly<{
     addAddressFlowState: AddAddressFlowState;
+    addressDetailDialog: ContactAddressDetailDialogProps;
     onClearSearch: () => void;
   }>;
 
@@ -60,7 +62,8 @@ export function useContactsViewModel(): ContactsPageViewModel {
     },
     [closeAddAddress, completeCurrencySelection, selectCurrency, startAddAddress],
   );
-  const { detail, onOpenMe, onOpenContact } = useContactDetailPaneAdapter(contacts, onAddAddress);
+  const { detail, addressDetailDialog, onOpenMe, onOpenContact } =
+    useContactDetailPaneAdapter(onAddAddress);
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const preference = useContactsFeatureIntroductionPreference();
@@ -123,6 +126,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
 
   return {
     addAddressFlowState,
+    addressDetailDialog,
     viewModel,
     labels,
     searchQuery,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9383,6 +9383,14 @@
         "contactDescription": "Save their wallet addresses to send to them by name next time."
       }
     },
+    "addressDetail": {
+      "send": "Send",
+      "copy": "Copy",
+      "copied": "Copied",
+      "edit": "Edit",
+      "delete": "Delete",
+      "networkTag": "{{name}} Network"
+    },
     "ledgerSyncIntroduction": {
       "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
       "dismiss": "Got it"

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -25,6 +25,7 @@
     "@domain/entity-contact": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
+    "@ledgerhq/crypto-icons": "catalog:",
     "@features/platform-feature-flags": "workspace:^",
     "@shared/feature-flags": "workspace:^"
   },

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  mockContact,
+  mockContactAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { createContactDetailAddressRowIntent } from "./model/viewModel";
 import type { ContactDetailLabels } from "./types";
 import { ContactDetailView } from "./ContactDetailView.web";
 
@@ -46,6 +52,54 @@ describe("ContactDetailView", () => {
     expect(
       screen.getByText("Save their wallet addresses to send to them by name next time."),
     ).toBeInTheDocument();
+  });
+
+  it("should render populated address rows when provided", () => {
+    const contact = mockContact({
+      id: "contact-benoit",
+      name: "Benoit",
+      addresses: [mockContactAddress()],
+    });
+    const address = contact.addresses[0]!;
+    const handleAddressRowPress = jest.fn();
+
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={contact}
+        addressGroups={[
+          {
+            networkId: getCryptoCurrencyById("ethereum").id,
+            networkName: getCryptoCurrencyById("ethereum").name,
+            networkTicker: getCryptoCurrencyById("ethereum").ticker,
+            rows: [
+              {
+                addressId: address.id,
+                label: address.label,
+                address: address.address,
+                currencyId: address.currencyId,
+                intent: createContactDetailAddressRowIntent(contact.id, address.id),
+              },
+            ],
+          },
+        ]}
+        onAddressRowPress={handleAddressRowPress}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-detail-address-list")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-network-group-ethereum")).toBeVisible();
+    expect(screen.getByTestId(`contacts-detail-address-row-${address.id}`)).toBeVisible();
+    expect(screen.getByText("1 address")).toBeVisible();
+    expect(screen.queryByTestId("contacts-detail-empty-state")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId(`contacts-detail-address-row-${address.id}`));
+
+    expect(handleAddressRowPress).toHaveBeenCalledWith({
+      type: "open-address-detail",
+      contactId: contact.id,
+      addressId: address.id,
+    });
   });
 
   it("should request adding an address when the action is pressed", () => {

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { ContactDetailViewProps } from "./types";
+import { ContactDetailAddressList } from "./components/ContactDetailAddressList/ContactDetailAddressList.web";
 import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.web";
 import { ContactDetailHeader } from "./components/ContactDetailHeader.web";
 
@@ -8,16 +9,31 @@ export function ContactDetailView({
   labels,
   meAvatarSrc,
   onAddAddress,
+  addressGroups,
+  onAddressRowPress,
 }: ContactDetailViewProps): React.ReactNode {
+  const hasPopulatedAddresses =
+    addressGroups !== undefined && onAddressRowPress !== undefined;
+
   return (
-    <div className="flex h-full flex-col" data-testid="contacts-detail-screen">
+    <div
+      className="flex h-full flex-col gap-32 px-16 py-32"
+      data-testid="contacts-detail-screen"
+    >
       <ContactDetailHeader
         contact={contact}
         labels={labels}
         meAvatarSrc={meAvatarSrc}
         onAddAddress={onAddAddress}
       />
-      <ContactDetailEmptyState contact={contact} labels={labels} />
+      {hasPopulatedAddresses ? (
+        <ContactDetailAddressList
+          addressGroups={addressGroups}
+          onAddressRowPress={onAddressRowPress}
+        />
+      ) : (
+        <ContactDetailEmptyState contact={contact} labels={labels} />
+      )}
     </div>
   );
 }

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.web.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { TileButton } from "@ledgerhq/lumen-ui-react";
+import {
+  ArrowUp,
+  Check,
+  Copy,
+  PenEdit,
+  Trash,
+} from "@ledgerhq/lumen-ui-react/symbols";
+import type { ContactAddressDetailDialogLabels } from "./types";
+
+type ContactAddressDetailActionsProps = Readonly<{
+  labels: ContactAddressDetailDialogLabels;
+  hasCopied: boolean;
+  onCopy: () => void;
+}>;
+
+export function ContactAddressDetailActions({
+  labels,
+  hasCopied,
+  onCopy,
+}: ContactAddressDetailActionsProps): React.ReactNode {
+  return (
+    <div className="grid w-full grid-cols-4 gap-8">
+      <TileButton icon={ArrowUp} isFull disabled>
+        {labels.send}
+      </TileButton>
+      <TileButton
+        icon={hasCopied ? Check : Copy}
+        onClick={onCopy}
+        data-testid="contacts-address-detail-copy"
+        isFull
+      >
+        {hasCopied ? labels.copied : labels.copy}
+      </TileButton>
+      <TileButton icon={PenEdit} isFull disabled>
+        {labels.edit}
+      </TileButton>
+      <TileButton
+        icon={Trash}
+        appearance="red"
+        data-testid="contacts-address-detail-delete"
+        isFull
+        disabled
+      >
+        {labels.delete}
+      </TileButton>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.web.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { createContactDetailAddressRowIntent } from "../../model/viewModel";
+import { ContactAddressDetailDialog } from "./ContactAddressDetailDialog.web";
+import type { ContactAddressDetailDialogProps } from "./types";
+
+function createProps(
+  overrides: Partial<ContactAddressDetailDialogProps> = {},
+): ContactAddressDetailDialogProps {
+  const contact = mockContact({
+    id: "contact-ben",
+    name: "Ben",
+    addresses: [mockContactAddress({ id: "address-ethereum", currencyId: "ethereum" })],
+  });
+  const address = contact.addresses[0]!;
+  const row = {
+    addressId: address.id,
+    label: address.label,
+    address: address.address,
+    currencyId: address.currencyId,
+    intent: createContactDetailAddressRowIntent(contact.id, address.id),
+  };
+  const network = {
+    networkId: getCryptoCurrencyById("ethereum").id,
+    networkName: getCryptoCurrencyById("ethereum").name,
+    networkTicker: getCryptoCurrencyById("ethereum").ticker,
+    rows: [row],
+  };
+
+  return {
+    isOpen: true,
+    contactName: contact.name,
+    row,
+    network,
+    labels: {
+      send: "Send",
+      copy: "Copy",
+      copied: "Copied",
+      edit: "Edit",
+      delete: "Delete",
+      formatNetworkTag: name => `${name} Network`,
+    },
+    onClose: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactAddressDetailDialog", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should render the selected address details", () => {
+    render(<ContactAddressDetailDialog {...createProps()} />);
+
+    expect(screen.getByTestId("contacts-address-detail-dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-address-detail-full-address")).toHaveTextContent(
+      "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    );
+    expect(screen.getByTestId("contacts-address-detail-network-tag")).toHaveAttribute(
+      "label",
+      "Ethereum Network",
+    );
+  });
+
+  it("should copy the address and show copied feedback", async () => {
+    render(<ContactAddressDetailDialog {...createProps()} />);
+
+    fireEvent.click(screen.getByTestId("contacts-address-detail-copy"));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-address-detail-copy")).toHaveTextContent("Copied");
+    });
+
+    jest.advanceTimersByTime(3000);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-address-detail-copy")).toHaveTextContent("Copy");
+    });
+  });
+
+  it("should render nothing when row or network is missing", () => {
+    const { container } = render(
+      <ContactAddressDetailDialog {...createProps({ row: undefined })} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.web.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+} from "@ledgerhq/lumen-ui-react";
+import { ContactAddressDetailActions } from "./ContactAddressDetailActions.web";
+import { ContactAddressDetailSummary } from "./ContactAddressDetailSummary.web";
+import type { ContactAddressDetailDialogProps } from "./types";
+
+const COPY_FEEDBACK_MS = 3000;
+
+export function ContactAddressDetailDialog({
+  isOpen,
+  contactName,
+  row,
+  network,
+  labels,
+  onClose,
+}: ContactAddressDetailDialogProps): React.ReactNode {
+  const [hasCopied, setHasCopied] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHasCopied(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!hasCopied) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setHasCopied(false), COPY_FEEDBACK_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [hasCopied]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
+
+  const handleCopy = async () => {
+    if (row === undefined) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(row.address);
+    setHasCopied(true);
+  };
+
+  if (row === undefined || network === undefined) {
+    return null;
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="w-[400px] bg-canvas-sheet"
+        data-testid="contacts-address-detail-dialog"
+      >
+        <DialogHeader title={contactName} onClose={onClose} />
+        <DialogBody className="flex flex-col items-center gap-40 p-24">
+          <ContactAddressDetailSummary
+            row={row}
+            network={network}
+            formatNetworkTag={labels.formatNetworkTag}
+          />
+          <ContactAddressDetailActions
+            labels={labels}
+            hasCopied={hasCopied}
+            onCopy={() => void handleCopy()}
+          />
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailSummary.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailSummary.web.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { Tag } from "@ledgerhq/lumen-ui-react";
+import { resolveContactAddressIconProps } from "../../model/resolveContactAddressIcon";
+import type { ContactAddressDetailDialogProps } from "./types";
+
+const ADDRESS_ICON_SIZE = 64;
+
+type ContactAddressDetailSummaryProps = Readonly<{
+  row: NonNullable<ContactAddressDetailDialogProps["row"]>;
+  network: NonNullable<ContactAddressDetailDialogProps["network"]>;
+  formatNetworkTag: ContactAddressDetailDialogProps["labels"]["formatNetworkTag"];
+}>;
+
+export function ContactAddressDetailSummary({
+  row,
+  network,
+  formatNetworkTag,
+}: ContactAddressDetailSummaryProps): React.ReactNode {
+  const iconProps = resolveContactAddressIconProps(
+    row.currencyId,
+    row.label,
+    network.networkId,
+  );
+
+  return (
+    <div className="flex flex-col items-center gap-32">
+      <CryptoIcon
+        ledgerId={iconProps.ledgerId}
+        ticker={iconProps.ticker}
+        network={iconProps.network}
+        size={ADDRESS_ICON_SIZE}
+        shape="circle"
+      />
+      <div className="flex flex-col items-center gap-8">
+        <Tag
+          appearance="gray"
+          size="sm"
+          label={formatNetworkTag(network.networkName)}
+          data-testid="contacts-address-detail-network-tag"
+        />
+        <div className="flex flex-col items-center text-center">
+          <p className="heading-3-semi-bold text-base">{row.label}</p>
+          <p
+            className="body-2 break-all text-muted"
+            data-testid="contacts-address-detail-full-address"
+          >
+            {row.address}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/types.ts
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/types.ts
@@ -1,0 +1,19 @@
+import type { ContactDetailAddressNetworkGroup, ContactDetailAddressRow } from "../../types";
+
+export type ContactAddressDetailDialogLabels = Readonly<{
+  send: string;
+  copy: string;
+  copied: string;
+  edit: string;
+  delete: string;
+  formatNetworkTag: (networkName: string) => string;
+}>;
+
+export type ContactAddressDetailDialogProps = Readonly<{
+  isOpen: boolean;
+  contactName: string;
+  row: ContactDetailAddressRow | undefined;
+  network: ContactDetailAddressNetworkGroup | undefined;
+  labels: ContactAddressDetailDialogLabels;
+  onClose: () => void;
+}>;

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressList/ContactDetailAddressList.web.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import type {
+  ContactDetailAddressNetworkGroup,
+  ContactDetailAddressRowIntent,
+} from "../../types";
+import { ContactDetailAddressNetworkSection } from "../ContactDetailAddressNetworkSection/ContactDetailAddressNetworkSection.web";
+
+type ContactDetailAddressListProps = Readonly<{
+  addressGroups: readonly ContactDetailAddressNetworkGroup[];
+  onAddressRowPress: (intent: ContactDetailAddressRowIntent) => void;
+}>;
+
+export function ContactDetailAddressList({
+  addressGroups,
+  onAddressRowPress,
+}: ContactDetailAddressListProps): React.ReactNode {
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col gap-24 overflow-y-auto"
+      data-testid="contacts-detail-address-list"
+    >
+      {addressGroups.map((group) => (
+        <ContactDetailAddressNetworkSection
+          key={group.networkId}
+          group={group}
+          onAddressRowPress={onAddressRowPress}
+        />
+      ))}
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressNetworkSection/ContactDetailAddressNetworkSection.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressNetworkSection/ContactDetailAddressNetworkSection.web.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import type { ContactDetailAddressNetworkGroup, ContactDetailAddressRowIntent } from "../../types";
+import { ContactDetailAddressRow as ContactDetailAddressRowView } from "../ContactDetailAddressRow/ContactDetailAddressRow.web";
+
+type ContactDetailAddressNetworkSectionProps = Readonly<{
+  group: ContactDetailAddressNetworkGroup;
+  onAddressRowPress: (intent: ContactDetailAddressRowIntent) => void;
+}>;
+
+export function ContactDetailAddressNetworkSection({
+  group,
+  onAddressRowPress,
+}: ContactDetailAddressNetworkSectionProps): React.ReactNode {
+  return (
+    <section
+      className="flex flex-col gap-8"
+      data-testid={`contacts-detail-network-group-${group.networkId}`}
+    >
+      <div className="flex items-center gap-8 px-8">
+        <CryptoIcon
+          ledgerId={group.networkId}
+          ticker={group.networkTicker}
+          size={16}
+          shape="square"
+        />
+        <p className="body-2 text-muted">{group.networkName}</p>
+      </div>
+      <div className="flex flex-col overflow-hidden rounded-lg">
+        {group.rows.map(row => (
+          <ContactDetailAddressRowView
+            key={row.addressId}
+            row={row}
+            networkId={group.networkId}
+            onPress={onAddressRowPress}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressRow/ContactDetailAddressRow.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAddressRow/ContactDetailAddressRow.web.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemDescription,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-react";
+import { MoreHorizontal } from "@ledgerhq/lumen-ui-react/symbols";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactDetailAddressRow } from "../../types";
+import { resolveContactAddressIconProps } from "../../model/resolveContactAddressIcon";
+import { truncateContactAddress } from "../../utils/truncateContactAddress";
+
+type ContactDetailAddressRowProps = Readonly<{
+  row: ContactDetailAddressRow;
+  networkId: CryptoCurrency["id"];
+  onPress: (intent: ContactDetailAddressRow["intent"]) => void;
+}>;
+
+export function ContactDetailAddressRow({
+  row,
+  networkId,
+  onPress,
+}: ContactDetailAddressRowProps): React.ReactNode {
+  const iconProps = resolveContactAddressIconProps(
+    row.currencyId,
+    row.label,
+    networkId,
+  );
+
+  return (
+    <ListItem
+      onClick={() => onPress(row.intent)}
+      className="bg-surface"
+      data-testid={`contacts-detail-address-row-${row.addressId}`}
+    >
+      <ListItemLeading>
+        <CryptoIcon
+          ledgerId={iconProps.ledgerId}
+          ticker={iconProps.ticker}
+          network={iconProps.network}
+          size={48}
+          shape="circle"
+        />
+        <ListItemContent>
+          <ListItemTitle>{row.label}</ListItemTitle>
+          <ListItemDescription>
+            {truncateContactAddress(row.address)}
+          </ListItemDescription>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <MoreHorizontal size={20} className="text-muted" aria-hidden />
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -1,5 +1,6 @@
 export { useEmptyContactDetail } from "./useEmptyContactDetail";
 export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+export { useContactAddressDetailDialog } from "./useContactAddressDetailDialog";
 export { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
 export type { UseContactDetailActionsViewModelResult } from "./useContactDetailActionsViewModel";
 export { useContactAddressDetail } from "./useContactAddressDetail";
@@ -36,6 +37,7 @@ export type {
   ContactAddressDetailViewModel,
   ContactDeleteLifecycle,
   ContactDetailActionsViewModel,
+  ContactDetailAddressNetworkGroup,
   ContactDetailAddressRow,
   ContactDetailAddressRowIntent,
   ContactDetailDeleteIntent,
@@ -44,3 +46,4 @@ export type {
   ContactDetailViewProps,
   PopulatedContactDetailViewModel,
 } from "./types";
+export type { ContactAddressDetailDialogLabels, ContactAddressDetailDialogProps } from "./components/ContactAddressDetailDialog/types";

--- a/features/flow/contacts/src/steps/Detail/model/findContactAddressDetailSelection.ts
+++ b/features/flow/contacts/src/steps/Detail/model/findContactAddressDetailSelection.ts
@@ -1,0 +1,25 @@
+import type { ContactAddressId } from "@domain/entity-contact";
+import type {
+  ContactDetailAddressNetworkGroup,
+  ContactDetailAddressRow,
+} from "../types";
+
+export type ContactAddressDetailSelection = Readonly<{
+  row: ContactDetailAddressRow;
+  network: ContactDetailAddressNetworkGroup;
+}>;
+
+export function findContactAddressDetailSelection(
+  addressGroups: readonly ContactDetailAddressNetworkGroup[],
+  addressId: ContactAddressId,
+): ContactAddressDetailSelection | undefined {
+  for (const group of addressGroups) {
+    const row = group.rows.find(addressRow => addressRow.addressId === addressId);
+
+    if (row !== undefined) {
+      return { row, network: group };
+    }
+  }
+
+  return undefined;
+}

--- a/features/flow/contacts/src/steps/Detail/model/findContactAddressDetailSelection.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/findContactAddressDetailSelection.web.test.ts
@@ -1,0 +1,51 @@
+import { createContactDetailAddressRowIntent } from "./viewModel";
+import { findContactAddressDetailSelection } from "./findContactAddressDetailSelection";
+import {
+  mockContact,
+  mockContactAddress,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+
+describe("findContactAddressDetailSelection", () => {
+  it("returns the selected row and its network group", () => {
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-ethereum",
+          currencyId: "ethereum",
+          label: "Ethereum",
+        }),
+      ],
+    });
+    const address = contact.addresses[0]!;
+    const row = {
+      addressId: address.id,
+      label: address.label,
+      address: address.address,
+      currencyId: address.currencyId,
+      intent: createContactDetailAddressRowIntent(contact.id, address.id),
+    };
+    const network = {
+      networkId: getCryptoCurrencyById("ethereum").id,
+      networkName: getCryptoCurrencyById("ethereum").name,
+      networkTicker: getCryptoCurrencyById("ethereum").ticker,
+      rows: [row],
+    };
+
+    expect(findContactAddressDetailSelection([network], address.id)).toEqual({
+      row,
+      network,
+    });
+  });
+
+  it("returns undefined when the address is not in any group", () => {
+    const contact = mockContact({
+      addresses: [mockContactAddress({ id: "address-ethereum" })],
+    });
+    const address = contact.addresses[0]!;
+
+    expect(
+      findContactAddressDetailSelection([], address.id),
+    ).toBeUndefined();
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/groupContactAddressRowsByNetwork.ts
+++ b/features/flow/contacts/src/steps/Detail/model/groupContactAddressRowsByNetwork.ts
@@ -1,0 +1,71 @@
+import {
+  findCryptoCurrencyById,
+  getCryptoCurrencyById,
+  type CryptoCurrency,
+} from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./ports";
+import type { ContactDetailAddressNetworkGroup, ContactDetailAddressRow } from "../types";
+
+export function groupContactAddressRowsByNetwork(
+  rows: readonly ContactDetailAddressRow[],
+  currencyPort: ContactAddressCurrencyPort,
+): readonly ContactDetailAddressNetworkGroup[] {
+  const groups: ContactDetailAddressNetworkGroup[] = [];
+
+  for (const row of rows) {
+    const networkId = currencyPort.resolveNetworkId(row.currencyId);
+    const groupKey = networkId ?? row.currencyId;
+    const lastGroup = groups.at(-1);
+    const lastGroupKey =
+      lastGroup === undefined
+        ? undefined
+        : (currencyPort.resolveNetworkId(lastGroup.rows[0]!.currencyId) ??
+          lastGroup.rows[0]!.currencyId);
+
+    if (lastGroup !== undefined && lastGroupKey === groupKey) {
+      groups[groups.length - 1] = {
+        ...lastGroup,
+        rows: [...lastGroup.rows, row],
+      };
+      continue;
+    }
+
+    groups.push(createNetworkGroup(row, networkId));
+  }
+
+  return groups;
+}
+
+function createNetworkGroup(
+  row: ContactDetailAddressRow,
+  networkId: CryptoCurrency["id"] | undefined,
+): ContactDetailAddressNetworkGroup {
+  if (networkId !== undefined) {
+    const network = getCryptoCurrencyById(networkId);
+
+    return {
+      networkId: network.id,
+      networkName: network.name,
+      networkTicker: network.ticker,
+      rows: [row],
+    };
+  }
+
+  const cryptoCurrency = findCryptoCurrencyById(row.currencyId);
+
+  if (cryptoCurrency !== undefined) {
+    return {
+      networkId: cryptoCurrency.id,
+      networkName: cryptoCurrency.name,
+      networkTicker: cryptoCurrency.ticker,
+      rows: [row],
+    };
+  }
+
+  return {
+    networkId: row.currencyId as CryptoCurrency["id"],
+    networkName: row.label,
+    networkTicker: row.label,
+    rows: [row],
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/groupContactAddressRowsByNetwork.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/groupContactAddressRowsByNetwork.web.test.ts
@@ -1,0 +1,103 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./ports";
+import { createContactDetailAddressRowIntent } from "./viewModel";
+import { groupContactAddressRowsByNetwork } from "./groupContactAddressRowsByNetwork";
+
+const currencyPort: ContactAddressCurrencyPort = {
+  resolveNetworkId: currencyId => {
+    if (currencyId === getCryptoCurrencyById("ethereum").id) {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("polygon").id) {
+      return getCryptoCurrencyById("polygon").id;
+    }
+
+    if (currencyId === "ethereum/erc20/usd-coin") {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    return undefined;
+  },
+};
+
+describe("groupContactAddressRowsByNetwork", () => {
+  it("groups consecutive rows by network while preserving row order inside each group", () => {
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-usdc",
+          currencyId: "ethereum/erc20/usd-coin",
+          label: "USDC",
+        }),
+        mockContactAddress({
+          id: "address-ethereum-base",
+          currencyId: "ethereum",
+          label: "Ethereum",
+        }),
+        mockContactAddress({
+          id: "address-polygon",
+          currencyId: "polygon",
+          label: "Polygon",
+        }),
+      ],
+    });
+
+    const rows = contact.addresses.map(address => ({
+      addressId: address.id,
+      label: address.label,
+      address: address.address,
+      currencyId: address.currencyId,
+      intent: createContactDetailAddressRowIntent(contact.id, address.id),
+    }));
+
+    expect(groupContactAddressRowsByNetwork(rows, currencyPort)).toEqual([
+      {
+        networkId: "ethereum",
+        networkName: getCryptoCurrencyById("ethereum").name,
+        networkTicker: getCryptoCurrencyById("ethereum").ticker,
+        rows: [rows[0], rows[1]],
+      },
+      {
+        networkId: "polygon",
+        networkName: getCryptoCurrencyById("polygon").name,
+        networkTicker: getCryptoCurrencyById("polygon").ticker,
+        rows: [rows[2]],
+      },
+    ]);
+  });
+
+  it("groups unknown-network rows instead of dropping them", () => {
+    const contact = mockContact({
+      addresses: [
+        mockContactAddress({
+          id: "address-unknown",
+          currencyId: "unknown-currency-id",
+          label: "Custom Asset",
+        }),
+      ],
+    });
+
+    const rows = contact.addresses.map(address => ({
+      addressId: address.id,
+      label: address.label,
+      address: address.address,
+      currencyId: address.currencyId,
+      intent: createContactDetailAddressRowIntent(contact.id, address.id),
+    }));
+
+    expect(groupContactAddressRowsByNetwork(rows, currencyPort)).toEqual([
+      {
+        networkId: "unknown-currency-id",
+        networkName: "Custom Asset",
+        networkTicker: "Custom Asset",
+        rows: [rows[0]],
+      },
+    ]);
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressIcon.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressIcon.ts
@@ -1,0 +1,30 @@
+import { findCryptoCurrencyById, type CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { ContactAddress } from "@domain/entity-contact";
+
+export type ContactAddressIconProps = Readonly<{
+  ledgerId: string;
+  ticker: string;
+  network?: CryptoCurrency["id"];
+}>;
+
+export function resolveContactAddressIconProps(
+  currencyId: ContactAddress["currencyId"],
+  label: ContactAddress["label"],
+  networkId: CryptoCurrency["id"],
+): ContactAddressIconProps {
+  const cryptoCurrency = findCryptoCurrencyById(currencyId);
+
+  if (cryptoCurrency) {
+    return {
+      ledgerId: cryptoCurrency.id,
+      ticker: cryptoCurrency.ticker,
+      network: cryptoCurrency.id === networkId ? undefined : networkId,
+    };
+  }
+
+  return {
+    ledgerId: currencyId,
+    ticker: label,
+    network: networkId,
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressIcon.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressIcon.web.test.ts
@@ -1,0 +1,64 @@
+import { mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { resolveContactAddressIconProps } from "./resolveContactAddressIcon";
+
+describe("resolveContactAddressIconProps", () => {
+  const ethereum = getCryptoCurrencyById("ethereum");
+  const unknownAddress = mockContactAddress({
+    currencyId: "unknown-currency-id",
+    label: "Custom Asset",
+  });
+
+  it("omits the network badge for native network currencies", () => {
+    const nativeAddress = mockContactAddress({
+      currencyId: "ethereum",
+      label: "Ethereum",
+    });
+
+    expect(
+      resolveContactAddressIconProps(
+        nativeAddress.currencyId,
+        nativeAddress.label,
+        ethereum.id,
+      ),
+    ).toEqual({
+      ledgerId: ethereum.id,
+      ticker: ethereum.ticker,
+      network: undefined,
+    });
+  });
+
+  it("shows the network badge when asset and network differ", () => {
+    const polygon = getCryptoCurrencyById("polygon");
+    const nativeAddress = mockContactAddress({
+      currencyId: "ethereum",
+      label: "Ethereum",
+    });
+
+    expect(
+      resolveContactAddressIconProps(
+        nativeAddress.currencyId,
+        nativeAddress.label,
+        polygon.id,
+      ),
+    ).toEqual({
+      ledgerId: "ethereum",
+      ticker: "ETH",
+      network: polygon.id,
+    });
+  });
+
+  it("falls back to the address label for unknown currency ids", () => {
+    expect(
+      resolveContactAddressIconProps(
+        unknownAddress.currencyId,
+        unknownAddress.label,
+        ethereum.id,
+      ),
+    ).toEqual({
+      ledgerId: unknownAddress.currencyId,
+      ticker: unknownAddress.label,
+      network: ethereum.id,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/viewModel.ts
@@ -1,6 +1,7 @@
 import type { Contact, ContactAddressId, ContactId } from "@domain/entity-contact";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { ContactAddressCurrencyPort } from "./ports";
+import { groupContactAddressRowsByNetwork } from "./groupContactAddressRowsByNetwork";
 import { sortContactAddressesByNetwork } from "./sortContactAddressesByNetwork";
 import type { ContactDetailAddressRow, PopulatedContactDetailViewModel } from "../types";
 
@@ -39,10 +40,14 @@ export function createPopulatedContactDetailViewModel(
     networkIds,
   );
 
+  const addressRows = orderedAddresses.map(address =>
+    createContactDetailAddressRow(contact, address),
+  );
+
   return {
     displayMode: "populated",
     contact,
     addressCount: contact.addresses.length,
-    addressRows: orderedAddresses.map(address => createContactDetailAddressRow(contact, address)),
+    addressGroups: groupContactAddressRowsByNetwork(addressRows, currencyPort),
   };
 }

--- a/features/flow/contacts/src/steps/Detail/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/viewModel.web.test.ts
@@ -123,12 +123,28 @@ describe("createPopulatedContactDetailViewModel", () => {
 
   it("orders address rows by network", () => {
     const contact = mockContactWithMultipleAddresses();
+    const viewModel = createPopulatedContactDetailViewModel(
+      contact,
+      currencyPort,
+      TEST_NETWORK_ORDER,
+    );
 
     expect(
-      createPopulatedContactDetailViewModel(contact, currencyPort, TEST_NETWORK_ORDER).addressRows.map(
-        row => row.addressId,
-      ),
+      viewModel.addressGroups.flatMap(group => group.rows.map(row => row.addressId)),
     ).toEqual(["address-ethereum", "address-polygon"]);
+  });
+
+  it("groups address rows by network", () => {
+    const contact = mockContactWithMultipleAddresses();
+    const viewModel = createPopulatedContactDetailViewModel(
+      contact,
+      currencyPort,
+      TEST_NETWORK_ORDER,
+    );
+
+    expect(viewModel.addressGroups.map(group => group.networkId)).toEqual(["ethereum", "polygon"]);
+    expect(viewModel.addressGroups[0]?.rows.map(row => row.addressId)).toEqual(["address-ethereum"]);
+    expect(viewModel.addressGroups[1]?.rows.map(row => row.addressId)).toEqual(["address-polygon"]);
   });
 
   it("exposes an open-address-detail intent on each row", () => {
@@ -145,7 +161,9 @@ describe("createPopulatedContactDetailViewModel", () => {
     const address = contact.addresses[0];
 
     expect(address).toBeDefined();
-    expect(createPopulatedContactDetailViewModel(contact, currencyPort).addressRows).toEqual([
+    expect(
+      createPopulatedContactDetailViewModel(contact, currencyPort).addressGroups[0]?.rows,
+    ).toEqual([
       {
         addressId: "address-ethereum",
         label: "Ethereum",

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -40,11 +40,18 @@ export type ContactDetailAddressRow = Readonly<{
   intent: ContactDetailAddressRowIntent;
 }>;
 
+export type ContactDetailAddressNetworkGroup = Readonly<{
+  networkId: CryptoCurrency["id"];
+  networkName: string;
+  networkTicker: string;
+  rows: readonly ContactDetailAddressRow[];
+}>;
+
 export type PopulatedContactDetailViewModel = Readonly<{
   displayMode: "populated";
   contact: Contact;
   addressCount: number;
-  addressRows: readonly ContactDetailAddressRow[];
+  addressGroups: readonly ContactDetailAddressNetworkGroup[];
 }>;
 
 export type ContactDetailLabels = Readonly<{
@@ -65,6 +72,8 @@ export type ContactDetailViewProps = Readonly<{
   meAvatarSrc: string;
   onAddAddress: () => void;
   onOpenLedgerWalletAddresses?: () => void;
+  addressGroups?: readonly ContactDetailAddressNetworkGroup[];
+  onAddressRowPress?: (intent: ContactDetailAddressRowIntent) => void;
 }>;
 
 export type ContactAddressDetailAsset = Readonly<{

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailDialog.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailDialog.ts
@@ -1,0 +1,51 @@
+import type { ContactAddressId } from "@domain/entity-contact";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { findContactAddressDetailSelection } from "./model/findContactAddressDetailSelection";
+import type {
+  ContactDetailAddressRowIntent,
+  PopulatedContactDetailViewModel,
+} from "./types";
+
+export function useContactAddressDetailDialog(
+  populatedContactDetail: PopulatedContactDetailViewModel | undefined,
+): Readonly<{
+  isOpen: boolean;
+  selection: ReturnType<typeof findContactAddressDetailSelection>;
+  onAddressRowPress: (intent: ContactDetailAddressRowIntent) => void;
+  onClose: () => void;
+  clearSelection: () => void;
+}> {
+  const [selectedAddressId, setSelectedAddressId] = useState<ContactAddressId | undefined>();
+
+  const clearSelection = useCallback(() => {
+    setSelectedAddressId(undefined);
+  }, []);
+  const onAddressRowPress = useCallback((intent: ContactDetailAddressRowIntent) => {
+    setSelectedAddressId(intent.addressId);
+  }, []);
+  const onClose = clearSelection;
+  const selection = useMemo(
+    () =>
+      selectedAddressId === undefined || populatedContactDetail === undefined
+        ? undefined
+        : findContactAddressDetailSelection(
+            populatedContactDetail.addressGroups,
+            selectedAddressId,
+          ),
+    [populatedContactDetail, selectedAddressId],
+  );
+
+  useEffect(() => {
+    if (selectedAddressId !== undefined && selection === undefined) {
+      setSelectedAddressId(undefined);
+    }
+  }, [selectedAddressId, selection]);
+
+  return {
+    isOpen: selection !== undefined,
+    selection,
+    onAddressRowPress,
+    onClose,
+    clearSelection,
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailDialog.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailDialog.web.test.tsx
@@ -1,0 +1,98 @@
+import { createElement, type ReactNode } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { ContactAddressIdSchema, contactsSlice } from "@domain/entity-contact";
+import {
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import type { ContactAddressCurrencyPort } from "./model/ports";
+import { createContactDetailAddressRowIntent } from "./model/viewModel";
+import { useContactAddressDetailDialog } from "./useContactAddressDetailDialog";
+import { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+
+const currencyPort: ContactAddressCurrencyPort = {
+  resolveNetworkId: currencyId => {
+    if (currencyId === getCryptoCurrencyById("ethereum").id) {
+      return getCryptoCurrencyById("ethereum").id;
+    }
+
+    if (currencyId === getCryptoCurrencyById("polygon").id) {
+      return getCryptoCurrencyById("polygon").id;
+    }
+
+    return undefined;
+  },
+};
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+describe("useContactAddressDetailDialog", () => {
+  it("opens the dialog when an address row is pressed", () => {
+    const contact = mockContactWithMultipleAddresses();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result: populatedResult } = renderHook(
+      () => usePopulatedContactDetail(contact.id, currencyPort),
+      { wrapper: Wrapper },
+    );
+    const populatedContactDetail = populatedResult.current;
+
+    expect(populatedContactDetail).toBeDefined();
+
+    const { result } = renderHook(() =>
+      useContactAddressDetailDialog(populatedContactDetail),
+    );
+
+    act(() => {
+      result.current.onAddressRowPress(
+        createContactDetailAddressRowIntent(
+          contact.id,
+          ContactAddressIdSchema.parse("address-ethereum"),
+        ),
+      );
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(result.current.selection?.row.addressId).toBe("address-ethereum");
+    expect(result.current.selection?.network.networkId).toBe("ethereum");
+  });
+
+  it("clears the dialog when closed", () => {
+    const contact = mockContactWithMultipleAddresses();
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result: populatedResult } = renderHook(
+      () => usePopulatedContactDetail(contact.id, currencyPort),
+      { wrapper: Wrapper },
+    );
+    const populatedContactDetail = populatedResult.current;
+    const { result } = renderHook(() =>
+      useContactAddressDetailDialog(populatedContactDetail),
+    );
+
+    act(() => {
+      result.current.onAddressRowPress(
+        createContactDetailAddressRowIntent(
+          contact.id,
+          ContactAddressIdSchema.parse("address-ethereum"),
+        ),
+      );
+    });
+    act(() => {
+      result.current.onClose();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.selection).toBeUndefined();
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.ts
+++ b/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.ts
@@ -11,11 +11,11 @@ import type { PopulatedContactDetailViewModel } from "./types";
 type ContactsStateRoot = Parameters<typeof selectContactById>[0];
 
 export function usePopulatedContactDetail(
-  contactId: ContactId,
+  contactId: ContactId | undefined,
   currencyPort: ContactAddressCurrencyPort,
 ): PopulatedContactDetailViewModel | undefined {
   const contact = useSelector((state: ContactsStateRoot) =>
-    selectContactById(state, contactId),
+    contactId ? selectContactById(state, contactId) : undefined,
   );
 
   return useMemo(() => {

--- a/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/usePopulatedContactDetail.web.test.tsx
@@ -75,7 +75,7 @@ describe("usePopulatedContactDetail", () => {
     expect(result.current).toBeUndefined();
   });
 
-  it("should expose address rows ordered by network", () => {
+  it("should expose address groups ordered by network", () => {
     const contact = mockContactWithMultipleAddresses();
     const Wrapper = makeWrapper([mockMeContact(), contact]);
     const { result } = renderHook(
@@ -83,9 +83,8 @@ describe("usePopulatedContactDetail", () => {
       { wrapper: Wrapper },
     );
 
-    expect(result.current?.addressRows.map(row => row.addressId)).toEqual([
-      "address-ethereum",
-      "address-polygon",
-    ]);
+    expect(
+      result.current?.addressGroups.flatMap(group => group.rows.map(row => row.addressId)),
+    ).toEqual(["address-ethereum", "address-polygon"]);
   });
 });

--- a/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.test.ts
+++ b/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.test.ts
@@ -1,0 +1,13 @@
+import { truncateContactAddress } from "./truncateContactAddress";
+
+describe("truncateContactAddress", () => {
+  it("returns short addresses unchanged", () => {
+    expect(truncateContactAddress("0x1234")).toBe("0x1234");
+  });
+
+  it("truncates long addresses with ellipsis", () => {
+    expect(truncateContactAddress("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034")).toBe(
+      "0x1ad23b...46c53034",
+    );
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.ts
+++ b/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.ts
@@ -1,0 +1,7 @@
+export function truncateContactAddress(address: string): string {
+  if (address.length <= 10) {
+    return address;
+  }
+
+  return `${address.slice(0, 8)}...${address.slice(-8)}`;
+}

--- a/features/flow/contacts/src/steps/Detail/web.ts
+++ b/features/flow/contacts/src/steps/Detail/web.ts
@@ -1,1 +1,2 @@
 export { ContactDetailView } from "./ContactDetailView.web";
+export { ContactAddressDetailDialog } from "./components/ContactAddressDetailDialog/ContactAddressDetailDialog.web";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4386,6 +4386,9 @@ importers:
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../../platform/feature-flags
+      '@ledgerhq/crypto-icons':
+        specifier: 'catalog:'
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(841e1162e8eaf064c6808dfad901f501))(@ledgerhq/lumen-ui-rnative@0.1.52(91c747930584a0677dd1168d06727d8c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@shared/feature-flags':
         specifier: workspace:^
         version: link:../../../shared/feature-flags
@@ -46386,6 +46389,16 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(841e1162e8eaf064c6808dfad901f501))(@ledgerhq/lumen-ui-rnative@0.1.52(91c747930584a0677dd1168d06727d8c))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-ui-react': 0.1.49(841e1162e8eaf064c6808dfad901f501)
+      '@ledgerhq/lumen-ui-rnative': 0.1.52(91c747930584a0677dd1168d06727d8c)
+      react-dom: 19.1.4(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
   '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

## Summary

Renders the **populated contact detail** state on Desktop when a contact has saved addresses (LIVE-33940).

Builds on the shared populated detail view model from `@features/flow-contacts` and adds:

- **Shared web UI** — address list grouped by network, with crypto icons on section headers (square) and rows (circle)
- **Desktop wiring** — currency port adapter, detail pane adapter, and integration with the contacts screen
- **Address detail dialog** — opens on row click; shows asset icon, network tag, label, full address, and action tiles (Send / Copy / Edit / Delete). Copy is functional; other actions are UI-only for now

## Changes

### `@features/flow-contacts`
- `ContactDetailView` switches between empty and populated states
- New components: `ContactDetailAddressList`, `ContactDetailAddressNetworkSection`, `ContactDetailAddressRow`
- `groupContactAddressRowsByNetwork` — groups network-ordered rows into sections
- `resolveContactAddressIconProps` — asset + network badge icon props
- Adds `@ledgerhq/crypto-icons` dependency

### `ledger-live-desktop`
- `useContactsAddressCurrencyAdapter` — resolves token parent networks for grouping/icons
- `useContactDetailPaneAdapter` — wires populated detail + address detail dialog state
- `ContactAddressDetailDialog` — mocked detail dialog (Lumen `Dialog`, `Tag`, `TileButton`)
- i18n keys under `contacts.addressDetail.*`
- Integration tests for populated detail, row click → dialog, and contact switching

## Test plan

- [ ] Open Contacts and select a contact **with saved addresses** — detail shows address count in header and network-grouped rows
- [ ] Select a contact **without addresses** — empty state still renders correctly
- [ ] Click an address row — address detail dialog opens with correct label, network tag, and full address
- [ ] Click **Copy** — address copied to clipboard; button shows "Copied" feedback
- [ ] Close dialog and switch to another contact with addresses — detail and dialog state update correctly
- [ ] Run unit tests: `pnpm nx test @features/flow-contacts`
- [ ] Run Desktop integration tests: `pnpm nx test ledger-live-desktop --testPathPattern=Contacts.integration`

## Notes

- Address detail dialog lives in Desktop (not shared flow), consistent with other Desktop-specific UI adapters
- Mobile populated detail is out of scope for this PR


https://github.com/user-attachments/assets/05ff3608-77c2-4ddf-967f-6b91c7c1a58c



### 🔗 Context

[LIVE-33940](https://ledgerhq.atlassian.net/browse/LIVE-33940)


[LIVE-33940]: https://ledgerhq.atlassian.net/browse/LIVE-33940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ