### PR TITLE
[LWM] fix(counter-values): keep persisted countervalue on restart (LIVE-35110)

### DIFF
--- a/.changeset/tidy-otters-attack.md
+++ b/.changeset/tidy-otters-attack.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix countervalue resetting to USD after killing and restarting the app when the selected fiat (e.g. AMD) is not part of the offline fallback list. The boot-time "reset unsupported countervalue" guard ran against the fallback fiats before the CVS supported-fiats query resolved; the reset now lives in the reactive path gated on `fiatsReady`, so it only acts on the authoritative CVS list.

--- a/.changeset/tidy-otters-attack.md
+++ b/.changeset/tidy-otters-attack.md
@@ -1,5 +1,5 @@
 ---
-"live-mobile": minor
+"live-mobile": patch
 ---
 
 Fix countervalue resetting to USD after killing and restarting the app when the selected fiat (e.g. AMD) is not part of the offline fallback list. The boot-time "reset unsupported countervalue" guard ran against the fallback fiats before the CVS supported-fiats query resolved; the reset now lives in the reactive path gated on `fiatsReady`, so it only acts on the authoritative CVS list.

--- a/apps/ledger-live-mobile/__tests__/test-renderer.tsx
+++ b/apps/ledger-live-mobile/__tests__/test-renderer.tsx
@@ -55,6 +55,7 @@ import type { FeatureId, Features, PartialFeatures, Feature } from "@shared/feat
 import { getEnv } from "@shared/env";
 import { marketSentimentApiExtra } from "@domain/api-market-sentiment";
 import { altcoinsSentimentApiExtra } from "@domain/api-altcoins-sentiment";
+import { cvsApiExtra } from "@domain/api-currency-fiat";
 import StyleProvider from "~/StyleProvider";
 import CustomLiveAppProvider from "./CustomLiveAppProvider";
 import { llmRtkApiInitialStates, applyLlmRTKApiMiddlewares } from "~/context/rtkQueryApi";
@@ -142,6 +143,7 @@ function createStore({ overrideInitialState }: { overrideInitialState: (state: S
           immutableCheck: false,
           thunk: {
             extraArgument: {
+              ...cvsApiExtra({ countervaluesServiceUrl: getEnv("LEDGER_COUNTERVALUES_API") }),
               ...marketSentimentApiExtra({ coinMarketCapApiUrl: getEnv("CMC_API_URL") }),
               ...altcoinsSentimentApiExtra({ coinMarketCapApiUrl: getEnv("CMC_API_URL") }),
             },

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -41,8 +41,6 @@ import { importBle } from "~/actions/ble";
 import { importKnownDevices } from "~/reducers/knownDevices";
 import { updateProtectData, updateProtectStatus } from "~/actions/protect";
 import {
-  INITIAL_STATE as settingsState,
-  counterValueIdOf,
   migrateLegacyCryptoCounterValue,
   migrateLegacyStarredMarketCoins,
 } from "~/reducers/settings";
@@ -54,7 +52,6 @@ import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/s
 import { importWalletState } from "@ledgerhq/live-wallet/store";
 import { importLargeMoverState } from "~/actions/largeMoverLandingPage";
 import { initHistory } from "~/reducers/history";
-import type { SettingsState } from "~/reducers/types";
 import { restoreTokensToCache, parsePersistedCAL } from "@domain/api-currency-token";
 import { setAllOverrides, setBannerVisible, type PartialFeatures } from "@shared/feature-flags";
 import { initIdentities } from "../helpers/identities";
@@ -273,7 +270,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
       setReady(true);
       onInitFinished();
 
-      updateSupportedCountervalues(store, settingsData);
+      updateSupportedCountervalues(store);
       await hydrateCurrencies().finally(() => setCurrencyInitialized(true)); // Don't block the App rendering for this
     } catch (error) {
       console.error(
@@ -333,19 +330,12 @@ async function hydrateCurrencies() {
   });
 }
 
-function updateSupportedCountervalues(store: Store, settingsData: Partial<SettingsState>) {
+// Seeds supportedCounterValues from the offline fallback fiats so the UI has a
+// list before the CVS query settles. The "reset unsupported counterValue to USD"
+// safety net intentionally lives in InitialQueriesProvider, gated on fiatsReady:
+// at boot only the fallback list is known, so resetting here would wrongly wipe
+// any valid CVS fiat absent from the fallback (e.g. AMD) on every restart.
+function updateSupportedCountervalues(store: Store) {
   const supportedFiats = selectSupportedFiats(store.getState());
-  const supportedCounterValues = buildSupportedCounterValues(supportedFiats);
-  store.dispatch(setSupportedCounterValues(supportedCounterValues));
-
-  if (
-    settingsData?.counterValue &&
-    !supportedCounterValues.find(
-      ({ currency }) => counterValueIdOf(currency) === settingsData.counterValue,
-    ) &&
-    settingsData.counterValue !== settingsState.counterValue
-  ) {
-    settingsData.counterValue = settingsState.counterValue;
-    store.dispatch(importSettings(settingsData));
-  }
+  store.dispatch(setSupportedCounterValues(buildSupportedCounterValues(supportedFiats)));
 }

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -330,11 +330,9 @@ async function hydrateCurrencies() {
   });
 }
 
-// Seeds supportedCounterValues from the offline fallback fiats so the UI has a
-// list before the CVS query settles. The "reset unsupported counterValue to USD"
-// safety net intentionally lives in InitialQueriesProvider, gated on fiatsReady:
-// at boot only the fallback list is known, so resetting here would wrongly wipe
-// any valid CVS fiat absent from the fallback (e.g. AMD) on every restart.
+// Seeds supportedCounterValues from the offline fallback fiats before the CVS query settles.
+// The "reset unsupported counterValue to USD" safety net lives in InitialQueriesProvider so it
+// runs against the authoritative CVS list, not the fallback.
 function updateSupportedCountervalues(store: Store) {
   const supportedFiats = selectSupportedFiats(store.getState());
   store.dispatch(setSupportedCounterValues(buildSupportedCounterValues(supportedFiats)));

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InitialQueriesContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InitialQueriesContext.tsx
@@ -21,7 +21,7 @@ export function InitialQueriesProvider({ children }: React.PropsWithChildren) {
   // OFAC Geo Blocking
   const ofacQueryResult = ofacGeoBlockApi.useCheckQuery();
   // Boot-time fiat fetch: onQueryStarted → setFiats populates the supportedFiats slice
-  useGetSupportedFiatsQuery();
+  const { isSuccess: fiatsResolvedFromCvs } = useGetSupportedFiatsQuery();
 
   const fiatsReady = useSelector(selectSupportedFiatsReady);
 
@@ -29,13 +29,16 @@ export function InitialQueriesProvider({ children }: React.PropsWithChildren) {
   const fiats = useSelector(selectSupportedFiats);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   useEffect(() => {
-    // Gate on fiatsReady so we act on the authoritative CVS list, not the boot-time
-    // fallback — resetting against the fallback would wipe valid but uncommon fiats.
     if (!fiatsReady) return;
     const supportedCounterValues = buildSupportedCounterValues(fiats);
     dispatch(setSupportedCounterValues(supportedCounterValues));
 
-    // Safety net: if the persisted counterValue is no longer supported by CVS, fall back to USD.
+    // Reset an unsupported persisted counterValue to USD, but only once CVS actually returned
+    // its list: fiatsReady also flips true on a CVS error/timeout (setFiatsReady runs in a
+    // finally), and then `fiats` is just the offline fallback — resetting there would wipe a
+    // valid uncommon fiat (e.g. AMD) and persist USD. A delisted fiat is corrected on the next
+    // successful load.
+    if (!fiatsResolvedFromCvs) return;
     const currentId = counterValueIdOf(counterValueCurrency);
     const isSupported = supportedCounterValues.some(
       ({ currency }) => counterValueIdOf(currency) === currentId,
@@ -43,7 +46,7 @@ export function InitialQueriesProvider({ children }: React.PropsWithChildren) {
     if (!isSupported) {
       dispatch(setCountervalue("USD"));
     }
-  }, [dispatch, fiats, fiatsReady, counterValueCurrency]);
+  }, [dispatch, fiats, fiatsReady, fiatsResolvedFromCvs, counterValueCurrency]);
   const ofacResult = useMemo(
     () => ({ blocked: ofacQueryResult.data ?? false, isLoading: ofacQueryResult.isLoading }),
     [ofacQueryResult.data, ofacQueryResult.isLoading],

--- a/apps/ledger-live-mobile/src/mvvm/contexts/InitialQueriesContext.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/InitialQueriesContext.tsx
@@ -3,9 +3,10 @@ import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
 import { useGetSupportedFiatsQuery } from "@domain/api-currency-fiat";
 import { selectSupportedFiats, selectSupportedFiatsReady } from "@domain/entity-currency-fiat";
 import { useDispatch, useSelector } from "~/context/hooks";
-import { setSupportedCounterValues } from "~/actions/settings";
+import { setCountervalue, setSupportedCounterValues } from "~/actions/settings";
 import { selectRemoteFlagsReady } from "@shared/feature-flags";
 import { buildSupportedCounterValues } from "~/logic/buildSupportedCounterValues";
+import { counterValueCurrencySelector, counterValueIdOf } from "~/reducers/settings";
 
 export const InitialQueriesContext = React.createContext({
   ofacResult: { blocked: false, isLoading: true },
@@ -26,10 +27,23 @@ export function InitialQueriesProvider({ children }: React.PropsWithChildren) {
 
   // Keep supportedCounterValues in sync: re-dispatch whenever the slice updates (fallback → CVS result)
   const fiats = useSelector(selectSupportedFiats);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
   useEffect(() => {
+    // Gate on fiatsReady so we act on the authoritative CVS list, not the boot-time
+    // fallback — resetting against the fallback would wipe valid but uncommon fiats.
     if (!fiatsReady) return;
-    dispatch(setSupportedCounterValues(buildSupportedCounterValues(fiats)));
-  }, [dispatch, fiats, fiatsReady]);
+    const supportedCounterValues = buildSupportedCounterValues(fiats);
+    dispatch(setSupportedCounterValues(supportedCounterValues));
+
+    // Safety net: if the persisted counterValue is no longer supported by CVS, fall back to USD.
+    const currentId = counterValueIdOf(counterValueCurrency);
+    const isSupported = supportedCounterValues.some(
+      ({ currency }) => counterValueIdOf(currency) === currentId,
+    );
+    if (!isSupported) {
+      dispatch(setCountervalue("USD"));
+    }
+  }, [dispatch, fiats, fiatsReady, counterValueCurrency]);
   const ofacResult = useMemo(
     () => ({ blocked: ofacQueryResult.data ?? false, isLoading: ofacQueryResult.isLoading }),
     [ofacQueryResult.data, ofacQueryResult.isLoading],

--- a/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/InitialQueriesContext.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/InitialQueriesContext.test.tsx
@@ -3,13 +3,14 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/native";
 import { waitFor } from "@testing-library/react-native";
 import { render } from "@tests/test-renderer";
+import { getEnv } from "@shared/env";
 import type { State } from "~/reducers/types";
 import { InitialQueriesContext, InitialQueriesProvider } from "../InitialQueriesContext";
 
 const contextSpy = jest.fn();
 const ofacResponse = jest.fn();
 
-const SUPPORTED_FIATS_URL = "https://countervalues.live.ledger.com/v3/supported/fiat";
+const SUPPORTED_FIATS_URL = `${getEnv("LEDGER_COUNTERVALUES_API")}/v3/supported/fiat`;
 
 const withCounterValue = (counterValue: string) => (state: State) => ({
   ...state,
@@ -55,8 +56,6 @@ describe("InitialQueriesContext", () => {
   });
 
   it("keeps an uncommon persisted counterValue (AMD) once CVS confirms it is supported", async () => {
-    // Regression for LIVE-35110: AMD is a valid CVS fiat but absent from the offline
-    // fallback list, so it must survive a restart instead of being reset to USD.
     ofacResponse.mockResolvedValueOnce(HttpResponse.json({}));
     server.use(http.get(SUPPORTED_FIATS_URL, () => HttpResponse.json(["USD", "EUR", "AMD"])));
 
@@ -85,6 +84,23 @@ describe("InitialQueriesContext", () => {
     );
 
     await waitFor(() => expect(store.getState().settings.counterValue).toBe("USD"));
+  });
+
+  it("keeps the persisted counterValue when the CVS supported-fiats query fails", async () => {
+    ofacResponse.mockResolvedValueOnce(HttpResponse.json({}));
+    server.use(http.get(SUPPORTED_FIATS_URL, () => HttpResponse.json({ not: "an array" })));
+
+    const { store } = render(
+      <InitialQueriesProvider>
+        <ContextSpy />
+      </InitialQueriesProvider>,
+      { overrideInitialState: withCounterValue("AMD") },
+    );
+
+    await waitFor(() =>
+      expect(contextSpy).toHaveBeenLastCalledWith(expect.objectContaining({ fiatsReady: true })),
+    );
+    expect(store.getState().settings.counterValue).toBe("AMD");
   });
 
   it("reports firebaseIsReady=false while remote flags have not settled", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/InitialQueriesContext.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/contexts/__tests__/InitialQueriesContext.test.tsx
@@ -3,10 +3,18 @@ import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/native";
 import { waitFor } from "@testing-library/react-native";
 import { render } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
 import { InitialQueriesContext, InitialQueriesProvider } from "../InitialQueriesContext";
 
 const contextSpy = jest.fn();
 const ofacResponse = jest.fn();
+
+const SUPPORTED_FIATS_URL = "https://countervalues.live.ledger.com/v3/supported/fiat";
+
+const withCounterValue = (counterValue: string) => (state: State) => ({
+  ...state,
+  settings: { ...state.settings, counterValue },
+});
 
 describe("InitialQueriesContext", () => {
   const server = setupServer(
@@ -44,6 +52,39 @@ describe("InitialQueriesContext", () => {
         }),
       ),
     );
+  });
+
+  it("keeps an uncommon persisted counterValue (AMD) once CVS confirms it is supported", async () => {
+    // Regression for LIVE-35110: AMD is a valid CVS fiat but absent from the offline
+    // fallback list, so it must survive a restart instead of being reset to USD.
+    ofacResponse.mockResolvedValueOnce(HttpResponse.json({}));
+    server.use(http.get(SUPPORTED_FIATS_URL, () => HttpResponse.json(["USD", "EUR", "AMD"])));
+
+    const { store } = render(
+      <InitialQueriesProvider>
+        <ContextSpy />
+      </InitialQueriesProvider>,
+      { overrideInitialState: withCounterValue("AMD") },
+    );
+
+    await waitFor(() =>
+      expect(contextSpy).toHaveBeenLastCalledWith(expect.objectContaining({ fiatsReady: true })),
+    );
+    expect(store.getState().settings.counterValue).toBe("AMD");
+  });
+
+  it("resets counterValue to USD once CVS reports the persisted fiat is unsupported", async () => {
+    ofacResponse.mockResolvedValueOnce(HttpResponse.json({}));
+    server.use(http.get(SUPPORTED_FIATS_URL, () => HttpResponse.json(["USD", "EUR"])));
+
+    const { store } = render(
+      <InitialQueriesProvider>
+        <ContextSpy />
+      </InitialQueriesProvider>,
+      { overrideInitialState: withCounterValue("AMD") },
+    );
+
+    await waitFor(() => expect(store.getState().settings.counterValue).toBe("USD"));
   });
 
   it("reports firebaseIsReady=false while remote flags have not settled", async () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Countervalue persistence across app kill/restart, especially for **uncommon fiats not in the offline fallback list** (e.g. AMD, and other less-common ISO currencies).
      - Common fiats (USD, EUR, GBP…) still behave as before.
      - A genuinely unsupported/delisted countervalue still falls back to USD once the CVS supported-fiats query has settled.
      - App boot / store hydration path (`LedgerStore`) — no crash or regression in the countervalue init.

### 📝 Description

> ⚠️ **This is a suggested fix that I'll send to the platform team** (owners of the RTK-Query supported-fiats / countervalues migration) for review before merge — sharing the diagnosis and a proposed patch rather than merging directly.

**Problem** — After selecting a less common countervalue (e.g. Armenian Dram, AMD) in Settings, killing the app, and restarting it, the balance is displayed in USD again instead of the selected currency.

**Root cause** — The recent RTK-Query supported-fiats migration introduced a two-stage flow: the `supportedFiats` slice starts with a static **offline fallback list** (`FALLBACK_FIAT_TICKERS`, ~36 common fiats, `fiatsReady: false`) and is only replaced by the full CVS list once `useGetSupportedFiatsQuery()` resolves. At store bootstrap, `LedgerStore.updateSupportedCountervalues` ran the *"reset unsupported countervalue to USD"* guard **synchronously, before the CVS query had resolved** — i.e. against the fallback list only. Since AMD (and other uncommon fiats) are valid CVS fiats but absent from the fallback list, the guard reset the persisted countervalue to USD and re-persisted it on every launch.

**Solution** — Move the reset out of the boot path and into the reactive `InitialQueriesProvider` effect, which is already gated on `fiatsReady`, so the "unsupported → USD" decision is only made against the **authoritative CVS list**. Boot now only seeds `supportedCounterValues` from the fallback (harmless) and never mutates the user's countervalue.

- `LedgerStore.tsx` — `updateSupportedCountervalues` no longer resets the countervalue; it just seeds the supported list from the fallback fiats.
- `InitialQueriesContext.tsx` — the existing `fiatsReady`-gated effect now also resets the countervalue to USD only when the authoritative supported list does not contain it.
- `test-renderer.tsx` — inject `cvsApiExtra` (CVS base URL) into the test store's thunk `extraArgument`, mirroring production, so `useGetSupportedFiatsQuery` resolves against MSW in integration tests.

**Verification**
- 2 new integration tests (MSW-mocked `/v3/supported/fiat`, no live API):
  - persisted AMD is kept once CVS confirms it is supported (regression guard);
  - persisted fiat is reset to USD once CVS reports it unsupported (safety net preserved).
- Manually verified on simulator: with the fix, the balance renders in AMD (֏) after relaunch instead of resetting to USD.

Uploading Simulator Screen Recording - iPhone 17 Pro Max - 2026-07-28 at 23.05.18.mov…



### ❓ Context

- **JIRA or GitHub link**: [LIVE-35110](https://ledgerhq.atlassian.net/browse/LIVE-35110)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35110]: https://ledgerhq.atlassian.net/browse/LIVE-35110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ