### PR TITLE
fix(ci): restore sonar coverage ingestion

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -86,7 +86,7 @@ devtools/registry/**,\
 features/platform/jest-config/**,\
 features/flow/**/jest.native.ts
 sonar.cpd.exclusions=libs/ledger-live-common/src/modularDrawer/hooks/useCurrenciesUnderFeatureFlag.ts,\
-libs/ledger-live-common/src/families/tron/bridge/api.ts,\
+libs/ledger-live-common/src/families/tron/bridge/api.ts
 sonar.javascript.lcov.reportPaths=lcov.info
 sonar.testExecutionReportPaths=sonar-executionTests-report.xml
 sonar.typescript.tsconfigPaths=tsconfig.base.json,apps/**/tsconfig.json,e2e/**/tsconfig.json,features/**/tsconfig.json,shared/**/tsconfig.json,domain/**/tsconfig.json,devtools/**/tsconfig.json


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset is required for this repository-level Sonar configuration fix.
- [x] **Covered by automatic tests.** The PR restores the existing LCOV reports already generated by the Desktop, Mobile, libraries, features, shared, and domain test jobs.
- [x] **Impact of the changes:**
      - SonarCloud LCOV ingestion
      - Pull request coverage quality gates

### 📝 Description

SonarCloud reported 0% coverage for tested new code because the LCOV report property was accidentally appended to `sonar.cpd.exclusions` when the final CPD exclusion was removed.

This PR terminates the CPD exclusion list correctly so this existing property is parsed independently again:

```properties
sonar.javascript.lcov.reportPaths=lcov.info
```

The existing Jest configurations, tests, and coverage collection remain unchanged.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35107

---

<img width="1820" height="1038" alt="image" src="https://github.com/user-attachments/assets/7cb7fe58-0bc1-4993-9ff3-2b94a8acb0b2" />

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
