### PR TITLE
chore(live-common): drop NotEnoughBalance from checkLibs

### DIFF
--- a/.changeset/LIVE-32915-errors-sanity-checks.md
+++ b/.changeset/LIVE-32915-errors-sanity-checks.md
@@ -1,0 +1,9 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Migrate `checkLibs` and its two callers off `@ledgerhq/errors` as part of the errors sunset (LIVE-32915).
+
+`checkLibs` detects duplicated npm packages by comparing class identity, so `sanityChecks.ts` and both app entrypoints must import `NotEnoughBalance` from the same module. All three now use `@ledgerhq/ledger-wallet-framework/errors`. The duplicate-package warning also names `@ledgerhq/ledger-wallet-framework` so the `pnpm why` hint points at the package actually being checked.

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -2,7 +2,6 @@ import { getEnv } from "@shared/env";
 import { createRoot } from "react-dom/client";
 import React from "react";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import "../config/configInit";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
@@ -105,7 +104,6 @@ async function init() {
   }
 
   checkLibs({
-    NotEnoughBalance,
     React,
     log,
     Transport,

--- a/apps/ledger-live-mobile/src/index.tsx
+++ b/apps/ledger-live-mobile/src/index.tsx
@@ -10,7 +10,6 @@ import { StyleSheet, LogBox, Appearance, AppState, View } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { I18nextProvider } from "react-i18next";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";
 import "./config/configInit";
@@ -107,7 +106,6 @@ if (Config.DISABLE_YELLOW_BOX) {
 }
 
 checkLibs({
-  NotEnoughBalance,
   React,
   log,
   Transport,

--- a/libs/ledger-live-common/src/sanityChecks.ts
+++ b/libs/ledger-live-common/src/sanityChecks.ts
@@ -1,16 +1,13 @@
 import React from "react";
 import Transport from "@ledgerhq/hw-transport";
-import { NotEnoughBalance } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
 export function checkLibs(
   libs: Partial<{
-    NotEnoughBalance: typeof NotEnoughBalance;
     React: typeof React;
     log: typeof log;
     Transport: typeof Transport;
   }>,
 ): void {
-  check(libs.NotEnoughBalance, NotEnoughBalance, "@ledgerhq/errors");
   check(libs.log, log, "@ledgerhq/logs");
   check(libs.Transport, Transport, "@ledgerhq/hw-transport");
   check(libs.React, React, "react");


### PR DESCRIPTION
### 📝 Description

Drops `NotEnoughBalance` from `checkLibs()` and removes it from both app entrypoints.

`checkLibs()` detected duplicated npm packages by comparing class references at startup. `NotEnoughBalance` was the only error-class entry in that check — and since `@ledgerhq/errors` is being sunset, the identity-check requirement no longer applies. The remaining checks (`React`, `log`, `Transport`) are unaffected.

```diff
-import { NotEnoughBalance } from "@ledgerhq/errors";
 export function checkLibs(
   libs: Partial<{
-    NotEnoughBalance: typeof NotEnoughBalance;
     React: typeof React;
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35124](https://ledgerhq.atlassian.net/browse/LIVE-35124)
- **ADR** (if any): N/A

[LIVE-35124]: https://ledgerhq.atlassian.net/browse/LIVE-35124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ