### PR TITLE
chore(wallet-cli-v2.1.0): consolidate to version 2.1.0

### DIFF
--- a/.changeset/wallet-cli-swap-amount-display-units.md
+++ b/.changeset/wallet-cli-swap-amount-display-units.md
@@ -1,5 +1,0 @@
----
-"@ledgerhq/wallet-cli": minor
----
-
-`swap execute` now reports `amountExpectedTo` in display units (e.g. `1.2345` ETH) instead of atomic units, both in the human output and the JSON envelope, and sends the same display-unit value as the `toAmount` analytics property. The atomic value is still available under the new `amountExpectedToAtomic` field for scripts that relied on the previous behaviour. `magnitudeAwareRate` is unchanged and stays an atomic-to over atomic-from ratio, matching live-common's convention.

--- a/apps/wallet-cli/CHANGELOG.md
+++ b/apps/wallet-cli/CHANGELOG.md
@@ -1,44 +1,22 @@
 # @ledgerhq/wallet-cli
 
-## 2.2.0
-
-### Minor Changes
-
-- [#19871](https://github.com/LedgerHQ/ledger-live/pull/19871) [`d243bd0`](https://github.com/LedgerHQ/ledger-live/commit/d243bd0cd2489a836961a724e60f6049a27f74d6) Thanks [@francois-guerin-ledger](https://github.com/francois-guerin-ledger)! - chore(llc): consume `validateAddress` through `CoinModuleApi` instance
-
-- [#19797](https://github.com/LedgerHQ/ledger-live/pull/19797) [`93c54da`](https://github.com/LedgerHQ/ledger-live/commit/93c54daf4076e1163a9b7db86107ab2765b81b5d) Thanks [@ysitbon](https://github.com/ysitbon)! - Repoint remaining @ledgerhq/cryptoassets value-barrel imports to @domain/entity-currency-crypto and @domain/entity-currency-fiat; inline ApiAsset wire-type into the dada-client entities module; drop @ledgerhq/cryptoassets from wallet-cli devDependencies
-
-- [#19161](https://github.com/LedgerHQ/ledger-live/pull/19161) [`4d5b3fb`](https://github.com/LedgerHQ/ledger-live/commit/4d5b3fbdf65100d34027d2140eff5478c97b3ac2) Thanks [@Justkant](https://github.com/Justkant)! - Add a one-time, agent-aware first-run nudge that prints a tailored hint to stderr (e.g. `wallet-cli skill install --agent claude`) on the first real command, so agents discover the embedded skill. It is shown at most once per user (persisted via an XDG state marker), silent under `--output json` and for `skill *` commands, opt-out via `WALLET_CLI_NO_NUDGE=1`, and fully best-effort (never throws or changes exit codes). Agent detection is centralized in a new `agent-detection` helper that `isAgentEnvironment()` now delegates to.
-
-- [#19160](https://github.com/LedgerHQ/ledger-live/pull/19160) [`d56837e`](https://github.com/LedgerHQ/ledger-live/commit/d56837e6a6063120931595f5c775fdb1521b79ac) Thanks [@Justkant](https://github.com/Justkant)! - Add `wallet-cli skill doctor` to detect drift between installed agent skills and the skills shipped in the running binary (`up-to-date`, `outdated`, `modified-locally`, `missing`), with a conservative `--fix` self-heal that reinstalls outdated/missing skills and only overwrites locally modified ones under `--force`. Skills are now version-locked via a `.wallet-cli-skill.json` provenance sidecar written on install, and the `skill install` JSON envelope surfaces the wallet-cli version and per-skill content hashes.
-
-## 2.2.0-next.0
-
-### Minor Changes
-
-- [#19871](https://github.com/LedgerHQ/ledger-live/pull/19871) [`d243bd0`](https://github.com/LedgerHQ/ledger-live/commit/d243bd0cd2489a836961a724e60f6049a27f74d6) Thanks [@francois-guerin-ledger](https://github.com/francois-guerin-ledger)! - chore(llc): consume `validateAddress` through `CoinModuleApi` instance
-
-- [#19797](https://github.com/LedgerHQ/ledger-live/pull/19797) [`93c54da`](https://github.com/LedgerHQ/ledger-live/commit/93c54daf4076e1163a9b7db86107ab2765b81b5d) Thanks [@ysitbon](https://github.com/ysitbon)! - Repoint remaining @ledgerhq/cryptoassets value-barrel imports to @domain/entity-currency-crypto and @domain/entity-currency-fiat; inline ApiAsset wire-type into the dada-client entities module; drop @ledgerhq/cryptoassets from wallet-cli devDependencies
-
-- [#19161](https://github.com/LedgerHQ/ledger-live/pull/19161) [`4d5b3fb`](https://github.com/LedgerHQ/ledger-live/commit/4d5b3fbdf65100d34027d2140eff5478c97b3ac2) Thanks [@Justkant](https://github.com/Justkant)! - Add a one-time, agent-aware first-run nudge that prints a tailored hint to stderr (e.g. `wallet-cli skill install --agent claude`) on the first real command, so agents discover the embedded skill. It is shown at most once per user (persisted via an XDG state marker), silent under `--output json` and for `skill *` commands, opt-out via `WALLET_CLI_NO_NUDGE=1`, and fully best-effort (never throws or changes exit codes). Agent detection is centralized in a new `agent-detection` helper that `isAgentEnvironment()` now delegates to.
-
-- [#19160](https://github.com/LedgerHQ/ledger-live/pull/19160) [`d56837e`](https://github.com/LedgerHQ/ledger-live/commit/d56837e6a6063120931595f5c775fdb1521b79ac) Thanks [@Justkant](https://github.com/Justkant)! - Add `wallet-cli skill doctor` to detect drift between installed agent skills and the skills shipped in the running binary (`up-to-date`, `outdated`, `modified-locally`, `missing`), with a conservative `--fix` self-heal that reinstalls outdated/missing skills and only overwrites locally modified ones under `--force`. Skills are now version-locked via a `.wallet-cli-skill.json` provenance sidecar written on install, and the `skill install` JSON envelope surfaces the wallet-cli version and per-skill content hashes.
-
 ## 2.1.0
 
 ### Minor Changes
 
-- [#19598](https://github.com/LedgerHQ/ledger-live/pull/19598) [`9dc6491`](https://github.com/LedgerHQ/ledger-live/commit/9dc6491192f071285315c4b48340e1a02688dae9) Thanks [@koda-apps](https://github.com/apps/koda-apps)! - fix: add missing provider field to swap_completed analytics event
-
 - [#19159](https://github.com/LedgerHQ/ledger-live/pull/19159) [`7096cea`](https://github.com/LedgerHQ/ledger-live/commit/7096cea26156431db96ff5ab977cfb04885211e7) Thanks [@Justkant](https://github.com/Justkant)! - Add a `skill` command group (`list`, `retrieve`, `install`) that ships the Ledger wallet-cli agent skill embedded inside the compiled binary, so `wallet-cli skill install` works with zero prior setup. Installs into the right location for most agents via `--agent` (`claude`, `cursor`, `codex`, or the generic `agents` → `.agents/skills`), with `--global` and `--dir` overrides.
 
-## 2.1.0-next.0
+- [#19160](https://github.com/LedgerHQ/ledger-live/pull/19160) [`d56837e`](https://github.com/LedgerHQ/ledger-live/commit/d56837e6a6063120931595f5c775fdb1521b79ac) Thanks [@Justkant](https://github.com/Justkant)! - Add `wallet-cli skill doctor` to detect drift between installed agent skills and the skills shipped in the running binary (`up-to-date`, `outdated`, `modified-locally`, `missing`), with a conservative `--fix` self-heal that reinstalls outdated/missing skills and only overwrites locally modified ones under `--force`. Skills are now version-locked via a `.wallet-cli-skill.json` provenance sidecar written on install, and the `skill install` JSON envelope surfaces the wallet-cli version and per-skill content hashes.
 
-### Minor Changes
+- [#19161](https://github.com/LedgerHQ/ledger-live/pull/19161) [`4d5b3fb`](https://github.com/LedgerHQ/ledger-live/commit/4d5b3fbdf65100d34027d2140eff5478c97b3ac2) Thanks [@Justkant](https://github.com/Justkant)! - Add a one-time, agent-aware first-run nudge that prints a tailored hint to stderr (e.g. `wallet-cli skill install --agent claude`) on the first real command, so agents discover the embedded skill. It is shown at most once per user (persisted via an XDG state marker), silent under `--output json` and for `skill *` commands, opt-out via `WALLET_CLI_NO_NUDGE=1`, and fully best-effort (never throws or changes exit codes). Agent detection is centralized in a new `agent-detection` helper that `isAgentEnvironment()` now delegates to.
+
+- [#19773](https://github.com/LedgerHQ/ledger-live/pull/19773) [`2a532b7`](https://github.com/LedgerHQ/ledger-live/commit/2a532b7a27f2536ae64b2e6e35829b91046ad968) Thanks [@koda-apps](https://github.com/apps/koda-apps)! - `swap execute` now reports `amountExpectedTo` in display units (e.g. `1.2345` ETH) instead of atomic units, both in the human output and the JSON envelope, and sends the same display-unit value as the `toAmount` analytics property. The atomic value is still available under the new `amountExpectedToAtomic` field for scripts that relied on the previous behaviour. `magnitudeAwareRate` is unchanged and stays an atomic-to over atomic-from ratio, matching live-common's convention.
 
 - [#19598](https://github.com/LedgerHQ/ledger-live/pull/19598) [`9dc6491`](https://github.com/LedgerHQ/ledger-live/commit/9dc6491192f071285315c4b48340e1a02688dae9) Thanks [@koda-apps](https://github.com/apps/koda-apps)! - fix: add missing provider field to swap_completed analytics event
 
-- [#19159](https://github.com/LedgerHQ/ledger-live/pull/19159) [`7096cea`](https://github.com/LedgerHQ/ledger-live/commit/7096cea26156431db96ff5ab977cfb04885211e7) Thanks [@Justkant](https://github.com/Justkant)! - Add a `skill` command group (`list`, `retrieve`, `install`) that ships the Ledger wallet-cli agent skill embedded inside the compiled binary, so `wallet-cli skill install` works with zero prior setup. Installs into the right location for most agents via `--agent` (`claude`, `cursor`, `codex`, or the generic `agents` → `.agents/skills`), with `--global` and `--dir` overrides.
+- [#19871](https://github.com/LedgerHQ/ledger-live/pull/19871) [`d243bd0`](https://github.com/LedgerHQ/ledger-live/commit/d243bd0cd2489a836961a724e60f6049a27f74d6) Thanks [@francois-guerin-ledger](https://github.com/francois-guerin-ledger)! - chore(llc): consume `validateAddress` through `CoinModuleApi` instance
+
+- [#19797](https://github.com/LedgerHQ/ledger-live/pull/19797) [`93c54da`](https://github.com/LedgerHQ/ledger-live/commit/93c54daf4076e1163a9b7db86107ab2765b81b5d) Thanks [@ysitbon](https://github.com/ysitbon)! - Repoint remaining @ledgerhq/cryptoassets value-barrel imports to @domain/entity-currency-crypto and @domain/entity-currency-fiat; inline ApiAsset wire-type into the dada-client entities module; drop @ledgerhq/cryptoassets from wallet-cli devDependencies
 
 ## 2.0.1
 

--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -1,10 +1,10 @@
 # wallet-cli (`@ledgerhq/wallet-cli`)
 
-Command-line tool for Ledger Wallet flows over **USB**, built on the **Device Management Kit (DMK)** and [Bunli](https://www.npmjs.com/package/bunli). Version **2.0.1**.
+Command-line tool for Ledger Wallet flows over **USB**, built on the **Device Management Kit (DMK)** and [Bunli](https://www.npmjs.com/package/bunli). Version **2.1.0**.
 
 ## Status (v2)
 
-wallet-cli is the stable CLI for USB-based Ledger Wallet flows. Its scope is intentionally focused: it does not aim for full Ledger Live desktop or mobile feature parity. The `2.0.0` release adds the **`earn`** (staking & DeFi yield) and **`ring`** (Ledger Key Ring / LKRP encryption) command groups.
+wallet-cli is the stable CLI for USB-based Ledger Wallet flows. Its scope is intentionally focused: it does not aim for full Ledger Live desktop or mobile feature parity. The `2.0.0` release adds the **`earn`** (staking & DeFi yield) and **`ring`** (Ledger Key Ring / LKRP encryption) command groups. The `2.1.0` release adds the **`skill`** command group, which installs the Ledger wallet-cli agent skill — embedded in the compiled binary — into your coding agent.
 
 **Supported networks** today: **bitcoin**, **ethereum**, and **solana** (aligned with `live-common-setup.ts`). Token flows are supported for tokens on those networks.
 
@@ -28,6 +28,9 @@ wallet-cli is the stable CLI for USB-based Ledger Wallet flows. Its scope is int
 | `ring init`                           | One-time provisioning of your Ledger Key Ring (LKRP) via the device. Prompts for a password unless `--unsecure-no-password`.                                                                                     |
 | `ring encrypt` / `ring decrypt`       | AES-256-GCM encrypt/decrypt of files (`-i`/`-o`) or text (stdin/stdout) under a named key (`--key`). **No device** after `init`; requires network to restore the trustchain.                                     |
 | `ring keys` / `ring destroy`          | List the keys this machine has used, or tear down the ring (local credentials + remote LKRP application).                                                                                                        |
+| `skill list` / `skill retrieve`       | List the agent skills shipped inside the binary, or print one to stdout. **No device** required.                                                                                                                |
+| `skill install`                       | Install the embedded agent skill for `--agent` (`claude`, `cursor`, `codex`, or generic `agents` → `.agents/skills`), with `--global` and `--dir` overrides. **No device** required.                             |
+| `skill doctor`                        | Detect drift between installed skills and those shipped in the running binary (`up-to-date`, `outdated`, `modified-locally`, `missing`); `--fix` self-heals, `--force` also overwrites local edits.              |
 
 Typical flow: run `account discover` with a currency id (e.g. `bitcoin`, `ethereum`), then pass the assigned **session label** (e.g. `--account ethereum-1`) to `balances`, `operations`, `send`, or `receive`. Use `session view` to see what's saved.
 
@@ -52,6 +55,8 @@ pnpm wallet-cli start -- earn withdraw --help
 pnpm wallet-cli start -- ring init --help
 pnpm wallet-cli start -- ring encrypt --help
 pnpm wallet-cli start -- ring decrypt --help
+pnpm wallet-cli start -- skill install --help
+pnpm wallet-cli start -- skill doctor --help
 ```
 
 From `apps/wallet-cli`, use `pnpm start` in place of `pnpm wallet-cli start` (same args after `--`).

--- a/apps/wallet-cli/npm/darwin-arm64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/darwin-arm64/CHANGELOG.md
@@ -1,12 +1,6 @@
 # @ledgerhq/wallet-cli-darwin-arm64
 
-## 2.2.0
-
-## 2.2.0-next.0
-
 ## 2.1.0
-
-## 2.1.0-next.0
 
 ## 2.0.1
 

--- a/apps/wallet-cli/npm/darwin-arm64/package.json
+++ b/apps/wallet-cli/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-darwin-arm64",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "macOS arm64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/linux-arm64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/linux-arm64/CHANGELOG.md
@@ -1,12 +1,6 @@
 # @ledgerhq/wallet-cli-linux-arm64
 
-## 2.2.0
-
-## 2.2.0-next.0
-
 ## 2.1.0
-
-## 2.1.0-next.0
 
 ## 2.0.1
 

--- a/apps/wallet-cli/npm/linux-arm64/package.json
+++ b/apps/wallet-cli/npm/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-linux-arm64",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Linux arm64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/linux-x64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/linux-x64/CHANGELOG.md
@@ -1,12 +1,6 @@
 # @ledgerhq/wallet-cli-linux-x64
 
-## 2.2.0
-
-## 2.2.0-next.0
-
 ## 2.1.0
-
-## 2.1.0-next.0
 
 ## 2.0.1
 

--- a/apps/wallet-cli/npm/linux-x64/package.json
+++ b/apps/wallet-cli/npm/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-linux-x64",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Linux x64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/npm/windows-x64/CHANGELOG.md
+++ b/apps/wallet-cli/npm/windows-x64/CHANGELOG.md
@@ -1,12 +1,6 @@
 # @ledgerhq/wallet-cli-windows-x64
 
-## 2.2.0
-
-## 2.2.0-next.0
-
 ## 2.1.0
-
-## 2.1.0-next.0
 
 ## 2.0.1
 

--- a/apps/wallet-cli/npm/windows-x64/package.json
+++ b/apps/wallet-cli/npm/windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli-windows-x64",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Windows x64 native binary for @ledgerhq/wallet-cli",
   "license": "Apache-2.0",

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/wallet-cli",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Ledger Wallet CLI using Device Management Kit (USB)",
   "license": "Apache-2.0",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. — n/a, the pending changeset is *consumed* here
- [ ] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - wallet-cli version, changelog and README

### 📝 Description

Prepare the manual wallet-cli **v2.1.0** release, in the spirit of #19515 but adapted: wallet-cli is now picked up by the monorepo release workflow, so part of the work was already done for us.

**State before this PR**

| | in repo | on npm (`latest`) |
|---|---|---|
| `@ledgerhq/wallet-cli` + 4 platform pkgs | `2.2.0` | `2.0.1` |

The release workflow bumped wallet-cli to `2.1.0` (Jul 23) then `2.2.0` (Jul 28) and wrote the matching CHANGELOG entries — but the npm publish is a **separate manual `workflow_dispatch`** (`publish-wallet-cli-npm.yml`) that never ran. So `2.1.0` and `2.2.0` exist only in the repo: **nothing was published, and no git tag exists** (the package is `private` with `"tag": false` in `.changeset/config.json`).

**What this PR does**

Rather than shipping `2.3.0` and leaving a `2.0.1 → 2.3.0` hole on the registry, it collapses the unpublished versions into a single `2.1.0` that follows `2.0.1` contiguously:

- Merge the `2.1.0` + `2.2.0` CHANGELOG entries, drop their duplicate `2.1.0-next.0` / `2.2.0-next.0` prerelease sections (never published either), and fold in the one pending wallet-cli changeset. Every entry keeps its original PR / commit / author attribution — nothing is dropped, only de-duplicated and reordered.
- Consume and delete `.changeset/wallet-cli-swap-amount-display-units.md` (`swap execute` display units). **No wallet-cli entry is left in any changeset** — verified with `grep -l wallet-cli .changeset/*.md`.
- Set `@ledgerhq/wallet-cli` and its 4 platform packages from `2.2.0` back to `2.1.0` (`prepare-npm.mjs:67` hard-fails if they diverge; the 5 are `fixed:` together in the changesets config).
- Sync the **README**, still stuck on `2.0.1` and never updated for the `skill` command group: version line, status paragraph, `skill list`/`retrieve`/`install`/`doctor` rows in the commands table, and the matching `--help` lines.

All merged content is additive, so `2.1.0` is the correct semver bump from `2.0.1`.

### ❓ Context

- Follows the pattern of #19515 / #19520.
- Going backwards `2.2.0 → 2.1.0` is safe here precisely because nothing was published and no tag was cut. Next release cycle the workflow will bump to `2.2.0` again from this base.
- Note this gap is structural: the release workflow bumps wallet-cli every cycle whether or not we publish, so gaps reappear unless we publish each cycle (or exclude wallet-cli from the automated bump).