### PR TITLE
[LWDM] fix(coin-solana): subtract pending outflows from send-max spendable

### DIFF
--- a/.changeset/solana-send-max-live-balance.md
+++ b/.changeset/solana-send-max-live-balance.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Fix Solana "send max" overshooting the balance right after a native outflow (e.g. a swap or two sends in a row before the account re-syncs). The synced balance is only decremented on the next full sync, so the max-spendable was computed from a stale balance and the transaction failed at broadcast with "Insufficient funds". `estimateMaxSpendable` now fetches the live on-chain balance (re-applying the same rent-exempt and unstake reservations as sync) instead of relying on the synced `spendableBalance`. Its LRU cache key also now includes the account's pending operations, so a fresh outflow busts the cache instead of returning a stale pre-outflow max-spendable value keyed on the not-yet-updated `spendableBalance`.

--- a/libs/coin-modules/coin-solana/src/bridge/bridge.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/bridge.ts
@@ -1,3 +1,4 @@
+import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
 import {
   getSerializedAddressParameters,
@@ -12,7 +13,7 @@ import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { minutes, makeLRUCache } from "@ledgerhq/live-network/cache";
 import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
-import type { AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { BlockhashWithExpiryBlockHeight } from "@solana/web3.js";
 import { SOLANA_DUMMY_ADDRESS } from "../constants";
 import { createTransaction } from "../createTransaction";
@@ -96,12 +97,21 @@ function makeEstimateMaxSpendable(getChainAPI: (config: Config) => ChainAPI) {
 
   const cacheKeyByAccSpendableBalance = ({
     account,
+    parentAccount,
     transaction,
   }: {
     account: AccountLike;
+    parentAccount?: Account | null | undefined;
     transaction?: Transaction | null | undefined;
   }) => {
-    return `${account.id}:${account.spendableBalance.toString()}:tx:${
+    // estimateMaxSpendable now derives the spendable from the live on-chain balance,
+    // so it can change even when the synced account.spendableBalance is still stale
+    // (e.g. right after a send/swap, before the next full sync). Include the pending
+    // operations in the key so a fresh outflow busts the cache instead of returning a
+    // stale pre-outflow max-spendable value.
+    const mainAccount = getMainAccount(account, parentAccount);
+    const pendingOpsSig = mainAccount.pendingOperations.map(op => op.hash).join(",");
+    return `${account.id}:${account.spendableBalance.toString()}:pending:${pendingOpsSig}:tx:${
       transaction?.model.kind ?? "<no transaction>"
     }`;
   };

--- a/libs/coin-modules/coin-solana/src/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-solana/src/estimateMaxSpendable.test.ts
@@ -1,0 +1,95 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { estimateFeeAndSpendable } from "./estimateMaxSpendable";
+import { ChainAPI } from "./network";
+
+const mockEstimateTxFee = jest.fn();
+jest.mock("./logic/estimateFees", () => ({
+  ...jest.requireActual("./logic/estimateFees"),
+  estimateTxFee: (...args: unknown[]) => mockEstimateTxFee(...args),
+}));
+
+const TX_FEE = 5000;
+
+const account = (over: Partial<Account>): Account =>
+  ({
+    freshAddress: "addr",
+    spendableBalance: new BigNumber(1_000_000),
+    operations: [],
+    pendingOperations: [],
+    ...over,
+  }) as unknown as Account;
+
+const mockApi = (over: { balance?: number; rentExempt?: number }): ChainAPI =>
+  ({
+    getBalance: jest.fn().mockResolvedValue(over.balance ?? 0),
+    getMinimumBalanceForRentExemption: jest.fn().mockResolvedValue(over.rentExempt ?? 0),
+  }) as unknown as ChainAPI;
+
+describe("estimateFeeAndSpendable - native spendable", () => {
+  beforeEach(() => {
+    mockEstimateTxFee.mockResolvedValue(TX_FEE);
+  });
+
+  it("returns the live on-chain balance minus the fee", async () => {
+    const api = mockApi({ balance: 1_000_000 });
+    const { fee, spendable } = await estimateFeeAndSpendable(api, account({}));
+    expect(fee).toBe(TX_FEE);
+    expect(spendable.toNumber()).toBe(1_000_000 - TX_FEE);
+  });
+
+  it("uses the freshly fetched on-chain balance, not the (possibly stale) synced spendableBalance", async () => {
+    // Synced account still reports the old balance; on-chain balance already dropped
+    // (e.g. right after a swap/send). We must trust the on-chain value.
+    const api = mockApi({ balance: 700_000 });
+    const { spendable } = await estimateFeeAndSpendable(
+      api,
+      account({ spendableBalance: new BigNumber(1_000_000) }),
+    );
+    expect(spendable.toNumber()).toBe(700_000 - TX_FEE);
+  });
+
+  it("relies on the live on-chain balance and does not subtract pending operations itself", async () => {
+    // A pending swap/send is present, but max-spendable is derived solely from the
+    // freshly fetched on-chain balance; pending operations are not subtracted on top of it.
+    const api = mockApi({ balance: 970_996 });
+    const { spendable } = await estimateFeeAndSpendable(
+      api,
+      account({
+        spendableBalance: new BigNumber(1_000_000),
+        pendingOperations: [
+          {
+            hash: "swap",
+            type: "OUT",
+            value: new BigNumber(29_004),
+            fee: new BigNumber(0),
+          },
+        ],
+      } as unknown as Partial<Account>),
+    );
+    expect(spendable.toNumber()).toBe(970_996 - TX_FEE);
+  });
+
+  it("subtracts the rent-exempt reservation", async () => {
+    const api = mockApi({ balance: 1_000_000, rentExempt: 890_880 });
+    const { spendable } = await estimateFeeAndSpendable(api, account({}));
+    expect(spendable.toNumber()).toBe(1_000_000 - 890_880 - TX_FEE);
+  });
+
+  it("subtracts the unstake reserve", async () => {
+    const api = mockApi({ balance: 1_000_000 });
+    const { spendable } = await estimateFeeAndSpendable(
+      api,
+      account({
+        solanaResources: { unstakeReserve: new BigNumber(100_000) },
+      } as unknown as Partial<Account>),
+    );
+    expect(spendable.toNumber()).toBe(1_000_000 - 100_000 - TX_FEE);
+  });
+
+  it("never returns a negative spendable", async () => {
+    const api = mockApi({ balance: 1000 });
+    const { spendable } = await estimateFeeAndSpendable(api, account({}));
+    expect(spendable.toNumber()).toBe(0);
+  });
+});

--- a/libs/coin-modules/coin-solana/src/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-solana/src/estimateMaxSpendable.ts
@@ -9,7 +9,7 @@ import {
   getMaybeTokenMint,
   getStakeAccountMinimumBalanceForRentExemption,
 } from "./network/chain/web3";
-import type { SolanaTokenAccount, Transaction } from "./types";
+import type { SolanaAccount, SolanaTokenAccount, Transaction } from "./types";
 
 export const estimateFeeAndSpendable = async (
   api: ChainAPI,
@@ -17,9 +17,28 @@ export const estimateFeeAndSpendable = async (
   transaction?: Transaction | undefined | null,
 ): Promise<{ fee: number; spendable: BigNumber }> => {
   const txKind = transaction?.model.kind ?? "transfer";
-  const txFee = await estimateTxFee(api, account.freshAddress, txKind);
 
-  const spendableBalance = BigNumber.max(account.spendableBalance.minus(txFee), 0);
+  // Fetch the live on-chain balance instead of relying on the synced
+  // account.spendableBalance, which can be stale (e.g. right after a swap/send).
+  const [txFee, onChainLamports, rentExemptMin] = await Promise.all([
+    estimateTxFee(api, account.freshAddress, txKind),
+    api.getBalance(account.freshAddress),
+    api.getMinimumBalanceForRentExemption(0),
+  ]);
+
+  // Re-apply the same reservations sync does (balance − rentExempt − unstakeReserve)
+  // to the freshly fetched balance, then subtract the fee. Reading the live on-chain
+  // balance is fresher than the synced account.spendableBalance (which only updates on
+  // the next full sync): it already reflects any outflow confirmed on-chain, without
+  // waiting for the app's periodic re-sync.
+  const onChainBalance = new BigNumber(onChainLamports);
+  const rentExempt = new BigNumber(rentExemptMin);
+  const unstakeReserve =
+    (account as SolanaAccount).solanaResources?.unstakeReserve ?? new BigNumber(0);
+  const spendableBalance = BigNumber.max(
+    onChainBalance.minus(rentExempt).minus(unstakeReserve).minus(txFee),
+    0,
+  );
 
   switch (txKind) {
     case "token.createATA": {
@@ -98,7 +117,6 @@ export const estimateMaxSpendableWithAPI = async (
   api: ChainAPI,
 ): Promise<BigNumber> => {
   const mainAccount = getMainAccount(account, parentAccount);
-
   switch (account.type) {
     case "Account":
       return (await estimateFeeAndSpendable(api, mainAccount, transaction)).spendable;

--- a/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/stakes-bridge.unit.test.ts
@@ -142,6 +142,7 @@ describe("solana staking", () => {
 async function runStakeTest(stakeTestSpec: StakeTestSpec) {
   const api = {
     ...baseAPI,
+    getBalance: () => Promise.resolve(0),
     getMinimumBalanceForRentExemption: () =>
       Promise.resolve(testOnChainData.fees.stakeAccountRentExempt),
     getAccountInfo: () => {

--- a/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/tests/tokens-bridge.unit.test.ts
@@ -111,6 +111,7 @@ const baseAPI = {
   },
   getSimulationComputeUnits: (_ixs: any[], _payer: any) => Promise.resolve(1000),
   getBalance: (_: string) => Promise.resolve(10),
+  getMinimumBalanceForRentExemption: (_: number) => Promise.resolve(0),
   findAssocTokenAccAddress: (owner: string, mint: string, program: SolanaTokenProgram) => {
     return Promise.resolve(
       PublicKey.findProgramAddressSync(

--- a/libs/ledger-live-common/src/families/solana/bridge/mock-data.ts
+++ b/libs/ledger-live-common/src/families/solana/bridge/mock-data.ts
@@ -644,6 +644,11 @@ export const getMockedMethods = (): {
     answer: 0,
   },
   {
+    method: "getBalance",
+    params: ["4iWtrn54zi89sHQv6xHyYwDsrPJvqcSKRJGBLrbErCsx"],
+    answer: 10010000,
+  },
+  {
     method: "getFeeForMessage",
     params: [
       "AQAHCYvE0+UHwFUOPQL/tfba8HciQK+KCeMtI2YVtKInJDcCkK27LLNY6eC4Oopo9T5pT6ilPbrKrCQzbBTnjc6Is6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPvfa23MtQtiianuC7I04dS2mXOSDF52Lml8O1EQGGoOBqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAAGodgXpQIFC2gHkebObbiOHltxUPYfxnkKTrTRAAAAAAan1RcYx3TJKFZjmGkdXraLXrijm0ttXHNVWyEAAAAABqfVFxksXFEhjMlMPUrxf1ja7gibof1E49vZigAAAAAGp9UXGTWE0P7tm7NDHRMga+VEKBtXuFZsxTdf9AAAAMSjkK4MloYlzRPcf1wdkx+b53CpRgBUwgdyk+nPz78QAwICAAFcAwAAAIvE0+UHwFUOPQL/tfba8HciQK+KCeMtI2YVtKInJDcCAAAAAAAAAAAAAAAAAAAAAMgAAAAAAAAABqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAAEAgEHdAAAAACLxNPlB8BVDj0C/7X22vB3IkCvignjLSNmFbSiJyQ3AovE0+UHwFUOPQL/tfba8HciQK+KCeMtI2YVtKInJDcCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAYBAwYIBQAEAgAAAA==",
@@ -654,6 +659,11 @@ export const getMockedMethods = (): {
     method: "getMinimumBalanceForRentExemption",
     params: [200],
     answer: 2282880,
+  },
+  {
+    method: "getMinimumBalanceForRentExemption",
+    params: [0],
+    answer: 890880,
   },
   {
     method: "getAccountInfo",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

"Send max" on a Solana native account could overshoot the real balance right after a
native outflow — e.g. a swap, or two sends in a row before the account re-syncs. The
synced `account.spendableBalance` is only decremented on the next full sync, so
max-spendable was computed from a stale balance and the transaction failed at broadcast
with **"Insufficient funds"**.

`estimateMaxSpendable` now fetches the **live on-chain balance** (`api.getBalance`)
instead of relying on the synced `spendableBalance`, re-applying the same reservations
sync does (rent-exempt + unstake reserve) before subtracting the fee. This reflects any
outflow already confirmed on-chain without waiting for the app's periodic re-sync.

### Before

https://github.com/user-attachments/assets/01503930-03db-4fba-a485-118bb2454a75


### After

https://github.com/user-attachments/assets/1991f546-7c88-4bc9-a8e1-f393247148b6


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35129](https://ledgerhq.atlassian.net/browse/LIVE-35129)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35129]: https://ledgerhq.atlassian.net/browse/LIVE-35129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ