### PR TITLE
[LWD] feat(desktop): add qr code scanner to send recipient field

### DIFF
--- a/.changeset/lucky-moons-scan.md
+++ b/.changeset/lucky-moons-scan.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add a QR code scanner to the new send flow recipient field: the QR icon shows while the field is empty and is replaced by the clear button once the user types

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -17,6 +17,7 @@ import {
   screen,
   waitFor,
   setMockBridgeRecipientValidation,
+  setMockScannedCode,
   setMockStatus,
   setMockStatusResolver,
   setMockTransaction,
@@ -68,6 +69,55 @@ describe("Send Flow Integration", () => {
       await waitFor(() => {
         expect(screen.queryByTestId("send-recipient-recent-history-step")).not.toBeInTheDocument();
         expect(screen.getByTestId("send-recent-history-warning")).toBeVisible();
+      });
+    });
+
+    it("should open the QR scanner from the empty recipient field and fill it with the scanned address", async () => {
+      setMockScannedCode(`ethereum:${VALID_EVM_RECIPIENT}`);
+      const { user } = renderSendFlow(ethereumAccount);
+
+      expect(await screen.findByTestId("send-recipient-intro-card")).toBeVisible();
+
+      await user.click(screen.getByRole("button", { name: /qr/i }));
+
+      expect(await screen.findByTestId("send-recipient-qr-scanner")).toBeVisible();
+      expect(screen.queryByTestId("send-recipient-intro-card")).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId("mock-qrcode-pick"));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("send-recipient-qr-scanner")).not.toBeInTheDocument();
+      });
+      expect(screen.getByTestId("send-recipient-input")).toHaveValue(VALID_EVM_RECIPIENT);
+    });
+
+    it("should show the clear button instead of the QR icon once the recipient field has content", async () => {
+      const { user } = renderSendFlow(ethereumAccount);
+      const recipientInput = await screen.findByTestId("send-recipient-input");
+
+      expect(screen.getByRole("button", { name: /qr/i })).toBeVisible();
+
+      await user.type(recipientInput, VALID_EVM_RECIPIENT);
+
+      expect(screen.queryByRole("button", { name: /qr/i })).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /clear/i }));
+
+      expect(recipientInput).toHaveValue("");
+      expect(screen.getByRole("button", { name: /qr/i })).toBeVisible();
+    });
+
+    it("should close the QR scanner as soon as the user types an address", async () => {
+      const { user } = renderSendFlow(ethereumAccount);
+      const recipientInput = await screen.findByTestId("send-recipient-input");
+
+      await user.click(screen.getByRole("button", { name: /qr/i }));
+      expect(await screen.findByTestId("send-recipient-qr-scanner")).toBeVisible();
+
+      await user.type(recipientInput, VALID_EVM_RECIPIENT);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("send-recipient-qr-scanner")).not.toBeInTheDocument();
       });
     });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__mocks__/sendFlowTestUtils.tsx
@@ -22,6 +22,7 @@ export type MockTransactionStatus = {
 
 let mockBridgeRecipientValidation = { errors: {}, warnings: {}, isLoading: false };
 let mockDeviceActionResult: unknown = null;
+let mockScannedCode = "";
 
 const mockSetTransaction = jest.fn();
 const mockUpdateTransaction = jest.fn();
@@ -134,11 +135,16 @@ export const setMockDeviceActionResult = (result: unknown) => {
   mockDeviceActionResult = result;
 };
 
+export const setMockScannedCode = (code: string) => {
+  mockScannedCode = code;
+};
+
 export const resetSendFlowTestState = (family: SupportedMockFamily = "evm") => {
   jest.clearAllMocks();
   resetBridgeState(family);
   setMockDeviceActionResult(null);
   setMockBridgeRecipientValidation({ errors: {}, warnings: {}, isLoading: false });
+  setMockScannedCode("");
 };
 
 jest.mock("@ledgerhq/live-common/market/state-manager/api", () => ({
@@ -258,6 +264,18 @@ jest.mock("~/renderer/components/DeviceAction", () => {
     return <div>Waiting for device...</div>;
   };
   return { __esModule: true, default: MockDeviceAction };
+});
+
+// jsdom has no camera: stub the scanner panel with a button that emits a scanned code
+jest.mock("../screens/Recipient/components/RecipientQrScanner", () => {
+  const MockRecipientQrScanner = ({ onPick }: { onPick: (code: string) => void }) => (
+    <div data-testid="send-recipient-qr-scanner">
+      <button type="button" data-testid="mock-qrcode-pick" onClick={() => onPick(mockScannedCode)}>
+        camera
+      </button>
+    </div>
+  );
+  return { RecipientQrScanner: MockRecipientQrScanner };
 });
 
 jest.mock("~/renderer/hooks/useConnectAppAction", () => ({

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendFlowLayout.tsx
@@ -3,6 +3,7 @@ import { Dialog, DialogContent } from "@ledgerhq/lumen-ui-react";
 import { cn } from "LLD/utils/cn";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
 import { useSendFlowData } from "../context/SendFlowContext";
+import { RecipientScannerProvider } from "../context/RecipientScannerContext";
 import { FLOW_STATUS } from "@ledgerhq/live-common/flows/wizard/types";
 import {
   type SendFlowStep,
@@ -61,30 +62,32 @@ export function SendFlowLayout({ isOpen, onClose }: SendFlowLayoutProps) {
             })}
           />
         )}
-        {shouldAnimateHeight ? (
-          <AnimatedHeight>
-            <div className="flex flex-col">
+        <RecipientScannerProvider>
+          {shouldAnimateHeight ? (
+            <AnimatedHeight>
+              <div className="flex flex-col">
+                <SendHeader />
+                {StepComponent && (
+                  <div key={wizard.currentStep} className="flex animate-fade-in flex-col">
+                    <StepComponent />
+                  </div>
+                )}
+              </div>
+            </AnimatedHeight>
+          ) : (
+            <>
               <SendHeader />
               {StepComponent && (
-                <div key={wizard.currentStep} className="flex animate-fade-in flex-col">
+                <div
+                  key={wizard.currentStep}
+                  className="flex min-h-0 flex-1 animate-fade-in flex-col"
+                >
                   <StepComponent />
                 </div>
               )}
-            </div>
-          </AnimatedHeight>
-        ) : (
-          <>
-            <SendHeader />
-            {StepComponent && (
-              <div
-                key={wizard.currentStep}
-                className="flex min-h-0 flex-1 animate-fade-in flex-col"
-              >
-                <StepComponent />
-              </div>
-            )}
-          </>
-        )}
+            </>
+          )}
+        </RecipientScannerProvider>
       </DialogContent>
     </Dialog>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -19,6 +19,7 @@ import { MemoTypeSelect } from "../screens/Recipient/components/Memo/MemoTypeSel
 import { MemoValueInput } from "../screens/Recipient/components/Memo/MemoValueInput";
 import { SkipMemoSection } from "../screens/Recipient/components/Memo/SkipMemoSection";
 import { useRecipientMemo } from "../screens/Recipient/hooks/useRecipientMemo";
+import { RecipientQrScanner } from "../screens/Recipient/components/RecipientQrScanner";
 import type { SendStepConfig } from "../types";
 
 export function SendHeader() {
@@ -86,6 +87,10 @@ export function SendHeader() {
     descriptionText,
     handleBack,
     handleRecipientInputClick,
+    handleRecipientInputChange,
+    handleQrCodeClick,
+    handleScanPicked,
+    isScannerOpen,
     showBackButton,
     showMemoControls,
     showRecipientInput,
@@ -130,14 +135,16 @@ export function SendHeader() {
           autoFocus
           prefix={t("newSendFlow.to")}
           value={addressInputValue}
-          onChange={e => recipientSearch.setValue(e.target.value)}
+          onChange={e => handleRecipientInputChange(e.target.value)}
           onClear={recipientSearch.clear}
+          onQrCodeClick={handleQrCodeClick}
           placeholder={
             uiConfig.recipientSupportsDomain
               ? t("newSendFlow.placeholder")
               : t("newSendFlow.placeholderNoENS")
           }
         />
+        {isScannerOpen && <RecipientQrScanner onPick={handleScanPicked} />}
         {showMemoControls && currencyId ? (
           <div className="px-24">
             <div className="flex flex-col gap-12">
@@ -204,6 +211,10 @@ export function SendHeader() {
     onSkipMemoCancelConfirm,
     onSkipMemoConfirm,
     handleRecipientInputClick,
+    handleRecipientInputChange,
+    handleQrCodeClick,
+    handleScanPicked,
+    isScannerOpen,
   ]);
 
   return (

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/context/RecipientScannerContext.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/context/RecipientScannerContext.tsx
@@ -1,0 +1,45 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * RecipientScannerContext
+ *
+ * Desktop-only UI state for the recipient QR code scanner. The QR icon lives in the flow header
+ * (SendHeader) while the panel replaces the recipient step body, so both need to read the same flag.
+ */
+
+type RecipientScannerContextValue = Readonly<{
+  isScannerOpen: boolean;
+  closeScanner: () => void;
+  toggleScanner: () => void;
+}>;
+
+const RecipientScannerContext = createContext<RecipientScannerContextValue | null>(null);
+
+type RecipientScannerProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+export function RecipientScannerProvider({ children }: RecipientScannerProviderProps) {
+  const [isScannerOpen, setIsScannerOpen] = useState(false);
+
+  const closeScanner = useCallback(() => setIsScannerOpen(false), []);
+  const toggleScanner = useCallback(() => setIsScannerOpen(previous => !previous), []);
+
+  const value = useMemo(
+    () => ({ isScannerOpen, closeScanner, toggleScanner }),
+    [isScannerOpen, closeScanner, toggleScanner],
+  );
+
+  return (
+    <RecipientScannerContext.Provider value={value}>{children}</RecipientScannerContext.Provider>
+  );
+}
+
+export function useRecipientScanner(): RecipientScannerContextValue {
+  const context = useContext(RecipientScannerContext);
+  if (!context) {
+    throw new Error("useRecipientScanner must be used within a RecipientScannerProvider");
+  }
+  return context;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
@@ -13,10 +13,21 @@ jest.mock("~/renderer/reducers/wallet", () => ({
   ...jest.requireActual("~/renderer/reducers/wallet"),
   useMaybeAccountName: jest.fn(),
 }));
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+  trackPage: jest.fn(),
+}));
+jest.mock("@ledgerhq/live-common/currencies/index", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
+  decodeURIScheme: jest.fn(),
+}));
 
 import { useFlowWizard } from "../../../FlowWizard/FlowWizardContext";
 import { useSendFlowData, useSendFlowActions } from "../../context/SendFlowContext";
 import { useMaybeAccountName } from "~/renderer/reducers/wallet";
+import { track } from "~/renderer/analytics/segment";
+import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
+import { RecipientScannerProvider } from "../../context/RecipientScannerContext";
 
 type VM = ReturnType<typeof useSendHeaderModel>;
 let container: HTMLElement;
@@ -72,21 +83,25 @@ const mockData = (
   uiConfig = { hasMemo: false },
   recipientSearch = { value: "" },
 ) => {
+  const search = { ...recipientSearch, setValue: jest.fn(), clear: jest.fn() };
   (useSendFlowData as jest.Mock).mockReturnValue({
     state,
     uiConfig,
-    recipientSearch: { ...recipientSearch, setValue: jest.fn(), clear: jest.fn() },
+    recipientSearch: search,
   });
+  return search;
 };
 
 function renderHook(availableText = "", resetViewState = () => {}) {
   act(() => {
     root.render(
-      <HookProbe
-        onResult={vm => (latestVM = vm)}
-        availableText={availableText}
-        resetViewState={resetViewState}
-      />,
+      <RecipientScannerProvider>
+        <HookProbe
+          onResult={vm => (latestVM = vm)}
+          availableText={availableText}
+          resetViewState={resetViewState}
+        />
+      </RecipientScannerProvider>,
     );
   });
 }
@@ -283,6 +298,108 @@ describe("useSendHeaderModel", () => {
 
       expect(latestVM?.title).toBe("");
       expect(latestVM?.descriptionText).toBe("");
+    });
+  });
+
+  describe("QR code scanner", () => {
+    const mockRecipientStep = () => {
+      (useFlowWizard as jest.Mock).mockReturnValue({
+        currentStep: SEND_FLOW_STEP.RECIPIENT,
+        currentStepConfig: { addressInput: true, showTitle: true },
+        navigation: { goToStep: jest.fn(), goToPreviousStep: jest.fn(), canGoBack: () => true },
+      });
+    };
+
+    const baseState = {
+      account: { currency: { ticker: "ETH" }, account: {} },
+      recipient: null,
+      transaction: { status: {} },
+    };
+
+    it("is closed by default and toggles open then closed, tracking both", () => {
+      mockActions();
+      mockData(baseState);
+      mockRecipientStep();
+
+      renderHook();
+      expect(latestVM?.isScannerOpen).toBe(false);
+
+      act(() => latestVM?.handleQrCodeClick());
+      expect(latestVM?.isScannerOpen).toBe(true);
+      expect(track).toHaveBeenCalledWith("Send Flow QR Code Opened", expect.any(Object));
+
+      act(() => latestVM?.handleQrCodeClick());
+      expect(latestVM?.isScannerOpen).toBe(false);
+      expect(track).toHaveBeenCalledWith("Send Flow QR Code Closed", expect.any(Object));
+    });
+
+    it("stays closed on steps other than recipient", () => {
+      mockNavigation();
+      mockActions();
+      mockData(baseState);
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+
+      expect(latestVM?.isScannerOpen).toBe(false);
+    });
+
+    it("closes the scanner once the user types in the recipient field", () => {
+      mockActions();
+      const search = mockData(baseState);
+      mockRecipientStep();
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+      act(() => latestVM?.handleRecipientInputChange("0x1"));
+
+      expect(search.setValue).toHaveBeenCalledWith("0x1");
+      expect(latestVM?.isScannerOpen).toBe(false);
+    });
+
+    it("keeps the scanner open when the field is cleared back to empty", () => {
+      mockActions();
+      const search = mockData(baseState);
+      mockRecipientStep();
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+      act(() => latestVM?.handleRecipientInputChange(""));
+
+      expect(search.setValue).toHaveBeenCalledWith("");
+      expect(latestVM?.isScannerOpen).toBe(true);
+    });
+
+    it("closes the scanner when navigating back", () => {
+      mockActions();
+      mockData(baseState);
+      mockRecipientStep();
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+      act(() => latestVM?.handleBack());
+
+      expect(latestVM?.isScannerOpen).toBe(false);
+    });
+
+    it("sets the decoded address and closes the scanner on a successful scan", () => {
+      mockActions();
+      const search = mockData(baseState);
+      mockRecipientStep();
+      (decodeURIScheme as jest.Mock).mockReturnValue({
+        address: "0xAbC",
+        amount: 1,
+        currency: { id: "ethereum" },
+      });
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+      act(() => latestVM?.handleScanPicked("ethereum:0xAbC?value=1"));
+
+      expect(decodeURIScheme).toHaveBeenCalledWith("ethereum:0xAbC?value=1");
+      expect(search.setValue).toHaveBeenCalledWith("0xAbC");
+      expect(search.setValue).toHaveBeenCalledTimes(1);
+      expect(latestVM?.isScannerOpen).toBe(false);
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -1,4 +1,5 @@
 import { SendFlowStep, SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
+import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
 import { t } from "i18next";
 import { useMemo, useCallback, useRef } from "react";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
@@ -14,8 +15,9 @@ import {
 import { SendStepConfig } from "../types";
 import BigNumber from "bignumber.js";
 import { useMaybeAccountName } from "~/renderer/reducers/wallet";
-import { trackPage } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../utils/tracking";
+import { useRecipientScanner } from "../context/RecipientScannerContext";
 
 type UseSendHeaderModelParams = Readonly<{
   availableText: string;
@@ -26,6 +28,10 @@ type UseSendHeaderModelResult = Readonly<{
   descriptionText: string | undefined;
   handleBack: () => void;
   handleRecipientInputClick: () => void;
+  handleRecipientInputChange: (value: string) => void;
+  handleQrCodeClick: () => void;
+  handleScanPicked: (code: string) => void;
+  isScannerOpen: boolean;
   showBackButton: boolean;
   showRecipientInput: boolean;
   showMemoControls: boolean;
@@ -41,6 +47,7 @@ export function useSendHeaderModel({
   const wizard = useFlowWizard<SendFlowStep, SendFlowBusinessContext, SendStepConfig>();
   const { state, uiConfig, recipientSearch, isRecipientAddressComplete } = useSendFlowData();
   const { close, transaction } = useSendFlowActions();
+  const { isScannerOpen, closeScanner, toggleScanner } = useRecipientScanner();
 
   const currencyName = state.account.currency?.ticker ?? "";
   const accountName = useMaybeAccountName(state.account.account ?? undefined);
@@ -89,6 +96,8 @@ export function useSendHeaderModel({
   const descriptionText = showTitle && showAvailable && accountSummary ? accountSummary : "";
 
   const handleBack = useCallback(() => {
+    closeScanner();
+
     // Per-step state cleanup that runs regardless of whether navigation uses backTarget
     // or goToPreviousStep, so floating steps and regular steps are treated uniformly
     if (currentStep === SEND_FLOW_STEP.AMOUNT) {
@@ -117,7 +126,7 @@ export function useSendHeaderModel({
     } else {
       close();
     }
-  }, [backTarget, close, currentStep, navigation, resetViewState, transaction]);
+  }, [backTarget, close, closeScanner, currentStep, navigation, resetViewState, transaction]);
 
   const addressInputValue = useMemo(() => {
     if (isRecipientStep) return recipientSearch.value;
@@ -136,6 +145,33 @@ export function useSendHeaderModel({
     handleBack();
   }, [handleBack, isAmountStep, recipientSearch, state.recipient]);
 
+  const showScanner = isScannerOpen && isRecipientStep;
+
+  const handleQrCodeClick = useCallback(() => {
+    track(
+      isScannerOpen ? "Send Flow QR Code Closed" : "Send Flow QR Code Opened",
+      trackingProperties,
+    );
+    toggleScanner();
+  }, [isScannerOpen, toggleScanner, trackingProperties]);
+
+  const handleRecipientInputChange = useCallback(
+    (value: string) => {
+      recipientSearch.setValue(value);
+      if (value.length > 0) closeScanner();
+    },
+    [closeScanner, recipientSearch],
+  );
+
+  const handleScanPicked = useCallback(
+    (code: string) => {
+      const { address } = decodeURIScheme(code);
+      recipientSearch.setValue(address);
+      closeScanner();
+    },
+    [closeScanner, recipientSearch],
+  );
+
   const transactionError = state.transaction.status?.errors?.transaction;
   const transactionErrorName = transactionError?.name;
 
@@ -144,6 +180,10 @@ export function useSendHeaderModel({
     descriptionText,
     handleBack,
     handleRecipientInputClick,
+    handleRecipientInputChange,
+    handleQrCodeClick,
+    handleScanPicked,
+    isScannerOpen: showScanner,
     showBackButton,
     showMemoControls,
     showRecipientInput,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/RecipientScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/RecipientScreen.tsx
@@ -4,6 +4,7 @@ import type { TokenCurrency } from "@domain/entity-currency-token";
 import React, { useCallback, useMemo, useRef } from "react";
 import { useFlowWizard } from "../../../FlowWizard/FlowWizardContext";
 import { useSendFlowActions, useSendFlowData } from "../../context/SendFlowContext";
+import { useRecipientScanner } from "../../context/RecipientScannerContext";
 import { trackPage } from "~/renderer/analytics/segment";
 import { getSendFlowTrackingProperties } from "../../utils/tracking";
 import { RecipientAddressModal } from "./components/RecipientAddressModal";
@@ -12,6 +13,7 @@ export function RecipientScreen() {
   const { state, uiConfig } = useSendFlowData();
   const { transaction, close } = useSendFlowActions();
   const { navigation } = useFlowWizard();
+  const { isScannerOpen } = useRecipientScanner();
 
   const account = state.account.account;
   const parentAccount = state.account.parentAccount ?? undefined;
@@ -47,7 +49,8 @@ export function RecipientScreen() {
     [transaction, state.recipient, navigation],
   );
 
-  if (!account || !currency) {
+  // While scanning, the camera panel rendered by the header is the only body content
+  if (!account || !currency || isScannerOpen) {
     return null;
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientQrScanner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientQrScanner.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { Spinner, Spot } from "@ledgerhq/lumen-ui-react";
+import { QrCodeScanner } from "@ledgerhq/lumen-ui-react/symbols";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import { useQrCodeScanner } from "../hooks/useQrCodeScanner";
+
+type RecipientQrScannerProps = Readonly<{
+  onPick: (code: string) => void;
+}>;
+
+const TARGET_SIZE = 176;
+const targetStyle = { width: TARGET_SIZE, height: TARGET_SIZE } as const;
+
+/**
+ * Blurs the frame in a single layer, then punches the target area out of it. One surface keeps
+ * the blur uniform, where several adjacent ones each sample only their own backdrop and seam
+ * along the edges they share.
+ */
+const blurCutoutStyle = {
+  maskImage: "linear-gradient(#000, #000), linear-gradient(#000, #000)",
+  maskSize: `100% 100%, ${TARGET_SIZE}px ${TARGET_SIZE}px`,
+  maskPosition: "center, center",
+  maskRepeat: "no-repeat",
+  maskComposite: "exclude",
+} as const;
+
+export function RecipientQrScanner({ onPick }: RecipientQrScannerProps) {
+  const { videoRef, error, isLoading } = useQrCodeScanner({ onPick });
+
+  return (
+    <div className="px-16 pb-16" data-testid="send-recipient-qr-scanner">
+      <div className="relative aspect-[4/3] w-full overflow-hidden rounded-sm bg-muted">
+        {error ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-10 px-24">
+            <Spot appearance="icon" icon={QrCodeScanner} size={56} />
+            <p className="body-2 text-center text-muted">
+              <TranslatedError error={error} />
+            </p>
+          </div>
+        ) : (
+          <>
+            <video
+              ref={videoRef}
+              autoPlay
+              playsInline
+              muted
+              className="h-full w-full object-cover"
+            />
+
+            {isLoading ? (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Spinner size={24} />
+              </div>
+            ) : (
+              <>
+                <div
+                  className="absolute inset-0 bg-black/20 backdrop-blur-md"
+                  style={blurCutoutStyle}
+                />
+                <div
+                  className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+                  style={targetStyle}
+                >
+                  <div className="absolute top-0 left-0 size-24 rounded-tl-xs border-t-2 border-l-2 border-white" />
+                  <div className="absolute top-0 right-0 size-24 rounded-tr-xs border-t-2 border-r-2 border-white" />
+                  <div className="absolute bottom-0 left-0 size-24 rounded-bl-xs border-b-2 border-l-2 border-white" />
+                  <div className="absolute right-0 bottom-0 size-24 rounded-br-xs border-r-2 border-b-2 border-white" />
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useQrCodeScanner.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useQrCodeScanner.test.tsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "tests/testSetup";
+import { NoAccessToCamera } from "@ledgerhq/live-common/errors";
+import jsQR from "jsqr";
+import { useQrCodeScanner } from "../useQrCodeScanner";
+
+jest.mock("jsqr", () => ({ __esModule: true, default: jest.fn() }));
+
+const DECODE_INTERVAL_MS = 400;
+const CAMERA_TIMEOUT_MS = 20000;
+
+type VM = ReturnType<typeof useQrCodeScanner>;
+
+let container: HTMLElement;
+let root: ReturnType<typeof createRoot>;
+let latestVM: VM | null = null;
+
+function HookProbe({ onPick }: { onPick: (code: string) => void }) {
+  const vm = useQrCodeScanner({ onPick });
+  latestVM = vm;
+  return <video ref={vm.videoRef} />;
+}
+
+const createTrack = () => ({ stop: jest.fn() });
+
+const mockStream = (tracks = [createTrack()]) =>
+  ({ getTracks: () => tracks }) as unknown as MediaStream;
+
+const setMediaDevices = (getUserMedia: jest.Mock | null) => {
+  Object.defineProperty(navigator, "mediaDevices", {
+    value: getUserMedia ? { getUserMedia } : undefined,
+    configurable: true,
+    writable: true,
+  });
+};
+
+/** Gives the video element the dimensions and readiness jsdom never computes on its own */
+const giveVideoDimensions = (width = 640, height = 480) => {
+  const video = container.querySelector("video") as HTMLVideoElement;
+  Object.defineProperty(video, "videoWidth", { value: width, configurable: true });
+  Object.defineProperty(video, "videoHeight", { value: height, configurable: true });
+  Object.defineProperty(video, "readyState", {
+    value: HTMLMediaElement.HAVE_ENOUGH_DATA,
+    configurable: true,
+  });
+  video.play = jest.fn().mockResolvedValue(undefined);
+  video.pause = jest.fn();
+  return video;
+};
+
+/** Mounts without flushing, so the video can be prepared before getUserMedia resolves */
+function renderHook(onPick: (code: string) => void) {
+  act(() => {
+    root.render(<HookProbe onPick={onPick} />);
+  });
+}
+
+async function flushCameraStart() {
+  await act(async () => {});
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  latestVM = null;
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  jest.useRealTimers();
+});
+
+describe("useQrCodeScanner", () => {
+  it("starts loading, then streams and clears the loading state", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+
+    renderHook(jest.fn());
+    giveVideoDimensions();
+    await flushCameraStart();
+
+    expect(latestVM?.isLoading).toBe(false);
+    expect(latestVM?.error).toBeNull();
+  });
+
+  it("calls onPick with the decoded data once a frame contains a QR code", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+    const onPick = jest.fn();
+    (jsQR as jest.Mock).mockReturnValue({ data: "ethereum:0xAbC" });
+
+    renderHook(onPick);
+    giveVideoDimensions();
+    await flushCameraStart();
+
+    await act(async () => {
+      jest.advanceTimersByTime(DECODE_INTERVAL_MS);
+    });
+
+    expect(onPick).toHaveBeenCalledWith("ethereum:0xAbC");
+  });
+
+  it("does not call onPick while no QR code is decoded", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+    const onPick = jest.fn();
+    (jsQR as jest.Mock).mockReturnValue(null);
+
+    renderHook(onPick);
+    giveVideoDimensions();
+    await flushCameraStart();
+
+    await act(async () => {
+      jest.advanceTimersByTime(DECODE_INTERVAL_MS * 4);
+    });
+
+    expect(jsQR).toHaveBeenCalled();
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it("decodes a downscaled frame instead of the camera's native resolution", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+    (jsQR as jest.Mock).mockReturnValue(null);
+
+    renderHook(jest.fn());
+    giveVideoDimensions(1920, 1080);
+    await flushCameraStart();
+
+    await act(async () => {
+      jest.advanceTimersByTime(DECODE_INTERVAL_MS);
+    });
+
+    expect(jsQR).toHaveBeenCalledWith(expect.anything(), 640, 360);
+  });
+
+  it("skips the frame while the video has no current data", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+
+    renderHook(jest.fn());
+    const video = giveVideoDimensions();
+    Object.defineProperty(video, "readyState", {
+      value: HTMLMediaElement.HAVE_METADATA,
+      configurable: true,
+    });
+    await flushCameraStart();
+
+    await act(async () => {
+      jest.advanceTimersByTime(DECODE_INTERVAL_MS * 2);
+    });
+
+    expect(jsQR).not.toHaveBeenCalled();
+  });
+
+  it("surfaces NoAccessToCamera when the video fails to play", async () => {
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream()));
+
+    renderHook(jest.fn());
+    const video = giveVideoDimensions();
+    video.play = jest.fn().mockRejectedValue(new Error("play interrupted"));
+    await flushCameraStart();
+
+    expect(latestVM?.error).toBeInstanceOf(NoAccessToCamera);
+    expect(latestVM?.isLoading).toBe(false);
+    expect(jsQR).not.toHaveBeenCalled();
+  });
+
+  it("surfaces NoAccessToCamera when the permission is denied", async () => {
+    setMediaDevices(jest.fn().mockRejectedValue(new Error("Permission denied")));
+
+    renderHook(jest.fn());
+    await flushCameraStart();
+
+    expect(latestVM?.error).toBeInstanceOf(NoAccessToCamera);
+    expect(latestVM?.isLoading).toBe(false);
+  });
+
+  it("surfaces NoAccessToCamera when mediaDevices is unavailable", async () => {
+    setMediaDevices(null);
+
+    renderHook(jest.fn());
+    await flushCameraStart();
+
+    expect(latestVM?.error).toBeInstanceOf(NoAccessToCamera);
+  });
+
+  it("surfaces NoAccessToCamera when the permission prompt never settles", async () => {
+    setMediaDevices(jest.fn().mockReturnValue(new Promise(() => {})));
+
+    renderHook(jest.fn());
+    await act(async () => {
+      jest.advanceTimersByTime(CAMERA_TIMEOUT_MS);
+    });
+
+    expect(latestVM?.error).toBeInstanceOf(NoAccessToCamera);
+  });
+
+  it("stops the camera tracks and the decode loop on unmount", async () => {
+    const track = createTrack();
+    setMediaDevices(jest.fn().mockResolvedValue(mockStream([track])));
+    const onPick = jest.fn();
+    (jsQR as jest.Mock).mockReturnValue({ data: "0xAbC" });
+
+    renderHook(onPick);
+    giveVideoDimensions();
+    await flushCameraStart();
+
+    act(() => {
+      root.unmount();
+    });
+
+    expect(track.stop).toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(DECODE_INTERVAL_MS * 4);
+    });
+
+    expect(onPick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useQrCodeScanner.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useQrCodeScanner.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import jsQR from "jsqr";
+import { NoAccessToCamera } from "@ledgerhq/live-common/errors";
+import logger from "~/renderer/logger";
+
+const DECODE_INTERVAL_MS = 400;
+const CAMERA_TIMEOUT_MS = 20000;
+// Decoding cost is per pixel, and a QR code needs far less than a camera's native resolution
+const DECODE_MAX_WIDTH = 640;
+const DECODE_IDEAL_HEIGHT = 480;
+
+type UseQrCodeScannerParams = Readonly<{
+  onPick: (code: string) => void;
+}>;
+
+type UseQrCodeScannerResult = Readonly<{
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  error: Error | null;
+  isLoading: boolean;
+}>;
+
+export function useQrCodeScanner({ onPick }: UseQrCodeScannerParams): UseQrCodeScannerResult {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Keeps the decode loop stable while still calling the latest handler
+  const onPickRef = useRef(onPick);
+  useEffect(() => {
+    onPickRef.current = onPick;
+  }, [onPick]);
+
+  const requestStream = useCallback(async (): Promise<MediaStream> => {
+    if (!navigator.mediaDevices) throw new NoAccessToCamera();
+
+    // getUserMedia never settles when the OS prompt is left unanswered
+    return Promise.race([
+      navigator.mediaDevices.getUserMedia({
+        video: {
+          facingMode: { ideal: "environment" },
+          width: { ideal: DECODE_MAX_WIDTH },
+          height: { ideal: DECODE_IDEAL_HEIGHT },
+        },
+      }),
+      new Promise<MediaStream>((_, reject) => {
+        setTimeout(() => reject(new NoAccessToCamera()), CAMERA_TIMEOUT_MS);
+      }),
+    ]);
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    let cancelled = false;
+    let stream: MediaStream | null = null;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+
+    const decodeFrame = () => {
+      if (!context || video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA) return;
+      if (!video.videoWidth || !video.videoHeight) return;
+
+      const scale = Math.min(1, DECODE_MAX_WIDTH / video.videoWidth);
+      const width = Math.round(video.videoWidth * scale);
+      const height = Math.round(video.videoHeight * scale);
+
+      if (canvas.width !== width || canvas.height !== height) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+
+      context.drawImage(video, 0, 0, width, height);
+
+      const { data } = context.getImageData(0, 0, width, height);
+      const code = jsQR(data, width, height);
+      if (code?.data) onPickRef.current(code.data);
+    };
+
+    const start = async () => {
+      try {
+        stream = await requestStream();
+      } catch (e) {
+        if (cancelled) return;
+        setError(new NoAccessToCamera(e instanceof Error ? e.message : undefined));
+        setIsLoading(false);
+        return;
+      }
+
+      if (cancelled) {
+        stream.getTracks().forEach(track => track.stop());
+        return;
+      }
+
+      video.srcObject = stream;
+      try {
+        await video.play();
+      } catch (e) {
+        if (cancelled) return;
+        logger.error(e);
+        setError(new NoAccessToCamera(e instanceof Error ? e.message : undefined));
+        setIsLoading(false);
+        return;
+      }
+
+      if (cancelled) return;
+      setError(null);
+      setIsLoading(false);
+      intervalId = setInterval(decodeFrame, DECODE_INTERVAL_MS);
+    };
+
+    start();
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== undefined) clearInterval(intervalId);
+      video.pause();
+      video.srcObject = null;
+      stream?.getTracks().forEach(track => track.stop());
+    };
+  }, [requestStream]);
+
+  return { videoRef, error, isLoading };
+}


### PR DESCRIPTION
### 📝 Description

The new send flow on desktop had no way to scan a recipient QR code. The legacy flow had one, and the new flow on mobile already has one, so desktop was the gap.

This adds it, and with it the behaviour asked for in the ticket: the recipient field shows a QR code icon while it is empty, and swaps it for the clear cross as soon as the user types.

**Approach**

Lumen's `AddressInput` already handles the icon/cross swap on its own: it renders the built-in QR icon only when the input is empty, and `BaseInput` replaces it with the clear button once there is content. Desktop simply never passed `onQrCodeClick`. So the acceptance criterion needed no new UI logic, and the actual work was the camera surface behind the icon.

Clicking the icon renders the camera feed inline in the dialog body, right under the address input, replacing the recipient step body. The header (title, account summary, close) stays as is. The panel closes on a second click of the icon, on the first keystroke, and on a successful scan.

- `context/RecipientScannerContext.tsx` (new): desktop-local scanner state, mounted in `SendFlowLayout` so both the header (which owns the input) and the step (which owns the body) can read it.
- `screens/Recipient/components/RecipientQrScanner.tsx` (new): thin wrapper over the existing legacy `QRCodeCameraPickerCanvas` (jsQR + `getUserMedia`), sized for the 400px dialog. No new scanner code and no new dependency.
- `useSendHeaderModel.ts`: `handleQrCodeClick` (toggle + tracking), `handleRecipientInputChange` (closes the panel on typing), `handleScanPicked` (`decodeURIScheme` then `recipientSearch.setValue(address)`), and `isScannerOpen` forced false outside the recipient step.
- `SendHeader.tsx` / `RecipientScreen.tsx`: pass `onQrCodeClick`, render the panel, and hide the step body while scanning.

**Trade-offs worth a reviewer's attention**

- A scanned URI contributes only its address. Amount and currency are discarded, matching mobile's `onScanned` path, so the normal address validation, ENS resolution and sanction checks run untouched. The legacy desktop flow also prefilled the amount; that was dropped deliberately for parity.
- This is not a new wizard step. `SEND_FLOW_STEP` lives in live-common and both apps key exhaustive `Record<SendFlowStep, …>` configs off it, so adding `SCAN_RECIPIENT` would have forced dead entries into mobile, which keeps using its native scanner screen. The panel is desktop-local UI state instead.
- Analytics reuse the legacy event names `Send Flow QR Code Opened` / `Closed` so existing dashboards keep working.

**Tests**

Covered by automatic tests: 5 unit cases on the view model (toggle plus tracking, typing closes, scan sets the decoded address, no scanner outside the recipient step) and 3 integration cases (scan fills the input, icon/cross swap, typing closes the panel). The full Send suite passes, 242 tests across 26 suites. jsdom has no camera, so the test harness stubs the canvas picker module rather than faking `getUserMedia` and `jsqr`.

Not covered by automatic tests, and worth checking manually: the real camera path, the camera framing against the Figma spec, and the `NoAccessToCamera` state when permission is denied.

**QA focus**

- Recipient field of the new send flow: QR icon when empty, clear cross when filled, icon back after clearing.
- Camera panel: opens under the input, hides the recent recipients body, dialog height animates, closes on second click, on typing, and on a successful scan.
- Scanning a plain address QR and a `ethereum:0x…` / `bitcoin:…` URI QR: only the address lands in the field, then validation and ENS behave as usual.
- Camera released when the panel closes (no OS camera indicator left on) and when the dialog is closed mid scan.
- Camera permission denied: the error renders inside the panel.
- Amount step: the read-only recipient field must show no QR icon.

| Empty field: QR icon | Scanner open | Field filled: clear cross |
| -------------------- | ------------ | ------------------------- |
| <img width="597" height="390" alt="1" src="https://github.com/user-attachments/assets/9e41cac7-f6e3-46dc-9a86-2940bff3bdfc" /> | <img width="502" height="528" alt="Screenshot 2026-07-30 at 11 08 12" src="https://github.com/user-attachments/assets/b2c3260c-4c69-4bfd-a80f-339116a5884b" />|<img width="646" height="533" alt="3" src="https://github.com/user-attachments/assets/c6b5dfb3-bbc2-4498-920b-a601f236c733" />|

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34431](https://ledgerhq.atlassian.net/browse/LIVE-34431)
- **ADR** (if any): n/a


[LIVE-34431]: https://ledgerhq.atlassian.net/browse/LIVE-34431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
