### PR TITLE
[LWDM] test(coin-celo): match node's fee-currency balance error for cip64

### DIFF
--- a/libs/coin-modules/coin-celo/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-celo/src/bridge/broadcast.integ.test.ts
@@ -46,7 +46,7 @@ describe("Broadcast", () => {
     const signed = await account.signTransaction(tx, { serializer: serializeCeloTx });
 
     await expect(broadcast({ signedOperation: { signature: signed } } as any)).rejects.toThrow(
-      /insufficient (funds|balance)/i,
+      /insufficient.*(funds|balance)/i,
     );
   });
 });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

The CIP-64 broadcast integ test asserted `/insufficient (funds|balance)/i`,
but the Celo node returns `insufficient fee-currency balance` — the
`fee-currency` infix meant the regex never matched, so the test failed on
every nightly run since #19441. Broadened to `/insufficient.*(funds|balance)/i`
(still matches the eip1559 sibling test).

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
