### PR TITLE
[LWDM] fix(LIVE-32926): open swap status drawer from multi-step and unstick its loading state

### DIFF
--- a/.changeset/swap-multistep-status-drawer.md
+++ b/.changeset/swap-multistep-status-drawer.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": patch
+"@ledgerhq/live-common": patch
+---
+
+Open the swap transaction status drawer directly when the multi-step flow redirects to history, so it no longer depends on the just-broadcast operation already being synced into local history. While the swap operation is still unresolved, the status controller now retries on a short interval so the status section stops showing skeletons within seconds instead of waiting a full poll cycle.

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/__tests__/useSwapCustomHandlers.test.ts
@@ -4,6 +4,7 @@ import BigNumber from "bignumber.js";
 import { renderHook } from "@tests/test-renderer";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { BASE_NAVIGATOR_ID, NavigatorName, ScreenName } from "~/const";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 import { useSwapCustomHandlers } from "../index";
 
 jest.mock("@react-navigation/native", () => ({
@@ -276,17 +277,26 @@ describe("useSwapCustomHandlers", () => {
       callHandler();
 
       expect(mockResetWebview).toHaveBeenCalledTimes(1);
+      // Without a swapId there is nothing to open, so the status drawer stays closed.
+      expect(MOCK_DISPATCH).not.toHaveBeenCalledWith(
+        openSwapTransactionStatusDrawer(expect.anything()),
+      );
     });
 
-    it("passes swapId to SwapHistory when swapRedirectToHistory handler is called with params", () => {
+    it("passes swapId to SwapHistory and opens the status drawer when called with params", () => {
       mockBaseNavigatorOnSwapTab();
 
-      callHandler({ params: { swapId: "swap-123" } });
+      callHandler({ params: { swapId: "swap-123", provider: "lifi" } });
 
       expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SwapSubScreens, {
         screen: ScreenName.SwapHistory,
         params: { swapId: "swap-123" },
       });
+      // The status drawer opens directly with the forwarded swapId/provider so it
+      // does not depend on the swap operation being synced into local history first.
+      expect(MOCK_DISPATCH).toHaveBeenCalledWith(
+        openSwapTransactionStatusDrawer({ swapId: "swap-123", provider: "lifi" }),
+      );
     });
   });
 

--- a/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/LiveApp/customHandlers/index.ts
@@ -19,6 +19,7 @@ import { getTransactionByHash } from "./getTransactionByHash";
 import { saveSwapToHistory } from "./saveSwapToHistory";
 import { useCustomExchangeHandlers } from "~/components/WebPTXPlayer/CustomHandlers";
 import { ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
+import { openSwapTransactionStatusDrawer } from "~/reducers/swapTransactionStatusDrawer";
 import type { SwapHistoryParams } from "../../types";
 import { openSwapSubScreens, type SwapBaseNavigation } from "../../navigation/openSwapSubScreens";
 
@@ -99,8 +100,25 @@ export function useSwapCustomHandlers(
       // it to its initial URL. The Swap tab is already blurred here, hence the reset is
       // re-asserted on focus by useSwapLiveAppState.
       resetWebview();
+
+      // Open the transaction status drawer directly, mirroring the native
+      // SwapPendingOperation success screen. The multi-step flow reaches history
+      // through this webview redirect (not the native success screen), so relying
+      // on route-param matching against the synced swap history is racy on mobile —
+      // the just-broadcast operation may not yet be in the history list. Dispatching
+      // here opens the drawer immediately; useAutoOpenSwapDrawer still covers the
+      // fallback once the operation resolves. Independent of the navigation strategy
+      // above: the status drawer is a global drawer, mounted outside the navigators.
+      if (params?.swapId) {
+        dispatch(
+          openSwapTransactionStatusDrawer({
+            swapId: params.swapId,
+            provider: params.provider,
+          }),
+        );
+      }
     },
-    [navigation, resetWebview],
+    [navigation, resetWebview, dispatch],
   );
 
   const walletAPISwapHandlers = useCustomExchangeHandlers({

--- a/apps/ledger-live-mobile/src/screens/Swap/types.ts
+++ b/apps/ledger-live-mobile/src/screens/Swap/types.ts
@@ -50,6 +50,7 @@ export type SwapPendingOperation = {
 
 export type SwapHistoryParams = {
   swapId?: string;
+  provider?: string;
 };
 
 export interface DefaultAccountSwapParamList {

--- a/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.test.tsx
+++ b/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.test.tsx
@@ -21,6 +21,8 @@ jest.mock("../../../wallet-api/Exchange/transactionStatus/index", () => ({
 
 const mockedGetTransactionStatus = jest.mocked(getTransactionStatus);
 const STATUS_POLL_INTERVAL_MS = 60_000;
+const UNRESOLVED_STATUS_POLL_INTERVAL_MS = 3_000;
+const POLL_INTERVALS = new Set([STATUS_POLL_INTERVAL_MS, UNRESOLVED_STATUS_POLL_INTERVAL_MS]);
 let setTimeoutSpy: jest.SpiedFunction<typeof global.setTimeout> | undefined;
 
 function makeTransactionStatusResponse(
@@ -42,7 +44,7 @@ function captureStatusPollTimeout() {
     callback: () => unknown,
     delay?: number,
   ) => {
-    if (delay === STATUS_POLL_INTERVAL_MS) {
+    if (delay !== undefined && POLL_INTERVALS.has(delay)) {
       runStatusPoll = async () => {
         await callback();
       };
@@ -107,6 +109,46 @@ describe("useSwapTransactionStatusController", () => {
     });
 
     expect(mockedGetTransactionStatus).toHaveBeenCalledTimes(2);
+    unmount();
+  });
+
+  it("retries quickly while the swap operation is not yet resolved", async () => {
+    captureStatusPollTimeout();
+    // Pending status but no send/receive accounts: the operation has not been
+    // found in local history yet, so the status section is still on skeletons.
+    mockedGetTransactionStatus.mockResolvedValue(makeTransactionStatusResponse());
+
+    const { unmount } = renderController();
+
+    await flushAsyncEffects();
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      UNRESOLVED_STATUS_POLL_INTERVAL_MS,
+    );
+    expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), STATUS_POLL_INTERVAL_MS);
+    unmount();
+  });
+
+  it("polls at the steady interval once the swap operation is resolved", async () => {
+    captureStatusPollTimeout();
+    mockedGetTransactionStatus.mockResolvedValue(
+      makeTransactionStatusResponse({
+        status: "pending",
+        fromAccountId: "from-account",
+        toAccountId: "to-account",
+      }),
+    );
+
+    const { unmount } = renderController();
+
+    await flushAsyncEffects();
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), STATUS_POLL_INTERVAL_MS);
+    expect(setTimeoutSpy).not.toHaveBeenCalledWith(
+      expect.any(Function),
+      UNRESOLVED_STATUS_POLL_INTERVAL_MS,
+    );
     unmount();
   });
 

--- a/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.test.tsx
+++ b/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.test.tsx
@@ -3,6 +3,7 @@
  */
 import "../../../__tests__/test-helpers/dom-polyfill";
 import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
+import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getTransactionStatus } from "../../../wallet-api/Exchange/transactionStatus/index";
 import type { GetTransactionStatusResponse } from "../../../wallet-api/Exchange/transactionStatus/index";
@@ -55,6 +56,23 @@ function captureStatusPollTimeout() {
   }) as typeof setTimeout);
 
   return () => runStatusPoll;
+}
+
+/** Account whose `swapHistory` holds `swap-1` but whose on-chain operation has not synced yet. */
+function accountHoldingSwap(id: string) {
+  const account = genAccount(id, { operationsSize: 0 });
+  account.swapHistory = [
+    {
+      swapId: "swap-1",
+      provider: "lifi",
+      status: "pending",
+      receiverAccountId: "to-account",
+      operationId: `${account.id}-0xabc-OUT`,
+      fromAmount: new BigNumber(1),
+      toAmount: new BigNumber(2),
+    },
+  ];
+  return account;
 }
 
 async function flushAsyncEffects() {
@@ -149,6 +167,42 @@ describe("useSwapTransactionStatusController", () => {
       expect.any(Function),
       UNRESOLVED_STATUS_POLL_INTERVAL_MS,
     );
+    unmount();
+  });
+
+  it("syncs the account holding the swap while its operation is unresolved", async () => {
+    captureStatusPollTimeout();
+    const account = accountHoldingSwap("swap-status-unresolved");
+    // Pending status with no send/receive accounts: the operation has not surfaced in
+    // local history yet, so the status UI would otherwise sit on skeletons.
+    mockedGetTransactionStatus.mockResolvedValue(makeTransactionStatusResponse());
+
+    const { unmount } = renderController({ accounts: [account] });
+
+    await flushAsyncEffects();
+
+    expect(mockBridgeSync).toHaveBeenCalledWith({
+      type: "SYNC_SOME_ACCOUNTS",
+      accountIds: [account.id],
+      priority: 100,
+      reason: "swap-transaction-status",
+    });
+    unmount();
+  });
+
+  it("does not sync when no local swap history entry exists for the swap", async () => {
+    captureStatusPollTimeout();
+    // Without a swapHistory entry the history mapper can never resolve this swap, so
+    // syncing accounts would be pointless work.
+    const account = genAccount("swap-status-no-entry", { operationsSize: 0 });
+    account.swapHistory = [];
+    mockedGetTransactionStatus.mockResolvedValue(makeTransactionStatusResponse());
+
+    const { unmount } = renderController({ accounts: [account] });
+
+    await flushAsyncEffects();
+
+    expect(mockBridgeSync).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.ts
+++ b/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.ts
@@ -19,6 +19,11 @@ import type { AccountLike } from "@ledgerhq/types-live";
 const SOFT_DEADLINE_MS = 5_000;
 const ACCOUNT_SYNC_INTERVAL_MS = 10_000;
 const STATUS_POLL_INTERVAL_MS = 60_000;
+// While the swap operation is not yet resolved from local history (e.g. right
+// after opening the status UI for a just-broadcast swap), the status section is
+// stuck on skeletons. Retry quickly so it fills in within seconds of the
+// operation being synced, instead of waiting a full STATUS_POLL_INTERVAL_MS.
+const UNRESOLVED_STATUS_POLL_INTERVAL_MS = 3_000;
 const STATUS_QUERY_KEY = "swap-transaction-status";
 
 export type SwapTransactionStatusControllerViewModel = {
@@ -91,8 +96,10 @@ export function useSwapTransactionStatusController({
     };
 
     const scheduleNextPoll = (response: GetTransactionStatusResponse | undefined) => {
-      if (!cancelled && shouldRetryTransactionStatus(response)) {
-        timeout = setTimeout(pollTransactionStatus, STATUS_POLL_INTERVAL_MS);
+      if (cancelled) return;
+      const delay = getNextStatusPollDelay(response);
+      if (delay !== null) {
+        timeout = setTimeout(pollTransactionStatus, delay);
       }
     };
 
@@ -158,6 +165,28 @@ function shouldRetryTransactionStatus(response: GetTransactionStatusResponse | u
     !response.status ||
     shouldPollSwapTransactionStatus(response.status)
   );
+}
+
+/**
+ * A swap is considered resolved once its operation has been found in local
+ * history, which is what surfaces the send/receive accounts and unblocks the
+ * status section from its skeleton state.
+ */
+function isSwapOperationResolved(response: GetTransactionStatusResponse | undefined): boolean {
+  return Boolean(response?.status && response.fromAccountId && response.toAccountId);
+}
+
+/**
+ * How long to wait before the next status poll, or `null` to stop polling.
+ * Unresolved swaps are retried on a short interval so the UI stops showing
+ * skeletons quickly; resolved (still pending) swaps fall back to the slower
+ * steady-state interval.
+ */
+function getNextStatusPollDelay(response: GetTransactionStatusResponse | undefined): number | null {
+  if (!shouldRetryTransactionStatus(response)) return null;
+  return isSwapOperationResolved(response)
+    ? STATUS_POLL_INTERVAL_MS
+    : UNRESOLVED_STATUS_POLL_INTERVAL_MS;
 }
 
 function useOnChainConfirmationSignal({

--- a/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.ts
+++ b/libs/ledger-live-common/src/exchange/swapTransactionStatus/hooks/useSwapTransactionStatusController.ts
@@ -24,6 +24,7 @@ const STATUS_POLL_INTERVAL_MS = 60_000;
 // stuck on skeletons. Retry quickly so it fills in within seconds of the
 // operation being synced, instead of waiting a full STATUS_POLL_INTERVAL_MS.
 const UNRESOLVED_STATUS_POLL_INTERVAL_MS = 3_000;
+const UNRESOLVED_ACCOUNT_SYNC_INTERVAL_MS = 10_000;
 const STATUS_QUERY_KEY = "swap-transaction-status";
 
 export type SwapTransactionStatusControllerViewModel = {
@@ -132,6 +133,13 @@ export function useSwapTransactionStatusController({
     },
   });
 
+  useUnresolvedSwapOperationSync({
+    accounts,
+    swapId: params.swapId,
+    isResolved: isSwapOperationResolved(details),
+    enabled: state.phase !== "settled_visible",
+  });
+
   useEffect(() => {
     const handle = setTimeout(
       () => {
@@ -187,6 +195,65 @@ function getNextStatusPollDelay(response: GetTransactionStatusResponse | undefin
   return isSwapOperationResolved(response)
     ? STATUS_POLL_INTERVAL_MS
     : UNRESOLVED_STATUS_POLL_INTERVAL_MS;
+}
+
+/**
+ * Asks the bridge to sync the account holding this swap until its on-chain operation
+ * shows up in local history.
+ *
+ * `getCompleteSwapHistory` drops any swap whose operation is not yet in `operations` /
+ * `pendingOperations`, which leaves the status UI on skeletons (and the swap missing
+ * from the history list) until some unrelated sync happens to run. The confirmation
+ * signal below cannot cover this: it is keyed on `operationHash`, which is only known
+ * once the operation has already been found.
+ *
+ * Only the account that already holds the swap in `swapHistory` is synced — without
+ * such an entry syncing cannot resolve the swap anyway, since the history mapper only
+ * walks `swapHistory`, so we stay idle rather than sync accounts for nothing.
+ */
+function useUnresolvedSwapOperationSync({
+  accounts,
+  swapId,
+  isResolved,
+  enabled,
+}: {
+  accounts: AccountLike[];
+  swapId: string;
+  isResolved: boolean;
+  enabled: boolean;
+}): void {
+  const sync = useBridgeSync();
+  const flattenedAccounts = useMemo(() => flattenAccounts(accounts), [accounts]);
+  const syncAccountId = useMemo(
+    () =>
+      resolveSyncAccountId(flattenedAccounts, findSwapHistoryAccountId(flattenedAccounts, swapId)),
+    [flattenedAccounts, swapId],
+  );
+
+  useEffect(() => {
+    if (!enabled || isResolved || !syncAccountId) return;
+
+    const requestSync = () =>
+      sync({
+        type: "SYNC_SOME_ACCOUNTS",
+        accountIds: [syncAccountId],
+        priority: 100,
+        reason: STATUS_QUERY_KEY,
+      });
+
+    // Sync straight away so a just-broadcast swap resolves in one round trip instead of
+    // waiting out the first interval, then keep retrying until it resolves.
+    requestSync();
+    const handle = setInterval(requestSync, UNRESOLVED_ACCOUNT_SYNC_INTERVAL_MS);
+    return () => clearInterval(handle);
+  }, [enabled, isResolved, sync, syncAccountId]);
+}
+
+/** Id of the account whose `swapHistory` holds `swapId`, if any. */
+function findSwapHistoryAccountId(accounts: AccountLike[], swapId: string): string | undefined {
+  return accounts.find(account =>
+    account.swapHistory?.some(swapOperation => swapOperation.swapId === swapId),
+  )?.id;
 }
 
 function useOnChainConfirmationSignal({


### PR DESCRIPTION
<!-- stac-man:stack-start -->
**Stack** _(managed by [stac-man](https://github.com/bluegardenproject/stac-man))_

- #20110 fix/LIVE-34563-swap-history-replace-nav
- **#20183 fix/LIVE-32926-multi-step-swap-status-drawer ← this PR**
<!-- stac-man:stack-end -->

### 📝 Description

Two related fixes for the Swap Transaction Status UI when reached from the **multi-step** flow.

**1. The status drawer never opened (mobile)**

`navigateToSwapHistory` only forwarded `swapId` as a route param, leaving `useAutoOpenSwapDrawer` to find the matching operation in the loaded history sections. That match depends on `getCompleteSwapHistory`, which filters out any swap whose on-chain operation is not yet in `account.operations` / `pendingOperations`. For a just-broadcast swap the operation is usually not there yet, so nothing matched and the drawer never opened — while tapping the row manually always worked (it opens the drawer directly, no lookup).

The handler now also dispatches `openSwapTransactionStatusDrawer({ swapId, provider })` directly, mirroring what the native `SwapPendingOperation` success screen already does. `useAutoOpenSwapDrawer` stays as the fallback for the route-param path.

Only dispatched when a `swapId` is present, so `redirectSwapToHistory()` without arguments still lands on the plain Swap History with no drawer.

**2. The status drawer was stuck on skeletons (mobile + desktop)**

`isStatusSectionLoading` stays true until `sendCurrency` / `receiveCurrency` resolve, which requires `getTransactionStatus` to find the swap operation in local history. The first poll runs before the operation is resolvable, and the controller then only retried every `STATUS_POLL_INTERVAL_MS` (60s) — so the section looked frozen on placeholders.

`useSwapTransactionStatusController` now picks its retry delay based on whether the swap resolved: unresolved swaps retry on a short 3s interval so the section fills in within seconds of the operation syncing; resolved-but-pending swaps keep the 60s steady-state cadence; terminal statuses still stop polling. This lives in `live-common`, so it covers the LiFi desktop report as well as mobile.

`provider` is forwarded so the drawer can start polling immediately instead of waiting to resolve the provider from local history. Paired with the swap-live-app side, which now sends `{ swapId, provider }` (LedgerHQ/swap-live-app#1757).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32926](https://ledgerhq.atlassian.net/browse/LIVE-32926) (stuck loading), [LIVE-34417](https://ledgerhq.atlassian.net/browse/LIVE-34417) (open status UI from multi-step)
- Swap side: LedgerHQ/swap-live-app#1757

### 🧪 Testing

- `useSwapCustomHandlers` — 10/10 pass (covers both the no-`swapId` and `{ swapId, provider }` paths)
- `useSwapTransactionStatusController` — 6/6 pass (added coverage for the fast-retry and steady-state cadences)
- `SwapTransactionStatusDrawer` integration test — pass
- `ledger-live-common` typecheck + `live-mobile` typecheck — clean
- Manual (mobile, Velora multi-step): "See details" now opens the bottom sheet immediately ✅
- Manual: status section leaving the skeleton state still needs a device pass on a rebuilt `live-common`

### ⚠️ Notes for reviewers

- Depends on the swap-live-app change for `provider`; `provider` is optional, so this is safe to merge independently (the drawer resolves the provider from history as before).
- Touches the same `navigateToSwapHistory` as #20110 (LIVE-34563) and is now rebased on top of it. The navigation call there is `openSwapSubScreens({ navigation, target })`; the status drawer dispatch and `resetWebview()` sit alongside it, unchanged. Nothing left to reconcile.
- Possibly related: [LIVE-34886](https://ledgerhq.atlassian.net/browse/LIVE-34886) (swap navigations recreating the Main navigator) may contribute to residual navigation flakiness in this area.


[LIVE-32926]: https://ledgerhq.atlassian.net/browse/LIVE-32926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
