### PR TITLE
test(e2e): wallet 40 Q2 is the new default

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -93,7 +93,6 @@ on:
         type: choice
         options:
           - defaults
-          - wallet40-q2
         default: defaults
       feature_flags_json:
         description: "JSON to override feature flags"
@@ -214,8 +213,8 @@ env:
   SPECULOS_IMAGE_TAG_IOS: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && 'speculos-38ccc68068db-coinapps-83978f0' || 'latest' }}
   COINAPPS: ${{ github.workspace }}/coin-apps
   SPECULOS_DEVICE: ${{ inputs.speculos_device || 'nanoX' }}
-  ANDROID_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1,3,5' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
-  IOS_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2,4' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
+  ANDROID_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
+  IOS_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
   USERDATA_CACHE_ENABLED: ${{ !inputs.production_firebase }}
   E2E_GENERATED_USERDATA_DIR: ${{ !inputs.production_firebase && format('{0}/e2e/userdata/generated', github.workspace) || '' }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -70,7 +70,6 @@ on:
         type: choice
         options:
           - defaults
-          - wallet40-q2
         default: defaults
       feature_flags_json:
         description: "JSON to override feature flags (takes precedence if set)"
@@ -140,7 +139,7 @@ permissions:
   contents: read
 
 env:
-  E2E_DESKTOP_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 4 * * 2,4' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
+  E2E_DESKTOP_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
 
 jobs:

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -120,7 +120,7 @@ It is possible to choose an optional Feature Flag set for the test run.
 Set the env var to the desired value, eg:
 
 ```bash
-export E2E_DESKTOP_FEATURE_FLAGS="wallet40-q2"
+export E2E_DESKTOP_FEATURE_FLAGS="some-preset"
 ```
 
 Or use the "Choose a feature flag set" options dropdown on the Github workflow.

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -35,27 +35,6 @@ export const isAssetDiscoverabilityEnabled = async (page: Page): Promise<boolean
 
 export const useLocalEarnManifest = process.env.USE_LOCAL_EARN_MANIFEST === "1";
 
-export const FF_LWD_WALLET_40_Q1 = {
-  lwdWallet40: {
-    enabled: true,
-    params: {
-      newReceiveDialog: true,
-      lazyOnboarding: true,
-      assetSection: false,
-      brazePlacement: true,
-      operationsList: false,
-      aggregatedAssets: false,
-      myWallet: false,
-      pnl: false,
-      earnUpselling: false,
-      earnSimulator: false,
-      finishOnboardingWidget: false,
-      assetDiscoverability: false,
-      q2Tour: false,
-    },
-  },
-} satisfies OptionalFeatureMap;
-
 export const FF_LWD_WALLET_40_Q2 = {
   lwdWallet40: {
     enabled: true,
@@ -147,7 +126,7 @@ export const FF_NEW_SEND_FLOW_DISABLED = {
 export const getMergedFeatureFlags = ({
   testFlags,
 }: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffEnvMapping: Record<string, OptionalFeatureMap> = {
+  const ffPresetMap: Record<string, OptionalFeatureMap> = {
     /*
      * The keys here are the values of the `E2E_DESKTOP_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -155,7 +134,7 @@ export const getMergedFeatureFlags = ({
      * This will reduce friction and provide CI stability for any callers of the workflow.
      * PLEASE NOTE: non-existing keys will return 'undefined' which spreads to an empty object.
      */
-    "wallet40-q2": FF_LWD_WALLET_40_Q2,
+    defaults: {},
   };
 
   const defaultFlags: OptionalFeatureMap = {
@@ -177,9 +156,9 @@ export const getMergedFeatureFlags = ({
       },
     },
     // default flags for wallet 4.0
-    ...FF_LWD_WALLET_40_Q1,
+    ...FF_LWD_WALLET_40_Q2,
     // any flags from env variable (if set)
-    ...ffEnvMapping[process.env.E2E_DESKTOP_FEATURE_FLAGS || ""],
+    ...ffPresetMap[process.env.E2E_DESKTOP_FEATURE_FLAGS || ""],
   };
 
   // parse JSON override flags for any overrides

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -155,7 +155,7 @@ It is possible to choose an optional Feature Flag set for the test run.
 Set the env var to the desired value, eg:
 
 ```bash
-export E2E_MOBILE_FEATURE_FLAGS="wallet40-q2"
+export E2E_MOBILE_FEATURE_FLAGS="some-preset"
 ```
 
 Or use the "Choose a feature flag set" options dropdown on the Github workflow.

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -3,26 +3,6 @@ import { getFlags } from "../bridge/server";
 
 import type { OptionalFeatureMap, Features } from "@shared/feature-flags";
 
-export const FF_LWM_WALLET_40_Q1 = {
-  lwmWallet40: {
-    enabled: true,
-    params: {
-      tour: false,
-      lazyOnboarding: true,
-      assetSection: false,
-      brazePlacement: true,
-      operationsList: false,
-      aggregatedAssets: false,
-      myWallet: false,
-      earnUpselling: false,
-      earnSimulator: false,
-      onboardingWidget: false,
-      assetDiscoverability: false,
-      q2Tour: false,
-    },
-  },
-} satisfies OptionalFeatureMap;
-
 export const FF_LWM_WALLET_40_Q2 = {
   lwmWallet40: {
     enabled: true,
@@ -57,7 +37,7 @@ export const FF_NEW_SEND_FLOW_ENABLED = {
 export const getMergedFeatureFlags = ({
   testFlags,
 }: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffEnvMapping: Record<string, OptionalFeatureMap> = {
+  const ffPresetMap: Record<string, OptionalFeatureMap> = {
     /*
      * The keys here are the values of the `E2E_MOBILE_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -65,7 +45,7 @@ export const getMergedFeatureFlags = ({
      * This will reduce friction and provide CI stability for any callers of the workflow.
      * PLEASE NOTE: non-existing keys will return 'undefined' which spreads to an empty object.
      */
-    "wallet40-q2": FF_LWM_WALLET_40_Q2,
+    defaults: {},
   };
 
   const defaultFlags: OptionalFeatureMap = {
@@ -88,9 +68,9 @@ export const getMergedFeatureFlags = ({
       },
     },
     // default flags for wallet 4.0
-    ...FF_LWM_WALLET_40_Q1,
+    ...FF_LWM_WALLET_40_Q2,
     // any flags from env variable (if set)
-    ...ffEnvMapping[process.env.E2E_MOBILE_FEATURE_FLAGS || ""],
+    ...ffPresetMap[process.env.E2E_MOBILE_FEATURE_FLAGS || ""],
   };
 
   // parse JSON override flags for any overrides


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wallet 40 Q2 is the new default.
- Q2 will be the default for CI and local execution
- Q2 will be removed from the presets drop down
- Presets drop down will only have 'defaults' (which will set Q2)

Regression:
- [Desktop](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d95c28aa-c707-4845-bef3-5b67f4e4ad29/)
- [iOS](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/f23b7fc5-c086-4cb3-a00d-953cc362d639/)
- [Android](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/57b162f3-3f6c-48f0-b574-cb8dc9ab7d47/)

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/QAA-1430
