### PR TITLE
[LWDM] feat(live-signer-solana): wire CAL_SERVICE_URL into DMK ContextModule

### DIFF
--- a/.changeset/gentle-waves-flow.md
+++ b/.changeset/gentle-waves-flow.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-solana": patch
+---
+
+Wire CAL_SERVICE_URL (with /v1 path) into DMK ContextModule via setCalConfig

--- a/libs/live-signer-solana/package.json
+++ b/libs/live-signer-solana/package.json
@@ -28,9 +28,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/coin-solana": "workspace:^",
+    "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-solana": "catalog:",
+    "@ledgerhq/live-env": "workspace:^",
     "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/hw-app-solana": "workspace:^",
     "@ledgerhq/hw-bolos": "workspace:^",

--- a/libs/live-signer-solana/src/DmkSignerSol.ts
+++ b/libs/live-signer-solana/src/DmkSignerSol.ts
@@ -20,6 +20,8 @@ import {
   DeviceActionStatus,
   DeviceManagementKit,
 } from "@ledgerhq/device-management-kit";
+import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
+import { getEnv } from "@ledgerhq/live-env";
 import bs58 from "bs58";
 import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 
@@ -49,11 +51,20 @@ export class DmkSignerSol implements SolanaSigner {
   constructor(dmk: DeviceManagementKit, sessionId: string) {
     const originToken =
       "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
+    const calUrl = getEnv("CAL_SERVICE_URL");
+    const calMode = calUrl.includes("ledger-test") || calUrl.includes(".stg.") ? "test" : "prod";
+    const contextModule = new ContextModuleBuilder({ originToken })
+      .setAppSource("ledger-wallet")
+      .setChain(ContextModuleChainID.Solana)
+      .setCalConfig({ url: `${calUrl}/v1`, mode: calMode, branch: "main" })
+      .build();
     this.dmkSigner = new SignerSolanaBuilder({
       dmk,
       sessionId,
       originToken,
-    }).build();
+    })
+      .withContextModule(contextModule)
+      .build();
   }
 
   private _mapError<E extends DAError>(error: E): Error {

--- a/libs/live-signer-solana/tests/DMKSignerSol.test.ts
+++ b/libs/live-signer-solana/tests/DMKSignerSol.test.ts
@@ -3,14 +3,32 @@
 // tests/DmkSignerSol.test.ts
 import { DmkSignerSol } from "../src/DmkSignerSol";
 import { DeviceActionStatus } from "@ledgerhq/device-management-kit";
+import { ContextModuleBuilder } from "@ledgerhq/context-module";
+import { getEnv } from "@ledgerhq/live-env";
 import { PubKeyDisplayMode, UserInputType, Resolution } from "@ledgerhq/coin-solana/signer";
 import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
 import bs58 from "bs58";
 import { of, throwError } from "rxjs";
 
+jest.mock("@ledgerhq/context-module", () => {
+  class MockContextModuleBuilder {
+    setAppSource() { return this; }
+    setChain() { return this; }
+    setCalConfig() { return this; }
+    build() { return {}; }
+  }
+  return {
+    ContextModuleBuilder: MockContextModuleBuilder,
+    ContextModuleChainID: { Solana: "solana" },
+  };
+});
+
+jest.mock("@ledgerhq/live-env", () => ({ getEnv: jest.fn() }));
+
 // Mock the SignerSolanaBuilder to avoid actual builder logic
 jest.mock("@ledgerhq/device-signer-kit-solana", () => ({
   SignerSolanaBuilder: jest.fn().mockImplementation(() => ({
+    withContextModule: jest.fn().mockReturnThis(),
     build: () => ({}),
   })),
   SignMessageVersion: { Raw: "raw", Legacy: "legacy", V0: "v0", V1: "v1" },
@@ -22,6 +40,7 @@ describe("DmkSignerSol", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getEnv).mockReturnValue("https://global.api.prd.ledger.com/cal" as never);
     signer = new DmkSignerSol(dmkMock, "sessionId");
   });
 
@@ -376,6 +395,45 @@ describe("DmkSignerSol", () => {
       const result = callMapError({ _tag: "NoErrorCode" });
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toBe("NoErrorCode");
+    });
+  });
+
+  describe("CAL config wiring", () => {
+    let setCalConfigSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      setCalConfigSpy = jest.spyOn(ContextModuleBuilder.prototype, "setCalConfig");
+    });
+
+    afterEach(() => {
+      setCalConfigSpy.mockRestore();
+    });
+
+    it("passes prod mode and the env URL with /v1 for a prod endpoint", () => {
+      const url = "https://global.api.prd.ledger.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerSol(dmkMock, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "prod", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains 'ledger-test'", () => {
+      const url = "https://global.api.stg.ledger-test.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerSol(dmkMock, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains '.stg.' but not 'ledger-test'", () => {
+      const url = "https://global.api.stg.example.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerSol(dmkMock, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12479,6 +12479,9 @@ importers:
       '@ledgerhq/coin-solana':
         specifier: workspace:^
         version: link:../coin-modules/coin-solana
+      '@ledgerhq/context-module':
+        specifier: 2.3.1
+        version: 2.3.1(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       '@ledgerhq/device-management-kit':
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
@@ -12506,6 +12509,9 @@ importers:
       '@ledgerhq/ledger-trust-service':
         specifier: workspace:^
         version: link:../ledger-services/trust
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       '@types/bs58':
         specifier: 'catalog:'
         version: 4.0.4


### PR DESCRIPTION
## Summary

- Passes `CAL_SERVICE_URL` (+ `/v1` version path) into `ContextModuleBuilder.setCalConfig()` in `DmkSignerSol`, replacing the context module's hardcoded default URL (`https://crypto-assets-service.api.ledger.com/v1`)
- Mode is derived from the URL at runtime (`"test"` for staging URLs, `"prod"` otherwise) — no new env var needed
- Adds `@ledgerhq/context-module` and `@ledgerhq/live-env` deps to `@ledgerhq/live-signer-solana`

Follow-up to #19860 (EVM). Closes LIVE-33607.

## Test plan

- [ ] `pnpm --filter @ledgerhq/live-signer-solana test` — all tests pass (3 new CAL config tests)
- [ ] Verify in a running app that SOL signing enrichment calls hit the URL set in `CAL_SERVICE_URL` with the `/v1` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)