### PR TITLE
[LWDM] getBlock support

### DIFF
--- a/.changeset/curly-melons-tickle.md
+++ b/.changeset/curly-melons-tickle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-concordium": minor
+---
+
+Implement getBlock (CoinModuleApi) using the wallet-proxy per-block transaction events endpoint, mapping CCD transfers to signed operations with decoded memos

--- a/libs/coin-modules/coin-concordium/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.integ.test.ts
@@ -114,6 +114,46 @@ describe("Concordium Api (testnet)", () => {
     });
   });
 
+  describe("getBlock", () => {
+    it("returns block info matching getBlockInfo and a list of transactions", async () => {
+      const lastBlock = await api.lastBlock();
+      const targetHeight = lastBlock.height - 10;
+
+      const [block, info] = await Promise.all([
+        api.getBlock(targetHeight),
+        api.getBlockInfo(targetHeight),
+      ]);
+
+      expect(block.info).toEqual(info);
+      expect(Array.isArray(block.transactions)).toBe(true);
+    });
+
+    it("maps a real CCD transfer to a signed operation pair with fees on the transaction", async () => {
+      const { items } = await api.listOperations(ADDRESS_WITH_BALANCE, {
+        minHeight: 0,
+        order: "desc",
+        limit: 20,
+      });
+      const transfer = items.find(op => !op.tx.failed && op.senders[0] && op.recipients[0]);
+      if (!transfer) {
+        throw new Error("no transfer found for ADDRESS_WITH_BALANCE to exercise getBlock");
+      }
+
+      const block = await api.getBlock(transfer.tx.block.height);
+      const tx = block.transactions.find(t => t.hash === transfer.tx.hash);
+
+      if (!tx) {
+        throw new Error(
+          `transaction ${transfer.tx.hash} not found in block ${transfer.tx.block.height}`,
+        );
+      }
+      expect(tx.failed).toBe(false);
+      expect(tx.fees).toBeGreaterThanOrEqual(BigInt(0));
+      const transferOps = tx.operations.filter(op => op.type === "transfer");
+      expect(transferOps.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
   describe("craftTransaction", () => {
     const RECIPIENT = ADDRESS_PRISTINE;
 
@@ -231,10 +271,6 @@ describe("Concordium Api (testnet)", () => {
   });
 
   describe("unsupported methods", () => {
-    it("getBlock throws not supported error", async () => {
-      await expect(async () => api.getBlock(100)).rejects.toThrow("getBlock is not supported");
-    });
-
     it("getStakes throws not supported error", async () => {
       await expect(async () => api.getStakes(ADDRESS_WITH_BALANCE)).rejects.toThrow();
     });

--- a/libs/coin-modules/coin-concordium/src/api/index.test.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.test.ts
@@ -10,6 +10,7 @@ jest.mock("../logic", () => ({
   craftRawTransaction: jest.fn(),
   estimateFees: jest.fn(),
   getBalance: jest.fn(),
+  getBlock: jest.fn(),
   getBlockInfo: jest.fn(),
   getNextValidSequence: jest.fn(),
   lastBlock: jest.fn(),
@@ -19,6 +20,7 @@ jest.mock("../logic", () => ({
 const {
   broadcast: broadcastMock,
   getBalance: getBalanceMock,
+  getBlock: getBlockMock,
   getBlockInfo: getBlockInfoMock,
   lastBlock: lastBlockMock,
   listOperations: listOperationsMock,
@@ -151,12 +153,23 @@ describe("api/index", () => {
     });
   });
 
-  describe("unsupported methods", () => {
-    it("should throw error for getBlock", () => {
+  describe("getBlock", () => {
+    it("should call getBlock with height and currency", async () => {
       const api = createApi(TESTNET_COIN_CONFIG, "concordium_testnet");
-      expect(() => api.getBlock(500)).toThrow("getBlock is not supported");
-    });
+      const mockBlock = {
+        info: { height: 600, hash: "block-600", time: new Date() },
+        transactions: [],
+      };
+      getBlockMock.mockResolvedValue(mockBlock);
 
+      const result = await api.getBlock(600);
+
+      expect(getBlockMock).toHaveBeenCalledWith(600, "concordium_testnet");
+      expect(result).toEqual(mockBlock);
+    });
+  });
+
+  describe("unsupported methods", () => {
     it("should throw error for getStakes", () => {
       const api = createApi(TESTNET_COIN_CONFIG, "concordium_testnet");
       expect(() => api.getStakes("address")).toThrow("getStakes is not supported");

--- a/libs/coin-modules/coin-concordium/src/api/index.ts
+++ b/libs/coin-modules/coin-concordium/src/api/index.ts
@@ -31,6 +31,7 @@ import {
   craftTransaction as craftTransactionLogic,
   estimateFees as estimateFeesLogic,
   getBalance,
+  getBlock,
   getBlockInfo,
   getNextValidSequence,
   lastBlock,
@@ -61,9 +62,7 @@ export function createApi(
     lastBlock: () => lastBlock(currencyId),
     listOperations: (address: string, options: ListOperationsOptions) =>
       listOperations(address, options, currencyId),
-    getBlock: (_height: number) => {
-      throw new Error("getBlock is not supported");
-    },
+    getBlock: (height: number) => getBlock(height, currencyId),
     getBlockInfo: (height: number) => getBlockInfo(height, currencyId),
     getStakes(_address: string, _cursor?: Cursor): Promise<Page<Stake>> {
       throw new Error("getStakes is not supported");

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlock.integ.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlock.integ.test.ts
@@ -1,0 +1,35 @@
+import { setupTestnetCoinConfig } from "../../test/fixtures";
+import { getBlock } from "./getBlock";
+import { getBlockInfo } from "./getBlockInfo";
+import { lastBlock } from "./lastBlock";
+
+const CURRENCY = "concordium_testnet";
+
+describe("getBlock", () => {
+  beforeAll(() => {
+    setupTestnetCoinConfig();
+  });
+
+  it("returns block info matching getBlockInfo and a well-formed transactions array", async () => {
+    // A recent finalized block, backed off from the tip to avoid the not-yet-finalized head.
+    const tip = await lastBlock(CURRENCY);
+    const height = tip.height - 10;
+
+    const [block, info] = await Promise.all([
+      getBlock(height, CURRENCY),
+      getBlockInfo(height, CURRENCY),
+    ]);
+
+    expect(block.info).toEqual(info);
+    expect(Array.isArray(block.transactions)).toBe(true);
+
+    for (const tx of block.transactions) {
+      expect(tx.hash).toMatch(/^[A-Fa-f0-9]{64}$/);
+      expect(typeof tx.failed).toBe("boolean");
+      expect(tx.fees >= BigInt(0)).toBe(true);
+      for (const op of tx.operations) {
+        expect(["transfer", "other"]).toContain(op.type);
+      }
+    }
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlock.test.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlock.test.ts
@@ -1,0 +1,295 @@
+import { getBlock } from "./getBlock";
+
+jest.mock("./getBlockInfo", () => ({
+  getBlockInfo: jest.fn(),
+}));
+
+jest.mock("../../network/proxyClient", () => ({
+  getBlockTransactionEvents: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/concordium-core", () => ({
+  decodeMemoFromCbor: jest.fn(),
+}));
+
+const { getBlockInfo: getBlockInfoMock } = jest.requireMock("./getBlockInfo");
+const { getBlockTransactionEvents: getBlockTransactionEventsMock } = jest.requireMock(
+  "../../network/proxyClient",
+);
+const { decodeMemoFromCbor: decodeMemoFromCborMock } = jest.requireMock(
+  "@ledgerhq/concordium-core",
+);
+
+const CURRENCY = "concordium_testnet";
+const SENDER = "3U6m951FWryY56SKFFHgMLGVHtJtk4VaxN7V2F9hjkR7Sg1FUx";
+const RECIPIENT = "4ox4d7b4S9Mi3qA696v3yYjBQB4f6GDEVATrH9oFnoHUd5zLgh";
+
+const BLOCK_INFO = {
+  height: 1000,
+  hash: "ab".repeat(32),
+  time: new Date("2024-01-12T00:00:00.000Z"),
+  parent: { height: 999, hash: "cd".repeat(32) },
+};
+
+const account = (address: string) => ({ type: "AddressAccount", address });
+
+describe("getBlock", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getBlockInfoMock.mockResolvedValue(BLOCK_INFO);
+    decodeMemoFromCborMock.mockReturnValue("");
+  });
+
+  it("reuses getBlockInfo for info and returns an empty transaction list for an empty block", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([]);
+
+    // WHEN
+    const result = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(getBlockInfoMock).toHaveBeenCalledWith(1000, CURRENCY);
+    expect(getBlockTransactionEventsMock).toHaveBeenCalledWith(CURRENCY, BLOCK_INFO.hash);
+    expect(result.info).toEqual(BLOCK_INFO);
+    expect(result.transactions).toEqual([]);
+  });
+
+  it("maps a Transferred event to a signed sender/recipient operation pair with fees on the transaction", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "aa".repeat(32),
+        sender: SENDER,
+        cost: "601",
+        result: {
+          outcome: "success",
+          events: [
+            {
+              tag: "Transferred",
+              amount: "1000000",
+              from: account(SENDER),
+              to: account(RECIPIENT),
+            },
+          ],
+        },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions).toEqual([
+      {
+        hash: "aa".repeat(32),
+        failed: false,
+        fees: 601n,
+        feesPayer: SENDER,
+        operations: [
+          {
+            type: "transfer",
+            address: SENDER,
+            peer: RECIPIENT,
+            asset: { type: "native" },
+            amount: -1000000n,
+          },
+          {
+            type: "transfer",
+            address: RECIPIENT,
+            peer: SENDER,
+            asset: { type: "native" },
+            amount: 1000000n,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("emits a single incoming operation with no peer when the sender is a contract", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "1a".repeat(32),
+        sender: SENDER,
+        cost: "400",
+        result: {
+          outcome: "success",
+          events: [
+            {
+              tag: "Transferred",
+              amount: "5000000",
+              from: { type: "AddressContract", address: { index: 1, subindex: 0 } },
+              to: account(RECIPIENT),
+            },
+          ],
+        },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions[0].operations).toEqual([
+      { type: "transfer", address: RECIPIENT, asset: { type: "native" }, amount: 5000000n },
+    ]);
+  });
+
+  it("emits no operations when both transfer parties are contracts", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "2b".repeat(32),
+        sender: SENDER,
+        cost: "400",
+        result: {
+          outcome: "success",
+          events: [
+            {
+              tag: "Transferred",
+              amount: "5000000",
+              from: { type: "AddressContract", address: { index: 1, subindex: 0 } },
+              to: { type: "AddressContract", address: { index: 2, subindex: 0 } },
+            },
+          ],
+        },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions[0].operations).toEqual([]);
+  });
+
+  it("decodes the memo of a TransferMemo event into the transaction details", async () => {
+    // GIVEN
+    decodeMemoFromCborMock.mockReturnValue("Hello");
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "bb".repeat(32),
+        sender: SENDER,
+        cost: "700",
+        result: {
+          outcome: "success",
+          events: [
+            {
+              tag: "Transferred",
+              amount: "2000000",
+              from: account(SENDER),
+              to: account(RECIPIENT),
+            },
+            { tag: "TransferMemo", memo: "6548656c6c6f" },
+          ],
+        },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(decodeMemoFromCborMock).toHaveBeenCalledWith(Buffer.from("6548656c6c6f", "hex"));
+    expect(transactions[0].details).toEqual({ memo: "Hello" });
+    expect(transactions[0].operations).toHaveLength(2);
+  });
+
+  it("keeps fees and marks rejected transactions as failed with no operations", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "cc".repeat(32),
+        sender: SENDER,
+        cost: "500",
+        result: { outcome: "reject", rejectReason: { tag: "AmountTooLarge" } },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions).toEqual([
+      { hash: "cc".repeat(32), failed: true, fees: 500n, feesPayer: SENDER, operations: [] },
+    ]);
+  });
+
+  it("represents non-transfer transaction types with no operations", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "dd".repeat(32),
+        sender: SENDER,
+        cost: "300",
+        type: { type: "accountTransaction", contents: "registerData" },
+        result: { outcome: "success", events: [{ tag: "DataRegistered", data: "abcd" }] },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions[0].operations).toEqual([]);
+    expect(transactions[0].failed).toBe(false);
+    expect(transactions[0].fees).toBe(300n);
+    expect(transactions[0].details).toBeUndefined();
+  });
+
+  it("skips the memo when CBOR decoding fails but keeps the transfer operations", async () => {
+    // GIVEN
+    decodeMemoFromCborMock.mockImplementation(() => {
+      throw new Error("bad cbor");
+    });
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "ee".repeat(32),
+        sender: SENDER,
+        cost: "700",
+        result: {
+          outcome: "success",
+          events: [
+            {
+              tag: "Transferred",
+              amount: "2000000",
+              from: account(SENDER),
+              to: account(RECIPIENT),
+            },
+            { tag: "TransferMemo", memo: "zz" },
+          ],
+        },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions[0].details).toBeUndefined();
+    expect(transactions[0].operations).toHaveLength(2);
+  });
+
+  it("omits feesPayer when the summary has no sender", async () => {
+    // GIVEN
+    getBlockTransactionEventsMock.mockResolvedValue([
+      {
+        hash: "ff".repeat(32),
+        sender: null,
+        cost: "0",
+        result: { outcome: "success", events: [] },
+      },
+    ]);
+
+    // WHEN
+    const { transactions } = await getBlock(1000, CURRENCY);
+
+    // THEN
+    expect(transactions[0]).toEqual({
+      hash: "ff".repeat(32),
+      failed: false,
+      fees: 0n,
+      operations: [],
+    });
+  });
+});

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
@@ -1,0 +1,104 @@
+import type {
+  Block,
+  BlockOperation,
+  BlockTransaction,
+} from "@ledgerhq/coin-module-framework/api/index";
+import { getBlockTransactionEvents } from "../../network/proxyClient";
+import type {
+  BlockTransactionEvent,
+  BlockTransactionSummary,
+  ConcordiumEventAddress,
+  TransferMemoEvent,
+  TransferredEvent,
+} from "../../types";
+import { getBlockInfo } from "./getBlockInfo";
+import { decodeMemo } from "./memo";
+
+const NATIVE_ASSET = { type: "native" } as const;
+
+/**
+ * Returns a full block (info + transactions) for a given height.
+ * `info` reuses the getBlockInfo logic (height → hash → info); transactions come
+ * from the per-block events endpoint and are mapped tag-by-tag.
+ */
+export async function getBlock(height: number, currencyId: string): Promise<Block> {
+  const info = await getBlockInfo(height, currencyId);
+  const summaries = await getBlockTransactionEvents(currencyId, info.hash);
+
+  return {
+    info,
+    transactions: summaries.map(toBlockTransaction),
+  };
+}
+
+function toBlockTransaction(summary: BlockTransactionSummary): BlockTransaction {
+  const { operations, memo } =
+    summary.result.outcome === "success"
+      ? mapEventsToOperations(summary.result.events, summary.hash)
+      : { operations: [] as BlockOperation[], memo: undefined };
+
+  return {
+    hash: summary.hash,
+    failed: summary.result.outcome === "reject",
+    fees: BigInt(summary.cost),
+    ...(summary.sender ? { feesPayer: summary.sender } : {}),
+    operations,
+    ...(memo ? { details: { memo } } : {}),
+  };
+}
+
+function mapEventsToOperations(
+  events: BlockTransactionEvent[],
+  txHash: string,
+): { operations: BlockOperation[]; memo: string | undefined } {
+  const operations: BlockOperation[] = [];
+  let memo: string | undefined;
+
+  // Tag-based dispatch; unknown tags (e.g. PLT, staking) intentionally emit no operations yet.
+  for (const event of events) {
+    if (isTransferredEvent(event)) {
+      operations.push(...toTransferOperations(event));
+    } else if (isTransferMemoEvent(event)) {
+      memo = decodeMemo(event.memo, txHash);
+    }
+  }
+
+  return { operations, memo };
+}
+
+function toTransferOperations(event: TransferredEvent): BlockOperation[] {
+  const from = accountAddress(event.from);
+  const to = accountAddress(event.to);
+  const amount = BigInt(event.amount);
+
+  const operations: BlockOperation[] = [];
+  if (from) {
+    operations.push({
+      type: "transfer",
+      address: from,
+      ...(to ? { peer: to } : {}),
+      asset: NATIVE_ASSET,
+      amount: -amount,
+    });
+  }
+  if (to) {
+    operations.push({
+      type: "transfer",
+      address: to,
+      ...(from ? { peer: from } : {}),
+      asset: NATIVE_ASSET,
+      amount,
+    });
+  }
+  return operations;
+}
+
+function accountAddress(address: ConcordiumEventAddress): string | undefined {
+  return address.type === "AddressAccount" ? address.address : undefined;
+}
+
+const isTransferredEvent = (event: BlockTransactionEvent): event is TransferredEvent =>
+  event.tag === "Transferred";
+
+const isTransferMemoEvent = (event: BlockTransactionEvent): event is TransferMemoEvent =>
+  event.tag === "TransferMemo";

--- a/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/getBlock.ts
@@ -5,8 +5,8 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { getBlockTransactionEvents } from "../../network/proxyClient";
 import type {
-  BlockTransactionEvent,
   BlockTransactionSummary,
+  TransactionEvent,
   ConcordiumEventAddress,
   TransferMemoEvent,
   TransferredEvent,
@@ -48,7 +48,7 @@ function toBlockTransaction(summary: BlockTransactionSummary): BlockTransaction 
 }
 
 function mapEventsToOperations(
-  events: BlockTransactionEvent[],
+  events: TransactionEvent[],
   txHash: string,
 ): { operations: BlockOperation[]; memo: string | undefined } {
   const operations: BlockOperation[] = [];
@@ -97,8 +97,8 @@ function accountAddress(address: ConcordiumEventAddress): string | undefined {
   return address.type === "AddressAccount" ? address.address : undefined;
 }
 
-const isTransferredEvent = (event: BlockTransactionEvent): event is TransferredEvent =>
+const isTransferredEvent = (event: TransactionEvent): event is TransferredEvent =>
   event.tag === "Transferred";
 
-const isTransferMemoEvent = (event: BlockTransactionEvent): event is TransferMemoEvent =>
+const isTransferMemoEvent = (event: TransactionEvent): event is TransferMemoEvent =>
   event.tag === "TransferMemo";

--- a/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/listOperations.ts
@@ -1,8 +1,8 @@
 import type { ListOperationsOptions } from "@ledgerhq/coin-module-framework/api/index";
-import { decodeMemoFromCbor } from "@ledgerhq/concordium-core";
 import { log } from "@ledgerhq/logs";
 import { getTransactions } from "../../network/proxyClient";
 import type { RawOperation, TransactionQueryParams, WalletProxyTransaction } from "../../types";
+import { decodeMemo } from "./memo";
 
 const DEFAULT_PAGE_SIZE = 100;
 
@@ -44,11 +44,7 @@ export function parseTransaction(tx: WalletProxyTransaction, address: string): R
 
   let memo: string | undefined;
   if (tx.details.memo) {
-    try {
-      memo = decodeMemoFromCbor(Buffer.from(tx.details.memo, "hex"));
-    } catch {
-      log("concordium", `Failed to decode memo for tx ${tx.transactionHash}`);
-    }
+    memo = decodeMemo(tx.details.memo, tx.transactionHash);
   }
 
   return {

--- a/libs/coin-modules/coin-concordium/src/logic/history/memo.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/memo.ts
@@ -1,0 +1,14 @@
+import { decodeMemoFromCbor } from "@ledgerhq/concordium-core";
+import { log } from "@ledgerhq/logs";
+
+/**
+ * Decodes a hex-encoded CBOR memo. Returns undefined (and logs) when decoding fails.
+ */
+export function decodeMemo(hex: string, txHash: string): string | undefined {
+  try {
+    return decodeMemoFromCbor(Buffer.from(hex, "hex"));
+  } catch {
+    log("concordium", `Failed to decode memo for tx ${txHash}`);
+    return undefined;
+  }
+}

--- a/libs/coin-modules/coin-concordium/src/logic/history/memo.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/history/memo.ts
@@ -7,8 +7,8 @@ import { log } from "@ledgerhq/logs";
 export function decodeMemo(hex: string, txHash: string): string | undefined {
   try {
     return decodeMemoFromCbor(Buffer.from(hex, "hex"));
-  } catch {
-    log("concordium", `Failed to decode memo for tx ${txHash}`);
+  } catch (error) {
+    log("concordium", `Failed to decode memo for tx ${txHash}`, { error });
     return undefined;
   }
 }

--- a/libs/coin-modules/coin-concordium/src/logic/index.ts
+++ b/libs/coin-modules/coin-concordium/src/logic/index.ts
@@ -5,6 +5,7 @@ export { craftRawTransaction } from "./transaction/craftRawTransaction";
 export { estimateFees } from "./transaction/estimateFees";
 export { getBalance } from "./account/getBalance";
 export { lastBlock } from "./history/lastBlock";
+export { getBlock } from "./history/getBlock";
 export { getBlockInfo } from "./history/getBlockInfo";
 export { listOperations } from "./history/listOperations";
 export { getNextValidSequence } from "./account/getNextSequence";

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.test.ts
@@ -3,6 +3,7 @@ import {
   getConsensusInfo,
   getBlockInfoByHash,
   getBlocksAtHeight,
+  getBlockTransactionEvents,
   getAccountsByPublicKey,
   getAccountBalance,
   getAccountNonce,
@@ -173,6 +174,30 @@ describe("proxyClient", () => {
         expect.objectContaining({
           method: "GET",
           url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/blocksAtHeight/1000",
+        }),
+      );
+    });
+  });
+
+  describe("getBlockTransactionEvents", () => {
+    it("should fetch block transaction events by block hash", async () => {
+      const mockResponse = [
+        {
+          hash: "aa".repeat(32),
+          sender: "3U6m951FWryY56SKFFHgMLGVHtJtk4VaxN7V2F9hjkR7Sg1FUx",
+          cost: "601",
+          result: { outcome: "success", events: [] },
+        },
+      ];
+      mockNetwork.mockResolvedValue({ data: mockResponse });
+
+      const result = await getBlockTransactionEvents(currencyId, "abc123");
+
+      expect(result).toEqual(mockResponse);
+      expect(mockNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "GET",
+          url: "https://ccd-wallet-proxy-testnet.coin.ledger-test.com/v0/blockTransactionEvents/abc123",
         }),
       );
     });

--- a/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
+++ b/libs/coin-modules/coin-concordium/src/network/proxyClient.ts
@@ -6,6 +6,7 @@ import type {
   AccountBalanceResponse,
   BlockInfoResponse,
   BlocksAtHeightResponse,
+  BlockTransactionEventsResponse,
   ConsensusInfoResponse,
   GetTransactionCostParams,
   TransactionsResponse,
@@ -123,6 +124,23 @@ export function getBlocksAtHeight(
     client.request<BlocksAtHeightResponse>({
       method: "GET",
       url: `/v0/blocksAtHeight/${height}`,
+    }),
+  );
+}
+
+/**
+ * Get all transaction summaries (with structured, tagged events) for a block.
+ * GET /v0/blockTransactionEvents/{blockHash}
+ * Returns an empty array for blocks with no transactions.
+ */
+export function getBlockTransactionEvents(
+  currencyId: string,
+  blockHash: string,
+): Promise<BlockTransactionEventsResponse> {
+  return withClient(currencyId, async client =>
+    client.request<BlockTransactionEventsResponse>({
+      method: "GET",
+      url: `/v0/blockTransactionEvents/${blockHash}`,
     }),
   );
 }

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -63,7 +63,7 @@ export type ConcordiumEventAddress =
  * tags are modelled explicitly; every other event is kept as an opaque tagged
  * object so the tag-based mapper can ignore it (PLT/staking tags added later).
  */
-export interface BlockTransactionEvent {
+export interface TransactionEvent {
   tag: string;
   [key: string]: unknown;
 }
@@ -71,7 +71,7 @@ export interface BlockTransactionEvent {
 /**
  * A native CCD transfer event.
  */
-export interface TransferredEvent extends BlockTransactionEvent {
+export interface TransferredEvent extends TransactionEvent {
   tag: "Transferred";
   amount: string; // microCCD as a string
   from: ConcordiumEventAddress;
@@ -82,7 +82,7 @@ export interface TransferredEvent extends BlockTransactionEvent {
  * A memo event. A `transferWithMemo` transaction emits both a `Transferred` and a
  * separate `TransferMemo` event within the same summary; the memo is hex-encoded CBOR.
  */
-export interface TransferMemoEvent extends BlockTransactionEvent {
+export interface TransferMemoEvent extends TransactionEvent {
   tag: "TransferMemo";
   memo: string; // hex-encoded CBOR
 }
@@ -92,7 +92,7 @@ export interface TransferMemoEvent extends BlockTransactionEvent {
  * produced no effective balance changes.
  */
 export type BlockTransactionResult =
-  | { outcome: "success"; events: BlockTransactionEvent[] }
+  | { outcome: "success"; events: TransactionEvent[] }
   | { outcome: "reject"; rejectReason?: { tag: string; contents?: unknown } };
 
 /**

--- a/libs/coin-modules/coin-concordium/src/types/network.ts
+++ b/libs/coin-modules/coin-concordium/src/types/network.ts
@@ -50,6 +50,72 @@ export interface BlockInfoResponse {
  */
 export type BlocksAtHeightResponse = string[];
 
+/**
+ * Concordium address as serialized by the node inside transaction events.
+ * Account addresses carry a base58 string; contract addresses carry an index/subindex pair.
+ */
+export type ConcordiumEventAddress =
+  | { type: "AddressAccount"; address: string }
+  | { type: "AddressContract"; address: { index: number; subindex: number } };
+
+/**
+ * A single event inside a successful transaction result. Only transfer-related
+ * tags are modelled explicitly; every other event is kept as an opaque tagged
+ * object so the tag-based mapper can ignore it (PLT/staking tags added later).
+ */
+export interface BlockTransactionEvent {
+  tag: string;
+  [key: string]: unknown;
+}
+
+/**
+ * A native CCD transfer event.
+ */
+export interface TransferredEvent extends BlockTransactionEvent {
+  tag: "Transferred";
+  amount: string; // microCCD as a string
+  from: ConcordiumEventAddress;
+  to: ConcordiumEventAddress;
+}
+
+/**
+ * A memo event. A `transferWithMemo` transaction emits both a `Transferred` and a
+ * separate `TransferMemo` event within the same summary; the memo is hex-encoded CBOR.
+ */
+export interface TransferMemoEvent extends BlockTransactionEvent {
+  tag: "TransferMemo";
+  memo: string; // hex-encoded CBOR
+}
+
+/**
+ * Outcome of a transaction in a block. Rejected transactions still paid fees but
+ * produced no effective balance changes.
+ */
+export type BlockTransactionResult =
+  | { outcome: "success"; events: BlockTransactionEvent[] }
+  | { outcome: "reject"; rejectReason?: { tag: string; contents?: unknown } };
+
+/**
+ * A transaction summary as returned by /v0/blockTransactionEvents/{blockHash}.
+ * This is the raw node `TransactionSummary` shape (structured, tagged events),
+ * distinct from the flattened /v3/accTransactions shape used by listOperations.
+ */
+export interface BlockTransactionSummary {
+  hash: string;
+  sender: string | null;
+  cost: string; // microCCD as a string
+  energyCost?: number;
+  index?: number;
+  type?: { type: string; contents?: string };
+  result: BlockTransactionResult;
+}
+
+/**
+ * Response from /v0/blockTransactionEvents/{blockHash}.
+ * An array of transaction summaries; empty for blocks with no transactions.
+ */
+export type BlockTransactionEventsResponse = BlockTransactionSummary[];
+
 export interface TransactionQueryParams {
   limit?: number;
   order?: "a" | "d"; // ascending or descending


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

getBlock was stubbed as "not supported" (no per-block endpoint). The wallet-proxy now ships GET /v0/blockTransactionEvents/{blockHash} (proxy #180), so this implements getBlock(height): Promise<Block> per the coin-module-framework contract.

- info reuses getBlockInfo (height → hash → info).
- Each tx summary → BlockTransaction (hash, fees, feesPayer, failed).
- Tag-based events: Transferred → signed sender/recipient pair; TransferMemo → memo decoded into details; rejected/other → no ops. Empty block → [].
- Shared CBOR memo decoder extracted to memo.ts (also used by listOperations).

```ts
const api = createApi(config, "concordium");
const { info, transactions } = await api.getBlock(1_000_000);
```

Covered by unit + integ tests (integ hits live testnet; schema verified against a real transferWithMemo). Not wired into the apps — this is the CoinModuleApi surface, not the bridge.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-30911](https://ledgerhq.atlassian.net/browse/LIVE-30911?atlOrigin=eyJpIjoiYmNmNmZjODMxZDU3NDhjOWJiNTY1YWYzYzcxOGE5MGYiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-30911]: https://ledgerhq.atlassian.net/browse/LIVE-30911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ