### PR TITLE
[LWDM] fix(zcash): pay the ZIP-317 fee the transaction's layout owes (LIVE-35152)

### DIFF
--- a/.changeset/LIVE-35152-zcash-zip317-transparent-fee.md
+++ b/.changeset/LIVE-35152-zcash-zip317-transparent-fee.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+---
+
+Fix Zcash transparent sends being rejected from the mempool for "unpaid actions is higher than the limit" (LIVE-35152).
+
+ZIP-317 charges per logical action — `max(inputs, outputs)`, floored at two actions, so 10 000 zats minimum — while the shared Bitcoin path prices transactions in sat/vByte. The account-wide rate was derived from the marginal fee spread over one input (5000 zats over ~148 vBytes ⇒ 34 sat/vB), which billed only 7684 zats on a one-input, two-output send: below the floor, and rejected by the node.
+
+A single rate cannot express ZIP-317, since the floor stays flat while the byte count grows — a rate covering a one-input send would charge nearly double the fee owed on a two-input one. The rate is now chosen per transaction: `getAccountNetworkInfo` provides the rate that covers ZIP-317 for any layout (~53 sat/vB, set by the smallest transaction), and the Zcash chain adapter tightens it to the transaction's actual layout through the new `ChainAdapter.resolveFeePerByte` hook, falling back to the safe rate whenever the tighter one cannot be confirmed. Resulting fees land within ~2% above the ZIP-317 amount instead of under it.
+
+Only the legacy transparent path is affected — the flows routed to the PCZT builder already compute their ZIP-317 fee directly.

--- a/libs/coin-modules/coin-bitcoin/src/__tests__/unit/prepareTransaction.resolveFeePerByte.unit.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/__tests__/unit/prepareTransaction.resolveFeePerByte.unit.test.ts
@@ -1,0 +1,150 @@
+import { BigNumber } from "bignumber.js";
+import { createFixtureAccount, networkInfo } from "../../fixtures/common.fixtures";
+import { bitcoinPickingStrategy, BitcoinAccount, BitcoinOutput, Transaction } from "../../types";
+
+jest.mock("../../getAccountNetworkInfo", () => ({
+  getAccountNetworkInfo: jest.fn(),
+}));
+
+jest.mock("../../getWalletAccount", () => ({
+  getWalletAccount: jest.fn(),
+}));
+
+const resolveFeePerByte = jest.fn();
+jest.mock("../../chain-adapters/registry", () => ({
+  getChainAdapter: () => ({
+    resolveFeePerByte: (...args: unknown[]) => resolveFeePerByte(...args),
+  }),
+}));
+
+import { prepareTransaction } from "../../prepareTransaction";
+
+const getAccountNetworkInfo = jest.requireMock("../../getAccountNetworkInfo").getAccountNetworkInfo;
+const getWalletAccount = jest.requireMock("../../getWalletAccount").getWalletAccount;
+
+const UNFETCHABLE_UTXO = {
+  hash: "ff".repeat(32),
+  outputIndex: 0,
+  blockHeight: 1000,
+  address: "1utxoaddress",
+  value: new BigNumber(100000),
+  rbf: false,
+  isChange: false,
+} as BitcoinOutput;
+
+// getExcludeUTXOsFromUnfetchable only carries the identity of a UTXO forward.
+const AS_EXCLUSION = { hash: UNFETCHABLE_UTXO.hash, outputIndex: UNFETCHABLE_UTXO.outputIndex };
+
+const mockNetworkInfo = {
+  ...networkInfo,
+  feeItems: {
+    ...networkInfo.feeItems,
+    items: networkInfo.feeItems.items.map(item => ({
+      ...item,
+      feePerByte: new BigNumber(item.feePerByte),
+    })),
+    defaultFeePerByte: new BigNumber("2"),
+  },
+  relayFeePerByte: new BigNumber("1"),
+};
+
+const makeTransaction = (overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    family: "bitcoin",
+    amount: new BigNumber(0),
+    recipient: "",
+    utxoStrategy: {
+      strategy: bitcoinPickingStrategy.OPTIMIZE_SIZE,
+      excludeUTXOs: [],
+    },
+    rbf: false,
+    feePerByte: new BigNumber(2),
+    networkInfo: mockNetworkInfo,
+    ...overrides,
+  }) as Transaction;
+
+/** An account holding one UTXO whose parent transaction cannot be fetched. */
+const accountWithUnfetchableUtxo = () =>
+  createFixtureAccount({
+    bitcoinResources: { utxos: [UNFETCHABLE_UTXO] },
+  }) as unknown as BitcoinAccount;
+
+describe("prepareTransaction — ChainAdapter.resolveFeePerByte", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveFeePerByte.mockReturnValue(undefined);
+    getAccountNetworkInfo.mockResolvedValue(mockNetworkInfo);
+    getWalletAccount.mockReturnValue({
+      xpub: { explorer: { getTxHex: jest.fn().mockResolvedValue("00") } },
+    });
+  });
+
+  it("hands over the merged exclusions, not the ones the caller came with", async () => {
+    // The auto-exclusions decide which UTXOs the selection may use, so a rate
+    // resolved before merging them can be too low for the layout finally built.
+    getWalletAccount.mockReturnValue({
+      xpub: { explorer: { getTxHex: jest.fn().mockRejectedValue(new Error("gone")) } },
+    });
+
+    await prepareTransaction(accountWithUnfetchableUtxo(), makeTransaction());
+
+    expect(resolveFeePerByte).toHaveBeenCalledTimes(1);
+    const [, handedOver] = resolveFeePerByte.mock.calls[0];
+    expect(handedOver.utxoStrategy.excludeUTXOs).toEqual([AS_EXCLUSION]);
+  });
+
+  it("hands over the inferred rate and the resolved networkInfo", async () => {
+    const account = createFixtureAccount({ bitcoinResources: { utxos: [] } }) as BitcoinAccount;
+
+    await prepareTransaction(account, makeTransaction({ feePerByte: new BigNumber(7) }));
+
+    const [, handedOver] = resolveFeePerByte.mock.calls[0];
+    expect(handedOver.feePerByte.toNumber()).toBe(7);
+    expect(handedOver.networkInfo).toBe(mockNetworkInfo);
+  });
+
+  it("prepares the transaction with the resolved rate", async () => {
+    const account = createFixtureAccount({ bitcoinResources: { utxos: [] } }) as BitcoinAccount;
+    resolveFeePerByte.mockResolvedValue(new BigNumber(53));
+
+    const result = await prepareTransaction(account, makeTransaction());
+
+    expect(result.feePerByte?.toNumber()).toBe(53);
+  });
+
+  it("keeps the inferred rate when the chain declines to resolve one", async () => {
+    const account = createFixtureAccount({ bitcoinResources: { utxos: [] } }) as BitcoinAccount;
+
+    const result = await prepareTransaction(
+      account,
+      makeTransaction({ feePerByte: new BigNumber(9) }),
+    );
+
+    expect(result.feePerByte?.toNumber()).toBe(9);
+  });
+
+  // A custom fee is the user's explicit choice, so it outranks the chain's
+  // resolution — the exclusions still get merged in.
+  it("lets a custom fee win over the resolved rate", async () => {
+    const account = createFixtureAccount({ bitcoinResources: { utxos: [] } }) as BitcoinAccount;
+    resolveFeePerByte.mockResolvedValue(new BigNumber(53));
+
+    const result = await prepareTransaction(
+      account,
+      makeTransaction({ feesStrategy: "custom", feePerByte: new BigNumber(9) }),
+    );
+
+    expect(result.feePerByte?.toNumber()).toBe(9);
+    expect(result.utxoStrategy.excludeUTXOs).toEqual([]);
+  });
+
+  it("settles at a fixed point, so repeated preparations stop producing new objects", async () => {
+    const account = createFixtureAccount({ bitcoinResources: { utxos: [] } }) as BitcoinAccount;
+    resolveFeePerByte.mockResolvedValue(new BigNumber(53));
+
+    const first = await prepareTransaction(account, makeTransaction());
+    const second = await prepareTransaction(account, first);
+
+    expect(second).toBe(first);
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/types.ts
@@ -143,6 +143,15 @@ export interface ChainAdapter {
   prepareTransaction?(account: Account, transaction: Transaction): Promise<Transaction> | undefined;
 
   /**
+   * Adjust the fee rate of an otherwise-prepared transaction. A chain whose
+   * consensus fee is not a rate per vByte uses this to pick the rate that makes
+   * the shared per-vByte machinery charge what its rules require for *this*
+   * transaction's layout — an account-wide rate cannot express it.
+   * Return `undefined` to keep the prepared rate.
+   */
+  resolveFeePerByte?(account: Account, transaction: Transaction): Promise<BigNumber> | undefined;
+
+  /**
    * Override hardware address resolution for chain-specific signer APIs.
    * Return `undefined` to fall through to the standard Bitcoin getWalletPublicKey path.
    */

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/transparent-fee-rate.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/transparent-fee-rate.test.ts
@@ -1,0 +1,185 @@
+import { BigNumber } from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import cryptoFactory from "@ledgerhq/wallet-btc/crypto/factory";
+import { DerivationModes } from "@ledgerhq/wallet-btc/types";
+import { maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
+import type { Transaction } from "../../../types";
+
+const calculateFees = jest.fn();
+jest.mock("../../../cache", () => ({
+  calculateFees: (...args: unknown[]) => calculateFees(...args),
+}));
+
+import { resolveZcashFeePerByte, zcashSafeFeePerByte } from "../transparent-fee-rate";
+import { ZIP317_MARGINAL_FEE, ZIP317_MINIMUM_FEE } from "../coin-selection";
+import { getChainAdapter } from "../../registry";
+import { setZcashShieldedEnabled } from "../constants";
+// Registers the Zcash adapter as a side effect.
+import "../index";
+
+const crypto = cryptoFactory("zcash");
+const DERIVATION_MODE = DerivationModes.LEGACY;
+
+const vbytes = (inputCount: number, outputCount: number) =>
+  maxTxVBytesCeil(
+    inputCount,
+    Array(Math.max(0, outputCount - 1)).fill(Buffer.alloc(25)),
+    outputCount > 0,
+    crypto,
+    DERIVATION_MODE,
+  );
+
+const zip317 = (inputCount: number, outputCount: number) =>
+  ZIP317_MARGINAL_FEE * Math.max(2, Math.max(inputCount, outputCount));
+
+/**
+ * Stands in for wallet-btc: charges `rate × vsize` for the layout its selection
+ * lands on. `layoutFor` expresses how that selection reacts to the rate, which is
+ * the whole reason the resolution has to verify a tightened rate rather than trust
+ * the arithmetic.
+ */
+const chargingLike = (layoutFor: (rate: number) => [number, number]) =>
+  jest.fn(({ transaction }: { transaction: Transaction }) => {
+    const rate = (transaction.feePerByte as BigNumber).toNumber();
+    const [inputCount, outputCount] = layoutFor(rate);
+    return Promise.resolve({
+      fees: new BigNumber(rate * vbytes(inputCount, outputCount)),
+      txInputs: Array(inputCount).fill({}),
+      txOutputs: Array(outputCount).fill({}),
+    });
+  });
+
+const account = { currency: { id: "zcash" } } as unknown as Account;
+const transaction = { amount: new BigNumber(100000) } as unknown as Transaction;
+
+const safeRate = zcashSafeFeePerByte(crypto, DERIVATION_MODE);
+const resolve = () => resolveZcashFeePerByte(account, transaction, safeRate);
+const feeAt = (rate: BigNumber, inputCount: number, outputCount: number) =>
+  rate.times(vbytes(inputCount, outputCount)).toNumber();
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("zcashSafeFeePerByte", () => {
+  it("covers ZIP-317 for every layout, the smallest transaction being the binding one", () => {
+    expect(feeAt(safeRate, 1, 1)).toBeGreaterThanOrEqual(ZIP317_MINIMUM_FEE);
+    for (let inputCount = 1; inputCount <= 25; inputCount++) {
+      for (const outputCount of [1, 2]) {
+        expect(feeAt(safeRate, inputCount, outputCount)).toBeGreaterThanOrEqual(
+          zip317(inputCount, outputCount),
+        );
+      }
+    }
+  });
+
+  it("is the tightest such rate — one zat less would underpay the smallest transaction", () => {
+    expect(feeAt(safeRate.minus(1), 1, 1)).toBeLessThan(ZIP317_MINIMUM_FEE);
+  });
+});
+
+describe("resolveZcashFeePerByte", () => {
+  it("tightens the rate to the ZIP-317 fee for the layout at hand", async () => {
+    calculateFees.mockImplementation(chargingLike(() => [1, 2]));
+
+    const rate = await resolve();
+
+    // Within one vByte's worth above ZIP-317 — the rounding of the last division.
+    expect(feeAt(rate, 1, 2)).toBeGreaterThanOrEqual(ZIP317_MINIMUM_FEE);
+    expect(feeAt(rate, 1, 2)).toBeLessThan(ZIP317_MINIMUM_FEE + vbytes(1, 2));
+  });
+
+  it("charges the two-action floor on a two-input send instead of twice its size", async () => {
+    calculateFees.mockImplementation(chargingLike(() => [2, 2]));
+
+    const rate = await resolve();
+
+    expect(feeAt(rate, 2, 2)).toBeGreaterThanOrEqual(ZIP317_MINIMUM_FEE);
+    expect(feeAt(rate, 2, 2)).toBeLessThan(ZIP317_MINIMUM_FEE + vbytes(2, 2));
+    // What the account-wide rate would have charged for the same transaction.
+    expect(feeAt(safeRate, 2, 2)).toBeGreaterThan(ZIP317_MINIMUM_FEE * 1.9);
+  });
+
+  it("bills the actions past the grace period once inputs outnumber them", async () => {
+    calculateFees.mockImplementation(chargingLike(() => [4, 2]));
+
+    const rate = await resolve();
+
+    expect(feeAt(rate, 4, 2)).toBeGreaterThanOrEqual(4 * ZIP317_MARGINAL_FEE);
+    expect(feeAt(rate, 4, 2)).toBeLessThan(4 * ZIP317_MARGINAL_FEE + vbytes(4, 2));
+  });
+
+  it("keeps the safe rate when tightening it changes the selection into underpaying", async () => {
+    // Below the safe rate more UTXOs become economical, so the layout grows and
+    // owes more than the tightened rate was computed to cover.
+    calculateFees.mockImplementation(
+      chargingLike(rate => (rate >= safeRate.toNumber() ? [2, 2] : [5, 2])),
+    );
+
+    const rate = await resolve();
+
+    expect(rate.toNumber()).toBe(safeRate.toNumber());
+    expect(feeAt(rate, 5, 2)).toBeGreaterThanOrEqual(zip317(5, 2));
+  });
+
+  it("keeps the safe rate when the transaction cannot be built", async () => {
+    calculateFees.mockRejectedValue(new Error("NotEnoughBalance"));
+
+    await expect(resolve()).resolves.toEqual(safeRate);
+  });
+
+  it("keeps the safe rate when the build reports no fee to reason from", async () => {
+    calculateFees.mockResolvedValue({
+      fees: new BigNumber(0),
+      txInputs: [{}],
+      txOutputs: [{}, {}],
+    });
+
+    await expect(resolve()).resolves.toEqual(safeRate);
+  });
+
+  it("never returns a rate that underpays, whatever the layout", async () => {
+    for (let inputCount = 1; inputCount <= 20; inputCount++) {
+      for (const outputCount of [1, 2]) {
+        calculateFees.mockImplementation(chargingLike(() => [inputCount, outputCount]));
+
+        const rate = await resolve();
+
+        expect(feeAt(rate, inputCount, outputCount)).toBeGreaterThanOrEqual(
+          zip317(inputCount, outputCount),
+        );
+      }
+    }
+  });
+});
+
+describe("the Zcash adapter's resolveFeePerByte hook", () => {
+  const hook = () => getChainAdapter("zcash").resolveFeePerByte!;
+  const prepared = (feePerByte: BigNumber | null) =>
+    ({ ...transaction, feePerByte }) as unknown as Transaction;
+
+  afterEach(() => setZcashShieldedEnabled(false));
+
+  it("resolves the ZIP-317 rate on the legacy transparent path", async () => {
+    setZcashShieldedEnabled(false);
+    calculateFees.mockImplementation(chargingLike(() => [2, 2]));
+
+    const rate = await hook()(account, prepared(safeRate))!;
+
+    expect(rate!.lt(safeRate)).toBe(true);
+    expect(feeAt(rate!, 2, 2)).toBeGreaterThanOrEqual(ZIP317_MINIMUM_FEE);
+  });
+
+  it("leaves the rate alone when the PCZT flows are in charge of the fee", () => {
+    setZcashShieldedEnabled(true);
+
+    expect(hook()(account, prepared(safeRate))).toBeUndefined();
+    expect(calculateFees).not.toHaveBeenCalled();
+  });
+
+  it("leaves the rate alone when no usable rate was prepared", () => {
+    setZcashShieldedEnabled(false);
+
+    expect(hook()(account, prepared(null))).toBeUndefined();
+    expect(hook()(account, prepared(new BigNumber(0)))).toBeUndefined();
+    expect(calculateFees).not.toHaveBeenCalled();
+  });
+});

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -63,6 +63,7 @@ import { getWalletAccount } from "../../getWalletAccount";
 import type { TX } from "@ledgerhq/wallet-btc/index";
 import { getZainoEndpoint, isZcashShieldedEnabled } from "./constants";
 import { resolveTransactionDetails } from "./transaction-details";
+import { resolveZcashFeePerByte } from "./transparent-fee-rate";
 
 // ── Lazy module import (renderer-safe) ────────────────────────────────────
 //
@@ -898,6 +899,21 @@ const zcashChainAdapter: ChainAdapter = {
 
     // Any other transfer type ⇒ legacy Bitcoin preparation.
     return undefined;
+  },
+
+  /**
+   * Prices the legacy transparent path — the one every Zcash send takes while the
+   * shielded flag is off, and the only one that goes through wallet-btc's
+   * sat/vByte fee. The PCZT flows above compute their ZIP-317 fee directly in
+   * prepareTransaction and never consult a rate.
+   */
+  resolveFeePerByte(account: Account, transaction: Transaction) {
+    if (isZcashShieldedEnabled()) return undefined;
+    // The prepared rate covers ZIP-317 for any layout (see zcashSafeFeePerByte);
+    // it is the starting point and the fallback of the resolution.
+    const safeFeePerByte = transaction.feePerByte;
+    if (!safeFeePerByte || safeFeePerByte.lte(0)) return undefined;
+    return resolveZcashFeePerByte(account, transaction, safeFeePerByte);
   },
 
   getAddress(deviceId, { currency, path, verify }, signerContext: SignerContext) {

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/transparent-fee-rate.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/transparent-fee-rate.ts
@@ -1,0 +1,103 @@
+import { BigNumber } from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
+import type { ICrypto } from "@ledgerhq/wallet-btc/crypto/types";
+import { calculateFees } from "../../cache";
+import type { Transaction } from "../../types";
+import { computeZip317Fee, ZIP317_MINIMUM_FEE } from "./coin-selection";
+
+/**
+ * ZIP-317 pricing for the legacy transparent path — the one every Zcash send
+ * takes while the `zcashShielded` feature is off, and which is priced by
+ * wallet-btc's sat/vByte model rather than by the PCZT builder.
+ *
+ * ZIP-317 charges per *logical action* — `max(inputs, outputs)`, floored at two
+ * — so the fee owed depends on a transaction's shape, not on its size. No single
+ * rate per vByte can express that, and the mismatch is not academic: a rate
+ * derived from the per-input cost (5000 zats over ~148 vBytes ⇒ 34 sat/vB) bills
+ * 7684 zats on a one-input, two-output send, under the 10_000 floor, and the node
+ * rejects it for "unpaid actions above the limit" (LIVE-35152).
+ *
+ * The way out is to choose the rate per transaction rather than per account.
+ */
+
+/**
+ * Rate that covers ZIP-317 for *every* layout — the starting point, and the
+ * fallback whenever the tighter rate cannot be established.
+ *
+ * The binding case is the smallest transaction that can be built, one input and
+ * one output, because the two-action floor applies to it in full: 10_000 zats
+ * over ~192 vBytes, so ~53 sat/vB. Every larger layout needs less, since the
+ * floor stays flat while the size grows (two inputs) and beyond that the action
+ * count grows more slowly than the byte count.
+ */
+export function zcashSafeFeePerByte(crypto: ICrypto, derivationMode: string): BigNumber {
+  const smallestTxVBytes = maxTxVBytesCeil(1, [], true, crypto, derivationMode);
+  return new BigNumber(Math.ceil(ZIP317_MINIMUM_FEE / Math.max(1, smallestTxVBytes)));
+}
+
+/** What a build at a given rate charges, against what ZIP-317 requires for it. */
+type FeeProbe = { charged: BigNumber; required: BigNumber };
+
+async function probeFee(
+  account: Account,
+  transaction: Transaction,
+  feePerByte: BigNumber,
+): Promise<FeeProbe | undefined> {
+  try {
+    const { fees, txInputs, txOutputs } = await calculateFees({
+      account,
+      transaction: { ...transaction, feePerByte },
+    });
+    if (!fees.isFinite() || fees.lte(0)) return undefined;
+    return {
+      charged: fees,
+      required: computeZip317Fee(0, 0, txInputs.length, txOutputs.length),
+    };
+  } catch {
+    // Not enough balance, unreachable explorer, … — getTransactionStatus runs the
+    // same build and surfaces the error. Here it only means the rate cannot be
+    // tightened, so the caller keeps the safe one.
+    return undefined;
+  }
+}
+
+/**
+ * Rate that makes the per-vByte model charge the ZIP-317 fee for the layout this
+ * transaction resolves to.
+ *
+ * The fee charged is `rate × vsize`, so the rate that would charge exactly what
+ * ZIP-317 requires is `rate × required / charged`. Deriving it from what a build
+ * actually charged avoids reproducing wallet-btc's sizing model here — the fee
+ * stays correct even if that model changes.
+ *
+ * A layout is only known once the inputs are selected, and lowering the rate can
+ * change that selection, so the tightened rate is confirmed by a second build and
+ * abandoned if it no longer covers ZIP-317. Both builds go through the
+ * `calculateFees` cache, and the status step that follows reuses the last one.
+ *
+ * Starting from — and falling back to — {@link zcashSafeFeePerByte} keeps "never
+ * below ZIP-317" true at every step: the worst outcome is overpaying, never a
+ * rejected transaction.
+ */
+export async function resolveZcashFeePerByte(
+  account: Account,
+  transaction: Transaction,
+  safeFeePerByte: BigNumber,
+): Promise<BigNumber> {
+  const atSafeRate = await probeFee(account, transaction, safeFeePerByte);
+  if (!atSafeRate) return safeFeePerByte;
+
+  const tightened = safeFeePerByte
+    .times(atSafeRate.required)
+    .div(atSafeRate.charged)
+    .integerValue(BigNumber.ROUND_CEIL);
+  // Nothing to gain when the safe rate is already at or below what this layout owes.
+  if (tightened.gte(safeFeePerByte)) return safeFeePerByte;
+
+  const atTightenedRate = await probeFee(account, transaction, tightened);
+  if (!atTightenedRate || atTightenedRate.charged.lt(atTightenedRate.required)) {
+    return safeFeePerByte;
+  }
+  return tightened;
+}

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.ts
@@ -4,27 +4,24 @@ import type { NetworkInfo } from "./types";
 import { getWalletAccount } from "./getWalletAccount";
 import { Account } from "@ledgerhq/types-live";
 import { BitcoinInfrastructureError } from "./errors";
-import { getRelayFeeFloorSatVb, maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
+import { getRelayFeeFloorSatVb } from "@ledgerhq/wallet-btc/utils";
 import type { Account as WalletAccount } from "@ledgerhq/wallet-btc/index";
-import { ZIP317_MARGINAL_FEE } from "./chain-adapters/zcash/coin-selection";
+import { zcashSafeFeePerByte } from "./chain-adapters/zcash/transparent-fee-rate";
 const speeds = ["fast", "medium", "slow"];
 
 /**
- * Zcash uses deterministic ZIP-317 fees (no sat/vByte fee market).
- * We approximate the ZIP-317 marginal fee (5000 zats/action) as a flat sat/vByte rate.
- * See: https://zips.z.cash/zip-0317 and LIVE-35152.
+ * Zcash prices transactions with ZIP-317 (per logical action), not with a
+ * sat/vByte fee market, so there is nothing to read from the explorer here. The
+ * rate below is the one that covers ZIP-317 for any layout; `prepareTransaction`
+ * then tightens it to the actual transaction through the chain adapter's
+ * `resolveFeePerByte`. See https://zips.z.cash/zip-0317 and LIVE-35152.
  */
 function getZcashNetworkInfo(
   walletAccount: WalletAccount,
   relayFeePerByte: BigNumber,
 ): NetworkInfo {
   const { crypto, derivationMode } = walletAccount.xpub;
-  const fixedVBytes = maxTxVBytesCeil(0, [], false, crypto, derivationMode);
-  const oneInputVBytes = maxTxVBytesCeil(1, [], false, crypto, derivationMode) - fixedVBytes;
-  const zip317FeePerByte = new BigNumber(
-    Math.max(1, Math.ceil(ZIP317_MARGINAL_FEE / Math.max(1, oneInputVBytes))),
-  );
-  const feePerByte = BigNumber.max(zip317FeePerByte, relayFeePerByte);
+  const feePerByte = BigNumber.max(zcashSafeFeePerByte(crypto, derivationMode), relayFeePerByte);
 
   // Zcash has no fee market: the three speeds all resolve to the same ZIP-317
   // rate. A "custom" fee remains available for advanced users via the UI.

--- a/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.zcash.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/getAccountNetworkInfo.zcash.test.ts
@@ -2,7 +2,7 @@ import { Account } from "@ledgerhq/types-live";
 import cryptoFactory from "@ledgerhq/wallet-btc/crypto/factory";
 import { DerivationModes } from "@ledgerhq/wallet-btc/types";
 import { maxTxVBytesCeil } from "@ledgerhq/wallet-btc/utils";
-import { ZIP317_MARGINAL_FEE } from "./chain-adapters/zcash/coin-selection";
+import { ZIP317_MARGINAL_FEE, ZIP317_MINIMUM_FEE } from "./chain-adapters/zcash/coin-selection";
 
 const getFees = jest.fn().mockResolvedValue({ "2": 1000002, "4": 1000001, "6": 1000000 });
 
@@ -26,24 +26,17 @@ import { getAccountNetworkInfo } from "./getAccountNetworkInfo";
 
 const zcashAccount = () => ({ currency: { id: "zcash" } }) as unknown as Account;
 
-// The ZIP-317 marginal fee (5000 zats) spread over one P2PKH input's vbytes.
-const oneInputVBytes =
-  maxTxVBytesCeil(1, [], false, zcashCrypto, DerivationModes.LEGACY) -
-  maxTxVBytesCeil(0, [], false, zcashCrypto, DerivationModes.LEGACY);
-const expectedFeePerByte = Math.ceil(ZIP317_MARGINAL_FEE / oneInputVBytes);
+const vbytes = (inputCount: number, outputCount: number) =>
+  maxTxVBytesCeil(
+    inputCount,
+    Array(Math.max(0, outputCount - 1)).fill(Buffer.alloc(25)),
+    outputCount > 0,
+    zcashCrypto,
+    DerivationModes.LEGACY,
+  );
 
 describe("getAccountNetworkInfo for Zcash (ZIP-317 pricing)", () => {
   beforeEach(() => jest.clearAllMocks());
-
-  it("prices from the ZIP-317 marginal fee, not the explorer's sat/vByte data", async () => {
-    // The derived sat/vB should be far below the explorer's `/fees` values (~1000 sat/vB).
-    expect(oneInputVBytes).toBeGreaterThan(0);
-    expect(expectedFeePerByte).toBeGreaterThan(0);
-    expect(expectedFeePerByte).toBeLessThan(200);
-
-    const info = await getAccountNetworkInfo(zcashAccount());
-    expect(info.feeItems.defaultFeePerByte.toNumber()).toBe(expectedFeePerByte);
-  });
 
   it("does not call the explorer's fee market for Zcash", async () => {
     await getAccountNetworkInfo(zcashAccount());
@@ -53,8 +46,29 @@ describe("getAccountNetworkInfo for Zcash (ZIP-317 pricing)", () => {
   it("returns three identical speeds (Zcash has no fee market)", async () => {
     const info = await getAccountNetworkInfo(zcashAccount());
     expect(info.feeItems.items.map(i => i.speed)).toEqual(["fast", "medium", "slow"]);
-    info.feeItems.items.forEach(item =>
-      expect(item.feePerByte.toNumber()).toBe(expectedFeePerByte),
+    const rates = info.feeItems.items.map(i => i.feePerByte.toNumber());
+    expect(new Set(rates).size).toBe(1);
+    expect(rates[0]).toBe(info.feeItems.defaultFeePerByte.toNumber());
+  });
+
+  // The account-wide rate is the fallback used whenever prepareTransaction cannot
+  // tighten it, so underpaying here means a transaction the network rejects.
+  it("covers the ZIP-317 minimum on the smallest transaction it can price", async () => {
+    const { defaultFeePerByte } = (await getAccountNetworkInfo(zcashAccount())).feeItems;
+    expect(defaultFeePerByte.times(vbytes(1, 1)).toNumber()).toBeGreaterThanOrEqual(
+      ZIP317_MINIMUM_FEE,
     );
+  });
+
+  it("covers ZIP-317 for every larger layout too", async () => {
+    const { defaultFeePerByte } = (await getAccountNetworkInfo(zcashAccount())).feeItems;
+    for (let inputCount = 1; inputCount <= 20; inputCount++) {
+      for (const outputCount of [1, 2]) {
+        const required = ZIP317_MARGINAL_FEE * Math.max(2, Math.max(inputCount, outputCount));
+        expect(
+          defaultFeePerByte.times(vbytes(inputCount, outputCount)).toNumber(),
+        ).toBeGreaterThanOrEqual(required);
+      }
+    }
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/prepareTransaction.ts
+++ b/libs/coin-modules/coin-bitcoin/src/prepareTransaction.ts
@@ -83,8 +83,6 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     invariant(networkInfo.family === "bitcoin", "bitcoin networkInfo expected");
   }
 
-  const feePerByte = inferFeePerByte(transaction, networkInfo);
-
   // Auto-populate excludeUTXOs from UTXOs whose transactions can't be fetched
   // This ensures stale/replaced UTXOs are not used
   const autoExcludeUTXOs = await getExcludeUTXOsFromUnfetchable(account);
@@ -100,6 +98,24 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     }
   }
 
+  const utxoStrategy = { ...transaction.utxoStrategy, excludeUTXOs: mergedExclusions };
+
+  const inferredFeePerByte = inferFeePerByte(transaction, networkInfo);
+
+  // A chain whose fee is not a rate per vByte resolves the rate from the layout
+  // this transaction resolves to (see ChainAdapter.resolveFeePerByte). It runs on
+  // the merged exclusions, so the rate is resolved against the very UTXO set the
+  // transaction will be built from, and before the change detection below, so
+  // repeated preparations settle at a fixed point instead of re-deriving a rate
+  // that inferFeePerByte would discard.
+  const feePerByte =
+    (await adapter.resolveFeePerByte?.(account, {
+      ...transaction,
+      networkInfo,
+      feePerByte: inferredFeePerByte,
+      utxoStrategy,
+    })) ?? inferredFeePerByte;
+
   if (
     transaction.networkInfo === networkInfo &&
     (feePerByte === transaction.feePerByte || feePerByte.eq(transaction.feePerByte || 0)) &&
@@ -113,10 +129,7 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     return {
       ...transaction,
       networkInfo,
-      utxoStrategy: {
-        ...transaction.utxoStrategy,
-        excludeUTXOs: mergedExclusions,
-      },
+      utxoStrategy,
     };
   }
 
@@ -124,10 +137,7 @@ export const prepareTransaction: AccountBridge<Transaction>["prepareTransaction"
     ...transaction,
     networkInfo,
     feePerByte,
-    utxoStrategy: {
-      ...transaction.utxoStrategy,
-      excludeUTXOs: mergedExclusions,
-    },
+    utxoStrategy,
   };
 };
 


### PR DESCRIPTION
### 📝 Description

Follow-up to #20188, which fixed the max-spendable estimate but left transparent sends unable to reach the mempool.

**Previous behaviour.** Broadcast failed with `failed to verify ZIP-317 transaction rules, transaction was not inserted to mempool: Unpaid actions is higher than the limit (-1) (102)`. The device signed correctly; the node refused the fee.

ZIP-317 charges per *logical action* — `max(inputs, outputs)`, floored at two actions, so 10 000 zats minimum — while the shared Bitcoin path prices transactions in sat/vByte. The account-wide rate was derived from the marginal fee spread over one input (5000 zats over ~148 vBytes ⇒ 34 sat/vB), which billed only 7684 zats on a one-input, two-output send: under the floor, and rejected.

**Why a single rate cannot work.** The floor stays flat while the byte count grows, so the rate that covers a one-input send charges nearly twice the fee owed on a two-input one (10 000 zats owed, ~19 800 charged). Pricing Zcash correctly means choosing the rate *per transaction*, not per account.

**The fix.** `getAccountNetworkInfo` now provides the rate that covers ZIP-317 for any layout (~53 sat/vB, set by the smallest transaction that can be built), and the Zcash chain adapter tightens it to the transaction's actual layout through a new `ChainAdapter.resolveFeePerByte` hook.

The tightened rate is derived from what a build actually charged (`rate × required / charged`) rather than from a reimplementation of wallet-btc's sizing model, so it stays correct if that model changes. Because lowering the rate can change the input selection, the tightened rate is confirmed by a second build and abandoned if it no longer covers ZIP-317. Both builds go through the existing `calculateFees` LRU cache, which the following status step reuses.

Starting from — and falling back to — the safe rate keeps the invariant *never below ZIP-317* true at every step: on an unbuildable transaction, an unreachable explorer, or a selection that shifts, the worst outcome is a slight overpayment, never a rejection.

Measured against the real selection strategies:

| Transaction | Before | After | Owed (ZIP-317) |
|---|---|---|---|
| 1 input / 2 outputs | 7684 ❌ | 10 170 | 10 000 |
| 2 inputs / 2 outputs | 7684 ❌ | 10 098 | 10 000 |
| 3 inputs / 2 outputs | 17 748 | 15 138 | 15 000 |

Fees land 1–2% above the amount owed instead of under it.

**Scope.** `coin-bitcoin` only — `wallet-btc` is untouched. Only the legacy transparent path is affected: the flows routed to the PCZT builder already compute their ZIP-317 fee directly, so the hook returns `undefined` when the `zcashShielded` flag is on.

**Regression cover.** `chain-adapters/zcash/__tests__/transparent-fee-rate.test.ts` asserts the resulting *fee* rather than the rate, against a double that charges `rate × vsize` like wallet-btc does. It pins the fee for the layout at hand, the two-action floor on a two-input send, the actions billed past the grace period, the fallback when tightening would underpay or the build fails, and — sweeping every layout from 1 to 20 inputs — that the resolved rate never underpays. `getAccountNetworkInfo.zcash.test.ts` drops its brittle rate assertions in favour of the same property on the account-wide rate.

743 tests green in `coin-bitcoin`. Also verified manually end to end: the send that previously failed to broadcast now goes through.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35152](https://ledgerhq.atlassian.net/browse/LIVE-35152)
- **ADR** (if any): n/a
- **Introduced by**: #20188
- **Spec**: [ZIP-317](https://zips.z.cash/zip-0317)


[LIVE-35152]: https://ledgerhq.atlassian.net/browse/LIVE-35152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ