### PR TITLE
[LWM] chore(LIVE-32915): migrate @ledgerhq/errors in ledger-live-mobile

### DIFF
--- a/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-mobile/src/components/DeviceAction/rendering.tsx
@@ -9,7 +9,8 @@ import { ParamListBase, T } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 import { getDeviceModel } from "@ledgerhq/devices";
-import { WrongDeviceForAccount, NanoSNotSupported } from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
+import { NanoSNotSupported } from "@ledgerhq/live-common/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import { isSyncOnboardingSupported } from "@ledgerhq/live-common/device/use-cases/screenSpecs";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/NetworkError.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Linking } from "react-native";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { Trans, useLocale } from "~/context/Locale";
 import styled from "styled-components/native";
 import { Flex, IconsLegacy } from "@ledgerhq/native-ui";
@@ -9,7 +8,12 @@ import Button from "../Button";
 import ExternalLink from "../ExternalLink";
 import { urls } from "~/utils/urls";
 
-const WebPTXPlayerNetworkFail = createCustomErrorClass("WebPTXPlayerNetworkFail");
+class WebPTXPlayerNetworkFail extends Error {
+  override name = "WebPTXPlayerNetworkFail";
+  constructor(message?: string) {
+    super(message || "WebPTXPlayerNetworkFail");
+  }
+}
 
 const ExternalLinkWrapper = styled.View`
   margin-top: 19px;

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -5,7 +5,7 @@ import { ActivityIndicator, Linking, Platform, StyleSheet, View } from "react-na
 import { WebView as RNWebView, WebViewMessageEvent } from "react-native-webview";
 import { useNavigation } from "@react-navigation/native";
 import { JSONRPCRequest } from "json-rpc-2.0";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Account, AccountLike, Operation } from "@ledgerhq/types-live";
 import type {
   RawPlatformTransaction,

--- a/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
+++ b/apps/ledger-live-mobile/src/context/AuthPass/auth.hooks.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef } from "react";
 import { AppState, Platform, Vibration } from "react-native";
 import type { Privacy } from "~/reducers/types";
 import * as Keychain from "react-native-keychain";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { VIBRATION_PATTERN_ERROR } from "~/utils/constants";
 
 interface UsePrivacyInitializationProps {

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { render, waitFor } from "@tests/test-renderer";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { ScreenName } from "~/const";
 import { MethodSelection } from "./MethodSelection";
 

--- a/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/bitcoin/EditTransactionFlow/MethodSelection.tsx
@@ -4,7 +4,7 @@ import type {
   TransactionRaw,
 } from "@ledgerhq/coin-bitcoin/types";
 import { isOldestBitcoinPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/ErrorSection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/canton/Onboard/OnboardScreen/__tests__/ErrorSection.test.tsx
@@ -1,4 +1,5 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { render, screen } from "@tests/test-renderer";
 import React from "react";
 import { ErrorSection } from "../components/ErrorSection";

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/OnboardScreen/__tests__/useOnboarding.test.ts
@@ -1,7 +1,10 @@
 import { renderHook, waitFor, act } from "@tests/test-renderer";
 import { Subject } from "rxjs";
-import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumSessionExpiredError, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumSessionExpiredError,
+} from "@ledgerhq/coin-concordium/types";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { CreateStatus, getConfirmationCode, useOnboarding } from "../hooks/useOnboarding";

--- a/apps/ledger-live-mobile/src/families/concordium/Onboard/__integrations__/onboardSignatureFailures.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/concordium/Onboard/__integrations__/onboardSignatureFailures.integration.test.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import { Linking } from "react-native";
 import { screen, render, waitFor } from "@tests/test-renderer";
 import { server } from "@tests/server";
-import { TransportStatusError, DisconnectedDeviceDuringOperation } from "@ledgerhq/errors";
+import {
+  TransportStatusError,
+  DisconnectedDeviceDuringOperation,
+} from "@ledgerhq/hw-transport/errors";
 import OnboardScreen from "../OnboardScreen";
 import {
   SESSION_TOPIC,

--- a/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/ClaimRewardsFlow/02-Claim.test.tsx
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import React from "react";
 import { fireEvent, screen } from "@testing-library/react-native";
 import { render } from "@tests/test-renderer";
-import { ClaimRewardsFeesWarning } from "@ledgerhq/errors";
+import { ClaimRewardsFeesWarning } from "@ledgerhq/coin-evm/errors";
 import type { Account } from "@ledgerhq/types-live";
 import type { StakingValidatorItem } from "@ledgerhq/live-common/families/evm/staking/types";
 import ClaimRewardsClaim from "./02-Claim";

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text } from "react-native";
 import { render, waitFor } from "@tests/test-renderer";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { ScreenName } from "~/const";
 import { MethodSelection } from "./MethodSelection";
 

--- a/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
+++ b/apps/ledger-live-mobile/src/families/evm/EditTransactionFlow/MethodSelection.tsx
@@ -1,7 +1,7 @@
 import { EditType } from "@ledgerhq/coin-evm/types/editTransaction";
 import { Transaction as EvmTransaction, TransactionRaw } from "@ledgerhq/coin-evm/types/index";
 import { isOldestPendingOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";

--- a/apps/ledger-live-mobile/src/families/solana/SendRows.test.tsx
+++ b/apps/ledger-live-mobile/src/families/solana/SendRows.test.tsx
@@ -4,7 +4,7 @@ import { render } from "@tests/test-renderer";
 import SolanaFeeRow from "./SendRowsFee";
 import { AccountLike } from "@ledgerhq/types-live";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/solana/types";
-import { NotEnoughGas } from "@ledgerhq/errors";
+import { NotEnoughGas } from "@ledgerhq/live-common/errors";
 import BigNumber from "bignumber.js";
 
 describe("SolanaFeeRow", () => {

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -13,7 +13,7 @@ import type {
   BroadcastConfig,
 } from "@ledgerhq/types-live";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import {
   addPendingOperation,

--- a/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/MyWallet/views/DeviceSection/__tests__/useDeviceSectionViewModel.test.ts
@@ -1,6 +1,6 @@
 import { Linking } from "react-native";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { BluetoothRequired } from "@ledgerhq/errors";
+import { BluetoothRequired } from "@ledgerhq/hw-transport/errors";
 import { disconnect } from "@ledgerhq/live-common/hw/index";
 import { findMatchingNewDevice } from "@ledgerhq/live-dmk-mobile";
 import { act, renderHook } from "@tests/test-renderer";

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenViewModel.test.ts
@@ -3,7 +3,8 @@ import { renderHook } from "@testing-library/react-native";
 import { BigNumber } from "bignumber.js";
 import type { Account } from "@ledgerhq/types-live";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import { DustLimit, FeeTooHigh } from "@ledgerhq/errors";
+import { FeeTooHigh } from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "@ledgerhq/coin-bitcoin/errors";
 import { useAmountScreenViewModel } from "../useAmountScreenViewModel";
 
 jest.mock("~/context/Locale", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -3,7 +3,7 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useSelector } from "~/context/hooks";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   getRecentAddressesStore,
   getMainAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -4,7 +4,10 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useClipboardRecipient } from "../useClipboardRecipient";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import { createMockAccount } from "./accounts";
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   getAccountCurrency,
   getMainAccount,

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@tests/test-renderer";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { SignedOperation } from "@ledgerhq/types-live";
 import { createIntent } from "@ledgerhq/device-intent";
 import { buildDeviceInitializationInput } from "LLM/components/DeviceIntentExecutor";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletApiSignature/components/TransactionSignatureDrawer/useTransactionSignatureDrawerViewModel.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { createIntent } from "@ledgerhq/device-intent";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/__integrations__/useAddMember.test.tsx
@@ -3,7 +3,7 @@ import { Text } from "react-native";
 import { render, screen, withFlagOverrides } from "@tests/test-renderer";
 import { useAddMember } from "../hooks/useAddMember";
 import { SceneKind } from "../hooks/useFollowInstructionDrawer";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { TrustchainNotAllowed } from "@ledgerhq/ledger-key-ring-protocol/errors";
 import { track } from "~/analytics";
 import { AnalyticsEvents } from "../Analytics/enums";

--- a/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
+++ b/apps/ledger-live-mobile/src/screens/Account/ErrorWarning/components/ErrorBanner.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { Box } from "@ledgerhq/native-ui";
 import HeaderErrorTitle from "~/components/HeaderErrorTitle";
 import { useNetInfo } from "@react-native-community/netinfo";
-import { NetworkDown } from "@ledgerhq/errors";
+import { NetworkDown } from "@ledgerhq/live-common/errors";
 
 type ErrorBannerProps = {
   error: Error;

--- a/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
+++ b/apps/ledger-live-mobile/src/screens/EditDeviceName.tsx
@@ -21,7 +21,7 @@ import { BleSaveDeviceNamePayload } from "~/actions/types";
 import { useRenameDeviceAction } from "~/hooks/deviceActions";
 import { HOOKS_TRACKING_LOCATIONS } from "~/analytics/hooks/variables";
 import { useToastsActions } from "~/actions/toast";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 
 const mapDispatchToProps = {
   saveBleDeviceName,

--- a/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
+++ b/apps/ledger-live-mobile/src/screens/SelectAccount.tsx
@@ -8,7 +8,7 @@ import {
 import { Flex } from "@ledgerhq/native-ui";
 import { getAccountSpendableBalance, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { useAccountBridgeMany } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { ScreenName, NavigatorName } from "~/const";
 import { accountsSelector } from "~/reducers/accounts";
 import { TrackScreen } from "~/analytics";

--- a/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/04-Summary.test.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { View, ScrollView } from "react-native";
 import { BigNumber } from "bignumber.js";
-import {
-  FeeNotLoaded,
-  GasLessThanEstimate,
-  NotEnoughBalance,
-  NotEnoughGas,
-} from "@ledgerhq/errors";
+import { FeeNotLoaded, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
+import { GasLessThanEstimate, NotEnoughGas } from "@ledgerhq/coin-evm/errors";
 import { render, screen } from "@tests/test-renderer";
 import { ScreenName } from "~/const";
 import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransaction";

--- a/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/ConfirmPassword.tsx
@@ -3,7 +3,7 @@ import { Platform, Vibration } from "react-native";
 import * as Keychain from "react-native-keychain";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 
 import { CompositeScreenProps } from "@react-navigation/native";
 import { setPrivacy } from "~/actions/settings";

--- a/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/General/PasswordRemove.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useState } from "react";
 import * as Keychain from "react-native-keychain";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { Vibration } from "react-native";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";

--- a/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
+++ b/apps/ledger-live-mobile/src/transport/bleTransport/makeMock.ts
@@ -3,7 +3,7 @@ import { firstValueFrom, from, PartialObserver } from "rxjs";
 import { take, first, filter } from "rxjs/operators";
 import type { Device } from "@ledgerhq/types-devices";
 import type { Observer as TransportObserver, DescriptorEvent } from "@ledgerhq/hw-transport";
-import { HwTransportError } from "@ledgerhq/errors";
+import type { HwTransportError } from "@ledgerhq/hw-transport/errors";
 import type { ApduMock } from "~/logic/createAPDUMock";
 import { hookRejections } from "~/logic/debugReject";
 import { e2eBridgeClient } from "~/e2e/bridge/client";

--- a/apps/ledger-live-mobile/src/types/error.ts
+++ b/apps/ledger-live-mobile/src/types/error.ts
@@ -1,6 +1,3 @@
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
-
-export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>> & {
-  name?: string;
+export type LedgerError = Error & {
   managerAppName?: string;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22719,7 +22719,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25063,7 +25063,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -34197,6 +34197,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -65680,7 +65681,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65804,54 +65805,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Removes direct imports of @ledgerhq/errors in apps/ledger-live-mobile, replacing them with native error classes from @ledgerhq/ledger-wallet-framework/errors, @ledgerhq/hw-transport/errors, @ledgerhq/live-common/errors, or local modules.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35180](https://ledgerhq.atlassian.net/browse/LIVE-35180)
- **ADR** (if any): N/A

[LIVE-35180]: https://ledgerhq.atlassian.net/browse/LIVE-35180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ