### PR TITLE
chore(wallet-cli): format build scripts and gate them with oxfmt

### DIFF
--- a/apps/wallet-cli/.oxfmtrc.json
+++ b/apps/wallet-cli/.oxfmtrc.json
@@ -4,5 +4,12 @@
   "trailingComma": "all",
   "arrowParens": "avoid",
   "sortPackageJson": false,
-  "ignorePatterns": ["**/*.md", "package.json", "**/*.json", "dist/**", ".bunli/commands.gen.ts"]
+  "ignorePatterns": [
+    "**/*.md",
+    "package.json",
+    "**/*.json",
+    "dist/**",
+    ".bunli/commands.gen.ts",
+    "src/skills/manifest.gen.ts"
+  ]
 }

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -38,9 +38,9 @@
     "coverage": "bun test src/ --coverage",
     "lint": "oxlint src bunli.config.ts",
     "lint:ci": "oxlint src bunli.config.ts --quiet",
-    "lint:fix": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts && oxlint src bunli.config.ts --fix --quiet",
-    "format": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts",
-    "format:check": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts --check"
+    "lint:fix": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts && oxlint src bunli.config.ts --fix --quiet",
+    "format": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts",
+    "format:check": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts --check"
   },
   "optionalDependencies": {
     "@ledgerhq/wallet-cli-darwin-arm64": "workspace:*",

--- a/apps/wallet-cli/package.json
+++ b/apps/wallet-cli/package.json
@@ -36,11 +36,11 @@
     "pretest": "node ./scripts/generate-skills-manifest.mjs",
     "test": "bun test src/",
     "coverage": "bun test src/ --coverage",
-    "lint": "oxlint src bunli.config.ts",
-    "lint:ci": "oxlint src bunli.config.ts --quiet",
-    "lint:fix": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts && oxlint src bunli.config.ts --fix --quiet",
-    "format": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts",
-    "format:check": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts scripts --check"
+    "lint": "oxlint .",
+    "lint:ci": "oxlint . --quiet",
+    "lint:fix": "oxfmt . && oxlint . --fix --quiet",
+    "format": "oxfmt .",
+    "format:check": "oxfmt . --check"
   },
   "optionalDependencies": {
     "@ledgerhq/wallet-cli-darwin-arm64": "workspace:*",

--- a/apps/wallet-cli/scripts/pack-check.mjs
+++ b/apps/wallet-cli/scripts/pack-check.mjs
@@ -99,9 +99,7 @@ async function packPackage(pkg, destination) {
 }
 
 function listTarball(tarball) {
-  return run("tar", ["-tf", tarball], { cwd: root })
-    .split("\n")
-    .filter(Boolean);
+  return run("tar", ["-tf", tarball], { cwd: root }).split("\n").filter(Boolean);
 }
 
 function assertPackageContents(pkg, entries) {

--- a/apps/wallet-cli/scripts/prepare-npm.mjs
+++ b/apps/wallet-cli/scripts/prepare-npm.mjs
@@ -101,7 +101,10 @@ async function prepareMainPackage() {
 
   await rm(packageDirectory, { recursive: true, force: true });
   await mkdir(packageDirectory, { recursive: true });
-  await writeFile(path.join(packageDirectory, "package.json"), `${JSON.stringify(publishPackage, null, 2)}\n`);
+  await writeFile(
+    path.join(packageDirectory, "package.json"),
+    `${JSON.stringify(publishPackage, null, 2)}\n`,
+  );
   await copyFile(path.join(root, "LICENSE"), path.join(packageDirectory, "LICENSE"));
   await copyFile(
     path.join(root, "THIRD_PARTY_NOTICES.md"),
@@ -134,7 +137,10 @@ async function preparePlatformBinaries() {
     await copyFile(source, target);
     await rm(packageDirectory, { recursive: true, force: true });
     await mkdir(path.join(packageDirectory, "bin"), { recursive: true });
-    await writeFile(path.join(packageDirectory, "package.json"), `${JSON.stringify(publishPackage, null, 2)}\n`);
+    await writeFile(
+      path.join(packageDirectory, "package.json"),
+      `${JSON.stringify(publishPackage, null, 2)}\n`,
+    );
     await copyFile(source, path.join(packageDirectory, platform.bin["wallet-cli"]));
     await copyFile(path.join(root, "LICENSE"), path.join(packageDirectory, "LICENSE"));
     await copyFile(

--- a/apps/wallet-cli/scripts/smoke-npm.mjs
+++ b/apps/wallet-cli/scripts/smoke-npm.mjs
@@ -60,7 +60,10 @@ const destination = await mkdtemp(path.join(tmpdir(), "wallet-cli-smoke-pack-"))
 const installDir = await mkdtemp(path.join(tmpdir(), "wallet-cli-smoke-install-"));
 
 try {
-  const platformTarball = await pack(path.join(root, platformPackagePath, ".npm-package"), destination);
+  const platformTarball = await pack(
+    path.join(root, platformPackagePath, ".npm-package"),
+    destination,
+  );
   const mainTarball = await pack(path.join(root, ".npm-package"), destination);
 
   await writeFile(


### PR DESCRIPTION
## Problem

`apps/wallet-cli/scripts/` was outside the oxfmt targets, so these three files had
drifted out of format on `develop` without CI ever noticing:

- `apps/wallet-cli/scripts/prepare-npm.mjs`
- `apps/wallet-cli/scripts/pack-check.mjs`
- `apps/wallet-cli/scripts/smoke-npm.mjs`

`pnpm exec oxfmt --check apps/wallet-cli` flagged all three, but wallet-cli's
`format:check` only covered `src` and `bunli.config.ts`, leaving `scripts/` ungated.

## What this does

**1. Fixes the drift** (`03f6c552a81`) — reformatted the three files. Pure formatting:
long `await writeFile(...)` and chained calls wrapped to the 100-col `printWidth`.
No behavioural change — the diff is whitespace and line breaks only.

**2. Fixes the root cause** (`8cd4ca4de9f`) — rather than just widening the target list,
wallet-cli now follows the same oxfmt/oxlint setup as the rest of the monorepo:

```diff
-"lint":         "oxlint src bunli.config.ts"
-"lint:ci":      "oxlint src bunli.config.ts --quiet"
-"lint:fix":     "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts && oxlint src bunli.config.ts --fix --quiet"
-"format":       "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts"
-"format:check": "oxfmt -c ../../.oxfmtrc.json src bunli.config.ts --check"
+"lint":         "oxlint ."
+"lint:ci":      "oxlint . --quiet"
+"lint:fix":     "oxfmt . && oxlint . --fix --quiet"
+"format":       "oxfmt ."
+"format:check": "oxfmt . --check"
```

### Why this is the right fix

wallet-cli was the **only** package passing `-c ../../.oxfmtrc.json`. Every other
package (`apps/cli`, `e2e/desktop`, `e2e/mobile`, `features/flow/*`, `libs/*`) relies on
oxfmt discovering its own package-local `.oxfmtrc.json`.

Two consequences, both fixed here:

- **`apps/wallet-cli/.oxfmtrc.json` was dead config** — it existed but was never loaded,
  because `-c` overrides discovery. It is now live.
- **Hand-maintained target lists are what caused this bug.** `oxfmt .` has no list to
  forget to update, and directory traversal honours `.gitignore`, so generated files are
  skipped without enumerating them.

The two configs differed in a load-bearing way: the root one ignores
`**/skills/manifest.gen.ts`, the local one did not. So the local config gains
`src/skills/manifest.gen.ts` in `ignorePatterns`, preserving the existing behaviour and
matching how `.bunli/commands.gen.ts` is already listed there.

`oxlint .` is behaviour-identical to `oxlint src bunli.config.ts` — 211 files,
9 warnings, 0 errors, both before and after. Note oxlint was already following the
convention (no `-c`, discovers its local `.oxlintrc.json`); only its target list changed.

## Verification

| Check | Result |
|---|---|
| `nx run @ledgerhq/wallet-cli:format:check` | ✅ passes, 217 files |
| same, with the reformat reverted to `develop` | ❌ fails on all 3 `.mjs` files |
| same, with a new unformatted file added to `scripts/` | ❌ fails — no target list to drift |
| `nx run @ledgerhq/wallet-cli:lint:ci` | ✅ 9 warnings, 0 errors (unchanged) |
| `node apps/wallet-cli/scripts/prepare-npm.mjs` | ✅ runs clean, before and after |
| `nx run @ledgerhq/wallet-cli:pack:check` | ✅ passes (+114 dependent tasks) |

All run with `--skip-nx-cache`.

## No changeset — deliberate

wallet-cli is `private: true`, but the monorepo release workflow still bumps it from
changesets, and a bump right now would undo the version consolidation from #20184
(wallet-cli pinned to 2.1.0 so npm goes 2.0.1 → 2.1.0 contiguously). This is a
formatting + tooling-config change with zero runtime impact, so no changeset is warranted.

Version fields, CHANGELOG and README are untouched — those are owned by #20184, which is
now merged; this branch is based on top of it, so `apps/wallet-cli/package.json` is
conflict-free.
