### PR TITLE
[LWDM] chore(LIVE-34655): drop @ledgerhq/types-cryptoassets from public libs

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -98,7 +98,8 @@
       "entry": ["src/useDebounce.ts", "src/useThrottledFunction.ts"]
     },
     "./libs/live-countervalues": {
-      "entry": ["src/logic.ts", "src/api/index.ts", "src/types.ts", "src/portfolio.ts"]
+      "entry": ["src/logic.ts", "src/api/index.ts", "src/types.ts", "src/portfolio.ts"],
+      "ignoreDependencies": ["@ledgerhq/live-network"]
     },
     "./libs/live-countervalues-react": {
       "entry": ["src/index.tsx", "src/portfolio.tsx"]

--- a/libs/live-countervalues-react/package.json
+++ b/libs/live-countervalues-react/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@ledgerhq/types-live": "workspace:*",
-    "@ledgerhq/types-cryptoassets": "workspace:*",
     "@ledgerhq/live-countervalues": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-hooks": "workspace:*",

--- a/libs/live-countervalues-react/src/index.tsx
+++ b/libs/live-countervalues-react/src/index.tsx
@@ -13,7 +13,7 @@ import type {
   TrackingPair,
 } from "@ledgerhq/live-countervalues/types";
 import { useDebounce } from "@ledgerhq/live-hooks/useDebounce";
-import type { Currency, Unit } from "@ledgerhq/types-cryptoassets";
+import type { Currency, Unit } from "@ledgerhq/ledger-wallet-framework/types";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import React, {

--- a/libs/live-countervalues-react/src/portfolio.tsx
+++ b/libs/live-countervalues-react/src/portfolio.tsx
@@ -1,4 +1,8 @@
-import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type {
+  CryptoCurrency,
+  Currency,
+  TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 import type {
   Account,
   AccountLike,

--- a/libs/live-countervalues-react/src/react.test.ts
+++ b/libs/live-countervalues-react/src/react.test.ts
@@ -1,9 +1,5 @@
 import React from "react";
-import {
-  CountervaluesProvider,
-  useTrackingPairForAccounts,
-  type CountervaluesBridge,
-} from ".";
+import { CountervaluesProvider, useTrackingPairForAccounts, type CountervaluesBridge } from ".";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { renderHook, act, render, waitFor } from "@testing-library/react";
 import {
@@ -16,7 +12,11 @@ import type {
   CounterValuesState,
   TrackingPair,
 } from "@ledgerhq/live-countervalues/types";
-import type { Currency, FiatCurrency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type {
+  Currency,
+  FiatCurrency,
+  TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 
 jest.mock("@ledgerhq/live-countervalues/logic", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues/logic"),

--- a/libs/live-countervalues/package.json
+++ b/libs/live-countervalues/package.json
@@ -22,7 +22,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/types-live": "workspace:*",
-    "@ledgerhq/types-cryptoassets": "workspace:*",
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/logs": "workspace:*",
     "@ledgerhq/live-network": "workspace:*",

--- a/libs/live-countervalues/src/api/api.ts
+++ b/libs/live-countervalues/src/api/api.ts
@@ -4,7 +4,7 @@ import { getEnv } from "@ledgerhq/live-env";
 import { promiseAllBatched } from "@ledgerhq/live-promise";
 import { formatPerGranularity, inferCurrencyAPIID, pairId } from "../helpers";
 import type { BatchStrategySolver, CounterValuesAPI, TrackingPair } from "../types";
-import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { Currency } from "@ledgerhq/ledger-wallet-framework/types";
 
 const baseURL = () => getEnv("LEDGER_COUNTERVALUES_API");
 

--- a/libs/live-countervalues/src/helpers.ts
+++ b/libs/live-countervalues/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Currency } from "@ledgerhq/types-cryptoassets";
+import type { Currency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { RateGranularity } from "./types";
 
 export const inferCurrencyAPIID = (currency: Currency): string => {

--- a/libs/live-countervalues/src/logic.test.ts
+++ b/libs/live-countervalues/src/logic.test.ts
@@ -11,7 +11,11 @@ import {
 } from "./logic";
 import type { CounterValuesState, TrackingPair } from "./types";
 import { datapointRetention, formatCounterValueDay, formatCounterValueHour } from "./helpers";
-import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type {
+  CryptoCurrency,
+  Currency,
+  TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 
 describe("inferTrackingPairForAccounts", () => {
   const accounts = Array(20)

--- a/libs/live-countervalues/src/logic.ts
+++ b/libs/live-countervalues/src/logic.ts
@@ -30,7 +30,7 @@ import {
   inferCurrencyAPIID,
 } from "./helpers";
 import type { Account } from "@ledgerhq/types-live";
-import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { Currency } from "@ledgerhq/ledger-wallet-framework/types";
 import api from "./api";
 
 /**

--- a/libs/live-countervalues/src/mock.test.ts
+++ b/libs/live-countervalues/src/mock.test.ts
@@ -4,7 +4,7 @@ import CountervaluesAPI from "./api";
 import { setEnv } from "@ledgerhq/live-env";
 import { getFiatCurrencyByTicker, getCryptoCurrencyById } from "./tests/currencies";
 import { formatCounterValueDay, formatCounterValueHour, parseFormattedDate } from "./helpers";
-import type { TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 
 // Setup mock store with DAI token for tests

--- a/libs/live-countervalues/src/portfolio.ts
+++ b/libs/live-countervalues/src/portfolio.ts
@@ -19,7 +19,11 @@ import type {
   AssetsDistribution,
   ValueChange,
 } from "@ledgerhq/types-live";
-import type { CryptoCurrency, Currency, TokenCurrency } from "@ledgerhq/types-cryptoassets";
+import type {
+  CryptoCurrency,
+  Currency,
+  TokenCurrency,
+} from "@ledgerhq/ledger-wallet-framework/types";
 
 export const defaultAssetsDistribution = {
   minShowFirst: 1,

--- a/libs/live-countervalues/src/tests/currencies.ts
+++ b/libs/live-countervalues/src/tests/currencies.ts
@@ -1,5 +1,4 @@
-import { CoinType } from "@ledgerhq/types-cryptoassets";
-import type { CryptoCurrency, FiatCurrency } from "@ledgerhq/types-cryptoassets";
+import type { CryptoCurrency, FiatCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 
 // Minimal currency fixtures so tests don't pull the full currency registry.
 // Only the fields consumed by the countervalues logic and the account mocks are populated.
@@ -10,7 +9,7 @@ const bitcoin: CryptoCurrency = {
   name: "Bitcoin",
   ticker: "BTC",
   managerAppName: "Bitcoin",
-  coinType: CoinType.BTC,
+  coinType: 0,
   scheme: "bitcoin",
   color: "#ffae35",
   family: "bitcoin",
@@ -27,7 +26,7 @@ const ethereum: CryptoCurrency = {
   name: "Ethereum",
   ticker: "ETH",
   managerAppName: "Ethereum",
-  coinType: CoinType.ETH,
+  coinType: 60,
   scheme: "ethereum",
   color: "#0ebdcd",
   family: "evm",

--- a/libs/live-countervalues/src/types.ts
+++ b/libs/live-countervalues/src/types.ts
@@ -1,6 +1,6 @@
 // CountervaluesSettings is user config that drives the countervalues logic.
 
-import type { Currency } from "@ledgerhq/types-cryptoassets";
+import type { Currency } from "@ledgerhq/ledger-wallet-framework/types";
 
 // we generally will just infer it from Accounts
 export type CountervaluesSettings = {

--- a/libs/live-currency-format/package.json
+++ b/libs/live-currency-format/package.json
@@ -21,7 +21,6 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/types-cryptoassets": "workspace:^",
     "bignumber.js": "^9.1.2",
     "@ledgerhq/live-env": "workspace:^"
   },

--- a/libs/live-currency-format/src/formatCurrencyUnit.test.ts
+++ b/libs/live-currency-format/src/formatCurrencyUnit.test.ts
@@ -1,7 +1,7 @@
 import { listCryptoCurrencies } from "@domain/entity-currency-crypto";
 import { formatCurrencyUnit, formatCurrencyUnitFragment } from "./formatCurrencyUnit";
 import { BigNumber } from "bignumber.js";
-import { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 
 const testCases: { name: string; unit: Unit }[] = listCryptoCurrencies(true).map(currency => ({
   name: currency.name,

--- a/libs/live-currency-format/src/formatCurrencyUnit.ts
+++ b/libs/live-currency-format/src/formatCurrencyUnit.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import { getSeparators } from "./localeUtility";
 import { toLocaleString } from "./BigNumberToLocaleString";
 import { forceLTRIfRTL } from "./rtl";
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 
 const nonBreakableSpace = " ";
 const defaultFormatOptions = {

--- a/libs/live-currency-format/src/index.ts
+++ b/libs/live-currency-format/src/index.ts
@@ -1,3 +1,4 @@
+export type { Unit } from "./types";
 export {
   formatCurrencyUnit,
   formatCurrencyUnitFragment,

--- a/libs/live-currency-format/src/parseCurrencyUnit.test.ts
+++ b/libs/live-currency-format/src/parseCurrencyUnit.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import { parseCurrencyUnit } from "./parseCurrencyUnit";
 
 const unit: Unit = {

--- a/libs/live-currency-format/src/parseCurrencyUnit.ts
+++ b/libs/live-currency-format/src/parseCurrencyUnit.ts
@@ -1,4 +1,4 @@
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import { BigNumber } from "bignumber.js";
 
 // parse a value that was formatted with formatCurrencyUnit

--- a/libs/live-currency-format/src/priceFormat.test.ts
+++ b/libs/live-currency-format/src/priceFormat.test.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import {
   formatPrice,
   formatPriceFragment,

--- a/libs/live-currency-format/src/priceFormat.ts
+++ b/libs/live-currency-format/src/priceFormat.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "bignumber.js";
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import {
   formatCurrencyUnit,
   formatCurrencyUnitFragment,

--- a/libs/live-currency-format/src/sanitizeValueString.test.ts
+++ b/libs/live-currency-format/src/sanitizeValueString.test.ts
@@ -1,4 +1,4 @@
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import { sanitizeValueString } from "./sanitizeValueString";
 
 const unit: Unit = {

--- a/libs/live-currency-format/src/sanitizeValueString.ts
+++ b/libs/live-currency-format/src/sanitizeValueString.ts
@@ -1,4 +1,4 @@
-import type { Unit } from "@ledgerhq/types-cryptoassets";
+import type { Unit } from "./types";
 import { getSeparators } from "./localeUtility";
 
 const numbers = "0123456789";

--- a/libs/live-currency-format/src/types.ts
+++ b/libs/live-currency-format/src/types.ts
@@ -1,0 +1,7 @@
+export interface Unit {
+  name: string;
+  code: string;
+  magnitude: number;
+  showAllDigits?: boolean;
+  prefixCode?: boolean;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11552,9 +11552,6 @@ importers:
       '@ledgerhq/logs':
         specifier: workspace:*
         version: link:../ledgerjs/packages/logs
-      '@ledgerhq/types-cryptoassets':
-        specifier: workspace:*
-        version: link:../ledgerjs/packages/types-cryptoassets
       '@ledgerhq/types-live':
         specifier: workspace:*
         version: link:../ledgerjs/packages/types-live
@@ -11592,9 +11589,6 @@ importers:
       '@ledgerhq/live-hooks':
         specifier: workspace:*
         version: link:../live-hooks
-      '@ledgerhq/types-cryptoassets':
-        specifier: workspace:*
-        version: link:../ledgerjs/packages/types-cryptoassets
       '@ledgerhq/types-live':
         specifier: workspace:*
         version: link:../ledgerjs/packages/types-live
@@ -11641,9 +11635,6 @@ importers:
       '@ledgerhq/live-env':
         specifier: workspace:^
         version: link:../env
-      '@ledgerhq/types-cryptoassets':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/types-cryptoassets
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2


### PR DESCRIPTION
## Summary

Drops \`@ledgerhq/types-cryptoassets\` from 3 published packages. Domain packages (\`@domain/*\`) are workspace-private and cannot be used in published packages, so the migration uses different approaches per package:

- \`libs/live-countervalues\` — import from \`@ledgerhq/ledger-wallet-framework/types\` (already a dep)
- \`libs/live-countervalues-react\` — import from \`@ledgerhq/ledger-wallet-framework/types\` (already a dep)
- \`libs/live-currency-format\` — local \`Unit\` interface (wallet-framework cannot be added — circular dep)

## Jira

[LIVE-35113](https://ledgerhq.atlassian.net/browse/LIVE-35113)

## Test plan

- [ ] typecheck passes for all 3 packages
- [ ] lint passes for all 3 packages
- [ ] unimported passes for all 3 packages

[LIVE-35113]: https://ledgerhq.atlassian.net/browse/LIVE-35113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ