### PR TITLE
[LWDM] fix(errors): resolve esm import crash from extensionless specifiers

### DIFF
--- a/.changeset/errors-esm-import-extensions.md
+++ b/.changeset/errors-esm-import-extensions.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/errors": patch
+---
+
+fix esm import crash caused by relative specifiers missing their file extension

--- a/libs/ledgerjs/packages/errors/jest.config.ts
+++ b/libs/ledgerjs/packages/errors/jest.config.ts
@@ -7,4 +7,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export default {
   ...baseConfig,
   rootDir: __dirname,
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
 };

--- a/libs/ledgerjs/packages/errors/src/index.ts
+++ b/libs/ledgerjs/packages/errors/src/index.ts
@@ -17,11 +17,11 @@ import {
   createCustomErrorClass,
   addCustomErrorDeserializer,
   LedgerErrorConstructor,
-} from "./helpers";
+} from "./helpers.js";
 
 export { createCustomErrorClass, addCustomErrorDeserializer };
 // Kept for wallet-api-core@1.35.0 (external) which imports these; remove once it's updated upstream
-export { serializeError, deserializeError } from "./helpers";
+export { serializeError, deserializeError } from "./helpers.js";
 
 export const AccountNameRequiredError = createCustomErrorClass("AccountNameRequired");
 export const AccountNotSupported = createCustomErrorClass("AccountNotSupported");

--- a/libs/live-signer-evm/jest.config.js
+++ b/libs/live-signer-evm/jest.config.js
@@ -4,6 +4,9 @@ module.exports = {
     customExportConditions: ["@ledgerhq/source"],
   },
   testPathIgnorePatterns: ["lib/", "lib-es/"],
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
     "^.+\\.(ts|tsx)?$": [
       "@swc/jest",


### PR DESCRIPTION
`@ledgerhq/errors` cannot be imported from an esm module, it crashes with `ERR_MODULE_NOT_FOUND`

the esm build uses `--moduleResolution bundler`, which emits relative specifiers exactly as written,
so `lib-es/index.js` ships `from "./helpers"` and node esm cannot resolve it

this adds the `.js` extension to the two specifiers in this package,
cjs is unaffected since `require("./helpers.js")` resolves the same either way,
and the jest configs get the usual `moduleNameMapper` so they still land on `helpers.ts`

checked `@ledgerhq/errors@6.37.0` from npm, not just the 6.32.0 the reporter's lockfile pins,
and after the change an esm consumer imports it while a `require()` consumer still works

Closes #15967
