### PR TITLE
fix(contacts): prevent add contact row from clipping in desktop list

### DIFF
--- a/.changeset/calm-lists-scroll.md
+++ b/.changeset/calm-lists-scroll.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Fix Desktop contacts list scroll so the add contact row stays full size at the end of the list.

--- a/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
+++ b/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
@@ -143,6 +143,24 @@ describe("ContactsPage", () => {
     expect(contactsList).toHaveTextContent("Add contact");
   });
 
+  it("renders the add contact row as the last item in the scrollable contacts list", () => {
+    const contacts = mockPopulatedContacts();
+    const me = contacts.find(contact => contact.isMe) ?? mockMeContact();
+
+    renderContactsPage({
+      viewModel: createPopulatedContactsListViewModel(me, contacts),
+    });
+
+    const scrollContainer = screen.getByTestId("contacts-list-scroll");
+    const addContactRow = screen.getByTestId("contacts-add-contact");
+
+    expect(scrollContainer).toContainElement(screen.getByTestId("contacts-section-A"));
+    expect(scrollContainer).toContainElement(addContactRow);
+    expect(addContactRow.compareDocumentPosition(screen.getByTestId("contacts-section-O"))).toBe(
+      Node.DOCUMENT_POSITION_PRECEDING,
+    );
+  });
+
   it("keeps the Contacts page visible while Ledger Sync is checking", () => {
     renderContactsPage({ ledgerSyncStatus: "checking" });
 

--- a/features/flow/contacts/src/steps/List/components/ContactsList/ContactsList.web.tsx
+++ b/features/flow/contacts/src/steps/List/components/ContactsList/ContactsList.web.tsx
@@ -71,7 +71,7 @@ export function ContactsList({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-16" data-testid="contacts-list">
-      <div className="flex flex-col gap-8">
+      <div className="flex shrink-0 flex-col gap-8">
         <SearchInput
           value={searchQuery}
           placeholder={labels.searchPlaceholder}
@@ -88,8 +88,15 @@ export function ContactsList({
           />
         ) : null}
       </div>
-      {savedContactsContent}
-      <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+      <div
+        className="min-h-0 flex-1 overflow-auto scrollbar-custom [scrollbar-gutter:auto]"
+        data-testid="contacts-list-scroll"
+      >
+        <div className="flex flex-col gap-16">
+          {savedContactsContent}
+          <ContactsAddContactListItem label={labels.addContact} onAddContact={onAddContact} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/features/flow/contacts/src/steps/List/components/PageLayout/ContactsListPane.web.tsx
+++ b/features/flow/contacts/src/steps/List/components/PageLayout/ContactsListPane.web.tsx
@@ -9,7 +9,7 @@ export function ContactsListPane({
 }: ContactsListPaneProps): React.ReactNode {
   return (
     <aside
-      className="flex w-2/5 min-w-[400px] max-w-[445px] shrink-0 flex-col overflow-auto rounded-lg bg-section p-16"
+      className="flex w-2/5 min-h-0 min-w-[400px] max-w-[445px] shrink-0 flex-col overflow-hidden rounded-lg bg-section p-16"
       data-testid="contacts-list-pane"
     >
       {children}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Fixes a layout bug on the Desktop Contacts list where the **Add contact** row shrank and eventually disappeared as more contacts were added.

The list pane used a flex column where search, contacts, and the add row all competed for height. With default `flex-shrink`, flexbox compressed items instead of scrolling once the list grew past the available space (~5–6 contacts).

The fix follows the same scroll pattern used elsewhere (History, Market):

- **Search + Me** stay fixed at the top of the list pane
- **Saved contacts + Add contact** scroll together as one list
- The add row remains the **last item in the list** (not pinned to the pane bottom) and keeps its full size

## Changes

- `ContactsListPane`: switch from `overflow-auto` to `overflow-hidden min-h-0` so scrolling is handled inside the list
- `ContactsList`: add a dedicated scroll container for contacts and the add row
- Add unit test ensuring the add contact row is the last item in the scrollable list



https://github.com/user-attachments/assets/b70faf79-dcde-41f0-aa7c-e0ddccdda937



### 🔗 Context

[LIVE-35064](https://ledgerhq.atlassian.net/browse/LIVE-35064)


[LIVE-35064]: https://ledgerhq.atlassian.net/browse/LIVE-35064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ