### PR TITLE
test(e2e): surface swap-init stall root cause in Allure (QAA-1326)

### DIFF
--- a/e2e/desktop/tests/page/speculos.page.ts
+++ b/e2e/desktop/tests/page/speculos.page.ts
@@ -1,5 +1,6 @@
 import { AppPage } from "./abstractClasses";
 import { step } from "../misc/reporters/step";
+import * as allure from "allure-js-commons";
 import {
   activateLedgerSync,
   expectValidAddressDevice,
@@ -23,6 +24,14 @@ import { Transaction } from "@ledgerhq/live-e2e-shared/models/Transaction";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 
 import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
+
+function formatSwapScenario(swap: Swap, amount: string): string {
+  const from = swap.accountToDebit.currency.name;
+  const to = swap.accountToCredit.currency.name;
+  const provider = swap.provider?.uiName ?? "unknown";
+  return `${from} → ${to} | amount ${amount} | provider ${provider}`;
+}
+
 export class SpeculosPage extends AppPage {
   @step("Verify receive address correctness on device")
   async expectValidAddressDevice(account: Account, addressDisplayed: string) {
@@ -51,7 +60,14 @@ export class SpeculosPage extends AppPage {
 
   @step("Verify amounts and accept swap")
   async verifyAmountsAndAcceptSwap(swap: Swap, amount: string) {
-    await verifyAmountsAndAcceptSwap(swap, amount);
+    const scenario = formatSwapScenario(swap, amount);
+    await allure.parameter("Swap scenario", scenario);
+    try {
+      await verifyAmountsAndAcceptSwap(swap, amount);
+    } catch (error) {
+      if (error instanceof Error) error.message += `\n↳ Swap scenario: ${scenario}`;
+      throw error;
+    }
   }
 
   @step("Verify amounts and accept swap for different seed")

--- a/e2e/desktop/tests/utils/allureUtils.ts
+++ b/e2e/desktop/tests/utils/allureUtils.ts
@@ -229,6 +229,16 @@ export async function captureArtifacts(
       body: Buffer.from(webviewCollector.getFormattedNetworkLogs()),
       contentType: "application/json",
     });
+
+    // Surface the swap-init root cause (QAA-1326) front-and-center: the failing
+    // custom.exchange.swap error is otherwise buried in the full console dump above.
+    const swapInitError = webviewCollector.getSwapInitError();
+    if (swapInitError) {
+      await testInfo.attach("⚠️ Swap-init error", {
+        body: Buffer.from(swapInitError),
+        contentType: "text/plain",
+      });
+    }
   }
 
   if (appCollector) {

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -23,6 +23,18 @@ export class PageLogCollector {
   private readonly requestsMap: Map<Request, NetworkLog> = new Map();
 
   private targetPage: Page | null = null;
+  private readonly attachedPages: Set<Page> = new Set();
+
+  // Signatures of a swap-init failure the swap live-app surfaces over wallet-api
+  // (custom.exchange.swap). This is the QAA-1326 root cause behind a device stranded on
+  // "Exchange app is ready": it appears ONLY in the webview console, never in the network log
+  // (the swap backend calls return 200). Kept in sync with the hint in speculos.ts.
+  private static readonly SWAP_INIT_ERROR_SIGNATURES = [
+    "CompleteExchangeError",
+    "PayloadStepError",
+    "FeeNotLoaded",
+    "SWAP_NOT_CREATED_ERROR",
+  ];
 
   private readonly onConsole = (msg: ConsoleMessage) => {
     this.consoleLogs.push({
@@ -107,15 +119,14 @@ export class PageLogCollector {
   }
 
   attachWebview(electronApp: ElectronApplication): void {
-    electronApp.on("window", (page: Page) => {
-      if (this.targetPage) return;
-
-      // The webview is the second window the app opens; revisit this if that assumption changes.
-      const windows = electronApp.windows();
-      if (windows.length <= 1) return;
-
+    const [mainWindow] = electronApp.windows();
+    const attachIfWebview = (page: Page) => {
+      if (page === mainWindow || this.attachedPages.has(page)) return;
+      this.attachedPages.add(page);
       this.attach(page);
-    });
+    };
+    electronApp.windows().forEach(attachIfWebview);
+    electronApp.on("window", attachIfWebview);
   }
 
   getFormattedConsoleLogs(): string {
@@ -124,6 +135,22 @@ export class PageLogCollector {
     return this.consoleLogs
       .map(entry => `[${entry.timestamp}] [${entry.level.toUpperCase()}] ${entry.text}`)
       .join("\n");
+  }
+
+  /**
+   * Extract the swap-init failure (custom.exchange.swap error) from the captured webview
+   * console, if present, so the QAA-1326 root cause can be surfaced as its own attachment
+   * instead of being buried in the full console dump. Returns null when no such error was seen.
+   */
+  getSwapInitError(): string | null {
+    const matches = this.consoleLogs.filter(entry =>
+      PageLogCollector.SWAP_INIT_ERROR_SIGNATURES.some(sig => entry.text.includes(sig)),
+    );
+    if (matches.length === 0) return null;
+
+    return matches
+      .map(entry => `[${entry.timestamp}] [${entry.level.toUpperCase()}] ${entry.text}`)
+      .join("\n\n");
   }
 
   getFormattedNetworkLogs(): string {

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -146,7 +146,21 @@ export class PageLogCollector {
     );
     if (matches.length === 0) return null;
 
-    return matches.map(entry => PageLogCollector.formatSwapInitEntry(entry)).join("\n\n");
+    const step = PageLogCollector.deriveSwapInitStep(matches);
+    const body = matches.map(entry => PageLogCollector.formatSwapInitEntry(entry)).join("\n\n");
+    return step ? `Step: ${step}\n\n${body}` : body;
+  }
+
+  private static deriveSwapInitStep(matches: ConsoleLog[]): string | null {
+    const text = matches.map(entry => entry.text).join(" ");
+    if (text.includes("PayloadStepError") || text.includes("swap002")) {
+      return "PAYLOAD (Backend Swap Payload Retrieval)";
+    }
+    if (text.includes("CompleteExchangeError")) {
+      const deviceStep = text.match(/"step"\s*:\s*"([^"]+)"/)?.[1] ?? "INIT";
+      return `device Exchange app (${deviceStep})`;
+    }
+    return null;
   }
 
   private static formatSwapInitEntry(entry: ConsoleLog): string {

--- a/e2e/desktop/tests/utils/pageLogCollector.ts
+++ b/e2e/desktop/tests/utils/pageLogCollector.ts
@@ -23,13 +23,11 @@ export class PageLogCollector {
   private readonly requestsMap: Map<Request, NetworkLog> = new Map();
 
   private targetPage: Page | null = null;
-  private readonly attachedPages: Set<Page> = new Set();
+  private readonly attachedPages: WeakSet<Page> = new WeakSet<Page>();
 
-  // Signatures of a swap-init failure the swap live-app surfaces over wallet-api
-  // (custom.exchange.swap). This is the QAA-1326 root cause behind a device stranded on
-  // "Exchange app is ready": it appears ONLY in the webview console, never in the network log
-  // (the swap backend calls return 200). Kept in sync with the hint in speculos.ts.
+  // Swap-init failure signatures (QAA-1326): used to surface the root cause when swap-init stalls.
   private static readonly SWAP_INIT_ERROR_SIGNATURES = [
+    "custom.exchange.swap",
     "CompleteExchangeError",
     "PayloadStepError",
     "FeeNotLoaded",
@@ -138,9 +136,9 @@ export class PageLogCollector {
   }
 
   /**
-   * Extract the swap-init failure (custom.exchange.swap error) from the captured webview
-   * console, if present, so the QAA-1326 root cause can be surfaced as its own attachment
-   * instead of being buried in the full console dump. Returns null when no such error was seen.
+   * Extract the swap-init failure (custom.exchange.swap request/response) from the captured
+   * webview console, formatted for readability: `%c` console styling stripped, the embedded
+   * JSON payload pretty-printed, and the noisy minified renderer stacks dropped. Null when none.
    */
   getSwapInitError(): string | null {
     const matches = this.consoleLogs.filter(entry =>
@@ -148,9 +146,51 @@ export class PageLogCollector {
     );
     if (matches.length === 0) return null;
 
-    return matches
-      .map(entry => `[${entry.timestamp}] [${entry.level.toUpperCase()}] ${entry.text}`)
-      .join("\n\n");
+    return matches.map(entry => PageLogCollector.formatSwapInitEntry(entry)).join("\n\n");
+  }
+
+  private static formatSwapInitEntry(entry: ConsoleLog): string {
+    const header = `[${entry.timestamp}] [${entry.level.toUpperCase()}]`;
+    const jsonStart = entry.text.indexOf("{");
+    if (jsonStart === -1) {
+      return `${header} ${PageLogCollector.stripConsoleStyling(entry.text)}`;
+    }
+
+    const label = PageLogCollector.stripConsoleStyling(entry.text.slice(0, jsonStart));
+    const rawJson = entry.text.slice(jsonStart);
+    try {
+      const pretty = JSON.stringify(PageLogCollector.dropStacks(JSON.parse(rawJson)), null, 2);
+      return `${header} ${label}\n${pretty}`;
+    } catch {
+      // Not valid JSON (e.g. a plain log line) — keep the cleaned text as-is.
+      return `${header} ${label} ${rawJson}`;
+    }
+  }
+
+  /** Remove `%c` console format tokens and their CSS style arguments, keeping the label text. */
+  private static stripConsoleStyling(text: string): string {
+    return text
+      .replace(/%c/g, "")
+      .replace(/background:[^;]*;?/gi, "")
+      .replace(/color:\s*#[0-9a-f]{3,8};?/gi, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  /** Recursively drop `stack` properties — the minified renderer stacks are noise for triage. */
+  private static dropStacks(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map(item => PageLogCollector.dropStacks(item));
+    }
+    if (value !== null && typeof value === "object") {
+      const result: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(value)) {
+        if (key === "stack") continue;
+        result[key] = PageLogCollector.dropStacks(val);
+      }
+      return result;
+    }
+    return value;
   }
 
   getFormattedNetworkLogs(): string {

--- a/libs/live-e2e-shared/src/enum/DeviceLabels.ts
+++ b/libs/live-e2e-shared/src/enum/DeviceLabels.ts
@@ -22,6 +22,7 @@ export enum DeviceLabels {
   DEPOSIT = "Deposit",
   EXPERT_MODE = "Expert mode",
   ENABLE_TRANSACTION_CHECK = "Enable Transaction Check",
+  EXCHANGE_APP_IS_READY = "Exchange app is ready",
   FEES = "Fees",
   GET = "Get",
   I_UNDERSTAND = "I understand",

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -585,12 +585,9 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
 }
 
 const SWAP_INIT_STALL_HINT =
-  `\n↳ Swap-init stall (QAA-1326): the device Exchange app is ready but Ledger Live never ` +
-  `delivered the swap payload, so "Review transaction" was never reached — a known transient ` +
-  `swap-init failure, not a slow render. Root cause: the "custom.exchange.swap" wallet-api call ` +
-  `failed after the Exchange app opened (e.g. FeeNotLoaded / SWAP_NOT_CREATED_ERROR). See the ` +
-  `"⚠️ Swap-init error" attachment (or the "Webview Console Logs" attachment) — NOT the network ` +
-  `log; the swap backend calls themselves return 200.`;
+  `\n The device Exchange app is ready but Ledger Live never ` +
+  `delivered the swap payload, so "Review transaction" was never reached. See the ` +
+  `"⚠️ Swap-init error" attachment (or the "Webview Console Logs" attachment).`;
 
 function isExchangeAppReadyStall(screenText: string): boolean {
   return screenText.toLowerCase().includes(DeviceLabels.EXCHANGE_APP_IS_READY.toLowerCase());
@@ -601,8 +598,10 @@ export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> 
     try {
       await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw isExchangeAppReadyStall(message) ? new Error(message + SWAP_INIT_STALL_HINT) : error;
+      if (error instanceof Error && isExchangeAppReadyStall(error.message)) {
+        error.message += SWAP_INIT_STALL_HINT;
+      }
+      throw error;
     }
     return;
   }

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -585,9 +585,9 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
 }
 
 const SWAP_INIT_STALL_HINT =
-  `\n The device Exchange app is ready but Ledger Live never ` +
-  `delivered the swap payload, so "Review transaction" was never reached. See the ` +
-  `"⚠️ Swap-init error" attachment (or the "Webview Console Logs" attachment).`;
+  `\nHint: The device Exchange app is ready but Ledger Live never ` +
+  `delivered the swap payload, so "Review transaction" was never reached.\nSee the ` +
+  `"⚠️ Swap-init error" attachment.`;
 
 function isExchangeAppReadyStall(screenText: string): boolean {
   return screenText.toLowerCase().includes(DeviceLabels.EXCHANGE_APP_IS_READY.toLowerCase());

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -584,9 +584,26 @@ export async function waitFor(text: string, maxAttempts = 60): Promise<string> {
   );
 }
 
+const SWAP_INIT_STALL_HINT =
+  `\n↳ Swap-init stall (QAA-1326): the device Exchange app is ready but Ledger Live never ` +
+  `delivered the swap payload, so "Review transaction" was never reached — a known transient ` +
+  `swap-init failure, not a slow render. Root cause: the "custom.exchange.swap" wallet-api call ` +
+  `failed after the Exchange app opened (e.g. FeeNotLoaded / SWAP_NOT_CREATED_ERROR). See the ` +
+  `"⚠️ Swap-init error" attachment (or the "Webview Console Logs" attachment) — NOT the network ` +
+  `log; the swap backend calls themselves return 200.`;
+
+function isExchangeAppReadyStall(screenText: string): boolean {
+  return screenText.toLowerCase().includes(DeviceLabels.EXCHANGE_APP_IS_READY.toLowerCase());
+}
+
 export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> {
   if (!isTouchDevice()) {
-    await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
+    try {
+      await waitFor(DeviceLabels.REVIEW_TRANSACTION, maxAttempts);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw isExchangeAppReadyStall(message) ? new Error(message + SWAP_INIT_STALL_HINT) : error;
+    }
     return;
   }
 
@@ -605,9 +622,8 @@ export async function waitForReviewTransaction(maxAttempts = 60): Promise<void> 
     await sleep(SCREEN_POLL_INTERVAL_MS);
   }
 
-  throw new Error(
-    `Text "${DeviceLabels.REVIEW_TRANSACTION}" not found on device screen after ${maxAttempts} attempts. Last screen text: "${texts}"`,
-  );
+  const base = `Text "${DeviceLabels.REVIEW_TRANSACTION}" not found on device screen after ${maxAttempts} attempts. Last screen text: "${texts}"`;
+  throw new Error(isExchangeAppReadyStall(texts) ? base + SWAP_INIT_STALL_HINT : base);
 }
 
 export async function fetchCurrentScreenTexts(speculosApiPort: number): Promise<string> {


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset needed — only private E2E packages changed (`@ledgerhq/live-e2e-shared` and the desktop E2E tests package are both `"private": true`; nothing published to version).
- [ ] **Covered by automatic tests.** _This is E2E diagnostics/reporting tooling — there is no unit-test harness for these E2E logging utilities. The capture + error-surfacing was validated by two manual Desktop E2E CI runs (broadcast + non-broadcast) on a real occurrence of the stall; the follow-up **swap-scenario / step surfacing** is reporting-only (no test timing or behaviour change) and typecheck-clean, and will be exercised by the next Desktop E2E run._
- [x] **Impact of the changes:**
  - On a swap E2E failure where the device is stuck on "Exchange app is ready", the Allure report now reliably attaches the swap live-app **Webview Console/Network Logs** plus a prominent **⚠️ Swap-init error** attachment containing the exact wallet-api error.
  - The report now also surfaces the **user-facing swap scenario** — `From → To | amount | provider` (a "Swap scenario" Allure parameter, also appended to the stall error message) — and the failing **Step** (`PAYLOAD (swap002)`, or the device `CompleteExchangeError` step such as `INIT`) at the top of the ⚠️ Swap-init error attachment. The provider is chosen at runtime and the thrown error never carries it, so this is what makes a failure actionable for hand-off to the Swap Live App team.
  - **No timing or behaviour change** to any test — passing runs and slow-but-working renders are unaffected (the QAA-1322 review-wait budget is preserved).
  - Diagnostics only: this does **not** fix the underlying stall (a Swap Live App / exchange-backend race); it surfaces it for hand-off.

### 📝 Description

The desktop swap E2E `send.swap.spec.ts` (`Swap - Accepted (without tx broadcast)`) intermittently fails on the first attempt with `Text "Review transaction" not found on device screen after 240 attempts. Last screen text: "Exchange app is ready"`, then passes on retry (QAA-1326). Until now that failure was opaque: the real cause was never captured — the webview logging latched onto an early transient window (~3 s of init), and the error message only said "Review transaction not found".

**Root cause (found via this instrumentation).** After "Exchange" is clicked, Ledger Live opens the device Exchange app (→ "Exchange app is ready"), then the swap live-app's `custom.exchange.swap` wallet-api call fails at the INIT / PAYLOAD step — `CompleteExchangeError: FeeNotLoaded` (LI.FI) or `PayloadStepError: SWAP_NOT_CREATED_ERROR` (Exodus) — and cancels, leaving the device stranded on "Exchange app is ready". The swap backend itself is healthy (every `/v5/quote` returns 200). This is a Swap Live App / exchange race, **not** a test bug — it will be handed to the Swap Live App team.

**This PR is diagnostics / reporting only** (QA-owned). It turns the opaque 2-minute timeout into an actionable report:

- `PageLogCollector.attachWebview` now attaches to **every** webview window for the whole test lifetime (previously it grabbed the first transient window and missed the swap-init traffic — the evidence gap).
- `waitForReviewTransaction` appends a **QAA-1326 hint** when the device stalls on "Exchange app is ready", pointing at the **⚠️ Swap-init error** attachment.
- `captureArtifacts` extracts the swap-init error from the webview console via a new `getSwapInitError()` and attaches it as a prominent **⚠️ Swap-init error**, so the exact `FeeNotLoaded` / `SWAP_NOT_CREATED_ERROR` is one click from the failure rather than buried in a ~100-line console dump. `getSwapInitError()` also prepends the derived **Step** (`PAYLOAD (swap002)` for a `PayloadStepError`, or the device Exchange-app step from a `CompleteExchangeError`, e.g. `INIT`).
- `SpeculosPage.verifyAmountsAndAcceptSwap` records the **swap scenario** (`From → To | amount | provider`) as a "Swap scenario" Allure parameter and appends it to the stall error message — so the runtime-chosen provider, the amount, and the exact pair are named in the failure itself instead of being unrecoverable from the report. Scoped to the accept path; the reject / different-seed flows assert on specific error strings and are left untouched.

Validated on two manual Desktop E2E runs (broadcast + non-broadcast): the stall recurred (Tether USD → Solana, Ethereum → Polkadot) and the new attachments captured the exact errors. The follow-up swap-scenario / step surfacing (commit `d35dbe44c39`) is reporting-only and typecheck-clean; it will be confirmed on the next Desktop E2E run.

Log example:
<img width="1031" height="151" alt="Screenshot 2026-08-03 at 16 02 15" src="https://github.com/user-attachments/assets/59f3057b-8098-4f00-84eb-51eaa497fea6" />


### ❓ Context

- **JIRA or GitHub link**: [QAA-1326](https://ledgerhq.atlassian.net/browse/QAA-1326)
-**CI run**: https://github.com/LedgerHQ/ledger-live/actions/runs/30364856706

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1326]: https://ledgerhq.atlassian.net/browse/QAA-1326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
