### PR TITLE
[LWM] feat(contacts): compose add address in one mobile drawer (LIVE-33917)

### DIFF
--- a/.changeset/bright-contacts-enter.md
+++ b/.changeset/bright-contacts-enter.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Compose Mobile Contacts currency and address steps in one queued drawer with reusable placeholders.

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10246,6 +10246,22 @@
       "confirmName": "Confirm name",
       "invalidNameError": "Special characters are not allowed."
     },
+    "addAddressEntry": {
+      "title": "Enter address",
+      "addressPlaceholder": "Address or ENS",
+      "confirmAddress": "Confirm address",
+      "validatingAddress": "Validating address",
+      "validAddress": "Valid address",
+      "invalidAddress": "Invalid address",
+      "domainNotFound": "No address found for this domain",
+      "validationUnavailable": "Address validation is temporarily unavailable",
+      "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing."
+    },
+    "addAddressFlow": {
+      "name": "Name",
+      "review": "Validation",
+      "success": "Success"
+    },
     "addressCount_zero": "0 address",
     "addressCount_one": "{{count}} address",
     "addressCount_other": "{{count}} addresses",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -578,6 +578,22 @@ describe("Contacts integration", () => {
     );
   });
 
+  it("should not start Add Address when no production network is eligible", async () => {
+    const { user } = render(<ContactDetailViewModelTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: ["unknown"] },
+        },
+      }),
+    });
+
+    await user.press(screen.getByTestId("contacts-start-add-address"));
+
+    expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+  });
+
   it("should expose the Add Address session started for a saved contact", async () => {
     const contact = mockContact({ id: "contact-benoit", name: "Benoit" });
     const { user } = render(<ContactDetailViewModelTestApp />, {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -2,12 +2,16 @@ import React from "react";
 import { Pressable, Text } from "react-native";
 import type { RouteProp } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { render, screen, withFlagOverrides, waitFor } from "@tests/test-renderer";
+import type { ContactId } from "@domain/entity-contact";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { ContactDetailView } from "@features/flow-contacts";
 import { NavigatorName, ScreenName } from "~/const";
 import type { AccountsNavigatorParamList } from "~/components/RootNavigator/types/AccountsNavigator";
 import { ContactsButton, ContactsScreen } from "LLM/features/Contacts";
 import { ContactDetailScreen } from "LLM/features/Contacts/screens/ContactDetail";
+import { ContactsAddAddressFlowDrawer } from "LLM/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer";
 import { useContactDetailScreenViewModel } from "LLM/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel";
 import MyWalletNavigator from "LLM/features/MyWallet/Navigator";
 import { useMyWalletHeaderViewModel } from "LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel";
@@ -15,12 +19,30 @@ import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import { mockEthCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 
 jest.mock("LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel");
+jest.mock("LLM/features/Contacts/hooks/useContactsAddressValidationAdapter", () => ({
+  useContactsAddressValidationAdapter: () => ({
+    validateAddress: async ({ address }: { address: string }) => ({
+      status: "valid",
+      resolvedAddress: address,
+      isDomain: false,
+    }),
+  }),
+}));
 
 const mockedViewModel = jest.mocked(useMyWalletHeaderViewModel);
 
 const Stack = createNativeStackNavigator();
 const AccountsStack = createNativeStackNavigator<AccountsNavigatorParamList>();
+type AddressEntryTestStackParamList = {
+  [ScreenName.MyWallet]: undefined;
+  [ScreenName.MyWalletContactDetail]: { contactId: ContactId };
+  [ScreenName.ScanRecipient]: {
+    onScanned: (value: string) => void;
+  };
+};
+const AddressEntryStack = createNativeStackNavigator<AddressEntryTestStackParamList>();
 const noop = () => undefined;
+const SCANNED_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
 
 const contactsNavigationState = {
   index: 1,
@@ -139,7 +161,6 @@ function ContactsGatingTestApp() {
 
 function ContactDetailViewModelProbe() {
   const viewModel = useContactDetailScreenViewModel();
-  const { closeDrawer, handleCurrencySelected, isOpen } = useModularDrawerController();
 
   if (viewModel.status === "redirecting") {
     return null;
@@ -153,6 +174,10 @@ function ContactDetailViewModelProbe() {
         return `selectingCurrency:${viewModel.addAddressFlowState.selectedContactId}`;
       case "enteringAddress":
         return `enteringAddress:${viewModel.addAddressFlowState.selectedContactId}:${viewModel.addAddressFlowState.selectedCurrencyId}`;
+      case "namingAddress":
+      case "reviewingAddress":
+      case "success":
+        return viewModel.addAddressFlowState.status;
     }
   })();
 
@@ -166,15 +191,20 @@ function ContactDetailViewModelProbe() {
       >
         <Text>Start Add Address</Text>
       </Pressable>
-      {isOpen ? (
+      {viewModel.addAddressFlowState.status === "selectingCurrency" ? (
         <>
           <Pressable
             testID="contacts-select-currency"
-            onPress={() => handleCurrencySelected(mockEthCryptoCurrency)}
+            onPress={() =>
+              viewModel.addAddressFlowProps.onCurrencySelected(mockEthCryptoCurrency.id)
+            }
           >
             <Text>Select currency</Text>
           </Pressable>
-          <Pressable testID="contacts-cancel-currency" onPress={closeDrawer}>
+          <Pressable
+            testID="contacts-cancel-currency"
+            onPress={viewModel.addAddressFlowProps.onClose}
+          >
             <Text>Cancel currency</Text>
           </Pressable>
         </>
@@ -192,6 +222,68 @@ function ContactDetailViewModelTestApp() {
         component={ContactDetailViewModelProbe}
       />
     </Stack.Navigator>
+  );
+}
+
+function ContactDetailAddressEntryTestScreen() {
+  const viewModel = useContactDetailScreenViewModel();
+  const { handleCurrencySelected } = useModularDrawerController();
+
+  if (viewModel.status === "redirecting") {
+    return null;
+  }
+
+  return (
+    <>
+      <ContactDetailView {...viewModel.pageProps} />
+      {viewModel.addAddressFlowState.status !== "closed" ? (
+        <ContactsAddAddressFlowDrawer {...viewModel.addAddressFlowProps} />
+      ) : null}
+      {viewModel.addAddressFlowState.status === "selectingCurrency" ? (
+        <Pressable
+          testID="contacts-address-entry-select-currency"
+          onPress={() => handleCurrencySelected(mockEthCryptoCurrency)}
+        >
+          <Text>Select currency</Text>
+        </Pressable>
+      ) : null}
+    </>
+  );
+}
+
+function ScanRecipientTestScreen({
+  navigation,
+  route,
+}: NativeStackScreenProps<
+  AddressEntryTestStackParamList,
+  typeof ScreenName.ScanRecipient
+>): React.JSX.Element {
+  return (
+    <Pressable
+      testID="contacts-scan-address"
+      onPress={() => {
+        route.params.onScanned(SCANNED_ADDRESS);
+        navigation.goBack();
+      }}
+    >
+      <Text>Scan address</Text>
+    </Pressable>
+  );
+}
+
+function ContactDetailAddressEntryTestApp() {
+  return (
+    <AddressEntryStack.Navigator screenOptions={{ headerShown: false }}>
+      <AddressEntryStack.Screen name={ScreenName.MyWallet} component={MyWalletHomeTestScreen} />
+      <AddressEntryStack.Screen
+        name={ScreenName.MyWalletContactDetail}
+        component={ContactDetailAddressEntryTestScreen}
+      />
+      <AddressEntryStack.Screen
+        name={ScreenName.ScanRecipient}
+        component={ScanRecipientTestScreen}
+      />
+    </AddressEntryStack.Navigator>
   );
 }
 
@@ -508,7 +600,7 @@ describe("Contacts integration", () => {
     await user.press(screen.getByTestId("contacts-cancel-currency"));
   });
 
-  it("should continue Add Address with the final currency selected by MAD", async () => {
+  it("should continue Add Address with the final currency selected in the shared drawer", async () => {
     const { user } = render(<ContactDetailViewModelTestApp />, {
       navigationInitialState: contactDetailNavigationState,
       overrideInitialState: withContactsPageReadyState({
@@ -531,6 +623,83 @@ describe("Contacts integration", () => {
       expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent(
         `enteringAddress:contact-me:${mockEthCryptoCurrency.id}`,
       );
+    });
+  });
+
+  it("should keep one Add Address drawer through QR, placeholders and success", async () => {
+    const { user } = render(<ContactDetailAddressEntryTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+        },
+      }),
+    });
+
+    await user.press(screen.getByTestId("contacts-detail-add-address"));
+    await user.press(screen.getByTestId("contacts-address-entry-select-currency"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-input")).toHaveProp(
+        "placeholder",
+        "Address or ENS",
+      );
+      expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Enter address");
+      expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
+      expect(screen.getByTestId("contacts-add-address-step-frame")).toHaveStyle({
+        height: "100%",
+      });
+      expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    });
+
+    await user.press(await screen.findByLabelText("Scan QR code"));
+    await user.press(await screen.findByTestId("contacts-scan-address"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-add-address-input")).toHaveProp("value", SCANNED_ADDRESS);
+      expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Enter address");
+      expect(screen.getByTestId("contacts-add-address-confirm")).toBeEnabled();
+    });
+
+    await user.press(screen.getByTestId("contacts-add-address-confirm"));
+    expect(await screen.findByTestId("contacts-add-address-name-screen-continue")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-add-address-name-screen-continue"));
+    expect(await screen.findByTestId("contacts-add-address-review-screen-continue")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-add-address-review-screen-continue"));
+    expect(await screen.findByTestId("contacts-add-address-success-screen-continue")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-add-address-success-screen-continue"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-add-address-flow-drawer")).toBeNull();
+      expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+    });
+  });
+
+  it("should return to currency selection without removing the contact detail route", async () => {
+    const { user } = render(<ContactDetailAddressEntryTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+        },
+      }),
+    });
+
+    await user.press(screen.getByTestId("contacts-detail-add-address"));
+    await user.press(screen.getByTestId("contacts-address-entry-select-currency"));
+    expect(await screen.findByTestId("contacts-add-address-input")).toBeVisible();
+
+    await user.press(screen.getByTestId("bottom-sheet-header-back-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
+      expect(screen.queryByTestId("contacts-add-address-input")).toBeNull();
+      expect(screen.getByTestId("contacts-address-entry-select-currency")).toBeVisible();
+      expect(screen.queryByTestId("my-wallet-home")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -17,25 +17,32 @@ const handleAccountSelected = jest.fn();
 const handleCurrencySelected = jest.fn();
 const mockedUseModularDrawerController = jest.mocked(useModularDrawerController);
 
+function mockModularDrawerController(
+  overrides: Partial<ReturnType<typeof useModularDrawerController>> = {},
+) {
+  mockedUseModularDrawerController.mockReturnValue({
+    areCurrenciesFiltered: true,
+    assetsConfiguration: undefined,
+    closeDrawer,
+    completionMode: "currency",
+    enableAccountSelection: false,
+    handleAccountSelected,
+    handleCurrencySelected,
+    isOpen: true,
+    networksConfiguration: undefined,
+    openDrawer,
+    presentation: "embedded",
+    preselectedCurrencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
+    uiUseCase: undefined,
+    useCase: undefined,
+    ...overrides,
+  });
+}
+
 describe("useContactsCurrencySelectionAdapter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseModularDrawerController.mockReturnValue({
-      areCurrenciesFiltered: true,
-      assetsConfiguration: undefined,
-      closeDrawer,
-      completionMode: "currency",
-      enableAccountSelection: false,
-      handleAccountSelected,
-      handleCurrencySelected,
-      isOpen: true,
-      networksConfiguration: undefined,
-      openDrawer,
-      presentation: "embedded",
-      preselectedCurrencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
-      uiUseCase: undefined,
-      useCase: undefined,
-    });
+    mockModularDrawerController();
   });
 
   it("should open the existing MAD in embedded currency mode", () => {
@@ -152,5 +159,42 @@ describe("useContactsCurrencySelectionAdapter", () => {
     rerender(undefined);
 
     expect(openDrawer).toHaveBeenCalledTimes(2);
+  });
+
+  it("should close MAD when unmounted during currency selection", () => {
+    const { unmount } = renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+
+    unmount();
+
+    expect(closeDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it("should use the latest close handler without closing MAD during a rerender", () => {
+    const updatedCloseDrawer = jest.fn();
+    const { rerender, unmount } = renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+
+    mockModularDrawerController({ closeDrawer: updatedCloseDrawer });
+    rerender(undefined);
+
+    expect(closeDrawer).not.toHaveBeenCalled();
+    expect(updatedCloseDrawer).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(updatedCloseDrawer).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -7,66 +7,150 @@ import { ScreenName } from "~/const";
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import { useContactsCurrencySelectionAdapter } from "./useContactsCurrencySelectionAdapter";
 
-const mockOpenDrawer = jest.fn();
-
 jest.mock("LLM/features/ModularDrawer", () => ({
   useModularDrawerController: jest.fn(),
 }));
 
+const openDrawer = jest.fn();
+const closeDrawer = jest.fn();
+const handleAccountSelected = jest.fn();
+const handleCurrencySelected = jest.fn();
 const mockedUseModularDrawerController = jest.mocked(useModularDrawerController);
 
 describe("useContactsCurrencySelectionAdapter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseModularDrawerController.mockReturnValue({
-      openDrawer: mockOpenDrawer,
-    } as unknown as ReturnType<typeof useModularDrawerController>);
+      areCurrenciesFiltered: true,
+      assetsConfiguration: undefined,
+      closeDrawer,
+      completionMode: "currency",
+      enableAccountSelection: false,
+      handleAccountSelected,
+      handleCurrencySelected,
+      isOpen: true,
+      networksConfiguration: undefined,
+      openDrawer,
+      presentation: "embedded",
+      preselectedCurrencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
+      uiUseCase: undefined,
+      useCase: undefined,
+    });
   });
 
-  it("opens MAD in currency mode with the exact eligible network ids", () => {
-    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
+  it("should open the existing MAD in embedded currency mode", () => {
+    const networkIds = [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id];
 
-    void result.current.selectCurrency([mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id]);
-
-    expect(mockOpenDrawer).toHaveBeenCalledWith(
-      expect.objectContaining({
-        currencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
-        areCurrenciesFiltered: true,
-        completionMode: "currency",
-        enableAccountSelection: false,
-        flow: "contacts_add_address",
-        source: ScreenName.MyWalletContactDetail,
+    renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds,
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
       }),
     );
+
+    expect(openDrawer).toHaveBeenCalledWith({
+      currencies: networkIds,
+      areCurrenciesFiltered: true,
+      completionMode: "currency",
+      enableAccountSelection: false,
+      flow: "contacts_add_address",
+      presentation: "embedded",
+      source: ScreenName.MyWalletContactDetail,
+      onCurrencySelected: expect.any(Function),
+    });
   });
 
-  it("returns only the selected currency id", async () => {
-    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
-    const selection = result.current.selectCurrency([mockEthCryptoCurrency.id]);
-    const onCurrencySelected = mockOpenDrawer.mock.calls[0][0].onCurrencySelected;
-
-    await act(async () => onCurrencySelected?.(mockEthCryptoCurrency));
-
-    await expect(selection).resolves.toBe(mockEthCryptoCurrency.id);
-  });
-
-  it("returns null on cancellation or an invalid MAD result", async () => {
-    const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
-    const cancelledSelection = result.current.selectCurrency([mockEthCryptoCurrency.id]);
-    const cancel = mockOpenDrawer.mock.calls[0][0].onCurrencySelected;
-
-    await act(async () => cancel?.(null));
-    await expect(cancelledSelection).resolves.toBeNull();
-
-    const invalidSelection = result.current.selectCurrency([mockEthCryptoCurrency.id]);
-    const selectInvalidCurrency = mockOpenDrawer.mock.calls[1][0].onCurrencySelected;
-
-    await act(async () =>
-      selectInvalidCurrency?.({
-        ...mockEthCryptoCurrency,
-        id: "",
-      } as typeof mockEthCryptoCurrency),
+  it("should return a valid selected currency id", () => {
+    const onCurrencySelected = jest.fn();
+    renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected,
+        onSelectionCancelled: jest.fn(),
+      }),
     );
-    await expect(invalidSelection).resolves.toBeNull();
+
+    const onMadCurrencySelected = openDrawer.mock.calls[0]?.[0].onCurrencySelected;
+    act(() => onMadCurrencySelected(mockEthCryptoCurrency));
+
+    expect(onCurrencySelected).toHaveBeenCalledWith(mockEthCryptoCurrency.id);
+  });
+
+  it.each([null, { ...mockEthCryptoCurrency, id: "" }])(
+    "should cancel when MAD does not return a valid currency",
+    currency => {
+      const onSelectionCancelled = jest.fn();
+      renderHook(() =>
+        useContactsCurrencySelectionAdapter({
+          isOpen: true,
+          networkIds: [mockEthCryptoCurrency.id],
+          onCurrencySelected: jest.fn(),
+          onSelectionCancelled,
+        }),
+      );
+
+      const onMadCurrencySelected = openDrawer.mock.calls[0]?.[0].onCurrencySelected;
+      act(() => onMadCurrencySelected(currency));
+
+      expect(onSelectionCancelled).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("should expose the controller wiring to ModularDrawerFlow", () => {
+    const { result } = renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: true,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+
+    expect(result.current.flowProps).toMatchObject({
+      areCurrenciesFiltered: true,
+      currencies: [mockEthCryptoCurrency.id, mockBtcCryptoCurrency.id],
+      isOpen: true,
+      onAccountSelected: handleAccountSelected,
+      onClose: closeDrawer,
+      onCurrencySelected: handleCurrencySelected,
+    });
+  });
+
+  it("should not open MAD outside the currency selection step", () => {
+    renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen: false,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+
+    expect(openDrawer).not.toHaveBeenCalled();
+  });
+
+  it("should open MAD only once per currency selection session", () => {
+    let isOpen = true;
+    const { rerender } = renderHook(() =>
+      useContactsCurrencySelectionAdapter({
+        isOpen,
+        networkIds: [mockEthCryptoCurrency.id],
+        onCurrencySelected: jest.fn(),
+        onSelectionCancelled: jest.fn(),
+      }),
+    );
+
+    rerender(undefined);
+    expect(openDrawer).toHaveBeenCalledTimes(1);
+
+    isOpen = false;
+    rerender(undefined);
+    isOpen = true;
+    rerender(undefined);
+
+    expect(openDrawer).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -34,6 +34,7 @@ export function useContactsCurrencySelectionAdapter({
   onSelectionCancelled,
 }: UseContactsCurrencySelectionAdapterOptions): ContactsCurrencySelectionAdapter {
   const selectionStartedRef = useRef(false);
+  const closeDrawerRef = useRef<() => void>(() => undefined);
   const {
     areCurrenciesFiltered,
     assetsConfiguration,
@@ -57,6 +58,20 @@ export function useContactsCurrencySelectionAdapter({
       }
     },
     [onCurrencySelected, onSelectionCancelled],
+  );
+
+  useEffect(() => {
+    closeDrawerRef.current = closeDrawer;
+  }, [closeDrawer]);
+
+  useEffect(
+    () => () => {
+      if (selectionStartedRef.current) {
+        selectionStartedRef.current = false;
+        closeDrawerRef.current();
+      }
+    },
+    [],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,11 +1,24 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { ContactCurrencyIdSchema, type ContactAddress } from "@domain/entity-contact";
-import type { ContactsCurrencySelectionPort } from "@features/flow-contacts";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { ScreenName } from "~/const";
-import { useModularDrawerController } from "LLM/features/ModularDrawer";
+import {
+  type ModularDrawerFlowProps,
+  useModularDrawerController,
+} from "LLM/features/ModularDrawer";
 
-type OpenModularDrawer = ReturnType<typeof useModularDrawerController>["openDrawer"];
+const FLOW = "contacts_add_address";
+
+type UseContactsCurrencySelectionAdapterOptions = Readonly<{
+  isOpen: boolean;
+  networkIds: readonly string[];
+  onCurrencySelected: (currencyId: ContactAddress["currencyId"]) => void;
+  onSelectionCancelled: () => void;
+}>;
+
+export type ContactsCurrencySelectionAdapter = Readonly<{
+  flowProps: Omit<ModularDrawerFlowProps, "children">;
+}>;
 
 function resolveContactCurrencyId(
   currency: CryptoOrTokenCurrency | null,
@@ -14,35 +27,86 @@ function resolveContactCurrencyId(
   return parsedCurrencyId.success ? parsedCurrencyId.data : null;
 }
 
-function selectCurrency(
-  openDrawer: OpenModularDrawer,
-  networkIds: Parameters<ContactsCurrencySelectionPort["selectCurrency"]>[0],
-): Promise<ContactAddress["currencyId"] | null> {
-  return new Promise(resolve => {
-    const onCurrencySelected = (currency: CryptoOrTokenCurrency | null) => {
-      resolve(resolveContactCurrencyId(currency));
-    };
+export function useContactsCurrencySelectionAdapter({
+  isOpen,
+  networkIds,
+  onCurrencySelected,
+  onSelectionCancelled,
+}: UseContactsCurrencySelectionAdapterOptions): ContactsCurrencySelectionAdapter {
+  const selectionStartedRef = useRef(false);
+  const {
+    areCurrenciesFiltered,
+    assetsConfiguration,
+    closeDrawer,
+    handleAccountSelected,
+    handleCurrencySelected,
+    isOpen: isModularDrawerOpen,
+    networksConfiguration,
+    openDrawer,
+    preselectedCurrencies,
+    uiUseCase,
+    useCase,
+  } = useModularDrawerController();
+  const completeSelection = useCallback(
+    (currency: CryptoOrTokenCurrency | null) => {
+      const currencyId = resolveContactCurrencyId(currency);
+      if (currencyId) {
+        onCurrencySelected(currencyId);
+      } else {
+        onSelectionCancelled();
+      }
+    },
+    [onCurrencySelected, onSelectionCancelled],
+  );
 
+  useEffect(() => {
+    if (!isOpen) {
+      selectionStartedRef.current = false;
+      return;
+    }
+    if (selectionStartedRef.current) {
+      return;
+    }
+
+    selectionStartedRef.current = true;
     openDrawer({
       currencies: [...networkIds],
       areCurrenciesFiltered: true,
       completionMode: "currency",
       enableAccountSelection: false,
-      flow: "contacts_add_address",
+      flow: FLOW,
+      presentation: "embedded",
       source: ScreenName.MyWalletContactDetail,
-      onCurrencySelected,
+      onCurrencySelected: completeSelection,
     });
-  });
-}
+  }, [completeSelection, isOpen, networkIds, openDrawer]);
 
-function createCurrencySelectionPort(openDrawer: OpenModularDrawer): ContactsCurrencySelectionPort {
-  return {
-    selectCurrency: networkIds => selectCurrency(openDrawer, networkIds),
-  };
-}
+  const flowProps = useMemo<Omit<ModularDrawerFlowProps, "children">>(
+    () => ({
+      areCurrenciesFiltered,
+      assetsConfiguration,
+      currencies: preselectedCurrencies,
+      isOpen: isModularDrawerOpen,
+      networksConfiguration,
+      onAccountSelected: handleAccountSelected,
+      onClose: closeDrawer,
+      onCurrencySelected: handleCurrencySelected,
+      uiUseCase,
+      useCase,
+    }),
+    [
+      areCurrenciesFiltered,
+      assetsConfiguration,
+      closeDrawer,
+      handleAccountSelected,
+      handleCurrencySelected,
+      isModularDrawerOpen,
+      networksConfiguration,
+      preselectedCurrencies,
+      uiUseCase,
+      useCase,
+    ],
+  );
 
-export function useContactsCurrencySelectionAdapter(): ContactsCurrencySelectionPort {
-  const { openDrawer } = useModularDrawerController();
-
-  return useMemo(() => createCurrencySelectionPort(openDrawer), [openDrawer]);
+  return { flowProps };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { View } from "react-native";
+import {
+  ContactsAddAddressEntry,
+  ContactsAddAddressPlaceholderView,
+} from "@features/flow-contacts";
+import {
+  QueuedDrawerFlow,
+  type QueuedDrawerFlowOptions,
+  type QueuedDrawerFlowScreenRegistry,
+} from "LLM/components/QueuedDrawerFlow";
+import type { ContactsAddAddressDrawerStep } from "./types";
+import type { ContactsAddAddressFlowContentViewModel } from "./useContactsAddAddressFlowContentViewModel";
+
+const FLOW_SNAP_POINT = "92%";
+const STEP_FRAME_HEIGHT = "100%";
+
+const FLOW_OPTIONS = {
+  snapPoints: [FLOW_SNAP_POINT],
+} as const satisfies QueuedDrawerFlowOptions;
+
+const LOCKED_STEP_OPTIONS = {
+  hasBackButton: true,
+  noCloseButton: true,
+  hideHandle: true,
+  preventBackdropClick: true,
+  enablePanDownToClose: false,
+} as const satisfies QueuedDrawerFlowOptions;
+
+function ContactsAddAddressStepFrame({ children }: React.PropsWithChildren): React.JSX.Element {
+  return (
+    <View testID="contacts-add-address-step-frame" style={{ height: STEP_FRAME_HEIGHT }}>
+      {children}
+    </View>
+  );
+}
+
+export function ContactsAddAddressFlowContentView({
+  addressEntryProps,
+  currencyShell,
+  currentStep,
+  isOpen,
+  labels,
+  onBack,
+  onClose,
+  onContinueFromName,
+  onContinueFromReview,
+  onFinish,
+}: ContactsAddAddressFlowContentViewModel): React.JSX.Element {
+  const screens: QueuedDrawerFlowScreenRegistry<ContactsAddAddressDrawerStep> = {
+    currency: {
+      content: currencyShell.content,
+      options: {
+        hasBackButton: currencyShell.hasBackButton,
+        enablePanDownToClose: true,
+      },
+    },
+    address: {
+      content: addressEntryProps ? (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressEntry {...addressEntryProps} />
+        </ContactsAddAddressStepFrame>
+      ) : null,
+      options: LOCKED_STEP_OPTIONS,
+    },
+    name: {
+      content: (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressPlaceholderView
+            title={labels.name}
+            buttonLabel={labels.continue}
+            testID="contacts-add-address-name-screen"
+            onContinue={onContinueFromName}
+          />
+        </ContactsAddAddressStepFrame>
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+    review: {
+      content: (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressPlaceholderView
+            title={labels.review}
+            buttonLabel={labels.continue}
+            testID="contacts-add-address-review-screen"
+            onContinue={onContinueFromReview}
+          />
+        </ContactsAddAddressStepFrame>
+      ),
+      options: LOCKED_STEP_OPTIONS,
+    },
+    success: {
+      content: (
+        <ContactsAddAddressStepFrame>
+          <ContactsAddAddressPlaceholderView
+            title={labels.success}
+            buttonLabel={labels.done}
+            testID="contacts-add-address-success-screen"
+            onContinue={onFinish}
+          />
+        </ContactsAddAddressStepFrame>
+      ),
+      options: {
+        ...LOCKED_STEP_OPTIONS,
+        hasBackButton: false,
+      },
+    },
+  };
+
+  return (
+    <QueuedDrawerFlow
+      currentStep={currentStep}
+      defaultOptions={FLOW_OPTIONS}
+      isOpen={isOpen}
+      onBack={onBack}
+      onClose={onClose}
+      screens={screens}
+      testID="contacts-add-address-flow-drawer"
+    />
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerContent.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerContent.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import type { ModularDrawerFlowRenderProps } from "LLM/features/ModularDrawer";
+import { ContactsAddAddressFlowContentView } from "./ContactsAddAddressFlowContentView";
+import { useContactsAddAddressFlowContentViewModel } from "./useContactsAddAddressFlowContentViewModel";
+import type { ContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
+
+type ContactsAddAddressFlowDrawerContentProps = Readonly<{
+  viewModel: ContactsAddAddressFlowDrawerViewModel;
+  currencyShell: ModularDrawerFlowRenderProps;
+}>;
+
+export function ContactsAddAddressFlowDrawerContent({
+  viewModel,
+  currencyShell,
+}: ContactsAddAddressFlowDrawerContentProps): React.JSX.Element {
+  const contentViewModel = useContactsAddAddressFlowContentViewModel({
+    viewModel,
+    currencyShell,
+  });
+
+  return <ContactsAddAddressFlowContentView {...contentViewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowDrawerView.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ModularDrawerFlow } from "LLM/features/ModularDrawer";
+import { ContactsAddAddressFlowDrawerContent } from "./ContactsAddAddressFlowDrawerContent";
+import type { ContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
+
+export function ContactsAddAddressFlowDrawerView(
+  viewModel: ContactsAddAddressFlowDrawerViewModel,
+): React.JSX.Element {
+  return (
+    <ModularDrawerFlow {...viewModel.currencySelection.flowProps}>
+      {currencyShell => (
+        <ContactsAddAddressFlowDrawerContent viewModel={viewModel} currencyShell={currencyShell} />
+      )}
+    </ModularDrawerFlow>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { ContactsAddAddressFlowDrawerView } from "./ContactsAddAddressFlowDrawerView";
+import type { ContactsAddAddressFlowDrawerProps } from "./types";
+import { useContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
+
+export function ContactsAddAddressFlowDrawer(
+  props: ContactsAddAddressFlowDrawerProps,
+): React.JSX.Element {
+  const viewModel = useContactsAddAddressFlowDrawerViewModel(props);
+  return <ContactsAddAddressFlowDrawerView {...viewModel} />;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
@@ -1,0 +1,17 @@
+import type { AddAddressFlowState, AddAddressInputSource } from "@features/flow-contacts";
+import type { ContactAddress } from "@domain/entity-contact";
+
+export type ContactsAddAddressFlowDrawerProps = Readonly<{
+  state: AddAddressFlowState;
+  eligibleNetworkIds: readonly string[];
+  onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
+  onAddressConfirm: () => void;
+  onBack: () => void;
+  onClose: () => void;
+  onContinueFromName: () => void;
+  onContinueFromReview: () => void;
+  onCurrencySelected: (currencyId: ContactAddress["currencyId"]) => void;
+  onQrCodeClick: () => void;
+}>;
+
+export type ContactsAddAddressDrawerStep = "currency" | "address" | "name" | "review" | "success";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowContentViewModel.ts
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+import { BackHandler, Platform } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import type { ModularDrawerFlowRenderProps } from "LLM/features/ModularDrawer";
+import type { ContactsAddAddressFlowDrawerViewModel } from "./useContactsAddAddressFlowDrawerViewModel";
+
+type UseContactsAddAddressFlowContentViewModelOptions = Readonly<{
+  viewModel: ContactsAddAddressFlowDrawerViewModel;
+  currencyShell: ModularDrawerFlowRenderProps;
+}>;
+
+export function useContactsAddAddressFlowContentViewModel({
+  viewModel,
+  currencyShell,
+}: UseContactsAddAddressFlowContentViewModelOptions) {
+  const { currentStep, onBack: onFlowBack } = viewModel;
+  const {
+    hasBackButton: hasCurrencyBackButton,
+    onBack: onCurrencyBack,
+    onClose: onCurrencyClose,
+  } = currencyShell;
+  const handleBack = useCallback(() => {
+    if (currentStep !== "currency") {
+      onFlowBack();
+    } else if (hasCurrencyBackButton) {
+      onCurrencyBack();
+    } else {
+      onCurrencyClose();
+    }
+  }, [currentStep, hasCurrencyBackButton, onCurrencyBack, onCurrencyClose, onFlowBack]);
+  const handleClose = useCallback(() => {
+    if (currentStep === "currency") {
+      onCurrencyClose();
+    }
+  }, [currentStep, onCurrencyClose]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (Platform.OS !== "android") return;
+
+      const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
+        handleBack();
+        return true;
+      });
+
+      return () => subscription.remove();
+    }, [handleBack]),
+  );
+
+  return {
+    ...viewModel,
+    currencyShell,
+    onBack: handleBack,
+    onClose: handleClose,
+  } as const;
+}
+
+export type ContactsAddAddressFlowContentViewModel = ReturnType<
+  typeof useContactsAddAddressFlowContentViewModel
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,0 +1,93 @@
+import { Platform } from "react-native";
+import { useTranslation } from "~/context/Locale";
+import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
+import { useContactsCurrencySelectionAdapter } from "../../../../hooks/useContactsCurrencySelectionAdapter";
+import type { ContactsAddAddressDrawerStep, ContactsAddAddressFlowDrawerProps } from "./types";
+
+function resolveDrawerStep(
+  status: ContactsAddAddressFlowDrawerProps["state"]["status"],
+): ContactsAddAddressDrawerStep {
+  switch (status) {
+    case "closed":
+    case "selectingCurrency":
+      return "currency";
+    case "enteringAddress":
+      return "address";
+    case "namingAddress":
+      return "name";
+    case "reviewingAddress":
+      return "review";
+    case "success":
+      return "success";
+  }
+}
+
+export function useContactsAddAddressFlowDrawerViewModel({
+  state,
+  eligibleNetworkIds,
+  onAddressChange,
+  onAddressConfirm,
+  onBack,
+  onClose,
+  onContinueFromName,
+  onContinueFromReview,
+  onCurrencySelected,
+  onQrCodeClick,
+}: ContactsAddAddressFlowDrawerProps) {
+  const { t } = useTranslation();
+  const { isKeyboardVisible, keyboardHeight } = useKeyboardVisible({
+    eventTiming: Platform.OS === "ios" ? "will" : "did",
+  });
+  const bottomOffset =
+    isKeyboardVisible && shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
+      ? keyboardHeight
+      : 0;
+  const currencySelection = useContactsCurrencySelectionAdapter({
+    isOpen: state.status === "selectingCurrency",
+    networkIds: eligibleNetworkIds,
+    onCurrencySelected,
+    onSelectionCancelled: onClose,
+  });
+
+  return {
+    addressEntryProps:
+      state.status === "enteringAddress"
+        ? {
+            addressEntry: state.addressEntry,
+            labels: {
+              title: t("contacts.addAddressEntry.title"),
+              addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+              confirmAddress: t("contacts.addAddressEntry.confirmAddress"),
+              validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+              validAddress: t("contacts.addAddressEntry.validAddress"),
+              invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+              domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+              validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+              ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+            },
+            bottomOffset,
+            onChangeText: onAddressChange,
+            onConfirm: onAddressConfirm,
+            onQrCodeClick,
+          }
+        : null,
+    currencySelection,
+    currentStep: resolveDrawerStep(state.status),
+    isOpen: state.status !== "closed",
+    labels: {
+      name: t("contacts.addAddressFlow.name"),
+      review: t("contacts.addAddressFlow.review"),
+      success: t("contacts.addAddressFlow.success"),
+      continue: t("common.continue"),
+      done: t("common.done"),
+    },
+    onBack,
+    onContinueFromName,
+    onContinueFromReview,
+    onFinish: onClose,
+  } as const;
+}
+
+export type ContactsAddAddressFlowDrawerViewModel = ReturnType<
+  typeof useContactsAddAddressFlowDrawerViewModel
+>;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ContactDetailView } from "@features/flow-contacts";
 import { TrackScreen } from "~/analytics";
+import { ContactsAddAddressFlowDrawer } from "./components/ContactsAddAddressFlowDrawer";
 import { useContactDetailScreenViewModel } from "./useContactDetailScreenViewModel";
 
 export function ContactDetailScreen(): React.JSX.Element | null {
@@ -14,6 +15,9 @@ export function ContactDetailScreen(): React.JSX.Element | null {
     <>
       <TrackScreen category="Contacts" />
       <ContactDetailView {...viewModel.pageProps} />
+      {viewModel.addAddressFlowState.status !== "closed" ? (
+        <ContactsAddAddressFlowDrawer {...viewModel.addAddressFlowProps} />
+      ) : null}
     </>
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -4,9 +4,10 @@ import type { RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import {
   type AddAddressFlowState,
+  type AddAddressInputSource,
   type ContactDetailLabels,
   type ContactDetailViewProps,
-  useAddAddressCurrencySelectionViewModel,
+  resolveEligibleAddressCurrencyIds,
   useAddAddressFlowViewModel,
   useContactsFeature,
   useEmptyContactDetail,
@@ -17,13 +18,16 @@ import { useTranslation } from "~/context/Locale";
 import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddressValidationAdapter";
-import { useContactsCurrencySelectionAdapter } from "../../hooks/useContactsCurrencySelectionAdapter";
+import type { ContactsAddAddressFlowDrawerProps } from "./components/ContactsAddAddressFlowDrawer/types";
+
+const MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS = 200;
 
 type ContactDetailScreenViewModel =
   | Readonly<{ status: "redirecting" }>
   | Readonly<{
       status: "ready";
       addAddressFlowState: AddAddressFlowState;
+      addAddressFlowProps: ContactsAddAddressFlowDrawerProps;
       pageProps: ContactDetailViewProps;
     }>;
 
@@ -35,36 +39,40 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const navigation = useNavigation<NavigationProp>();
   const route =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWalletContactDetail>>();
-  const { isEnabled } = useContactsFeature("mobile");
+  const { isEnabled, eligibleAddressFamilies } = useContactsFeature("mobile");
   const { t } = useTranslation();
   const contact = useEmptyContactDetail(route.params.contactId);
-  const currencySelection = useContactsCurrencySelectionAdapter();
   const addressValidation = useContactsAddressValidationAdapter();
-  const { selectCurrency } = useAddAddressCurrencySelectionViewModel({
-    platform: "mobile",
-    currencySelection,
-  });
+  const eligibleNetworkIds = useMemo(
+    () => resolveEligibleAddressCurrencyIds(eligibleAddressFamilies),
+    [eligibleAddressFamilies],
+  );
   const {
     state: addAddressFlowState,
     start: startAddAddress,
     completeCurrencySelection,
+    updateAddress,
+    confirmAddress,
+    continueFromName,
+    continueFromReview,
+    goBack: goBackAddAddress,
     close: closeAddAddress,
-  } = useAddAddressFlowViewModel({ addressValidation });
+  } = useAddAddressFlowViewModel({
+    addressValidation,
+    manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
+  });
   const onAddAddress = useCallback(() => {
     if (!contact) return;
-
-    const contactId = contact.id;
-    startAddAddress(contactId);
-    void selectCurrency()
-      .then(result => {
-        if (result.status === "selected") {
-          completeCurrencySelection(contactId, result.currencyId);
-        } else if (result.status === "cancelled" || result.status === "unavailable") {
-          closeAddAddress();
-        }
-      })
-      .catch(closeAddAddress);
-  }, [closeAddAddress, completeCurrencySelection, contact, selectCurrency, startAddAddress]);
+    startAddAddress(contact.id);
+  }, [contact, startAddAddress]);
+  const onCurrencySelected = useCallback<ContactsAddAddressFlowDrawerProps["onCurrencySelected"]>(
+    currencyId => {
+      if (addAddressFlowState.status === "selectingCurrency") {
+        completeCurrencySelection(addAddressFlowState.selectedContactId, currencyId);
+      }
+    },
+    [addAddressFlowState, completeCurrencySelection],
+  );
   const onOpenLedgerWalletAddresses = useCallback(() => {
     navigation.navigate(NavigatorName.Accounts, {
       screen: ScreenName.CryptoAddresses,
@@ -73,6 +81,19 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       },
     });
   }, [navigation]);
+  const onAddressChange = useCallback(
+    (value: string, inputMethod: AddAddressInputSource) => {
+      void updateAddress(value, inputMethod);
+    },
+    [updateAddress],
+  );
+  const onQrCodeClick = useCallback(() => {
+    navigation.navigate(ScreenName.ScanRecipient, {
+      onScanned: value => {
+        void updateAddress(value, "qr_code");
+      },
+    });
+  }, [navigation, updateAddress]);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
@@ -106,6 +127,18 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   return {
     status: "ready",
     addAddressFlowState,
+    addAddressFlowProps: {
+      state: addAddressFlowState,
+      eligibleNetworkIds,
+      onAddressChange,
+      onAddressConfirm: confirmAddress,
+      onBack: goBackAddAddress,
+      onClose: closeAddAddress,
+      onContinueFromName: continueFromName,
+      onContinueFromReview: continueFromReview,
+      onCurrencySelected,
+      onQrCodeClick,
+    },
     pageProps: {
       contact,
       labels,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -62,9 +62,9 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
   });
   const onAddAddress = useCallback(() => {
-    if (!contact) return;
+    if (!contact || eligibleNetworkIds.length === 0) return;
     startAddAddress(contact.id);
-  }, [contact, startAddAddress]);
+  }, [contact, eligibleNetworkIds.length, startAddAddress]);
   const onCurrencySelected = useCallback<ContactsAddAddressFlowDrawerProps["onCurrencySelected"]>(
     currencyId => {
       if (addAddressFlowState.status === "selectingCurrency") {

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -31,8 +31,14 @@ After a successful selection, the session retains the selected contact and final
 identifiers and moves to `enteringAddress`. The `AddAddress` step owns its injected validation
 port, currency and token resolution, domain orchestration, input methods, asynchronous validation
 state, resolved-address storage, and stale-result protection. Consuming apps adapt coin bridges,
-domain services, token stores, clipboard access, and other app-owned or platform-specific
-integrations.
+domain services, token stores, and other app-owned or platform-specific integrations.
+
+The native Add Address views render the shared address-entry states and temporary Name, Validation,
+and Success steps as composable Lumen bottom-sheet content. The Flow owns their order, back
+transitions, resolved-address session and valid-only confirmation. Mobile owns the single queued
+bottom-sheet container, currency-selection adapter, translations, keyboard behavior, scanner
+routing and safe-area inset. Native paste events are classified without reading the clipboard
+proactively, while manual validation can be debounced without delaying paste or QR validation.
 
 ## Public API
 
@@ -80,9 +86,9 @@ src/
 │   │   ├── components/ContactNameInput/ (web + native)
 │   │   ├── model/                       # Contact-name validation and creation contract
 │   │   └── index.ts / web.ts / native.ts
-│   ├── AddAddress/                      # Shared currency selection and address-entry session
+│   ├── AddAddress/                      # Shared address-entry flow and native step content
 │   │   ├── model/                       # Network resolver, MAD port and address validation
-│   │   └── useAddAddressCurrencySelectionViewModel.ts / useAddAddressFlowViewModel.ts / types.ts / index.ts
+│   │   └── ContactsAddAddressEntry.native.tsx / ContactsAddAddressPlaceholderView.native.tsx / useAddAddressFlowViewModel.ts / types.ts / index.ts
 │   ├── Introduction/                    # Feature intro + Ledger Sync intro (ex featureIntroduction)
 │   │   ├── Feature/ (web dialog + native content) / LedgerSync/ (web dialog + native content)
 │   │   ├── useContactsFeatureIntroductionState.ts / resolver.ts / ports.ts / constants.ts / types.ts

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -3,6 +3,7 @@ export * from "./steps/List/native";
 export * from "./steps/AddContact";
 export * from "./steps/AddContact/native";
 export * from "./steps/AddAddress";
+export * from "./steps/AddAddress/native";
 export * from "./steps/Introduction";
 export * from "./steps/Introduction/native";
 export * from "./steps/Detail";

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import type { AddAddressEntryLabels, AddAddressEntryState } from "./types";
+import { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.native";
+
+const labels: AddAddressEntryLabels = {
+  title: "Enter address",
+  addressPlaceholder: "Address or ENS",
+  confirmAddress: "Confirm address",
+  validatingAddress: "Validating address",
+  validAddress: "Valid address",
+  invalidAddress: "Invalid address",
+  domainNotFound: "No address found for this domain",
+  validationUnavailable: "Address validation is unavailable",
+  ensDisclaimer: "ENS names resolve to wallet addresses.",
+};
+
+const VALID_ADDRESS = ContactAddressValueSchema.parse("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
+
+function renderEntry(addressEntry: AddAddressEntryState, bottomOffset?: number) {
+  const onChangeText = jest.fn();
+  const onConfirm = jest.fn();
+  const onQrCodeClick = jest.fn();
+
+  render(
+    <ContactsAddAddressEntry
+      addressEntry={addressEntry}
+      labels={labels}
+      {...(bottomOffset === undefined ? {} : { bottomOffset })}
+      onChangeText={onChangeText}
+      onConfirm={onConfirm}
+      onQrCodeClick={onQrCodeClick}
+    />,
+  );
+
+  return { onChangeText, onConfirm, onQrCodeClick };
+}
+
+describe("ContactsAddAddressEntry", () => {
+  it("should render an empty address entry with QR access and a disabled confirmation", () => {
+    const { onQrCodeClick } = renderEntry({
+      status: "empty",
+      value: "",
+      resolvedAddress: null,
+      inputMethod: null,
+    });
+
+    const addressInput = screen.getByTestId("contacts-add-address-input");
+    expect(screen.UNSAFE_getByProps({ title: "Enter address" }).props.title).toBe("Enter address");
+    expect(addressInput.props.placeholder).toBe("Address or ENS");
+    expect(screen.getByTestId("contacts-add-address-entry-screen")).toHaveStyle({
+      bottom: 0,
+      paddingBottom: 32,
+    });
+    expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
+
+    fireEvent(addressInput, "qrCodeClick");
+
+    expect(onQrCodeClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should submit manual input changes", () => {
+    const { onChangeText } = renderEntry({
+      status: "empty",
+      value: "",
+      resolvedAddress: null,
+      inputMethod: null,
+    });
+
+    fireEvent.changeText(screen.getByTestId("contacts-add-address-input"), "0");
+
+    expect(onChangeText).toHaveBeenCalledWith("0", "manual");
+  });
+
+  it("should keep the confirmation above the keyboard offset", () => {
+    renderEntry(
+      {
+        status: "empty",
+        value: "",
+        resolvedAddress: null,
+        inputMethod: null,
+      },
+      320,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-entry-screen")).toHaveStyle({
+      bottom: 320,
+      paddingBottom: 32,
+    });
+  });
+
+  it("should identify content inserted in one native event as a paste", () => {
+    const { onChangeText } = renderEntry({
+      status: "empty",
+      value: "",
+      resolvedAddress: null,
+      inputMethod: null,
+    });
+    const input = screen.getByTestId("contacts-add-address-input");
+
+    fireEvent.changeText(input, VALID_ADDRESS);
+
+    expect(onChangeText).toHaveBeenCalledWith(VALID_ADDRESS, "paste");
+  });
+
+  it.each([
+    ["0xabdc", "manual"],
+    ["0xabXYZc", "paste"],
+  ] as const)(
+    "should identify the %s insertion inside the current value as %s",
+    (value, inputMethod) => {
+      const { onChangeText } = renderEntry({
+        status: "validating",
+        value: "0xabc",
+        resolvedAddress: null,
+        inputMethod: "manual",
+      });
+
+      fireEvent.changeText(screen.getByTestId("contacts-add-address-input"), value);
+
+      expect(onChangeText).toHaveBeenCalledWith(value, inputMethod);
+    },
+  );
+
+  it("should render validation progress with confirmation disabled", () => {
+    renderEntry({
+      status: "validating",
+      value: VALID_ADDRESS,
+      resolvedAddress: null,
+      inputMethod: "manual",
+    });
+
+    expect(screen.getByTestId("contacts-add-address-input").props.helperText).toBe(
+      "Validating address",
+    );
+    expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
+  });
+
+  it("should render a valid address with confirmation enabled", () => {
+    const { onConfirm } = renderEntry({
+      status: "valid",
+      value: VALID_ADDRESS,
+      resolvedAddress: VALID_ADDRESS,
+      inputMethod: "manual",
+    });
+
+    expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
+      helperText: "Valid address",
+      status: "success",
+    });
+    expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(false);
+
+    fireEvent.press(screen.getByTestId("contacts-add-address-confirm"));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["invalid_format", "Invalid address"],
+    ["domain_not_found", "No address found for this domain"],
+  ] as const)("should render the %s error", (error, expectedMessage) => {
+    renderEntry({
+      status: "invalid",
+      value: "invalid",
+      resolvedAddress: null,
+      inputMethod: error === "domain_not_found" ? "ens" : "manual",
+      error,
+    });
+
+    expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
+      helperText: expectedMessage,
+      status: "error",
+    });
+    expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
+  });
+
+  it("should render validation unavailability as a blocking error", () => {
+    renderEntry({
+      status: "unavailable",
+      value: VALID_ADDRESS,
+      resolvedAddress: null,
+      inputMethod: "manual",
+    });
+
+    expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
+      helperText: "Address validation is unavailable",
+      status: "error",
+    });
+    expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
+  });
+
+  it("should render the ENS disclaimer when the shared state marks the input as ENS", () => {
+    renderEntry({
+      status: "valid",
+      value: "ledger.eth",
+      resolvedAddress: VALID_ADDRESS,
+      inputMethod: "ens",
+    });
+
+    expect(screen.getByTestId("contacts-add-address-ens-disclaimer").props.description).toBe(
+      "ENS names resolve to wallet addresses.",
+    );
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { ContactsAddAddressEntryView } from "./ContactsAddAddressEntryView.native";
+import type { ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.types";
+import { useContactsAddAddressEntryViewModel } from "./useContactsAddAddressEntryViewModel.native";
+
+export function ContactsAddAddressEntry(props: ContactsAddAddressEntryProps): React.JSX.Element {
+  const viewModel = useContactsAddAddressEntryViewModel(props);
+
+  return <ContactsAddAddressEntryView {...viewModel} />;
+}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.types.ts
@@ -1,0 +1,24 @@
+import type { AddAddressEntryLabels, AddAddressEntryState, AddAddressInputSource } from "./types";
+
+export type ContactsAddAddressEntryProps = Readonly<{
+  addressEntry: AddAddressEntryState;
+  labels: AddAddressEntryLabels;
+  bottomOffset?: number;
+  onChangeText: (value: string, inputMethod: AddAddressInputSource) => void;
+  onConfirm: () => void;
+  onQrCodeClick: () => void;
+}>;
+
+export type ContactsAddAddressEntryViewProps = Readonly<{
+  value: string;
+  labels: AddAddressEntryLabels;
+  bottomOffset: number;
+  bottomPadding: number;
+  inputStatus?: "error" | "success";
+  helperText?: string;
+  showEnsDisclaimer: boolean;
+  isConfirmEnabled: boolean;
+  onAddressChange: (value: string) => void;
+  onConfirm: () => void;
+  onQrCodeClick: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import {
+  AddressInput,
+  Banner,
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsAddAddressEntryViewProps } from "./ContactsAddAddressEntry.types";
+
+export function ContactsAddAddressEntryView({
+  value,
+  labels,
+  bottomOffset,
+  bottomPadding,
+  inputStatus,
+  helperText,
+  showEnsDisclaimer,
+  isConfirmEnabled,
+  onAddressChange,
+  onConfirm,
+  onQrCodeClick,
+}: ContactsAddAddressEntryViewProps): React.JSX.Element {
+  return (
+    <BottomSheetView
+      testID="contacts-add-address-entry-screen"
+      style={{ bottom: bottomOffset, paddingBottom: bottomPadding }}
+    >
+      <BottomSheetHeader density="expanded" title={labels.title} />
+      <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
+        <Box lx={{ gap: "s16" }}>
+          <AddressInput
+            testID="contacts-add-address-input"
+            prefix=""
+            value={value}
+            placeholder={labels.addressPlaceholder}
+            onChangeText={onAddressChange}
+            onQrCodeClick={onQrCodeClick}
+            status={inputStatus}
+            helperText={helperText}
+            autoFocus
+            autoCapitalize="none"
+            autoCorrect={false}
+            spellCheck={false}
+          />
+          {showEnsDisclaimer ? (
+            <Banner
+              testID="contacts-add-address-ens-disclaimer"
+              appearance="info"
+              description={labels.ensDisclaimer}
+            />
+          ) : null}
+        </Box>
+        <Button
+          testID="contacts-add-address-confirm"
+          appearance="base"
+          size="lg"
+          isFull
+          disabled={!isConfirmEnabled}
+          onPress={onConfirm}
+        >
+          {labels.confirmAddress}
+        </Button>
+      </Box>
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressPlaceholderView.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressPlaceholderView.native.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { ContactsAddAddressPlaceholderView } from "./ContactsAddAddressPlaceholderView.native";
+
+describe("ContactsAddAddressPlaceholderView", () => {
+  it("should render its content and continue the flow", () => {
+    const onContinue = jest.fn();
+
+    render(
+      <ContactsAddAddressPlaceholderView
+        title="Name"
+        buttonLabel="Continue"
+        testID="name-screen"
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(screen.getByTestId("name-screen")).toHaveStyle({
+      bottom: 0,
+      paddingBottom: 32,
+    });
+    expect(screen.getByText("Name")).toBeVisible();
+
+    fireEvent.press(screen.getByTestId("name-screen-continue"));
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressPlaceholderView.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressPlaceholderView.native.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { BottomSheetHeader, BottomSheetView, Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { AddAddressPlaceholderViewProps } from "./types";
+
+export function ContactsAddAddressPlaceholderView({
+  title,
+  buttonLabel,
+  testID,
+  onContinue,
+}: AddAddressPlaceholderViewProps): React.JSX.Element {
+  return (
+    <BottomSheetView testID={testID} style={{ bottom: 0, paddingBottom: 32 }}>
+      <BottomSheetHeader density="expanded" />
+      <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between" }}>
+        <Box lx={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+          <Text typography="heading3SemiBold" lx={{ color: "base" }}>
+            {title}
+          </Text>
+        </Box>
+        <Button
+          testID={`${testID}-continue`}
+          appearance="base"
+          size="lg"
+          isFull
+          onPress={onContinue}
+        >
+          {buttonLabel}
+        </Button>
+      </Box>
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -19,11 +19,14 @@ export {
   type UseAddAddressCurrencySelectionViewModelOptions,
 } from "./useAddAddressCurrencySelectionViewModel";
 export type {
+  AddAddressEntryLabels,
   AddAddressEntryState,
   AddAddressFlowState,
   AddAddressFlowViewModel,
   AddAddressInputMethod,
   AddAddressInputSource,
+  AddAddressPlaceholderViewProps,
+  ValidAddAddressEntryState,
 } from "./types";
 export {
   useAddAddressFlowViewModel,

--- a/features/flow/contacts/src/steps/AddAddress/native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/native.ts
@@ -1,0 +1,3 @@
+export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.native";
+export type { ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.types";
+export { ContactsAddAddressPlaceholderView } from "./ContactsAddAddressPlaceholderView.native";

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -36,18 +36,29 @@ export type AddAddressEntryState =
       inputMethod: AddAddressInputSource;
     }>;
 
+export type ValidAddAddressEntryState = Extract<AddAddressEntryState, { status: "valid" }>;
+
+type AddAddressSession = Readonly<{
+  selectedContactId: ContactId;
+  selectedCurrencyId: ContactAddress["currencyId"];
+  addressEntry: AddAddressEntryState;
+}>;
+
+type ConfirmedAddAddressSession = Omit<AddAddressSession, "addressEntry"> &
+  Readonly<{
+    addressEntry: ValidAddAddressEntryState;
+  }>;
+
 export type AddAddressFlowState =
   | Readonly<{ status: "closed" }>
   | Readonly<{
       status: "selectingCurrency";
       selectedContactId: ContactId;
     }>
-  | Readonly<{
-      status: "enteringAddress";
-      selectedContactId: ContactId;
-      selectedCurrencyId: ContactAddress["currencyId"];
-      addressEntry: AddAddressEntryState;
-    }>;
+  | (AddAddressSession & Readonly<{ status: "enteringAddress" }>)
+  | (ConfirmedAddAddressSession & Readonly<{ status: "namingAddress" }>)
+  | (ConfirmedAddAddressSession & Readonly<{ status: "reviewingAddress" }>)
+  | (ConfirmedAddAddressSession & Readonly<{ status: "success" }>);
 
 export type AddAddressFlowViewModel = Readonly<{
   state: AddAddressFlowState;
@@ -57,5 +68,28 @@ export type AddAddressFlowViewModel = Readonly<{
     currencyId: ContactAddress["currencyId"],
   ) => void;
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
+  confirmAddress: () => void;
+  continueFromName: () => void;
+  continueFromReview: () => void;
+  goBack: () => void;
   close: () => void;
+}>;
+
+export type AddAddressEntryLabels = Readonly<{
+  title: string;
+  addressPlaceholder: string;
+  confirmAddress: string;
+  validatingAddress: string;
+  validAddress: string;
+  invalidAddress: string;
+  domainNotFound: string;
+  validationUnavailable: string;
+  ensDisclaimer: string;
+}>;
+
+export type AddAddressPlaceholderViewProps = Readonly<{
+  title: string;
+  buttonLabel: string;
+  testID: string;
+  onContinue: () => void;
 }>;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -25,7 +25,12 @@ const UNAVAILABLE_ADDRESS_VALIDATION: ContactsAddressValidationPort = {
 
 export type UseAddAddressFlowViewModelOptions = Readonly<{
   addressValidation?: ContactsAddressValidationPort;
+  manualValidationDebounceMs?: number;
 }>;
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, delayMs));
+}
 
 function resolveAddressEntryState(
   value: string,
@@ -106,6 +111,7 @@ function applyAddressEntryState(
 
 export function useAddAddressFlowViewModel({
   addressValidation = UNAVAILABLE_ADDRESS_VALIDATION,
+  manualValidationDebounceMs = 0,
 }: UseAddAddressFlowViewModelOptions = {}): AddAddressFlowViewModel {
   const [state, setState] = useState<AddAddressFlowState>(CLOSED_ADD_ADDRESS_FLOW_STATE);
   const validationRequestId = useRef(0);
@@ -168,6 +174,13 @@ export function useAddAddressFlowViewModel({
         ),
       );
 
+      if (inputMethod === "manual" && manualValidationDebounceMs > 0) {
+        await wait(manualValidationDebounceMs);
+        if (validationRequestId.current !== requestId) {
+          return;
+        }
+      }
+
       const validationResult = await requestAddressValidation(
         addressValidation,
         selectedCurrencyId,
@@ -187,8 +200,62 @@ export function useAddAddressFlowViewModel({
         ),
       );
     },
-    [addressValidation, state],
+    [addressValidation, manualValidationDebounceMs, state],
   );
+  const confirmAddress = useCallback(() => {
+    cancelAddressValidation();
+    setState(currentState => {
+      if (
+        currentState.status !== "enteringAddress" ||
+        currentState.addressEntry.status !== "valid"
+      ) {
+        return currentState;
+      }
+
+      return {
+        status: "namingAddress",
+        selectedContactId: currentState.selectedContactId,
+        selectedCurrencyId: currentState.selectedCurrencyId,
+        addressEntry: currentState.addressEntry,
+      };
+    });
+  }, [cancelAddressValidation]);
+  const continueFromName = useCallback(() => {
+    setState(currentState =>
+      currentState.status === "namingAddress"
+        ? { ...currentState, status: "reviewingAddress" }
+        : currentState,
+    );
+  }, []);
+  const continueFromReview = useCallback(() => {
+    setState(currentState =>
+      currentState.status === "reviewingAddress"
+        ? { ...currentState, status: "success" }
+        : currentState,
+    );
+  }, []);
+  const goBack = useCallback(() => {
+    cancelAddressValidation();
+    setState(currentState => {
+      switch (currentState.status) {
+        case "closed":
+          return currentState;
+        case "selectingCurrency":
+          return CLOSED_ADD_ADDRESS_FLOW_STATE;
+        case "enteringAddress":
+          return {
+            status: "selectingCurrency",
+            selectedContactId: currentState.selectedContactId,
+          };
+        case "namingAddress":
+          return { ...currentState, status: "enteringAddress" };
+        case "reviewingAddress":
+          return { ...currentState, status: "namingAddress" };
+        case "success":
+          return currentState;
+      }
+    });
+  }, [cancelAddressValidation]);
   const close = useCallback(() => {
     cancelAddressValidation();
     setState(CLOSED_ADD_ADDRESS_FLOW_STATE);
@@ -201,6 +268,10 @@ export function useAddAddressFlowViewModel({
     start,
     completeCurrencySelection,
     updateAddress,
+    confirmAddress,
+    continueFromName,
+    continueFromReview,
+    goBack,
     close,
   };
 }

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -191,6 +191,75 @@ describe("useAddAddressFlowViewModel", () => {
     });
   });
 
+  it("should advance through the placeholder steps with the resolved address", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort({
+      status: "valid",
+      resolvedAddress: RESOLVED_ADDRESS,
+      isDomain: true,
+    });
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contactId));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    await act(() => result.current.updateAddress("ledger.eth", "manual"));
+    act(() => result.current.confirmAddress());
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressEntry: {
+        value: "ledger.eth",
+        resolvedAddress: RESOLVED_ADDRESS,
+      },
+    });
+
+    act(() => result.current.continueFromName());
+    expect(result.current.state.status).toBe("reviewingAddress");
+
+    act(() => result.current.continueFromReview());
+    expect(result.current.state.status).toBe("success");
+  });
+
+  it("should not confirm an invalid address", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort({ status: "invalid_format" });
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contactId));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    await act(() => result.current.updateAddress("invalid", "manual"));
+    act(() => result.current.confirmAddress());
+
+    expect(result.current.state.status).toBe("enteringAddress");
+  });
+
+  it("should navigate back through the composed flow", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contactId));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.continueFromName());
+
+    act(() => result.current.goBack());
+    expect(result.current.state.status).toBe("namingAddress");
+
+    act(() => result.current.goBack());
+    expect(result.current.state.status).toBe("enteringAddress");
+
+    act(() => result.current.goBack());
+    expect(result.current.state).toEqual({
+      status: "selectingCurrency",
+      selectedContactId: contactId,
+    });
+
+    act(() => result.current.goBack());
+    expect(result.current.state).toEqual({ status: "closed" });
+  });
+
   it.each([
     ["invalid_format", "manual"],
     ["domain_not_found", "ens"],
@@ -306,6 +375,66 @@ describe("useAddAddressFlowViewModel", () => {
       });
       await update;
     });
+  });
+
+  it("should debounce manual validation and only validate the latest value", async () => {
+    jest.useFakeTimers();
+    try {
+      const contactId = mockContact().id;
+      const addressValidation = createValidationPort();
+      const { result } = renderHook(() =>
+        useAddAddressFlowViewModel({
+          addressValidation,
+          manualValidationDebounceMs: 200,
+        }),
+      );
+
+      act(() => result.current.start(contactId));
+      act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+
+      let firstUpdate = Promise.resolve();
+      let secondUpdate = Promise.resolve();
+      act(() => {
+        firstUpdate = result.current.updateAddress("first", "manual");
+        secondUpdate = result.current.updateAddress("second", "manual");
+      });
+
+      expect(addressValidation.validateAddress).not.toHaveBeenCalled();
+      expect(result.current.state).toMatchObject({
+        status: "enteringAddress",
+        addressEntry: { status: "validating", value: "second" },
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(200);
+        await Promise.all([firstUpdate, secondUpdate]);
+      });
+
+      expect(addressValidation.validateAddress).toHaveBeenCalledTimes(1);
+      expect(addressValidation.validateAddress).toHaveBeenCalledWith({
+        currencyId: ETHEREUM_CURRENCY_ID,
+        address: "second",
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("should validate pasted input without the manual debounce", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() =>
+      useAddAddressFlowViewModel({
+        addressValidation,
+        manualValidationDebounceMs: 200,
+      }),
+    );
+
+    act(() => result.current.start(contactId));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "paste"));
+
+    expect(addressValidation.validateAddress).toHaveBeenCalledTimes(1);
   });
 
   it("should reset to empty without validating blank input", async () => {

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
@@ -1,0 +1,111 @@
+import { useCallback } from "react";
+import type {
+  ContactsAddAddressEntryProps,
+  ContactsAddAddressEntryViewProps,
+} from "./ContactsAddAddressEntry.types";
+import type { AddAddressEntryLabels, AddAddressEntryState } from "./types";
+
+type AddressInputPresentation = Readonly<{
+  status?: "error" | "success";
+  helperText?: string;
+  showEnsDisclaimer: boolean;
+  isConfirmEnabled: boolean;
+}>;
+
+function getInsertedCharacterCount(previousValue: string, nextValue: string): number {
+  // Native only exposes the full next value, so isolate the changed middle section to detect paste.
+  let prefixLength = 0;
+  while (
+    prefixLength < previousValue.length &&
+    prefixLength < nextValue.length &&
+    previousValue[prefixLength] === nextValue[prefixLength]
+  ) {
+    prefixLength += 1;
+  }
+
+  let suffixLength = 0;
+  while (
+    suffixLength < previousValue.length - prefixLength &&
+    suffixLength < nextValue.length - prefixLength &&
+    previousValue[previousValue.length - 1 - suffixLength] ===
+      nextValue[nextValue.length - 1 - suffixLength]
+  ) {
+    suffixLength += 1;
+  }
+
+  return nextValue.length - prefixLength - suffixLength;
+}
+
+function resolveAddressInputPresentation(
+  addressEntry: AddAddressEntryState,
+  labels: AddAddressEntryLabels,
+): AddressInputPresentation {
+  switch (addressEntry.status) {
+    case "empty":
+      return {
+        showEnsDisclaimer: false,
+        isConfirmEnabled: false,
+      };
+    case "validating":
+      return {
+        helperText: labels.validatingAddress,
+        showEnsDisclaimer: false,
+        isConfirmEnabled: false,
+      };
+    case "valid":
+      return {
+        status: "success",
+        helperText: labels.validAddress,
+        showEnsDisclaimer: addressEntry.inputMethod === "ens",
+        isConfirmEnabled: true,
+      };
+    case "invalid":
+      return {
+        status: "error",
+        helperText:
+          addressEntry.error === "domain_not_found" ? labels.domainNotFound : labels.invalidAddress,
+        showEnsDisclaimer: addressEntry.inputMethod === "ens",
+        isConfirmEnabled: false,
+      };
+    case "unavailable":
+      return {
+        status: "error",
+        helperText: labels.validationUnavailable,
+        showEnsDisclaimer: false,
+        isConfirmEnabled: false,
+      };
+  }
+}
+
+export function useContactsAddAddressEntryViewModel({
+  addressEntry,
+  labels,
+  bottomOffset = 0,
+  onChangeText,
+  onConfirm,
+  onQrCodeClick,
+}: ContactsAddAddressEntryProps): ContactsAddAddressEntryViewProps {
+  const presentation = resolveAddressInputPresentation(addressEntry, labels);
+  const onAddressChange = useCallback(
+    (value: string) => {
+      const inputMethod =
+        getInsertedCharacterCount(addressEntry.value, value) > 1 ? "paste" : "manual";
+      onChangeText(value, inputMethod);
+    },
+    [addressEntry.value, onChangeText],
+  );
+
+  return {
+    value: addressEntry.value,
+    labels,
+    bottomOffset,
+    bottomPadding: 32,
+    inputStatus: presentation.status,
+    helperText: presentation.helperText,
+    showEnsDisclaimer: presentation.showEnsDisclaimer,
+    isConfirmEnabled: presentation.isConfirmEnabled,
+    onAddressChange,
+    onConfirm,
+    onQrCodeClick,
+  };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Flow transitions and Native views are covered by 41 tests; the Mobile currency adapter and Contacts integration are covered by 24 tests, including the complete QR-to-success sequence.
- [x] **Impact of the changes:**
      Verify that Add Address remains in one drawer from currency selection through Address, Name, Validation and Success; verify Asset/Network back navigation, QR scanner return, Android/header back and the 32-point bottom spacing.

### 📝 Description

Compose the Contacts Add Address flow in a single reusable `QueuedDrawerFlow`.

- Reuse the extracted Asset/Network currency selection without opening the full Redux MAD flow.
- Render the shared address-entry screen in the same drawer.
- Keep the resolved address and selected currency in the shared Flow state.
- Add replaceable Name, Validation and Success placeholders with bottom CTAs.
- Preserve the session while navigating to and returning from the QR scanner.
- Remove the dedicated second address-entry drawer.

This PR is stacked on PR #20175.

### Screenshots

https://github.com/user-attachments/assets/e7932bcd-f450-4d8f-9b1a-62f263840e70


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33917

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
