### PR TITLE
[LWD] chore(LIVE-32915): migrate @ledgerhq/errors in ledger-live-desktop

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/__integrations__/SendFlow.integration.test.tsx
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { bitcoinPickingStrategy } from "@ledgerhq/live-common/families/bitcoin/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import {
@@ -165,7 +165,7 @@ describe("Send Flow Integration", () => {
 
   describe("Invalid recipient", () => {
     it("should not allow proceeding with invalid address", async () => {
-      const { InvalidAddress } = jest.requireActual("@ledgerhq/errors");
+      const { InvalidAddress } = jest.requireActual("@ledgerhq/ledger-wallet-framework/errors");
       setMockBridgeRecipientValidation({
         errors: { recipient: new InvalidAddress() },
         warnings: {},

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenMessage.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Amount/hooks/__tests__/useAmountScreenMessage.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import { BigNumber } from "bignumber.js";
 import { renderHook } from "tests/testSetup";
-import { DustLimit, FeeTooHigh } from "@ledgerhq/errors";
+import { FeeTooHigh } from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "@ledgerhq/live-common/errors";
 import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { useAmountScreenMessage } from "../useAmountScreenMessage";
 import { useTranslatedBridgeError } from "../../../Recipient/hooks/useTranslatedBridgeError";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientAddressModalViewModel.test.ts
@@ -6,7 +6,10 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { createMockAccount } from "../../__integrations__/__fixtures__/accounts";
 import type { SendFlowState } from "@ledgerhq/live-common/flows/send/types";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -2,7 +2,7 @@ import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
 import type { DomainServiceStatus } from "@ledgerhq/domain-service/hooks/types";
-import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import { InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";

--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.ts
@@ -2,7 +2,7 @@ import { Account, AccountUserData } from "@ledgerhq/types-live";
 import { AccountComparator } from "@ledgerhq/live-wallet/ordering";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getKey } from "~/renderer/storage";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { checkAccountSupported } from "@ledgerhq/live-common/account/index";
 import { accountsSelector } from "~/renderer/reducers/accounts";

--- a/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/CurrencyDownStatusAlert.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import ErrorBanner from "./ErrorBanner";
@@ -8,7 +7,14 @@ type Props = {
   currencies: Array<CryptoCurrency | TokenCurrency>;
   hideStatusIncidents?: boolean;
 };
-const ServiceStatusWarning = createCustomErrorClass("ServiceStatusWarning");
+class ServiceStatusWarning extends Error {
+  override name = "ServiceStatusWarning";
+  description?: string;
+  constructor(message?: string, options?: ErrorOptions & { description?: string }) {
+    super(message, options);
+    this.description = options?.description;
+  }
+}
 const CurrencyDownStatusAlert = ({ currencies, hideStatusIncidents }: Props) => {
   const errors: Error[] = [];
 

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/index.tsx
@@ -4,8 +4,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { Action } from "@ledgerhq/live-common/hw/actions/types";
 import type { Theme } from "@ledgerhq/react-ui";
-import { EConnResetError } from "@ledgerhq/live-common/errors";
-import { UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { EConnResetError, UnresponsiveDeviceError } from "@ledgerhq/live-common/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import {
   addNewDeviceModel,
@@ -56,7 +55,6 @@ import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { AppAndVersion, DeviceDeprecationRules } from "@ledgerhq/live-common/hw/connectApp";
 import { Device } from "@ledgerhq/types-devices";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
 import { TokenCurrency } from "@domain/entity-currency-token";
 import {
   FlowName,
@@ -84,7 +82,7 @@ import {
   DeviceDeprecationScreens,
 } from "./Screen/DeviceDeprecationScreen";
 
-export type LedgerError = InstanceType<LedgerErrorConstructor<{ [key: string]: unknown }>>;
+export type LedgerError = Error;
 
 type PartialNullable<T> = {
   [P in keyof T]?: T[P] | null;

--- a/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/DeviceAction/rendering.tsx
@@ -21,7 +21,8 @@ import {
   Text,
   Theme,
 } from "@ledgerhq/react-ui";
-import { WrongDeviceForAccount, DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Transaction } from "@ledgerhq/live-common/generated/types";
 import { ExchangeRate, ExchangeSwap } from "@ledgerhq/live-common/exchange/swap/types";
 import { getNoticeType, getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";

--- a/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/IsUnlocked.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useSelector, useDispatch } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { setEncryptionKey, isEncryptionKeyCorrect, hasBeenDecrypted } from "~/renderer/storage";
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import { useHardReset } from "~/renderer/reset";

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -31,7 +31,6 @@ import { ExchangeType } from "@ledgerhq/live-common/wallet-api/Exchange/server";
 import { getIncompatibleCurrencyKeys } from "@ledgerhq/live-common/exchange/swap/index";
 import { Exchange, isExchangeSwap } from "@ledgerhq/live-common/exchange/types";
 import { HardwareUpdate, renderLoading } from "./DeviceAction/rendering";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { HOOKS_TRACKING_LOCATIONS } from "../analytics/hooks/variables";
 import { getProviderName } from "@ledgerhq/live-common/exchange/swap/utils/index";
@@ -66,7 +65,9 @@ export function isStartExchangeData(data: unknown): data is StartExchangeData {
   return "exchangeType" in data;
 }
 
-const DrawerClosedError = createCustomErrorClass("DrawerClosedError");
+class DrawerClosedError extends Error {
+  override name = "DrawerClosedError";
+}
 
 export const LiveAppDrawer = () => {
   const [dismissDisclaimerChecked, setDismissDisclaimerChecked] = useState<boolean>(false);

--- a/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/OnboardingAppInstall/InstallSetOfApps.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "tests/testSetup";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { SkipReason } from "@ledgerhq/live-common/apps/types";
-import { UserRefusedAllowManager } from "@ledgerhq/errors";
+import { UserRefusedAllowManager } from "@ledgerhq/live-common/errors";
 import { createConnectAppMock } from "tests/mocks/createConnectAppMock";
 import InstallSetOfApps from "./InstallSetOfApps";
 

--- a/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/QRCodeCameraPickerCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from "react";
 import jsQR from "jsqr";
 import styled from "styled-components";
-import { NoAccessToCamera } from "@ledgerhq/errors";
+import { NoAccessToCamera } from "@ledgerhq/live-common/errors";
 import logger from "~/renderer/logger";
 import IconCameraError from "~/renderer/icons/CameraError";
 import IconCross from "~/renderer/icons/Cross";

--- a/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/Web3AppWebview/PlatformAPIWebview.tsx
@@ -2,7 +2,7 @@ import { JSONRPCRequest } from "json-rpc-2.0";
 import React, { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { useToasts } from "@ledgerhq/live-common/notifications/ToastProvider/index";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/sendFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/aleo/__integrations__/sendFlow.integ.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import BigNumber from "bignumber.js";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
 import { mockDomMeasurements } from "LLD/features/__tests__/shared";
 import { importLLDCoinFamily } from "~/renderer/families";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import { render } from "tests/testSetup";
 import ErrorBanner from "~/renderer/components/ErrorBanner";

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendRecipientFields.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/SendRecipientFields.tsx
@@ -1,4 +1,4 @@
-import { PendingOperation } from "@ledgerhq/errors";
+import { PendingOperation } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import {
   BitcoinAccount,

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZCashExportKeyFlowModal/steps/StepDevice.tsx
@@ -6,7 +6,7 @@ import type { BitcoinAccountBridge } from "@ledgerhq/coin-bitcoin/bridge/js";
 import { getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { HOOKS_TRACKING_LOCATIONS } from "~/renderer/analytics/hooks/variables";
 import useConnectAppAction from "~/renderer/hooks/useConnectAppAction";

--- a/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/celo/SendStepAmount.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { render, screen } from "tests/testSetup";
-import { FeeNotLoaded, NotEnoughBalanceFees } from "@ledgerhq/errors";
+import { FeeNotLoaded, NotEnoughBalanceFees } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import type { StepProps } from "~/renderer/modals/Send/types";
 import SendStepAmount, { FEES_BANNER_TESTID } from "./SendStepAmount";

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/__tests__/OnboardModal.test.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { cleanup, render, screen, waitFor } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { AccountOnboardStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumPairingExpiredError,
+} from "@ledgerhq/coin-concordium/types";
 import { Account } from "@ledgerhq/types-live";
 import OnboardModal from "../index";
 import {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/OnboardError.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/OnboardError.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render } from "tests/testSetup";
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import OnboardError from "../OnboardError";
 
 describe("OnboardError", () => {

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/StepOnboard.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/components/__tests__/StepOnboard.test.tsx
@@ -90,7 +90,7 @@ describe("StepOnboard", () => {
   });
 
   it("should display user refused error message", () => {
-    const { UserRefusedOnDevice } = jest.requireActual("@ledgerhq/errors");
+    const { UserRefusedOnDevice } = jest.requireActual("@ledgerhq/ledger-wallet-framework/errors");
     const userRefusedError = new UserRefusedOnDevice();
     const props = {
       ...defaultProps,
@@ -105,7 +105,7 @@ describe("StepOnboard", () => {
   });
 
   it("should display locked device error message", () => {
-    const { LockedDeviceError } = jest.requireActual("@ledgerhq/errors");
+    const { LockedDeviceError } = jest.requireActual("@ledgerhq/ledger-wallet-framework/errors");
     const lockedError = new LockedDeviceError();
     const props = {
       ...defaultProps,

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/OnboardModal/utils/__tests__/pairing.test.ts
@@ -1,5 +1,8 @@
-import { AccountOnboardStatus, ConcordiumPairingStatus } from "@ledgerhq/coin-concordium/types";
-import { ConcordiumPairingExpiredError } from "@ledgerhq/errors";
+import {
+  AccountOnboardStatus,
+  ConcordiumPairingStatus,
+  ConcordiumPairingExpiredError,
+} from "@ledgerhq/coin-concordium/types";
 import {
   getConfirmationCode,
   shouldRetryPairing,

--- a/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/concordium/StepReceiveFunds/index.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { firstValueFrom } from "rxjs";
 import { Account } from "@ledgerhq/types-live";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { getEnv } from "@shared/env";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/__tests__/TransactionErrorBanner.test.tsx
@@ -1,4 +1,4 @@
-import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { NotEnoughGas, TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import { render } from "tests/testSetup";
 import ErrorBanner from "~/renderer/components/ErrorBanner";

--- a/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/evm/EditTransaction/components/TransactionErrorBanner.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import React from "react";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/StakeFlowModal/__tests__/StepValidator.test.tsx
@@ -3,7 +3,7 @@ import BigNumber from "bignumber.js";
 import { act, fireEvent, render, screen } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
-import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/errors";
+import { InvalidAddress, NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { TezosAccount, Transaction } from "@ledgerhq/live-common/families/tezos/types";
 import type { StepProps } from "../types";
 

--- a/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/tezos/UnstakeFlowModal/__tests__/Body.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import BigNumber from "bignumber.js";
 import { act, render, screen } from "tests/testSetup";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import type {

--- a/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useConnectAppAction.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { catchError, throwError } from "rxjs";
-import { GenuineCheckFailed } from "@ledgerhq/errors";
+import { GenuineCheckFailed } from "@ledgerhq/live-common/errors";
 import { isCounterfeitError } from "@ledgerhq/live-common/hw/isCounterfeitError";
 import connectApp from "@ledgerhq/live-common/hw/connectApp";
 import connectManager from "@ledgerhq/live-common/hw/connectManager";
@@ -118,7 +118,7 @@ export function useGenuineCheckAction(): Action<ManagerRequest, ManagerState, Ma
           if (isCounterfeitError(error)) return throwError(() => error);
           if (isDeviceNotOnboardedError(error)) return throwError(() => error);
 
-          return throwError(() => new GenuineCheckFailed("", undefined, { cause: error }));
+          return throwError(() => new GenuineCheckFailed("", { cause: error }));
         }),
       );
     return createManagerAction(task);

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -1,7 +1,7 @@
-import { getEnv } from "@shared/env";
 import { createRoot } from "react-dom/client";
 import React from "react";
 import Transport from "@ledgerhq/hw-transport";
+import { getEnv } from "@shared/env";
 import { log } from "@ledgerhq/logs";
 import "../config/configInit";
 import { checkLibs } from "@ledgerhq/live-common/sanityChecks";

--- a/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/DisablePasswordModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch } from "LLD/hooks/redux";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { useTranslation } from "react-i18next";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { closeModal } from "~/renderer/actions/modals";
@@ -10,7 +10,7 @@ import InputPassword from "~/renderer/components/InputPassword";
 import Label from "~/renderer/components/Label";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const DisablePasswordModal = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/PasswordForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from "react";
-import { PasswordsDontMatchError } from "@ledgerhq/errors";
+import { PasswordsDontMatchError } from "@ledgerhq/live-common/errors";
 import { TFunction } from "i18next";
 import Box from "~/renderer/components/Box";
 import InputPassword from "~/renderer/components/InputPassword";

--- a/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/PasswordModal/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useTranslation } from "react-i18next";
-import { PasswordIncorrectError } from "@ledgerhq/errors";
+import { PasswordIncorrectError } from "@ledgerhq/live-common/errors";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -10,7 +10,7 @@ import PasswordForm from "./PasswordForm";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { setHasPassword } from "~/renderer/actions/application";
-type MaybePasswordIncorrectError = ReturnType<typeof PasswordIncorrectError> | undefined | null;
+type MaybePasswordIncorrectError = PasswordIncorrectError | undefined | null;
 const PasswordModal = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -5,7 +5,7 @@ import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import useTheme from "~/renderer/hooks/useTheme";

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/fields/RecipientField.react.test.tsx
@@ -6,7 +6,7 @@ import BigNumber from "bignumber.js";
 import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { Account } from "@ledgerhq/types-live";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { DomainServiceProvider } from "@ledgerhq/domain-service/hooks/index";
 import { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/impl";

--- a/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Send/steps/StepConfirmation.tsx
@@ -1,4 +1,4 @@
-import { TransactionHasBeenValidatedError } from "@ledgerhq/errors";
+import { TransactionHasBeenValidatedError } from "@ledgerhq/live-common/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/bridge/react/index";
 import React from "react";

--- a/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from "react-i18next";
 import type { Account } from "@ledgerhq/types-live";
 import { validateNameEdition } from "@ledgerhq/live-wallet/accountName";
 import { setAccountName as actionSetAccountName } from "@ledgerhq/live-wallet/store";
-import { AccountNameRequiredError } from "@ledgerhq/errors";
+import { AccountNameRequiredError } from "~/errors";
 import { getEnv } from "@shared/env";
 import { urls } from "~/config/urls";
 import { setDataModal } from "~/renderer/actions/modals";

--- a/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/manager/DeviceDashboard/DeviceInformationSummary/EditDeviceName.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo } from "react";
 import { Button, Flex, Divider, Text, Input, IconsLegacy, BoxedIcon } from "@ledgerhq/react-ui";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import { useTranslation } from "react-i18next";
-import { DeviceNameInvalid } from "@ledgerhq/errors";
+import { DeviceNameInvalid } from "@ledgerhq/live-common/errors";
 import Label from "~/renderer/components/Label";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import Box from "~/renderer/components/Box";

--- a/apps/ledger-live-desktop/src/support/os.ts
+++ b/apps/ledger-live-desktop/src/support/os.ts
@@ -1,8 +1,6 @@
 import os from "os";
 import semverSatisfies from "semver/functions/satisfies";
 import { getEnv } from "@shared/env";
-import { createCustomErrorClass } from "@ledgerhq/errors";
-import { LedgerErrorConstructor } from "@ledgerhq/errors/helpers";
 
 type OperatingSystemOutdatedInfos = {
   type: string;
@@ -10,10 +8,16 @@ type OperatingSystemOutdatedInfos = {
   criteria: string;
 };
 
-export const OperatingSystemOutdated = createCustomErrorClass<
-  OperatingSystemOutdatedInfos,
-  LedgerErrorConstructor<OperatingSystemOutdatedInfos>
->("OperatingSystemOutdated");
+export class OperatingSystemOutdated extends Error {
+  override name = "OperatingSystemOutdated";
+  type?: string;
+  release?: string;
+  criteria?: string;
+  constructor(message?: string, fields?: Partial<OperatingSystemOutdatedInfos>) {
+    super(message || "OperatingSystemOutdated");
+    if (fields) Object.assign(this, fields);
+  }
+}
 
 export type SupportStatus =
   | {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22719,7 +22719,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25063,7 +25063,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -34197,6 +34197,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -65680,7 +65681,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -65804,54 +65805,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Removes direct imports of @ledgerhq/errors in apps/ledger-live-desktop, replacing them with native error classes from @ledgerhq/ledger-wallet-framework/errors, @ledgerhq/hw-transport/errors, or local modules.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35181](https://ledgerhq.atlassian.net/browse/LIVE-35181)
- **ADR** (if any): N/A

[LIVE-35181]: https://ledgerhq.atlassian.net/browse/LIVE-35181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ