### PR TITLE
[LWDM] refactor(coin-near): migrate NearBlocks indexer client to v3 (LIVE-34441)

### DIFF
--- a/.changeset/near-nearblocks-indexer-v3.md
+++ b/.changeset/near-nearblocks-indexer-v3.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-near": minor
+---
+
+Migrate the NearBlocks indexer client from v1 to v3

--- a/libs/coin-modules/coin-near/src/api/indexer.integ.test.ts
+++ b/libs/coin-modules/coin-near/src/api/indexer.integ.test.ts
@@ -1,0 +1,85 @@
+import { setCoinConfig } from "../config";
+import { getOperations } from "./indexer";
+import { getGasPrice, getStakingPositions, getValidators } from "./node";
+
+const ACCOUNT_WITH_HISTORY = "nearkat.near";
+const DELEGATOR = "81afe80a9d91c82f66122c35ef400da709bde01eada5aae8d7a63bbf68f42040";
+
+describe("NearBlocks indexer (integration)", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_NEAR_PRIVATE_NODE: "https://near.coin.ledger.com/node",
+        API_NEAR_PUBLIC_NODE: "https://rpc.mainnet.near.org",
+        API_NEAR_INDEXER: "https://near.coin.ledger.com/indexer",
+        API_NEARBLOCKS_INDEXER: "https://near-indexer.coin.ledger.com",
+      },
+    }));
+  });
+
+  it("maps a real account history into operations", async () => {
+    const operations = await getOperations("accountId", ACCOUNT_WITH_HISTORY);
+
+    expect(operations.length).toBeGreaterThan(0);
+    expect(operations.length).toBeLessThanOrEqual(25);
+
+    operations.forEach(operation => {
+      expect(operation.hash).toMatch(/\S/);
+      expect(operation.value.isNaN()).toBe(false);
+      expect(operation.value.isNegative()).toBe(false);
+      expect(operation.fee.isNaN()).toBe(false);
+      expect(typeof operation.blockHeight).toBe("number");
+      expect(Number.isFinite(operation.blockHeight as number)).toBe(true);
+      expect(operation.blockHash).toMatch(/\S/);
+      expect(operation.date.getTime()).toBeGreaterThan(new Date("2020-01-01").getTime());
+      expect(operation.date.getTime()).toBeLessThan(Date.now() + 60_000);
+    });
+  });
+
+  it("reads a usable gas price", async () => {
+    const gasPrice = await getGasPrice();
+
+    expect(gasPrice).toMatch(/^\d+$/);
+    expect(BigInt(gasPrice) > 0n).toBe(true);
+  });
+
+  it("walks the cursor to collect the requested number of distinct validators", async () => {
+    const validators = await getValidators({ total: 200 });
+
+    expect(validators).toHaveLength(200);
+    expect(new Set(validators.map(validator => validator.account_id)).size).toBe(200);
+
+    validators.forEach(validator => {
+      expect(validator.account_id).toMatch(/\S/);
+      expect(validator.stake).toMatch(/^\d+$/);
+      expect(Number.isInteger(validator.commission)).toBe(true);
+      expect(validator.commission).toBeGreaterThanOrEqual(0);
+      expect(validator.commission).toBeLessThanOrEqual(100);
+    });
+  });
+
+  it("honours a total smaller than a single indexer page", async () => {
+    getValidators.reset();
+
+    const validators = await getValidators({ total: 7 });
+
+    expect(validators).toHaveLength(7);
+  });
+
+  it("resolves the staking positions of a delegating account", async () => {
+    const { stakingPositions, totalStaked, totalAvailable, totalPending } =
+      await getStakingPositions(DELEGATOR);
+
+    expect(totalStaked.isNaN()).toBe(false);
+    expect(totalAvailable.isNaN()).toBe(false);
+    expect(totalPending.isNaN()).toBe(false);
+
+    stakingPositions.forEach(position => {
+      expect(position.validatorId).toMatch(/\S/);
+      expect(position.staked.isNaN()).toBe(false);
+      expect(position.available.isNaN()).toBe(false);
+      expect(position.pending.isNaN()).toBe(false);
+    });
+  });
+});

--- a/libs/coin-modules/coin-near/src/api/indexer.test.ts
+++ b/libs/coin-modules/coin-near/src/api/indexer.test.ts
@@ -1,0 +1,384 @@
+import { http, HttpResponse } from "msw";
+import { setCoinConfig } from "../config";
+import { getOperations } from "./indexer";
+import { mockServer, NEAR_BASE_URL_MOCKED } from "./node.mock";
+import { NearTransaction } from "./sdk.types";
+
+const ACCOUNT_ID = "accountId";
+const ADDRESS = "sender.near";
+
+const txn = (overrides: Partial<NearTransaction> = {}): NearTransaction => ({
+  signer_account_id: ADDRESS,
+  receiver_account_id: "receiver.near",
+  transaction_hash: "GgQ6xTuNhTNGVsRAhLFGRUBB1cUv9kmvhBZBrLPZbNSJ",
+  block_timestamp: "1755192310610741506",
+  block: {
+    block_hash: "DsWyc6swGSDezgvweB561FLbL1nsBsU3QJtZFLHq79Ru",
+    block_height: "159618979",
+    block_timestamp: "1755192310610741506",
+  },
+  outcomes: { status: true },
+  outcomes_agg: { transaction_fee: "1114233164157900000000" },
+  actions_agg: { deposit: "10000000000000000000000" },
+  actions: [{ action: "TRANSFER", method: null }],
+  ...overrides,
+});
+
+let lastRequestUrl: URL | undefined;
+
+const respondWith = (data: NearTransaction[] | null): void => {
+  mockServer.use(
+    http.get(`${NEAR_BASE_URL_MOCKED}/v3/accounts/:address/txns`, ({ request }) => {
+      lastRequestUrl = new URL(request.url);
+      return HttpResponse.json({ data });
+    }),
+  );
+};
+
+describe("getOperations", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_NEAR_PRIVATE_NODE: NEAR_BASE_URL_MOCKED,
+        API_NEAR_PUBLIC_NODE: NEAR_BASE_URL_MOCKED,
+        API_NEAR_INDEXER: NEAR_BASE_URL_MOCKED,
+        API_NEARBLOCKS_INDEXER: NEAR_BASE_URL_MOCKED,
+      },
+    }));
+
+    mockServer.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+    lastRequestUrl = undefined;
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  describe("request", () => {
+    it("targets the v3 account txns endpoint", async () => {
+      respondWith([]);
+
+      await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(lastRequestUrl?.pathname).toBe(`/v3/accounts/${ADDRESS}/txns`);
+    });
+
+    it("sends no paging params, preserving the v1 default page size", async () => {
+      respondWith([]);
+
+      await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(lastRequestUrl?.searchParams.get("limit")).toBeNull();
+      expect(lastRequestUrl?.search).toBe("");
+    });
+  });
+
+  describe("envelope", () => {
+    it("unwraps data", async () => {
+      respondWith([txn(), txn({ transaction_hash: "second" })]);
+
+      const operations = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operations).toHaveLength(2);
+    });
+
+    it("returns no operations when data is null", async () => {
+      respondWith(null);
+
+      const operations = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operations).toEqual([]);
+    });
+  });
+
+  describe("operation type", () => {
+    it.each([
+      ["deposit_and_stake", "STAKE"],
+      ["unstake", "UNSTAKE"],
+      ["unstake_all", "UNSTAKE"],
+      ["withdraw", "WITHDRAW_UNSTAKED"],
+      ["withdraw_all", "WITHDRAW_UNSTAKED"],
+    ])("maps method %s to %s", async (method, expected) => {
+      respondWith([txn({ actions: [{ action: "FUNCTION_CALL", method }] })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.type).toBe(expected);
+    });
+
+    it("falls back to OUT when the account is the signer", async () => {
+      respondWith([txn({ actions: [{ action: "TRANSFER", method: null }] })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.type).toBe("OUT");
+    });
+
+    it("falls back to IN when the account is not the signer", async () => {
+      respondWith([
+        txn({
+          signer_account_id: "someone-else.near",
+          actions: [{ action: "TRANSFER", method: null }],
+        }),
+      ]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.type).toBe("IN");
+    });
+
+    it("falls back to OUT/IN for an unknown method", async () => {
+      respondWith([txn({ actions: [{ action: "FUNCTION_CALL", method: "mint_sbt" }] })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.type).toBe("OUT");
+    });
+  });
+
+  describe("operation value", () => {
+    it("reads the aggregated deposit", async () => {
+      respondWith([
+        txn({
+          actions: [{ action: "FUNCTION_CALL", method: "deposit_and_stake" }],
+          actions_agg: { deposit: "5000000000000000000000" },
+        }),
+      ]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.value.toFixed()).toBe("5000000000000000000000");
+    });
+
+    it("adds the transaction fee for an outgoing operation", async () => {
+      respondWith([
+        txn({
+          actions_agg: { deposit: "10000000000000000000000" },
+          outcomes_agg: { transaction_fee: "1114233164157900000000" },
+        }),
+      ]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.type).toBe("OUT");
+      expect(operation.value.toFixed()).toBe("11114233164157900000000");
+      expect(operation.fee.toFixed()).toBe("1114233164157900000000");
+    });
+
+    it("preserves full yoctoNEAR precision", async () => {
+      respondWith([
+        txn({
+          signer_account_id: "someone-else.near",
+          actions_agg: { deposit: "123456789012345678901234" },
+        }),
+      ]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.value.toFixed()).toBe("123456789012345678901234");
+    });
+  });
+
+  describe("block fields", () => {
+    it("reads the block hash from the block object", async () => {
+      respondWith([txn()]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.blockHash).toBe("DsWyc6swGSDezgvweB561FLbL1nsBsU3QJtZFLHq79Ru");
+    });
+
+    it("converts the block height from string to number", async () => {
+      respondWith([txn({ block: { block_height: "159618979" } })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.blockHeight).toBe(159618979);
+    });
+
+    it("leaves block fields undefined when the block object is empty", async () => {
+      respondWith([txn({ block: {} })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.blockHash).toBeUndefined();
+      expect(operation.blockHeight).toBeUndefined();
+    });
+
+    it("derives the date from the nanosecond timestamp", async () => {
+      respondWith([txn({ block_timestamp: "1755192310610741506" })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.date).toEqual(new Date(1755192310610));
+    });
+  });
+
+  describe("failure flag", () => {
+    it("is false for a successful outcome", async () => {
+      respondWith([txn({ outcomes: { status: true } })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.hasFailed).toBe(false);
+    });
+
+    it("is true for a failed outcome", async () => {
+      respondWith([txn({ outcomes: { status: false } })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.hasFailed).toBe(true);
+    });
+
+    it("is false when the status is absent, since the outcome is not indexed yet", async () => {
+      respondWith([txn({ outcomes: {} })]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.hasFailed).toBe(false);
+    });
+
+    it("is false when the outcomes object itself is absent", async () => {
+      const malformed = txn();
+      delete malformed.outcomes;
+      respondWith([malformed]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.hasFailed).toBe(false);
+    });
+  });
+
+  describe("participants", () => {
+    it("maps senders and recipients", async () => {
+      respondWith([txn()]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.senders).toEqual([ADDRESS]);
+      expect(operation.recipients).toEqual(["receiver.near"]);
+      expect(operation.hash).toBe("GgQ6xTuNhTNGVsRAhLFGRUBB1cUv9kmvhBZBrLPZbNSJ");
+    });
+  });
+
+  describe("payloads captured from the indexer", () => {
+    const functionCall = {
+      actions: [{ action: "FUNCTION_CALL", method: "mint_sbt" }],
+      actions_agg: { deposit: "10000000000000000000000" },
+      block: {
+        block_hash: "DsWyc6swGSDezgvweB561FLbL1nsBsU3QJtZFLHq79Ru",
+        block_height: "159618979",
+        block_timestamp: "1755192310610741506",
+      },
+      block_timestamp: "1755192310610741506",
+      index_in_chunk: 12,
+      outcomes: { status: true },
+      outcomes_agg: { transaction_fee: "1114233164157900000000" },
+      receiver_account_id: "initiate.nearlegion.near",
+      shard_id: 4,
+      signer_account_id: "nearkat.near",
+      transaction_hash: "CRw2Fu7yATn2yxyDf1xyYfbZSBqjXi4hD9Lc7LeWm3bJ",
+    };
+
+    const notYetExecuted = {
+      actions: [],
+      actions_agg: { deposit: "0" },
+      block: {
+        block_hash: "Cs4y7fCpkv5yqhSyjPb7nQfRYK5SUhTWXxx9vxtjM4ce",
+        block_height: "208952176",
+        block_timestamp: "1785272779403516018",
+      },
+      block_timestamp: "1785272779403516018",
+      index_in_chunk: 0,
+      outcomes: {},
+      outcomes_agg: { transaction_fee: "31382922951500000000" },
+      receiver_account_id: "wrap.near",
+      shard_id: 8,
+      signer_account_id: "burrow-liquidation-bot-04.ref-labs.near",
+      transaction_hash: "5U17hHtwFeqFswsimtvm7wjQeAZd1zeriJsuUd88rbWX",
+    };
+
+    it("maps a real FUNCTION_CALL transaction", async () => {
+      respondWith([functionCall]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, "nearkat.near");
+
+      expect(operation.type).toBe("OUT");
+      expect(operation.value.toFixed()).toBe("11114233164157900000000");
+      expect(operation.fee.toFixed()).toBe("1114233164157900000000");
+      expect(operation.blockHash).toBe("DsWyc6swGSDezgvweB561FLbL1nsBsU3QJtZFLHq79Ru");
+      expect(operation.blockHeight).toBe(159618979);
+      expect(operation.senders).toEqual(["nearkat.near"]);
+      expect(operation.recipients).toEqual(["initiate.nearlegion.near"]);
+      expect(operation.hasFailed).toBe(false);
+    });
+
+    it("maps a real transaction whose outcome is not indexed yet", async () => {
+      respondWith([notYetExecuted]);
+
+      const [operation] = await getOperations(
+        ACCOUNT_ID,
+        "burrow-liquidation-bot-04.ref-labs.near",
+      );
+
+      expect(operation.type).toBe("OUT");
+      expect(operation.value.toFixed()).toBe("31382922951500000000");
+      expect(operation.blockHeight).toBe(208952176);
+      expect(operation.hasFailed).toBe(false);
+    });
+
+    it("maps a full page of both shapes without dropping any operation", async () => {
+      respondWith([functionCall, notYetExecuted]);
+
+      const operations = await getOperations(ACCOUNT_ID, "nearkat.near");
+
+      expect(operations).toHaveLength(2);
+      expect(operations.map(operation => operation.hash)).toEqual([
+        "CRw2Fu7yATn2yxyDf1xyYfbZSBqjXi4hD9Lc7LeWm3bJ",
+        "5U17hHtwFeqFswsimtvm7wjQeAZd1zeriJsuUd88rbWX",
+      ]);
+    });
+  });
+
+  describe("resilience", () => {
+    it.each(["actions_agg", "outcomes_agg", "outcomes", "block", "actions"] as const)(
+      "keeps mapping the page when a transaction omits %s",
+      async field => {
+        const malformed = txn({ transaction_hash: "malformed" });
+        delete malformed[field];
+        respondWith([malformed, txn({ transaction_hash: "healthy" })]);
+
+        const operations = await getOperations(ACCOUNT_ID, ADDRESS);
+
+        expect(operations).toHaveLength(2);
+        expect(operations[1].value.toFixed()).toBe("11114233164157900000000");
+      },
+    );
+
+    it("maps a transaction that carries nothing but its identity", async () => {
+      respondWith([
+        {
+          signer_account_id: ADDRESS,
+          receiver_account_id: "receiver.near",
+          transaction_hash: "bare",
+          block_timestamp: "1755192310610741506",
+        },
+      ]);
+
+      const [operation] = await getOperations(ACCOUNT_ID, ADDRESS);
+
+      expect(operation.hash).toBe("bare");
+      expect(operation.value.toFixed()).toBe("0");
+      expect(operation.fee.toFixed()).toBe("0");
+      expect(operation.blockHash).toBeUndefined();
+      expect(operation.blockHeight).toBeUndefined();
+      expect(operation.hasFailed).toBe(false);
+    });
+  });
+});

--- a/libs/coin-modules/coin-near/src/api/indexer.ts
+++ b/libs/coin-modules/coin-near/src/api/indexer.ts
@@ -3,16 +3,16 @@ import liveNetwork from "@ledgerhq/live-network";
 import { Operation, OperationType } from "@ledgerhq/types-live";
 import { BigNumber } from "bignumber.js";
 import { getCoinConfig } from "../config";
-import { NearTransaction } from "./sdk.types";
+import { NearTransaction, NearV3Response } from "./sdk.types";
 
 const fetchTransactions = async (address: string): Promise<NearTransaction[]> => {
   const currencyConfig = getCoinConfig();
 
-  const response = await liveNetwork<{ txns: NearTransaction[] }>({
-    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v1/account/${address}/txns-only`,
+  const response = await liveNetwork<NearV3Response<NearTransaction[]>>({
+    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v3/accounts/${address}/txns`,
   });
 
-  return response.data.txns || [];
+  return response.data.data ?? [];
 };
 
 function isSender(transaction: NearTransaction, address: string): boolean {
@@ -35,10 +35,10 @@ function getOperationType(transaction: NearTransaction, address: string): Operat
 }
 
 function getOperationValue(transaction: NearTransaction, type: OperationType): BigNumber {
-  const amount = transaction.actions?.at(0)?.deposit || 0;
+  const amount = transaction.actions_agg?.deposit || 0;
 
   if (type === "OUT") {
-    return new BigNumber(amount).plus(transaction.outcomes_agg.transaction_fee);
+    return new BigNumber(amount).plus(transaction.outcomes_agg?.transaction_fee || 0);
   }
 
   return new BigNumber(amount);
@@ -54,17 +54,20 @@ async function transactionToOperation(
   return {
     id: encodeOperationId(accountId, transaction.transaction_hash, type),
     accountId,
-    fee: new BigNumber(transaction.outcomes_agg.transaction_fee || 0),
+    fee: new BigNumber(transaction.outcomes_agg?.transaction_fee || 0),
     value: getOperationValue(transaction, type),
     type,
     hash: transaction.transaction_hash,
-    blockHash: transaction.included_in_block_hash,
-    blockHeight: transaction.block.block_height,
+    blockHash: transaction.block?.block_hash,
+    blockHeight:
+      transaction.block?.block_height !== undefined
+        ? Number(transaction.block.block_height)
+        : undefined,
     date: new Date(parseFloat(transaction.block_timestamp) / 1000000),
     extra: {},
     senders: transaction.signer_account_id ? [transaction.signer_account_id] : [],
     recipients: transaction.receiver_account_id ? [transaction.receiver_account_id] : [],
-    hasFailed: !transaction.outcomes.status,
+    hasFailed: transaction.outcomes?.status === false,
   };
 }
 

--- a/libs/coin-modules/coin-near/src/api/node.test.ts
+++ b/libs/coin-modules/coin-near/src/api/node.test.ts
@@ -1,0 +1,478 @@
+import { http, HttpResponse } from "msw";
+import { setCoinConfig } from "../config";
+import { getGasPrice, getStakingPositions, getValidators } from "./node";
+import { mockServer, NEAR_BASE_URL_MOCKED } from "./node.mock";
+
+const RPC_GAS_PRICE = "123000000";
+const ADDRESS = "delegator.near";
+const VALIDATOR_ID = "astro-stakers.poolv1.near";
+
+type IndexerValidator = {
+  account_id: string;
+  current_epoch_stake: string | null;
+  fee_numerator: number | null;
+  fee_denominator: number | null;
+};
+
+const validator = (overrides: Partial<IndexerValidator> = {}): IndexerValidator => ({
+  account_id: VALIDATOR_ID,
+  current_epoch_stake: "31516203410952749364980772561846",
+  fee_numerator: 1,
+  fee_denominator: 100,
+  ...overrides,
+});
+
+const page = (count: number, prefix: string): IndexerValidator[] =>
+  Array.from({ length: count }, (_, index) => validator({ account_id: `${prefix}-${index}.near` }));
+
+const viewResult = (value: unknown) => ({
+  jsonrpc: "2.0",
+  id: "id",
+  result: {
+    result: Array.from(Buffer.from(JSON.stringify(value))),
+    logs: [],
+    block_height: 1,
+    block_hash: "DsWyc6swGSDezgvweB561FLbL1nsBsU3QJtZFLHq79Ru",
+  },
+});
+
+const mockRpc = (views: Record<string, unknown> = {}): void => {
+  mockServer.use(
+    http.post(NEAR_BASE_URL_MOCKED, async ({ request }) => {
+      const body = (await request.json()) as {
+        method: string;
+        params: { request_type?: string; method_name?: string };
+      };
+
+      if (body.method === "gas_price") {
+        return HttpResponse.json({
+          jsonrpc: "2.0",
+          id: "id",
+          result: { gas_price: RPC_GAS_PRICE },
+        });
+      }
+
+      if (body.params?.request_type === "call_function") {
+        const methodName = body.params.method_name as string;
+        return HttpResponse.json(viewResult(views[methodName]));
+      }
+
+      return HttpResponse.json({ jsonrpc: "2.0", id: "id", result: {} });
+    }),
+  );
+};
+
+const mockStats = (data: { gas_price: string | null } | null): void => {
+  mockServer.use(http.get(`${NEAR_BASE_URL_MOCKED}/v3/stats`, () => HttpResponse.json({ data })));
+};
+
+describe("node api (indexer-backed calls)", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_NEAR_PRIVATE_NODE: NEAR_BASE_URL_MOCKED,
+        API_NEAR_PUBLIC_NODE: NEAR_BASE_URL_MOCKED,
+        API_NEAR_INDEXER: NEAR_BASE_URL_MOCKED,
+        API_NEARBLOCKS_INDEXER: NEAR_BASE_URL_MOCKED,
+      },
+    }));
+
+    mockServer.listen({ onUnhandledRequest: "error" });
+  });
+
+  beforeEach(() => {
+    getValidators.reset();
+  });
+
+  afterEach(() => {
+    mockServer.resetHandlers();
+  });
+
+  afterAll(() => {
+    mockServer.close();
+  });
+
+  describe("getGasPrice", () => {
+    it("reads the gas price from the v3 stats envelope", async () => {
+      let requestedPath: string | undefined;
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/stats`, ({ request }) => {
+          requestedPath = new URL(request.url).pathname;
+          return HttpResponse.json({ data: { gas_price: "100000000" } });
+        }),
+      );
+
+      const gasPrice = await getGasPrice();
+
+      expect(requestedPath).toBe("/v3/stats");
+      expect(gasPrice).toBe("100000000");
+    });
+
+    it("falls back to the node RPC when the indexer gas price is null", async () => {
+      mockStats({ gas_price: null });
+      mockRpc();
+
+      const gasPrice = await getGasPrice();
+
+      expect(gasPrice).toBe(RPC_GAS_PRICE);
+    });
+
+    it("falls back to the node RPC when the envelope data is null", async () => {
+      mockStats(null);
+      mockRpc();
+
+      const gasPrice = await getGasPrice();
+
+      expect(gasPrice).toBe(RPC_GAS_PRICE);
+    });
+
+    it("falls back to the node RPC when the indexer reports an empty gas price", async () => {
+      mockStats({ gas_price: "" });
+      mockRpc();
+
+      const gasPrice = await getGasPrice();
+
+      expect(gasPrice).toBe(RPC_GAS_PRICE);
+    });
+
+    it("reports the node error when the fallback cannot read a gas price either", async () => {
+      mockStats(null);
+      mockServer.use(
+        http.post(NEAR_BASE_URL_MOCKED, () =>
+          HttpResponse.json({
+            jsonrpc: "2.0",
+            id: "id",
+            error: { message: "node unavailable" },
+          }),
+        ),
+      );
+
+      await expect(getGasPrice()).rejects.toThrow("node unavailable");
+    });
+  });
+
+  describe("getStakingPositions", () => {
+    it("discovers delegated validators through the v3 kitwallet endpoint", async () => {
+      let requestedPath: string | undefined;
+      mockServer.use(
+        http.get(
+          `${NEAR_BASE_URL_MOCKED}/v3/kitwallet/staking-deposits/:address`,
+          ({ request }) => {
+            requestedPath = new URL(request.url).pathname;
+            return HttpResponse.json([
+              { deposit: "1000000000000000000000000", validator_id: VALIDATOR_ID },
+            ]);
+          },
+        ),
+      );
+      mockRpc({
+        get_account_staked_balance: "1000000000000000000000000",
+        get_account_unstaked_balance: "0",
+        is_account_unstaked_balance_available: false,
+      });
+
+      const { stakingPositions, totalStaked } = await getStakingPositions(ADDRESS);
+
+      expect(requestedPath).toBe(`/v3/kitwallet/staking-deposits/${ADDRESS}`);
+      expect(totalStaked.toFixed()).toBe("1000000000000000000000000");
+      expect(stakingPositions).toHaveLength(1);
+      expect(stakingPositions[0].validatorId).toBe(VALIDATOR_ID);
+    });
+
+    it("handles an account with no deposits", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/kitwallet/staking-deposits/:address`, () =>
+          HttpResponse.json([]),
+        ),
+      );
+      mockRpc();
+
+      const { stakingPositions, totalStaked } = await getStakingPositions(ADDRESS);
+
+      expect(stakingPositions).toEqual([]);
+      expect(totalStaked.toFixed()).toBe("0");
+    });
+
+    it("reports an unstaked balance as available once the node says it is withdrawable", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/kitwallet/staking-deposits/:address`, () =>
+          HttpResponse.json([{ deposit: "1000000000000000000000000", validator_id: VALIDATOR_ID }]),
+        ),
+      );
+      mockRpc({
+        get_account_staked_balance: "0",
+        get_account_unstaked_balance: "2000000000000000000000000",
+        is_account_unstaked_balance_available: true,
+      });
+
+      const { stakingPositions, totalAvailable, totalPending } = await getStakingPositions(ADDRESS);
+
+      expect(totalAvailable.toFixed()).toBe("2000000000000000000000000");
+      expect(totalPending.toFixed()).toBe("0");
+      expect(stakingPositions[0].available.toFixed()).toBe("2000000000000000000000000");
+    });
+
+    it("reports an unstaked balance as pending while it is still locked", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/kitwallet/staking-deposits/:address`, () =>
+          HttpResponse.json([{ deposit: "1000000000000000000000000", validator_id: VALIDATOR_ID }]),
+        ),
+      );
+      mockRpc({
+        get_account_staked_balance: "0",
+        get_account_unstaked_balance: "3000000000000000000000000",
+        is_account_unstaked_balance_available: false,
+      });
+
+      const { totalAvailable, totalPending } = await getStakingPositions(ADDRESS);
+
+      expect(totalAvailable.toFixed()).toBe("0");
+      expect(totalPending.toFixed()).toBe("3000000000000000000000000");
+    });
+  });
+
+  describe("getValidators", () => {
+    it("maps the flat snake_case v3 shape", async () => {
+      let requestedUrl: URL | undefined;
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          requestedUrl = new URL(request.url);
+          return HttpResponse.json({ data: [validator()] });
+        }),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(requestedUrl?.pathname).toBe("/v3/validators");
+      expect(requestedUrl?.searchParams.get("limit")).toBe("100");
+      expect(validators).toEqual([
+        {
+          account_id: VALIDATOR_ID,
+          stake: "31516203410952749364980772561846",
+          commission: 1,
+        },
+      ]);
+    });
+
+    it("computes the same commission percentage as the previous fee shape", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () =>
+          HttpResponse.json({
+            data: [validator({ fee_numerator: 7, fee_denominator: 100 })],
+          }),
+        ),
+      );
+
+      const [mapped] = await getValidators({ total: 200 });
+
+      expect(mapped.commission).toBe(7);
+    });
+
+    it("walks the cursor until the requested total is collected", async () => {
+      const cursor = "eyJhY2NvdW50X2lkIjoid2Fja2F6b25nLnBvb2x2MS5uZWFyIn0=";
+      const receivedCursors: (string | null)[] = [];
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          const next = new URL(request.url).searchParams.get("next");
+          receivedCursors.push(next);
+
+          if (!next) {
+            return HttpResponse.json({
+              data: page(100, "first"),
+              meta: { next_page: cursor },
+            });
+          }
+
+          return HttpResponse.json({ data: page(100, "second") });
+        }),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(validators).toHaveLength(200);
+      expect(receivedCursors).toEqual([null, cursor]);
+      expect(validators[0].account_id).toBe("first-0.near");
+      expect(validators[100].account_id).toBe("second-0.near");
+    });
+
+    it("url-encodes the cursor so an opaque base64 token survives the round trip", async () => {
+      const cursor = "YWJjZGVm+Z2hpamts/bW5vcA==";
+      const receivedCursors: (string | null)[] = [];
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          const next = new URL(request.url).searchParams.get("next");
+          receivedCursors.push(next);
+
+          if (!next) {
+            return HttpResponse.json({ data: page(100, "first"), meta: { next_page: cursor } });
+          }
+
+          return HttpResponse.json({ data: page(100, "second") });
+        }),
+      );
+
+      await getValidators({ total: 200 });
+
+      expect(receivedCursors[1]).toBe(cursor);
+    });
+
+    it("stops when the indexer returns no further cursor", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () =>
+          HttpResponse.json({ data: page(100, "only") }),
+        ),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(validators).toHaveLength(100);
+    });
+
+    it("never returns more than the requested total", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          const next = new URL(request.url).searchParams.get("next");
+
+          if (!next) {
+            return HttpResponse.json({ data: page(100, "first"), meta: { next_page: "cursor" } });
+          }
+
+          return HttpResponse.json({ data: page(100, "second") });
+        }),
+      );
+
+      const validators = await getValidators({ total: 150 });
+
+      expect(validators).toHaveLength(150);
+    });
+
+    it("returns no validators when the envelope data is null", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () => HttpResponse.json({ data: null })),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(validators).toEqual([]);
+    });
+
+    it("defaults the stake when the current epoch stake is null", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () =>
+          HttpResponse.json({ data: [validator({ current_epoch_stake: null })] }),
+        ),
+      );
+
+      const [mapped] = await getValidators({ total: 200 });
+
+      expect(mapped.stake).toBe("0");
+    });
+
+    it.each([
+      ["a null denominator", { fee_denominator: null }],
+      ["a null numerator", { fee_numerator: null }],
+      ["a zero denominator", { fee_denominator: 0 }],
+    ])("returns a zero commission for %s", async (_label, overrides) => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () =>
+          HttpResponse.json({ data: [validator(overrides)] }),
+        ),
+      );
+
+      const [mapped] = await getValidators({ total: 200 });
+
+      expect(mapped.commission).toBe(0);
+    });
+
+    it("stops on an empty page even if the indexer keeps advertising a cursor", async () => {
+      let requests = 0;
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () => {
+          requests += 1;
+          return HttpResponse.json({ data: [], meta: { next_page: "same-cursor-every-time" } });
+        }),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(requests).toBe(1);
+      expect(validators).toEqual([]);
+    });
+
+    it("never issues more requests than the pages needed for the total", async () => {
+      let requests = 0;
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, () => {
+          requests += 1;
+          return HttpResponse.json({
+            data: [validator({ account_id: `v${requests}.near` })],
+            meta: { next_page: "same-cursor-every-time" },
+          });
+        }),
+      );
+
+      const validators = await getValidators({ total: 200 });
+
+      expect(requests).toBe(2);
+      expect(validators).toHaveLength(2);
+    });
+
+    it("requests only the outstanding validators on each page", async () => {
+      const requestedLimits: (string | null)[] = [];
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          const url = new URL(request.url);
+          requestedLimits.push(url.searchParams.get("limit"));
+
+          if (!url.searchParams.get("next")) {
+            return HttpResponse.json({ data: page(100, "first"), meta: { next_page: "cursor" } });
+          }
+
+          return HttpResponse.json({ data: page(50, "second") });
+        }),
+      );
+
+      const validators = await getValidators({ total: 150 });
+
+      expect(requestedLimits).toEqual(["100", "50"]);
+      expect(validators).toHaveLength(150);
+    });
+
+    it("caches per requested total rather than serving one total's result to another", async () => {
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          const limit = Number(new URL(request.url).searchParams.get("limit"));
+          return HttpResponse.json({ data: page(limit, "any") });
+        }),
+      );
+
+      const five = await getValidators({ total: 5 });
+      const ten = await getValidators({ total: 10 });
+
+      expect(five).toHaveLength(5);
+      expect(ten).toHaveLength(10);
+    });
+
+    it("issues a single request when the total fits in one page", async () => {
+      const requestedLimits: (string | null)[] = [];
+
+      mockServer.use(
+        http.get(`${NEAR_BASE_URL_MOCKED}/v3/validators`, ({ request }) => {
+          requestedLimits.push(new URL(request.url).searchParams.get("limit"));
+          return HttpResponse.json({ data: page(20, "only"), meta: { next_page: "cursor" } });
+        }),
+      );
+
+      const validators = await getValidators({ total: 20 });
+
+      expect(requestedLimits).toEqual(["20"]);
+      expect(validators).toHaveLength(20);
+    });
+  });
+});

--- a/libs/coin-modules/coin-near/src/api/node.ts
+++ b/libs/coin-modules/coin-near/src/api/node.ts
@@ -16,6 +16,7 @@ import {
   NearProtocolConfig,
   NearRawValidator,
   NearStakingPosition,
+  NearV3Response,
 } from "./sdk.types";
 
 export const fetchAccountDetails = async (address: string): Promise<NearAccountDetails> => {
@@ -100,36 +101,42 @@ export const getProtocolConfig = async (): Promise<NearProtocolConfig> => {
   return data.result;
 };
 
-type statsResponseType = {
-  stats: {
-    id: number;
-    total_supply: string;
-    circulating_supply: string;
-    avg_block_time: string;
-    gas_price: string;
-    nodes_online: number;
-    near_price: string;
-    near_btc_price: string;
-    market_cap: string;
-    volume: string;
-    high_24h: string;
-    high_all: string;
-    low_24h: string;
-    low_all: string;
-    change_24: string;
-    total_txns: string;
-    tps: number;
-  }[];
+type NearStats = {
+  gas_price: string | null;
+};
+
+const getGasPriceFromRpc = async (): Promise<string> => {
+  const currencyConfig = getCoinConfig();
+  const { data } = await network<{
+    result?: { gas_price: string };
+    error?: { message: string };
+  }>({
+    method: "POST",
+    url: currencyConfig.infra.API_NEAR_PRIVATE_NODE,
+    data: {
+      jsonrpc: "2.0",
+      id: "id",
+      method: "gas_price",
+      params: [null],
+    },
+  });
+
+  if (!data.result?.gas_price) {
+    log("Near", "getGasPrice fallback failed", data.error);
+    throw new Error(data.error?.message || "Near: the node returned no gas price");
+  }
+
+  return data.result.gas_price;
 };
 
 export const getGasPrice = async (): Promise<string> => {
   const currencyConfig = getCoinConfig();
 
-  const response = await liveNetwork<statsResponseType>({
-    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v1/stats`,
+  const response = await liveNetwork<NearV3Response<NearStats>>({
+    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v3/stats`,
   });
 
-  return response.data.stats[0].gas_price;
+  return response.data.data?.gas_price || (await getGasPriceFromRpc());
 };
 
 export const getAccessKey = async ({
@@ -236,7 +243,7 @@ export const getStakingPositions = async (
   const stakingThreshold = getYoctoThreshold();
 
   const delegatedValidators = await liveNetwork<{ deposit: string; validator_id: string }[]>({
-    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v1/kitwallet/staking-deposits/${address}`,
+    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v3/kitwallet/staking-deposits/${address}`,
   });
 
   const stakingPositions = await Promise.all(
@@ -305,55 +312,57 @@ export const getStakingPositions = async (
   };
 };
 
-type validatorsType = {
-  validatorFullData: {
-    deposit: string;
-    validator_id: string;
-    percent: string;
-    accountId: string;
-    poolInfo: {
-      fee: {
-        numerator: number;
-        denominator: number;
-      };
-      delegatorsCount: number;
-    };
-    cumulativeStake: {
-      accumulatedPercent: string;
-      cumulativePercent: string;
-      ownPercentage: string;
-    };
-    currentEpoch: {
-      stake: string;
-    };
-  }[];
+type NearIndexerValidator = {
+  account_id: string;
+  current_epoch_stake: string | null;
+  fee_numerator: number | null;
+  fee_denominator: number | null;
 };
 
 type NearValidator = NearRawValidator & {
   commission: number;
 };
 
-type fetchValidators = {
-  per_page: number;
-  page: number;
+type FetchValidatorsParams = {
+  total: number;
 };
 
-async function fetchValidators({ per_page, page }: fetchValidators): Promise<NearValidator[]> {
+const VALIDATORS_PAGE_SIZE = 100;
+
+async function fetchValidators({ total }: FetchValidatorsParams): Promise<NearValidator[]> {
   const currencyConfig = getCoinConfig();
+  const collected: NearIndexerValidator[] = [];
+  const maxPages = Math.ceil(total / VALIDATORS_PAGE_SIZE);
+  let next: string | undefined;
 
-  const delegatedValidators = await liveNetwork<validatorsType>({
-    url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v1/validators?per_page=${per_page}&page=${page}`,
-  });
+  for (let page = 0; page < maxPages; page++) {
+    const limit = Math.min(VALIDATORS_PAGE_SIZE, total - collected.length);
+    const cursor = next ? `&next=${encodeURIComponent(next)}` : "";
+    const response = await liveNetwork<NearV3Response<NearIndexerValidator[]>>({
+      url: `${currencyConfig.infra.API_NEARBLOCKS_INDEXER}/v3/validators?limit=${limit}${cursor}`,
+    });
 
-  const validators = delegatedValidators.data.validatorFullData.map(
-    ({ accountId, currentEpoch, poolInfo }) => ({
-      account_id: accountId,
-      stake: currentEpoch.stake,
-      commission: Math.round((poolInfo.fee.numerator / poolInfo.fee.denominator) * 100),
-    }),
-  );
+    const validators = response.data.data ?? [];
+    collected.push(...validators);
+    next = response.data.meta?.next_page;
 
-  return validators || [];
+    if (!validators.length || !next || collected.length >= total) {
+      break;
+    }
+  }
+
+  return collected
+    .slice(0, total)
+    .map(({ account_id, current_epoch_stake, fee_numerator, fee_denominator }) => ({
+      account_id,
+      stake: current_epoch_stake ?? "0",
+      commission:
+        fee_numerator !== null && fee_denominator
+          ? Math.round((fee_numerator / fee_denominator) * 100)
+          : 0,
+    }));
 }
 
-export const getValidators = makeLRUCache(fetchValidators, () => "", { ttl: 30 * 60 * 1000 });
+export const getValidators = makeLRUCache(fetchValidators, ({ total }) => String(total), {
+  ttl: 30 * 60 * 1000,
+});

--- a/libs/coin-modules/coin-near/src/api/sdk.types.ts
+++ b/libs/coin-modules/coin-near/src/api/sdk.types.ts
@@ -7,27 +7,32 @@ export type NearAccountDetails = {
   block_height: number;
 };
 
+export type NearV3Response<T> = {
+  data: T | null;
+  meta?: { next_page?: string };
+};
+
 export type NearTransaction = {
   signer_account_id: string;
   receiver_account_id: string;
   transaction_hash: string;
-  outcomes_agg: {
+  block_timestamp: string;
+  outcomes_agg?: {
     transaction_fee: string;
   };
-  outcomes: { status: boolean };
-  block: {
-    block_height: number;
+  outcomes?: { status?: boolean };
+  block?: {
+    block_hash?: string;
+    block_height?: string;
+    block_timestamp?: string;
   };
-  included_in_block_hash: string;
-  block_timestamp: string;
-  actions?: [
-    {
-      action: string;
-      deposit: string;
-      fee: string;
-      method: string;
-    },
-  ];
+  actions_agg?: {
+    deposit: string;
+  };
+  actions?: {
+    action: string;
+    method: string | null;
+  }[];
 };
 
 export type NearProtocolConfig = {

--- a/libs/coin-modules/coin-near/src/preload.integ.test.ts
+++ b/libs/coin-modules/coin-near/src/preload.integ.test.ts
@@ -1,0 +1,53 @@
+import { setCoinConfig } from "./config";
+import { hydrate, preload } from "./preload";
+import { getCurrentNearPreloadData, setNearPreloadData } from "./preload-data";
+
+const VALIDATOR_COUNT = 200;
+
+describe("preload (integration)", () => {
+  beforeAll(() => {
+    setCoinConfig(() => ({
+      status: { type: "active" },
+      infra: {
+        API_NEAR_PRIVATE_NODE: "https://near.coin.ledger.com/node",
+        API_NEAR_PUBLIC_NODE: "https://rpc.mainnet.near.org",
+        API_NEAR_INDEXER: "https://near.coin.ledger.com/indexer",
+        API_NEARBLOCKS_INDEXER: "https://near-indexer.coin.ledger.com",
+      },
+    }));
+  });
+
+  it("resolves validators, gas price and the protocol costs", async () => {
+    const data = await preload();
+
+    expect(data.validators).toHaveLength(VALIDATOR_COUNT);
+    expect(new Set(data.validators.map(validator => validator.validatorAddress)).size).toBe(
+      VALIDATOR_COUNT,
+    );
+    expect(data.gasPrice.isNaN()).toBe(false);
+    expect(data.gasPrice.gt(0)).toBe(true);
+    expect(data.storageCost.gt(0)).toBe(true);
+
+    data.validators.forEach(validator => {
+      expect(validator.validatorAddress).toMatch(/\S/);
+      expect(String(validator.tokens)).toMatch(/^\d+$/);
+      expect(validator.commission).toBeGreaterThanOrEqual(0);
+      expect(validator.commission).toBeLessThanOrEqual(100);
+    });
+  }, 120_000);
+
+  it("survives the serialize and hydrate round trip", async () => {
+    const data = await preload();
+
+    setNearPreloadData({ ...data, validators: [] });
+    expect(getCurrentNearPreloadData().validators).toHaveLength(0);
+
+    hydrate(JSON.parse(JSON.stringify(data)));
+    const rehydrated = getCurrentNearPreloadData();
+
+    expect(rehydrated.validators).toHaveLength(VALIDATOR_COUNT);
+    expect(rehydrated.gasPrice.toFixed()).toBe(data.gasPrice.toFixed());
+    expect(rehydrated.storageCost.toFixed()).toBe(data.storageCost.toFixed());
+    expect(rehydrated.validators[0].validatorAddress).toBe(data.validators[0].validatorAddress);
+  }, 120_000);
+});

--- a/libs/coin-modules/coin-near/src/preload.ts
+++ b/libs/coin-modules/coin-near/src/preload.ts
@@ -60,7 +60,7 @@ export const preload = async (): Promise<NearPreloadedData> => {
 
   const [protocolConfig, rawValidators, gasPrice] = await Promise.all([
     getProtocolConfig(),
-    getValidators({ per_page: 200, page: 1 }), // get first 200 validators
+    getValidators({ total: 200 }),
     getGasPrice(),
   ]);
 


### PR DESCRIPTION
### 📝 Description

NearBlocks published a new API generation and asked us to move off `/v1`. This migrates the four
indexer call sites in `coin-near` to `/v3`. Client-only change: the host (`API_NEARBLOCKS_INDEXER`)
and the bearer auth are unchanged, and the NEAR JSON-RPC node path is untouched.

| Call | Before | After |
|---|---|---|
| Transaction history | `/v1/account/{a}/txns-only` | `/v3/accounts/{a}/txns` |
| Gas price | `/v1/stats` | `/v3/stats` |
| Delegated validators | `/v1/kitwallet/staking-deposits/{a}` | `/v3/kitwallet/staking-deposits/{a}` |
| Validator list | `/v1/validators?per_page=&page=` | `/v3/validators?limit=&next=` |

Response handling:

- Every enveloped route is unwrapped from `{ data, meta }`, and `data: null` is handled (v3 types it
  as nullable). `/v3/kitwallet/*` is the exception and stays a bare array.
- `included_in_block_hash` → `block.block_hash`; `block.block_height` is now a string and is
  converted; the transfer amount moves from `actions[0].deposit` to `actions_agg.deposit`.
- Validators become a flat snake_case shape (`account_id`, `current_epoch_stake`, `fee_numerator`,
  `fee_denominator`). A single page is capped at 100, so reaching the same 200 validators needs a
  cursor walk. The walk is bounded by the requested total rather than by the cursor, so an indexer
  that keeps advertising a next page cannot loop the client indefinitely.
- `gas_price` is nullable in v3, so `getGasPrice` falls back to the node's JSON-RPC `gas_price`
  method rather than failing.
- Every nested object in a transaction is now typed optional and read defensively. `getOperations`
  maps a page through `Promise.all`, so one malformed transaction would otherwise discard the whole
  account history. Live data confirms `outcomes: {}` and `actions: []` do occur.

**Precondition (verified).** The origin behind `near-indexer.coin.ledger.com` serves `/v3`:
`GET /v3/stats` → `200`, `{"data":{"gas_price":"100000000","nodes_online":413, …}}` (2026-07-29).
No client-side API key is needed; the proxy injects it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34441](https://ledgerhq.atlassian.net/browse/LIVE-34441)
- **ADR** (if any): n/a

[LIVE-34441]: https://ledgerhq.atlassian.net/browse/LIVE-34441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Allure reports

- Desktop (nanoSP): https://ledger-live.allure.green.ledgerlabs.net/allure/reports/db5491a7-3870-481f-83aa-1e68a4683069/
- iOS: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/492d6827-264c-46cd-a9ff-9e1326e28530/
- Android: https://ledger-live.allure.green.ledgerlabs.net/allure/reports/112de07c-4f16-4611-b498-a77213c5ef05/

