### PR TITLE
[LWDM] feat(send): rework network fee display to include crypto amounts (LIVE-34432)

### DIFF
--- a/.changeset/network-fee-display-crypto-and-fiat.md
+++ b/.changeset/network-fee-display-crypto-and-fiat.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Show the network fee in the currency users care about in the new send flow. When the fee is editable the row follows the amount input's fiat/crypto toggle; when it is not, the row shows the fiat value alongside the native amount, since it is the only place that fee is visible. Fee presets now sub-label both amounts, except coins priced by fee rate (Bitcoin, Kaspa) which keep their sat/vB legend.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -26,10 +26,19 @@ jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features", () => ({
     canEstimateFeePresetsWithZeroAmount: jest.fn(() => false),
     getFeePresetOptions: jest.fn(() => []),
     getFeeCurrencyAccountId: jest.fn(() => null),
-    showFeeCurrencyAmount: jest.fn(() => false),
-    getDefaultStrategyPatch: jest.fn(() => ({ feesStrategy: undefined, fees: undefined })),
+    getDefaultStrategyPatch: jest.fn(() => ({
+      feesStrategy: undefined,
+      fees: undefined,
+    })),
     hasFeeRateLegend: jest.fn(() => false),
   },
+}));
+let mockDisplayMode: "fiat" | "crypto" = "fiat";
+jest.mock("@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext", () => ({
+  useSendAmountDisplayMode: () => ({
+    displayMode: mockDisplayMode,
+    setDisplayMode: jest.fn(),
+  }),
 }));
 jest.mock("@ledgerhq/live-countervalues-react", () => ({
   ...jest.requireActual("@ledgerhq/live-countervalues-react"),
@@ -51,6 +60,7 @@ function isAccount(account: unknown): account is Account {
 
 function buildBaseParams(overrides?: {
   transaction?: Partial<Transaction>;
+  status?: Partial<TransactionStatus>;
   uiConfig?: {
     hasFeePresets?: boolean;
     hasCustomFees?: boolean;
@@ -81,6 +91,7 @@ function buildBaseParams(overrides?: {
     estimatedFees: new BigNumber(0),
     amount: new BigNumber(0),
     totalSpent: new BigNumber(0),
+    ...overrides?.status,
   } as TransactionStatus;
   const updateTransaction = jest.fn();
 
@@ -103,6 +114,7 @@ function buildBaseParams(overrides?: {
 describe("useNetworkFees", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDisplayMode = "fiat";
 
     const bridge = {
       updateTransaction: (tx: Record<string, unknown>, patch: Record<string, unknown>) => ({
@@ -111,7 +123,10 @@ describe("useNetworkFees", () => {
       }),
     };
     mockedGetAccountBridge.mockReturnValue(
-      Object.assign(Promise.resolve(bridge), { status: "fulfilled", value: bridge }) as never,
+      Object.assign(Promise.resolve(bridge), {
+        status: "fulfilled",
+        value: bridge,
+      }) as never,
     );
   });
 
@@ -119,7 +134,9 @@ describe("useNetworkFees", () => {
     const params = buildBaseParams({ uiConfig: { hasFeePresets: true } });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.showNetworkFees).toBe(true);
@@ -129,7 +146,9 @@ describe("useNetworkFees", () => {
     const params = buildBaseParams({ uiConfig: { hasFeePresets: false } });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.feeSelector.options).toHaveLength(0);
@@ -151,7 +170,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.selectedFeeStrategy).toBe("fast");
@@ -162,7 +183,9 @@ describe("useNetworkFees", () => {
     const params = buildBaseParams({ uiConfig: { hasFeePresets: true } });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.selectedFeeStrategy).toBeNull();
@@ -176,7 +199,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.feesRowStrategyLabel).toBe("Custom");
@@ -184,24 +209,103 @@ describe("useNetworkFees", () => {
 
   it("returns feesRowStrategyLabel Default network fee for a preset-less coin with no override", () => {
     const params = buildBaseParams({
-      uiConfig: { hasFeePresets: false, hasCustomFees: true, hasDefaultStrategy: true },
+      uiConfig: {
+        hasFeePresets: false,
+        hasCustomFees: true,
+        hasDefaultStrategy: true,
+      },
     });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.feesRowStrategyLabel).toBe("Default network fee");
   });
 
-  it("returns feesRowValue as -- when no preset selected and no fee summary", () => {
-    const params = buildBaseParams({ uiConfig: { hasFeePresets: true } });
+  it("returns feesRowValue as -- when the fee is editable but unknown", () => {
+    const params = buildBaseParams({
+      uiConfig: { hasFeePresets: true, hasCustomFees: true },
+    });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.feesRowValue).toBe("--");
+  });
+
+  it("follows the fiat⇄crypto toggle for the row value when fees are editable", () => {
+    const params = buildBaseParams({
+      uiConfig: { hasFeePresets: true, hasCustomFees: true },
+      status: { estimatedFees: new BigNumber(1_000) },
+    });
+
+    const { result: fiat } = renderHook(() => useNetworkFees(params), {
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
+    });
+    expect(fiat.current.feesRowValue).toMatch(/\$/);
+    expect(fiat.current.feesRowSecondaryValue).toBeNull();
+
+    mockDisplayMode = "crypto";
+    const { result: crypto } = renderHook(() => useNetworkFees(params), {
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
+    });
+    expect(crypto.current.feesRowValue).toMatch(/BTC/);
+    expect(crypto.current.feesRowSecondaryValue).toBeNull();
+  });
+
+  it("exposes both values on the row when fees are not editable", () => {
+    const params = buildBaseParams({
+      uiConfig: {
+        hasFeePresets: false,
+        hasCustomFees: false,
+        hasCoinControl: false,
+      },
+      status: { estimatedFees: new BigNumber(1_000) },
+    });
+
+    const { result } = renderHook(() => useNetworkFees(params), {
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
+    });
+
+    expect(result.current.feeSelector.canOpen).toBe(false);
+    expect(result.current.feesRowValue).toMatch(/\$/);
+    expect(result.current.feesRowSecondaryValue).toMatch(/BTC/);
+  });
+
+  it("sub-labels presets with both amounts", () => {
+    const mockedSendFeatures = jest.requireMock(
+      "@ledgerhq/live-common/bridge/descriptor/send/features",
+    ).sendFeatures;
+    mockedSendFeatures.hasFeePresets.mockReturnValue(true);
+    mockedSendFeatures.getFeePresetOptions.mockReturnValue([
+      { id: "slow", amount: new BigNumber(1_000) },
+      { id: "medium", amount: new BigNumber(2_000) },
+    ]);
+
+    const params = buildBaseParams({ uiConfig: { hasFeePresets: true } });
+
+    const { result } = renderHook(() => useNetworkFees(params), {
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
+    });
+
+    const slow = result.current.feeSelector.options.find(o => o.id === "slow");
+    expect(slow?.sublabel).toContain(" · ");
+    expect(slow?.sublabel).toMatch(/\$/);
+    expect(slow?.sublabel).toMatch(/BTC/);
   });
 
   it("feeSelector option onSelect calls updateTransaction with bridge-updated transaction", () => {
@@ -220,7 +324,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     const mediumOption = result.current.feeSelector.options.find(o => o.id === "medium");
@@ -246,7 +352,9 @@ describe("useNetworkFees", () => {
     const params = buildBaseParams({ uiConfig: { hasFeePresets: true } });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current).toMatchObject({
@@ -268,7 +376,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees({ ...params, onSelectCustomFees }), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     const customOption = result.current.feeSelector.options.find(o => o.id === "custom");
@@ -285,7 +395,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees(params), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     expect(result.current.feeSelector.options.some(o => o.id === "custom")).toBe(false);
@@ -298,7 +410,9 @@ describe("useNetworkFees", () => {
     });
 
     const { result } = renderHook(() => useNetworkFees({ ...params, onSelectCoinControl }), {
-      initialState: { settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" } },
+      initialState: {
+        settings: { ...INITIAL_STATE_SETTINGS, counterValue: "USD" },
+      },
     });
 
     const coinControlOption = result.current.feeSelector.options.find(o => o.id === "coinControl");

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -17,7 +17,11 @@ import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-r
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useNetworkFeesCore } from "@ledgerhq/live-common/flows/send/hooks/useNetworkFeesCore";
 import { feeSelectorLabelKeySuffix } from "@ledgerhq/live-common/flows/send/utils/feeStrategyLabels";
-import { buildFeeSelectorOptions } from "@ledgerhq/live-common/flows/send/utils/feeSelectorOptions";
+import {
+  buildFeeSelectorOptions,
+  feeStrategySublabel,
+} from "@ledgerhq/live-common/flows/send/utils/feeSelectorOptions";
+import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
 import type { FeeSelectorOption } from "../screens/Amount/types";
 
 type UseNetworkFeesParams = Readonly<{
@@ -54,6 +58,7 @@ export function useNetworkFees({
   const calculateCountervalue = useCalculateCountervalueCallback({
     to: counterValueCurrency,
   });
+  const { displayMode } = useSendAmountDisplayMode();
 
   const core = useNetworkFeesCore({
     account,
@@ -65,6 +70,7 @@ export function useNetworkFees({
     fiatUnit,
     accountUnit,
     locale,
+    displayMode,
     calculateCountervalue,
   });
 
@@ -81,7 +87,9 @@ export function useNetworkFees({
             defaultValue: option.id.toUpperCase(),
           }),
         sublabelFor: option =>
-          shouldShowFeeRateLegend ? option.sublabelLegend : option.sublabelFiat,
+          feeStrategySublabel(option, {
+            preferLegend: shouldShowFeeRateLegend,
+          }),
         custom: {
           enabled: core.hasCustomFees,
           label: t("fees.custom"),
@@ -109,11 +117,8 @@ export function useNetworkFees({
   return useMemo(
     () => ({
       feesRowLabel: t("fees.networkFees"),
-      // A selected preset's fiat value takes precedence here. Coins using `showFeeCurrencyAmount`
-      // have no fee presets today, so this never drops the combined value; revisit if that changes.
-      feesRowValue:
-        core.selectedPresetFiatValue ??
-        (core.displayFeesValue === "-" ? "--" : core.displayFeesValue),
+      feesRowValue: core.feesRowValue === "-" ? "--" : core.feesRowValue,
+      feesRowSecondaryValue: core.feesRowSecondaryValue,
       feesRowStrategyLabel: t(`fees.${feeSelectorLabelKeySuffix(core.selectedFeeStrategyId)}`, {
         defaultValue: core.selectedFeeStrategyId.toUpperCase(),
       }),

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountFooter.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountFooter.tsx
@@ -8,6 +8,7 @@ import { NetworkFeesMenu } from "./Fees/NetworkFeesMenu";
 type AmountFooterProps = Readonly<{
   feesRowLabel: string;
   feesRowValue: string;
+  feesRowSecondaryValue: string | null;
   feesRowStrategyLabel: string;
   feeSelector: Readonly<{
     options: readonly FeeSelectorOption[];
@@ -25,6 +26,7 @@ type AmountFooterProps = Readonly<{
 export function AmountFooter({
   feesRowLabel,
   feesRowValue,
+  feesRowSecondaryValue,
   feesRowStrategyLabel,
   feeSelector,
   reviewLabel,
@@ -51,6 +53,7 @@ export function AmountFooter({
         display={{
           label: feesRowLabel,
           value: feesRowValue,
+          secondaryValue: feesRowSecondaryValue,
           strategyLabel: feesRowStrategyLabel,
         }}
         feeSelector={feeSelector}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/AmountScreenView.tsx
@@ -17,6 +17,7 @@ export function AmountScreenView({
   secondaryValue,
   feesRowLabel,
   feesRowValue,
+  feesRowSecondaryValue,
   feesRowStrategyLabel,
   feeSelector,
   quickActions,
@@ -55,6 +56,7 @@ export function AmountScreenView({
       <AmountFooter
         feesRowLabel={feesRowLabel}
         feesRowValue={feesRowValue}
+        feesRowSecondaryValue={feesRowSecondaryValue}
         feesRowStrategyLabel={feesRowStrategyLabel}
         feeSelector={feeSelector}
         reviewLabel={reviewLabel}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/components/Fees/NetworkFeesMenu.tsx
@@ -26,6 +26,8 @@ import type { FeeSelectorOption } from "../../types";
 type FeesDisplay = Readonly<{
   label: string;
   value: string;
+  /** Native fee amount shown after `value`, set only when fees are read-only. */
+  secondaryValue: string | null;
   strategyLabel: string;
 }>;
 
@@ -41,7 +43,12 @@ type NetworkFeesMenuProps = Readonly<{
 }>;
 
 export function NetworkFeesMenu({ display, feeSelector }: NetworkFeesMenuProps) {
-  const { label: feesLabel, value: feesValue, strategyLabel: feesStrategyLabel } = display;
+  const {
+    label: feesLabel,
+    value: feesValue,
+    secondaryValue: feesSecondaryValue,
+    strategyLabel: feesStrategyLabel,
+  } = display;
   const { options, selectedId, canOpen } = feeSelector;
   const { t } = useTranslation();
   const { state } = useSendFlowData();
@@ -88,7 +95,12 @@ export function NetworkFeesMenu({ display, feeSelector }: NetworkFeesMenuProps) 
           <span className="body-3">{feesLabel}</span>
           {informationIcon}
         </span>
-        <span className="body-3 text-base">{feesValue}</span>
+        <span className="flex items-center gap-4">
+          <span className="body-3 text-base">{feesValue}</span>
+          {feesSecondaryValue ? (
+            <span className="body-3 text-muted">{feesSecondaryValue}</span>
+          ) : null}
+        </span>
       </div>
     );
   }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/types.ts
@@ -50,6 +50,7 @@ type AmountInputProps = Readonly<{
 type FeesProps = Readonly<{
   feesRowLabel: string;
   feesRowValue: string;
+  feesRowSecondaryValue: string | null;
   feesRowStrategyLabel: string;
   showNetworkFees: boolean;
   selectedFeeStrategy: string | null;

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlFooter.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CoinControl/components/CoinControlFooter.tsx
@@ -46,6 +46,7 @@ export function CoinControlFooter({
         display={{
           label: networkFees.feesRowLabel,
           value: networkFees.feesRowValue,
+          secondaryValue: networkFees.feesRowSecondaryValue,
           strategyLabel: networkFees.feesRowStrategyLabel,
         }}
         feeSelector={networkFees.feeSelector}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/NetworkFeesRow.tsx
@@ -149,7 +149,13 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
             <Text typography="body3" lx={{ color: "base" }}>
               {viewModel.value}
             </Text>
-            {viewModel.showFeeCurrencyAmount ? null : (
+            {viewModel.secondaryValue ? (
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {viewModel.secondaryValue}
+              </Text>
+            ) : null}
+            {/* A read-only fee has no strategy to name. */}
+            {canOpenFeeSelector ? (
               <>
                 <Text typography="body3" lx={{ color: "muted" }}>
                   •
@@ -158,7 +164,7 @@ export function NetworkFeesRow({ viewModel }: NetworkFeesRowProps) {
                   {viewModel.strategyLabel}
                 </Text>
               </>
-            )}
+            ) : null}
           </View>
           {canOpenFeeSelector ? <ChevronDown size={16} /> : null}
         </Pressable>

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/NetworkFeesRow.test.tsx
@@ -44,7 +44,9 @@ jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => ({
 }));
 jest.mock("@ledgerhq/lumen-ui-rnative/styles", () => ({
   useStyleSheet: (createStyles: (theme: { spacings: Record<string, number> }) => unknown) =>
-    createStyles({ spacings: { s4: 4, s8: 8, s10: 10, s12: 12, s16: 16, s24: 24 } }),
+    createStyles({
+      spacings: { s4: 4, s8: 8, s10: 10, s12: 12, s16: 16, s24: 24 },
+    }),
 }));
 jest.mock("~/context/Locale", () => ({
   useTranslation: () => ({
@@ -53,9 +55,13 @@ jest.mock("~/context/Locale", () => ({
   }),
 }));
 jest.mock("../../context/SendFlowContext", () => ({
-  useSendFlowData: () => ({ state: { account: { account: null, parentAccount: null } } }),
+  useSendFlowData: () => ({
+    state: { account: { account: null, parentAccount: null } },
+  }),
 }));
-jest.mock("~/analytics", () => ({ useAnalytics: () => ({ track: jest.fn() }) }));
+jest.mock("~/analytics", () => ({
+  useAnalytics: () => ({ track: jest.fn() }),
+}));
 jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
   getSendFlowTrackingProperties: () => ({}),
 }));
@@ -63,37 +69,59 @@ jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
 const baseViewModel: NetworkFeesViewModel = {
   label: "Network fees",
   value: "0 TRX",
+  secondaryValue: null,
   strategyLabel: "",
-  showFeeCurrencyAmount: false,
   selectedFeeStrategy: null,
   displayOptions: [],
   canOpenSelector: false,
   networkFeesInfo: null,
 };
 
+const editableViewModel: NetworkFeesViewModel = {
+  ...baseViewModel,
+  canOpenSelector: true,
+  displayOptions: [
+    {
+      id: "medium",
+      kind: "preset",
+      label: "Medium option",
+      sublabel: null,
+      selected: true,
+      onSelect: jest.fn(),
+    },
+  ],
+};
+
 describe("NetworkFeesRow fee value", () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it("shows the value followed by the strategy label by default", () => {
+  it("shows the value followed by the strategy label when the fee is editable", () => {
     render(
-      <NetworkFeesRow viewModel={{ ...baseViewModel, value: "$0.12", strategyLabel: "Medium" }} />,
+      <NetworkFeesRow
+        viewModel={{
+          ...editableViewModel,
+          value: "$0.12",
+          strategyLabel: "Medium",
+        }}
+      />,
     );
     expect(screen.getByText("$0.12")).toBeOnTheScreen();
     expect(screen.getByText("Medium")).toBeOnTheScreen();
   });
 
-  it("shows the fiat • crypto value alone (no strategy label) when showFeeCurrencyAmount is set", () => {
+  it("shows both values and no strategy label when the fee is read-only", () => {
     render(
       <NetworkFeesRow
         viewModel={{
           ...baseViewModel,
-          value: "$0.00 • 0 TRX",
+          value: "$0.10",
+          secondaryValue: "0.00056 SOL",
           strategyLabel: "Medium",
-          showFeeCurrencyAmount: true,
         }}
       />,
     );
-    expect(screen.getByText("$0.00 • 0 TRX")).toBeOnTheScreen();
+    expect(screen.getByText("$0.10")).toBeOnTheScreen();
+    expect(screen.getByText("0.00056 SOL")).toBeOnTheScreen();
     expect(screen.queryByText("Medium")).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useNetworkFees.test.ts
@@ -23,6 +23,13 @@ jest.mock("@ledgerhq/live-countervalues-react", () => ({
   useCalculateCountervalueCallback: jest.fn(() => jest.fn()),
 }));
 jest.mock("@ledgerhq/live-common/flows/send/hooks/useNetworkFeesCore");
+let mockDisplayMode: "fiat" | "crypto" = "fiat";
+jest.mock("@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext", () => ({
+  useSendAmountDisplayMode: () => ({
+    displayMode: mockDisplayMode,
+    setDisplayMode: jest.fn(),
+  }),
+}));
 
 const mockUseNetworkFeesCore = jest.requireMock(
   "@ledgerhq/live-common/flows/send/hooks/useNetworkFeesCore",
@@ -95,30 +102,48 @@ function mockCore(overrides?: {
     id: string;
     kind: "preset" | "default";
     sublabelFiat: string | null;
+    sublabelCrypto: string | null;
     sublabelLegend: string | null;
   }>;
   selectedFeeStrategyId?: string;
   selectedFeeStrategy?: string | null;
-  displayFeesValue?: string;
+  feesRowValue?: string;
+  feesRowSecondaryValue?: string | null;
   hasCustomFees?: boolean;
   hasCoinControl?: boolean;
   onSelectFeeStrategyId?: jest.Mock;
 }) {
   mockUseNetworkFeesCore.mockReturnValue({
     feeStrategyOptions: overrides?.feeStrategyOptions ?? [
-      { id: "slow", kind: "preset", sublabelFiat: "$1.00", sublabelLegend: null },
-      { id: "medium", kind: "preset", sublabelFiat: "$2.00", sublabelLegend: null },
-      { id: "fast", kind: "preset", sublabelFiat: "$3.00", sublabelLegend: null },
+      {
+        id: "slow",
+        kind: "preset",
+        sublabelFiat: "$1.00",
+        sublabelCrypto: "1 BTC",
+        sublabelLegend: null,
+      },
+      {
+        id: "medium",
+        kind: "preset",
+        sublabelFiat: "$2.00",
+        sublabelCrypto: "2 BTC",
+        sublabelLegend: null,
+      },
+      {
+        id: "fast",
+        kind: "preset",
+        sublabelFiat: "$3.00",
+        sublabelCrypto: "3 BTC",
+        sublabelLegend: null,
+      },
     ],
     selectedFeeStrategyId: overrides?.selectedFeeStrategyId ?? "",
     selectedFeeStrategy: overrides?.selectedFeeStrategy ?? null,
-    selectedPresetFiatValue: null,
     onSelectFeeStrategyId: overrides?.onSelectFeeStrategyId ?? jest.fn(),
-    displayFeesValue: overrides?.displayFeesValue ?? "-",
-    formattedEstimatedFeesFiat: null,
+    feesRowValue: overrides?.feesRowValue ?? "-",
+    feesRowSecondaryValue: overrides?.feesRowSecondaryValue ?? null,
     hasCustomFees: overrides?.hasCustomFees ?? false,
     hasCoinControl: overrides?.hasCoinControl ?? false,
-    showFeeCurrencyAmount: false,
   });
 }
 
@@ -190,14 +215,14 @@ describe("useNetworkFees", () => {
     );
   });
 
-  it("maps fee strategy options with translated labels and fiat sublabels", () => {
+  it("maps fee strategy options with translated labels and combined sublabels", () => {
     const { result } = renderHook(() => useNetworkFees(buildParams()));
 
     expect(result.current.displayOptions[0]).toEqual({
       id: "slow",
       kind: "preset",
       label: "send.fees.slow",
-      sublabel: "$1.00",
+      sublabel: "$1.00 · 1 BTC",
       selected: false,
       onSelect: expect.any(Function),
     });
@@ -216,26 +241,46 @@ describe("useNetworkFees", () => {
     expect(slow?.selected).toBe(false);
   });
 
-  it("uses core displayFeesValue and selected strategy label", () => {
+  it("uses the core row value and selected strategy label", () => {
     mockCore({
       feeStrategyOptions: [],
       selectedFeeStrategyId: "fast",
       selectedFeeStrategy: "fast",
-      displayFeesValue: "$15.00 USD",
+      feesRowValue: "$15.00",
     });
 
     const { result } = renderHook(() =>
       useNetworkFees(buildParams({ uiConfig: { hasFeePresets: true } })),
     );
 
-    expect(result.current.value).toBe("$15.00 USD");
+    expect(result.current.value).toBe("$15.00");
     expect(result.current.strategyLabel).toBe("send.fees.fast");
+  });
+
+  it("forwards the core's secondary value for a read-only fee", () => {
+    mockCore({
+      feeStrategyOptions: [],
+      feesRowValue: "$0.10",
+      feesRowSecondaryValue: "0.00056 SOL",
+    });
+
+    const { result } = renderHook(() => useNetworkFees(buildParams()));
+
+    expect(result.current.value).toBe("$0.10");
+    expect(result.current.secondaryValue).toBe("0.00056 SOL");
+    expect(result.current.canOpenSelector).toBe(false);
   });
 
   it("uses the default-network-fee label when selectedFeeStrategyId is 'default' (preset-less coin)", () => {
     mockCore({
       feeStrategyOptions: [
-        { id: "default", kind: "default", sublabelFiat: null, sublabelLegend: null },
+        {
+          id: "default",
+          kind: "default",
+          sublabelFiat: null,
+          sublabelCrypto: null,
+          sublabelLegend: null,
+        },
       ],
       selectedFeeStrategyId: "default",
       selectedFeeStrategy: null,
@@ -291,7 +336,11 @@ describe("useNetworkFees", () => {
   });
 
   it("canOpenSelector is false when there are no options at all", () => {
-    mockCore({ feeStrategyOptions: [], hasCustomFees: false, hasCoinControl: false });
+    mockCore({
+      feeStrategyOptions: [],
+      hasCustomFees: false,
+      hasCoinControl: false,
+    });
 
     const { result } = renderHook(() => useNetworkFees(buildParams()));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useNetworkFees.ts
@@ -17,7 +17,11 @@ import { useCalculateCountervalueCallback } from "@ledgerhq/live-countervalues-r
 import { useNetworkFeesCore } from "@ledgerhq/live-common/flows/send/hooks/useNetworkFeesCore";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { feeSelectorLabelKeySuffix } from "@ledgerhq/live-common/flows/send/utils/feeStrategyLabels";
-import { buildFeeSelectorOptions } from "@ledgerhq/live-common/flows/send/utils/feeSelectorOptions";
+import {
+  buildFeeSelectorOptions,
+  feeStrategySublabel,
+} from "@ledgerhq/live-common/flows/send/utils/feeSelectorOptions";
+import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
 import type { FeeSelectorOption, NetworkFeesViewModel } from "../types";
 
 type UseNetworkFeesParams = Readonly<{
@@ -55,6 +59,7 @@ export function useNetworkFees({
   const calculateCountervalue = useCalculateCountervalueCallback({
     to: counterValueCurrency,
   });
+  const { displayMode } = useSendAmountDisplayMode();
 
   const core = useNetworkFeesCore({
     account,
@@ -66,8 +71,11 @@ export function useNetworkFees({
     fiatUnit,
     accountUnit,
     locale,
+    displayMode,
     calculateCountervalue,
   });
+
+  const shouldShowFeeRateLegend = sendFeatures.hasFeeRateLegend(accountCurrency);
 
   const networkFeesInfo = useMemo(
     () => sendFeatures.getNetworkFeesInfo(accountCurrency, { transaction, status }),
@@ -82,7 +90,8 @@ export function useNetworkFees({
         onSelectFeeStrategyId: core.onSelectFeeStrategyId,
         labelFor: option =>
           t(option.kind === "default" ? "send.fees.defaultNetworkFee" : `send.fees.${option.id}`),
-        sublabelFor: option => option.sublabelFiat,
+        sublabelFor: option =>
+          feeStrategySublabel(option, { preferLegend: shouldShowFeeRateLegend }),
         custom: {
           enabled: core.hasCustomFees,
           label: t("send.fees.customFees"),
@@ -102,6 +111,7 @@ export function useNetworkFees({
       core.selectedFeeStrategyId,
       onSelectCoinControl,
       onSelectCustomFees,
+      shouldShowFeeRateLegend,
       t,
     ],
   );
@@ -109,19 +119,19 @@ export function useNetworkFees({
   return useMemo(
     () => ({
       label: t("send.fees.title"),
-      value: core.displayFeesValue,
+      value: core.feesRowValue,
+      secondaryValue: core.feesRowSecondaryValue,
       strategyLabel: t(`send.fees.${feeSelectorLabelKeySuffix(core.selectedFeeStrategyId)}`),
-      showFeeCurrencyAmount: core.showFeeCurrencyAmount,
       selectedFeeStrategy: core.selectedFeeStrategy,
       displayOptions,
       canOpenSelector: displayOptions.length > 0,
       networkFeesInfo,
     }),
     [
-      core.displayFeesValue,
+      core.feesRowSecondaryValue,
+      core.feesRowValue,
       core.selectedFeeStrategy,
       core.selectedFeeStrategyId,
-      core.showFeeCurrencyAmount,
       displayOptions,
       networkFeesInfo,
       t,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/types.ts
@@ -35,9 +35,12 @@ export type SendFlowNavigationProp = NativeStackNavigationProp<SendFlowStackPara
 export type NetworkFeesViewModel = Readonly<{
   label: string;
   value: string;
+  /**
+   * Native fee amount rendered after `value` in the muted colour. Only set when the fee is not
+   * editable, where the row is the user's only view of what the network will take.
+   */
+  secondaryValue: string | null;
   strategyLabel: string;
-  /** When true, `value` already includes the native fee-currency amount (with fiat when a rate exists); the row omits the strategy label. */
-  showFeeCurrencyAmount: boolean;
   selectedFeeStrategy: string | null;
   displayOptions: readonly FeeSelectorOption[];
   canOpenSelector: boolean;

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -646,7 +646,7 @@
     "src/flows/send/customFees/hooks/useStableGasOptions.ts",
     "src/flows/send/customFees/utils/customFeeUtils.ts",
     "src/flows/send/effects/hooks/useFlowEffects.ts",
-    "src/flows/send/hooks/useFeePresetFiatValuesCore.ts",
+    "src/flows/send/hooks/useFeePresetValuesCore.ts",
     "src/flows/send/hooks/useNetworkFeesCore.ts",
     "src/flows/send/hooks/useSendFlowAccount.ts",
     "src/flows/send/hooks/useSendFlowAmountReviewCore.ts",

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -51,7 +51,6 @@ export const sendFeatures = {
   getCustomAssetsConfig: fromDescriptor(d => d.fees.customAssets, noFeeAssetsConfig),
   hasCoinControl: fromDescriptor(d => d.fees.hasCoinControl, false),
   getCoinControlConfig: fromDescriptor(d => d.fees.coinControl, noCoinControlConfig),
-  showFeeCurrencyAmount: fromDescriptor(d => d.fees.showFeeCurrencyAmount, false),
   getFeePresetOptions: (
     currency: CryptoOrTokenCurrency | undefined,
     transaction: unknown,

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -228,12 +228,6 @@ export type FeeDescriptor = {
   hasCustom: boolean;
   hasCustomAssets?: boolean;
   hasCoinControl?: boolean;
-  /**
-   * Opt-in: also display the fee amount in its own fee currency (native) next to the fiat value on
-   * the Amount fee row, and render `0` explicitly instead of the `"-"` sentinel for a zero fee. Off
-   * by default (fiat value, with a native-amount fallback). Independent of `getNetworkFeesInfo`.
-   */
-  showFeeCurrencyAmount?: boolean;
   presets?: {
     /**
      * Optional UI legend for presets (ex: fee rate like `2 sat/vbyte`).

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
@@ -18,8 +18,12 @@ const status = (fields: {
 });
 
 describe("tron descriptor", () => {
-  it("opts into showing the fee-currency amount on the fee row", () => {
-    expect(descriptor.send.fees.showFeeCurrencyAmount).toBe(true);
+  // Tron fees are not editable, which is what makes the fee row show both the fiat and the TRX
+  // amount. Guard that so a future preset/custom-fee opt-in does not silently drop the TRX amount.
+  it("declares no editable fees", () => {
+    expect(descriptor.send.fees.hasPresets).toBe(false);
+    expect(descriptor.send.fees.hasCustom).toBe(false);
+    expect(descriptor.send.fees.hasCoinControl).toBeUndefined();
   });
 });
 

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.ts
@@ -55,7 +55,6 @@ export const descriptor: CoinDescriptor = {
     fees: {
       hasPresets: false,
       hasCustom: false,
-      showFeeCurrencyAmount: true,
       getNetworkFeesInfo,
     },
   },

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useFeePresetValuesCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useFeePresetValuesCore.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { BigNumber } from "bignumber.js";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { useFeePresetFiatValuesCore } from "../useFeePresetFiatValuesCore";
+import { useFeePresetValuesCore } from "../useFeePresetValuesCore";
 import { getAccountBridge } from "../../../../bridge/impl";
 import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import type { Transaction } from "../../../../coin-modules/transaction-types";
@@ -20,6 +20,7 @@ const mockedGetAccountBridge = jest.mocked(getAccountBridge);
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
 
 const usdUnit: Unit = { name: "US Dollar", code: "USD", magnitude: 2 };
+const btcUnit: Unit = { name: "Bitcoin", code: "BTC", magnitude: 8 };
 const flushAsyncEstimation = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
 const mockCurrency = {
@@ -42,7 +43,7 @@ const createMainAccount = (overrides?: Partial<Account>): Account =>
     ...overrides,
   }) as unknown as Account;
 
-describe("useFeePresetFiatValuesCore", () => {
+describe("useFeePresetValuesCore", () => {
   const mockCalculateCountervalue = jest.fn();
   const defaultBridge = {
     updateTransaction: jest.fn((tx: Record<string, unknown>, patch: Record<string, unknown>) => ({
@@ -72,6 +73,7 @@ describe("useFeePresetFiatValuesCore", () => {
       { id: "fast", amount: new BigNumber(3_000) },
     ] satisfies readonly FeePresetOption[],
     fiatUnit: usdUnit,
+    displayUnit: btcUnit,
     enabled: true,
     shouldEstimateWithBridge: false,
     allowZeroAmountEstimation: false,
@@ -82,31 +84,34 @@ describe("useFeePresetFiatValuesCore", () => {
     jest.clearAllMocks();
     mockedGetAccountBridge.mockResolvedValue(defaultBridge as never);
     mockCalculateCountervalue.mockImplementation((_currency, value) => value);
-    mockedFormatCurrencyUnit.mockImplementation((_unit, value) => value.toString());
+    // Tag the unit so the assertions can tell the fiat side from the native side.
+    mockedFormatCurrencyUnit.mockImplementation(
+      (unit, value) => `${unit.code}_${value.toString()}`,
+    );
   });
 
-  it("returns direct fiat values when preset amounts are available", () => {
+  it("returns direct fiat and native values when preset amounts are available", () => {
     const feePresetOptions = [
       { id: "slow", amount: new BigNumber(1) },
       { id: "fast", amount: new BigNumber(3) },
     ] satisfies readonly FeePresetOption[];
 
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({
+      useFeePresetValuesCore({
         ...defaultParams,
         feePresetOptions,
       }),
     );
 
     expect(result.current).toEqual({
-      slow: "1",
-      fast: "3",
+      slow: { fiat: "USD_1", crypto: "BTC_1" },
+      fast: { fiat: "USD_3", crypto: "BTC_3" },
     });
   });
 
   it("returns empty map when enabled is false", () => {
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({ ...defaultParams, enabled: false }),
+      useFeePresetValuesCore({ ...defaultParams, enabled: false }),
     );
 
     expect(result.current).toEqual({});
@@ -114,32 +119,37 @@ describe("useFeePresetFiatValuesCore", () => {
 
   it("returns empty map when feePresetOptions is empty and no fallback ids", () => {
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({ ...defaultParams, feePresetOptions: [] }),
+      useFeePresetValuesCore({ ...defaultParams, feePresetOptions: [] }),
     );
 
     expect(result.current).toEqual({});
   });
 
-  it("returns null for a preset when countervalue is unavailable", () => {
+  it("returns a null fiat side, but keeps the native amount, when countervalue is unavailable", () => {
     mockCalculateCountervalue.mockReturnValue(null);
 
-    const { result } = renderHook(() => useFeePresetFiatValuesCore(defaultParams));
+    const { result } = renderHook(() => useFeePresetValuesCore(defaultParams));
 
-    Object.values(result.current).forEach(value => {
-      expect(value).toBeNull();
+    expect(result.current).toEqual({
+      slow: { fiat: null, crypto: "BTC_1000" },
+      medium: { fiat: null, crypto: "BTC_2000" },
+      fast: { fiat: null, crypto: "BTC_3000" },
     });
   });
 
   it("does not use direct path when shouldEstimateWithBridge is true", () => {
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({ ...defaultParams, shouldEstimateWithBridge: true }),
+      useFeePresetValuesCore({
+        ...defaultParams,
+        shouldEstimateWithBridge: true,
+      }),
     );
 
     expect(result.current).toEqual({});
   });
 
   it("passes locale to formatCurrencyUnit", () => {
-    renderHook(() => useFeePresetFiatValuesCore({ ...defaultParams, locale: "fr" }));
+    renderHook(() => useFeePresetValuesCore({ ...defaultParams, locale: "fr" }));
 
     expect(mockedFormatCurrencyUnit).toHaveBeenCalledWith(
       usdUnit,
@@ -162,13 +172,16 @@ describe("useFeePresetFiatValuesCore", () => {
           fast: new BigNumber(3),
         };
         const strategy = typeof tx.feesStrategy === "string" ? tx.feesStrategy : "";
-        return { estimatedFees: feesByStrategy[strategy] ?? new BigNumber(0), errors: {} };
+        return {
+          estimatedFees: feesByStrategy[strategy] ?? new BigNumber(0),
+          errors: {},
+        };
       },
     };
     mockedGetAccountBridge.mockResolvedValue(bridge as never);
 
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({
+      useFeePresetValuesCore({
         ...defaultParams,
         feePresetOptions: [],
         fallbackPresetIds: ["slow", "medium", "fast"],
@@ -185,9 +198,9 @@ describe("useFeePresetFiatValuesCore", () => {
 
     await waitFor(() => {
       expect(result.current).toEqual({
-        slow: "1",
-        medium: "2",
-        fast: "3",
+        slow: { fiat: "USD_1", crypto: "BTC_1" },
+        medium: { fiat: "USD_2", crypto: "BTC_2" },
+        fast: { fiat: "USD_3", crypto: "BTC_3" },
       });
     });
   });
@@ -220,13 +233,16 @@ describe("useFeePresetFiatValuesCore", () => {
           medium: new BigNumber(2),
           fast: new BigNumber(3),
         };
-        return { estimatedFees: feesByStrategy[strategy] ?? new BigNumber(0), errors: {} };
+        return {
+          estimatedFees: feesByStrategy[strategy] ?? new BigNumber(0),
+          errors: {},
+        };
       },
     };
     mockedGetAccountBridge.mockResolvedValue(bridge as never);
 
     const { result } = renderHook(() =>
-      useFeePresetFiatValuesCore({
+      useFeePresetValuesCore({
         ...defaultParams,
         feePresetOptions: [],
         fallbackPresetIds: ["slow", "medium", "fast"],
@@ -251,9 +267,9 @@ describe("useFeePresetFiatValuesCore", () => {
 
     await waitFor(() => {
       expect(result.current).toEqual({
-        slow: "1",
-        medium: "2",
-        fast: "3",
+        slow: { fiat: "USD_1", crypto: "BTC_1" },
+        medium: { fiat: "USD_2", crypto: "BTC_2" },
+        fast: { fiat: "USD_3", crypto: "BTC_3" },
       });
     });
   });
@@ -262,7 +278,7 @@ describe("useFeePresetFiatValuesCore", () => {
     mockedGetAccountBridge.mockRejectedValueOnce(new Error("Bridge error"));
 
     const { result, rerender } = renderHook(() =>
-      useFeePresetFiatValuesCore({
+      useFeePresetValuesCore({
         ...defaultParams,
         shouldEstimateWithBridge: true,
       }),
@@ -281,9 +297,9 @@ describe("useFeePresetFiatValuesCore", () => {
     await waitFor(() => {
       expect(mockedGetAccountBridge).toHaveBeenCalledTimes(2);
       expect(result.current).toEqual({
-        slow: "1000",
-        medium: "1000",
-        fast: "1000",
+        slow: { fiat: "USD_1000", crypto: "BTC_1000" },
+        medium: { fiat: "USD_1000", crypto: "BTC_1000" },
+        fast: { fiat: "USD_1000", crypto: "BTC_1000" },
       });
     });
   });
@@ -310,10 +326,13 @@ describe("useFeePresetFiatValuesCore", () => {
 
     const { rerender } = renderHook(
       ({ recipient }: { recipient: string }) =>
-        useFeePresetFiatValuesCore({
+        useFeePresetValuesCore({
           ...defaultParams,
           feePresetOptions: presetsWithoutAmounts,
-          transaction: { ...defaultParams.transaction, recipient } as Transaction,
+          transaction: {
+            ...defaultParams.transaction,
+            recipient,
+          } as Transaction,
           shouldEstimateWithBridge: true,
         }),
       { initialProps: { recipient: "bc1qrecipient" } },

--- a/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/__tests__/useNetworkFeesCore.test.ts
@@ -16,11 +16,11 @@ import type { SendFlowUiConfig } from "../../types";
 jest.mock("../../../../bridge/descriptor/send/features");
 jest.mock("../../../../bridge/useAccountBridge");
 jest.mock("@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit");
-jest.mock("../useFeePresetFiatValuesCore", () => ({
-  useFeePresetFiatValuesCore: jest.fn(() => ({
-    slow: "$1.00",
-    medium: "$2.00",
-    fast: "$3.00",
+jest.mock("../useFeePresetValuesCore", () => ({
+  useFeePresetValuesCore: jest.fn(() => ({
+    slow: { fiat: "$1.00", crypto: "0.00001 BTC" },
+    medium: { fiat: "$2.00", crypto: "0.00002 BTC" },
+    fast: { fiat: "$3.00", crypto: "0.00003 BTC" },
   })),
 }));
 jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers", () => ({
@@ -31,9 +31,9 @@ jest.mock("@ledgerhq/ledger-wallet-framework/account/helpers", () => ({
 const mockedSendFeatures = jest.mocked(sendFeatures);
 const mockedUseAccountBridge = jest.mocked(useAccountBridge);
 const mockedFormatCurrencyUnit = jest.mocked(formatCurrencyUnit);
-const mockedUseFeePresetFiatValuesCore = jest.requireMock(
-  "../useFeePresetFiatValuesCore",
-).useFeePresetFiatValuesCore;
+const mockedUseFeePresetValuesCore = jest.requireMock(
+  "../useFeePresetValuesCore",
+).useFeePresetValuesCore;
 
 const btcUnit: Unit = { name: "Bitcoin", code: "BTC", magnitude: 8 };
 const usdUnit: Unit = { name: "US Dollar", code: "USD", magnitude: 2 };
@@ -118,6 +118,7 @@ describe("useNetworkFeesCore", () => {
     transaction?: Partial<Transaction>;
     status?: Partial<TransactionStatus>;
     uiConfig?: Partial<SendFlowUiConfig>;
+    displayMode?: "fiat" | "crypto";
   }) =>
     renderHook(() =>
       useNetworkFeesCore({
@@ -126,76 +127,137 @@ describe("useNetworkFeesCore", () => {
         transaction: buildTransaction(overrides?.transaction),
         status: { ...mockStatus, ...overrides?.status },
         uiConfig: { ...mockUiConfig, ...overrides?.uiConfig },
-        transactionActions: { updateTransaction: mockUpdateTransaction } as never,
+        transactionActions: {
+          updateTransaction: mockUpdateTransaction,
+        } as never,
         fiatUnit: usdUnit,
         accountUnit: btcUnit,
+        displayMode: overrides?.displayMode ?? "fiat",
         calculateCountervalue: mockCalculateCountervalue,
       }),
     );
 
-  it("returns selected preset fiat value when a non-custom strategy is selected", () => {
+  /** No presets, no custom fees, no coin control: the read-only fee case (SOL, XRP, TRX). */
+  const readOnlyFees = {
+    hasFeePresets: false,
+    hasCustomFees: false,
+    hasCoinControl: false,
+  };
+
+  it("prefers the selected preset's own estimate over the transaction status", () => {
     const { result } = renderCore({ transaction: { feesStrategy: "medium" } });
 
     expect(result.current.selectedFeeStrategy).toBe("medium");
-    expect(result.current.selectedPresetFiatValue).toBe("$2.00");
+    expect(result.current.feesRowValue).toBe("$2.00");
   });
 
-  it("returns null selectedPresetFiatValue for custom strategy", () => {
-    const { result } = renderCore({ transaction: { feesStrategy: "custom" } });
+  it("shows the selected preset's native amount in crypto mode", () => {
+    const { result } = renderCore({
+      transaction: { feesStrategy: "medium" },
+      displayMode: "crypto",
+    });
 
-    expect(result.current.selectedPresetFiatValue).toBeNull();
+    expect(result.current.feesRowValue).toBe("0.00002 BTC");
+  });
+
+  it("falls back to the status estimate for the custom strategy", () => {
+    const { result } = renderCore({
+      transaction: { feesStrategy: "custom" },
+      uiConfig: { hasCustomFees: true },
+    });
+
+    expect(result.current.feesRowValue).toBe("FORMATTED_10");
   });
 
   it("formats estimated fees for display", () => {
     const { result } = renderCore();
 
-    expect(result.current.displayFeesValue).toBe("FORMATTED_10");
-    expect(result.current.formattedEstimatedFeesFiat).toBe("FORMATTED_10");
+    expect(result.current.feesRowValue).toBe("FORMATTED_10");
   });
 
   it("returns '-' when estimated fees are zero", () => {
-    const { result } = renderCore({ status: { estimatedFees: new BigNumber(0) } });
-
-    expect(result.current.displayFeesValue).toBe("-");
-  });
-
-  it("shows fiat • crypto (incl. a zero fee) when the coin opts into showFeeCurrencyAmount", () => {
-    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
-
-    const { result: nonZero } = renderCore();
-    expect(nonZero.current.showFeeCurrencyAmount).toBe(true);
-    expect(nonZero.current.displayFeesValue).toBe("FORMATTED_10 • FORMATTED_1000");
-
-    const { result: zero } = renderCore({ status: { estimatedFees: new BigNumber(0) } });
-    expect(zero.current.displayFeesValue).toBe("FORMATTED_0 • FORMATTED_0");
-  });
-
-  it("falls back to the default display for a zero fee while the transaction has errors", () => {
-    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
-
     const { result } = renderCore({
-      status: { estimatedFees: new BigNumber(0), errors: { recipient: new Error("bad") } },
+      status: { estimatedFees: new BigNumber(0) },
     });
 
-    expect(result.current.displayFeesValue).toBe("-");
+    expect(result.current.feesRowValue).toBe("-");
   });
 
-  it("still shows the combined value for a known (non-zero) fee despite a transaction error", () => {
-    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+  it("follows the display mode when fees are editable", () => {
+    const { result: fiat } = renderCore({ displayMode: "fiat" });
+    expect(fiat.current.feesRowValue).toBe("FORMATTED_10");
+    expect(fiat.current.feesRowSecondaryValue).toBeNull();
 
+    const { result: crypto } = renderCore({ displayMode: "crypto" });
+    expect(crypto.current.feesRowValue).toBe("FORMATTED_1000");
+    expect(crypto.current.feesRowSecondaryValue).toBeNull();
+  });
+
+  it.each(["fiat", "crypto"] as const)(
+    "shows both values (incl. a zero fee) when fees are read-only, in %s mode",
+    displayMode => {
+      const { result: nonZero } = renderCore({
+        uiConfig: readOnlyFees,
+        displayMode,
+      });
+      expect(nonZero.current.feesRowValue).toBe("FORMATTED_10");
+      expect(nonZero.current.feesRowSecondaryValue).toBe("FORMATTED_1000");
+
+      const { result: zero } = renderCore({
+        uiConfig: readOnlyFees,
+        displayMode,
+        status: { estimatedFees: new BigNumber(0) },
+      });
+      expect(zero.current.feesRowValue).toBe("FORMATTED_0");
+      expect(zero.current.feesRowSecondaryValue).toBe("FORMATTED_0");
+    },
+  );
+
+  it("falls back to the single-value display for a zero fee while the transaction has errors", () => {
     const { result } = renderCore({
-      status: { estimatedFees: new BigNumber(1_000), errors: { amount: new Error("too much") } },
+      uiConfig: readOnlyFees,
+      status: {
+        estimatedFees: new BigNumber(0),
+        errors: { recipient: new Error("bad") },
+      },
     });
 
-    expect(result.current.displayFeesValue).toBe("FORMATTED_10 • FORMATTED_1000");
+    expect(result.current.feesRowValue).toBe("-");
+    expect(result.current.feesRowSecondaryValue).toBeNull();
   });
 
-  it("falls back to the default display for a non-finite estimate", () => {
-    mockedSendFeatures.showFeeCurrencyAmount.mockReturnValue(true);
+  it("still shows both values for a known (non-zero) fee despite a transaction error", () => {
+    const { result } = renderCore({
+      uiConfig: readOnlyFees,
+      status: {
+        estimatedFees: new BigNumber(1_000),
+        errors: { amount: new Error("too much") },
+      },
+    });
 
-    const { result } = renderCore({ status: { estimatedFees: new BigNumber(NaN) } });
+    expect(result.current.feesRowValue).toBe("FORMATTED_10");
+    expect(result.current.feesRowSecondaryValue).toBe("FORMATTED_1000");
+  });
 
-    expect(result.current.displayFeesValue).toBe("-");
+  it("falls back to the single-value display for a non-finite estimate", () => {
+    const { result } = renderCore({
+      uiConfig: readOnlyFees,
+      status: { estimatedFees: new BigNumber(NaN) },
+    });
+
+    expect(result.current.feesRowValue).toBe("-");
+    expect(result.current.feesRowSecondaryValue).toBeNull();
+  });
+
+  it.each([
+    ["presets", { hasFeePresets: true, hasCustomFees: false, hasCoinControl: false }],
+    ["custom fees only", { hasFeePresets: false, hasCustomFees: true, hasCoinControl: false }],
+    ["coin control only", { hasFeePresets: false, hasCustomFees: false, hasCoinControl: true }],
+  ] as const)("treats fees as editable with %s", (_label, uiConfig) => {
+    const { result } = renderCore({ uiConfig });
+
+    expect(result.current.feesRowValue).toBe("FORMATTED_10");
+    expect(result.current.feesRowSecondaryValue).toBeNull();
   });
 
   it("calls updateTransaction when selecting a preset fee strategy id", () => {
@@ -206,7 +268,9 @@ describe("useNetworkFeesCore", () => {
     });
 
     expect(mockUpdateTransaction).toHaveBeenCalled();
-    expect(bridgeUpdateTransaction).toHaveBeenCalledWith(mockTransaction, { feesStrategy: "fast" });
+    expect(bridgeUpdateTransaction).toHaveBeenCalledWith(mockTransaction, {
+      feesStrategy: "fast",
+    });
   });
 
   it("calls updateTransaction with the descriptor's default-strategy patch when selecting the default id", () => {
@@ -216,7 +280,11 @@ describe("useNetworkFeesCore", () => {
     });
 
     const { result } = renderCore({
-      uiConfig: { hasFeePresets: false, hasCustomFees: true, hasDefaultStrategy: true },
+      uiConfig: {
+        hasFeePresets: false,
+        hasCustomFees: true,
+        hasDefaultStrategy: true,
+      },
       transaction: { feesStrategy: "custom" },
     });
 
@@ -236,7 +304,11 @@ describe("useNetworkFeesCore", () => {
     mockedSendFeatures.getDefaultStrategyPatch.mockReturnValue(null);
 
     const { result } = renderCore({
-      uiConfig: { hasFeePresets: false, hasCustomFees: true, hasDefaultStrategy: true },
+      uiConfig: {
+        hasFeePresets: false,
+        hasCustomFees: true,
+        hasDefaultStrategy: true,
+      },
       transaction: { feesStrategy: "custom" },
     });
 
@@ -255,7 +327,7 @@ describe("useNetworkFeesCore", () => {
 
     renderCore();
 
-    expect(mockedUseFeePresetFiatValuesCore).toHaveBeenCalledWith(
+    expect(mockedUseFeePresetValuesCore).toHaveBeenCalledWith(
       expect.objectContaining({
         fallbackPresetIds: ["slow", "medium", "fast"],
         shouldEstimateWithBridge: true,
@@ -266,7 +338,7 @@ describe("useNetworkFeesCore", () => {
   it("disables preset fiat values when presets are hidden by ui config", () => {
     renderCore({ uiConfig: { hasFeePresets: false } });
 
-    expect(mockedUseFeePresetFiatValuesCore).toHaveBeenCalledWith(
+    expect(mockedUseFeePresetValuesCore).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: false,
       }),
@@ -275,14 +347,18 @@ describe("useNetworkFeesCore", () => {
 
   describe("hasCustomFees / hasCoinControl mirror uiConfig", () => {
     it("mirrors true values", () => {
-      const { result } = renderCore({ uiConfig: { hasCustomFees: true, hasCoinControl: true } });
+      const { result } = renderCore({
+        uiConfig: { hasCustomFees: true, hasCoinControl: true },
+      });
 
       expect(result.current.hasCustomFees).toBe(true);
       expect(result.current.hasCoinControl).toBe(true);
     });
 
     it("mirrors false values", () => {
-      const { result } = renderCore({ uiConfig: { hasCustomFees: false, hasCoinControl: false } });
+      const { result } = renderCore({
+        uiConfig: { hasCustomFees: false, hasCoinControl: false },
+      });
 
       expect(result.current.hasCustomFees).toBe(false);
       expect(result.current.hasCoinControl).toBe(false);
@@ -290,12 +366,13 @@ describe("useNetworkFeesCore", () => {
   });
 
   describe("feeStrategyOptions", () => {
-    it("builds preset options preserving order with fiat + legend sublabels", () => {
+    it("builds preset options preserving order with fiat + crypto + legend sublabels", () => {
       const { result } = renderCore({ uiConfig: { hasFeePresets: true } });
 
       expect(result.current.feeStrategyOptions.map(o => o.id)).toEqual(["slow", "medium", "fast"]);
       expect(result.current.feeStrategyOptions.every(o => o.kind === "preset")).toBe(true);
       expect(result.current.feeStrategyOptions[1].sublabelFiat).toBe("$2.00");
+      expect(result.current.feeStrategyOptions[1].sublabelCrypto).toBe("0.00002 BTC");
     });
 
     it("falls back to fallbackPresetIds when feePresetOptions is empty", () => {
@@ -310,17 +387,31 @@ describe("useNetworkFeesCore", () => {
 
     it("builds a single default option when the descriptor declares hasDefaultStrategy", () => {
       const { result } = renderCore({
-        uiConfig: { hasFeePresets: false, hasCustomFees: true, hasDefaultStrategy: true },
+        uiConfig: {
+          hasFeePresets: false,
+          hasCustomFees: true,
+          hasDefaultStrategy: true,
+        },
       });
 
       expect(result.current.feeStrategyOptions).toEqual([
-        { id: "default", kind: "default", sublabelFiat: null, sublabelLegend: null },
+        {
+          id: "default",
+          kind: "default",
+          sublabelFiat: null,
+          sublabelCrypto: null,
+          sublabelLegend: null,
+        },
       ]);
     });
 
     it("is empty when there are no presets and the descriptor has no default strategy", () => {
       const { result } = renderCore({
-        uiConfig: { hasFeePresets: false, hasCustomFees: false, hasDefaultStrategy: false },
+        uiConfig: {
+          hasFeePresets: false,
+          hasCustomFees: false,
+          hasDefaultStrategy: false,
+        },
       });
 
       expect(result.current.feeStrategyOptions).toEqual([]);
@@ -328,7 +419,11 @@ describe("useNetworkFeesCore", () => {
 
     it("is empty when custom fees exist but the descriptor has no default strategy", () => {
       const { result } = renderCore({
-        uiConfig: { hasFeePresets: false, hasCustomFees: true, hasDefaultStrategy: false },
+        uiConfig: {
+          hasFeePresets: false,
+          hasCustomFees: true,
+          hasDefaultStrategy: false,
+        },
       });
 
       expect(result.current.feeStrategyOptions).toEqual([]);
@@ -336,7 +431,11 @@ describe("useNetworkFeesCore", () => {
 
     it("never includes custom or coinControl entries", () => {
       const { result } = renderCore({
-        uiConfig: { hasFeePresets: true, hasCustomFees: true, hasCoinControl: true },
+        uiConfig: {
+          hasFeePresets: true,
+          hasCustomFees: true,
+          hasCoinControl: true,
+        },
       });
 
       expect(result.current.feeStrategyOptions.some(o => (o.kind as string) === "custom")).toBe(
@@ -371,11 +470,18 @@ describe("useNetworkFeesCore", () => {
     for (const { hasFeePresets, hasCustomFees, hasDefaultStrategy } of boolCombos) {
       for (const hasCoinControl of coinControlCombos) {
         for (const feesStrategy of feesStrategies) {
-          const label = `hasFeePresets=${hasFeePresets} hasCustomFees=${hasCustomFees} hasCoinControl=${hasCoinControl} hasDefaultStrategy=${hasDefaultStrategy} feesStrategy=${feesStrategy ?? "undefined"}`;
+          const label = `hasFeePresets=${hasFeePresets} hasCustomFees=${hasCustomFees} hasCoinControl=${hasCoinControl} hasDefaultStrategy=${hasDefaultStrategy} feesStrategy=${
+            feesStrategy ?? "undefined"
+          }`;
 
           it(`[${label}] satisfies the selection + presence invariants`, () => {
             const { result } = renderCore({
-              uiConfig: { hasFeePresets, hasCustomFees, hasCoinControl, hasDefaultStrategy },
+              uiConfig: {
+                hasFeePresets,
+                hasCustomFees,
+                hasCoinControl,
+                hasDefaultStrategy,
+              },
               transaction: { feesStrategy },
             });
 

--- a/libs/ledger-live-common/src/flows/send/hooks/useFeePresetValuesCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useFeePresetValuesCore.ts
@@ -3,7 +3,6 @@ import { BigNumber } from "bignumber.js";
 import type { Account, AccountBridge, AccountLike } from "@ledgerhq/types-live";
 import type { Unit } from "@domain/entity-currency-unit";
 import type { Currency } from "@domain/entity-currency";
-import { formatCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies/formatCurrencyUnit";
 import type { FeePresetOption } from "../../../bridge/descriptor/types";
 import { getAccountBridge } from "../../../bridge/impl";
 import type { Transaction } from "../../../coin-modules/transaction-types";
@@ -12,10 +11,17 @@ import {
   buildPresetEstimationPatch,
   getFeesStrategyForPreset,
 } from "../utils/feeEstimation";
+import { formatFeeCurrencyAmount } from "../utils/networkFeesDisplay";
 
-export type FeeFiatMap = Readonly<Record<string, string | null>>;
+/** Formatted fee amounts for one preset. Either side is `null` when it cannot be computed. */
+export type FeePresetValues = Readonly<{
+  fiat: string | null;
+  crypto: string | null;
+}>;
 
-export type UseFeePresetFiatValuesCoreParams = Readonly<{
+export type FeePresetValueMap = Readonly<Record<string, FeePresetValues>>;
+
+export type UseFeePresetValuesCoreParams = Readonly<{
   account: AccountLike;
   parentAccount: Account | null;
   mainAccount: Account;
@@ -23,6 +29,8 @@ export type UseFeePresetFiatValuesCoreParams = Readonly<{
   feePresetOptions: readonly FeePresetOption[];
   fallbackPresetIds?: readonly string[];
   fiatUnit: Unit;
+  /** Unit of the currency the fee is actually paid in, used for the native amount. */
+  displayUnit: Unit;
   locale?: string;
   enabled: boolean;
   shouldEstimateWithBridge: boolean;
@@ -36,26 +44,23 @@ function formatCountervalueAsFiat(
   locale?: string,
 ): string | null {
   return countervalue !== null && countervalue !== undefined
-    ? formatCurrencyUnit(fiatUnit, countervalue, {
-        showCode: true,
-        disableRounding: true,
-        ...(locale ? { locale } : {}),
-      })
+    ? formatFeeCurrencyAmount(fiatUnit, countervalue, locale)
     : null;
 }
 
-async function estimateFiatValuesForPresets(params: {
+async function estimateValuesForPresets(params: {
   bridge: AccountBridge<Transaction>;
   mainAccount: Account;
   transaction: Transaction;
   presetIds: readonly string[];
   calculateCountervalue: (currency: Currency, value: BigNumber) => BigNumber | null | undefined;
   fiatUnit: Unit;
+  displayUnit: Unit;
   locale?: string;
   requestId: number;
   requestIdRef: React.RefObject<number>;
   inFlightRef: React.RefObject<string | null>;
-  setFiatByPreset: (value: FeeFiatMap) => void;
+  setValuesByPreset: (value: FeePresetValueMap) => void;
 }): Promise<void> {
   try {
     const entries = await Promise.all(
@@ -76,19 +81,22 @@ async function estimateFiatValuesForPresets(params: {
           params.mainAccount.currency,
           estimatedFees,
         );
-        const fiatValue = formatCountervalueAsFiat(params.fiatUnit, countervalue, params.locale);
+        const values: FeePresetValues = {
+          fiat: formatCountervalueAsFiat(params.fiatUnit, countervalue, params.locale),
+          crypto: formatFeeCurrencyAmount(params.displayUnit, estimatedFees, params.locale),
+        };
 
-        return [presetId, fiatValue] as const;
+        return [presetId, values] as const;
       }),
     );
 
     if (params.requestIdRef.current !== params.requestId) return;
 
-    const next: Record<string, string | null> = {};
+    const next: Record<string, FeePresetValues> = {};
     for (const [id, value] of entries) {
       next[id] = value;
     }
-    params.setFiatByPreset(next);
+    params.setValuesByPreset(next);
   } finally {
     if (params.requestIdRef.current === params.requestId) {
       params.inFlightRef.current = null;
@@ -96,7 +104,7 @@ async function estimateFiatValuesForPresets(params: {
   }
 }
 
-export function useFeePresetFiatValuesCore({
+export function useFeePresetValuesCore({
   account,
   parentAccount,
   mainAccount,
@@ -104,13 +112,14 @@ export function useFeePresetFiatValuesCore({
   feePresetOptions,
   fallbackPresetIds,
   fiatUnit,
+  displayUnit,
   locale,
   enabled,
   shouldEstimateWithBridge,
   allowZeroAmountEstimation,
   calculateCountervalue,
-}: UseFeePresetFiatValuesCoreParams): FeeFiatMap {
-  const [fiatByPreset, setFiatByPreset] = useState<FeeFiatMap>({});
+}: UseFeePresetValuesCoreParams): FeePresetValueMap {
+  const [valuesByPreset, setValuesByPreset] = useState<FeePresetValueMap>({});
 
   const recipient = transaction.recipient ?? "";
   const amount = useMemo(() => transaction.amount ?? new BigNumber(0), [transaction.amount]);
@@ -147,19 +156,23 @@ export function useFeePresetFiatValuesCore({
   const inFlightRef = useRef<string | null>(null);
   const requestIdRef = useRef(0);
 
-  const directFiatValues = useMemo<FeeFiatMap>(() => {
+  const directValues = useMemo<FeePresetValueMap>(() => {
     if (!enabled || shouldEstimateWithBridge || feePresetOptions.length === 0) {
       return {};
     }
 
-    const next: Record<string, string | null> = {};
+    const next: Record<string, FeePresetValues> = {};
     for (const option of feePresetOptions) {
       const countervalue = calculateCountervalue(mainAccount.currency, option.amount);
-      next[option.id] = formatCountervalueAsFiat(fiatUnit, countervalue, locale);
+      next[option.id] = {
+        fiat: formatCountervalueAsFiat(fiatUnit, countervalue, locale),
+        crypto: formatFeeCurrencyAmount(displayUnit, option.amount, locale),
+      };
     }
     return next;
   }, [
     calculateCountervalue,
+    displayUnit,
     enabled,
     feePresetOptions,
     fiatUnit,
@@ -187,18 +200,19 @@ export function useFeePresetFiatValuesCore({
       void (async () => {
         try {
           const bridge = await getAccountBridge(account, parentAccount ?? undefined);
-          await estimateFiatValuesForPresets({
+          await estimateValuesForPresets({
             bridge,
             mainAccount,
             transaction,
             presetIds: presetIdsToEstimate,
             calculateCountervalue,
             fiatUnit,
+            displayUnit,
             locale,
             requestId,
             requestIdRef,
             inFlightRef,
-            setFiatByPreset,
+            setValuesByPreset,
           });
         } catch {
           if (requestIdRef.current === requestId) {
@@ -210,5 +224,5 @@ export function useFeePresetFiatValuesCore({
     });
   }
 
-  return shouldEstimateWithBridge ? fiatByPreset : directFiatValues;
+  return shouldEstimateWithBridge ? valuesByPreset : directValues;
 }

--- a/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
+++ b/libs/ledger-live-common/src/flows/send/hooks/useNetworkFeesCore.ts
@@ -14,16 +14,16 @@ import type { SendFlowTransactionActions, SendFlowUiConfig } from "../types";
 import { buildFeePresetLegendMap } from "../utils/feePresetLegends";
 import { asFeesStrategy } from "../utils/feesStrategy";
 import {
-  formatCombinedFeesValue,
-  formatDisplayFeesValue,
+  formatFeesValue,
   getFeePresetEstimationConfig,
-  getSelectedPresetFiatValue,
   resolveFeeDisplayContext,
 } from "../utils/networkFeesDisplay";
-import { useFeePresetFiatValuesCore } from "./useFeePresetFiatValuesCore";
+import type { FeesValueMode } from "../utils/networkFeesDisplay";
+import { useFeePresetValuesCore } from "./useFeePresetValuesCore";
+import type { SendAmountDisplayMode } from "../amount/SendAmountDisplayModeContext";
 import type { FeeStrategyOption } from "../utils/feeSelectorOptions";
 
-export type { FeeFiatMap } from "./useFeePresetFiatValuesCore";
+export type { FeePresetValueMap, FeePresetValues } from "./useFeePresetValuesCore";
 export type { FeePresetLegendMap } from "../utils/feePresetLegends";
 export type { FeeStrategyOption } from "../utils/feeSelectorOptions";
 
@@ -37,6 +37,8 @@ export type UseNetworkFeesCoreParams = Readonly<{
   fiatUnit: Unit;
   accountUnit: Unit;
   locale?: string;
+  /** The amount input's fiat⇄crypto toggle, which the fee row follows when fees are editable. */
+  displayMode: SendAmountDisplayMode;
   calculateCountervalue: (from: Currency, value: BigNumber) => BigNumber | null | undefined;
 }>;
 
@@ -44,15 +46,15 @@ export type UseNetworkFeesCoreResult = Readonly<{
   mainAccount: Account;
   accountCurrency: ReturnType<typeof getAccountCurrency>;
   selectedFeeStrategy: string | null;
-  selectedPresetFiatValue: string | null;
-  displayFeesValue: string;
-  formattedEstimatedFeesFiat: string | null;
+  /** Ready-to-render fee row value. `"-"` when unknown; apps localise that placeholder themselves. */
+  feesRowValue: string;
+  /** Native amount shown after `feesRowValue` in the dimmer colour; `null` unless fees are read-only. */
+  feesRowSecondaryValue: string | null;
   selectedFeeStrategyId: string;
   feeStrategyOptions: readonly FeeStrategyOption[];
   onSelectFeeStrategyId: (id: string) => void;
   hasCustomFees: boolean;
   hasCoinControl: boolean;
-  showFeeCurrencyAmount: boolean;
 }>;
 
 export function useNetworkFeesCore({
@@ -65,6 +67,7 @@ export function useNetworkFeesCore({
   fiatUnit,
   accountUnit,
   locale,
+  displayMode,
   calculateCountervalue,
 }: UseNetworkFeesCoreParams): UseNetworkFeesCoreResult {
   const mainAccount = useMemo(
@@ -79,26 +82,6 @@ export function useNetworkFeesCore({
     [accountCurrency, transaction],
   );
 
-  const fiatByPreset = useFeePresetFiatValuesCore({
-    account,
-    parentAccount,
-    mainAccount,
-    transaction,
-    feePresetOptions: presetEstimation.feePresetOptions,
-    fallbackPresetIds: presetEstimation.fallbackPresetIds,
-    fiatUnit,
-    locale,
-    enabled: uiConfig.hasFeePresets && presetEstimation.hasFeePresets,
-    shouldEstimateWithBridge: presetEstimation.shouldEstimateFeePresets,
-    allowZeroAmountEstimation: presetEstimation.allowZeroAmountEstimation,
-    calculateCountervalue,
-  });
-
-  const legendByPreset = useMemo(
-    () => buildFeePresetLegendMap(accountCurrency, presetEstimation.feePresetOptions),
-    [accountCurrency, presetEstimation.feePresetOptions],
-  );
-
   const feeCurrencyAccountId = sendFeatures.getFeeCurrencyAccountId(accountCurrency, transaction);
   const { displayUnit, displayCurrency } = useMemo(
     () =>
@@ -111,6 +94,27 @@ export function useNetworkFeesCore({
     [accountCurrency, accountUnit, feeCurrencyAccountId, mainAccount],
   );
 
+  const valuesByPreset = useFeePresetValuesCore({
+    account,
+    parentAccount,
+    mainAccount,
+    transaction,
+    feePresetOptions: presetEstimation.feePresetOptions,
+    fallbackPresetIds: presetEstimation.fallbackPresetIds,
+    fiatUnit,
+    displayUnit,
+    locale,
+    enabled: uiConfig.hasFeePresets && presetEstimation.hasFeePresets,
+    shouldEstimateWithBridge: presetEstimation.shouldEstimateFeePresets,
+    allowZeroAmountEstimation: presetEstimation.allowZeroAmountEstimation,
+    calculateCountervalue,
+  });
+
+  const legendByPreset = useMemo(
+    () => buildFeePresetLegendMap(accountCurrency, presetEstimation.feePresetOptions),
+    [accountCurrency, presetEstimation.feePresetOptions],
+  );
+
   const estimatedFees = useMemo(
     () => status.estimatedFees ?? new BigNumber(0),
     [status.estimatedFees],
@@ -118,25 +122,6 @@ export function useNetworkFeesCore({
   const estimatedFeesCountervalue = useMemo(
     () => calculateCountervalue(displayCurrency, estimatedFees),
     [calculateCountervalue, displayCurrency, estimatedFees],
-  );
-  // Coin-declared opt-in: append the fee amount in its own currency next to fiat.
-  const showFeeCurrencyAmount = sendFeatures.showFeeCurrencyAmount(accountCurrency);
-  // A zero fee only means "covered" once fees are actually estimated. Estimation can be skipped
-  // while the transaction has errors, leaving a defaulted 0 — fall back to the default display so
-  // an unknown fee is not shown as a confirmed zero. A non-finite estimate is likewise unknown.
-  const hasErrors = Object.keys(status.errors ?? {}).length > 0;
-  const useCombinedFeesValue =
-    showFeeCurrencyAmount && estimatedFees.isFinite() && !(hasErrors && estimatedFees.lte(0));
-  const { displayFeesValue, formattedEstimatedFeesFiat } = useMemo(
-    () =>
-      (useCombinedFeesValue ? formatCombinedFeesValue : formatDisplayFeesValue)({
-        estimatedFees,
-        estimatedFeesCountervalue,
-        fiatUnit,
-        displayUnit,
-        locale,
-      }),
-    [displayUnit, estimatedFees, estimatedFeesCountervalue, fiatUnit, locale, useCombinedFeesValue],
   );
 
   const updateTransactionWithPatch = useCallback(
@@ -147,12 +132,19 @@ export function useNetworkFeesCore({
   );
 
   const selectedFeeStrategy = transaction.feesStrategy ?? null;
-  const selectedPresetFiatValue = getSelectedPresetFiatValue(selectedFeeStrategy, fiatByPreset);
 
   const feeStrategyOptions = useMemo<readonly FeeStrategyOption[]>(() => {
     if (!uiConfig.hasFeePresets) {
       return uiConfig.hasDefaultStrategy
-        ? [{ id: "default", kind: "default", sublabelFiat: null, sublabelLegend: null }]
+        ? [
+            {
+              id: "default",
+              kind: "default",
+              sublabelFiat: null,
+              sublabelCrypto: null,
+              sublabelLegend: null,
+            },
+          ]
         : [];
     }
 
@@ -164,17 +156,56 @@ export function useNetworkFeesCore({
     return presetIds.map(id => ({
       id,
       kind: "preset" as const,
-      sublabelFiat: fiatByPreset[id] ?? null,
+      sublabelFiat: valuesByPreset[id]?.fiat ?? null,
+      sublabelCrypto: valuesByPreset[id]?.crypto ?? null,
       sublabelLegend: legendByPreset[id] ?? null,
     }));
   }, [
-    fiatByPreset,
     legendByPreset,
     presetEstimation.fallbackPresetIds,
     presetEstimation.feePresetOptions,
     uiConfig.hasDefaultStrategy,
     uiConfig.hasFeePresets,
+    valuesByPreset,
   ]);
+
+  const areFeesEditable =
+    feeStrategyOptions.length > 0 || uiConfig.hasCustomFees || uiConfig.hasCoinControl;
+
+  // A zero fee only means "covered" once fees are actually estimated. Estimation can be skipped
+  // while the transaction has errors, leaving a defaulted 0 — fall back to the single-value display
+  // so an unknown fee is not shown as a confirmed zero. A non-finite estimate is likewise unknown.
+  const hasErrors = Object.keys(status.errors ?? {}).length > 0;
+  const canTrustZeroFee = estimatedFees.isFinite() && !(hasErrors && estimatedFees.lte(0));
+  const requestedMode: FeesValueMode = areFeesEditable ? displayMode : "both";
+  const feesValueMode: FeesValueMode =
+    requestedMode === "both" && !canTrustZeroFee ? "fiat" : requestedMode;
+
+  const { displayFeesValue, secondaryFeesValue } = useMemo(
+    () =>
+      formatFeesValue({
+        estimatedFees,
+        estimatedFeesCountervalue,
+        fiatUnit,
+        displayUnit,
+        locale,
+        mode: feesValueMode,
+      }),
+    [displayUnit, estimatedFees, estimatedFeesCountervalue, feesValueMode, fiatUnit, locale],
+  );
+
+  // The selected preset's own estimate takes precedence: for bridge-estimated presets (EVM) the
+  // transaction status can still hold the previous strategy's fee right after a switch. Non-editable
+  // coins have no presets, so this can never shadow the two-value display.
+  const selectedPresetValues =
+    selectedFeeStrategy && selectedFeeStrategy !== "custom"
+      ? (valuesByPreset[selectedFeeStrategy] ?? null)
+      : null;
+  const selectedPresetDisplayValue = !areFeesEditable
+    ? null
+    : displayMode === "crypto"
+      ? (selectedPresetValues?.crypto ?? null)
+      : (selectedPresetValues?.fiat ?? null);
 
   const selectedFeeStrategyId = useMemo(() => {
     const presetIds = feeStrategyOptions.filter(o => o.kind === "preset").map(o => o.id);
@@ -203,14 +234,12 @@ export function useNetworkFeesCore({
     mainAccount,
     accountCurrency,
     selectedFeeStrategy,
-    selectedPresetFiatValue,
-    displayFeesValue,
-    formattedEstimatedFeesFiat,
+    feesRowValue: selectedPresetDisplayValue ?? displayFeesValue,
+    feesRowSecondaryValue: secondaryFeesValue,
     selectedFeeStrategyId,
     feeStrategyOptions,
     onSelectFeeStrategyId,
     hasCustomFees: uiConfig.hasCustomFees,
     hasCoinControl: uiConfig.hasCoinControl,
-    showFeeCurrencyAmount,
   };
 }

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/feeSelectorOptions.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/feeSelectorOptions.test.ts
@@ -1,12 +1,51 @@
-import { buildFeeSelectorOptions } from "../feeSelectorOptions";
+import { buildFeeSelectorOptions, feeStrategySublabel } from "../feeSelectorOptions";
 import type { FeeStrategyOption } from "../feeSelectorOptions";
 
 const preset = (id: string, over: Partial<FeeStrategyOption> = {}): FeeStrategyOption => ({
   id,
   kind: "preset",
   sublabelFiat: `${id}-fiat`,
+  sublabelCrypto: `${id}-crypto`,
   sublabelLegend: `${id}-legend`,
   ...over,
+});
+
+describe("feeStrategySublabel", () => {
+  it("joins the fiat and native amounts", () => {
+    expect(feeStrategySublabel(preset("slow"), { preferLegend: false })).toBe(
+      "slow-fiat · slow-crypto",
+    );
+  });
+
+  it("prefers the fee-rate legend for coins that price fees by rate", () => {
+    expect(feeStrategySublabel(preset("slow"), { preferLegend: true })).toBe("slow-legend");
+  });
+
+  it("falls back to the amounts when a legend coin has no legend for the preset", () => {
+    expect(
+      feeStrategySublabel(preset("slow", { sublabelLegend: null }), {
+        preferLegend: true,
+      }),
+    ).toBe("slow-fiat · slow-crypto");
+  });
+
+  it("degrades to whichever amount is available", () => {
+    expect(
+      feeStrategySublabel(preset("slow", { sublabelCrypto: null }), {
+        preferLegend: false,
+      }),
+    ).toBe("slow-fiat");
+    expect(
+      feeStrategySublabel(preset("slow", { sublabelFiat: null }), {
+        preferLegend: false,
+      }),
+    ).toBe("slow-crypto");
+    expect(
+      feeStrategySublabel(preset("slow", { sublabelFiat: null, sublabelCrypto: null }), {
+        preferLegend: false,
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("buildFeeSelectorOptions", () => {
@@ -27,7 +66,11 @@ describe("buildFeeSelectorOptions", () => {
       label: "label:slow",
       selected: false,
     });
-    expect(options[1]).toMatchObject({ id: "medium", label: "label:medium", selected: true });
+    expect(options[1]).toMatchObject({
+      id: "medium",
+      label: "label:medium",
+      selected: true,
+    });
 
     options[0].onSelect();
     expect(onSelectFeeStrategyId).toHaveBeenCalledWith("slow");
@@ -64,7 +107,11 @@ describe("buildFeeSelectorOptions", () => {
       onSelectFeeStrategyId: jest.fn(),
       labelFor: o => o.id,
       sublabelFor: () => null,
-      coinControl: { enabled: true, label: "Coin control", onSelect: onCoinControl },
+      coinControl: {
+        enabled: true,
+        label: "Coin control",
+        onSelect: onCoinControl,
+      },
     });
 
     expect(options.map(o => o.id)).toEqual(["fast", "coinControl"]);
@@ -94,7 +141,11 @@ describe("buildFeeSelectorOptions", () => {
       labelFor: o => o.id,
       sublabelFor: () => null,
       custom: { enabled: false, label: "Custom", onSelect: jest.fn() },
-      coinControl: { enabled: true, label: "Coin control", onSelect: undefined },
+      coinControl: {
+        enabled: true,
+        label: "Coin control",
+        onSelect: undefined,
+      },
     });
 
     expect(options.map(o => o.kind)).toEqual(["preset"]);

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.realformat.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.realformat.test.ts
@@ -4,61 +4,100 @@
  * Uses the REAL `formatCurrencyUnit` (no mock) to lock the actually-rendered fee row strings.
  * The sibling `networkFeesDisplay.test.ts` mocks the formatter and so cannot catch how zero and
  * fractional amounts render — notably that a zero fee is `0 TRX` / `0 USD` (not `0.00`), which is
- * the accepted format for the combined row.
+ * the accepted format for the read-only two-value row.
  */
 import { BigNumber } from "bignumber.js";
 import type { Unit } from "@domain/entity-currency-unit";
-import { formatCombinedFeesValue, formatDisplayFeesValue } from "../networkFeesDisplay";
+import { formatFeeCurrencyAmount, formatFeesValue } from "../networkFeesDisplay";
 
 const trxUnit: Unit = { name: "TRX", code: "TRX", magnitude: 6 };
 const usdUnit: Unit = { name: "US Dollar", code: "USD", magnitude: 2 };
+const ethUnit: Unit = { name: "ETH", code: "ETH", magnitude: 18 };
 
 // `formatCurrencyUnit` separates the amount and code with a non-breaking space; normalise it so the
-// assertions read naturally while still locking the amount precision and the " • " composition.
+// assertions read naturally while still locking the amount precision.
 const norm = (value: string) => value.replace(/[\u00A0\u202F\u2009]/g, " ");
 
+describe("formatFeeCurrencyAmount", () => {
+  // An 18-magnitude gas fee printed in full wraps the fee row onto two lines, so the amount must
+  // stay rounded to significant digits.
+  it.each([
+    ["26052026217000", "0.00002605 ETH"],
+    ["31386997971000", "0.00003138 ETH"],
+    ["70482175575000", "0.00007048 ETH"],
+    ["32938000000000000", "0.032938 ETH"],
+  ])("rounds a wei fee of %s to significant digits", (wei, expected) => {
+    expect(norm(formatFeeCurrencyAmount(ethUnit, new BigNumber(wei)))).toBe(expected);
+  });
+
+  it("keeps short native amounts intact", () => {
+    expect(norm(formatFeeCurrencyAmount(trxUnit, new BigNumber(56)))).toBe("0.000056 TRX");
+    expect(norm(formatFeeCurrencyAmount(usdUnit, new BigNumber(5)))).toBe("0.05 USD");
+  });
+});
+
 describe("networkFeesDisplay (real formatter)", () => {
-  it("formatCombinedFeesValue renders `<fiat> • <crypto>` with explicit zeros for a covered fee", () => {
-    const { displayFeesValue } = formatCombinedFeesValue({
+  it("both mode renders explicit zeros for a covered fee", () => {
+    const { displayFeesValue, secondaryFeesValue } = formatFeesValue({
       estimatedFees: new BigNumber(0),
       estimatedFeesCountervalue: null,
       fiatUnit: usdUnit,
       displayUnit: trxUnit,
+      mode: "both",
     });
 
-    expect(norm(displayFeesValue)).toBe("0 USD • 0 TRX");
+    expect(norm(displayFeesValue)).toBe("0 USD");
+    expect(norm(secondaryFeesValue ?? "")).toBe("0 TRX");
   });
 
-  it("formatCombinedFeesValue renders full native precision alongside fiat for a shortfall", () => {
-    const { displayFeesValue } = formatCombinedFeesValue({
+  it("both mode renders full native precision alongside fiat for a shortfall", () => {
+    const { displayFeesValue, secondaryFeesValue } = formatFeesValue({
       estimatedFees: new BigNumber(56), // 0.000056 TRX
       estimatedFeesCountervalue: new BigNumber(35), // 0.35 USD
       fiatUnit: usdUnit,
       displayUnit: trxUnit,
+      mode: "both",
     });
 
-    expect(norm(displayFeesValue)).toBe("0.35 USD • 0.000056 TRX");
+    expect(norm(displayFeesValue)).toBe("0.35 USD");
+    expect(norm(secondaryFeesValue ?? "")).toBe("0.000056 TRX");
   });
 
-  it("formatDisplayFeesValue (default) is unchanged: `-` for zero, fiat when a rate exists", () => {
+  it("fiat mode is unchanged: `-` for zero, fiat when a rate exists", () => {
     expect(
-      formatDisplayFeesValue({
+      formatFeesValue({
         estimatedFees: new BigNumber(0),
         estimatedFeesCountervalue: null,
         fiatUnit: usdUnit,
         displayUnit: trxUnit,
+        mode: "fiat",
       }).displayFeesValue,
     ).toBe("-");
 
     expect(
       norm(
-        formatDisplayFeesValue({
+        formatFeesValue({
           estimatedFees: new BigNumber(56),
           estimatedFeesCountervalue: new BigNumber(35),
           fiatUnit: usdUnit,
           displayUnit: trxUnit,
+          mode: "fiat",
         }).displayFeesValue,
       ),
     ).toBe("0.35 USD");
+  });
+
+  it("crypto mode renders full native precision even when a rate exists", () => {
+    expect(
+      norm(
+        formatFeesValue({
+          estimatedFees: new BigNumber(56),
+          estimatedFeesCountervalue: new BigNumber(35),
+          fiatUnit: usdUnit,
+          displayUnit: trxUnit,
+          mode: "crypto",
+        }).displayFeesValue,
+      ),
+    ).toBe("0.000056 TRX");
   });
 });

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/networkFeesDisplay.test.ts
@@ -3,9 +3,8 @@
  */
 import { BigNumber } from "bignumber.js";
 import {
-  formatCombinedFeesValue,
-  formatDisplayFeesValue,
-  getSelectedPresetFiatValue,
+  formatFeesValue,
+  joinFeeSublabelValues,
   resolveFeeDisplayContext,
 } from "../networkFeesDisplay";
 import type { Account } from "@ledgerhq/types-live";
@@ -53,112 +52,141 @@ describe("networkFeesDisplay", () => {
     expect(context.displayCurrency.ticker).toBe("USDC");
   });
 
-  it("formatDisplayFeesValue returns '-' when fees are zero", () => {
-    expect(
-      formatDisplayFeesValue({
-        estimatedFees: new BigNumber(0),
-        estimatedFeesCountervalue: null,
-        fiatUnit: usdUnit,
-        displayUnit: btcUnit,
-      }).displayFeesValue,
-    ).toBe("-");
+  const baseParams: {
+    estimatedFeesCountervalue: BigNumber | null;
+    fiatUnit: typeof usdUnit;
+    displayUnit: typeof btcUnit;
+  } = {
+    estimatedFeesCountervalue: null,
+    fiatUnit: usdUnit,
+    displayUnit: btcUnit,
+  };
+
+  describe.each(["fiat", "crypto"] as const)("%s mode", mode => {
+    it("returns '-' when fees are zero", () => {
+      expect(
+        formatFeesValue({
+          ...baseParams,
+          estimatedFees: new BigNumber(0),
+          mode,
+        }).displayFeesValue,
+      ).toBe("-");
+    });
+
+    it("returns '-' for a non-finite estimate (never renders NaN)", () => {
+      expect(
+        formatFeesValue({
+          ...baseParams,
+          estimatedFees: new BigNumber(NaN),
+          mode,
+        }).displayFeesValue,
+      ).toBe("-");
+    });
+
+    it("never sets a secondary value", () => {
+      expect(
+        formatFeesValue({
+          ...baseParams,
+          estimatedFees: new BigNumber(1000),
+          mode,
+        }).secondaryFeesValue,
+      ).toBeNull();
+    });
   });
 
-  it("formatDisplayFeesValue prefers fiat formatting when countervalue is available", () => {
-    const result = formatDisplayFeesValue({
+  it("fiat mode prefers fiat formatting when a countervalue is available", () => {
+    const result = formatFeesValue({
+      ...baseParams,
       estimatedFees: new BigNumber(1000),
       estimatedFeesCountervalue: new BigNumber(42),
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
+      mode: "fiat",
     });
 
     expect(result.displayFeesValue).toBe("FMT_42");
-    expect(result.formattedEstimatedFeesFiat).toBe("FMT_42");
   });
 
-  it("formatDisplayFeesValue falls back to the crypto amount when no countervalue is available", () => {
-    const result = formatDisplayFeesValue({
+  it("fiat mode falls back to the crypto amount when no countervalue is available", () => {
+    const result = formatFeesValue({
+      ...baseParams,
       estimatedFees: new BigNumber(1000),
-      estimatedFeesCountervalue: null,
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
+      mode: "fiat",
     });
 
     expect(result.displayFeesValue).toBe("FMT_1000");
-    expect(result.formattedEstimatedFeesFiat).toBeNull();
   });
 
-  it("formatDisplayFeesValue returns '-' for a non-finite estimate (never renders NaN)", () => {
-    expect(
-      formatDisplayFeesValue({
-        estimatedFees: new BigNumber(NaN),
-        estimatedFeesCountervalue: null,
-        fiatUnit: usdUnit,
-        displayUnit: btcUnit,
-      }).displayFeesValue,
-    ).toBe("-");
-  });
-
-  it("formatCombinedFeesValue shows fiat • crypto and 0 (not '-') for a zero fee", () => {
-    const result = formatCombinedFeesValue({
-      estimatedFees: new BigNumber(0),
-      estimatedFeesCountervalue: null,
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
-    });
-
-    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
-    expect(result.formattedEstimatedFeesFiat).toBe("FMT_0");
-  });
-
-  it("formatCombinedFeesValue shows fiat • crypto for a non-zero fee with a countervalue", () => {
-    const result = formatCombinedFeesValue({
+  it("crypto mode shows the native amount even when a countervalue is available", () => {
+    const result = formatFeesValue({
+      ...baseParams,
       estimatedFees: new BigNumber(1000),
       estimatedFeesCountervalue: new BigNumber(42),
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
-    });
-
-    expect(result.displayFeesValue).toBe("FMT_42 • FMT_1000");
-    expect(result.formattedEstimatedFeesFiat).toBe("FMT_42");
-  });
-
-  it("formatCombinedFeesValue shows the crypto amount alone for a non-zero fee with no countervalue", () => {
-    const result = formatCombinedFeesValue({
-      estimatedFees: new BigNumber(1000),
-      estimatedFeesCountervalue: null,
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
+      mode: "crypto",
     });
 
     expect(result.displayFeesValue).toBe("FMT_1000");
-    expect(result.formattedEstimatedFeesFiat).toBeNull();
   });
 
-  it("formatCombinedFeesValue clamps a negative/invalid estimate to zero", () => {
-    const result = formatCombinedFeesValue({
+  it("both mode shows fiat + crypto, and 0 (not '-') for a zero fee", () => {
+    const result = formatFeesValue({
+      ...baseParams,
+      estimatedFees: new BigNumber(0),
+      mode: "both",
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_0");
+    expect(result.secondaryFeesValue).toBe("FMT_0");
+  });
+
+  it("both mode shows fiat + crypto for a non-zero fee with a countervalue", () => {
+    const result = formatFeesValue({
+      ...baseParams,
+      estimatedFees: new BigNumber(1000),
+      estimatedFeesCountervalue: new BigNumber(42),
+      mode: "both",
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_42");
+    expect(result.secondaryFeesValue).toBe("FMT_1000");
+  });
+
+  it("both mode promotes the crypto amount for a non-zero fee with no countervalue", () => {
+    const result = formatFeesValue({
+      ...baseParams,
+      estimatedFees: new BigNumber(1000),
+      mode: "both",
+    });
+
+    expect(result.displayFeesValue).toBe("FMT_1000");
+    expect(result.secondaryFeesValue).toBeNull();
+  });
+
+  it("both mode clamps a negative/invalid estimate to zero", () => {
+    const result = formatFeesValue({
+      ...baseParams,
       estimatedFees: new BigNumber(-5),
       estimatedFeesCountervalue: new BigNumber(3),
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
+      mode: "both",
     });
 
-    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
+    expect(result.displayFeesValue).toBe("FMT_0");
+    expect(result.secondaryFeesValue).toBe("FMT_0");
   });
 
-  it("formatCombinedFeesValue treats a non-finite estimate as zero (never renders NaN)", () => {
-    const result = formatCombinedFeesValue({
+  it("both mode treats a non-finite estimate as zero (never renders NaN)", () => {
+    const result = formatFeesValue({
+      ...baseParams,
       estimatedFees: new BigNumber(NaN),
-      estimatedFeesCountervalue: null,
-      fiatUnit: usdUnit,
-      displayUnit: btcUnit,
+      mode: "both",
     });
 
-    expect(result.displayFeesValue).toBe("FMT_0 • FMT_0");
+    expect(result.displayFeesValue).toBe("FMT_0");
+    expect(result.secondaryFeesValue).toBe("FMT_0");
   });
 
-  it("getSelectedPresetFiatValue ignores custom strategy", () => {
-    expect(getSelectedPresetFiatValue("custom", { slow: "$1" })).toBeNull();
-    expect(getSelectedPresetFiatValue("slow", { slow: "$1" })).toBe("$1");
+  it("joinFeeSublabelValues joins both values and degrades to whichever side exists", () => {
+    expect(joinFeeSublabelValues("$0.03", "0.000329 ETH")).toBe("$0.03 · 0.000329 ETH");
+    expect(joinFeeSublabelValues("$0.03", null)).toBe("$0.03");
+    expect(joinFeeSublabelValues(null, "0.000329 ETH")).toBe("0.000329 ETH");
+    expect(joinFeeSublabelValues(null, null)).toBeNull();
   });
 });

--- a/libs/ledger-live-common/src/flows/send/utils/feeSelectorOptions.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/feeSelectorOptions.ts
@@ -1,9 +1,25 @@
+import { joinFeeSublabelValues } from "./networkFeesDisplay";
+
 export type FeeStrategyOption = Readonly<{
   id: string;
   kind: "preset" | "default";
   sublabelFiat: string | null;
+  sublabelCrypto: string | null;
   sublabelLegend: string | null;
 }>;
+
+/**
+ * A preset's sublabel shows what it costs in both fiat and the network's own currency. Coins that
+ * price fees by rate (Bitcoin, Kaspa: `12 sat/vB`) keep that legend instead — the rate is what users
+ * compare presets by there.
+ */
+export function feeStrategySublabel(
+  option: FeeStrategyOption,
+  { preferLegend }: { preferLegend: boolean },
+): string | null {
+  if (preferLegend && option.sublabelLegend) return option.sublabelLegend;
+  return joinFeeSublabelValues(option.sublabelFiat, option.sublabelCrypto);
+}
 
 export type FeeSelectorOptionKind = "preset" | "default" | "custom" | "coinControl";
 

--- a/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/networkFeesDisplay.ts
@@ -31,13 +31,34 @@ export function resolveFeeDisplayContext(params: {
   };
 }
 
-function formatFeeAmount(unit: Unit, amount: BigNumber, locale?: string): string {
+/**
+ * Rounding is left on: an 18-magnitude fee printed in full (`0.000026052026217 ETH`) wraps onto two
+ * lines and buries the digits that matter. The default dynamic rounding keeps ~8 significant digits,
+ * which is what the designs show and is still far more precision than a fee needs.
+ */
+export function formatFeeCurrencyAmount(unit: Unit, amount: BigNumber, locale?: string): string {
   return formatCurrencyUnit(unit, amount, {
     showCode: true,
-    disableRounding: true,
     ...(locale ? { locale } : {}),
   });
 }
+
+/** Separator between the fiat and native amounts of a fee-preset sublabel (`$0.03 · 0.000329 ETH`). */
+const FEE_SUBLABEL_SEPARATOR = " · ";
+
+export function joinFeeSublabelValues(fiat: string | null, crypto: string | null): string | null {
+  if (fiat && crypto) return `${fiat}${FEE_SUBLABEL_SEPARATOR}${crypto}`;
+  return fiat ?? crypto;
+}
+
+/**
+ * How the fee row renders its amount:
+ * - `"fiat"` / `"crypto"`: a single value, following the amount input's fiat⇄crypto toggle. Only
+ *   reachable for coins whose fees the user can edit.
+ * - `"both"`: fiat plus the native fee-currency amount, for coins whose fees are not editable — the
+ *   row is the only place they can see what the network will actually take.
+ */
+export type FeesValueMode = "fiat" | "crypto" | "both";
 
 export type FormatFeesValueParams = Readonly<{
   estimatedFees: BigNumber;
@@ -45,64 +66,60 @@ export type FormatFeesValueParams = Readonly<{
   fiatUnit: Unit;
   displayUnit: Unit;
   locale?: string;
+  mode: FeesValueMode;
 }>;
 
 export type FormattedFeesValue = Readonly<{
+  /** Main value: fiat in `"fiat"`/`"both"`, the native amount in `"crypto"`, `"-"` when unknown. */
   displayFeesValue: string;
-  formattedEstimatedFeesFiat: string | null;
+  /** Native amount rendered after (and dimmer than) the main value. Only set in `"both"`. */
+  secondaryFeesValue: string | null;
 }>;
 
 /**
- * Default fee row value: fiat when a positive countervalue exists, native amount otherwise, `"-"`
- * when the fee is not a positive finite value (zero, negative, or non-finite).
+ * Fee row value for the requested mode. `"fiat"` prefers fiat and falls back to the native amount
+ * when there is no rate; `"crypto"` always shows the native amount. Both of those single-value modes
+ * render `"-"` when the fee is not a positive finite value (zero, negative, or non-finite).
+ *
+ * `"both"` treats a non-finite/negative estimate as zero and shows `0 fiat` next to `0 <code>`, since
+ * a zero fee is accurate information rather than a missing value. With no rate for a non-zero fee the
+ * native amount takes the main slot alone rather than implying a zero fiat rate.
  */
-export function formatDisplayFeesValue(params: FormatFeesValueParams): FormattedFeesValue {
-  if (!params.estimatedFees.isFinite() || params.estimatedFees.lte(0)) {
-    return { displayFeesValue: "-", formattedEstimatedFeesFiat: null };
+export function formatFeesValue(params: FormatFeesValueParams): FormattedFeesValue {
+  const isZeroFee = !params.estimatedFees.isFinite() || params.estimatedFees.lte(0);
+
+  if (params.mode === "both") {
+    const cryptoAmount = isZeroFee ? new BigNumber(0) : params.estimatedFees;
+    const crypto = formatFeeCurrencyAmount(params.displayUnit, cryptoAmount, params.locale);
+
+    const fiatAmount = isZeroFee
+      ? new BigNumber(0)
+      : new BigNumber(params.estimatedFeesCountervalue ?? 0);
+    if (isZeroFee || fiatAmount.gt(0)) {
+      return {
+        displayFeesValue: formatFeeCurrencyAmount(params.fiatUnit, fiatAmount, params.locale),
+        secondaryFeesValue: crypto,
+      };
+    }
+
+    return { displayFeesValue: crypto, secondaryFeesValue: null };
+  }
+
+  if (isZeroFee) {
+    return { displayFeesValue: "-", secondaryFeesValue: null };
   }
 
   const fiatAmount = new BigNumber(params.estimatedFeesCountervalue ?? 0);
-  if (fiatAmount.gt(0)) {
-    const formattedEstimatedFeesFiat = formatFeeAmount(params.fiatUnit, fiatAmount, params.locale);
-    return { displayFeesValue: formattedEstimatedFeesFiat, formattedEstimatedFeesFiat };
-  }
+  const fiat =
+    params.mode === "fiat" && fiatAmount.gt(0)
+      ? formatFeeCurrencyAmount(params.fiatUnit, fiatAmount, params.locale)
+      : null;
 
-  const displayFeesValue = formatFeeAmount(params.displayUnit, params.estimatedFees, params.locale);
-  return { displayFeesValue, formattedEstimatedFeesFiat: null };
-}
-
-/**
- * Fee row value for coins that opt into `FeeDescriptor.showFeeCurrencyAmount`: the native fee-currency
- * amount shown next to the fiat value (`<fiat> • <amount> <code>`). Fiat is prepended when the fee is
- * zero (0 fiat is accurate) or a positive countervalue exists; with no rate for a non-zero fee the
- * native amount is shown alone rather than implying a zero fiat rate. A non-finite/negative estimate
- * is treated as zero.
- */
-export function formatCombinedFeesValue(params: FormatFeesValueParams): FormattedFeesValue {
-  const isZeroFee = !params.estimatedFees.isFinite() || params.estimatedFees.lte(0);
-  const cryptoAmount = isZeroFee ? new BigNumber(0) : params.estimatedFees;
-  const crypto = formatFeeAmount(params.displayUnit, cryptoAmount, params.locale);
-
-  const fiatAmount = isZeroFee
-    ? new BigNumber(0)
-    : new BigNumber(params.estimatedFeesCountervalue ?? 0);
-  if (isZeroFee || fiatAmount.gt(0)) {
-    const formattedEstimatedFeesFiat = formatFeeAmount(params.fiatUnit, fiatAmount, params.locale);
-    return {
-      displayFeesValue: `${formattedEstimatedFeesFiat} • ${crypto}`,
-      formattedEstimatedFeesFiat,
-    };
-  }
-
-  return { displayFeesValue: crypto, formattedEstimatedFeesFiat: null };
-}
-
-export function getSelectedPresetFiatValue(
-  selectedFeeStrategy: string | null,
-  fiatByPreset: Readonly<Record<string, string | null>>,
-): string | null {
-  if (!selectedFeeStrategy || selectedFeeStrategy === "custom") return null;
-  return fiatByPreset[selectedFeeStrategy] ?? null;
+  return {
+    displayFeesValue:
+      fiat ?? formatFeeCurrencyAmount(params.displayUnit, params.estimatedFees, params.locale),
+    secondaryFeesValue: null,
+  };
 }
 
 export type FeePresetEstimationConfig = Readonly<{


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Unit tests cover the shared formatter, the core hook (all three display modes plus the zero-fee and error guards), the per-preset values hook, and both apps' view models. The mobile row component is tested directly; the desktop row markup is covered by `SendFlow.integration.test.tsx`. The two-tone styling itself needs a visual check._
- [x] **Impact of the changes:**
  - **ETH / EVM**: the fee row must follow the amount input's fiat ⇄ crypto toggle, and the fee selector presets must show both amounts.
  - **SOL, XRP**: fees are not editable, so the row must show the fiat value followed by the native amount in the muted colour, with no `•` separator and no strategy label. The row must not be clickable.
  - **TRX**: this is a behaviour change, not a regression. Tron previously showed `$0.10 • 0.00056 TRX` via a coin specific flag. It now goes through the generic non editable rule, so the `•` disappears and the TRX amount becomes muted. Please confirm the Tron fee explanation drawer still works.
  - **BTC / Kaspa**: presets must still show the fee rate legend (`12 sat/vB`), not the amounts. Coin control must stay reachable, and the coin control footer fee row must still render.
  - Zero and unknown fees: a covered fee should read `0 USD 0 TRX`, while an unknown fee (estimation skipped because the transaction has errors) must still read `--` rather than a confirmed zero.

### 📝 Description

**Problem.** In the new send flow, the network fee row showed a fiat only value, falling back to the native amount only when no countervalue rate existed. Fee preset sublabels were fiat only too. Users signing a transaction could not see what they would actually pay in the network's own currency, which matters most for the coins whose fee they cannot adjust at all.

**Solution.** The fee display now depends on whether the user can change the fee:

- **Fee editable** (presets, custom fees, or coin control available): the row shows a single value that follows the amount input's fiat ⇄ crypto toggle. `$0.10 • Fast` in fiat mode, `0.032938 ETH • Fast` in crypto mode.
- **Fee not editable**: the row always shows both values, fiat in the base colour followed by the native amount in the muted colour, and no strategy label. The row is the only place that fee is visible, so it should not hide either half.
- **Fee selector**: each preset sublabel shows both amounts, `$0.03 · 0.000329 ETH`. Coins that price fees by rate (Bitcoin, Kaspa) keep their `12 sat/vB` legend instead, since the rate is what users compare presets by there.

Almost all of the work lives in the shared core so both apps change once:

- `flows/send/utils/networkFeesDisplay.ts`: the two formatters collapse into one `formatFeesValue({ mode })` with modes `"fiat" | "crypto" | "both"`, returning a main value plus an optional secondary native amount (split rather than pre joined, so the two halves can be styled differently).
- `flows/send/hooks/useFeePresetValuesCore.ts` (renamed from `useFeePresetFiatValuesCore`): each preset now carries `{ fiat, crypto }`. The bridge estimation path already computed the native amount per preset and discarded it.
- `flows/send/utils/feeSelectorOptions.ts`: `FeeStrategyOption` gains `sublabelCrypto`, and a new `feeStrategySublabel()` resolves legend versus amounts in one place shared by both apps.
- `flows/send/hooks/useNetworkFeesCore.ts`: takes the display mode as a parameter (injected like `fiatUnit` and `locale` already are, rather than reading context, so the hook stays testable without mounting a provider) and derives editability from the descriptor driven UI config.

The per coin `FeeDescriptor.showFeeCurrencyAmount` flag, which only Tron used, is **deleted**. Tron's fees are not editable, so it now gets the two value display from the generic rule. This removes a coin specific flag in favour of the underlying mechanism, per the coin families contract.

The desktop change threads one extra prop (`feesRowSecondaryValue`) through the existing flat prop chain (`AmountFooter` → `AmountScreenView` → `CoinControlFooter`), which accounts for most of the remaining touched files.

### 📸 Screenshots

**Fee editable (ETH): the row follows the amount input's fiat ⇄ crypto toggle**

| Fiat mode | Crypto mode |
| --------- | ----------- |
|<img width="639" height="753" alt="Screenshot 2026-07-29 at 16 55 35" src="https://github.com/user-attachments/assets/184aba79-7be9-46a2-b8bb-a15fb008ced6" />| <img width="489" height="633" alt="Screenshot 2026-07-29 at 16 55 14" src="https://github.com/user-attachments/assets/6423fc4a-c6fc-42d5-9220-d593aaf3bdd0" />|

**Fee selector, and a coin whose fee is not editable**

| Fee selector: both amounts per preset (ETH) | Fee not editable: both values (SOL) |
| ------------------------------------------- | ----------------------------------- |
| <img width="570" height="595" alt="Screenshot 2026-07-29 at 16 55 24" src="https://github.com/user-attachments/assets/ca5d9e48-6070-4b66-a807-49c5c334d101" />|<img width="553" height="605" alt="Screenshot 2026-07-29 at 16 56 46" src="https://github.com/user-attachments/assets/69ca82b0-5985-4c73-a689-70e1863b90d9" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34432](https://ledgerhq.atlassian.net/browse/LIVE-34432)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-34432]: https://ledgerhq.atlassian.net/browse/LIVE-34432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
