### PR TITLE
[LWDM] fix(lwdm): new send flow wait for valid address to display memo

### DIFF
--- a/.changeset/wise-apricots-compete.md
+++ b/.changeset/wise-apricots-compete.md
@@ -1,0 +1,7 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(lwdm): new send flow wait for valid address to display memo

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModal.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientAddressModal.tsx
@@ -23,7 +23,7 @@ export function RecipientAddressModal({
   recipientSupportsDomain = false,
 }: RecipientAddressModalProps) {
   const { setIsRecipientAddressComplete } = useSendFlowActions();
-  const { handleAddressSelect, ...viewModel } = useRecipientAddressModalViewModel({
+  const { handleAddressSelect, isAddressValid, ...viewModel } = useRecipientAddressModalViewModel({
     account,
     parentAccount,
     currency,
@@ -32,8 +32,8 @@ export function RecipientAddressModal({
   });
 
   useEffect(() => {
-    setIsRecipientAddressComplete(viewModel.isAddressComplete);
-  }, [viewModel.isAddressComplete, setIsRecipientAddressComplete]);
+    setIsRecipientAddressComplete(isAddressValid);
+  }, [isAddressValid, setIsRecipientAddressComplete]);
 
   return <RecipientAddressModalView {...viewModel} onAddressSelect={handleAddressSelect} />;
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -98,6 +98,7 @@ describe("AddressMatchedSection", () => {
       ],
       bridgeErrors: undefined,
       bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
     };
 
     render(
@@ -139,6 +140,7 @@ describe("AddressMatchedSection", () => {
       ],
       bridgeErrors: undefined,
       bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
     };
 
     render(

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -62,6 +62,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: false,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -172,6 +173,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: "sanctioned",
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: false,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -213,6 +215,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: "incorrect_format",
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: false,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -254,6 +257,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: true,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -279,6 +283,7 @@ describe("useRecipientAddressModalViewModel", () => {
 
     expect(result.current.showMatchedAddress).toBe(true);
     expect(result.current.showEmptyState).toBe(false);
+    expect(result.current.isAddressValid).toBe(true);
   });
 
   it("identifies self-transfer error correctly", () => {
@@ -296,6 +301,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: { recipient: selfTransferError },
         bridgeWarnings: {},
+        hasBridgeValidationResult: true,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -321,6 +327,7 @@ describe("useRecipientAddressModalViewModel", () => {
 
     expect(result.current.showBridgeRecipientError).toBe(true);
     expect(result.current.bridgeRecipientError).toBe(selfTransferError);
+    expect(result.current.isAddressValid).toBe(false);
   });
 
   it("treats InvalidAddress as incorrect format for domain-like strings", () => {
@@ -338,6 +345,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: { recipient: invalidAddressError },
         bridgeWarnings: {},
+        hasBridgeValidationResult: true,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -378,6 +386,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: false,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,
@@ -411,6 +420,7 @@ describe("useRecipientAddressModalViewModel", () => {
         error: null,
         bridgeErrors: {},
         bridgeWarnings: {},
+        hasBridgeValidationResult: false,
         matchedAccounts: [],
         resolvedAddress: undefined,
         ensName: undefined,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -335,6 +335,7 @@ export function useAddressValidation({
       bridgeErrors: filteredBridgeErrors,
       bridgeWarnings: bridgeValidation.warnings,
       isBridgeLoading: bridgeValidation.isLoading && bridgeValidation.status === null,
+      hasBridgeValidationResult: bridgeValidation.status !== null,
     };
   }, [
     validationState,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -54,6 +54,7 @@ export const RecipientScreenView = ({
     bridgeRecipientWarning,
     handleAddressSelect,
     isAddressComplete,
+    isAddressValid,
     addressValidationErrorType,
     clipboardAddress,
     handlePasteFromClipboard,
@@ -86,7 +87,7 @@ export const RecipientScreenView = ({
   }, [track, onMemoProceed, trackingProperties]);
 
   const resolvedAddress = result?.resolvedAddress ?? searchValue;
-  const showMemo = uiConfig.hasMemo && isAddressComplete;
+  const showMemo = uiConfig.hasMemo && isAddressValid;
   const memoVm = useMemoViewModel({
     address: showMemo ? resolvedAddress : "",
     onSkip: handleSkipMemo,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -31,6 +31,7 @@ const idleResult = {
   error: null,
   bridgeErrors: {},
   bridgeWarnings: {},
+  hasBridgeValidationResult: false,
   matchedAccounts: [],
   resolvedAddress: undefined,
   ensName: undefined,
@@ -195,7 +196,7 @@ describe("useRecipientScreenView", () => {
     });
 
     mockedUseAddressValidation.mockReturnValue({
-      result: { ...idleResult, status: "valid" },
+      result: { ...idleResult, status: "valid", hasBridgeValidationResult: true },
       isLoading: false,
       validateAddress: jest.fn(),
     });
@@ -210,6 +211,7 @@ describe("useRecipientScreenView", () => {
     );
 
     expect(result.current.showMatchedAddress).toBe(true);
+    expect(result.current.isAddressValid).toBe(true);
   });
 
   it("identifies self-transfer error correctly", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -314,6 +314,7 @@ export function useAddressValidation({
       bridgeErrors: filteredBridgeErrors,
       bridgeWarnings: bridgeValidation.warnings,
       isBridgeLoading: bridgeValidation.isLoading && bridgeValidation.status === null,
+      hasBridgeValidationResult: bridgeValidation.status !== null,
     };
   }, [
     validationState,

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -21,6 +21,7 @@ const createDefaultResult = (overrides?: Partial<AddressSearchResult>): AddressS
     matchedAccounts: [],
     bridgeErrors: undefined,
     bridgeWarnings: undefined,
+    hasBridgeValidationResult: false,
     ...overrides,
   }) as AddressSearchResult;
 
@@ -80,6 +81,52 @@ describe("useRecipientSearchState", () => {
     );
 
     expect(result.current.isAddressComplete).toBe(true);
+  });
+
+  it("should set isAddressValid only after bridge validation succeeds", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "0xvalid",
+        result: createDefaultResult({
+          status: "valid",
+          hasBridgeValidationResult: true,
+        }),
+      }),
+    );
+
+    expect(result.current.isAddressValid).toBe(true);
+  });
+
+  it("should not set isAddressValid before bridge validation returns", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "invalid",
+        result: createDefaultResult({
+          status: "valid",
+          hasBridgeValidationResult: false,
+        }),
+      }),
+    );
+
+    expect(result.current.isAddressValid).toBe(false);
+  });
+
+  it("should not set isAddressValid when bridge validation returns a recipient error", () => {
+    const { result } = renderHook(() =>
+      useRecipientSearchState({
+        ...defaultProps,
+        searchValue: "invalid",
+        result: createDefaultResult({
+          status: "valid",
+          bridgeErrors: { recipient: new InvalidAddress() },
+          hasBridgeValidationResult: true,
+        }),
+      }),
+    );
+
+    expect(result.current.isAddressValid).toBe(false);
   });
 
   it("should set isAddressComplete for ens_resolved status", () => {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/useRecipientSearchState.ts
@@ -28,6 +28,7 @@ export function useRecipientSearchState({
 
   const hasValidatedAddress =
     result.status === "valid" || result.status === "ens_resolved" || result.status === "sanctioned";
+  const hasValidAddress = result.status === "valid" || result.status === "ens_resolved";
 
   const showSearchResults = hasSearchValue && (!isLoading || hasValidatedAddress);
 
@@ -37,6 +38,10 @@ export function useRecipientSearchState({
   const isAddressComplete = useMemo(() => {
     return hasValidatedAddress && !isBridgeInvalidAddress && !result.isBridgeLoading;
   }, [hasValidatedAddress, isBridgeInvalidAddress, result.isBridgeLoading]);
+
+  const isAddressValid = useMemo(() => {
+    return hasValidAddress && result.hasBridgeValidationResult && !bridgeRecipientError;
+  }, [hasValidAddress, result.hasBridgeValidationResult, bridgeRecipientError]);
 
   const hasAnyMatches =
     (result.matchedAccounts && result.matchedAccounts.length > 0) ||
@@ -114,6 +119,7 @@ export function useRecipientSearchState({
     showBridgeRecipientWarning,
     isSanctioned,
     isAddressComplete,
+    isAddressValid,
     addressValidationErrorType,
     bridgeRecipientError,
     bridgeRecipientWarning,

--- a/libs/ledger-live-common/src/flows/send/recipient/types.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/types.ts
@@ -56,4 +56,5 @@ export type AddressSearchResult = Readonly<{
   bridgeErrors: BridgeValidationErrors | undefined;
   bridgeWarnings: BridgeValidationWarnings | undefined;
   isBridgeLoading?: boolean;
+  hasBridgeValidationResult: boolean;
 }>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Previously, the new Send flow showed the memo field as soon as the recipient address looked complete, even before bridge validation finished or confirmed the address was actually valid. This code introduces `isAddressValid`, which requires a successful bridge validation result with no recipient error, and uses it (instead of `isAddressComplete`) to control when the memo UI appears on lwdm


https://github.com/user-attachments/assets/f2b02506-fcff-40d5-93d2-5782e3415e11



### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34975)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
