### PR TITLE
docs(skills): add impacting-prs skill

### DIFF
--- a/.agents/skills/impacting-prs/SKILL.md
+++ b/.agents/skills/impacting-prs/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: impacting-prs
+description: Find which open PRs are impacted by a migration/sunset/refactor and notify their authors — blocking review when the old path is already gone from develop, heads-up comment when it is only deprecated or its removal is still in review, silent study report only when the replacement does not exist yet. Use when asked to check/flag/notify/block open PRs about a breaking change, deprecation or migration they need to follow.
+---
+
+# Notify open PRs impacted by an ongoing migration
+
+**When:** a change is landing (or has landed) that every in-flight PR must follow — a package sunset, an API deprecation, a moved module, a new architectural rule.
+
+**Three modes.** What gates the ping is **whether the replacement is already on `develop`**, not where the removal lives — an author can only act on advice they can commit today. Whether the old path is *already gone* only sets the severity:
+
+| Replacement on `develop`? | Old path on `develop`? | Mode | What we do |
+| --- | --- | --- | --- |
+| ✅ yes | gone | 🔴 **Blocking** | review requesting changes on each impacted PR |
+| ✅ yes | still there (deprecated, or removed only in a pending PR) | 🟠 **Heads-up** | comment on each impacted PR |
+| ❌ not yet | anything | 🔍 **Study** | **no ping.** Report the blast radius to the user, or as one comment on their own migration PR |
+
+The middle row is the common case and the one easy to get wrong: a sunset PR usually only deletes the *last legacy alias* of something whose successor landed weeks ago. The impacted authors can migrate right now, so ping them — the migration PR being unmerged is a reason to say "landing soon", not a reason to stay silent. Reserve 🔍 study for when the successor genuinely does not exist yet.
+
+**Hard rules:**
+
+- 🚫 Never post anything before the user has read and approved the drafts.
+- 🚫 Never guess the migration pattern. Derive it from the merged work, then have the user confirm it (step 1).
+- 🚫 **In study mode, never comment on an impacted PR.** There is nothing they can do yet: the target API does not exist on `develop`, so a ping is noise that ages badly.
+- ⚖️ **Never pick 🔍 study just because the migration PR is open.** Check the replacement on `develop` first (step 1); if it resolves there, this is 🟠, and offer the user the choice of pinging now.
+- 🇬🇧 **Everything we post is in English**, whatever language the conversation happens in. Being prompted in French is not a reason to write French comments — the PR authors are an international audience.
+- 🤖 Every posted message starts with the `🤖` icon, so authors can tell at a glance it came from an agent, and so a later run can detect the PR was already informed.
+
+## 1. Pin down the change and the migration pattern
+
+Ask the user for what only they know (use `AskUserQuestion`, batched):
+
+- **On whose behalf** we speak (the person who did the migration) — the comments are written for them.
+- **The merged/prepared PRs** implementing the migration, and a migration guide/ADR if one exists.
+- **The mode**, once you have established both axes yourself (below) — confirm it rather than let the user guess, and when the answer is 🟠 on an unmerged migration, explicitly offer to ping now.
+
+Establish the two axes with `git`, not by asking. Mixed cases are normal — one artifact dropped, another only deprecated — so the mode is **per artifact**:
+
+```bash
+gh pr view <migration-pr> --json state,mergedAt      # is the removal on develop yet?
+git fetch origin <base> -q                           # your worktree is probably stale
+git grep -l '<dropped-import>' origin/<base>         # old path: still resolvable?
+git grep -l '<replacement-symbol>' origin/<base>     # replacement: does it exist TODAY?
+```
+
+That last line is the one that decides 🔍 vs 🟠. Counting *how* the rest of the repo already imports the symbol on `origin/<base>` also hands you the per-layer replacement for free, and proves it rather than assuming it:
+
+```bash
+git grep -hE '\b<Symbol>\b' origin/<base> -- '<layer-path>' \
+  | grep -oE 'from "[^"]+"' | sort | uniq -c | sort -rn
+```
+
+Then do the homework yourself, don't ask for it:
+
+```bash
+gh pr diff <migration-pr>                       # the actual before → after
+gh pr list --state merged --author <login> --limit 30 --json number,title,mergedAt
+gh api repos/$GH_REPO/commits?path=<dropped-path> --jq '.[].commit.message'
+```
+
+Read enough of the merged diffs to answer: **how do I detect the problem in a diff**, and **what exactly replaces it, per layer**. The replacement is rarely uniform — e.g. a public lib may not import an app-internal domain module, while `libs/coin-modules/*` reach the same data through the coin framework. Build a matrix:
+
+| Layer / path | Detection signal (added lines) | Replacement | Severity |
+| --- | --- | --- | --- |
+| `apps/**` | `from "@x/dropped"` | `useFoo()` from `@x/new` | 🔴 blocking |
+| `libs/coin-modules/**` | same import | `coinConfig.getStore()` | 🔴 blocking |
+| any | `from "@x/deprecated-types"` | `@x/new-types` | 🟠 heads-up |
+
+Severity is a property of the row, not of the campaign: the same scan routinely yields one 🔴 artifact already deleted from `develop` and one 🟠 artifact whose deletion is still in review.
+
+**Show the matrix and the severity policy to the user and get an explicit OK before scanning.** Also agree on the detection regex — a too-broad one produces noise, and noise on 20 PRs is expensive.
+
+## 2. Select eligible PRs
+
+Three exclusions, all handled by `scan-prs.sh` — don't re-implement them by hand:
+
+- PRs that do **not target `develop`**.
+- PRs **already conflicting** with `develop` — they have to rebase anyway, and will pick the change up then.
+- PRs **somebody already informed** (a comment/review body matching `-m`, default `[Oo]n behalf of @`) — commenting twice is pure noise, and the most common way this skill becomes annoying. The default is deliberately broad, so it also excludes PRs informed about *another* migration: when two campaigns overlap, narrow it to something specific to yours (`-m '#20040'`, `-m '@ledgerhq/errors'`) — our bodies always name the migration PR, so that always has something to match.
+
+```bash
+.agents/skills/impacting-prs/scan-prs.sh -p 'cryptoassets' -o "$TMPDIR/scan"
+# -p regex (required, matched on added lines only)  -b base (develop)  -l list limit
+# -j parallel jobs  -x excluded-paths regex  -m already-informed marker  -o output dir
+```
+
+It writes `prs.json` (eligible PRs), `diffs/<n>.diff`, `hits.tsv` (`pr ⇥ path ⇥ line ⇥ content`), `already-informed.txt`, and prints the skip counts. `line` is the **RIGHT-side line number**, ready to use as the `line` of a review comment — anchor on it rather than recomputing. Notes:
+
+- Matching **added lines only** matters: a PR that *removes* the old import is doing the migration, not breaking it.
+- GitHub computes mergeability lazily — the first `gh pr list` returns `UNKNOWN` for most PRs and warms the cache; the script queries twice for that reason. Re-run if some stay `UNKNOWN`.
+- Run `gh` **outside the sandbox** (`dangerouslyDisableSandbox: true`).
+
+## 3. Analyse each hit
+
+For every PR with hits, read the surrounding diff (`$OUT/diffs/<n>.diff`) and decide:
+
+- **False positive?** Drop it: moved/renamed lines, comments, changesets, fixtures, generated files, code that was already there, or a usage the matrix explicitly allows.
+- **Which layer** the file belongs to → which row of the matrix applies → severity.
+- **What the author must do**, in one sentence, referring to their own file paths and symbols.
+- **The exact line to comment on**, from `hits.tsv` — every surviving hit becomes an inline comment, not a paragraph in a wall of text.
+- **Is the replacement mechanical?** Then attach a ` ```suggestion ` block the author can commit in one click. Only when you can write the *exact* resulting line(s) — a wrong suggestion is worse than none, and a suggestion is a claim we are sure, so keep the hedging in the prose around it.
+
+The strongest suggestion you can write is one copied from the PR's own neighbours: if sibling files in the same directory already import the symbol the new way on `origin/<base>`, quote that and the fix becomes indisputable.
+
+**Then look past `hits.tsv`.** It only sees added lines *containing the pattern*, so it structurally misses a PR that **edits a file the migration deletes** — the added line (`+  newField?: string;`) never names the package. Those are the expensive cases: guaranteed rebase conflicts, and often the author already made the same change in the right place and just left a stale duplicate. Check every PR with hits, and cheaply check the others:
+
+```bash
+grep -lE '^\+\+\+ b/(<deleted-path-1>|<deleted-path-2>)' "$OUT"/diffs/*.diff
+```
+
+Keep a table: PR · author · what it is about · files · severity · required action. Verify a couple of the target APIs really exist before recommending them — `git grep` on `origin/<base>` in 🟠/🔴 mode, on the migration PR's branch in 🔍 study mode (`gh pr diff <migration-pr>`), since on `develop` they do not exist yet. Recommending a symbol that does not exist destroys the credibility of the whole batch.
+
+## 4. 🔍 Study mode: one report, zero pings
+
+Only when the replacement is **not on `develop`** — re-read the mode table before landing here, since an unmerged migration PR is usually still 🟠. The impacted authors cannot act yet, so nothing is posted on their PRs. Deliver the blast radius to the person doing the migration instead — steps 5 to 7 do not apply:
+
+- **They have a PR for the migration** → one comment on *their own* PR, updated in place on later runs (`gh pr comment <migration-pr> --body-file report.md --edit-last`).
+- **They don't** → just answer in the conversation. Nothing is posted anywhere.
+
+The report is for sizing the work, not for shaming anyone — group by required action, not by PR, since that is what tells the author whether they need a codemod, a migration guide, or a compat shim:
+
+```markdown
+🔍 Impact study for `<artifact>` (this PR, not on `develop` yet) — 6 open PRs affected
+
+**Mechanical import swap (4)** — #20204 (57 files, wallet-api refactor) · #19581 · #19191 · #20045
+**Needs the coin-framework accessor (1)** — #20018 (coin-vechain, no access to the new store)
+**Unclear, worth a chat (1)** — #20221 (adds a new dependency on the dropped path)
+
+Scanned N open PRs targeting `develop`; skipped M conflicting + K other-base.
+Rerun once this lands to notify them, or say the word and I'll draft the heads-up now.
+```
+
+Two things this makes visible early, which is the point of the mode: PRs so large the migration should wait for them to land, and layers with no replacement yet.
+
+## 5. Draft and get approval
+
+One comment per PR, from the templates in [references/comment-templates.md](references/comment-templates.md). Tone: `🤖 On behalf of @<author>` in the summary body only — **never repeat the attribution in each inline comment**, it reads like a robot signing every line. Hedged ("it looks like", "you may need to") — we are never 100% sure, the PR author knows their code better. In English, nice, short, actionable, open to being wrong.
+
+Show all drafts to the user in one message, grouped by severity, and wait. Expect the user to correct the expected code change — fold their corrections back into the matrix and re-check the other drafts against it.
+
+## 6. Post (🟠 / 🔴 only)
+
+**Default form: one review carrying a short summary body + one inline comment per hit** (with a `suggestion` block where relevant). Anchored comments land next to the offending line, so the author sees the impact in their own code instead of in a wall of text — see [references/comment-templates.md](references/comment-templates.md) for the payload.
+
+```bash
+# event: REQUEST_CHANGES for 🔴 blocking, COMMENT for 🟠 heads-up (does not block)
+gh api repos/$GH_REPO/pulls/<n>/reviews --input payload.json --jq .html_url
+```
+
+Sequentially, out of the sandbox, capturing each returned URL. Fallbacks:
+
+- `422 line must be part of the diff` → the hit is outside the PR's own hunks; drop that inline comment (keep it in the body) rather than retrying on another line.
+- `REQUEST_CHANGES` on your own PR is rejected by GitHub → post with `event: COMMENT` and say in the body that it would otherwise be blocking.
+- No inline anchor at all (nothing mechanical, or all 422s) → `gh pr comment <n> --body-file draft.md`.
+
+State drifts between the scan and the posting, so right before each post re-check that the PR is still open, still `MERGEABLE` and still free of the marker — the scan's exclusions are only as fresh as the scan:
+
+```bash
+gh pr view <n> --json state,mergeable --jq '"\(.state) \(.mergeable)"'   # expect: OPEN MERGEABLE
+```
+
+## 7. Recap
+
+Report back a copy-pasteable summary, grouped by severity, each line linking the **posted comment** (the URL returned above, e.g. `#issuecomment-…` / `#pullrequestreview-…`) plus a 2-4 word label of what the PR is about:
+
+```
+:red_circle: Blocking (@x/dropped removed from develop)
+- #19806 (<comment url>) — Kaspa coin tester
+- #19645 (<comment url>) — Readiness + Tezos
+
+:large_orange_circle: Deprecated (@x/deprecated-types)
+- #20034 (<comment url>) — Polkadot
+```
+
+List separately what was skipped and why (conflicting, other base, false positive) so the user can double-check the blind spots.

--- a/.agents/skills/impacting-prs/references/comment-templates.md
+++ b/.agents/skills/impacting-prs/references/comment-templates.md
@@ -1,0 +1,110 @@
+# Comment templates & tone
+
+## Tone rules
+
+- **Start with `🤖`** and **speak on behalf** of the person who did the migration, in the summary body: `🤖 On behalf of @author: …`. The icon says "an agent wrote this" and doubles as the already-informed marker for later runs.
+- **Attribute once.** The summary body carries the `on behalf of @author`; inline comments must *not* repeat it — they are already part of that review.
+- **English only**, even when the conversation driving the run is in another language.
+- **Hedge, always.** We read a diff, we did not run their branch: "it looks like", "you may need to", "if I read this right". Never "your PR is broken".
+- **Concise**: what changed · why it touches this PR · what to do · where to look. ~10 lines max in the body, 1-3 lines per inline comment.
+- **Actionable**: name their files/symbols, link the migration PR or guide.
+- **Open the door**: invite a correction if we misread, offer help. No blame, no deadline pressure.
+- No "generated with Claude" mention.
+
+## Review payload (default form)
+
+One review = a short summary body + one anchored comment per hit. `path` and `line` come
+straight from `hits.tsv`; `side: "RIGHT"` because we always comment on added lines.
+
+```bash
+jq -n --rawfile body body.md --rawfile c1 comment1.md '{
+  event: "REQUEST_CHANGES",                       # or "COMMENT" for a non-blocking heads-up
+  body: $body,
+  comments: [
+    { path: "libs/foo/src/bar.ts", line: 12, side: "RIGHT", body: $c1 }
+  ]
+}' > payload.json
+
+gh api repos/$GH_REPO/pulls/<n>/reviews --input payload.json --jq .html_url
+```
+
+Multi-line hunk: add `start_line` (+ `start_side`) alongside `line`, `line` being the last line.
+Reading the bodies from files via `--rawfile` avoids any escaping problem with backticks and
+newlines in suggestion blocks.
+
+## Inline comment, with a committable fix
+
+Only when you can write the exact resulting line — the suggestion replaces the anchored
+line(s) verbatim, so a stray indent or a missing symbol makes it uncommittable. Keep the
+hedge in the prose, not in the block.
+
+````markdown
+`<artifact>` was dropped in #<migration-pr> — for <this layer> the equivalent is `<replacement>`:
+
+```suggestion
+import { X } from "@x/new";
+```
+
+Feel free to ignore if this file is handled elsewhere.
+````
+
+When the fix is not mechanical, comment on the line without a suggestion:
+
+```markdown
+This one probably needs `<replacement>` instead, but it depends on how `<symbol>` is used below — happy to dig if useful.
+```
+
+No `🤖` and no "on behalf of" here: the review body already carries both.
+
+## 🔴 Blocking body — the change is already in `develop`
+
+Posted as `event: REQUEST_CHANGES`, so the PR cannot merge as-is.
+
+````markdown
+> [!IMPORTANT]
+> 🤖 On behalf of @<author>: `<artifact>` was removed from `develop` in #<migration-pr>, so this PR will likely not build once rebased.
+
+I left <n> inline note(s) on the spots that look affected. The migration for <this layer> is:
+
+```diff
+- import { X } from "@x/dropped";
++ import { X } from "@x/new";
+```
+
+Requesting changes only so this does not land by accident — happy to be told I misread the diff, and glad to help with the migration if useful. See #<migration-pr> for the reference change.
+````
+
+## 🟠 Heads-up body — deprecated, still working
+
+Posted as `event: COMMENT` (or `gh pr comment` if nothing can be anchored) — no block.
+
+```markdown
+🤖 On behalf of @<author>: `<artifact>` is now deprecated (see #<migration-pr>) and should disappear soon, so this PR may need a small follow-up — see the inline note(s).
+
+Nothing blocking today, mostly to avoid adding new usages that we will have to migrate again later. Let me know if this does not apply to your case.
+```
+
+## 🟠 Heads-up body — removal is still in review
+
+Same `event: COMMENT`, for the very common case where the migration PR is open but its
+replacement has been on `develop` for a while. Two things must be explicit: the removal has
+**not** landed yet (so nothing is broken right now, and CI is green for a reason), and the fix
+is nonetheless committable **today**. Naming the date/PR is what keeps the ping from reading
+as a false alarm.
+
+````markdown
+🤖 On behalf of @<author>: #<migration-pr> deletes `<artifact>` — it is in review now, not on `develop` yet, so nothing is broken on your branch today.
+
+I left <n> inline note(s) where this PR adds new usages. The replacement already exists on `develop`, so it is safe to apply right away and it saves you a conflict later:
+
+```diff
+- import { X } from "@x/dropped";
++ import { X } from "@x/new";
+```
+
+Not blocking — and if #<migration-pr> lands first, this becomes a build error rather than a suggestion. Tell me if I misread your diff and I will drop this.
+````
+
+If the user explicitly wants these blocked before the migration lands, keep this body but post
+it as `REQUEST_CHANGES`, and say so in one added sentence — never let the event contradict a
+body that claims to be non-blocking.

--- a/.agents/skills/impacting-prs/scan-prs.sh
+++ b/.agents/skills/impacting-prs/scan-prs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Scan open PRs for a detection pattern on ADDED diff lines.
+# Usage: scan-prs.sh -p '<extended-regex>' [-b develop] [-o outdir] [-j 8] [-l 300]
+#                    [-x '<exclude-path-regex>'] [-m '<already-informed-marker>']
+set -uo pipefail
+
+BASE=develop
+OUT="${TMPDIR:-/tmp}/impacting-prs"
+JOBS=8
+LIMIT=300
+PATTERN=""
+EXCLUDE='(^|/)(pnpm-lock\.yaml|package-lock\.json|yarn\.lock|Podfile\.lock)$|^\.changeset/|\.snap$'
+MARKER='[Oo]n behalf of @'
+
+while getopts "p:b:o:j:l:x:m:" opt; do
+  case "$opt" in
+    p) PATTERN="$OPTARG" ;;
+    b) BASE="$OPTARG" ;;
+    o) OUT="$OPTARG" ;;
+    j) JOBS="$OPTARG" ;;
+    l) LIMIT="$OPTARG" ;;
+    x) EXCLUDE="$OPTARG" ;;
+    m) MARKER="$OPTARG" ;;
+    *) exit 2 ;;
+  esac
+done
+[ -z "$PATTERN" ] && { echo "missing -p <regex>" >&2; exit 2; }
+
+mkdir -p "$OUT/diffs"
+
+# Pinned so gh keeps resolving the repo once we leave the working tree.
+GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+export GH_REPO
+echo "repo: $GH_REPO" >&2
+
+# GitHub computes mergeability lazily: the first query returns UNKNOWN for most
+# PRs and warms the cache, the second one returns real values.
+list() {
+  gh pr list --state open --limit "$LIMIT" \
+    --json number,title,url,isDraft,mergeable,baseRefName,headRefName,author,updatedAt >/dev/null 2>&1
+  sleep 3
+  gh pr list --state open --limit "$LIMIT" \
+    --json number,title,url,isDraft,mergeable,baseRefName,headRefName,author,updatedAt
+}
+list > "$OUT/all.json"
+
+jq --arg base "$BASE" '[ .[] | select(.baseRefName == $base and .mergeable == "MERGEABLE")
+  | {number, title, url, isDraft, author: .author.login, name: .author.name, headRefName, updatedAt} ]' \
+  "$OUT/all.json" > "$OUT/prs.json"
+
+jq -r --arg base "$BASE" '
+  "eligible (base \($base), no conflict): \([.[]|select(.baseRefName==$base and .mergeable=="MERGEABLE")]|length)",
+  "skipped  (conflicting with \($base)): \([.[]|select(.baseRefName==$base and .mergeable=="CONFLICTING")]|length)",
+  "skipped  (other base branch): \([.[]|select(.baseRefName!=$base)]|length)",
+  "skipped  (mergeability still unknown): \([.[]|select(.baseRefName==$base and .mergeable=="UNKNOWN")]|length)"
+' "$OUT/all.json" >&2
+
+# BSD xargs caps -I lines at 255 bytes, so fetch from inside the diffs dir.
+jq -r '.[].number' "$OUT/prs.json" \
+  | (cd "$OUT/diffs" && xargs -P "$JOBS" -I@ sh -c 'gh pr diff @ > @.diff 2>/dev/null || rm -f @.diff')
+
+# Matching added lines, with the RIGHT-side line number to anchor a review
+# comment on (`line` in the reviews API), skipping excluded paths.
+printf 'pr\tpath\tline\tcontent\n' > "$OUT/hits.tsv"
+for f in "$OUT"/diffs/*.diff; do
+  [ -e "$f" ] || continue
+  pr="$(basename "$f" .diff)"
+  awk -v pr="$pr" -v pat="$PATTERN" -v excl="$EXCLUDE" '
+    /^\+\+\+ / { path = $2; sub(/^b\//, "", path); skip = (path ~ excl); next }
+    /^--- /    { next }
+    /^@@/      { split($3, h, ","); n = substr(h[1], 2) + 0 - 1; next }
+    /^\+/      { n++; line = substr($0, 2)   # without the diff marker, so ^-anchored patterns work
+                 if (!skip && line ~ pat) printf "%s\t%s\t%d\t%s\n", pr, path, n, line
+                 next }
+    /^ /       { n++ }
+  ' "$f" >> "$OUT/hits.tsv"
+done
+
+# Drop PRs somebody already informed: any comment or review body carrying the
+# marker means the authors have been told, re-posting would just be noise.
+: > "$OUT/already-informed.txt"
+for pr in $(awk -F'\t' 'NR > 1 { print $1 }' "$OUT/hits.tsv" | sort -u); do
+  # grep -c, not -q: -q exits early, SIGPIPEs the gh calls and trips pipefail.
+  found=$({ gh api "repos/$GH_REPO/issues/$pr/comments" --jq '.[].body'
+            gh api "repos/$GH_REPO/pulls/$pr/reviews" --jq '.[].body'
+            gh api "repos/$GH_REPO/pulls/$pr/comments" --jq '.[].body'
+          } 2>/dev/null | grep -cE "$MARKER")
+  [ "${found:-0}" -gt 0 ] && echo "$pr" >> "$OUT/already-informed.txt"
+done
+if [ -s "$OUT/already-informed.txt" ]; then
+  awk -F'\t' 'NR == FNR { informed[$1]; next } FNR == 1 || !($1 in informed)' \
+    "$OUT/already-informed.txt" "$OUT/hits.tsv" > "$OUT/hits.filtered.tsv"
+  mv "$OUT/hits.filtered.tsv" "$OUT/hits.tsv"
+  echo "skipped  (already informed): $(wc -l < "$OUT/already-informed.txt" | tr -d ' ')" >&2
+fi
+
+echo >&2
+echo "PRs with hits (pr / files / added lines):" >&2
+awk -F'\t' 'NR > 1 {
+    lines[$1]++; if (!seen[$1 SUBSEP $2]++) files[$1]++ }
+  END { for (p in lines) printf "  #%s  %d file(s)  %d line(s)\n", p, files[p], lines[p] }
+' "$OUT/hits.tsv" | sort -t'#' -k2 -rn >&2
+echo >&2
+echo "artifacts: $OUT/prs.json  $OUT/hits.tsv  $OUT/already-informed.txt  $OUT/diffs/" >&2


### PR DESCRIPTION
`/impacting-prs inform ongoing PRs that they need to stop using @ledgerhq/errors lib`

<img width="894" height="662" alt="Screenshot 2026-07-30 at 17 09 16" src="https://github.com/user-attachments/assets/b7863691-5267-451b-9e70-123da27d97d9" />

---

other example using Study mode:

```
/impacting-prs https://github.com/LedgerHQ/ledger-live/pull/20251
```


<img width="1174" height="1560" alt="Screenshot 2026-07-30 at 17 21 30" src="https://github.com/user-attachments/assets/915d4f8d-5a50-4313-90f6-83ed1b6c60b4" />

<img width="927" height="612" alt="Screenshot 2026-07-30 at 17 39 47" src="https://github.com/user-attachments/assets/c0fa0826-0589-46d3-a209-7dce426e12fb" />



> [!NOTE]
> I'll personally give it a try on a real migration and will likely iterate on it a bit more. Anyone is free to try it locally too — feedback very welcome.

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

New `impacting-prs` skill: when a change lands in `develop` that every in-flight PR must follow (a package sunset, an API deprecation, a moved module, a new architectural rule), it studies which open PRs are impacted, explains the concrete impact per PR, and posts tailored comments — a blocking review when the breakage is already in `develop`, a heads-up when the artifact is only deprecated.

Born out of the `@ledgerhq/cryptoassets` sunset, where ~20 open PRs each had to be told what to migrate to, with the answer depending on the layer (a public lib cannot reach app-internal domain code, while `libs/coin-modules/*` go through the coin framework).

Workflow in 6 steps:

1. **Pin down the change** — ask for whose behalf we speak, the merged PRs implementing the migration, and dropped-vs-deprecated status; then read those diffs to derive a **per-layer migration matrix** (detection signal → replacement → severity), confirmed by the user before anything is scanned.
2. **Select PRs** — `scan-prs.sh` keeps only PRs targeting `develop` that are not already conflicting (those rebase anyway) and greps the detection pattern on **added lines only**, so a PR removing the old import is not flagged for doing the migration.
3. **Analyse** — drop false positives, map each file to a matrix row, and check the recommended API really exists on `develop`.
4. **Draft + approval** — hedged, on-behalf-of tone; nothing is posted before the user reads and approves every draft.
5. **Post** — one review per PR: short summary body + one comment anchored on the offending line, with a ` ```suggestion ` block when the fix is mechanical.
6. **Recap** — Slack-ready summary grouped by severity, linking each posted comment, plus what was skipped and why.

The scanner outputs the RIGHT-side line number for every hit, so comments can be anchored without recomputing positions:

```
pr	path	line	content
20034	libs/ledger-live-common/src/families/polkadot/react.ts	4	import type { CryptoCurrency } from "@ledgerhq/types-cryptoassets";
```

```bash
.agents/skills/impacting-prs/scan-prs.sh -p 'cryptoassets' -o "$TMPDIR/scan"
# → prs.json (eligible PRs) · diffs/<n>.diff · hits.tsv (pr ⇥ path ⇥ line ⇥ content)
```

Validated against the live repo: 56 eligible PRs scanned in ~13s, and the four anchors it reported were checked line-by-line against the PR head files (all exact). Two gotchas are baked in: GitHub computes mergeability lazily, so the first `gh pr list` returns `UNKNOWN` for most PRs and the script queries twice (that alone decides who gets skipped); and BSD `xargs -I` caps lines at 255 bytes, so diffs are fetched from inside the output dir with `GH_REPO` pinned.

Docs only — no product code, no changeset.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — tooling
- **ADR** (if any): n/a
