### PR TITLE
[LWDM] feat(live-signer-concordium): wire CAL_SERVICE_URL into DMK ContextModule

### DIFF
--- a/.changeset/quick-plants-shout.md
+++ b/.changeset/quick-plants-shout.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-concordium": patch
+---
+
+Wire CAL_SERVICE_URL (with /v1 path) into DMK ContextModule via setCalConfig

--- a/libs/live-signer-concordium/package.json
+++ b/libs/live-signer-concordium/package.json
@@ -31,6 +31,7 @@
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-concordium": "catalog:",
     "@ledgerhq/errors": "workspace:^",
+    "@ledgerhq/live-env": "workspace:^",
     "rxjs": "catalog:"
   },
   "scripts": {

--- a/libs/live-signer-concordium/src/DmkSignerConcordium.ts
+++ b/libs/live-signer-concordium/src/DmkSignerConcordium.ts
@@ -1,5 +1,7 @@
 import { lastValueFrom } from "rxjs";
 import type { ConcordiumSigner, ConcordiumNetwork } from "@ledgerhq/coin-concordium/types";
+import { ContextModuleBuilder, ContextModuleChainID } from "@ledgerhq/context-module";
+import { getEnv } from "@ledgerhq/live-env";
 import {
   serializeTransaction,
   serializeCredentialDeploymentValues,
@@ -41,7 +43,18 @@ export class DmkSignerConcordium implements ConcordiumSigner {
   private readonly signer: SignerConcordium;
 
   constructor(dmk: DeviceManagementKit, sessionId: string) {
-    this.signer = new SignerConcordiumBuilder({ dmk, sessionId }).build();
+    const originToken =
+      "1e55ba3959f4543af24809d9066a2120bd2ac9246e626e26a1ff77eb109ca0e5"; // gitleaks:allow
+    const calUrl = getEnv("CAL_SERVICE_URL");
+    const calMode = calUrl.includes("ledger-test") || calUrl.includes(".stg.") ? "test" : "prod";
+    const contextModule = new ContextModuleBuilder({ originToken })
+      .setAppSource("ledger-wallet")
+      .setChain(ContextModuleChainID.Concordium)
+      .setCalConfig({ url: `${calUrl}/v1`, mode: calMode, branch: "main" })
+      .build();
+    this.signer = new SignerConcordiumBuilder({ dmk, sessionId })
+      .withContextModule(contextModule)
+      .build();
   }
 
   async getPublicKey(path: string, confirm = false): Promise<string> {

--- a/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
+++ b/libs/live-signer-concordium/tests/DmkSignerConcordium.test.ts
@@ -7,6 +7,8 @@ import {
   UserRefusedOnDevice,
 } from "@ledgerhq/errors";
 import { SignerConcordiumBuilder } from "@ledgerhq/device-signer-kit-concordium";
+import { ContextModuleBuilder } from "@ledgerhq/context-module";
+import { getEnv } from "@ledgerhq/live-env";
 import { TransactionType, AccountAddress } from "@ledgerhq/concordium-core";
 import type { Transaction, CredentialDeploymentTransaction } from "@ledgerhq/concordium-core";
 import { of } from "rxjs";
@@ -17,6 +19,29 @@ jest.mock("@ledgerhq/device-signer-kit-concordium", () => {
     SignerConcordiumBuilder: jest.fn(),
   };
 });
+
+jest.mock("@ledgerhq/context-module", () => {
+  class MockContextModuleBuilder {
+    setAppSource() {
+      return this;
+    }
+    setChain() {
+      return this;
+    }
+    setCalConfig() {
+      return this;
+    }
+    build() {
+      return {};
+    }
+  }
+  return {
+    ContextModuleBuilder: MockContextModuleBuilder,
+    ContextModuleChainID: { Concordium: "concordium" },
+  };
+});
+
+jest.mock("@ledgerhq/live-env", () => ({ getEnv: jest.fn() }));
 
 describe("DmkSignerConcordium", () => {
   let signer: DmkSignerConcordium;
@@ -35,8 +60,10 @@ describe("DmkSignerConcordium", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(getEnv).mockReturnValue("https://global.api.prd.ledger.com/cal" as never);
     jest.mocked(SignerConcordiumBuilder).mockImplementation(() => {
       return {
+        withContextModule: jest.fn().mockReturnThis(),
         build: () => mockSignerConcordium,
       } as unknown as SignerConcordiumBuilder;
     });
@@ -415,6 +442,45 @@ describe("DmkSignerConcordium", () => {
       await expect(signer.verifyAddress(mockPath, ADDRESS, NETWORK)).rejects.toThrow(
         backendMessage,
       );
+    });
+  });
+
+  describe("CAL config wiring", () => {
+    let setCalConfigSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      setCalConfigSpy = jest.spyOn(ContextModuleBuilder.prototype, "setCalConfig");
+    });
+
+    afterEach(() => {
+      setCalConfigSpy.mockRestore();
+    });
+
+    it("passes prod mode and the env URL with /v1 for a prod endpoint", () => {
+      const url = "https://global.api.prd.ledger.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerConcordium(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "prod", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains 'ledger-test'", () => {
+      const url = "https://global.api.stg.ledger-test.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerConcordium(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
+    });
+
+    it("passes test mode when CAL_SERVICE_URL contains '.stg.' but not 'ledger-test'", () => {
+      const url = "https://global.api.stg.example.com/cal";
+      jest.mocked(getEnv).mockReturnValue(url as never);
+
+      new DmkSignerConcordium(dmkMock as unknown as DeviceManagementKit, "sessionId");
+
+      expect(setCalConfigSpy).toHaveBeenCalledWith({ url: `${url}/v1`, mode: "test", branch: "main" });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12289,6 +12289,9 @@ importers:
       '@ledgerhq/errors':
         specifier: workspace:^
         version: link:../ledgerjs/packages/errors
+      '@ledgerhq/live-env':
+        specifier: workspace:^
+        version: link:../env
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -65670,7 +65673,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65794,54 +65797,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
## Summary

- Passes `CAL_SERVICE_URL` (+ `/v1` version path) into `ContextModuleBuilder.setCalConfig()` in `DmkSignerConcordium`, replacing the context module's hardcoded default URL (`https://crypto-assets-service.api.ledger.com/v1`)
- Mode is derived from the URL at runtime (`"test"` for staging URLs, `"prod"` otherwise) — no new env var needed
- Adds `@ledgerhq/live-env` dep to `@ledgerhq/live-signer-concordium` (`@ledgerhq/context-module` was already declared)

Follow-up to #19860 (EVM) and #20179 (Solana). Closes LIVE-33608.

## Test plan

- [x] `pnpm --filter @ledgerhq/live-signer-concordium test` — 27 tests pass (3 new CAL config tests)
- [x] `tsc` typecheck & `oxlint` pass
- [ ] Verify in a running app that CCD signing enrichment calls hit the URL set in `CAL_SERVICE_URL` with the `/v1` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)