### PR TITLE
[LWDM] feat(send): show 8 address characters around the ellipsis (LIVE-34434)

### DIFF
--- a/.changeset/send-flow-address-eight-digits.md
+++ b/.changeset/send-flow-address-eight-digits.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Show 8 characters on each side of the ellipsis when truncating the recipient address in the new send flow, consistently across mobile and desktop

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/__tests__/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/__tests__/utils.test.ts
@@ -25,8 +25,8 @@ describe("getRecipientDisplayValue", () => {
 
     expect(getRecipientDisplayValue(recipient)).toBe("0x1234...5678");
     expect(mockedFormatAddress).toHaveBeenCalledWith(recipient.address, {
-      prefixLength: 5,
-      suffixLength: 5,
+      prefixLength: 8,
+      suffixLength: 8,
     });
   });
 
@@ -39,8 +39,8 @@ describe("getRecipientDisplayValue", () => {
 
     expect(getRecipientDisplayValue(recipient)).toBe("vitalik.eth (0x1234...5678)");
     expect(mockedFormatAddress).toHaveBeenCalledWith(recipient.address, {
-      prefixLength: 5,
-      suffixLength: 5,
+      prefixLength: 8,
+      suffixLength: 8,
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
@@ -1,4 +1,5 @@
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import {
   ListItem,
   ListItemContent,
@@ -47,11 +48,11 @@ export function AddressListItem({
 }: AddressListItemProps) {
   const { t } = useTranslation();
   const formatRelativeDate = useFormatRelativeDate();
-  const displayName = name ?? formatAddress(address, { prefixLength: 5, suffixLength: 5 });
+  const displayName = name ?? formatAddress(address, SEND_ADDRESS_FORMAT_OPTIONS);
 
   const fallbackDescription = date
     ? formatRelativeDate(date)
-    : formatAddress(address, { prefixLength: 5, suffixLength: 5 });
+    : formatAddress(address, SEND_ADDRESS_FORMAT_OPTIONS);
 
   const subtitle = disabled || hideDescription ? undefined : (description ?? fallbackDescription);
   const icon = isLedgerAccount ? LedgerLogo : Wallet;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -1,5 +1,6 @@
 import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import { Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -44,10 +45,10 @@ export function AddressMatchedSection({
     return null;
   }
 
-  const formattedAddress = formatAddress(resolvedAddress ?? searchValue, {
-    prefixLength: 5,
-    suffixLength: 5,
-  });
+  const formattedAddress = formatAddress(
+    resolvedAddress ?? searchValue,
+    SEND_ADDRESS_FORMAT_OPTIONS,
+  );
 
   const getENSDisplayTitle = (): string => {
     return `${ensName} (${formattedAddress})`;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -14,7 +14,9 @@ import { useCurrentSendFlowStep } from "./useCurrentSendFlowStep";
 import {
   getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
+  SEND_ADDRESS_FORMAT_OPTIONS,
 } from "@ledgerhq/live-common/flows/send/utils";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import type { SendFlowNavigationProp } from "../types";
 
 export type SendHeaderViewModel = {
@@ -87,15 +89,10 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
 
   const formattedAddress = useMemo(() => {
     if (isRecipientStep) {
-      return recipientSearch.value.length > 11
-        ? `${recipientSearch.value.slice(0, 4)}...${recipientSearch.value.slice(-4)}`
-        : recipientSearch.value;
+      return formatAddress(recipientSearch.value, SEND_ADDRESS_FORMAT_OPTIONS);
     }
     if (isAmountStep) {
-      return getRecipientDisplayValue(recipientFromTransaction, {
-        prefixLength: 4,
-        suffixLength: 4,
-      });
+      return getRecipientDisplayValue(recipientFromTransaction);
     }
     return "";
   }, [isRecipientStep, isAmountStep, recipientSearch.value, recipientFromTransaction]);

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AccountRowWithBalance.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AccountRowWithBalance.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Account } from "@ledgerhq/types-live";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import { useTranslation } from "~/context/Locale";
 import { AddressListItem } from "./AddressListItem";
 import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
@@ -33,7 +34,7 @@ export function AccountRowWithBalance({
     <AddressListItem
       address={account.freshAddress}
       name={displayName}
-      description={formatAddress(account.freshAddress, { prefixLength: 5, suffixLength: 5 })}
+      description={formatAddress(account.freshAddress, SEND_ADDRESS_FORMAT_OPTIONS)}
       balance={formattedBalance}
       balanceFormatted={formattedCounterValue}
       onSelect={onSelect}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressListItem.tsx
@@ -1,4 +1,5 @@
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import {
   ListItem,
   ListItemContent,
@@ -46,12 +47,12 @@ export function AddressListItem({
   testID,
 }: AddressListItemProps) {
   const { t } = useTranslation();
-  const displayName = name ?? formatAddress(address, { prefixLength: 5, suffixLength: 5 });
+  const displayName = name ?? formatAddress(address, SEND_ADDRESS_FORMAT_OPTIONS);
   const formatRelativeDate = useFormatRelativeDate();
 
   const fallbackDescription = date
     ? formatRelativeDate(date)
-    : formatAddress(address, { prefixLength: 5, suffixLength: 5 });
+    : formatAddress(address, SEND_ADDRESS_FORMAT_OPTIONS);
 
   const subtitle = disabled || hideDescription ? undefined : (description ?? fallbackDescription);
   const icon = isLedgerAccount ? LedgerLogo : Wallet;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -1,5 +1,6 @@
 import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import {
   Banner,
   BottomSheet,
@@ -61,10 +62,10 @@ export function AddressMatchedSection({
     return null;
   }
 
-  const formattedAddress = formatAddress(resolvedAddress ?? searchValue, {
-    prefixLength: 5,
-    suffixLength: 5,
-  });
+  const formattedAddress = formatAddress(
+    resolvedAddress ?? searchValue,
+    SEND_ADDRESS_FORMAT_OPTIONS,
+  );
 
   const getENSDisplayTitle = (): string => {
     return `${ensName} (${formattedAddress})`;
@@ -117,10 +118,10 @@ export function AddressMatchedSection({
         {hasRecentMatch && !hasMatchedAccounts && !hasENS && (
           <AddressListItem
             address={matchedRecentAddress?.address ?? searchValue}
-            name={formatAddress(matchedRecentAddress?.address ?? searchValue, {
-              prefixLength: 5,
-              suffixLength: 5,
-            })}
+            name={formatAddress(
+              matchedRecentAddress?.address ?? searchValue,
+              SEND_ADDRESS_FORMAT_OPTIONS,
+            )}
             description={getRecentDescription()}
             onSelect={() =>
               onSelect(matchedRecentAddress?.address ?? searchValue, matchedRecentAddress?.ensName)

--- a/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
+++ b/libs/ledger-live-common/src/flows/send/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import {
   getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
   saveRecentSendRecipient,
+  SEND_ADDRESS_FORMAT_OPTIONS,
 } from "../utils";
 import { getMainAccount, getRecentAddressesStore } from "../../../account/index";
 import type { Transaction } from "../../../coin-modules/transaction-types";
@@ -56,37 +57,35 @@ describe("saveRecentSendRecipient", () => {
   });
 });
 
+const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+
 describe("getRecipientDisplayValue", () => {
   it("should return empty for null recipient", () => {
     expect(getRecipientDisplayValue(null)).toBe("");
   });
 
   it("should return formatted address without ENS", () => {
-    expect(getRecipientDisplayValue({ address: "0x1234567890abcdef" })).toBe("0x123...bcdef");
+    expect(getRecipientDisplayValue({ address: ADDRESS })).toBe("0x123456...12345678");
+  });
+
+  it("should keep 8 characters on each side of the ellipsis by default", () => {
+    expect(SEND_ADDRESS_FORMAT_OPTIONS).toEqual({ prefixLength: 8, suffixLength: 8 });
+  });
+
+  it("should return the address untouched when shorter than the ellipsis threshold", () => {
+    expect(getRecipientDisplayValue({ address: "0x1234567890abcdef" })).toBe("0x1234567890abcdef");
   });
 
   it("should use custom options for formatting", () => {
     expect(
-      getRecipientDisplayValue(
-        { address: "0x1234567890abcdef" },
-        { prefixLength: 4, suffixLength: 4 },
-      ),
-    ).toBe("0x12...cdef");
+      getRecipientDisplayValue({ address: ADDRESS }, { prefixLength: 4, suffixLength: 4 }),
+    ).toBe("0x12...5678");
   });
 
   it("should return ENS name with formatted address when ENS exists", () => {
-    expect(
-      getRecipientDisplayValue({ address: "0x1234567890abcdef", ensName: "vitalik.eth" }),
-    ).toBe("vitalik.eth (0x123...bcdef)");
-  });
-
-  it("should support custom prefix/suffix length", () => {
-    expect(
-      getRecipientDisplayValue(
-        { address: "0x1234567890abcdef" },
-        { prefixLength: 4, suffixLength: 4 },
-      ),
-    ).toBe("0x12...cdef");
+    expect(getRecipientDisplayValue({ address: ADDRESS, ensName: "vitalik.eth" })).toBe(
+      "vitalik.eth (0x123456...12345678)",
+    );
   });
 });
 

--- a/libs/ledger-live-common/src/flows/send/utils.ts
+++ b/libs/ledger-live-common/src/flows/send/utils.ts
@@ -28,6 +28,9 @@ export function saveRecentSendRecipient(
   getRecentAddressesStore().addAddress(mainAccount.currency.id, recipient, ensName);
 }
 
+/** Number of characters displayed on each side of the ellipsis in the send flow. */
+export const SEND_ADDRESS_FORMAT_OPTIONS = { prefixLength: 8, suffixLength: 8 } as const;
+
 /**
  * Get the display value for a recipient (formatted address with optional ENS name).
  */
@@ -38,8 +41,8 @@ export function getRecipientDisplayValue(
   if (!recipient?.address) return "";
 
   const formattedAddress = formatAddress(recipient.address, {
-    prefixLength: options?.prefixLength ?? 5,
-    suffixLength: options?.suffixLength ?? 5,
+    prefixLength: options?.prefixLength ?? SEND_ADDRESS_FORMAT_OPTIONS.prefixLength,
+    suffixLength: options?.suffixLength ?? SEND_ADDRESS_FORMAT_OPTIONS.suffixLength,
   });
 
   if (recipient.ensName?.trim()) {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Existing unit tests for `getRecipientDisplayValue` and the desktop send utils were updated to the new 8/8 expectations, and a test now pins the default. They could not be executed locally (dependencies are not installed in my working copy), so CI is the first real run._
- [x] **Impact of the changes:**
      - New send flow header (`To: 0x…`) on both mobile and desktop, on the Recipient and Amount steps
      - Recipient search results: matched accounts, ENS matches, recently used addresses, sanctioned/invalid address rows
      - Possible text overflow, since the displayed address is now ~6 characters longer — check narrow widths, and ENS rows where the name and the address are concatenated (`vitalik.eth (0x…)`)
      - Short addresses (≤ 19 characters) are now displayed in full instead of being truncated

### 📝 Description

**Problem**: in the new send flow the recipient address was truncated too aggressively, making it hard for users to visually verify the address they are sending to. The truncation was also inconsistent across screens and platforms: 4/4 in the mobile header, 5/5 in the desktop header, and 5/5 in the recipient search results.

**Solution**: display **8 characters on each side of the ellipsis** (the `0x` prefix counts towards the 8), consistently everywhere in the flow — `0x95df32...b15ed343`.

A single source of truth is introduced in `@ledgerhq/live-common` and every hard-coded digit count in the send flow now references it:

```ts
// libs/ledger-live-common/src/flows/send/utils.ts
/** Number of characters displayed on each side of the ellipsis in the send flow. */
export const SEND_ADDRESS_FORMAT_OPTIONS = { prefixLength: 8, suffixLength: 8 } as const;
```

Notable details:

- `getRecipientDisplayValue` now defaults to that constant instead of a hard-coded `5`, so the desktop header picks up the change with no code edit.
- The mobile header had a hand-rolled truncation (`slice(0, 4)` / `slice(-4)` behind a `length > 11` threshold) that bypassed the shared helper; it now calls `formatAddress` with the shared options, which also removes its magic threshold.
- Because `formatAddress` derives its threshold from `prefixLength + separator + suffixLength`, that threshold grows from 13 to 19 — addresses shorter than that are now shown in full rather than ellipsised, which is the desired behaviour.
- Untouched on purpose: address truncation outside the send flow (AssetDetail, Accounts, OperationsHistory, ModularDrawer/ModularDialog, CryptoAddresses, `History/utils/truncateAddress`).

### 📸 Screenshots

| Mobile | Desktop |
| ------ | ------- |
| <img width="464" height="507" alt="Screenshot 2026-07-29 at 12 37 46" src="https://github.com/user-attachments/assets/9cdb78fa-e214-4a4a-9b9a-b52b53335204" /> |<img width="1206" height="2622" alt="simulator_screenshot_28FA4F2F-E94A-4EA7-994E-1379017590E4" src="https://github.com/user-attachments/assets/ac077244-577c-40f1-908b-f55940b30bbc" />|
| <img width="571" height="674" alt="Screenshot 2026-07-29 at 12 38 01" src="https://github.com/user-attachments/assets/52cb0aba-fb8e-405d-a075-d015b3c77a2d" /> | <img width="1206" height="2622" alt="simulator_screenshot_26E13E00-5AE3-4C57-9A7C-AABD38E28034" src="https://github.com/user-attachments/assets/8e48dbf9-d2e7-4578-b07d-3abe1afe1886" />|


### ❓ Context

- **JIRA or GitHub link**: [LIVE-34434](https://ledgerhq.atlassian.net/browse/LIVE-34434)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34434]: https://ledgerhq.atlassian.net/browse/LIVE-34434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
