### PR TITLE
[LWDM] chore(errors): migrate @ledgerhq/errors imports — platform

### DIFF
--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -6,7 +6,7 @@ import set from "lodash/set";
 import pick from "lodash/pick";
 import fs from "fs/promises";
 import { getEnv } from "@shared/env";
-import { NoDBPathGiven, DBWrongPassword } from "@ledgerhq/errors";
+import { NoDBPathGiven, DBWrongPassword } from "../../errors";
 import { INITIAL_STATE as trustchainInitialState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { exportWalletState, initialState as walletInitialState } from "@ledgerhq/live-wallet/store";
 import { LARGE_SCREEN_UPSELL_MODAL } from "@domain/entity-large-screen-upsell-modal";

--- a/apps/ledger-live-desktop/src/main/updater/createAppUpdater.ts
+++ b/apps/ledger-live-desktop/src/main/updater/createAppUpdater.ts
@@ -1,4 +1,4 @@
-import { UpdateIncorrectHash, UpdateIncorrectSig } from "@ledgerhq/errors";
+import { UpdateIncorrectHash, UpdateIncorrectSig } from "../../errors";
 import * as sslHelper from "./sslHelper";
 type Opts = {
   filename: string;

--- a/apps/ledger-live-desktop/src/main/updater/createElectronAppUpdater.ts
+++ b/apps/ledger-live-desktop/src/main/updater/createElectronAppUpdater.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import fs from "fs";
-import { UpdateFetchFileFail } from "@ledgerhq/errors";
+import { UpdateFetchFileFail } from "../../errors";
 import network from "@ledgerhq/live-network/network";
 import createAppUpdater from "./createAppUpdater";
 import pubKey from "./ledger-pubkey";

--- a/apps/ledger-live-desktop/src/main/updater/sslHelper.test.ts
+++ b/apps/ledger-live-desktop/src/main/updater/sslHelper.test.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { UpdateIncorrectSig } from "@ledgerhq/errors";
+import { UpdateIncorrectSig } from "../../errors";
 import * as sslHelper from "./sslHelper";
 
 // Test keys and data for consistent testing

--- a/apps/ledger-live-desktop/src/main/updater/sslHelper.ts
+++ b/apps/ledger-live-desktop/src/main/updater/sslHelper.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import keyto from "@trust/keyto";
-import { UpdateIncorrectSig } from "@ledgerhq/errors";
+import { UpdateIncorrectSig } from "../../errors";
 export async function getFingerprint(pubKey: string) {
   const hash = crypto.createHash("sha256");
   hash.update(pubKey);

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -57,7 +57,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:*",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-mocker": "workspace:*",
     "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:*",

--- a/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/HWDeviceProvider.ts
@@ -1,5 +1,5 @@
 import { from, lastValueFrom } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { ApduDevice } from "@ledgerhq/hw-ledger-key-ring-protocol/ApduDevice";
 import { StatusCodes } from "@ledgerhq/hw-transport";
 import { crypto, device } from "@ledgerhq/hw-ledger-key-ring-protocol";

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/HWDeviceProvider.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/HWDeviceProvider.test.ts
@@ -1,5 +1,5 @@
 import { of, throwError } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { HWDeviceProvider } from "../../HWDeviceProvider";
 import { TrustchainNotAllowed } from "../../errors";

--- a/libs/ledger-key-ring-protocol/tests/scenarios/userRefusesAuth.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/userRefusesAuth.ts
@@ -1,4 +1,4 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { RecorderConfig, ScenarioOptions, recorderConfigDefaults } from "../test-helpers/types";
 
 export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {

--- a/libs/ledger-key-ring-protocol/tests/scenarios/userRefusesRemoveMember.ts
+++ b/libs/ledger-key-ring-protocol/tests/scenarios/userRefusesRemoveMember.ts
@@ -1,4 +1,4 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import { RecorderConfig, ScenarioOptions } from "../test-helpers/types";
 
 export async function scenario(deviceId: string, { sdkForName }: ScenarioOptions) {

--- a/libs/ledger-live-common/src/network-troubleshooting/index.ts
+++ b/libs/ledger-live-common/src/network-troubleshooting/index.ts
@@ -1,4 +1,4 @@
-import { WebsocketConnectionError } from "@ledgerhq/errors";
+import { WebsocketConnectionError } from "../errors";
 import axios from "axios";
 import WS from "isomorphic-ws";
 import { Observable } from "rxjs";

--- a/libs/ledger-live-common/src/socket/index.ts
+++ b/libs/ledger-live-common/src/socket/index.ts
@@ -3,14 +3,16 @@ import { LocalTracer, TraceContext } from "@ledgerhq/logs";
 import WS from "isomorphic-ws";
 import { Observable, Subject } from "rxjs";
 import {
-  WebsocketConnectionError,
-  DeviceSocketFail,
   DisconnectedDeviceDuringOperation,
   TransportStatusError,
+  StatusCodes,
+} from "@ledgerhq/hw-transport/errors";
+import {
+  WebsocketConnectionError,
+  DeviceSocketFail,
   UserRefusedAllowManager,
   ManagerDeviceLockedError,
-  StatusCodes,
-} from "@ledgerhq/errors";
+} from "../errors";
 import { cancelDeviceAction } from "../hw/deviceAccess";
 import { getEnv } from "@shared/env";
 import type { SocketEvent } from "@ledgerhq/types-live";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8893,9 +8893,6 @@ importers:
 
   libs/ledger-key-ring-protocol:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:*
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-ledger-key-ring-protocol':
         specifier: workspace:*
         version: link:../hw-ledger-key-ring-protocol
@@ -14094,7 +14091,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -22630,7 +22627,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24638,7 +24635,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24974,7 +24971,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
### 📝 Description

Migrates the `@ledgerhq/errors` import sites owned by `@ledgerhq/platform` to the per-package error modules that replace it. Behaviour-neutral: no error class is renamed, all `error.name` checks and translation keys are unaffected.

Files changed (12):

| Package | Files |
|---|---|
| `ledger-live-desktop` (main process) | `db/index.ts`, `updater/createAppUpdater.ts`, `createElectronAppUpdater.ts`, `sslHelper.ts`, `sslHelper.test.ts` |
| `ledger-key-ring-protocol` | `HWDeviceProvider.ts`, `HWDeviceProvider.test.ts`, `userRefusesAuth.ts`, `userRefusesRemoveMember.ts` |
| `ledger-live-common` | `network-troubleshooting/index.ts`, `socket/index.ts` |
| `hw-app-str` | `tsconfig.json` |

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35103](https://ledgerhq.atlassian.net/browse/LIVE-35103)
- **ADR** (if any): N/A

[LIVE-35103]: https://ledgerhq.atlassian.net/browse/LIVE-35103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ