### PR TITLE
[LWM] fix(mobile): migrate engagement to SafeAreaViewFixed (LIVE-34624)

### DIFF
--- a/.changeset/migrate-engagement-safe-area-view.md
+++ b/.changeset/migrate-engagement-safe-area-view.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Migrate engagement-scope screens to SafeAreaViewFixed for experimental header compatibility

--- a/apps/ledger-live-mobile/src/mvvm/features/Reborn/screens/PostBuySuccess/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Reborn/screens/PostBuySuccess/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Flex, IconsLegacy, Text, Box } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTranslation } from "~/context/Locale";
 import Button from "~/components/wrappedUi/Button";
 import usePostBuySuccessModel from "./usePostBuySuccessModel";

--- a/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingQuiz.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingQuiz.tsx
@@ -3,7 +3,7 @@ import { Flex, FlowStepper, Text, Button, Transitions } from "@ledgerhq/native-u
 import { useTranslation } from "~/context/Locale";
 import { RenderTransitionProps } from "@ledgerhq/native-ui/components/Navigation/FlowStepper/index";
 import { StyleSheet } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/OnboardingView.tsx
@@ -3,7 +3,7 @@ import { View, TouchableOpacity } from "react-native";
 import { useNavigation, StackActions } from "@react-navigation/native";
 import { IconsLegacy } from "@ledgerhq/native-ui/assets/index";
 import { Flex, Text, ScrollListContainer } from "@ledgerhq/native-ui";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useTheme } from "styled-components/native";
 
 const hitSlop = {

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/BleDevicePairingFlow.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/BleDevicePairingFlow.tsx
@@ -1,4 +1,4 @@
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { Flex } from "@ledgerhq/native-ui";
 import BleDevicePairingFlowComponent, {
   SetHeaderOptionsRequest,

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/PairNew.tsx
@@ -22,7 +22,7 @@ import {
 import { OnboardingNavigatorParamList } from "~/components/RootNavigator/types/OnboardingNavigator";
 import { BaseOnboardingNavigatorParamList } from "~/components/RootNavigator/types/BaseOnboardingNavigator";
 import styled from "styled-components/native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import Button from "~/components/PreventDoubleClickButton";
 import { hasCompletedOnboardingSelector, onboardingTypeSelector } from "~/reducers/settings";
 import { OnboardingType } from "~/reducers/types";

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/newDeviceInfo.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/newDeviceInfo.tsx
@@ -3,7 +3,7 @@ import Animated, { FadeIn } from "react-native-reanimated";
 import { useTranslation } from "~/context/Locale";
 import { Flex, Carousel, Text, Button, IconsLegacy } from "@ledgerhq/native-ui";
 import { useNavigation, useRoute } from "@react-navigation/native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import styled from "styled-components/native";
 import { StyleSheet } from "react-native";
 import { DeviceModelId } from "@ledgerhq/types-devices";

--- a/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
+++ b/apps/ledger-live-mobile/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
@@ -4,7 +4,7 @@ import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RenderTransitionProps } from "@ledgerhq/native-ui/components/Navigation/FlowStepper/index";
 import { Flex, FlowStepper, IconsLegacy, Transitions, SlideIndicator } from "@ledgerhq/native-ui";
 
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import styled from "styled-components/native";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Button from "~/components/PreventDoubleClickButton";

--- a/apps/ledger-live-mobile/src/screens/PostBuyDeviceSetupNanoWallScreen.tsx
+++ b/apps/ledger-live-mobile/src/screens/PostBuyDeviceSetupNanoWallScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { Text, Box } from "@ledgerhq/native-ui";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "~/context/Locale";
 import { Pressable, StyleSheet } from "react-native";

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/TransactionsAlerts.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Features/TransactionsAlerts.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Flex, Text, Alert, Tag, Divider } from "@ledgerhq/native-ui";
 import { useFeature } from "@features/platform-feature-flags";
 import { ChainwatchAccount, ChainwatchNetwork } from "@ledgerhq/types-live";
-import { SafeAreaView } from "react-native-safe-area-context";
+import SafeAreaView from "~/components/SafeAreaView";
 import NavigationScrollView from "~/components/NavigationScrollView";
 import styled from "styled-components/native";
 import { useSelector } from "~/context/hooks";


### PR DESCRIPTION
## Summary

Migrates engagement-scope mobile screens from raw `SafeAreaView` (`react-native-safe-area-context`) to the shared `~/components/SafeAreaView` wrapper (`SafeAreaViewFixed`).

The custom component accounts for the experimental header and avoids double safe-area insets. This is an import-only change — no layout or behavior changes beyond safe-area handling.

**Files updated (9):**
- `screens/PostBuyDeviceSetupNanoWallScreen.tsx`
- `screens/Settings/Debug/Features/TransactionsAlerts.tsx`
- `screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx`
- `screens/Onboarding/steps/newDeviceInfo.tsx`
- `screens/Onboarding/steps/PairNew.tsx`
- `screens/Onboarding/steps/BleDevicePairingFlow.tsx`
- `screens/Onboarding/OnboardingView.tsx`
- `screens/Onboarding/OnboardingQuiz.tsx`
- `mvvm/features/Reborn/screens/PostBuySuccess/index.tsx`

**Note:** `screens/Onboarding/steps/discoverLiveInfo.tsx` was listed on [LIVE-34624](https://ledgerhq.atlassian.net/browse/LIVE-34624) but no longer exists in the codebase.

**Out of scope:** `screens/SyncOnboarding/index.tsx` is tracked under [LIVE-34623](https://ledgerhq.atlassian.net/browse/LIVE-34623) (live-devices). Several other engagement-owned screens were already migrated in prior PRs.

## Test plan

- [ ] Visual smoke-test onboarding flows (setup device, pair new device, quiz) with experimental header **on** and **off**
- [ ] Visual smoke-test Post Buy success and Post Buy device setup screens
- [ ] No regressions on existing Detox e2e tests for onboarding
- [x] ESLint passes on changed files

[LIVE-34624]: https://ledgerhq.atlassian.net/browse/LIVE-34624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34623]: https://ledgerhq.atlassian.net/browse/LIVE-34623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ