### PR TITLE
[LWDM] feat(LIVE-33596): tokens swap incompatibility warning

### DIFF
--- a/.changeset/silly-tips-relate.md
+++ b/.changeset/silly-tips-relate.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat: aleo tokens swap incompatibility warning

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -541,7 +541,9 @@
       "zcash_title": "Ledger Nano S™ does not support swapping Zcash",
       "zcash_description": "To swap Zcash, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
       "aleo_title": "Ledger Nano S™ does not support swapping Aleo",
-      "aleo_description": "To swap Aleo, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
+      "aleo_description": "To swap Aleo, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
+      "aleo_tokens_title": "Ledger Nano S™ does not support swapping Aleo tokens",
+      "aleo_tokens_description": "To swap Aleo tokens, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
     },
     "providers": {
       "title": "Choose a provider to swap crypto",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4295,7 +4295,9 @@
         "zcash_title": "Ledger Nano S™ does not support swapping Zcash",
         "zcash_description": "To swap Zcash, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
         "aleo_title": "Ledger Nano S™ does not support swapping Aleo",
-        "aleo_description": "To swap Aleo, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
+        "aleo_description": "To swap Aleo, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™.",
+        "aleo_tokens_title": "Ledger Nano S™ does not support swapping Aleo tokens",
+        "aleo_tokens_description": "To swap Aleo tokens, use any other compatible Ledger device, such as the Ledger Nano S Plus™, Ledger Nano X™, Ledger Flex™ or Ledger Stax™."
       }
     },
     "lending": {

--- a/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
+++ b/libs/ledger-live-common/src/exchange/swap/getIncompatibleCurrencyKeys.ts
@@ -24,6 +24,10 @@ const INCOMPATIBLE_NANO_S_TOKENS_KEYS: Keys = {
     title: "swap.incompatibility.ton_tokens_title",
     description: "swap.incompatibility.ton_tokens_description",
   },
+  aleo: {
+    title: "swap.incompatibility.aleo_tokens_title",
+    description: "swap.incompatibility.aleo_tokens_description",
+  },
 };
 
 const INCOMPATIBLE_NANO_S_CURRENCY_KEYS: Keys = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Ledger Nano S already shows an incompatibility warning when swapping native Aleo, but Aleo tokens fell through with no warning since the token-level incompatibility map had no entry for the aleo parent currency. This adds aleo to INCOMPATIBLE_NANO_S_TOKENS_KEYS in getIncompatibleCurrencyKeys.ts, alongside new aleo_tokens_title/aleo_tokens_description strings in both the desktop and mobile English locale files, mirroring the existing pattern for Solana, Sui, and TON tokens.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-33596