### PR TITLE
feat(contacts): add address detail quick actions with delete lifecycle

### DIFF
--- a/.changeset/address-detail-quick-actions.md
+++ b/.changeset/address-detail-quick-actions.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Add shared address detail quick-action scenario state with send, edit, and delete intents and mocked delete lifecycle.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -12,6 +12,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Populated contact detail view model (address rows, count, and open-detail intents)
 - Contact detail edit/delete scenario state (edit intent, delete intent, and delete lifecycle)
 - Contact address detail view model (selected address payload, QR payload string, and not-found state)
+- Contact address detail quick-action scenario state (send, edit, and delete intents with delete lifecycle)
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
 - Add Address session and address-entry validation state
 - Add Address network eligibility and final currency selection state (MAD integration uses an
@@ -89,8 +90,8 @@ src/
 │   │   ├── internals/useSingleFireDismiss.ts
 │   │   └── index.ts / web.ts / native.ts
 │   └── Detail/                          # Contact detail (web + native)
-│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / useContactAddressDetail.ts / types.ts
-│       ├── model/                       # empty + populated + address detail view-model builders
+│       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / useContactAddressDetail.ts / useContactAddressDetailActionsViewModel.ts / types.ts
+│       ├── model/                       # empty + populated + address detail + quick-action builders
 │       ├── components/                  # Header, EmptyState, Avatar (web + native)
 │       └── index.ts / web.ts / native.ts
 ├── components/                          # Cross-step shared UI

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -3,6 +3,8 @@ export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
 export { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
 export type { UseContactDetailActionsViewModelResult } from "./useContactDetailActionsViewModel";
 export { useContactAddressDetail } from "./useContactAddressDetail";
+export { useContactAddressDetailActionsViewModel } from "./useContactAddressDetailActionsViewModel";
+export type { UseContactAddressDetailActionsViewModelResult } from "./useContactAddressDetailActionsViewModel";
 export {
   createContactDetailAddressRowIntent,
   createPopulatedContactDetailViewModel,
@@ -21,9 +23,25 @@ export {
   type ContactDetailActionsController,
 } from "./model/contactActionsController";
 export { createContactAddressDetailViewModel } from "./model/addressDetailViewModel";
+export {
+  createContactAddressDetailDeleteIntent,
+  createContactAddressDetailEditIntent,
+  createContactAddressDetailSendIntent,
+  createErrorContactAddressDeleteLifecycle,
+  createIdleContactAddressDeleteLifecycle,
+  createOpenContactAddressDeleteLifecycle,
+  createSuccessContactAddressDeleteLifecycle,
+} from "./model/addressDetailActionsViewModel";
+export {
+  createContactAddressDetailActionsController,
+  type ContactAddressDetailActionsController,
+} from "./model/addressDetailActionsController";
 export { sortContactAddressesByNetwork } from "./model/sortContactAddressesByNetwork";
 export type {
   ContactAddressCurrencyPort,
+  ContactAddressDeletionInput,
+  ContactAddressDeletionPort,
+  ContactAddressDetailActionsPorts,
   ContactAddressDetailPort,
   ContactDeletionPort,
   ContactDetailActionsPorts,
@@ -31,8 +49,13 @@ export type {
   ContactRenameInput,
 } from "./model/ports";
 export type {
+  ContactAddressDeleteLifecycle,
+  ContactAddressDetailActionsViewModel,
   ContactAddressDetailAsset,
+  ContactAddressDetailDeleteIntent,
+  ContactAddressDetailEditIntent,
   ContactAddressDetailNetwork,
+  ContactAddressDetailSendIntent,
   ContactAddressDetailViewModel,
   ContactDeleteLifecycle,
   ContactDetailActionsViewModel,

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.ts
@@ -1,0 +1,30 @@
+import type { ContactAddressId, ContactId } from "@domain/entity-contact";
+import type { ContactAddressDetailActionsPorts } from "./ports";
+import {
+  createErrorContactAddressDeleteLifecycle,
+  createSuccessContactAddressDeleteLifecycle,
+} from "./addressDetailActionsViewModel";
+import type { ContactAddressDeleteLifecycle } from "../types";
+
+export type ContactAddressDetailActionsController = Readonly<{
+  confirmDelete: (
+    contactId: ContactId,
+    addressId: ContactAddressId,
+  ) => Promise<ContactAddressDeleteLifecycle>;
+}>;
+
+export function createContactAddressDetailActionsController(
+  ports: ContactAddressDetailActionsPorts,
+): ContactAddressDetailActionsController {
+  return {
+    confirmDelete: async (contactId, addressId) => {
+      try {
+        await ports.deletion.deleteAddress({ contactId, addressId });
+
+        return createSuccessContactAddressDeleteLifecycle(contactId, addressId);
+      } catch {
+        return createErrorContactAddressDeleteLifecycle(contactId, addressId);
+      }
+    },
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.web.test.ts
@@ -1,0 +1,46 @@
+import { ContactAddressIdSchema, ContactIdSchema } from "@domain/entity-contact";
+import { createContactAddressDetailActionsController } from "./addressDetailActionsController";
+import type { ContactAddressDetailActionsPorts } from "./ports";
+
+function createPorts(
+  overrides: Partial<ContactAddressDetailActionsPorts> = {},
+): ContactAddressDetailActionsPorts {
+  return {
+    deletion: {
+      deleteAddress: jest.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+}
+
+describe("createContactAddressDetailActionsController", () => {
+  it("returns success lifecycle when deletion succeeds", async () => {
+    const contactId = ContactIdSchema.parse("contact-ben");
+    const addressId = ContactAddressIdSchema.parse("address-ethereum");
+    const controller = createContactAddressDetailActionsController(createPorts());
+
+    await expect(controller.confirmDelete(contactId, addressId)).resolves.toEqual({
+      status: "success",
+      contactId,
+      addressId,
+    });
+  });
+
+  it("returns error lifecycle when deletion fails", async () => {
+    const contactId = ContactIdSchema.parse("contact-ben");
+    const addressId = ContactAddressIdSchema.parse("address-ethereum");
+    const controller = createContactAddressDetailActionsController(
+      createPorts({
+        deletion: {
+          deleteAddress: jest.fn().mockRejectedValue(new Error("delete failed")),
+        },
+      }),
+    );
+
+    await expect(controller.confirmDelete(contactId, addressId)).resolves.toEqual({
+      status: "error",
+      contactId,
+      addressId,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
@@ -1,0 +1,67 @@
+import type { ContactAddress, ContactAddressId, ContactId } from "@domain/entity-contact";
+import type {
+  ContactAddressDeleteLifecycle,
+  ContactAddressDetailDeleteIntent,
+  ContactAddressDetailEditIntent,
+  ContactAddressDetailSendIntent,
+} from "../types";
+
+export function createContactAddressDetailSendIntent(
+  contactId: ContactId,
+  contactAddress: ContactAddress,
+): ContactAddressDetailSendIntent {
+  return {
+    type: "send-address",
+    contactId,
+    addressId: contactAddress.id,
+    currencyId: contactAddress.currencyId,
+    address: contactAddress.address,
+  };
+}
+
+export function createContactAddressDetailEditIntent(
+  contactId: ContactId,
+  contactAddress: ContactAddress,
+): ContactAddressDetailEditIntent {
+  return {
+    type: "edit-address",
+    contactId,
+    addressId: contactAddress.id,
+  };
+}
+
+export function createContactAddressDetailDeleteIntent(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactAddressDetailDeleteIntent {
+  return {
+    type: "delete-address",
+    contactId,
+    addressId,
+  };
+}
+
+export function createIdleContactAddressDeleteLifecycle(): ContactAddressDeleteLifecycle {
+  return { status: "idle" };
+}
+
+export function createOpenContactAddressDeleteLifecycle(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactAddressDeleteLifecycle {
+  return { status: "open", contactId, addressId };
+}
+
+export function createSuccessContactAddressDeleteLifecycle(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactAddressDeleteLifecycle {
+  return { status: "success", contactId, addressId };
+}
+
+export function createErrorContactAddressDeleteLifecycle(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+): ContactAddressDeleteLifecycle {
+  return { status: "error", contactId, addressId };
+}

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.web.test.ts
@@ -1,0 +1,76 @@
+import { ContactAddressIdSchema } from "@domain/entity-contact";
+import { mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import {
+  createContactAddressDetailDeleteIntent,
+  createContactAddressDetailEditIntent,
+  createContactAddressDetailSendIntent,
+  createErrorContactAddressDeleteLifecycle,
+  createIdleContactAddressDeleteLifecycle,
+  createOpenContactAddressDeleteLifecycle,
+  createSuccessContactAddressDeleteLifecycle,
+} from "./addressDetailActionsViewModel";
+
+describe("createContactAddressDetailSendIntent", () => {
+  it("exposes a send-address intent with address payload when the address exists", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+
+    expect(createContactAddressDetailSendIntent(contact.id, address)).toEqual({
+      type: "send-address",
+      contactId: contact.id,
+      addressId: address.id,
+      currencyId: address.currencyId,
+      address: address.address,
+    });
+  });
+});
+
+describe("createContactAddressDetailEditIntent", () => {
+  it("exposes an edit-address intent for the selected address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+
+    expect(createContactAddressDetailEditIntent(contact.id, address)).toEqual({
+      type: "edit-address",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+});
+
+describe("createContactAddressDetailDeleteIntent", () => {
+  it("exposes a delete-address intent for the selected address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+
+    expect(createContactAddressDetailDeleteIntent(contact.id, address.id)).toEqual({
+      type: "delete-address",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+});
+
+describe("contact address delete lifecycle builders", () => {
+  it("creates idle, open, success, and error lifecycle states", () => {
+    const contact = mockContactWithAddress();
+    const addressId = ContactAddressIdSchema.parse("address-ethereum");
+
+    expect(createIdleContactAddressDeleteLifecycle()).toEqual({ status: "idle" });
+    expect(createOpenContactAddressDeleteLifecycle(contact.id, addressId)).toEqual({
+      status: "open",
+      contactId: contact.id,
+      addressId,
+    });
+    expect(createSuccessContactAddressDeleteLifecycle(contact.id, addressId)).toEqual({
+      status: "success",
+      contactId: contact.id,
+      addressId,
+    });
+    expect(createErrorContactAddressDeleteLifecycle(contact.id, addressId)).toEqual({
+      status: "error",
+      contactId: contact.id,
+      addressId,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -1,4 +1,10 @@
-import type { Contact, ContactAddress, ContactId, ContactInput } from "@domain/entity-contact";
+import type {
+  Contact,
+  ContactAddress,
+  ContactAddressId,
+  ContactId,
+  ContactInput,
+} from "@domain/entity-contact";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { ContactAddressDetailAsset, ContactAddressDetailNetwork } from "../types";
 
@@ -22,6 +28,19 @@ export type ContactDeletionPort = Readonly<{
 export type ContactDetailActionsPorts = Readonly<{
   edit: ContactEditPort;
   deletion: ContactDeletionPort;
+}>;
+
+export type ContactAddressDeletionInput = Readonly<{
+  contactId: ContactId;
+  addressId: ContactAddressId;
+}>;
+
+export type ContactAddressDeletionPort = Readonly<{
+  deleteAddress(input: ContactAddressDeletionInput): Promise<void>;
+}>;
+
+export type ContactAddressDetailActionsPorts = Readonly<{
+  deletion: ContactAddressDeletionPort;
 }>;
 
 /** Injected by app wiring; aligns with the future @features/platform-contacts contract. */

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -88,3 +88,36 @@ export type ContactAddressDetailViewModel =
       asset: ContactAddressDetailAsset;
       qrPayload: string;
     }>;
+
+export type ContactAddressDetailSendIntent = Readonly<{
+  type: "send-address";
+  contactId: ContactId;
+  addressId: ContactAddressId;
+  currencyId: ContactAddress["currencyId"];
+  address: ContactAddress["address"];
+}>;
+
+export type ContactAddressDetailEditIntent = Readonly<{
+  type: "edit-address";
+  contactId: ContactId;
+  addressId: ContactAddressId;
+}>;
+
+export type ContactAddressDetailDeleteIntent = Readonly<{
+  type: "delete-address";
+  contactId: ContactId;
+  addressId: ContactAddressId;
+}>;
+
+export type ContactAddressDeleteLifecycle =
+  | Readonly<{ status: "idle" }>
+  | Readonly<{ status: "open"; contactId: ContactId; addressId: ContactAddressId }>
+  | Readonly<{ status: "success"; contactId: ContactId; addressId: ContactAddressId }>
+  | Readonly<{ status: "error"; contactId: ContactId; addressId: ContactAddressId }>;
+
+export type ContactAddressDetailActionsViewModel = Readonly<{
+  sendIntent: ContactAddressDetailSendIntent | undefined;
+  editIntent: ContactAddressDetailEditIntent | undefined;
+  deleteIntent: ContactAddressDetailDeleteIntent;
+  deleteLifecycle: ContactAddressDeleteLifecycle;
+}>;

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.ts
@@ -1,0 +1,88 @@
+import {
+  selectContactAddressById,
+  type ContactAddressId,
+  type ContactId,
+} from "@domain/entity-contact";
+import { useCallback, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { createContactAddressDetailActionsController } from "./model/addressDetailActionsController";
+import type { ContactAddressDetailActionsPorts } from "./model/ports";
+import {
+  createContactAddressDetailDeleteIntent,
+  createContactAddressDetailEditIntent,
+  createContactAddressDetailSendIntent,
+  createIdleContactAddressDeleteLifecycle,
+  createOpenContactAddressDeleteLifecycle,
+} from "./model/addressDetailActionsViewModel";
+import type {
+  ContactAddressDeleteLifecycle,
+  ContactAddressDetailActionsViewModel,
+} from "./types";
+
+type ContactsStateRoot = Parameters<typeof selectContactAddressById>[0];
+
+export type UseContactAddressDetailActionsViewModelResult = ContactAddressDetailActionsViewModel &
+  Readonly<{
+    openDelete: () => void;
+    cancelDelete: () => void;
+    confirmDelete: () => Promise<void>;
+  }>;
+
+/**
+ * Shared address detail quick-action scenario state for Contacts UI.
+ * Pass stable `ContactAddressDetailActionsPorts`; a new reference each render recreates the controller.
+ */
+export function useContactAddressDetailActionsViewModel(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+  ports: ContactAddressDetailActionsPorts,
+): UseContactAddressDetailActionsViewModelResult {
+  const contactAddress = useSelector((state: ContactsStateRoot) =>
+    selectContactAddressById(state, contactId, addressId),
+  );
+  const controller = useMemo(() => createContactAddressDetailActionsController(ports), [ports]);
+  const [deleteLifecycle, setDeleteLifecycle] = useState<ContactAddressDeleteLifecycle>(() =>
+    createIdleContactAddressDeleteLifecycle(),
+  );
+
+  const sendIntent = useMemo(
+    () =>
+      contactAddress === undefined
+        ? undefined
+        : createContactAddressDetailSendIntent(contactId, contactAddress),
+    [contactAddress, contactId],
+  );
+  const editIntent = useMemo(
+    () =>
+      contactAddress === undefined
+        ? undefined
+        : createContactAddressDetailEditIntent(contactId, contactAddress),
+    [contactAddress, contactId],
+  );
+  const deleteIntent = useMemo(
+    () => createContactAddressDetailDeleteIntent(contactId, addressId),
+    [contactId, addressId],
+  );
+
+  const openDelete = useCallback(() => {
+    setDeleteLifecycle(createOpenContactAddressDeleteLifecycle(contactId, addressId));
+  }, [addressId, contactId]);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteLifecycle(createIdleContactAddressDeleteLifecycle());
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    setDeleteLifecycle(await controller.confirmDelete(contactId, addressId));
+  }, [addressId, contactId, controller]);
+
+  return {
+    sendIntent,
+    editIntent,
+    deleteIntent,
+    deleteLifecycle,
+    openDelete,
+    cancelDelete,
+    confirmDelete,
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
@@ -1,0 +1,182 @@
+import { createElement, type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { ContactAddressIdSchema, contactsSlice } from "@domain/entity-contact";
+import {
+  mockContactWithAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
+import type { ContactAddressDetailActionsPorts } from "./model/ports";
+import { useContactAddressDetailActionsViewModel } from "./useContactAddressDetailActionsViewModel";
+
+function createPorts(
+  overrides: Partial<ContactAddressDetailActionsPorts> = {},
+): ContactAddressDetailActionsPorts {
+  return {
+    deletion: {
+      deleteAddress: jest.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+}
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return createElement(Provider, { store, children });
+  };
+}
+
+describe("useContactAddressDetailActionsViewModel", () => {
+  it("exposes a send intent when the address exists", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactAddressDetailActionsViewModel(contact.id, address.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.sendIntent).toEqual({
+      type: "send-address",
+      contactId: contact.id,
+      addressId: address.id,
+      currencyId: address.currencyId,
+      address: address.address,
+    });
+  });
+
+  it("exposes an edit intent when the address exists", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactAddressDetailActionsViewModel(contact.id, address.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.editIntent).toEqual({
+      type: "edit-address",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+
+  it("exposes undefined send and edit intents when the address is not found", () => {
+    const contact = mockContactWithAddress();
+    const missingAddressId = ContactAddressIdSchema.parse("address-missing");
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsViewModel(contact.id, missingAddressId, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.sendIntent).toBeUndefined();
+    expect(result.current.editIntent).toBeUndefined();
+  });
+
+  it("exposes a delete intent for the selected address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => useContactAddressDetailActionsViewModel(contact.id, address.id, createPorts()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.deleteIntent).toEqual({
+      type: "delete-address",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+
+  it("opens, cancels, and confirms delete through the mocked lifecycle", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const deleteAddress = jest.fn().mockResolvedValue(undefined);
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsViewModel(
+          contact.id,
+          address.id,
+          createPorts({ deletion: { deleteAddress } }),
+        ),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.deleteLifecycle).toEqual({ status: "idle" });
+
+    act(() => {
+      result.current.openDelete();
+    });
+    expect(result.current.deleteLifecycle).toEqual({
+      status: "open",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+
+    act(() => {
+      result.current.cancelDelete();
+    });
+    expect(result.current.deleteLifecycle).toEqual({ status: "idle" });
+
+    act(() => {
+      result.current.openDelete();
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(deleteAddress).toHaveBeenCalledWith({
+      contactId: contact.id,
+      addressId: address.id,
+    });
+    expect(result.current.deleteLifecycle).toEqual({
+      status: "success",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+
+  it("exposes an error lifecycle when delete confirmation fails", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsViewModel(
+          contact.id,
+          address.id,
+          createPorts({
+            deletion: {
+              deleteAddress: jest.fn().mockRejectedValue(new Error("delete failed")),
+            },
+          }),
+        ),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.openDelete();
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.deleteLifecycle).toEqual({
+      status: "error",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Add shared address detail quick-action scenario state to `@features/flow-contacts`, following the same pattern as contact detail edit/delete actions.
- Expose `send-address`, `edit-address`, and `delete-address` intents via `useContactAddressDetailActionsViewModel`, with a mocked delete lifecycle (`idle` → `open` → `success` / `error`) driven by an injected `ContactAddressDeletionPort`.
- Send remains a mocked intent only (includes `currencyId` and `address` payload for future Send wiring); no Desktop/Mobile UI or navigation in this PR.

## Details

**New hook:** `useContactAddressDetailActionsViewModel(contactId, addressId, ports)`

| Export | Purpose |
|--------|---------|
| `sendIntent` | Mocked send intent when address exists |
| `editIntent` | Edit intent when address exists |
| `deleteIntent` | Always available for the selected address |
| `openDelete` / `cancelDelete` / `confirmDelete` | Delete confirmation flow |

**Architecture** (mirrors contact detail actions):
- Pure builders in `model/addressDetailActionsViewModel.ts`
- Side effects in `model/addressDetailActionsController.ts` via `ContactAddressDetailActionsPorts`
- Redux read via `selectContactAddressById`


### 🔗 Context

[LIVE-33948](https://ledgerhq.atlassian.net/browse/LIVE-33948)


[LIVE-33948]: https://ledgerhq.atlassian.net/browse/LIVE-33948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ