### PR TITLE
[LWD] feat(datadog): expose trackUserInteractions and trackResources via FF

### DIFF
--- a/apps/ledger-live-desktop/src/datadog/renderer.ts
+++ b/apps/ledger-live-desktop/src/datadog/renderer.ts
@@ -72,6 +72,8 @@ export async function initDatadog(
         traceSampleRate?: number;
         allowedTracingUrls?: string[];
         profilingSampleRate?: number;
+        trackUserInteractions?: boolean;
+        trackResources?: boolean;
       }
     | undefined,
   store: Store<State>,
@@ -104,8 +106,8 @@ export async function initDatadog(
       allowedTracingUrls,
       ...(profilingSampleRate !== undefined && { profilingSampleRate }),
       trackViewsManually: true,
-      trackUserInteractions: true,
-      trackResources: true,
+      trackUserInteractions: params?.trackUserInteractions ?? true,
+      trackResources: params?.trackResources ?? true,
       beforeSend: buildBeforeSend(shouldSend),
       sessionPersistence: "local-storage",
     });

--- a/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/ConnectEnvsToDatadog.tsx
@@ -60,6 +60,8 @@ export const ConnectEnvsToDatadog = () => {
         traceSampleRate: lldDatadog.params?.traceSampleRate,
         allowedTracingUrls: lldDatadog.params?.allowedTracingUrls,
         profilingSampleRate: lldDatadog.params?.profilingSampleRate,
+        trackUserInteractions: lldDatadog.params?.trackUserInteractions,
+        trackResources: lldDatadog.params?.trackResources,
       },
       store,
     ).then(done => {

--- a/shared/feature-flags/src/flags/team-platform/lldDatadog.ts
+++ b/shared/feature-flags/src/flags/team-platform/lldDatadog.ts
@@ -9,6 +9,8 @@ export const lldDatadog = flagWith(
     traceSampleRate: z.number().optional(),
     allowedTracingUrls: z.array(z.string()).optional(),
     profilingSampleRate: z.number().optional(),
+    trackUserInteractions: z.boolean().optional(),
+    trackResources: z.boolean().optional(),
   },
   {
     enabled: false,
@@ -19,6 +21,8 @@ export const lldDatadog = flagWith(
       traceSampleRate: 100,
       allowedTracingUrls: ["/^https:\\/\\/[^/]+\\.ledger\\.com(\\/|$)/"],
       profilingSampleRate: 25,
+      trackUserInteractions: true,
+      trackResources: true,
     },
   },
 );


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add new parameters to datadogLLD to change trackUserInteractions and trackRessources and wire them to initDatadog (datadogRum.init)
It reproduces the logic on mobile 

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35108](https://ledgerhq.atlassian.net/browse/LIVE-35108) <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35108]: https://ledgerhq.atlassian.net/browse/LIVE-35108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ