### PR TITLE
[LWDM] fix(evm): keep legacy custom fees on non eip1559 like etc

### DIFF
--- a/.changeset/clever-cougars-judge.md
+++ b/.changeset/clever-cougars-judge.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-evm": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(evm): keep legacy custom fees on non-EIP-1559 chains like Ethereum Classic

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
@@ -581,6 +581,44 @@ describe("estimateFees", () => {
     });
   });
 
+  it("keeps legacy type when custom gasPrice is paired with orphaned EIP-1559 zeros", async () => {
+    // createTransaction seeds maxFeePerGas/maxPriorityFeePerGas as BigNumber(0).
+    // Those zeros are truthy objects and used to flip the tx to type 2 after a
+    // custom legacy fee confirm (e.g. Ethereum Classic).
+    nodeApiMock.getGasEstimation.mockResolvedValue(new BigNumber("21000"));
+    nodeApiMock.getTransactionCount.mockResolvedValue(42);
+
+    const result = await estimateFees(
+      mockCurrency,
+      {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: BigInt("1000000000000000000"),
+        asset: { type: "native" },
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+      } as SendTransactionIntent<MemoNotSupported, BufferTxData>,
+      {
+        feesStrategy: "custom",
+        gasPrice: 1_000_000_000n,
+        maxFeePerGas: 0n,
+        maxPriorityFeePerGas: 0n,
+      },
+    );
+
+    expect(result.parameters).toEqual(
+      expect.objectContaining({
+        gasPrice: 1_000_000_000n,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        nextBaseFee: null,
+        type: 0,
+      }),
+    );
+    expect(result.value).toBe(21_000_000_000_000n); // 21000 * 1e9
+  });
+
   it("uses custom gas limit from customFeesParameters", async () => {
     nodeApiMock.getFeeData.mockResolvedValue({
       gasPrice: new BigNumber("20000000000"),

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -180,15 +180,28 @@ export async function estimateFees(
       feeDataPromise,
     ]);
 
-  // Recompute the transaction type from the fee data, since
-  // the one in input may not be supported by the Blockchain.
+  // Prevent BigNumber(0) placeholders from being interpreted as EIP-1559 fees
   const finalType =
-    finalFeeData.maxFeePerGas && finalFeeData.maxPriorityFeePerGas
+    BigNumber.isBigNumber(finalFeeData.maxFeePerGas) &&
+    finalFeeData.maxFeePerGas.gt(0) &&
+    BigNumber.isBigNumber(finalFeeData.maxPriorityFeePerGas)
       ? TransactionTypes.eip1559
       : TransactionTypes.legacy;
 
+  // Drop fee fields that don't belong to the resolved type so orphans
+  // (e.g. maxFeePerGas: 0 from createTransaction) are not re-propagated.
+  const typedFeeData: FeeData =
+    finalType === TransactionTypes.eip1559
+      ? { ...finalFeeData, gasPrice: null }
+      : {
+          ...finalFeeData,
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+          nextBaseFee: null,
+        };
+
   const gasPrice =
-    finalType === TransactionTypes.legacy ? finalFeeData.gasPrice : finalFeeData.maxFeePerGas;
+    finalType === TransactionTypes.legacy ? typedFeeData.gasPrice : typedFeeData.maxFeePerGas;
   const fee = gasPrice?.multipliedBy(gasLimit) || new BigNumber(0);
 
   const unsignedTransaction: TransactionLike = {
@@ -217,7 +230,7 @@ export async function estimateFees(
   return {
     value: BigInt(fee.toString()),
     parameters: {
-      ...toApiFeeData(finalFeeData),
+      ...toApiFeeData(typedFeeData),
       type: finalType,
       additionalFees: additionalFees && BigInt(additionalFees.toFixed()),
       gasLimit: BigInt(gasLimit.toFixed()),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -38,11 +38,22 @@ function propagateField(estimation: FeeEstimation, field: string, dest: GenericT
         return;
       dest[field] = Number(value.toString());
       return;
-    case "storageLimit":
-    case "gasLimit":
     case "gasPrice":
     case "maxFeePerGas":
     case "maxPriorityFeePerGas":
+      // Explicit null clears orphaned placeholders (e.g. maxFeePerGas: 0 from
+      // createTransaction after a switch to legacy). Omitted (undefined) keeps
+      // the existing value — parameters may simply not include the field.
+      if (value === null) {
+        dest[field] = null;
+        return;
+      }
+      if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string")
+        return;
+      dest[field] = new BigNumber(value.toString());
+      return;
+    case "storageLimit":
+    case "gasLimit":
     case "additionalFees":
       if (typeof value !== "bigint" && typeof value !== "number" && typeof value !== "string")
         return;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -215,6 +215,63 @@ describe("genericPrepareTransaction", () => {
     },
   );
 
+  it("clears orphaned EIP-1559 fee fields when estimation returns null", async () => {
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: new BigNumber(491),
+        parameters: {
+          type: 0,
+          gasPrice: 20_000_000_000n,
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+        },
+      }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, {
+      ...baseTransaction,
+      type: 2,
+      maxFeePerGas: new BigNumber(0),
+      maxPriorityFeePerGas: new BigNumber(0),
+      customFees: undefined,
+    } as GenericTransaction);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        type: 0,
+        gasPrice: new BigNumber(20_000_000_000),
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+      }),
+    );
+  });
+
+  it("does not clear fee fields when estimation omits them", async () => {
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: new BigNumber(491),
+        parameters: { gasLimit: 21000n },
+      }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, {
+      ...baseTransaction,
+      maxFeePerGas: new BigNumber(24),
+      maxPriorityFeePerGas: new BigNumber(3),
+      customFees: undefined,
+    } as GenericTransaction);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        maxFeePerGas: new BigNumber(24),
+        maxPriorityFeePerGas: new BigNumber(3),
+        gasLimit: new BigNumber(21000),
+      }),
+    );
+  });
+
   it("does not propagate the custom gas limit", async () => {
     (getCoinModuleApi as jest.Mock).mockReturnValue({
       estimateFees: jest.fn().mockResolvedValue({

--- a/libs/ledger-live-common/src/families/evm/descriptor/send/fees.test.ts
+++ b/libs/ledger-live-common/src/families/evm/descriptor/send/fees.test.ts
@@ -1,0 +1,72 @@
+import BigNumber from "bignumber.js";
+import { evmCustomFeeConfig, isEip1559 } from "./fees";
+
+describe("evm custom fee descriptor", () => {
+  describe("isEip1559", () => {
+    it("should return true when transaction type is 2", () => {
+      expect(isEip1559({ type: 2 })).toBe(true);
+    });
+
+    it("should return false for legacy type without EIP-1559 gasOptions", () => {
+      expect(
+        isEip1559({
+          type: 0,
+          gasPrice: new BigNumber(1_000_000_000),
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("buildTransactionPatch", () => {
+    it("should force legacy type and clear EIP-1559 fields for gasPrice custom fees", () => {
+      expect(evmCustomFeeConfig.buildTransactionPatch({ gasPrice: "1" })).toEqual({
+        feesStrategy: "custom",
+        type: 0,
+        gasPrice: new BigNumber(1_000_000_000),
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+      });
+    });
+
+    it("should force EIP-1559 type and clear gasPrice for max fee custom fees", () => {
+      expect(
+        evmCustomFeeConfig.buildTransactionPatch({
+          maxFeePerGas: "20",
+          maxPriorityFeePerGas: "2",
+        }),
+      ).toEqual({
+        feesStrategy: "custom",
+        type: 2,
+        gasPrice: null,
+        maxFeePerGas: new BigNumber(20_000_000_000),
+        maxPriorityFeePerGas: new BigNumber(2_000_000_000),
+      });
+    });
+  });
+
+  describe("getInitialValues", () => {
+    it("should expose a single gasPrice field for legacy transactions", () => {
+      expect(
+        evmCustomFeeConfig.getInitialValues({
+          type: 0,
+          gasPrice: new BigNumber(1_000_000_000),
+        }),
+      ).toEqual({ gasPrice: "1" });
+    });
+
+    it("should expose EIP-1559 fields for type 2 transactions", () => {
+      expect(
+        evmCustomFeeConfig.getInitialValues({
+          type: 2,
+          maxFeePerGas: new BigNumber(20_000_000_000),
+          maxPriorityFeePerGas: new BigNumber(2_000_000_000),
+        }),
+      ).toEqual({
+        maxFeePerGas: "20",
+        maxPriorityFeePerGas: "2",
+      });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/evm/descriptor/send/fees.ts
+++ b/libs/ledger-live-common/src/families/evm/descriptor/send/fees.ts
@@ -171,14 +171,25 @@ export const evmCustomFeeConfig: CustomFeeConfig = {
       feesStrategy: "custom",
     };
 
-    if ("maxFeePerGas" in values) {
-      patch.maxFeePerGas = gweiToWei(values.maxFeePerGas);
+    if ("maxFeePerGas" in values || "maxPriorityFeePerGas" in values) {
+      patch.type = 2;
+      patch.gasPrice = null;
+      if ("maxFeePerGas" in values) {
+        patch.maxFeePerGas = gweiToWei(values.maxFeePerGas);
+      }
+      if ("maxPriorityFeePerGas" in values) {
+        patch.maxPriorityFeePerGas = gweiToWei(values.maxPriorityFeePerGas);
+      }
+      return patch;
     }
-    if ("maxPriorityFeePerGas" in values) {
-      patch.maxPriorityFeePerGas = gweiToWei(values.maxPriorityFeePerGas);
-    }
+
     if ("gasPrice" in values) {
+      // Legacy custom fees: force type 0 and drop any leftover EIP-1559 fields
+      // so estimateFees / isEip1559 do not flip the UI to dual inputs.
+      patch.type = 0;
       patch.gasPrice = gweiToWei(values.gasPrice);
+      patch.maxFeePerGas = null;
+      patch.maxPriorityFeePerGas = null;
     }
     return patch;
   },

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -279,6 +279,45 @@ describe("useRecipientSearchState", () => {
     expect(result.current.showMatchedAddress).toBe(true);
   });
 
+  it("should keep matched address while recipient validation reloads a complete result", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "0xvalid",
+        isLoading: true,
+        result: createDefaultResult({
+          status: "valid",
+          error: null,
+          isBridgeLoading: false,
+        }),
+      }),
+    );
+
+    expect(result.current.showMatchedAddress).toBe(true);
+  });
+
+  it("should hide empty state and validation error while recipient validation is loading", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "dsjkfhkjsdfhds",
+        isLoading: true,
+        result: createDefaultResult({
+          status: "loading",
+          error: null,
+          matchedAccounts: [],
+          matchedRecentAddress: undefined,
+          ensName: undefined,
+          isLedgerAccount: false,
+        }),
+      }),
+    );
+
+    expect(result.current.showEmptyState).toBe(false);
+    expect(result.current.showMatchedAddress).toBe(false);
+    expect(result.current.showAddressValidationError).toBe(false);
+  });
+
   it("should show matched address when has matchedRecentAddress", () => {
     const recent = {
       address: "0xrecent",

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -51,6 +51,8 @@ export function useRecipientSearchState({
     !!bridgeRecipientError && !isBridgeInvalidAddress && !showSanctionedBanner;
   const hasBridgeRecipientWarning = !!bridgeRecipientWarning;
 
+  // Keep a complete match visible while search revalidates
+  // first bridge wait is via isAddressComplete.
   const showMatchedAddress =
     showSearchResults &&
     (hasAnyMatches ||
@@ -65,6 +67,7 @@ export function useRecipientSearchState({
 
   const showAddressValidationError =
     showSearchResults &&
+    !isLoading &&
     !showSanctionedBanner &&
     !hasAnyMatches &&
     (!!result.error || isBridgeInvalidAddress);
@@ -93,6 +96,7 @@ export function useRecipientSearchState({
 
   const showEmptyState =
     showSearchResults &&
+    !isLoading &&
     (!isAddressComplete || !hasAnyMatches) &&
     !showMatchedAddress &&
     !showSanctionedBanner &&


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

On ETC, leftover `maxFeePerGas`/`maxPriorityFeePerGas` as `BigNumber(0)` from `createTransaction` were truthy, so custom legacy fees were misclassified as eip1559. `estimateFees` now requires those fields to be > 0 and clears fee fields that do not match the resolved type

`prepareTransaction` propagates explicit `null` to drop orphans, and the custom-fee patch forces type 0 when the user sets `gasPrice`

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34904)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
