### PR TITLE
test(e2e): q2 as default with support for q1

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -93,7 +93,7 @@ on:
         type: choice
         options:
           - defaults
-          - wallet40-q2
+          - wallet40-q1
         default: defaults
       feature_flags_json:
         description: "JSON to override feature flags"
@@ -214,8 +214,8 @@ env:
   SPECULOS_IMAGE_TAG_IOS: ghcr.io/ledgerhq/speculos:${{ inputs.speculos_device == 'nanoS' && 'speculos-38ccc68068db-coinapps-83978f0' || 'latest' }}
   COINAPPS: ${{ github.workspace }}/coin-apps
   SPECULOS_DEVICE: ${{ inputs.speculos_device || 'nanoX' }}
-  ANDROID_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 1,3,5' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
-  IOS_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 3 * * 2,4' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
+  ANDROID_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
+  IOS_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
   USERDATA_CACHE_ENABLED: ${{ !inputs.production_firebase }}
   E2E_GENERATED_USERDATA_DIR: ${{ !inputs.production_firebase && format('{0}/e2e/userdata/generated', github.workspace) || '' }}

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -70,7 +70,7 @@ on:
         type: choice
         options:
           - defaults
-          - wallet40-q2
+          - wallet40-q1
         default: defaults
       feature_flags_json:
         description: "JSON to override feature flags (takes precedence if set)"
@@ -139,7 +139,7 @@ permissions:
   contents: read
 
 env:
-  E2E_DESKTOP_FEATURE_FLAGS: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 4 * * 2,4' && 'wallet40-q2') || inputs.feature_flags || 'defaults' }}
+  E2E_DESKTOP_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
 
 jobs:

--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -120,7 +120,7 @@ It is possible to choose an optional Feature Flag set for the test run.
 Set the env var to the desired value, eg:
 
 ```bash
-export E2E_DESKTOP_FEATURE_FLAGS="wallet40-q2"
+export E2E_DESKTOP_FEATURE_FLAGS="some-preset"
 ```
 
 Or use the "Choose a feature flag set" options dropdown on the Github workflow.

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -147,7 +147,7 @@ export const FF_NEW_SEND_FLOW_DISABLED = {
 export const getMergedFeatureFlags = ({
   testFlags,
 }: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffEnvMapping: Record<string, OptionalFeatureMap> = {
+  const ffPresetMap: Record<string, OptionalFeatureMap> = {
     /*
      * The keys here are the values of the `E2E_DESKTOP_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -155,7 +155,7 @@ export const getMergedFeatureFlags = ({
      * This will reduce friction and provide CI stability for any callers of the workflow.
      * PLEASE NOTE: non-existing keys will return 'undefined' which spreads to an empty object.
      */
-    "wallet40-q2": FF_LWD_WALLET_40_Q2,
+    "wallet40-q1": FF_LWD_WALLET_40_Q1,
   };
 
   const defaultFlags: OptionalFeatureMap = {
@@ -177,9 +177,9 @@ export const getMergedFeatureFlags = ({
       },
     },
     // default flags for wallet 4.0
-    ...FF_LWD_WALLET_40_Q1,
+    ...FF_LWD_WALLET_40_Q2,
     // any flags from env variable (if set)
-    ...ffEnvMapping[process.env.E2E_DESKTOP_FEATURE_FLAGS || ""],
+    ...ffPresetMap[process.env.E2E_DESKTOP_FEATURE_FLAGS || ""],
   };
 
   // parse JSON override flags for any overrides

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -155,7 +155,7 @@ It is possible to choose an optional Feature Flag set for the test run.
 Set the env var to the desired value, eg:
 
 ```bash
-export E2E_MOBILE_FEATURE_FLAGS="wallet40-q2"
+export E2E_MOBILE_FEATURE_FLAGS="some-preset"
 ```
 
 Or use the "Choose a feature flag set" options dropdown on the Github workflow.

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -57,7 +57,7 @@ export const FF_NEW_SEND_FLOW_ENABLED = {
 export const getMergedFeatureFlags = ({
   testFlags,
 }: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
-  const ffEnvMapping: Record<string, OptionalFeatureMap> = {
+  const ffPresetMap: Record<string, OptionalFeatureMap> = {
     /*
      * The keys here are the values of the `E2E_MOBILE_FEATURE_FLAGS` environment variable.
      * We can add more mappings here in the future to test different feature flag combinations.
@@ -65,7 +65,7 @@ export const getMergedFeatureFlags = ({
      * This will reduce friction and provide CI stability for any callers of the workflow.
      * PLEASE NOTE: non-existing keys will return 'undefined' which spreads to an empty object.
      */
-    "wallet40-q2": FF_LWM_WALLET_40_Q2,
+    "wallet40-q1": FF_LWM_WALLET_40_Q1,
   };
 
   const defaultFlags: OptionalFeatureMap = {
@@ -88,9 +88,9 @@ export const getMergedFeatureFlags = ({
       },
     },
     // default flags for wallet 4.0
-    ...FF_LWM_WALLET_40_Q1,
+    ...FF_LWM_WALLET_40_Q2,
     // any flags from env variable (if set)
-    ...ffEnvMapping[process.env.E2E_MOBILE_FEATURE_FLAGS || ""],
+    ...ffPresetMap[process.env.E2E_MOBILE_FEATURE_FLAGS || ""],
   };
 
   // parse JSON override flags for any overrides


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wallet 40 Q2 is the new default.

- Q2 will be the default for CI and local execution
- Q2 will be swapped for Q1 in the presets drop down

Regression:
- [Desktop](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/66d676a7-3a07-4cb1-b16f-882c506277ac/#)
- [iOS](https://github.com/LedgerHQ/ledger-live/actions/runs/30465125616)
- [Android](https://github.com/LedgerHQ/ledger-live/actions/runs/30465125616)

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/QAA-1430