### PR TITLE
[LWDM] fix(zash): fee pricing and max estimation [LIVE-35152]

### DIFF
--- a/.changeset/zcash-zip317-fee-pricing.md
+++ b/.changeset/zcash-zip317-fee-pricing.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+---
+
+Fix Zcash fee pricing calculations and max estimation.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendAmountFields.tsx
@@ -1,4 +1,3 @@
-import { useFeature } from "@features/platform-feature-flags";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
 import { useFeesStrategy } from "@ledgerhq/live-common/families/bitcoin/react";
 import { Transaction } from "@ledgerhq/live-common/families/bitcoin/types";
@@ -37,12 +36,15 @@ const Fields: Props = ({
   const bridge = useAccountBridge<Transaction>(account);
   const { t } = useTranslation();
   const [coinControlOpened, setCoinControlOpened] = useState(false);
-  const shieldedEnabled = useFeature("zcashShielded")?.enabled ?? false;
-  const hideAdvancedFees = account.currency.id === "zcash" && shieldedEnabled;
+  // Zcash prices fees with ZIP-317 (deterministic, action-based): there is no
+  // sat/vByte fee market, so the whole fee selector — the strategy list AND the
+  // advanced/custom controls — is removed. The ZIP-317 fee is applied
+  // automatically (see getAccountNetworkInfo).
+  const hideFeeSelection = account.currency.id === "zcash";
   const [advanceMode, setAdvanceMode] = useState(
     !transaction.feesStrategy || transaction.feesStrategy === "custom",
   );
-  const isAdvanceMode = !hideAdvancedFees && advanceMode;
+  const isAdvanceMode = advanceMode;
   const strategies = useFeesStrategy(account, transaction);
   const onCoinControlOpen = useCallback(() => setCoinControlOpened(true), []);
   const onCoinControlClose = useCallback(() => setCoinControlOpened(false), []);
@@ -87,11 +89,11 @@ const Fields: Props = ({
     },
     [onChange, trackProperties],
   );
+  if (hideFeeSelection) return null;
+
   return (
     <>
-      {!hideAdvancedFees && (
-        <SendFeeMode isAdvanceMode={isAdvanceMode} setAdvanceMode={setAdvanceModeAndTrack} />
-      )}
+      <SendFeeMode isAdvanceMode={isAdvanceMode} setAdvanceMode={setAdvanceModeAndTrack} />
       {isAdvanceMode ? (
         <Box>
           <FeesField

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/SendAmountFields.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/SendAmountFields.test.tsx
@@ -114,28 +114,26 @@ describe("bitcoin SendAmountFields", () => {
     });
   });
 
-  describe("zcash shielded handling", () => {
-    it("should hide the fee mode selector and advanced fields for a zcash account when shielded is enabled", () => {
-      renderFields({
-        account: buildZcashAccount(),
-        transaction: buildTransaction({ feesStrategy: "custom" }),
-        flagEnabled: true,
-      });
+  describe("zcash fee handling", () => {
+    // Zcash uses ZIP-317 fees (no sat/vByte market), so the entire fee selector —
+    // the strategy list, the standard/advanced toggle and the custom input — is
+    // removed, independent of the zcashShielded feature flag.
+    it.each([true, false])(
+      "renders no fee selector for a zcash account (shielded flag = %s)",
+      flagEnabled => {
+        renderFields({
+          account: buildZcashAccount(),
+          transaction: buildTransaction({ feesStrategy: "custom" }),
+          flagEnabled,
+        });
 
-      expect(screen.queryByTestId("send-fee-mode")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("currency-textbox")).not.toBeInTheDocument();
-    });
-
-    it("should keep the advanced fee controls for a zcash account when shielded is disabled", () => {
-      renderFields({
-        account: buildZcashAccount(),
-        transaction: buildTransaction({ feesStrategy: "custom" }),
-        flagEnabled: false,
-      });
-
-      expect(screen.getByTestId("send-fee-mode")).toBeVisible();
-      expect(screen.getByTestId("currency-textbox")).toBeVisible();
-    });
+        expect(screen.queryByTestId("send-fee-mode")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("currency-textbox")).not.toBeInTheDocument();
+        // The standard fast/medium/slow strategy list must be gone too.
+        expect(screen.queryByText("Medium")).not.toBeInTheDocument();
+        expect(screen.queryByText("Slow")).not.toBeInTheDocument();
+      },
+    );
   });
 
   describe("coin control button", () => {

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
@@ -457,7 +457,9 @@ describe("zcash chain adapter — transaction routing", () => {
     it("does not use Orchard notes for ironwood transfer type", async () => {
       // An account with orchard notes but zero ironwood notes — ironwood should
       // return empty selectedNotes, not accidentally pick orchard notes.
-      const orchardNote = makeSpendableNote({ amount: new BigNumber(1_000_000) });
+      const orchardNote = makeSpendableNote({
+        amount: new BigNumber(1_000_000),
+      });
       const account = makeZcashAccount({
         orchardBalance: new BigNumber(1_000_000),
         ironwoodBalance: new BigNumber(0),
@@ -505,7 +507,9 @@ describe("zcash chain adapter — transaction routing", () => {
 
     it("returns error when amount <= 0", async () => {
       const note = makeSpendableNote({ amount: new BigNumber(500_000) });
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       const tx = makeTx("shielded", new BigNumber(0), {
         selectedNotes: [note],
         zcashFee: new BigNumber(10_000),
@@ -517,7 +521,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns error for insufficient shielded balance", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(5_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(5_000),
+      });
       const tx = makeTx("shielded", new BigNumber(100_000), {
         selectedNotes: [makeSpendableNote()],
         zcashFee: new BigNumber(10_000),
@@ -529,7 +535,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns insufficient balance error when selectedNotes is empty", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       const tx = makeTx("shielded", new BigNumber(100_000), {
         zcashFee: new BigNumber(10_000),
         selectedNotes: [],
@@ -541,7 +549,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns recipient error for shielded-to-transparent without recipient", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       const tx = makeTx("shielded-to-transparent", new BigNumber(100_000), {
         selectedNotes: [makeSpendableNote()],
         zcashFee: new BigNumber(10_000),
@@ -553,7 +563,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns recipient error for shielded (private -> private) without recipient", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       // Selecting the private balance with an empty address derives transferType
       // "shielded"; the recipient step must not be considered valid.
       const tx = makeTx("shielded", new BigNumber(100_000), {
@@ -567,7 +579,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns insufficient balance error when selectedNotes is undefined (prepareTransaction not called)", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       // No selectedNotes at all — tx was not prepared
       const tx = makeTx("shielded", new BigNumber(100_000), {
         zcashFee: new BigNumber(10_000),
@@ -579,7 +593,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns error when selectedNotes do not cover amount + fee", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       // amount(100k) + fee(10k) = 110k, but selectedNotes only total 50k
       const tx = makeTx("shielded", new BigNumber(100_000), {
         selectedNotes: [makeSpendableNote({ amount: new BigNumber(50_000) })],
@@ -592,7 +608,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns no errors for a valid shielded transaction", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       const tx = makeTx("shielded", new BigNumber(100_000), {
         recipient: UA_ORCHARD_ONLY,
         selectedNotes: [makeSpendableNote({ amount: new BigNumber(120_000) })],
@@ -606,7 +624,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("uses default fee of 10_000 when zcashFee is not set on tx", async () => {
-      const account = makeZcashAccount({ orchardBalance: new BigNumber(500_000) });
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(500_000),
+      });
       const tx = makeTx("shielded", new BigNumber(100_000), {
         selectedNotes: [makeSpendableNote({ amount: new BigNumber(200_000) })],
       });
@@ -708,7 +728,7 @@ describe("zcash chain adapter — transaction routing", () => {
   // ── computeAccountBalance ──────────────────────────────────────
 
   describe("computeAccountBalance", () => {
-    it("returns transparent + private (orchard + sapling)", () => {
+    it("returns transparent + private (orchard + sapling) when the flag is ON", () => {
       const account = makeZcashAccount({
         orchardBalance: new BigNumber(5_000),
         saplingBalance: new BigNumber(2_000),
@@ -718,7 +738,9 @@ describe("zcash chain adapter — transaction routing", () => {
     });
 
     it("returns the transparent balance when there is no privateInfo", () => {
-      const account = { currency: { id: "zcash" } } as unknown as BitcoinAccount;
+      const account = {
+        currency: { id: "zcash" },
+      } as unknown as BitcoinAccount;
       const result = adapter.computeAccountBalance!(account, new BigNumber(10_000));
       expect(result).toEqual(new BigNumber(10_000));
     });
@@ -731,6 +753,18 @@ describe("zcash chain adapter — transaction routing", () => {
       }) as unknown as BitcoinAccount;
       const result = adapter.computeAccountBalance!(account, new BigNumber(10_000));
       expect(result).toEqual(new BigNumber(20_000));
+    });
+
+    it("ignores shielded funds and returns transparent-only when the flag is OFF", () => {
+      // Flag OFF ⇒ shielded pools aren't spendable (legacy transparent path), so
+      // they must not inflate the balance beyond the transparent max spendable.
+      setZcashShieldedEnabled(false);
+      const account = makeZcashAccount({
+        orchardBalance: new BigNumber(5_000),
+        saplingBalance: new BigNumber(2_000),
+      }) as unknown as BitcoinAccount;
+      const result = adapter.computeAccountBalance!(account, new BigNumber(10_000));
+      expect(result).toEqual(new BigNumber(10_000));
     });
   });
 
@@ -853,7 +887,9 @@ describe("zcash chain adapter — transaction routing", () => {
     it("does not use orchard notes for ironwood transfer type", async () => {
       // Account with a large orchard balance but no ironwood notes — ironwood
       // estimate must be 0, not accidentally use orchard notes.
-      const orchardNote = makeSpendableNote({ amount: new BigNumber(2_000_000) });
+      const orchardNote = makeSpendableNote({
+        amount: new BigNumber(2_000_000),
+      });
       const account = makeZcashAccount({
         orchardBalance: new BigNumber(2_000_000),
         ironwoodBalance: new BigNumber(0),

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -465,6 +465,13 @@ const zcashChainAdapter: ChainAdapter = {
   buildExtraSyncObservable,
 
   computeAccountBalance(account: BitcoinAccount | undefined, transparentBalance: BigNumber) {
+    // Flag OFF ⇒ every send falls back to the legacy transparent Bitcoin path,
+    // so the shielded (Orchard/Sapling) pools are NOT spendable. Counting them in
+    // the balance would make the account show more than the transparent max
+    // spendable — the displayed balance and the send flow's "maximum estimated
+    // amount" could never agree, and toggling "Send max" could not reach the
+    // shown balance. Report the transparent balance only until the feature is on.
+    if (!isZcashShieldedEnabled()) return transparentBalance;
     return computeZcashBalance(
       transparentBalance,
       (account as ZcashAccount | undefined)?.privateInfo,

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
@@ -4,8 +4,39 @@ import type { NetworkInfo } from "./types";
 import { getWalletAccount } from "./getWalletAccount";
 import { Account } from "@ledgerhq/types-live";
 import { BitcoinInfrastructureError } from "./errors";
-import { getRelayFeeFloorSatVb } from "@ledgerhq/wallet-btc/utils";
+import { getRelayFeeFloorSatVb, maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
+import type { Account as WalletAccount } from "@ledgerhq/wallet-btc/index";
+import { ZIP317_MARGINAL_FEE } from "./chain-adapters/zcash/coin-selection";
 const speeds = ["fast", "medium", "slow"];
+
+/**
+ * Zcash uses deterministic ZIP-317 fees (no sat/vByte fee market).
+ * We approximate the ZIP-317 marginal fee (5000 zats/action) as a flat sat/vByte rate.
+ * See: https://zips.z.cash/zip-0317 and LIVE-35152.
+ */
+function getZcashNetworkInfo(
+  walletAccount: WalletAccount,
+  relayFeePerByte: BigNumber,
+): NetworkInfo {
+  const { crypto, derivationMode } = walletAccount.xpub;
+  const fixedVBytes = maxTxVBytesCeil(0, [], false, crypto, derivationMode);
+  const oneInputVBytes = maxTxVBytesCeil(1, [], false, crypto, derivationMode) - fixedVBytes;
+  const zip317FeePerByte = new BigNumber(
+    Math.max(1, Math.ceil(ZIP317_MARGINAL_FEE / Math.max(1, oneInputVBytes))),
+  );
+  const feePerByte = BigNumber.max(zip317FeePerByte, relayFeePerByte);
+
+  // Zcash has no fee market: the three speeds all resolve to the same ZIP-317
+  // rate. A "custom" fee remains available for advanced users via the UI.
+  return {
+    family: "bitcoin",
+    feeItems: {
+      items: speeds.map((speed, i) => ({ key: String(i), speed, feePerByte })),
+      defaultFeePerByte: feePerByte,
+    },
+    relayFeePerByte,
+  };
+}
 
 // Clamp each level to ≥ floor + ε and return integers
 export function clamp(
@@ -29,8 +60,14 @@ export function avoidDups(nums: Array<BigNumber>): Array<BigNumber> {
 }
 export async function getAccountNetworkInfo(account: Account): Promise<NetworkInfo> {
   const walletAccount = getWalletAccount(account);
-  const rawFees = await walletAccount.xpub.explorer.getFees();
   const floorSatPerVB = await getRelayFeeFloorSatVb(walletAccount.xpub.explorer);
+
+  // Zcash: price with ZIP-317 instead of the explorer's (Bitcoin-scale) fee data.
+  if (account.currency.id === "zcash") {
+    return getZcashNetworkInfo(walletAccount, floorSatPerVB);
+  }
+
+  const rawFees = await walletAccount.xpub.explorer.getFees();
 
   // Convoluted logic to convert from:
   // { "2": 2435, "3": 1241, "6": 1009, "last_updated": 1627973170 }

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.zcash.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.zcash.test.ts
@@ -1,0 +1,60 @@
+import { Account } from "@ledgerhq/types-live";
+import cryptoFactory from "@ledgerhq/wallet-btc/crypto/factory";
+import { DerivationModes } from "@ledgerhq/wallet-btc/types";
+import { maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
+import { ZIP317_MARGINAL_FEE } from "./chain-adapters/zcash/coin-selection";
+
+const getFees = jest.fn().mockResolvedValue({ "2": 1000002, "4": 1000001, "6": 1000000 });
+
+const zcashCrypto = cryptoFactory("zcash");
+const walletAccount = {
+  xpub: {
+    crypto: zcashCrypto,
+    derivationMode: DerivationModes.LEGACY,
+    explorer: {
+      getFees,
+      getNetwork: jest.fn().mockResolvedValue({ relay_fee: "0.000001" }),
+    },
+  },
+};
+
+jest.mock("./getWalletAccount", () => ({
+  getWalletAccount: jest.fn(() => walletAccount),
+}));
+
+import { getAccountNetworkInfo } from "./getAccountNetworkInfo";
+
+const zcashAccount = () => ({ currency: { id: "zcash" } }) as unknown as Account;
+
+// The ZIP-317 marginal fee (5000 zats) spread over one P2PKH input's vbytes.
+const oneInputVBytes =
+  maxTxVBytesCeil(1, [], false, zcashCrypto, DerivationModes.LEGACY) -
+  maxTxVBytesCeil(0, [], false, zcashCrypto, DerivationModes.LEGACY);
+const expectedFeePerByte = Math.ceil(ZIP317_MARGINAL_FEE / oneInputVBytes);
+
+describe("getAccountNetworkInfo for Zcash (ZIP-317 pricing)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("prices from the ZIP-317 marginal fee, not the explorer's sat/vByte data", async () => {
+    // The derived sat/vB should be far below the explorer's `/fees` values (~1000 sat/vB).
+    expect(oneInputVBytes).toBeGreaterThan(0);
+    expect(expectedFeePerByte).toBeGreaterThan(0);
+    expect(expectedFeePerByte).toBeLessThan(200);
+
+    const info = await getAccountNetworkInfo(zcashAccount());
+    expect(info.feeItems.defaultFeePerByte.toNumber()).toBe(expectedFeePerByte);
+  });
+
+  it("does not call the explorer's fee market for Zcash", async () => {
+    await getAccountNetworkInfo(zcashAccount());
+    expect(getFees).not.toHaveBeenCalled();
+  });
+
+  it("returns three identical speeds (Zcash has no fee market)", async () => {
+    const info = await getAccountNetworkInfo(zcashAccount());
+    expect(info.feeItems.items.map(i => i.speed)).toEqual(["fast", "medium", "slow"]);
+    info.feeItems.items.forEach(item =>
+      expect(item.feePerByte.toNumber()).toBe(expectedFeePerByte),
+    );
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**Fix Zcash balance when the `zcashShielded` feature is OFF.**
With the feature disabled, every send falls back to the legacy transparent Bitcoin path, so shielded (Orchard/Sapling) funds are not spendable. `computeAccountBalance` no longer counts them into the account balance while the feature is off, so the displayed balance matches the transparent maximum spendable again. This fixes the "maximum estimated amount" not matching the account balance and the "Send max" toggle not filling in the estimated amount.

**Price Zcash transactions with ZIP-317 instead of the explorer's fee data.**
The Ledger `zec` explorer `/fees` endpoint returns Bitcoin-scale values (~1,000,000 sat/kB ⇒ ~1001 sat/vByte). Fed through the legacy per-byte model this over-charged transparent sends by ~100× and made the per-input cost exceed small UTXOs, so `estimateMaxSpendable` silently dropped them as "dust" (e.g. a 0.0128 ZEC balance showing only 0.00581512 ZEC spendable). `getAccountNetworkInfo` now derives a flat `feePerByte` from the ZIP-317 marginal fee (5000 zats per transparent action ≈ one P2PKH input) for Zcash, so estimateMaxSpendable, prepareTransaction, getTransactionStatus and buildTransaction all agree on a sane fee and no longer exclude legitimate UTXOs.


### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35152
