### PR TITLE
[LWDM] chore(LIVE-32915): migrate @ledgerhq/errors imports – live-devices team

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -4,8 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Action } from "@ledgerhq/live-common/hw/actions/types";
 import type { Theme } from "@ledgerhq/react-ui";
-import { EConnResetError } from "@ledgerhq/live-common/errors";
-import { UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { EConnResetError, UnresponsiveDeviceError } from "@ledgerhq/live-common/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import {
   addNewDeviceModel,
@@ -56,7 +55,6 @@ import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { AppAndVersion, DeviceDeprecationRules } from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/types-devices";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import {
   FlowName,
@@ -84,7 +82,7 @@ import {
   DeviceDeprecationScreens,
 } from "./Screen/DeviceDeprecationScreen";
 
-export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
+export type LedgerError = Error;
 
 type PartialNullable<T> = {
   [P in keyof T]?: T[P] | null;

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -21,7 +21,8 @@ import {
   Text,
   Theme,
 } from "@ledgerhq/react-ui";
-import { WrongDeviceForAccount, DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { getNoticeType, getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "tests/testSetup";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SkipReason } from "@ledgerhq/live-common/apps/types";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { createConnectAppMock } from "tests/mocks/createConnectAppMock";
 import InstallSetOfApps from "./InstallSetOfApps";
 

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { Button, Flex, Divider, Text, Input, IconsLegacy, BoxedIcon } from "@ledgerhq/react-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTranslation } from "react-i18next";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 import Label from "~/renderer/components/Label";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -9,7 +9,8 @@ import { ParamListBase, T } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import { getDeviceModel } from "@ledgerhq/devices";
-import { WrongDeviceForAccount, NanoSNotSupported } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NanoSNotSupported } from "@ledgerhq/live-common/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";

--- a/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
+++ b/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
@@ -3,7 +3,7 @@ import { firstValueFrom, from, PartialObserver } from "rxjs";
 import { take, first, filter } from "rxjs/operators";
 import type { Device } from "@ledgerhq/types-devices";
 import type { Observer as TransportObserver, DescriptorEvent } from "@ledgerhq/hw-transport";
-import { HwTransportError } from "@ledgerhq/errors";
+import { HwTransportError } from "@ledgerhq/hw-transport/errors";
 import type { ApduMock } from "~/logic/createAPDUMock";
 import { hookRejections } from "~/logic/debugReject";
 import { e2eBridgeClient } from "~/e2e/bridge/client";

--- a/libs/device-core/package.json
+++ b/libs/device-core/package.json
@@ -20,7 +20,6 @@
   "module": "lib-es/index.js",
   "dependencies": {
     "@ledgerhq/devices": "workspace:*",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/live-network": "workspace:^",
     "@ledgerhq/logs": "workspace:^",

--- a/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.test.ts
+++ b/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.test.ts
@@ -1,6 +1,7 @@
 import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { reinstallConfigurationConsent } from "./reinstallConfigurationConsent";
-import { PinNotSet, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import { PinNotSet } from "../../../errors";
 
 describe("reinstallConfigurationConsent", () => {
   let transport: Transport;

--- a/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.ts
+++ b/libs/device-core/src/commands/use-cases/consent/reinstallConfigurationConsent.ts
@@ -1,6 +1,7 @@
 import Transport, { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport";
 import { LocalTracer } from "@ledgerhq/logs";
-import { UserRefusedOnDevice, PinNotSet } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import { PinNotSet } from "../../../errors";
 import type { APDU } from "../../entities/APDU";
 import type { ReinstallConfigArgs } from "../../entities/ReinstallConfigEntity";
 

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.test.ts
@@ -1,4 +1,4 @@
-import { FirmwareNotRecognized, NetworkDown } from "@ledgerhq/errors";
+import { FirmwareNotRecognized, NetworkDown } from "../../errors";
 import { FinalFirmware } from "@ledgerhq/types-live";
 import { DeviceInfoEntity } from "../entities/DeviceInfoEntity";
 import { DeviceVersionEntity } from "../entities/DeviceVersionEntity";

--- a/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
+++ b/libs/device-core/src/managerApi/repositories/HttpManagerApiRepository.ts
@@ -1,6 +1,6 @@
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network/network";
-import { FirmwareNotRecognized, NetworkDown } from "@ledgerhq/errors";
+import { FirmwareNotRecognized, NetworkDown } from "../../errors";
 import { getUserHashes } from "../use-cases/getUserHashes";
 import URL from "url";
 import { ManagerApiRepository } from "./ManagerApiRepository";

--- a/libs/device-core/src/managerApi/use-cases/getLatestFirmwareForDevice.test.ts
+++ b/libs/device-core/src/managerApi/use-cases/getLatestFirmwareForDevice.test.ts
@@ -1,7 +1,7 @@
 import { getLatestFirmwareForDevice } from "./getLatestFirmwareForDevice";
 import { ManagerApiRepository } from "../repositories/ManagerApiRepository";
 import { DeviceVersion, FinalFirmware, McuVersion, OsuFirmware } from "@ledgerhq/types-live";
-import { UnknownMCU } from "@ledgerhq/errors";
+import { UnknownMCU } from "../../errors";
 import { StubManagerApiRepository } from "../repositories/StubManagerApiRepository";
 import { aDeviceInfoBuilder } from "../entities/mocks/aDeviceInfo";
 

--- a/libs/device-core/src/managerApi/use-cases/getLatestFirmwareForDevice.ts
+++ b/libs/device-core/src/managerApi/use-cases/getLatestFirmwareForDevice.ts
@@ -1,4 +1,4 @@
-import { UnknownMCU } from "@ledgerhq/errors";
+import { UnknownMCU } from "../../errors";
 import { DeviceInfoEntity } from "../entities/DeviceInfoEntity";
 import { FirmwareUpdateContextEntity } from "../entities/FirmwareUpdateContextEntity";
 import { ManagerApiRepository } from "../repositories/ManagerApiRepository";

--- a/libs/ledger-live-common/src/apps/listApps.test.ts
+++ b/libs/ledger-live-common/src/apps/listApps.test.ts
@@ -1,5 +1,5 @@
 import { from, lastValueFrom } from "rxjs";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "../errors";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { listApps } from "./listApps";
 import ManagerAPI, { ListInstalledAppsEvent } from "../manager/api";

--- a/libs/ledger-live-common/src/apps/listApps.ts
+++ b/libs/ledger-live-common/src/apps/listApps.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId, getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "../errors";
 import { Observable, throwError, Subscription } from "rxjs";
 import { App, DeviceInfo, idsToLanguage, languageIds } from "@ledgerhq/types-live";
 import { LocalTracer } from "@ledgerhq/logs";

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -5,10 +5,9 @@ import semver from "semver";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { AppOp, State, Action, ListAppsResult, AppsDistribution, SkipReason } from "./types";
 import { findCryptoCurrency, findCryptoCurrencyById, isCurrencySupported } from "../currencies";
-import { NoSuchAppOnProvider } from "../errors";
+import { NoSuchAppOnProvider, LatestFirmwareVersionRequired } from "../errors";
 import { App } from "@ledgerhq/types-live";
 import { getEnv } from "@shared/env";
-import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 
 const RESERVED_BLOCKS = 1;
 

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -1,5 +1,5 @@
 import { of, throwError } from "rxjs";
-import { ManagerAppDepInstallRequired, ManagerAppDepUninstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired, ManagerAppDepUninstallRequired } from "../errors";
 import { getDependencies, getDependents, whitelistDependencies } from "./polyfill";
 import { findCryptoCurrency } from "../currencies";
 import type { ListAppsResult, AppOp, Exec, InstalledItem } from "./types";

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
@@ -1,6 +1,5 @@
 import { type AppStorageInfo, isAppStorageInfo } from "@ledgerhq/device-core";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 
 /**
  * The interface for the storage provider used to store the application data, should be implemented in a platform-specific context.
@@ -90,7 +89,9 @@ export type BackupAppDataEvent =
 /**
  * An error that occurs during the backup process, the error message should be descriptive when thrown.
  */
-export const BackupAppDataError = createCustomErrorClass("BackupAppDataError");
+export class BackupAppDataError extends Error {
+  override name = "BackupAppDataError";
+}
 
 export enum RestoreAppDataEventType {
   /**
@@ -141,7 +142,9 @@ export type RestoreAppDataEvent =
 /**
  * An error that occurs during the restore process, the error message should be descriptive when thrown.
  */
-export const RestoreAppDataError = createCustomErrorClass("RestoreAppDataError");
+export class RestoreAppDataError extends Error {
+  override name = "RestoreAppDataError";
+}
 
 export enum DeleteAppDataEventType {
   AppDataDeleteStarted = "appDataDeleteStarted",
@@ -169,4 +172,6 @@ export type DeleteAppDataEvent =
 /**
  * An error that occurs during the delete process (local data), the error message should be descriptive when thrown.
  */
-export const DeleteAppDataError = createCustomErrorClass("DeleteAppDataError");
+export class DeleteAppDataError extends Error {
+  override name = "DeleteAppDataError";
+}

--- a/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
@@ -1,5 +1,5 @@
 import { Observable, of } from "rxjs";
-import { LockedDeviceError, TransportRaceCondition } from "@ledgerhq/errors";
+import { LockedDeviceError, TransportRaceCondition } from "@ledgerhq/hw-transport/errors";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
 import { getDeviceInfoTask, internalGetDeviceInfoTask } from "../tasks/getDeviceInfo";

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
@@ -11,7 +11,7 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   UserRefusedFirmwareUpdate,
   DeviceOnDashboardExpected,
-} from "@ledgerhq/errors";
+} from "../../../errors";
 import { LOG_TYPE, UnresponsiveCmdEvent } from "../core";
 
 export type InstallFirmwareCommandRequest = {

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
-import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { UnresponsiveCmdEvent } from "./core";
 import { Observable, from, of } from "rxjs";
 import { switchMap } from "rxjs/operators";

--- a/libs/ledger-live-common/src/deviceSDK/commands/toggleOnboardingEarlyCheck.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/toggleOnboardingEarlyCheck.test.ts
@@ -1,6 +1,6 @@
 import { MockTransport } from "@ledgerhq/hw-transport-mocker";
 import { ToggleTypeP2, toggleOnboardingEarlyCheckCmd } from "./toggleOnboardingEarlyCheck";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport/errors";
 
 describe("@deviceSDK/commands/toggleOnboardingEarlyCheckCmd", () => {
   describe("When the device is neither in the WELCOME and WELCOME_STEP2 onboarding state, and it returns 0x6982", () => {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
@@ -1,6 +1,6 @@
 import { of, throwError } from "rxjs";
 import { retryOnErrorsCommandWrapper, sharedLogicTaskWrapper, isDmkError } from "./core";
-import { DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { DisconnectedDevice, LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import { DeviceBusyError } from "@ledgerhq/device-management-kit";
 import { concatMap } from "rxjs/operators";
 import { TransportRef } from "../transports/core";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -1,4 +1,4 @@
-import { DisconnectedDevice, StatusCodes } from "@ledgerhq/errors";
+import { DisconnectedDevice, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import type { DeviceId } from "@ledgerhq/types-live";
 
 import { Observable, concat, of, throwError } from "rxjs";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getDeviceInfo.ts
@@ -1,4 +1,5 @@
-import { DisconnectedDevice, UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import type { DeviceId, DeviceInfo, FirmwareInfo } from "@ledgerhq/types-live";
 

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.test.ts
@@ -1,5 +1,5 @@
 import { from, of, throwError } from "rxjs";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import { toggleOnboardingEarlyCheckTask } from "./toggleOnboardingEarlyCheck";
 import { toggleOnboardingEarlyCheckCmd } from "../commands/toggleOnboardingEarlyCheck";
 import { withTransport } from "../transports/core";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
@@ -7,7 +7,7 @@ import {
   toggleOnboardingEarlyCheckCmd,
   ToggleTypeP2,
 } from "../commands/toggleOnboardingEarlyCheck";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 
 export type ToggleOnboardingEarlyCheckTaskError =
   | "DeviceInInvalidState"

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -2,8 +2,8 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { LocalTracer } from "@ledgerhq/logs";
 import type {
   DeviceId,

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -2,7 +2,8 @@ import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
-import { CantOpenDevice, DeviceHalted, FirmwareOrAppUpdateRequired } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
+import { DeviceHalted, FirmwareOrAppUpdateRequired } from "../../errors";
 import { open, close } from "../../hw/index";
 
 export { Transport };

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -14,7 +14,7 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
 import { catchError, debounce, delayWhen, filter, switchMap, tap, timeout } from "rxjs/operators";
 import { Device } from "./types";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -3,7 +3,7 @@ import { scan, map, tap } from "rxjs/operators";
 import { useEffect, useMemo, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
-import { UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { UserRefusedDeviceNameChange } from "../../errors";
 import { useReplaySubject } from "../../observable";
 import type { Action, Device } from "./types";
 import {

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -1,13 +1,13 @@
 import semver from "semver";
 import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   FirmwareOrAppUpdateRequired,
-  UserRefusedOnDevice,
   UpdateYourApp,
-  StatusCodes,
   LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
+} from "../errors";
 import type Transport from "@ledgerhq/hw-transport";
 import { type DerivationMode, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import type { AppOp, SkippedAppOp } from "../apps/types";

--- a/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
@@ -22,19 +22,20 @@ import type {
   ConnectAppDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   UserRefusedAllowManager,
-  UserRefusedOnDevice,
   LatestFirmwareVersionRequired,
   UnsupportedFeatureError,
-} from "@ledgerhq/errors";
+  DeviceNotOnboarded,
+  NoSuchAppOnProvider,
+} from "../errors";
 import { DeviceId } from "@domain/entity-client-identity";
 
 import type { SkippedAppOp } from "../apps/types";
 import { SkipReason } from "../apps/types";
 import { parseDeviceInfo } from "../deviceSDK/tasks/getDeviceInfo";
 import { ConnectAppEvent } from "./connectApp";
-import { DeviceNotOnboarded, NoSuchAppOnProvider } from "../errors";
 
 export class ConnectAppEventMapper {
   private openAppRequested: boolean = false;

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -1,6 +1,6 @@
 import { Observable, concat, concatWith, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { isCharonSupported } from "@ledgerhq/device-core";
 import { identifyTargetId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
@@ -14,7 +14,7 @@ import type {
   PrepareConnectManagerDAError,
   PrepareConnectManagerDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 
 import { LockedDeviceEvent } from "./actions/types";
 

--- a/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
@@ -1,6 +1,6 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import { TransportError, StatusCodes } from "@ledgerhq/errors";
+import { TransportError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
@@ -2,8 +2,8 @@ import customLockScreenLoad from "./customLockScreenLoad";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/device-core";
 import { lastValueFrom, of } from "rxjs";
-import { ManagerNotEnoughSpaceError, StatusCodes, TransportError } from "@ledgerhq/errors";
-import { ImageLoadRefusedOnDevice } from "../errors";
+import { StatusCodes, TransportError } from "@ledgerhq/hw-transport/errors";
+import { ImageLoadRefusedOnDevice, ManagerNotEnoughSpaceError } from "../errors";
 
 const mockTransport = {
   send: jest.fn(),

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
@@ -1,15 +1,14 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
+import { StatusCodes, TransportError, DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import {
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-  DisconnectedDevice,
-} from "@ledgerhq/errors";
+  ImageLoadRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+} from "../errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "../errors";
 import getAppAndVersion from "./getAppAndVersion";
 import { isDashboardName } from "./isDashboardName";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
@@ -1,7 +1,8 @@
-import { StatusCodes, UnexpectedBootloader, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import removeImage, { command } from "./customLockScreenRemove";
 import Transport from "@ledgerhq/hw-transport";
-import { ImageDoesNotExistOnDevice } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { from } from "rxjs";
 import getDeviceInfo from "./getDeviceInfo";

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
@@ -1,15 +1,11 @@
-import {
-  TransportStatusError,
-  UnexpectedBootloader,
-  StatusCodes,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of, throwError } from "rxjs";
 import { withDevice } from "./deviceAccess";
 import { catchError, delay, mergeMap } from "rxjs/operators";
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageDoesNotExistOnDevice } from "../errors";
 
 export type RemoveImageEvent =
   | {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -1,12 +1,8 @@
 import { firstValueFrom, from, Observable, throwError, timer } from "rxjs";
 import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  CantOpenDevice,
-  FirmwareOrAppUpdateRequired,
-  TransportStatusError,
-  DeviceHalted,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { FirmwareOrAppUpdateRequired, DeviceHalted } from "../errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@shared/env";
 import { open, close, OpenOptions } from ".";

--- a/libs/ledger-live-common/src/hw/editDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/editDeviceName.ts
@@ -1,5 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedDeviceNameChange } from "../errors";
 
 /**
  * Specify a new name for a device. This is technically supported on all models

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { CharonStatus, extractOnboardingState, OnboardingStep } from "./extractOnboardingState";
 
 describe("@hw/extractOnboardingState", () => {

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { SeedPhraseType } from "@ledgerhq/types-live";
 
 const CHARON_STEP_BIT_MASK = 0x1000;

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
@@ -1,7 +1,7 @@
 import { log } from "@ledgerhq/logs";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import { concatMap, delay, scan, distinctUntilChanged, throttleTime } from "rxjs/operators";
-import { DeviceInOSUExpected } from "@ledgerhq/errors";
+import { DeviceInOSUExpected } from "../errors";
 import { withDevicePolling, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
 import flash from "./flash";

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
@@ -2,7 +2,7 @@ import { log } from "@ledgerhq/logs";
 import type { FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { Observable, from, of, concat, throwError } from "rxjs";
 import { mergeMap, delay, filter, map } from "rxjs/operators";
-import { DeviceOnDashboardExpected } from "@ledgerhq/errors";
+import { DeviceOnDashboardExpected } from "../errors";
 import getDeviceInfo from "./getDeviceInfo";
 import installOsuFirmware from "./installOsuFirmware";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
@@ -1,5 +1,5 @@
 import { log } from "@ledgerhq/logs";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
+import { MCUNotGenuineToDashboard } from "../errors";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import type { DeviceVersion, FinalFirmware, McuVersion } from "@ledgerhq/types-live";
 import { concatMap, delay, filter, map, mergeMap, throttleTime } from "rxjs/operators";

--- a/libs/ledger-live-common/src/hw/getAddress/index.ts
+++ b/libs/ledger-live-common/src/hw/getAddress/index.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "@ledgerhq/errors";
+import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import { Resolver } from "./types";
 import { loadSetupForFamily } from "../../coin-modules/registry";

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
-import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 
 import { LOG_TYPE } from ".";

--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
-import { DeviceOnDashboardExpected, StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnDashboardExpected, DeviceNotOnboarded } from "../errors";
 import { LocalTracer, log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
@@ -7,7 +8,6 @@ import isDevFirmware from "./isDevFirmware";
 import getAppAndVersion from "./getAppAndVersion";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
-import { DeviceNotOnboarded } from "../errors";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 
 const ManagerAllowedFlag = 0x08;

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
@@ -1,7 +1,11 @@
 import { firstValueFrom, from, Observable, of, timer } from "rxjs";
 import { delay } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import { CantOpenDevice, DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  CantOpenDevice,
+  DisconnectedDevice,
+  LockedDeviceError,
+} from "@ledgerhq/hw-transport/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import getDeviceInfo from "./getDeviceInfo";
 import { getDeviceRunningMode } from "./getDeviceRunningMode";

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
@@ -8,7 +8,7 @@ import {
   getGenuineCheckFromDeviceId,
   GetGenuineCheckFromDeviceIdResult,
 } from "./getGenuineCheckFromDeviceId";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -4,13 +4,12 @@ import * as rxjsOperators from "rxjs/operators";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import {
-  DeviceExtractOnboardingStateError,
   DisconnectedDevice,
   LockedDeviceError,
   TransportStatusError,
   StatusCodes,
-  UnexpectedBootloader,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { DeviceExtractOnboardingStateError, UnexpectedBootloader } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { extractOnboardingState, OnboardingState, OnboardingStep } from "./extractOnboardingState";
@@ -96,7 +95,7 @@ describe("getOnboardingStatePolling", () => {
           next: value => {
             try {
               expect(value.onboardingState).toBeNull();
-              expect(value.allowedError).toBeInstanceOf(DisconnectedDevice);
+              expect(value.allowedError).toMatchObject({ name: "DisconnectedDevice" });
               expect(value.lockedDevice).toBe(false);
               done();
             } catch (expectError) {
@@ -125,7 +124,9 @@ describe("getOnboardingStatePolling", () => {
           next: value => {
             try {
               expect(value.onboardingState).toBeNull();
-              expect(value.allowedError).toBeInstanceOf(DeviceDisconnectedWhileSendingError);
+              expect(value.allowedError).toMatchObject({
+                name: "DeviceDisconnectedWhileSendingError",
+              });
               expect(value.lockedDevice).toBe(false);
               done();
             } catch (expectError) {
@@ -154,7 +155,7 @@ describe("getOnboardingStatePolling", () => {
           next: value => {
             try {
               expect(value.onboardingState).toBeNull();
-              expect(value.allowedError).toBeInstanceOf(LockedDeviceError);
+              expect(value.allowedError).toMatchObject({ name: "LockedDeviceError" });
               expect(value.lockedDevice).toBe(true);
               done();
             } catch (expectError) {
@@ -185,7 +186,7 @@ describe("getOnboardingStatePolling", () => {
           next: value => {
             try {
               expect(value.onboardingState).toBeNull();
-              expect(value.allowedError).toBeInstanceOf(TimeoutError);
+              expect(value.allowedError).toMatchObject({ name: "TimeoutError" });
               expect(value.lockedDevice).toBe(false);
               done();
             } catch (expectError) {
@@ -243,7 +244,7 @@ describe("getOnboardingStatePolling", () => {
         next: value => {
           try {
             expect(value.onboardingState).toBeNull();
-            expect(value.allowedError).toBeInstanceOf(DeviceExtractOnboardingStateError);
+            expect(value.allowedError).toMatchObject({ name: "DeviceExtractOnboardingStateError" });
             expect(value.lockedDevice).toBe(false);
             done();
           } catch (expectError) {
@@ -407,7 +408,7 @@ describe("getOnboardingStatePolling", () => {
 
         expect(values.length).toBeGreaterThanOrEqual(1);
         expect(values[0].onboardingState).toBeNull();
-        expect(values[0].allowedError).toBeInstanceOf(TransportStatusError);
+        expect(values[0].allowedError).toMatchObject({ name: "TransportStatusError" });
         expect(mockedQuitApp).toHaveBeenCalledTimes(1);
       },
     );
@@ -478,7 +479,7 @@ describe("getOnboardingStatePolling", () => {
         },
         error: error => {
           try {
-            expect(error).toBeInstanceOf(UnexpectedBootloader);
+            expect(error).toMatchObject({ name: "UnexpectedBootloader" });
             done();
           } catch (expectError) {
             done(expectError);
@@ -501,7 +502,7 @@ describe("getOnboardingStatePolling", () => {
       }).subscribe({
         error: error => {
           try {
-            expect(error).toBeInstanceOf(UnexpectedBootloader);
+            expect(error).toMatchObject({ name: "UnexpectedBootloader" });
             expect(mockedQuitApp).not.toHaveBeenCalled();
             done();
           } catch (expectError) {

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -2,11 +2,8 @@ import { defer, from, of, throwError, Observable, timer } from "rxjs";
 import { map, catchError, first, timeout, repeat, switchMap } from "rxjs/operators";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { withDevice } from "./deviceAccess";
-import {
-  StatusCodes,
-  DeviceOnboardingStatePollingError,
-  UnexpectedBootloader,
-} from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnboardingStatePollingError, UnexpectedBootloader } from "../errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
 import { DeviceDisconnectedWhileSendingError } from "@ledgerhq/device-management-kit";

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
@@ -3,12 +3,8 @@
  */
 import { renderHook, act } from "@testing-library/react";
 import { of, throwError } from "rxjs";
-import {
-  UserRefusedAllowManager,
-  DisconnectedDeviceDuringOperation,
-  UnresponsiveDeviceError,
-  DeviceSocketFail,
-} from "@ledgerhq/errors";
+import { DisconnectedDeviceDuringOperation } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedAllowManager, UnresponsiveDeviceError, DeviceSocketFail } from "../../errors";
 import { useGenuineCheck } from "./useGenuineCheck";
 import {
   getGenuineCheckFromDeviceId,
@@ -115,7 +111,7 @@ describe("useGenuineCheck", () => {
       });
 
       expect(result.current.genuineState).toEqual("unchecked");
-      expect(result.current.error).toBeInstanceOf(DisconnectedDeviceDuringOperation);
+      expect(result.current.error).toMatchObject({ name: "DisconnectedDeviceDuringOperation" });
     });
 
     it("should set genuineState to non-genuine when HSM returns a counterfeit error", async () => {
@@ -297,7 +293,7 @@ describe("useGenuineCheck", () => {
       });
 
       // Then the hook consumer should be notified of the error
-      expect(result.current.error).toBeInstanceOf(UnresponsiveDeviceError);
+      expect(result.current.error).toMatchObject({ name: "UnresponsiveDeviceError" });
       expect(result.current.devicePermissionState).toEqual("requested");
     });
   });

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { isCounterfeitError } from "../isCounterfeitError";
 import type { DeviceId } from "@ledgerhq/types-live";
 import { getGenuineCheckFromDeviceId as defaultGetGenuineCheckFromDeviceId } from "../getGenuineCheckFromDeviceId";

--- a/libs/ledger-live-common/src/hw/index.test.ts
+++ b/libs/ledger-live-common/src/hw/index.test.ts
@@ -1,6 +1,6 @@
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { registerTransportModule, open } from ".";
-import { CantOpenDevice, TransportError } from "@ledgerhq/errors";
+import { CantOpenDevice, TransportError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 
@@ -19,7 +19,7 @@ describe("open", () => {
       });
 
       const openPromise = open("device_0");
-      await expect(openPromise).rejects.toBeInstanceOf(CantOpenDevice);
+      await expect(openPromise).rejects.toMatchObject({ name: "CantOpenDevice" });
     });
   });
 
@@ -65,7 +65,7 @@ describe("open", () => {
 
       const openPromise = open("device_2", { openTimeoutMs: timeoutMs });
       jest.advanceTimersByTime(timeoutMs);
-      await expect(openPromise).rejects.toBeInstanceOf(CantOpenDevice);
+      await expect(openPromise).rejects.toMatchObject({ name: "CantOpenDevice" });
     });
 
     test("And the Transport/module implementation timeouts before open, it should still reject with an error", async () => {
@@ -91,7 +91,7 @@ describe("open", () => {
       const openPromise = open("device_3", { openTimeoutMs: timeoutMs });
       // Advances time after the implementation timeout but before the `open` timeout
       jest.advanceTimersByTime(timeoutMs - 100);
-      await expect(openPromise).rejects.toBeInstanceOf(TransportError);
+      await expect(openPromise).rejects.toMatchObject({ name: "TransportError" });
     });
   });
 

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -4,7 +4,7 @@ import { catchError } from "rxjs/operators";
 import type { DeviceModel } from "@ledgerhq/types-devices";
 import Transport from "@ledgerhq/hw-transport";
 import { TraceContext, trace } from "@ledgerhq/logs";
-import { CantOpenDevice } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
 
 export const LOG_TYPE = "hw";
 

--- a/libs/ledger-live-common/src/hw/installApp.test.ts
+++ b/libs/ledger-live-common/src/hw/installApp.test.ts
@@ -4,11 +4,8 @@ import ManagerAPI from "../manager/api";
 import { defer, of, throwError } from "rxjs";
 import { anAppBuilder } from "../mock/fixtures/anApp";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
-import {
-  LockedDeviceError,
-  ManagerDeviceLockedError,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { ManagerDeviceLockedError, UnresponsiveDeviceError } from "../errors";
 import { quitApp } from "../deviceSDK/commands/quitApp";
 
 // Mocking ManagerAPI

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -1,6 +1,6 @@
 import { Observable, throwError, timer } from "rxjs";
 import { throttleTime, filter, map, catchError, retry, switchMap } from "rxjs/operators";
-import { ManagerAppDepInstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -1,16 +1,15 @@
+import { StatusCodes, TransportError } from "@ledgerhq/hw-transport/errors";
 import {
   LanguageNotFound,
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-} from "@ledgerhq/errors";
+  LanguageInstallRefusedOnDevice,
+} from "../errors";
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 
 import Transport from "@ledgerhq/hw-transport";
 import network from "@ledgerhq/live-network/network";
 import { Language, LanguagePackage } from "@ledgerhq/types-live";
-import { LanguageInstallRefusedOnDevice } from "../errors";
 import ManagerAPI from "../manager/api";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
+++ b/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
@@ -1,5 +1,5 @@
 import { isCounterfeitError } from "./isCounterfeitError";
-import { DeviceSocketFail } from "@ledgerhq/errors";
+import { DeviceSocketFail } from "../errors";
 
 describe("isCounterfeitError", () => {
   it("should return true if the error is a DeviceSocketFail", () => {

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
@@ -1,4 +1,5 @@
-import { StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { command as uninstallAllApps } from "./uninstallAllApps";
 import Transport from "@ledgerhq/hw-transport";
 

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of } from "rxjs";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/uninstallApp.ts
+++ b/libs/ledger-live-common/src/hw/uninstallApp.ts
@@ -1,6 +1,6 @@
 import { ignoreElements, catchError } from "rxjs/operators";
 import { Observable, throwError } from "rxjs";
-import { ManagerAppDepUninstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepUninstallRequired } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import ManagerAPI from "../manager/api";
 import type { App, ApplicationVersion } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { NetworkDown } from "@ledgerhq/live-network/errors";
 import {
   DeviceOnDashboardExpected,
   FirmwareNotRecognized,
@@ -6,9 +7,8 @@ import {
   ManagerDeviceLockedError,
   ManagerFirmwareNotEnoughSpaceError,
   ManagerNotEnoughSpaceError,
-  NetworkDown,
   UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
+} from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network/network";

--- a/libs/ledgerjs/packages/hw-transport-http/package.json
+++ b/libs/ledgerjs/packages/hw-transport-http/package.json
@@ -45,7 +45,6 @@
   "types": "lib/withStaticURLs.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/logs": "workspace:^",
     "axios": "catalog:",

--- a/libs/ledgerjs/packages/hw-transport-http/src/HttpTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/HttpTransport.ts
@@ -1,5 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import { TransportError } from "@ledgerhq/errors";
+import { TransportError } from "@ledgerhq/hw-transport/errors";
 import axios from "axios";
 import { log } from "@ledgerhq/logs";
 /**

--- a/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-http/src/WebSocketTransport.ts
@@ -1,5 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import { TransportError } from "@ledgerhq/errors";
+import { TransportError } from "@ledgerhq/hw-transport/errors";
 import { log } from "@ledgerhq/logs";
 
 declare global {

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/package.json
@@ -28,7 +28,6 @@
   "types": "lib/SpeculosHttpTransport.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/logs": "workspace:^",
     "axios": "catalog:",

--- a/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos-http/src/SpeculosHttpTransport.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import Transport from "@ledgerhq/hw-transport";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { log } from "@ledgerhq/logs";
 import { Subject } from "rxjs";
 

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/package.json
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/package.json
@@ -28,7 +28,6 @@
   "types": "lib/SpeculosTransport.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/logs": "workspace:^",
     "rxjs": "catalog:"

--- a/libs/ledgerjs/packages/hw-transport-node-speculos/src/SpeculosTransport.ts
+++ b/libs/ledgerjs/packages/hw-transport-node-speculos/src/SpeculosTransport.ts
@@ -5,7 +5,7 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   TransportError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
 import { log } from "@ledgerhq/logs";
 
 /**

--- a/libs/ledgerjs/packages/hw-transport-vault/package.json
+++ b/libs/ledgerjs/packages/hw-transport-vault/package.json
@@ -25,7 +25,7 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/hw-transport-http": "workspace:^",
     "@ledgerhq/logs": "workspace:^"
   },

--- a/libs/ledgerjs/packages/hw-transport-vault/src/index.ts
+++ b/libs/ledgerjs/packages/hw-transport-vault/src/index.ts
@@ -1,5 +1,5 @@
 import { log } from "@ledgerhq/logs";
-import { TransportError } from "@ledgerhq/errors";
+import { TransportError } from "@ledgerhq/hw-transport/errors";
 import WebSocketTransport from "@ledgerhq/hw-transport-http/WebSocketTransport";
 
 type VaultData = {

--- a/libs/ledgerjs/packages/hw-transport/package.json
+++ b/libs/ledgerjs/packages/hw-transport/package.json
@@ -26,7 +26,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/devices": "workspace:*",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "events": "^3.3.0"
   },
@@ -55,12 +54,25 @@
     "@swc/core": "catalog:",
     "ts-node": "^10.4.0"
   },
+  "typesVersions": {
+    "*": {
+      "errors": [
+        "./src/errors.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "@ledgerhq/source": "./src/Transport.ts",
       "import": "./lib-es/Transport.js",
       "require": "./lib/Transport.js",
       "default": "./lib/Transport.js"
+    },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "import": "./lib-es/errors.js",
+      "require": "./lib/errors.js",
+      "default": "./lib/errors.js"
     },
     "./lib-es/*": "./lib-es/*.js",
     "./lib/*": "./lib/*.js",

--- a/libs/ledgerjs/packages/hw-transport/src/Transport.ts
+++ b/libs/ledgerjs/packages/hw-transport/src/Transport.ts
@@ -6,7 +6,7 @@ import {
   StatusCodes,
   getAltStatusMessage,
   TransportStatusError,
-} from "@ledgerhq/errors";
+} from "./errors";
 import { LocalTracer, TraceContext, LogType } from "@ledgerhq/logs";
 export { TransportError, TransportStatusError, StatusCodes, getAltStatusMessage };
 

--- a/libs/live-dmk-mobile/package.json
+++ b/libs/live-dmk-mobile/package.json
@@ -35,7 +35,6 @@
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-transport-kit-react-native-ble": "catalog:",
     "@ledgerhq/devices": "workspace:*",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/live-dmk-shared": "workspace:^",
     "@ledgerhq/logs": "workspace:^",

--- a/libs/live-dmk-mobile/src/connectDevice/utils.test.ts
+++ b/libs/live-dmk-mobile/src/connectDevice/utils.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@ledgerhq/device-transport-kit-react-native-ble";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
 import { DeviceModelId } from "@ledgerhq/types-devices";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
+import { PeerRemovedPairing } from "../errors";
 import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
 
 import { BaseConnectionErrorTypes, ConnectionErrorTypes } from "./types";

--- a/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
+++ b/libs/live-dmk-mobile/src/hooks/useBleDevicePairing.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { DmkError } from "@ledgerhq/device-management-kit";
-import { PeerRemovedPairing } from "@ledgerhq/errors";
+import { PeerRemovedPairing } from "../errors";
 import {
   rnBleTransportIdentifier,
   PeerRemovedPairingError,

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -29,10 +29,10 @@ import type {
   Observer as TransportObserver,
   Subscription as TransportSubscription,
 } from "@ledgerhq/hw-transport";
-import { HwTransportError, PairingFailed, PeerRemovedPairing } from "@ledgerhq/errors";
+import { HwTransportError } from "@ledgerhq/hw-transport/errors";
+import { PairingFailed, PeerRemovedPairing, isPeerRemovedPairingError } from "../errors";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 import { BlePlxManager } from "./BlePlxManager";
-import { isPeerRemovedPairingError } from "../errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { findMatchingDiscoveredDevice, matchDeviceByName } from "../utils/matchDevicesByNameOrId";
 

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.test.ts
@@ -16,7 +16,7 @@ import {
   activeDeviceSessionSubject,
 } from "./DeviceManagementKitHIDTransport";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 
 function createMockDMK(): DeviceManagementKit {
   const mock = {

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHIDTransport.ts
@@ -6,7 +6,7 @@ import {
   SendApduEmptyResponseError,
 } from "@ledgerhq/device-management-kit";
 import { rnHidTransportIdentifier } from "@ledgerhq/device-transport-kit-react-native-hid";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import Transport from "@ledgerhq/hw-transport";
 import { LocalTracer, TraceContext } from "@ledgerhq/logs";
 import { BehaviorSubject, Subscription, firstValueFrom } from "rxjs";

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.test.ts
@@ -10,7 +10,7 @@ import {
   DeviceDisconnectedBeforeSendingApdu,
   DeviceDisconnectedWhileSendingError,
 } from "@ledgerhq/device-management-kit";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { DeviceManagementKitHTTPProxyTransport } from "./DeviceManagementKitHTTPProxyTransport";
 import {
   buildHttpProxyLegacyDeviceId,

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitHTTPProxyTransport.ts
@@ -6,7 +6,7 @@ import {
   DeviceDisconnectedBeforeSendingApdu,
   type DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import Transport from "@ledgerhq/hw-transport";
 import { firstValueFrom, type Subscription } from "rxjs";
 import { filter, timeout } from "rxjs/operators";

--- a/libs/live-signer-aleo/package.json
+++ b/libs/live-signer-aleo/package.json
@@ -31,7 +31,7 @@
     "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-aleo": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:^",
     "rxjs": "catalog:"
   },
   "scripts": {
@@ -62,6 +62,11 @@
       "import": "./lib-es/index.js",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
     },
     "./lib-es/*": "./lib-es/*.js",
     "./lib/*": "./lib/*.js",

--- a/libs/live-signer-aleo/src/DmkSignerAleo.ts
+++ b/libs/live-signer-aleo/src/DmkSignerAleo.ts
@@ -14,7 +14,8 @@ import {
   DeviceActionStatus,
   type DeviceManagementKit,
 } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   SignerAleo,
   SignerAleoBuilder,

--- a/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
+++ b/libs/live-signer-aleo/tests/DmkSignerAleo.test.ts
@@ -1,5 +1,6 @@
 import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "../src/errors";
 import { SignerAleoBuilder } from "@ledgerhq/device-signer-kit-aleo";
 import { of } from "rxjs";
 import { DmkSignerAleo } from "../src/DmkSignerAleo";

--- a/libs/live-signer-canton/package.json
+++ b/libs/live-signer-canton/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "@ledgerhq/coin-canton": "workspace:^",
     "@ledgerhq/devices": "workspace:*",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-canton": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "semver": "catalog:"
@@ -63,6 +62,11 @@
       "import": "./lib-es/index.js",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
     },
     "./lib-es/*": "./lib-es/*.js",
     "./lib/*": "./lib/*.js",

--- a/libs/live-signer-canton/src/LegacySignerCanton.ts
+++ b/libs/live-signer-canton/src/LegacySignerCanton.ts
@@ -1,6 +1,6 @@
 import semver from "semver";
 import Transport from "@ledgerhq/hw-transport";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "./errors";
 import {
   CantonSigner,
   CantonAddress,

--- a/libs/live-signer-canton/tests/LegacySignerCanton.test.ts
+++ b/libs/live-signer-canton/tests/LegacySignerCanton.test.ts
@@ -1,6 +1,6 @@
 import Canton from "@ledgerhq/hw-app-canton";
 import { LegacySignerCanton } from "../src/LegacySignerCanton";
-import { UpdateYourApp } from "@ledgerhq/errors";
+import { UpdateYourApp } from "../src/errors";
 import Transport from "@ledgerhq/hw-transport";
 
 const PATH = "44'/6767'/0'/0'/0'";

--- a/libs/live-signer-concordium/package.json
+++ b/libs/live-signer-concordium/package.json
@@ -30,7 +30,7 @@
     "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-concordium": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:^",
     "rxjs": "catalog:"
   },
   "scripts": {
@@ -59,6 +59,11 @@
       "import": "./lib-es/index.js",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
     },
     "./lib-es/*": "./lib-es/*.js",
     "./lib/*": "./lib/*.js",

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -19,9 +19,9 @@ import {
   ConcordiumAddressVerificationFailedError,
   ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   type SignerConcordium,
   SignerConcordiumBuilder,

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -3,9 +3,9 @@ import {
   ConcordiumAddressVerificationFailedError,
   ConcordiumInvalidMaxFeeError,
   ConcordiumTrustedMetadataServiceError,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "../src/errors";
 import { SignerConcordiumBuilder } from "@ledgerhq/device-signer-kit-concordium";
 import { TransactionType, AccountAddress } from "@ledgerhq/concordium-core";
 import type { Transaction, CredentialDeploymentTransaction } from "@ledgerhq/concordium-core";

--- a/libs/live-signer-evm/package.json
+++ b/libs/live-signer-evm/package.json
@@ -30,8 +30,9 @@
     "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-eth": "workspace:^",
+    "@ledgerhq/hw-transport": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-dmk-shared": "workspace:^",
     "rxjs": "catalog:"
   },

--- a/libs/live-signer-evm/src/DmkSignerEth.ts
+++ b/libs/live-signer-evm/src/DmkSignerEth.ts
@@ -18,11 +18,9 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
 import { EIP712Message } from "@ledgerhq/types-live";
-import {
-  EthAppPleaseEnableContractData,
-  LockedDeviceError,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { EthAppPleaseEnableContractData } from "./errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { EvmAddress, EvmSigner, EvmSignerEvent } from "./types";
 import type { LoadConfig, ResolutionConfig } from "@ledgerhq/hw-app-eth/services/types";
 import {

--- a/libs/live-signer-solana/package.json
+++ b/libs/live-signer-solana/package.json
@@ -31,11 +31,11 @@
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-solana": "catalog:",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-solana": "workspace:^",
     "@ledgerhq/hw-bolos": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",
     "@ledgerhq/ledger-cal-service": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/ledger-trust-service": "workspace:^",
     "@types/bs58": "catalog:",
     "bs58": "catalog:",
@@ -71,6 +71,11 @@
       "import": "./lib-es/index.js",
       "require": "./lib/index.js",
       "default": "./lib/index.js"
+    },
+    "./errors": {
+      "@ledgerhq/source": "./src/errors.ts",
+      "require": "./lib/errors.js",
+      "default": "./lib-es/errors.js"
     },
     "./lib-es/*": "./lib-es/*.js",
     "./lib/*": "./lib/*.js",

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -16,12 +16,10 @@ import {
   TransactionResolutionContext,
   SignMessageVersion,
 } from "@ledgerhq/device-signer-kit-solana";
-import {
-  DeviceActionStatus,
-  DeviceManagementKit,
-} from "@ledgerhq/device-management-kit";
+import { DeviceActionStatus, DeviceManagementKit } from "@ledgerhq/device-management-kit";
 import bs58 from "bs58";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 
 export type DAError =
   | GetAddressDAError
@@ -47,8 +45,7 @@ export class DmkSignerSol implements SolanaSigner {
    * @param sessionId - active session ID of the connected device
    */
   constructor(dmk: DeviceManagementKit, sessionId: string) {
-    const originToken =
-      "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
+    const originToken = "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
     this.dmkSigner = new SignerSolanaBuilder({
       dmk,
       sessionId,
@@ -77,13 +74,12 @@ export class DmkSignerSol implements SolanaSigner {
     const { observable } = this.dmkSigner.getAppConfiguration();
     return new Promise<AppConfig>((resolve, reject) => {
       observable.subscribe({
-        next: (state) => {
+        next: state => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<GetAppConfigurationDAError>(state.error));
           }
           if (state.status === DeviceActionStatus.Completed) {
-            const { version, blindSigningEnabled, pubKeyDisplayMode } =
-              state.output;
+            const { version, blindSigningEnabled, pubKeyDisplayMode } = state.output;
             const mode =
               pubKeyDisplayMode === this.DMKPubKeyDisplayMode.long
                 ? PubKeyDisplayMode.LONG
@@ -91,7 +87,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ version, blindSigningEnabled, pubKeyDisplayMode: mode });
           }
         },
-        error: (err) => {
+        error: err => {
           reject(err);
         },
       });
@@ -110,7 +106,7 @@ export class DmkSignerSol implements SolanaSigner {
     });
     return new Promise<SolanaAddress>((resolve, reject) => {
       observable.subscribe({
-        next: (state) => {
+        next: state => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<GetAddressDAError>(state.error));
           }
@@ -120,7 +116,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ address: addressBytes });
           }
         },
-        error: (err) => {
+        error: err => {
           reject(err);
         },
       });
@@ -131,17 +127,14 @@ export class DmkSignerSol implements SolanaSigner {
    * Converts a Resolution from coin-solana to a TransactionResolutionContext for device-signer-kit-solana.
    * The userInputType values are identical between both types ("sol" | "ata") but defined separately
    */
-  private _toTransactionResolutionContext(
-    resolution: Resolution,
-  ): TransactionResolutionContext {
+  private _toTransactionResolutionContext(resolution: Resolution): TransactionResolutionContext {
     return {
       tokenAddress: resolution.tokenAddress,
       tokenInternalId: resolution.tokenInternalId,
       createATA: resolution.createATA,
       templateId: resolution.templateId,
       // Cast is safe: UserInputType enum values ("sol" | "ata") are identical in both types
-      userInputType:
-        resolution.userInputType as TransactionResolutionContext["userInputType"],
+      userInputType: resolution.userInputType as TransactionResolutionContext["userInputType"],
     };
   }
 
@@ -166,7 +159,7 @@ export class DmkSignerSol implements SolanaSigner {
     });
     return new Promise<SolanaSignature>((resolve, reject) => {
       observable.subscribe({
-        next: (state) => {
+        next: state => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<SignTransactionDAError>(state.error));
           }
@@ -175,7 +168,7 @@ export class DmkSignerSol implements SolanaSigner {
             resolve({ signature: signatureBuffer });
           }
         },
-        error: (err) => {
+        error: err => {
           reject(err);
         },
       });
@@ -187,10 +180,7 @@ export class DmkSignerSol implements SolanaSigner {
    * @param path - BIP32 derivation path
    * @param messageHex - message to sign in hexadecimal format
    */
-  async signMessage(
-    path: string,
-    messageHex: string,
-  ): Promise<SolanaSignature> {
+  async signMessage(path: string, messageHex: string): Promise<SolanaSignature> {
     const { observable } = this.dmkSigner.signMessage(
       path,
       new Uint8Array(Buffer.from(messageHex, "hex")),
@@ -198,18 +188,16 @@ export class DmkSignerSol implements SolanaSigner {
     );
     return new Promise<SolanaSignature>((resolve, reject) => {
       observable.subscribe({
-        next: (state) => {
+        next: state => {
           if (state.status === DeviceActionStatus.Error) {
             reject(this._mapError<SignMessageDAError>(state.error));
           }
           if (state.status === DeviceActionStatus.Completed) {
-            const signatureBuffer = Buffer.from(
-              bs58.decode(state.output.signature),
-            );
+            const signatureBuffer = Buffer.from(bs58.decode(state.output.signature));
             resolve({ signature: signatureBuffer });
           }
         },
-        error: (err) => {
+        error: err => {
           reject(err);
         },
       });

--- a/libs/live-signer-solana/src/LegacySignerSolana.ts
+++ b/libs/live-signer-solana/src/LegacySignerSolana.ts
@@ -12,7 +12,7 @@ import { DeviceModelId } from "@ledgerhq/devices";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";
 import { loadPKI } from "@ledgerhq/hw-bolos";
-import { LatestFirmwareVersionRequired, UpdateYourApp } from "@ledgerhq/errors";
+import { LatestFirmwareVersionRequired, UpdateYourApp } from "./errors";
 
 /**
  * Required minimum version of App Solana for non NanoS devices.

--- a/libs/live-signer-solana/tests/DMKSignerSol.test.ts
+++ b/libs/live-signer-solana/tests/DMKSignerSol.test.ts
@@ -4,7 +4,7 @@
 import { DmkSignerSol } from "../src/DmkSignerSol";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
 import { PubKeyDisplayMode, UserInputType, Resolution } from "@ledgerhq/coin-solana/signer";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
 import bs58 from "bs58";
 import { of, throwError } from "rxjs";
 
@@ -358,12 +358,12 @@ describe("DmkSignerSol", () => {
 
     it("maps error code 5515 to LockedDeviceError", () => {
       const result = callMapError(makeDAError("5515"));
-      expect(result).toBeInstanceOf(LockedDeviceError);
+      expect(result).toMatchObject({ name: "LockedDeviceError" });
     });
 
     it("maps error code 6985 to UserRefusedOnDevice", () => {
       const result = callMapError(makeDAError("6985"));
-      expect(result).toBeInstanceOf(UserRefusedOnDevice);
+      expect(result).toMatchObject({ name: "UserRefusedOnDevice" });
     });
 
     it("maps unknown error code to generic Error with _tag", () => {

--- a/libs/live-signer-solana/tests/LegacySignerSolana.test.ts
+++ b/libs/live-signer-solana/tests/LegacySignerSolana.test.ts
@@ -2,11 +2,8 @@ import Solana from "@ledgerhq/hw-app-solana";
 import { LegacySignerSolana } from "../src/LegacySignerSolana";
 import { PubKeyDisplayMode } from "@ledgerhq/coin-solana/signer";
 import * as loadPKIModule from "@ledgerhq/hw-bolos";
-import {
-  LatestFirmwareVersionRequired,
-  TransportStatusError,
-  UpdateYourApp,
-} from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { LatestFirmwareVersionRequired, UpdateYourApp } from "../src/errors";
 import { DeviceModelId } from "@ledgerhq/devices/index";
 import calService from "@ledgerhq/ledger-cal-service";
 import trustService from "@ledgerhq/ledger-trust-service";

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-zcash": "0.4.3",
-    "@ledgerhq/errors": "workspace:^",
     "rxjs": "catalog:"
   },
   "devDependencies": {

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -11,7 +11,7 @@ import type {
   SignPcztTransactionResult,
 } from "./types";
 import { lastValueFrom, type Observable } from "rxjs";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "./errors";
 import {
   DeviceActionStatus,
   type DeviceActionState,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8394,9 +8394,6 @@ importers:
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -11021,9 +11018,6 @@ importers:
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/logs':
         specifier: workspace:^
         version: link:../logs
@@ -11061,9 +11055,6 @@ importers:
 
   libs/ledgerjs/packages/hw-transport-http:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -11147,9 +11138,6 @@ importers:
 
   libs/ledgerjs/packages/hw-transport-node-speculos:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -11190,9 +11178,6 @@ importers:
 
   libs/ledgerjs/packages/hw-transport-node-speculos-http:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../hw-transport
@@ -11236,9 +11221,9 @@ importers:
 
   libs/ledgerjs/packages/hw-transport-vault:
     dependencies:
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../errors
+      '@ledgerhq/hw-transport':
+        specifier: workspace:*
+        version: link:../hw-transport
       '@ledgerhq/hw-transport-http':
         specifier: workspace:^
         version: link:../hw-transport-http
@@ -11645,9 +11630,6 @@ importers:
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-transport':
         specifier: workspace:*
         version: link:../ledgerjs/packages/hw-transport
@@ -12048,9 +12030,9 @@ importers:
       '@ledgerhq/device-signer-kit-aleo':
         specifier: 'catalog:'
         version: 0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
+      '@ledgerhq/hw-transport':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/hw-transport
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -12091,9 +12073,6 @@ importers:
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-app-canton':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-canton
@@ -12195,9 +12174,9 @@ importers:
       '@ledgerhq/device-signer-kit-concordium':
         specifier: 'catalog:'
         version: 0.4.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
+      '@ledgerhq/hw-transport':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/hw-transport
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -12293,12 +12272,15 @@ importers:
       '@ledgerhq/device-signer-kit-ethereum':
         specifier: 'catalog:'
         version: 1.16.0(@ledgerhq/context-module@2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2)))(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-app-eth':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-eth
+      '@ledgerhq/hw-transport':
+        specifier: workspace:*
+        version: link:../ledgerjs/packages/hw-transport
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../ledger-wallet-framework
       '@ledgerhq/live-dmk-shared':
         specifier: workspace:^
         version: link:../live-dmk-shared
@@ -12394,9 +12376,6 @@ importers:
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/hw-app-solana':
         specifier: workspace:^
         version: link:../ledgerjs/packages/hw-app-solana
@@ -12412,6 +12391,9 @@ importers:
       '@ledgerhq/ledger-trust-service':
         specifier: workspace:^
         version: link:../ledger-services/trust
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../ledger-wallet-framework
       '@types/bs58':
         specifier: 'catalog:'
         version: 4.0.4
@@ -12467,9 +12449,6 @@ importers:
       '@ledgerhq/device-signer-kit-zcash':
         specifier: 0.4.3
         version: 0.4.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -14094,7 +14073,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -22630,7 +22609,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: '*'
+      webpack: ^5.89.0
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -24638,7 +24617,7 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -24974,7 +24953,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: '*'
+      rxjs: ^5.5.10
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:


### PR DESCRIPTION
### 📝 Description

Migrate \`@ledgerhq/errors\` imports to per-package \`errors.ts\` native classes for files owned by the live-devices team.

Part of the [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915) errors library sunset initiative. All 106 changed files verified as \`@ledgerhq/live-devices\` owned via CODEOWNERS.

Error matching in tests updated from \`toBeInstanceOf\` to \`.name\` assertions per the migration rule: always match errors by \`.name\`, never by \`instanceof\`.

### 🔗 Context

Super-PR: #20040

[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ