### PR TITLE
test(e2e): review and refactor subAccount spec (QAA-1114)

### DIFF
--- a/.changeset/QAA-1114-review-subaccount-spec.md
+++ b/.changeset/QAA-1114-review-subaccount-spec.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": minor
+---
+
+Review and refactor `subAccount.spec` (QAA-1114): mark the legacy send-flow tests with a `legacy -` prefix and drop that prefix + the `newSendFlow` feature-flag override from the non-send-flow blocks (add account, receive, token visible), add a Solana (SOL_GIGA) sub-account to the add-account coverage, remove the redundant `ETH_LIDO` receive case, and consolidate the SOL + ETH true-e2e sends into a single parameterized `transactionE2E` loop.

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -21,7 +21,12 @@ import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
 import { FF_NEW_SEND_FLOW_DISABLED } from "tests/utils/featureFlagUtils";
 import { buildTags } from "tests/utils/tagsUtils";
 
-const subAccounts = [
+const subAccounts: Array<{
+  account: TokenAccount;
+  xrayTicket1: string;
+  xrayTicket2: string;
+  notPreSeeded?: boolean;
+}> = [
   {
     account: TokenAccount.ETH_USDT_1,
     xrayTicket1: "B2CQA-2577, B2CQA-1079",
@@ -57,6 +62,12 @@ const subAccounts = [
     xrayTicket1: "B2CQA-3904",
     xrayTicket2: "B2CQA-3905",
   },
+  {
+    account: TokenAccount.SOL_GIGA_1,
+    xrayTicket1: "B2CQA-XXXX",
+    xrayTicket2: "B2CQA-XXXX",
+    notPreSeeded: true,
+  },
 ];
 
 const subAccountReceive: Array<{
@@ -70,11 +81,6 @@ const subAccountReceive: Array<{
     xrayTicket: "B2CQA-2492",
     shouldSelectReceiveCryptoOption: true,
   },
-  {
-    account: TokenAccount.ETH_LIDO,
-    xrayTicket: "B2CQA-2491",
-    shouldSelectReceiveCryptoOption: true,
-  },
   { account: TokenAccount.TRX_USDT, xrayTicket: "B2CQA-2496" },
   { account: TokenAccount.BSC_BUSD_1, xrayTicket: "B2CQA-2489" },
   { account: TokenAccount.POL_DAI_1, xrayTicket: "B2CQA-2493" },
@@ -82,15 +88,16 @@ const subAccountReceive: Array<{
   { account: TokenAccount.SUI_USDC_1, xrayTicket: "B2CQA-3906" },
 ];
 
+const SKIP_LNS_PARENT_CURRENCY_IDS = new Set<string>([Currency.SUI.id, Currency.SOL.id]);
+const shouldSkipLNS = (account: TokenAccount): boolean =>
+  SKIP_LNS_PARENT_CURRENCY_IDS.has(account.parentAccount?.currency.id ?? "");
+
 for (const token of subAccounts) {
-  test.describe("legacy send flow - Add subAccount without parent", () => {
+  test.describe("Add subAccount without parent", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: token.account.parentAccount?.currency.speculosApp,
-      featureFlags: {
-        ...FF_NEW_SEND_FLOW_DISABLED,
-      },
     });
 
     test(
@@ -98,7 +105,7 @@ for (const token of subAccounts) {
       {
         tag: buildTags({
           currencyId: token.account.currency.id,
-          skipLNS: token.account.parentAccount?.currency.id === Currency.SUI.id,
+          skipLNS: shouldSkipLNS(token.account),
           extraTags: token.account === TokenAccount.ETH_USDT_1 ? ["@smoke"] : [],
         }),
         annotation: {
@@ -138,14 +145,11 @@ for (const token of subAccounts) {
 }
 
 for (const token of subAccountReceive) {
-  test.describe("legacy send flow - Add subAccount when parent exists", () => {
+  test.describe("Add subAccount when parent exists", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
       speculosApp: token.account.currency.speculosApp,
-      featureFlags: {
-        ...FF_NEW_SEND_FLOW_DISABLED,
-      },
     });
 
     test(
@@ -153,7 +157,7 @@ for (const token of subAccountReceive) {
       {
         tag: buildTags({
           currencyId: token.account.currency.id,
-          skipLNS: token.account.parentAccount?.currency.id === Currency.SUI.id,
+          skipLNS: shouldSkipLNS(token.account),
         }),
         annotation: {
           type: "TMS",
@@ -189,14 +193,11 @@ for (const token of subAccountReceive) {
   });
 }
 
-for (const token of subAccounts) {
-  test.describe("legacy send flow - Token visible in parent account", () => {
+for (const token of subAccounts.filter(subAccount => !subAccount.notPreSeeded)) {
+  test.describe("Token visible in parent account", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "speculos-subAccount",
-      featureFlags: {
-        ...FF_NEW_SEND_FLOW_DISABLED,
-      },
     });
 
     test(
@@ -204,7 +205,7 @@ for (const token of subAccounts) {
       {
         tag: buildTags({
           currencyId: token.account.currency.id,
-          skipLNS: token.account.parentAccount?.currency.id === Currency.SUI.id,
+          skipLNS: shouldSkipLNS(token.account),
           extraTags: token.account === TokenAccount.ETH_USDT_1 ? ["@smoke"] : [],
         }),
         annotation: {
@@ -224,7 +225,12 @@ for (const token of subAccounts) {
   });
 }
 
-const transactionE2E = [
+const transactionE2E: Array<{
+  tx: Transaction;
+  xrayTicket: string;
+  checkInputValidity?: boolean;
+  extraTags?: string[];
+}> = [
   {
     tx: new Transaction(
       TokenAccount.SOL_GIGA_1,
@@ -234,11 +240,18 @@ const transactionE2E = [
       "noTag",
     ),
     xrayTicket: "B2CQA-3055, B2CQA-3057",
+    extraTags: ["@solana", "@family-solana"],
+  },
+  {
+    tx: new Transaction(TokenAccount.ETH_USDT_1, TokenAccount.ETH_USDT_3, "1", Fee.MEDIUM),
+    xrayTicket: "B2CQA-2703, B2CQA-475, B2CQA-3901",
+    checkInputValidity: true,
+    extraTags: ["@ethereum", "@family-evm"],
   },
 ];
 
 for (const transaction of transactionE2E) {
-  test.describe("legacy send flow - Send token - E2E", () => {
+  test.describe("legacy - Send token - E2E", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -257,7 +270,7 @@ for (const transaction of transactionE2E) {
     test(
       `Send from ${transaction.tx.accountToDebit.accountName} to ${transaction.tx.accountToCredit.accountName} - ${transaction.tx.accountToDebit.currency.name} - E2E test`,
       {
-        tag: buildTags({ skipLNS: true, extraTags: ["@solana", "@family-solana"] }),
+        tag: buildTags({ skipLNS: true, extraTags: transaction.extraTags ?? [] }),
         annotation: {
           type: "TMS",
           description: transaction.xrayTicket,
@@ -272,7 +285,18 @@ for (const transaction of transactionE2E) {
         );
         await app.account.navigateToTokenInAccount(transaction.tx.accountToDebit);
         await app.account.clickSend();
-        await app.send.craftTx(transaction.tx);
+
+        if (transaction.checkInputValidity) {
+          await app.send.fillRecipient(transaction.tx.accountToCredit.address);
+          await app.send.checkContinueButtonEnable();
+          await app.send.checkInputErrorVisibility("hidden");
+          await app.send.continue();
+          await app.send.fillAmount(transaction.tx.amount);
+          await app.send.checkContinueButtonEnable();
+        } else {
+          await app.send.craftTx(transaction.tx);
+        }
+
         await app.send.continueAmountModal();
         await app.send.expectTxInfoValidity(transaction.tx);
         await app.send.clickContinueToDevice();
@@ -333,7 +357,7 @@ const transactionsAddressInvalid = [
 ];
 
 for (const transaction of transactionsAddressInvalid) {
-  test.describe("legacy send flow - Send token - invalid address input", () => {
+  test.describe("legacy - Send token - invalid address input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -394,7 +418,7 @@ const transactionsAddressValid = [
 ];
 
 for (const transaction of transactionsAddressValid) {
-  test.describe("legacy send flow - Send token - valid address input", () => {
+  test.describe("legacy - Send token - valid address input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -467,7 +491,7 @@ const tokenTransactionInvalid = [
 ];
 
 for (const transaction of tokenTransactionInvalid) {
-  test.describe("legacy send flow - Send token (subAccount) - invalid amount input", () => {
+  test.describe("legacy - Send token (subAccount) - invalid amount input", () => {
     test.use({
       teamOwner: Team.COIN_INTEGRATION,
       userdata: "skip-onboarding-with-last-seen-device",
@@ -512,62 +536,3 @@ for (const transaction of tokenTransactionInvalid) {
     );
   });
 }
-
-test.describe("legacy send flow - Send token (subAccount) - valid address & amount input", () => {
-  const tokenTransactionValid = new Transaction(
-    TokenAccount.ETH_USDT_1,
-    TokenAccount.ETH_USDT_3,
-    "1",
-    Fee.MEDIUM,
-  );
-  test.use({
-    teamOwner: Team.COIN_INTEGRATION,
-    userdata: "skip-onboarding-with-last-seen-device",
-    speculosApp: tokenTransactionValid.accountToDebit.currency.speculosApp,
-    cliCommands: [
-      liveDataWithParentAddressCommand(
-        tokenTransactionValid.accountToDebit,
-        tokenTransactionValid.accountToCredit,
-      ),
-    ],
-    featureFlags: {
-      ...FF_NEW_SEND_FLOW_DISABLED,
-    },
-  });
-
-  test(
-    `Send from ${tokenTransactionValid.accountToDebit.accountName} to ${tokenTransactionValid.accountToCredit.accountName} - valid address & amount input`,
-    {
-      tag: buildTags({ extraTags: ["@ethereum", "@family-evm"] }),
-      annotation: {
-        type: "TMS",
-        description: "B2CQA-2703, B2CQA-475, B2CQA-3901",
-      },
-    },
-    async ({ app }) => {
-      await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
-
-      await app.mainNavigation.openTargetFromMainNavigation("accounts");
-      await app.accounts.navigateToAccountByName(
-        getParentAccountName(tokenTransactionValid.accountToDebit),
-      );
-      await app.account.navigateToTokenInAccount(tokenTransactionValid.accountToDebit);
-      await app.account.clickSend();
-      await app.send.fillRecipient(tokenTransactionValid.accountToCredit.address);
-      await app.send.checkContinueButtonEnable();
-      await app.send.checkInputErrorVisibility("hidden");
-      await app.send.continue();
-      await app.send.fillAmount(tokenTransactionValid.amount);
-      await app.send.checkContinueButtonEnable();
-
-      await app.send.continueAmountModal();
-      await app.send.expectTxInfoValidity(tokenTransactionValid);
-      await app.send.clickContinueToDevice();
-
-      await app.speculos.signSendTransaction(tokenTransactionValid);
-      await app.send.expectTxSent();
-      await app.account.navigateToViewDetails();
-      await app.sendDrawer.addressValueIsVisible(tokenTransactionValid.accountToCredit.address);
-    },
-  );
-});

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -88,9 +88,10 @@ const subAccountReceive: Array<{
   { account: TokenAccount.SUI_USDC_1, xrayTicket: "B2CQA-3906" },
 ];
 
-const SKIP_LNS_PARENT_CURRENCY_IDS = new Set<string>([Currency.SUI.id, Currency.SOL.id]);
-const shouldSkipLNS = (account: TokenAccount): boolean =>
-  SKIP_LNS_PARENT_CURRENCY_IDS.has(account.parentAccount?.currency.id ?? "");
+const shouldSkipLNS = (account: TokenAccount): boolean => {
+  const parentCurrencyId = account.parentAccount?.currency.id;
+  return parentCurrencyId === Currency.SUI.id || parentCurrencyId === Currency.SOL.id;
+};
 
 for (const token of subAccounts) {
   test.describe("Add subAccount without parent", () => {

--- a/e2e/desktop/tests/specs/subAccount.spec.ts
+++ b/e2e/desktop/tests/specs/subAccount.spec.ts
@@ -64,8 +64,8 @@ const subAccounts: Array<{
   },
   {
     account: TokenAccount.SOL_GIGA_1,
-    xrayTicket1: "B2CQA-XXXX",
-    xrayTicket2: "B2CQA-XXXX",
+    xrayTicket1: "B2CQA-6119",
+    xrayTicket2: "B2CQA-6128",
     notPreSeeded: true,
   },
 ];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is Playwright E2E test code; validated via the LWD E2E CI (scoped to `subAccount`)._
- [x] **Impact of the changes:**
  - Desktop sub-account **add-account** flow, including new **Solana (SOL_GIGA)** live token discovery
  - Sub-account **receive / verify-address** flow (redundant `ETH_LIDO` case removed)
  - **Token visible in parent account** check
  - Consolidated **SOL + ETH true-e2e send** (device signing + broadcast)
  - **Legacy vs new send-flow** test marking

### 📝 Description

Review and refactor of `e2e/desktop/tests/specs/subAccount.spec.ts` for QAA-1114.

**Context:** the suite had been reframed around the production `newSendFlow` feature flag, but the `legacy send flow -` describe prefix and the `FF_NEW_SEND_FLOW_DISABLED` override had been applied to every block — including ones that never exercise the send flow.

**Changes:**

- Mark only the genuine legacy send-flow tests with a shorter `legacy -` prefix; drop the prefix and the pointless `newSendFlow` override from the add-account, receive and token-visible blocks (verified against the flag's production consumers under `apps/ledger-live-desktop/src/mvvm/features/Send`).
- Add a Solana `SOL_GIGA` sub-account to the add-account coverage (`B2CQA-6119` / `B2CQA-6128`). It is discovered live only, so it is excluded from the pre-seeded "token visible" check.
- Remove the redundant `ETH_LIDO` receive case (one Ethereum ERC20 is sufficient).
- Consolidate the standalone SOL and ETH true-e2e sends into a single parameterized `transactionE2E` loop (device signing + broadcast), adding the requested ERC20 coverage.
- Extend the LNS-skip guard to Solana (Nano S cannot run the Solana app).

_Deferred to a follow-up PR: merging the "Token visible in parent account" loop into a single parameterized test using soft assertions._

### ❓ Context

- **JIRA or GitHub link**: [QAA-1114](https://ledgerhq.atlassian.net/browse/QAA-1114)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1114]: https://ledgerhq.atlassian.net/browse/QAA-1114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ