### PR TITLE
feat(feature-flags): add lazy onboarding banner flag

### DIFF
--- a/.changeset/lazy-banner-modes.md
+++ b/.changeset/lazy-banner-modes.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Add the `lazyOnboardingBanner` feature flag with shop direct and feature intro modes

--- a/shared/feature-flags/src/flags/team-engagement/index.ts
+++ b/shared/feature-flags/src/flags/team-engagement/index.ts
@@ -12,6 +12,7 @@ export * from "./lwdAnalyticsOptInScreenV2";
 export * from "./lldNanoSUpsellBanners";
 export * from "./lldOnboardingEnableSync";
 export * from "./largeScreenUpsell";
+export * from "./lazyOnboardingBanner";
 export * from "./lwdProductTour";
 export { analyticsOptIn } from "./analyticsOptIn";
 export * from "./llmNanoOnboardingFundWallet";

--- a/shared/feature-flags/src/flags/team-engagement/lazyOnboardingBanner.test.ts
+++ b/shared/feature-flags/src/flags/team-engagement/lazyOnboardingBanner.test.ts
@@ -1,0 +1,26 @@
+import { lazyOnboardingBanner } from "./lazyOnboardingBanner";
+
+describe("lazyOnboardingBanner", () => {
+  it("should default to the disabled shop direct mode", () => {
+    expect(lazyOnboardingBanner.parse(undefined)).toEqual({
+      enabled: false,
+      params: { mode: "shop_direct" },
+    });
+  });
+
+  it.each(["shop_direct", "feature_intro"] as const)("should accept the %s mode", mode => {
+    expect(lazyOnboardingBanner.parse({ enabled: true, params: { mode } })).toEqual({
+      enabled: true,
+      params: { mode },
+    });
+  });
+
+  it("should reject an unsupported mode", () => {
+    expect(() =>
+      lazyOnboardingBanner.parse({
+        enabled: true,
+        params: { mode: "unsupported" },
+      }),
+    ).toThrow();
+  });
+});

--- a/shared/feature-flags/src/flags/team-engagement/lazyOnboardingBanner.ts
+++ b/shared/feature-flags/src/flags/team-engagement/lazyOnboardingBanner.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { flagWith } from "../../define";
+
+export const lazyOnboardingBanner = flagWith(
+  { mode: z.enum(["shop_direct", "feature_intro"]) },
+  { enabled: false, params: { mode: "shop_direct" } },
+);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Shared feature flag registry, generated types and default resolution
  - Lazy onboarding banner modes and Firebase Remote Config key derivation

### 📝 Description

The Lazy Onboarding banner needs an independent feature flag so its availability and behavior can be configured remotely before consumer UI wiring is introduced.

This PR adds the shared `lazyOnboardingBanner` flag, exports it through the Engagement registry and covers its default and supported modes with unit tests. Types, defaults and the Firebase key `feature_lazy_onboarding_banner` are derived automatically by the existing feature flag infrastructure. No UI or consumer logic is included.

```ts
useFeature("lazyOnboardingBanner");
// { enabled: boolean, params?: { mode: "shop_direct" | "feature_intro" } }
```

The flag defaults to `{ enabled: false, params: { mode: "shop_direct" } }`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34515](https://ledgerhq.atlassian.net/browse/LIVE-34515)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-34515]: https://ledgerhq.atlassian.net/browse/LIVE-34515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ