### PR TITLE
ci(e2e): collect Android runner telemetry and attach to qaa-allure

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -807,6 +807,11 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.determine-builds.outputs.matrix_android) }}
     steps:
+      - name: Start resource usage sampler
+        id: start-sampler
+        continue-on-error: true
+        uses: LedgerHQ/ledger-live/tools/actions/composites/start-usage-sampler@develop
+
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.ref || github.sha }}
@@ -995,6 +1000,15 @@ jobs:
           E2E_FEATURE_FLAGS_JSON: ${{ env.E2E_FEATURE_FLAGS_JSON }}
           E2E_MOBILE_FEATURE_FLAGS: ${{ env.ANDROID_FEATURE_FLAGS }}
         run: pnpm run mobile e2e:ci -p android -t --e2e $([[ "$PRODUCTION" == "true" ]] && printf %s '--production') $SHARD_TEST_FILES --outputFile=artifacts/${{ env.E2E_TEST_RESULTS_PREFIX_ANDROID }}-${{ matrix.shard }}.json
+
+      - name: Stop resource usage sampler
+        if: always()
+        continue-on-error: true
+        uses: LedgerHQ/ledger-live/tools/actions/composites/stop-usage-sampler@develop
+        with:
+          sampler_pid: ${{ steps.start-sampler.outputs.sampler_pid }}
+          csv_path: ${{ steps.start-sampler.outputs.csv_path }}
+          artifact_name: usage-metrics-android-${{ matrix.shard }}
 
       - name: Upload Android artifacts
         if: (!cancelled() || steps.run-android.outcome == 'cancelled')
@@ -1216,6 +1230,12 @@ jobs:
           path: android-test-artifacts
           pattern: android-test-artifacts*
           merge-multiple: true
+      - name: Download usage metrics CSVs (per shard)
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: report-attachments
+          pattern: usage-metrics-android-*
       - name: Upload to qaa-allure (sandbox)
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report-qaa@develop
         with:
@@ -1224,6 +1244,7 @@ jobs:
           name: "mobile-e2e-android-${{ github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual') }}"
           tags: ${{ format('["mobile","android",{0}]', toJSON(github.event_name == 'schedule' && 'nightly' || (inputs.smoke_tests && 'smoke' || 'manual'))) }}
           branch: ${{ inputs.ref || github.ref_name }}
+          report_attachments: report-attachments
 
   upload-to-xray:
     name: "Test Mobile E2E > XRAY Report"

--- a/tools/actions/composites/start-usage-sampler/action.yml
+++ b/tools/actions/composites/start-usage-sampler/action.yml
@@ -1,0 +1,17 @@
+name: "Start Resource Usage Sampler"
+description: "Starts a background process sampling CPU/memory/disk/network every 5s into a CSV file"
+outputs:
+  sampler_pid:
+    description: "PID of the background sampler process"
+    value: ${{ steps.start.outputs.sampler_pid }}
+  csv_path:
+    description: "Path to the generated usage-metrics CSV"
+    value: ${{ steps.start.outputs.csv_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Start sampler
+      id: start
+      shell: bash
+      run: ${{ github.action_path }}/sample-usage.sh

--- a/tools/actions/composites/start-usage-sampler/sample-usage.sh
+++ b/tools/actions/composites/start-usage-sampler/sample-usage.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Start a background sampler that records runner resource usage to a CSV.
+#
+# Samples CPU / memory / disk-free / network throughput from Linux procfs
+# every 5s and appends one row per interval. The sampler is backgrounded and
+# keeps running after this script exits; stop it later with the PID written to
+# GITHUB_OUTPUT (see stop-usage-sampler).
+#
+# Required env:
+#   RUNNER_TEMP   — writable temp dir (set automatically on GitHub runners)
+#
+# Optional env:
+#   GITHUB_OUTPUT — when set, writes `csv_path` and `sampler_pid`
+#
+# CSV columns:
+#   timestamp,cpu_percent,mem_used_mb,mem_total_mb,disk_free_gb,net_rx_kbps,net_tx_kbps
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+
+mkdir -p "${RUNNER_TEMP}/usage-metrics"
+CSV="${RUNNER_TEMP}/usage-metrics/usage-metrics.csv"
+echo "timestamp,cpu_percent,mem_used_mb,mem_total_mb,disk_free_gb,net_rx_kbps,net_tx_kbps" > "$CSV"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "csv_path=$CSV" >> "$GITHUB_OUTPUT"
+fi
+
+# First non-loopback interface, used to read rx/tx byte counters.
+iface=$(awk -F: '$1 !~ /lo/ && NR>2 {gsub(/ /,"",$1); print $1; exit}' /proc/net/dev)
+
+(
+  prev_idle=0; prev_total=0; prev_rx=0; prev_tx=0; first=1
+  while true; do
+    read -r u n s i w x y z < <(awk '/^cpu /{print $2, $3, $4, $5, $6, $7, $8, $9}' /proc/stat)
+    idle=$((i + w)); total=$((u + n + s + i + w + x + y + z))
+
+    read -r rx tx < <(awk -v ifc="${iface}:" '{for (k=1;k<=NF;k++) if ($k==ifc) {print $(k+1), $(k+9); exit}}' /proc/net/dev)
+    rx=${rx:-0}; tx=${tx:-0}
+
+    if [ "$first" = "0" ]; then
+      totald=$((total - prev_total)); idled=$((idle - prev_idle))
+      cpu_pct=0
+      [ "$totald" -gt 0 ] && cpu_pct=$(( (1000 * (totald - idled) / totald + 5) / 10 ))
+      rx_kbps=$(( (rx - prev_rx) / 1024 / 5 ))
+      tx_kbps=$(( (tx - prev_tx) / 1024 / 5 ))
+      read -r mem_total mem_avail < <(awk '/MemTotal/{t=$2} /MemAvailable/{a=$2} END{print t, a}' /proc/meminfo)
+      mem_used_mb=$(( (mem_total - mem_avail) / 1024 )); mem_total_mb=$(( mem_total / 1024 ))
+      disk_free_gb=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+      echo "$(date -u +%FT%TZ),$cpu_pct,$mem_used_mb,$mem_total_mb,$disk_free_gb,$rx_kbps,$tx_kbps" >> "$CSV"
+    fi
+    prev_idle=$idle; prev_total=$total; prev_rx=$rx; prev_tx=$tx; first=0
+    sleep 5
+  done
+# Redirect stdout/stderr off the step's pipe so the runner never waits on it
+# (which could hang the step), and disown so the loop isn't SIGHUP'd when this
+# script exits — the sampler must outlive this step and run across the job.
+) >/dev/null 2>&1 &
+sampler_pid=$!
+disown 2>/dev/null || true
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "sampler_pid=$sampler_pid" >> "$GITHUB_OUTPUT"
+fi

--- a/tools/actions/composites/stop-usage-sampler/action.yml
+++ b/tools/actions/composites/stop-usage-sampler/action.yml
@@ -1,0 +1,37 @@
+name: "Stop Resource Usage Sampler"
+description: "Stops the background usage sampler and uploads the collected CSV as a build artifact"
+inputs:
+  sampler_pid:
+    description: "PID returned by start-usage-sampler"
+    required: true
+  csv_path:
+    description: "Path to the CSV written by start-usage-sampler"
+    required: true
+  artifact_name:
+    description: "Name for the uploaded usage-metrics artifact"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Stop sampler
+      id: stop
+      shell: bash
+      run: |
+        kill "${{ inputs.sampler_pid }}" 2>/dev/null || true
+        # Only upload when the sampler actually produced a CSV — skip silently
+        # otherwise so a sampler that never started adds no failing/noisy step.
+        if [ -n "${{ inputs.csv_path }}" ] && [ -f "${{ inputs.csv_path }}" ]; then
+          echo "csv_exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "csv_exists=false" >> "$GITHUB_OUTPUT"
+          echo "::notice title=usage-sampler::No usage-metrics CSV found; skipping upload."
+        fi
+
+    - name: Upload usage metrics artifact
+      if: steps.stop.outputs.csv_exists == 'true'
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.csv_path }}
+        if-no-files-found: error

--- a/tools/actions/composites/upload-allure-report-qaa/action.yml
+++ b/tools/actions/composites/upload-allure-report-qaa/action.yml
@@ -26,6 +26,14 @@ inputs:
     required: false
     default: ""
     description: "Git branch the run came from, shown/filterable on the portal."
+  report_attachments:
+    required: false
+    default: ""
+    description: >
+      Path to a directory of report-level attachment files (e.g. CI runner
+      telemetry CSVs). Every file found under it is sent on the qaa-allure
+      `reportAttachments` field and rendered in the report's Global Attachments
+      tab. Missing/empty directory is a no-op.
 outputs:
   report_id:
     description: "ID of the uploaded report."
@@ -51,4 +59,5 @@ runs:
         QAA_ALLURE_HISTORY: ${{ inputs.history_level }}
         QAA_ALLURE_JOB_URL: ${{ inputs.job_url }}
         QAA_ALLURE_BRANCH: ${{ inputs.branch }}
+        QAA_ALLURE_REPORT_ATTACHMENTS: ${{ inputs.report_attachments }}
       run: ${{ github.action_path }}/upload.sh

--- a/tools/actions/composites/upload-allure-report-qaa/upload.sh
+++ b/tools/actions/composites/upload-allure-report-qaa/upload.sh
@@ -18,6 +18,11 @@
 #                         deep-link back to the CI run that produced the report
 #   QAA_ALLURE_BRANCH   — when set, sent as multipart `branch` so the portal can
 #                         show/filter which git branch the run came from
+#   QAA_ALLURE_REPORT_ATTACHMENTS — when set to a directory, every file under it
+#                         is sent on the `reportAttachments` field (report-level
+#                         attachments, e.g. runner telemetry CSVs). The sent
+#                         filename is the file's path relative to the directory
+#                         with `/` → `-`, so per-shard subdirs stay distinct.
 #   GITHUB_OUTPUT       — when set, writes report_id / report_url / view_url
 #
 # Exits 0 with a warning when the API key is empty or the path has no files,
@@ -33,6 +38,7 @@ QAA_ALLURE_TAGS="${QAA_ALLURE_TAGS:-}"
 QAA_ALLURE_HISTORY="${QAA_ALLURE_HISTORY:-50}"
 QAA_ALLURE_JOB_URL="${QAA_ALLURE_JOB_URL:-}"
 QAA_ALLURE_BRANCH="${QAA_ALLURE_BRANCH:-}"
+QAA_ALLURE_REPORT_ATTACHMENTS="${QAA_ALLURE_REPORT_ATTACHMENTS:-}"
 
 warn() { echo "::warning title=qaa-allure::$*"; }
 fail() { echo "::error title=qaa-allure::$*"; exit 1; }
@@ -99,6 +105,25 @@ if [ -n "${QAA_ALLURE_JOB_URL}" ]; then
 fi
 if [ -n "${QAA_ALLURE_BRANCH}" ]; then
   curl_args+=(--form-string "branch=${QAA_ALLURE_BRANCH}")
+fi
+
+# Report-level attachments: send every file under the given directory on the
+# `reportAttachments` field. The sent filename is the path relative to the dir
+# with `/` → `-` so files from per-shard subdirs (all basename usage-metrics.csv)
+# stay distinct. `;` and `"` are stripped from the derived name so it can't break
+# out of curl's `-F` form-part syntax. Missing/empty dir is a silent no-op.
+if [ -n "${QAA_ALLURE_REPORT_ATTACHMENTS}" ] && [ -d "${QAA_ALLURE_REPORT_ATTACHMENTS}" ]; then
+  attach_count=0
+  root="${QAA_ALLURE_REPORT_ATTACHMENTS%/}"
+  while IFS= read -r -d '' f; do
+    rel="${f#"${root}/"}"
+    name="${rel//\//-}"
+    name="${name//;/_}"
+    name="${name//\"/_}"
+    curl_args+=(-F "reportAttachments=@${f};filename=${name}")
+    attach_count=$((attach_count + 1))
+  done < <(find "${root}" -type f -print0 | sort -z)
+  echo "Attaching ${attach_count} report-level file(s) from ${root}"
 fi
 
 # Capture body + exit code separately so we can log the body when curl fails


### PR DESCRIPTION
## What

Collects per-shard runner resource telemetry (CPU / memory / disk / network) during the **Android** mobile E2E Detox jobs and surfaces it for performance analysis — as a build artifact and in the qaa-allure report's **Global Attachments** tab.

Scope is intentionally **Android only**; desktop and iOS are untouched (iOS runners are macOS — no procfs — and are covered by Grafana).

## How

- **`start-usage-sampler` / `stop-usage-sampler` composite actions.** The sampler logic lives in `start-usage-sampler/sample-usage.sh` (mirroring the existing `upload-allure-report-qaa/upload.sh` layout). It samples Linux procfs (`/proc/stat`, `/proc/net/dev`, `/proc/meminfo`) every 5s into a CSV. Each Android shard uploads its `usage-metrics-android-<shard>` CSV as a build artifact.
- **`upload-allure-report-qaa` gains a `report_attachments` input.** Every file under the given directory is sent on the qaa-allure `reportAttachments` field (see LedgerHQ/qaa-allure#25), named by its path relative to the dir so per-shard CSVs stay distinct. Renders in the report's Global Attachments tab.
- **`qaa-allure-upload-android`** downloads the per-shard CSVs and forwards them.

## Non-blocking

Telemetry is best-effort and never blocks the E2E run: the sampler start/stop steps are `continue-on-error`, and the qaa upload job is `continue-on-error` at job level.

## Testing

Validated on CI (Android E2E), with the composites temporarily pinned to the branch so they resolve pre-merge:

- **Smoke — Android Only** ([run 30360705042](https://github.com/LedgerHQ/ledger-live/actions/runs/30360705042)): ✅ green. Sampler ran per shard, CSVs uploaded, and the qaa-allure upload attached them.
- **Full — Android Only** ([run 30362106424](https://github.com/LedgerHQ/ledger-live/actions/runs/30362106424)): the telemetry path succeeded end-to-end — `QAA Allure Upload - Android` was green and per-shard CSVs were attached. The overall run is red only from unrelated flaky e2e test shards, which did **not** block telemetry collection — confirming the non-blocking design under real conditions.

Also ran `sample-usage.sh` in an `ubuntu:24.04` container (matching the runner OS) against real procfs — correct CSV output under the runner's `mawk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
