### PR TITLE
fix(coin-solana): drop warmupCooldownRate from stake schema

### DIFF
--- a/.changeset/solana-stake-warmup-cooldown-rate.md
+++ b/.changeset/solana-stake-warmup-cooldown-rate.md
@@ -1,0 +1,14 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+fix(coin-solana): drop warmupCooldownRate from stake schema
+
+Agave removed `warmupCooldownRate` from `UiDelegation` in 4.1 (deprecated since 1.16.7 in
+favour of `solana_stake_interface::state::warmup_cooldown_rate()`), and mainnet now serves
+`apiVersion: 4.1.0`. Our `Delegation` struct still required it, so parsing threw a
+`StructError` for any account holding stake accounts — breaking the legacy sync path
+(`synchronization.ts`) as well as `logic/getStakes` and `logic/getBalance`.
+
+The field was never read: the activation math uses a hardcoded `WARMUP_COOLDOWN_RATE`, as
+upstream recommends. Dropping it from the schema restores parsing with no behaviour change.

--- a/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/getStakes.unit.test.ts
@@ -63,7 +63,6 @@ function makeStakeAccount(overrides?: {
             stake: new BigNumber(4_997_717_120),
             activationEpoch: new BigNumber(300),
             deactivationEpoch: new BigNumber("18446744073709551615"),
-            warmupCooldownRate: 0.09,
           },
           creditsObserved: 100000,
         },

--- a/libs/coin-modules/coin-solana/src/network/chain/account/stake.ts
+++ b/libs/coin-modules/coin-solana/src/network/chain/account/stake.ts
@@ -26,7 +26,6 @@ export const Delegation = type({
   stake: BigNumFromString,
   activationEpoch: BigNumFromString,
   deactivationEpoch: BigNumFromString,
-  warmupCooldownRate: number(),
 });
 export type Delegation = Infer<typeof Delegation>;
 


### PR DESCRIPTION
### 📝 Description

Parsing a Solana stake account currently throws, which breaks account sync for **any account holding stake accounts**:

```
StructError: At path: stake.delegation.warmupCooldownRate -- Expected a number, but received: undefined
```

**Root cause.** Agave removed `warmupCooldownRate` from `UiDelegation` in **4.1**. It had been deprecated since 1.16.7 with the note *"Please use `solana_stake_interface::state::warmup_cooldown_rate()` instead"*, because the rate is a protocol constant rather than per-account data. Mainnet now reports `"apiVersion": "4.1.0"`, so the field is simply gone from `jsonParsed` output — verified absent both on the Ledger proxy and on the public `api.mainnet-beta.solana.com`, and confirmed against the upstream source:

| Agave | `UiDelegation` |
| --- | --- |
| [v4.0](https://raw.githubusercontent.com/anza-xyz/agave/v4.0/account-decoder/src/parse_stake.rs) | `pub warmup_cooldown_rate: f64` (deprecated) |
| [v4.1](https://raw.githubusercontent.com/anza-xyz/agave/v4.1/account-decoder/src/parse_stake.rs) | field removed |

Our `Delegation` struct still declared it as required, so `create(info, StakeAccountInfo)` rejected every real stake account.

**Impact.** `getStakeAccounts` is used by `synchronization.ts` (the legacy bridge sync path) as well as `logic/getStakes` and `logic/getBalance`, so the failure reaches account synchronization, not just the coin-module API.

**Fix.** Remove the field from the schema. It was never read: the activation math in `network/chain/stake-activation/delegation.ts` uses a hardcoded `WARMUP_COOLDOWN_RATE = 0.09`, which is exactly what the upstream deprecation note prescribes. `Delegation` is a superstruct `type()`, which ignores unknown properties, so payloads still carrying the field keep validating. No behaviour change beyond parsing succeeding again.

Verified A/B on the real sync path, same mainnet address and endpoint, the fix as the only variable:

```
WITH the fix       SYNC OK — stakes: 3
WITHOUT the fix    SYNC FAILS: StructError - At path: stake.delegation.warmupCooldownRate
```

Values cross-check against the raw RPC response (stake amount `3296012` matches the account's `lamports`, delegate is the Ledger by Figment vote account).

**Testing.** No new test: `getBalance.integ.test.ts` already destructures and asserts `stake1`/`stake2`/`stake3`, which is precisely why it caught this. It goes from failing to passing here, along with the other 11 integration suites (26 tests) and the 39 unit suites (408 tests).

Worth flagging separately: `getStakes.integ.test.ts` passes **vacuously** today, because its test address now holds zero stake accounts and its assertions loop over an empty array. Not changed here, since pinning it to an address that currently has stakes would make CI fail the day that address unstakes, and `getBalance.integ.test.ts` already covers the regression.

### 🔗 Context

- **JIRA / GitHub issue**: none — opened without a ticket by decision; happy to link one after the fact.
- Surfaced as an unrelated red CI job on #20111.