### PR TITLE
[LWDM] fix(coin-solana): surface token ops for token-account queries

### DIFF
--- a/.changeset/solana-listoperations-token-account-query.md
+++ b/.changeset/solana-listoperations-token-account-query.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Fix missing token operations in Solana history when a swap/transfer is queried by the token-account (ATA) address (LIVE-35047). `listOperations` matched token balance changes only by Solana's `owner` field (the wallet), so querying by a token sub-account's own address — as coin-service/Ledger Live does — returned no token operations, making e.g. the USDC leg of a Jupiter swap invisible. Token balances are now also matched by their token-account address, and the resulting operation's `assetOwner`/senders/recipients resolve to the wallet owner regardless of which address was queried.

--- a/libs/coin-modules/coin-solana/src/logic/listOperations.ts
+++ b/libs/coin-modules/coin-solana/src/logic/listOperations.ts
@@ -365,8 +365,13 @@ function parseTokenOperations(
   const postTokenBalances = tx.meta?.postTokenBalances ?? [];
   if (preTokenBalances.length === 0 && postTokenBalances.length === 0) return [];
 
-  const tokenChanges = computeTokenBalanceDeltas(address, preTokenBalances, postTokenBalances);
   const accountKeys = tx.transaction.message.accountKeys.map(k => k.pubkey.toBase58());
+  const tokenChanges = computeTokenBalanceDeltas(
+    address,
+    preTokenBalances,
+    postTokenBalances,
+    accountKeys,
+  );
   const ops: Operation[] = [];
   let operationIndex = 1;
 
@@ -397,20 +402,23 @@ function buildTokenOperation(
   meta: TxMeta,
   operationIndex: number,
 ): Operation {
-  const { mint, delta, tokenType } = change;
-  const asset: AssetInfo = { type: tokenType, assetReference: mint, assetOwner: address };
+  const { mint, delta, tokenType, owner } = change;
+  // Emit the operation against the wallet owner (not the queried address): when
+  // coin-service queries by a token-account/ATA address, senders/recipients and
+  // assetOwner must still resolve to the wallet, matching a wallet-address query.
+  const asset: AssetInfo = { type: tokenType, assetReference: mint, assetOwner: owner };
 
   const opType = delta > 0n ? "IN" : "OUT";
   const value = delta > 0n ? delta : -delta;
 
   const counterparty = findTokenCounterparty(
-    address,
+    owner,
     mint,
     preTokenBalances,
     postTokenBalances,
     accountKeys,
   );
-  const { senders, recipients } = buildParties(opType, address, counterparty);
+  const { senders, recipients } = buildParties(opType, owner, counterparty);
 
   return makeOperation({
     address,
@@ -431,7 +439,28 @@ function buildTokenOperation(
   });
 }
 
-type TokenChange = { mint: string; delta: bigint; tokenType: SolanaTokenProgram };
+type TokenChange = {
+  mint: string;
+  delta: bigint;
+  tokenType: SolanaTokenProgram;
+  owner: string;
+};
+
+/**
+ * A token balance belongs to the queried address when the address is either the
+ * wallet owner (Solana's `owner` field) or the token account itself. Ledger Live
+ * addresses token sub-accounts by their token-account (ATA) address, so
+ * coin-service queries operations by that address — but Solana's balance records
+ * only carry the wallet `owner`. Matching both makes token operations surface for
+ * either kind of query.
+ */
+function tokenBalanceMatchesAddress(
+  tb: TokenBalance,
+  address: string,
+  accountKeys: string[],
+): boolean {
+  return tb.owner === address || accountKeys[tb.accountIndex] === address;
+}
 
 /** Maps a program ID to the internal token type name, defaulting to SPL_TOKEN for unknown IDs. */
 function resolveTokenType(programId: string | undefined): SolanaTokenProgram {
@@ -440,44 +469,57 @@ function resolveTokenType(programId: string | undefined): SolanaTokenProgram {
 }
 
 /**
- * Computes per-mint balance deltas for the given owner across a transaction.
+ * Computes per-mint balance deltas for the given address across a transaction.
+ * The address may be the wallet owner or one of its token accounts (see
+ * {@link tokenBalanceMatchesAddress}).
  *
  * Two passes:
- *  1. Iterate postTokenBalances for the owner → delta = post − (matched pre or 0).
+ *  1. Iterate postTokenBalances for the address → delta = post − (matched pre or 0).
  *     Covers tokens that still exist after the tx (increase, decrease, or unchanged).
  *  2. Iterate preTokenBalances for entries not yet seen → delta = −pre.
  *     Covers tokens fully consumed by the tx (e.g. account closed / all tokens sent away).
  */
 function computeTokenBalanceDeltas(
-  ownerAddress: string,
+  address: string,
   preTokenBalances: TokenBalance[],
   postTokenBalances: TokenBalance[],
+  accountKeys: string[],
 ): Map<string, TokenChange> {
   const changes = new Map<string, TokenChange>();
 
   const preBalancesByMint = new Map<string, bigint>();
   for (const pre of preTokenBalances) {
-    if (pre.owner !== ownerAddress) continue;
+    if (!tokenBalanceMatchesAddress(pre, address, accountKeys)) continue;
     if (!preBalancesByMint.has(pre.mint)) {
       preBalancesByMint.set(pre.mint, BigInt(pre.uiTokenAmount.amount));
     }
   }
 
   for (const post of postTokenBalances) {
-    if (post.owner !== ownerAddress) continue;
+    if (!tokenBalanceMatchesAddress(post, address, accountKeys)) continue;
     const tokenType = resolveTokenType(post.programId);
     const key = `${post.mint}-${tokenType}`;
     const postAmount = BigInt(post.uiTokenAmount.amount);
     const preAmount = preBalancesByMint.get(post.mint) ?? 0n;
-    changes.set(key, { mint: post.mint, delta: postAmount - preAmount, tokenType });
+    changes.set(key, {
+      mint: post.mint,
+      delta: postAmount - preAmount,
+      tokenType,
+      owner: post.owner ?? address,
+    });
   }
 
   for (const pre of preTokenBalances) {
-    if (pre.owner !== ownerAddress) continue;
+    if (!tokenBalanceMatchesAddress(pre, address, accountKeys)) continue;
     const tokenType = resolveTokenType(pre.programId);
     const key = `${pre.mint}-${tokenType}`;
     if (!changes.has(key)) {
-      changes.set(key, { mint: pre.mint, delta: -BigInt(pre.uiTokenAmount.amount), tokenType });
+      changes.set(key, {
+        mint: pre.mint,
+        delta: -BigInt(pre.uiTokenAmount.amount),
+        tokenType,
+        owner: pre.owner ?? address,
+      });
     }
   }
 

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.integ.test.ts
@@ -1,4 +1,5 @@
-import { Keypair } from "@solana/web3.js";
+import { getAssociatedTokenAddressSync } from "@solana/spl-token";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import { getChainAPI } from "../../network";
 import { listOperations } from "../listOperations";
 
@@ -6,6 +7,13 @@ const api = getChainAPI({ endpoint: "https://solana.coin.ledger.com" });
 
 const ACTIVE_ADDRESS = "7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE";
 const UNUSED_ADDRESS = Keypair.generate().publicKey.toBase58();
+
+const LIVE_35047_WALLET = "4to9dpNnBqvAbgKd17vjeMXiQVbXi2ewn6QbtT3opF8N";
+const USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+const LIVE_35047_USDC_ATA = getAssociatedTokenAddressSync(
+  new PublicKey(USDC_MINT),
+  new PublicKey(LIVE_35047_WALLET),
+).toBase58();
 
 const KNOWN_TYPES = ["IN", "OUT", "FEES", "NONE", "DELEGATE", "UNDELEGATE", "WITHDRAW_UNBONDED"];
 
@@ -71,6 +79,31 @@ describe("listOperations (integration)", () => {
     const page1Hashes = new Set(page1.items.map(op => op.tx.hash));
     for (const op of page2.items) {
       expect(page1Hashes.has(op.tx.hash)).toBe(false);
+    }
+  });
+
+  // Regression for LIVE-35047: a SOL -> USDC Jupiter swap's USDC leg was
+  // invisible because token balances were matched by wallet `owner` only, while
+  // coin-service queries token sub-accounts by their token-account (ATA)
+  // address. Querying by the ATA must surface the token ops, resolved to the
+  // wallet owner (not the queried ATA).
+  it("surfaces token operations when queried by the token-account (ATA) address (LIVE-35047)", async () => {
+    const result = await listOperations(api, LIVE_35047_USDC_ATA, {
+      minHeight: 0,
+      order: "desc",
+      limit: 100,
+    });
+
+    const tokenOps = result.items.filter(op => op.asset.type !== "native");
+
+    expect(tokenOps.length).toBeGreaterThan(0);
+    for (const op of tokenOps) {
+      // Resolves to the wallet owner regardless of the queried ATA.
+      expect(op.asset).toMatchObject({
+        assetReference: USDC_MINT,
+        assetOwner: LIVE_35047_WALLET,
+      });
+      expect(op.type === "IN" ? op.recipients : op.senders).toContain(LIVE_35047_WALLET);
     }
   });
 });

--- a/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/logic/tests/listOperations.unit.test.ts
@@ -812,6 +812,55 @@ describe("listOperations", () => {
       expect(tokenOps[0].value).toBe(5_000_000n);
     });
 
+    // Regression for LIVE-35047: Ledger Live / coin-service address token
+    // sub-accounts by their token-account (ATA) address, but Solana's token
+    // balance records only carry the wallet `owner`. Querying by the ATA must
+    // still surface the token operation (previously the owner-only match dropped
+    // it, making e.g. a swap's USDC leg invisible).
+    it("surfaces token ops when queried by the token-account (ATA) address (LIVE-35047)", async () => {
+      const blockTime = 1700000000;
+      const TOKEN_ACCOUNT = "AVHhsobqNw3b3XD43fz7Crq3d3UxFYZfHAByh7ogZoeN";
+      mockGetSignaturesForAddress.mockResolvedValue([
+        { signature: "sig1", slot: 100, blockTime, err: null },
+      ]);
+      mockGetParsedTransactions.mockResolvedValue([
+        makeTxWithTokenBalances(
+          [
+            {
+              accountIndex: 1,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS, // Solana records the WALLET as owner, never the ATA
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "3576636", decimals: 6, uiAmount: 3.576636 },
+            },
+          ],
+          [
+            {
+              accountIndex: 1,
+              mint: USDC_MINT,
+              owner: TEST_ADDRESS,
+              programId: TOKEN_PROGRAM_ID_STR,
+              uiTokenAmount: { amount: "5112194", decimals: 6, uiAmount: 5.112194 },
+            },
+          ],
+          [TEST_ADDRESS, TOKEN_ACCOUNT], // ATA is accountKeys[1]
+        ),
+      ]);
+
+      // Query by the token-account address, not the wallet.
+      const result = await listOperations(api, TOKEN_ACCOUNT, { minHeight: 0, order: "desc" });
+
+      const tokenOps = result.items.filter(op => op.asset.type !== "native");
+      expect(tokenOps).toHaveLength(1);
+      expect(tokenOps[0].type).toBe("IN");
+      expect(tokenOps[0].value).toBe(1_535_558n);
+      expect(tokenOps[0].asset).toEqual({
+        type: "spl-token",
+        assetReference: USDC_MINT,
+        assetOwner: TEST_ADDRESS, // resolves to the wallet owner, not the queried ATA
+      });
+    });
+
     it("should skip tokens with zero delta", async () => {
       const blockTime = 1700000000;
       mockGetSignaturesForAddress.mockResolvedValue([


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

listOperations matched token balance changes only by Solana's owner field (the wallet), so querying by a token sub-account's own address (as coin-service/Ledger Live does) returned no token operations, hiding e.g. the USDC leg of a Jupiter swap. Token balances are now also matched by their token-account address, and the operation's assetOwner/senders/recipients resolve to the wallet owner regardless of which address was queried.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35047](https://ledgerhq.atlassian.net/browse/LIVE-35047)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35047]: https://ledgerhq.atlassian.net/browse/LIVE-35047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ