### PR TITLE
[LWDM] chore(LIVE-32915): migrate @ledgerhq/errors in ledger-live-common

### DIFF
--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -52,6 +52,9 @@
       "exchange/swapTransactionStatus/transactionStatus": [
         "lib-es/exchange/swapTransactionStatus/transactionStatus"
       ],
+      "errors": [
+        "./src/errors.ts"
+      ],
       "*": [
         "lib-es/*"
       ],
@@ -261,6 +264,7 @@
     "@blooo/hw-app-acre": "^1.1.1",
     "@cardano-foundation/ledgerjs-hw-app-cardano": "^7.1.2",
     "@domain/api-currency-token": "workspace:^",
+    "@domain/entity-client-identity": "workspace:^",
     "@domain/entity-currency": "workspace:^",
     "@domain/entity-currency-crypto": "workspace:^",
     "@domain/entity-currency-fiat": "workspace:^",
@@ -269,12 +273,10 @@
     "@features/platform-env": "workspace:^",
     "@features/platform-feature-flags": "workspace:^",
     "@ledgerhq/asset-aggregation": "workspace:^",
-    "@domain/entity-client-identity": "workspace:^",
     "@ledgerhq/coin-aleo": "workspace:^",
     "@ledgerhq/coin-algorand": "workspace:^",
     "@ledgerhq/coin-aptos": "workspace:^",
     "@ledgerhq/coin-bitcoin": "workspace:^",
-    "@ledgerhq/wallet-btc": "workspace:^",
     "@ledgerhq/coin-canton": "workspace:^",
     "@ledgerhq/coin-cardano": "workspace:^",
     "@ledgerhq/coin-casper": "workspace:^",
@@ -359,6 +361,7 @@
     "@ledgerhq/wallet-api-core": "^1.35.0",
     "@ledgerhq/wallet-api-exchange-module": "workspace:^",
     "@ledgerhq/wallet-api-server": "^3.4.2",
+    "@ledgerhq/wallet-btc": "workspace:^",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "1.8.0",
     "@reduxjs/toolkit": "catalog:",

--- a/libs/ledger-live-common/src/__tests__/manager.ts
+++ b/libs/ledger-live-common/src/__tests__/manager.ts
@@ -1,4 +1,4 @@
-import { FirmwareNotRecognized } from "@ledgerhq/errors";
+import { FirmwareNotRecognized } from "../errors";
 import Manager from "../manager/api";
 import "./test-helpers/setup";
 describe("getDeviceVersion", () => {

--- a/libs/ledger-live-common/src/account/support.ts
+++ b/libs/ledger-live-common/src/account/support.ts
@@ -1,4 +1,4 @@
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { checkAccountSupported as checkAccountDerivationSupported } from "@ledgerhq/ledger-wallet-framework/account/support";
 import { isCoinModuleRegistered } from "../coin-modules/registry";

--- a/libs/ledger-live-common/src/apps/listApps.test.ts
+++ b/libs/ledger-live-common/src/apps/listApps.test.ts
@@ -1,5 +1,5 @@
 import { from, lastValueFrom } from "rxjs";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "../errors";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { listApps } from "./listApps";
 import ManagerAPI, { ListInstalledAppsEvent } from "../manager/api";

--- a/libs/ledger-live-common/src/apps/listApps.ts
+++ b/libs/ledger-live-common/src/apps/listApps.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { DeviceModelId, getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
-import { UnexpectedBootloader } from "@ledgerhq/errors";
+import { UnexpectedBootloader } from "../errors";
 import { Observable, throwError, Subscription } from "rxjs";
 import { App, DeviceInfo, idsToLanguage, languageIds } from "@ledgerhq/types-live";
 import { LocalTracer } from "@ledgerhq/logs";

--- a/libs/ledger-live-common/src/apps/logic.ts
+++ b/libs/ledger-live-common/src/apps/logic.ts
@@ -5,10 +5,9 @@ import semver from "semver";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { AppOp, State, Action, ListAppsResult, AppsDistribution, SkipReason } from "./types";
 import { findCryptoCurrency, findCryptoCurrencyById, isCurrencySupported } from "../currencies";
-import { NoSuchAppOnProvider } from "../errors";
+import { NoSuchAppOnProvider, LatestFirmwareVersionRequired } from "../errors";
 import { App } from "@ledgerhq/types-live";
 import { getEnv } from "@shared/env";
-import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
 
 const RESERVED_BLOCKS = 1;
 

--- a/libs/ledger-live-common/src/apps/mock.ts
+++ b/libs/ledger-live-common/src/apps/mock.ts
@@ -1,5 +1,5 @@
 import { of, throwError } from "rxjs";
-import { ManagerAppDepInstallRequired, ManagerAppDepUninstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired, ManagerAppDepUninstallRequired } from "../errors";
 import { getDependencies, getDependents, whitelistDependencies } from "./polyfill";
 import { findCryptoCurrency } from "../currencies";
 import type { ListAppsResult, AppOp, Exec, InstalledItem } from "./types";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -1,5 +1,5 @@
 import { AccountBridge } from "@ledgerhq/types-live";
-import { AccountAwaitingSendPendingOperations } from "@ledgerhq/errors";
+import { AccountAwaitingSendPendingOperations } from "../../errors";
 import BigNumber from "bignumber.js";
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -4,7 +4,7 @@ import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledg
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
 import { bigNumberToBigIntDeep, buildOptimisticOperation, transactionToIntent } from "./utils";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { type GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { lastValueFrom } from "rxjs";
 import { toArray } from "rxjs/operators";
 import { genericSignOperation } from "../signOperation";
-import { FeeNotLoaded } from "@ledgerhq/errors";
+import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCoinModuleApi } from "../api";
 import { buildOptimisticOperation } from "../utils";
 

--- a/libs/ledger-live-common/src/bridge/impl.test.ts
+++ b/libs/ledger-live-common/src/bridge/impl.test.ts
@@ -1,6 +1,7 @@
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { BigNumber } from "bignumber.js";
-import { AccountNotSupported, CurrencyNotSupported } from "@ledgerhq/errors";
+import { AccountNotSupported } from "@ledgerhq/ledger-wallet-framework/errors";
+import { CurrencyNotSupported } from "../errors";
 import { initialBitcoinResourcesValue } from "@ledgerhq/coin-bitcoin/types";
 import type { BitcoinAccount } from "@ledgerhq/coin-bitcoin/types";
 import type { DerivationMode } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/bridge/impl.ts
+++ b/libs/ledger-live-common/src/bridge/impl.ts
@@ -2,7 +2,7 @@ import {
   isAddressSanctioned,
   isCheckSanctionedAddressEnabled,
 } from "@ledgerhq/ledger-wallet-framework/sanction/index";
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { decodeAccountId, getMainAccount, checkAccountSupported } from "../account";
 import { getEnv } from "@shared/env";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";

--- a/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/useAccountBridge.test.ts
@@ -4,7 +4,7 @@
 import "../__tests__/test-helpers/dom-polyfill";
 import React from "react";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { render, renderHook, act, screen } from "@testing-library/react";
 import { genAccount } from "../mock/account";
 import { useAccountBridge, useAccountBridgeMany } from "./useAccountBridge";

--- a/libs/ledger-live-common/src/coin-modules/registry.test.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.test.ts
@@ -1,4 +1,4 @@
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import {
   registerCoinModules,

--- a/libs/ledger-live-common/src/coin-modules/registry.ts
+++ b/libs/ledger-live-common/src/coin-modules/registry.ts
@@ -1,4 +1,4 @@
-import { CurrencyNotSupported } from "@ledgerhq/errors";
+import { CurrencyNotSupported } from "../errors";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { CoinModuleLoader, MockAccountModule } from "./types";

--- a/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
+++ b/libs/ledger-live-common/src/device/use-cases/appDataBackup/types.ts
@@ -1,6 +1,5 @@
 import { type AppStorageInfo, isAppStorageInfo } from "@ledgerhq/device-core";
 import { DeviceModelId } from "@ledgerhq/devices";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 
 /**
  * The interface for the storage provider used to store the application data, should be implemented in a platform-specific context.
@@ -90,7 +89,12 @@ export type BackupAppDataEvent =
 /**
  * An error that occurs during the backup process, the error message should be descriptive when thrown.
  */
-export const BackupAppDataError = createCustomErrorClass("BackupAppDataError");
+export class BackupAppDataError extends Error {
+  override name = "BackupAppDataError";
+  constructor(message?: string) {
+    super(message || "BackupAppDataError");
+  }
+}
 
 export enum RestoreAppDataEventType {
   /**
@@ -141,7 +145,12 @@ export type RestoreAppDataEvent =
 /**
  * An error that occurs during the restore process, the error message should be descriptive when thrown.
  */
-export const RestoreAppDataError = createCustomErrorClass("RestoreAppDataError");
+export class RestoreAppDataError extends Error {
+  override name = "RestoreAppDataError";
+  constructor(message?: string) {
+    super(message || "RestoreAppDataError");
+  }
+}
 
 export enum DeleteAppDataEventType {
   AppDataDeleteStarted = "appDataDeleteStarted",
@@ -169,4 +178,9 @@ export type DeleteAppDataEvent =
 /**
  * An error that occurs during the delete process (local data), the error message should be descriptive when thrown.
  */
-export const DeleteAppDataError = createCustomErrorClass("DeleteAppDataError");
+export class DeleteAppDataError extends Error {
+  override name = "DeleteAppDataError";
+  constructor(message?: string) {
+    super(message || "DeleteAppDataError");
+  }
+}

--- a/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getLatestAvailableFirmware.test.ts
@@ -1,5 +1,5 @@
 import { Observable, of } from "rxjs";
-import { LockedDeviceError, TransportRaceCondition } from "@ledgerhq/errors";
+import { LockedDeviceError, TransportRaceCondition } from "@ledgerhq/hw-transport/errors";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 
 import { getDeviceInfoTask, internalGetDeviceInfoTask } from "../tasks/getDeviceInfo";

--- a/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/firmwareUpdate/installFirmware.ts
@@ -11,7 +11,7 @@ import {
   ManagerFirmwareNotEnoughSpaceError,
   UserRefusedFirmwareUpdate,
   DeviceOnDashboardExpected,
-} from "@ledgerhq/errors";
+} from "../../../errors";
 import { LOG_TYPE, UnresponsiveCmdEvent } from "../core";
 
 export type InstallFirmwareCommandRequest = {

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
-import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { UnresponsiveCmdEvent } from "./core";
 import { Observable, from, of } from "rxjs";
 import { switchMap } from "rxjs/operators";

--- a/libs/ledger-live-common/src/deviceSDK/commands/toggleOnboardingEarlyCheck.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/toggleOnboardingEarlyCheck.test.ts
@@ -1,6 +1,6 @@
 import { MockTransport } from "@ledgerhq/hw-transport-mocker";
 import { ToggleTypeP2, toggleOnboardingEarlyCheckCmd } from "./toggleOnboardingEarlyCheck";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport/errors";
 
 describe("@deviceSDK/commands/toggleOnboardingEarlyCheckCmd", () => {
   describe("When the device is neither in the WELCOME and WELCOME_STEP2 onboarding state, and it returns 0x6982", () => {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/core.test.ts
@@ -1,6 +1,6 @@
 import { of, throwError } from "rxjs";
 import { retryOnErrorsCommandWrapper, sharedLogicTaskWrapper, isDmkError } from "./core";
-import { DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import { DisconnectedDevice, LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 import { DeviceBusyError } from "@ledgerhq/device-management-kit";
 import { concatMap } from "rxjs/operators";
 import { TransportRef } from "../transports/core";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -1,4 +1,4 @@
-import { DisconnectedDevice, StatusCodes } from "@ledgerhq/errors";
+import { DisconnectedDevice, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import type { DeviceId } from "@ledgerhq/types-live";
 
 import { Observable, concat, of, throwError } from "rxjs";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getDeviceInfo.ts
@@ -1,4 +1,5 @@
-import { DisconnectedDevice, UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import type { DeviceId, DeviceInfo, FirmwareInfo } from "@ledgerhq/types-live";
 

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.test.ts
@@ -1,5 +1,5 @@
 import { from, of, throwError } from "rxjs";
-import { StatusCodes, TransportStatusError } from "@ledgerhq/errors";
+import { StatusCodes, TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import { toggleOnboardingEarlyCheckTask } from "./toggleOnboardingEarlyCheck";
 import { toggleOnboardingEarlyCheckCmd } from "../commands/toggleOnboardingEarlyCheck";
 import { withTransport } from "../transports/core";

--- a/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/toggleOnboardingEarlyCheck.ts
@@ -7,7 +7,7 @@ import {
   toggleOnboardingEarlyCheckCmd,
   ToggleTypeP2,
 } from "../commands/toggleOnboardingEarlyCheck";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 
 export type ToggleOnboardingEarlyCheckTaskError =
   | "DeviceInInvalidState"

--- a/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/updateFirmware.ts
@@ -2,8 +2,8 @@ import {
   CantOpenDevice,
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { LocalTracer } from "@ledgerhq/logs";
 import type {
   DeviceId,

--- a/libs/ledger-live-common/src/deviceSDK/transports/core.ts
+++ b/libs/ledger-live-common/src/deviceSDK/transports/core.ts
@@ -2,7 +2,8 @@ import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
-import { CantOpenDevice, DeviceHalted, FirmwareOrAppUpdateRequired } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
+import { DeviceHalted, FirmwareOrAppUpdateRequired } from "../../errors";
 import { open, close } from "../../hw/index";
 
 export { Transport };

--- a/libs/ledger-live-common/src/errors/transactionBroadcastErrors.ts
+++ b/libs/ledger-live-common/src/errors/transactionBroadcastErrors.ts
@@ -1,11 +1,13 @@
-import { createCustomErrorClass } from "@ledgerhq/errors";
-
-export const TransactionBroadcastError = createCustomErrorClass<{ url?: string } & TxData>(
-  "TransactionBroadcastError",
-);
-
-export interface TransactionBroadcastError extends Error, TxData {
+export class TransactionBroadcastError extends Error {
+  override name = "TransactionBroadcastError";
+  coin?: string;
+  network?: string;
   url?: string;
+
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message);
+    if (fields) Object.assign(this, fields);
+  }
 }
 
 export const createTransactionBroadcastError = (

--- a/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
+++ b/libs/ledger-live-common/src/families/aleo/hw/getViewKey/index.test.ts
@@ -1,4 +1,4 @@
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import type Transport from "@ledgerhq/hw-transport";
 import type { Account } from "@ledgerhq/types-live";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";

--- a/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/algorand/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type {
   AlgorandAccount,
   AlgorandTransaction,

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/api.ts
@@ -1,4 +1,4 @@
-import { FeeEstimationFailed } from "@ledgerhq/errors";
+import { FeeEstimationFailed } from "../../../errors";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";

--- a/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/bridge/mock.ts
@@ -5,8 +5,8 @@ import {
   InvalidAddress,
   FeeTooHigh,
   AmountRequired,
-  DustLimit,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { DustLimit } from "@ledgerhq/coin-bitcoin/errors";
 import type { FeeItems, Transaction } from "@ledgerhq/coin-bitcoin/types";
 import {
   makeAccountBridgeReceive,

--- a/libs/ledger-live-common/src/families/bitcoin/descriptor/coinControl.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/descriptor/coinControl.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import type { TransactionStatus as BtcTransactionStatus } from "@ledgerhq/coin-bitcoin/types";
 import type { AccountLike } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.test.ts
@@ -1,4 +1,4 @@
-import { ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import { BigNumber } from "bignumber.js";
 import { validateEditTransaction, getEditTransactionStatus } from "./getTransactionStatus";
 import type {

--- a/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/bitcoin/editTransaction/getTransactionStatus.ts
@@ -1,4 +1,5 @@
-import { AmountRequired, ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import type { TransactionStatusCommon } from "@ledgerhq/types-live";
 import type { BigNumber } from "bignumber.js";
 import { getMinFees } from "./getMinEditTransactionFees";

--- a/libs/ledger-live-common/src/families/cardano/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/cardano/bridge/mock.ts
@@ -14,7 +14,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { CardanoMinAmountError, CardanoNotEnoughFunds } from "@ledgerhq/coin-cardano/errors";
 import { buildTransaction } from "@ledgerhq/coin-cardano/buildTransaction";
 import { CARDANO_DUMMY_ADDRESS, CARDANO_MAX_SUPPLY } from "@ledgerhq/coin-cardano/constants";

--- a/libs/ledger-live-common/src/families/casper/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/casper/bridge/mock.ts
@@ -5,7 +5,7 @@ import {
   RecipientRequired,
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { CASPER_DUMMY_ADDRESS } from "@ledgerhq/coin-casper/constants";
 import type { Transaction, TransactionStatus } from "../types";

--- a/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/cosmos/bridge/mock.ts
@@ -23,7 +23,7 @@ import {
   InvalidAddress,
   NotEnoughBalance,
   RecipientRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getCosmosDummyRecipient } from "@ledgerhq/coin-cosmos/logic";
 import {

--- a/libs/ledger-live-common/src/families/cosmos/datasets/cosmos.ts
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/cosmos.ts
@@ -4,8 +4,8 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   AmountRequired,
-  RecommendUndelegation,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { RecommendUndelegation } from "../../../errors";
 import invariant from "invariant";
 import type { CosmosAccount, Transaction } from "@ledgerhq/coin-cosmos/types/index";
 import { AccountRaw, CurrenciesData } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/families/cosmos/datasets/osmosis.ts
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/osmosis.ts
@@ -4,7 +4,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import invariant from "invariant";
 import type { CosmosAccount, Transaction } from "../types";
 import { fromTransactionRaw } from "@ledgerhq/coin-cosmos/transaction";

--- a/libs/ledger-live-common/src/families/evm/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/evm/bridge/api.ts
@@ -8,7 +8,7 @@ import type {
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
-import { InvalidTransactionError } from "@ledgerhq/errors";
+import { InvalidTransactionError } from "@ledgerhq/ledger-wallet-framework/errors";
 import eip55 from "eip55";
 import BigNumber from "bignumber.js";
 import { ethers } from "ethers";

--- a/libs/ledger-live-common/src/families/evm/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/evm/bridge/mock.ts
@@ -1,5 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { InvalidAddress, NotEnoughBalance, RecipientRequired } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  NotEnoughBalance,
+  RecipientRequired,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/coin-evm/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getEvmDummyAddress } from "@ledgerhq/coin-evm/constants";

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.test.ts
@@ -1,8 +1,5 @@
-import {
-  AmountRequired,
-  RecipientRequired,
-  ReplacementTransactionUnderpriced,
-} from "@ledgerhq/errors";
+import { AmountRequired, RecipientRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import BigNumber from "bignumber.js";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";
 import {

--- a/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/families/evm/editTransaction/getTransactionStatus.ts
@@ -1,4 +1,5 @@
-import { AmountRequired, ReplacementTransactionUnderpriced } from "@ledgerhq/errors";
+import { AmountRequired } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ReplacementTransactionUnderpriced } from "../../../errors";
 import { TransactionStatusCommon } from "@ledgerhq/types-live";
 import { getMinEip1559Fees, getMinLegacyFees } from "./getMinEditTransactionFees";
 import { NotEnoughNftOwned, NotOwnedNft } from "@ledgerhq/coin-evm/errors";

--- a/libs/ledger-live-common/src/families/hedera/exchange.ts
+++ b/libs/ledger-live-common/src/families/hedera/exchange.ts
@@ -1,4 +1,4 @@
-import { LatestFirmwareVersionRequired } from "@ledgerhq/errors";
+import { LatestFirmwareVersionRequired } from "../../errors";
 import Exchange from "@ledgerhq/hw-app-exchange";
 import { loadPKI } from "@ledgerhq/hw-bolos";
 import calService from "@ledgerhq/ledger-cal-service";

--- a/libs/ledger-live-common/src/families/icon/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/icon/bridge/mock.ts
@@ -1,5 +1,10 @@
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "../types";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { ICON_DUMMY_ADDRESS } from "@ledgerhq/coin-icon/constants";

--- a/libs/ledger-live-common/src/families/multiversx/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/multiversx/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { MultiversXAccount, Transaction } from "@ledgerhq/coin-multiversx/types";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { MULTIVERSX_DUMMY_ADDRESS } from "@ledgerhq/coin-multiversx/constants";

--- a/libs/ledger-live-common/src/families/polkadot/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/polkadot/bridge/mock.ts
@@ -1,7 +1,12 @@
 // TODO: update path by moving mockHelpers to ledger-wallet-framework
 
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress, FeeTooHigh } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+  FeeTooHigh,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { PolkadotAccount, Transaction } from "@ledgerhq/coin-polkadot/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { POLKADOT_NULL_ADDRESS } from "@ledgerhq/coin-polkadot/constants";

--- a/libs/ledger-live-common/src/families/stellar/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/stellar/bridge/mock.ts
@@ -9,7 +9,7 @@ import {
   InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalanceBecauseDestinationNotCreated,
   NotEnoughSpendableBalance,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { STELLAR_DUMMY_ADDRESS } from "@ledgerhq/coin-stellar/constants";
 import { getSerializedAddressParameters } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";

--- a/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tezos/bridge/mock.ts
@@ -5,12 +5,11 @@ import {
   InvalidAddress,
   FeeTooHigh,
   InvalidAddressBecauseDestinationIsAlsoSource,
-  NotSupportedLegacyAddress,
   NotEnoughBalanceInParentAccount,
   AmountRequired,
-  RecommendSubAccountsToEmpty,
   NotEnoughBalanceToDelegate,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
+import { NotSupportedLegacyAddress, RecommendSubAccountsToEmpty } from "../../../errors";
 import type { TezosAccount, Transaction } from "../types";
 import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { TEZOS_DUMMY_ADDRESS } from "@ledgerhq/coin-tezos/constants";

--- a/libs/ledger-live-common/src/families/tron/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/tron/bridge/mock.ts
@@ -1,5 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { NotEnoughBalance, RecipientRequired, InvalidAddress } from "@ledgerhq/errors";
+import {
+  NotEnoughBalance,
+  RecipientRequired,
+  InvalidAddress,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/coin-tron/types/index";
 import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { TRON_DUMMY_ADDRESS } from "@ledgerhq/coin-tron/constants";

--- a/libs/ledger-live-common/src/families/xrp/bridge/mock.ts
+++ b/libs/ledger-live-common/src/families/xrp/bridge/mock.ts
@@ -7,7 +7,7 @@ import {
   RecipientRequired,
   FeeTooHigh,
   AmountRequired,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import {

--- a/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
+++ b/libs/ledger-live-common/src/flows/send/coinControl/hooks/__tests__/useCoinControlScreenViewModelCore.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { NotEnoughBalance } from "@ledgerhq/errors";
+import { NotEnoughBalance } from "@ledgerhq/ledger-wallet-framework/errors";
 import { BigNumber } from "bignumber.js";
 import { renderHook } from "@testing-library/react";
 import type {

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useBridgeRecipientValidation.test.ts
@@ -3,7 +3,7 @@
  */
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { InvalidAddress } from "@ledgerhq/errors";
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { Account } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/hooks/__tests__/useRecipientSearchState.test.ts
@@ -1,7 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { InvalidAddress, InvalidAddressBecauseDestinationIsAlsoSource } from "@ledgerhq/errors";
+import {
+  InvalidAddress,
+  InvalidAddressBecauseDestinationIsAlsoSource,
+} from "@ledgerhq/ledger-wallet-framework/errors";
 import { renderHook } from "@testing-library/react";
 import type { AddressSearchResult } from "../../types";
 import { useRecipientSearchState } from "../useRecipientSearchState";

--- a/libs/ledger-live-common/src/hw/actions/implementations.ts
+++ b/libs/ledger-live-common/src/hw/actions/implementations.ts
@@ -14,7 +14,7 @@ import {
   DisconnectedDevice,
   DisconnectedDeviceDuringOperation,
   LockedDeviceError,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
 import { catchError, debounce, delayWhen, filter, switchMap, tap, timeout } from "rxjs/operators";
 import { Device } from "./types";
 import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";

--- a/libs/ledger-live-common/src/hw/actions/renameDevice.ts
+++ b/libs/ledger-live-common/src/hw/actions/renameDevice.ts
@@ -3,7 +3,7 @@ import { scan, map, tap } from "rxjs/operators";
 import { useEffect, useMemo, useCallback, useState } from "react";
 import { log } from "@ledgerhq/logs";
 import type { DeviceInfo } from "@ledgerhq/types-live";
-import { UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { UserRefusedDeviceNameChange } from "../../errors";
 import { useReplaySubject } from "../../observable";
 import type { Action, Device } from "./types";
 import {

--- a/libs/ledger-live-common/src/hw/connectApp.ts
+++ b/libs/ledger-live-common/src/hw/connectApp.ts
@@ -1,13 +1,13 @@
 import semver from "semver";
 import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   FirmwareOrAppUpdateRequired,
-  UserRefusedOnDevice,
   UpdateYourApp,
-  StatusCodes,
   LatestFirmwareVersionRequired,
-} from "@ledgerhq/errors";
+} from "../errors";
 import type Transport from "@ledgerhq/hw-transport";
 import { type DerivationMode, DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
 import type { AppOp, SkippedAppOp } from "../apps/types";

--- a/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectAppEventMapper.ts
@@ -22,19 +22,20 @@ import type {
   ConnectAppDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
 import { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/types-live";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import {
   UserRefusedAllowManager,
-  UserRefusedOnDevice,
   LatestFirmwareVersionRequired,
   UnsupportedFeatureError,
-} from "@ledgerhq/errors";
+  DeviceNotOnboarded,
+  NoSuchAppOnProvider,
+} from "../errors";
 import { DeviceId } from "@domain/entity-client-identity";
 
 import type { SkippedAppOp } from "../apps/types";
 import { SkipReason } from "../apps/types";
 import { parseDeviceInfo } from "../deviceSDK/tasks/getDeviceInfo";
 import { ConnectAppEvent } from "./connectApp";
-import { DeviceNotOnboarded, NoSuchAppOnProvider } from "../errors";
 
 export class ConnectAppEventMapper {
   private openAppRequested: boolean = false;

--- a/libs/ledger-live-common/src/hw/connectManager.ts
+++ b/libs/ledger-live-common/src/hw/connectManager.ts
@@ -1,6 +1,6 @@
 import { Observable, concat, concatWith, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import { StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { isCharonSupported } from "@ledgerhq/device-core";
 import { identifyTargetId } from "@ledgerhq/devices";
 import { DeviceInfo } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
+++ b/libs/ledger-live-common/src/hw/connectManagerEventMapper.ts
@@ -14,7 +14,7 @@ import type {
   PrepareConnectManagerDAError,
   PrepareConnectManagerDAIntermediateValue,
 } from "@ledgerhq/live-dmk-shared";
-import { DisconnectedDevice } from "@ledgerhq/errors";
+import { DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 
 import { LockedDeviceEvent } from "./actions/types";
 

--- a/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetch.ts
@@ -1,6 +1,6 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
-import { TransportError, StatusCodes } from "@ledgerhq/errors";
+import { TransportError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchHash.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenFetchSize.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UnexpectedBootloader, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 /**

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.test.ts
@@ -2,8 +2,8 @@ import customLockScreenLoad from "./customLockScreenLoad";
 import { DeviceModelId } from "@ledgerhq/devices";
 import { CLSSupportedDeviceModelId } from "@ledgerhq/device-core";
 import { lastValueFrom, of } from "rxjs";
-import { ManagerNotEnoughSpaceError, StatusCodes, TransportError } from "@ledgerhq/errors";
-import { ImageLoadRefusedOnDevice } from "../errors";
+import { StatusCodes, TransportError } from "@ledgerhq/hw-transport/errors";
+import { ImageLoadRefusedOnDevice, ManagerNotEnoughSpaceError } from "../errors";
 
 const mockTransport = {
   send: jest.fn(),

--- a/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenLoad.ts
@@ -1,15 +1,14 @@
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
+import { StatusCodes, TransportError, DisconnectedDevice } from "@ledgerhq/hw-transport/errors";
 import {
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-  DisconnectedDevice,
-} from "@ledgerhq/errors";
+  ImageLoadRefusedOnDevice,
+  ImageCommitRefusedOnDevice,
+} from "../errors";
 import { getDeviceModel } from "@ledgerhq/devices";
 
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageLoadRefusedOnDevice, ImageCommitRefusedOnDevice } from "../errors";
 import getAppAndVersion from "./getAppAndVersion";
 import { isDashboardName } from "./isDashboardName";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.test.ts
@@ -1,7 +1,8 @@
-import { StatusCodes, UnexpectedBootloader, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import removeImage, { command } from "./customLockScreenRemove";
 import Transport from "@ledgerhq/hw-transport";
-import { ImageDoesNotExistOnDevice } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { from } from "rxjs";
 import getDeviceInfo from "./getDeviceInfo";

--- a/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
+++ b/libs/ledger-live-common/src/hw/customLockScreenRemove.ts
@@ -1,15 +1,11 @@
-import {
-  TransportStatusError,
-  UnexpectedBootloader,
-  StatusCodes,
-  UserRefusedOnDevice,
-} from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { ImageDoesNotExistOnDevice, UnexpectedBootloader } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of, throwError } from "rxjs";
 import { withDevice } from "./deviceAccess";
 import { catchError, delay, mergeMap } from "rxjs/operators";
 import getDeviceInfo from "./getDeviceInfo";
-import { ImageDoesNotExistOnDevice } from "../errors";
 
 export type RemoveImageEvent =
   | {

--- a/libs/ledger-live-common/src/hw/deviceAccess.ts
+++ b/libs/ledger-live-common/src/hw/deviceAccess.ts
@@ -1,12 +1,8 @@
 import { firstValueFrom, from, Observable, throwError, timer } from "rxjs";
 import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import {
-  CantOpenDevice,
-  FirmwareOrAppUpdateRequired,
-  TransportStatusError,
-  DeviceHalted,
-} from "@ledgerhq/errors";
+import { CantOpenDevice, TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { FirmwareOrAppUpdateRequired, DeviceHalted } from "../errors";
 import { LocalTracer, TraceContext, trace } from "@ledgerhq/logs";
 import { getEnv } from "@shared/env";
 import { open, close, OpenOptions } from ".";

--- a/libs/ledger-live-common/src/hw/editDeviceName.ts
+++ b/libs/ledger-live-common/src/hw/editDeviceName.ts
@@ -1,5 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
-import { StatusCodes, UserRefusedDeviceNameChange } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedDeviceNameChange } from "../errors";
 
 /**
  * Specify a new name for a device. This is technically supported on all models

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.test.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { CharonStatus, extractOnboardingState, OnboardingStep } from "./extractOnboardingState";
 
 describe("@hw/extractOnboardingState", () => {

--- a/libs/ledger-live-common/src/hw/extractOnboardingState.ts
+++ b/libs/ledger-live-common/src/hw/extractOnboardingState.ts
@@ -1,4 +1,4 @@
-import { DeviceExtractOnboardingStateError } from "@ledgerhq/errors";
+import { DeviceExtractOnboardingStateError } from "../errors";
 import { SeedPhraseType } from "@ledgerhq/types-live";
 
 const CHARON_STEP_BIT_MASK = 0x1000;

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-main.ts
@@ -1,7 +1,7 @@
 import { log } from "@ledgerhq/logs";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import { concatMap, delay, scan, distinctUntilChanged, throttleTime } from "rxjs/operators";
-import { DeviceInOSUExpected } from "@ledgerhq/errors";
+import { DeviceInOSUExpected } from "../errors";
 import { withDevicePolling, withDevice } from "./deviceAccess";
 import getDeviceInfo from "./getDeviceInfo";
 import flash from "./flash";

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-prepare.ts
@@ -2,7 +2,7 @@ import { log } from "@ledgerhq/logs";
 import type { FirmwareUpdateContext } from "@ledgerhq/types-live";
 import { Observable, from, of, concat, throwError } from "rxjs";
 import { mergeMap, delay, filter, map } from "rxjs/operators";
-import { DeviceOnDashboardExpected } from "@ledgerhq/errors";
+import { DeviceOnDashboardExpected } from "../errors";
 import getDeviceInfo from "./getDeviceInfo";
 import installOsuFirmware from "./installOsuFirmware";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
+++ b/libs/ledger-live-common/src/hw/firmwareUpdate-repair.ts
@@ -1,5 +1,5 @@
 import { log } from "@ledgerhq/logs";
-import { MCUNotGenuineToDashboard } from "@ledgerhq/errors";
+import { MCUNotGenuineToDashboard } from "../errors";
 import { Observable, from, of, EMPTY, concat, throwError } from "rxjs";
 import type { DeviceVersion, FinalFirmware, McuVersion } from "@ledgerhq/types-live";
 import { concatMap, delay, filter, map, mergeMap, throttleTime } from "rxjs/operators";

--- a/libs/ledger-live-common/src/hw/getAddress/index.ts
+++ b/libs/ledger-live-common/src/hw/getAddress/index.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "@ledgerhq/errors";
+import { DeviceAppVerifyNotSupported, UserRefusedAddress } from "../../errors";
 import { log } from "@ledgerhq/logs";
 import { Resolver } from "./types";
 import { loadSetupForFamily } from "../../coin-modules/registry";

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -1,6 +1,6 @@
 import Transport from "@ledgerhq/hw-transport";
 import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
-import { TransportStatusError, StatusCodes } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 
 import { LOG_TYPE } from ".";

--- a/libs/ledger-live-common/src/hw/getDeviceInfo.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceInfo.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-bitwise */
-import { DeviceOnDashboardExpected, StatusCodes } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnDashboardExpected, DeviceNotOnboarded } from "../errors";
 import { LocalTracer, log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
@@ -7,7 +8,6 @@ import isDevFirmware from "./isDevFirmware";
 import getAppAndVersion from "./getAppAndVersion";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
-import { DeviceNotOnboarded } from "../errors";
 import type { DeviceInfo } from "@ledgerhq/types-live";
 
 const ManagerAllowedFlag = 0x08;

--- a/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
+++ b/libs/ledger-live-common/src/hw/getDeviceRunningMode.test.ts
@@ -1,7 +1,11 @@
 import { firstValueFrom, from, Observable, of, timer } from "rxjs";
 import { delay } from "rxjs/operators";
 import Transport from "@ledgerhq/hw-transport";
-import { CantOpenDevice, DisconnectedDevice, LockedDeviceError } from "@ledgerhq/errors";
+import {
+  CantOpenDevice,
+  DisconnectedDevice,
+  LockedDeviceError,
+} from "@ledgerhq/hw-transport/errors";
 import { DeviceInfo } from "@ledgerhq/types-live";
 import getDeviceInfo from "./getDeviceInfo";
 import { getDeviceRunningMode } from "./getDeviceRunningMode";

--- a/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
+++ b/libs/ledger-live-common/src/hw/getGenuineCheckFromDeviceId.test.ts
@@ -8,7 +8,7 @@ import {
   getGenuineCheckFromDeviceId,
   GetGenuineCheckFromDeviceIdResult,
 } from "./getGenuineCheckFromDeviceId";
-import { LockedDeviceError } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.test.ts
@@ -4,13 +4,12 @@ import * as rxjsOperators from "rxjs/operators";
 import { DeviceModelId } from "@ledgerhq/devices";
 import Transport from "@ledgerhq/hw-transport";
 import {
-  DeviceExtractOnboardingStateError,
   DisconnectedDevice,
   LockedDeviceError,
   TransportStatusError,
   StatusCodes,
-  UnexpectedBootloader,
-} from "@ledgerhq/errors";
+} from "@ledgerhq/hw-transport/errors";
+import { DeviceExtractOnboardingStateError, UnexpectedBootloader } from "../errors";
 import { withDevice } from "./deviceAccess";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { extractOnboardingState, OnboardingState, OnboardingStep } from "./extractOnboardingState";

--- a/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
+++ b/libs/ledger-live-common/src/hw/getOnboardingStatePolling.ts
@@ -2,11 +2,8 @@ import { defer, from, of, throwError, Observable, timer } from "rxjs";
 import { map, catchError, first, timeout, repeat, switchMap } from "rxjs/operators";
 import { getVersion } from "../device/use-cases/getVersionUseCase";
 import { withDevice } from "./deviceAccess";
-import {
-  StatusCodes,
-  DeviceOnboardingStatePollingError,
-  UnexpectedBootloader,
-} from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { DeviceOnboardingStatePollingError, UnexpectedBootloader } from "../errors";
 import { FirmwareInfo } from "@ledgerhq/types-live";
 import { extractOnboardingState, OnboardingState } from "./extractOnboardingState";
 import { DeviceDisconnectedWhileSendingError } from "@ledgerhq/device-management-kit";

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.test.ts
@@ -3,12 +3,8 @@
  */
 import { renderHook, act } from "@testing-library/react";
 import { of, throwError } from "rxjs";
-import {
-  UserRefusedAllowManager,
-  DisconnectedDeviceDuringOperation,
-  UnresponsiveDeviceError,
-  DeviceSocketFail,
-} from "@ledgerhq/errors";
+import { DisconnectedDeviceDuringOperation } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedAllowManager, UnresponsiveDeviceError, DeviceSocketFail } from "../../errors";
 import { useGenuineCheck } from "./useGenuineCheck";
 import {
   getGenuineCheckFromDeviceId,

--- a/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
+++ b/libs/ledger-live-common/src/hw/hooks/useGenuineCheck.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
-import { UnresponsiveDeviceError } from "@ledgerhq/errors";
+import { UnresponsiveDeviceError } from "../../errors";
 import { isCounterfeitError } from "../isCounterfeitError";
 import type { DeviceId } from "@ledgerhq/types-live";
 import { getGenuineCheckFromDeviceId as defaultGetGenuineCheckFromDeviceId } from "../getGenuineCheckFromDeviceId";

--- a/libs/ledger-live-common/src/hw/index.test.ts
+++ b/libs/ledger-live-common/src/hw/index.test.ts
@@ -1,6 +1,6 @@
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
 import { registerTransportModule, open } from ".";
-import { CantOpenDevice, TransportError } from "@ledgerhq/errors";
+import { CantOpenDevice, TransportError } from "@ledgerhq/hw-transport/errors";
 
 jest.useFakeTimers();
 

--- a/libs/ledger-live-common/src/hw/index.ts
+++ b/libs/ledger-live-common/src/hw/index.ts
@@ -4,7 +4,7 @@ import { catchError } from "rxjs/operators";
 import type { DeviceModel } from "@ledgerhq/types-devices";
 import Transport from "@ledgerhq/hw-transport";
 import { TraceContext, trace } from "@ledgerhq/logs";
-import { CantOpenDevice } from "@ledgerhq/errors";
+import { CantOpenDevice } from "@ledgerhq/hw-transport/errors";
 
 export const LOG_TYPE = "hw";
 

--- a/libs/ledger-live-common/src/hw/installApp.test.ts
+++ b/libs/ledger-live-common/src/hw/installApp.test.ts
@@ -4,11 +4,8 @@ import ManagerAPI from "../manager/api";
 import { defer, of, throwError } from "rxjs";
 import { anAppBuilder } from "../mock/fixtures/anApp";
 import { aTransportBuilder } from "@ledgerhq/hw-transport-mocker";
-import {
-  LockedDeviceError,
-  ManagerDeviceLockedError,
-  UnresponsiveDeviceError,
-} from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { ManagerDeviceLockedError, UnresponsiveDeviceError } from "../errors";
 import { quitApp } from "../deviceSDK/commands/quitApp";
 
 // Mocking ManagerAPI

--- a/libs/ledger-live-common/src/hw/installApp.ts
+++ b/libs/ledger-live-common/src/hw/installApp.ts
@@ -1,6 +1,6 @@
 import { Observable, throwError, timer } from "rxjs";
 import { throttleTime, filter, map, catchError, retry, switchMap } from "rxjs/operators";
-import { ManagerAppDepInstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepInstallRequired } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import type { ApplicationVersion, App } from "@ledgerhq/types-live";
 import ManagerAPI from "../manager/api";

--- a/libs/ledger-live-common/src/hw/installLanguage.ts
+++ b/libs/ledger-live-common/src/hw/installLanguage.ts
@@ -1,16 +1,15 @@
+import { StatusCodes, TransportError } from "@ledgerhq/hw-transport/errors";
 import {
   LanguageNotFound,
   ManagerNotEnoughSpaceError,
-  StatusCodes,
-  TransportError,
-} from "@ledgerhq/errors";
+  LanguageInstallRefusedOnDevice,
+} from "../errors";
 import { Observable, from, of, throwError } from "rxjs";
 import { catchError, concatMap, delay, mergeMap } from "rxjs/operators";
 
 import Transport from "@ledgerhq/hw-transport";
 import network from "@ledgerhq/live-network/network";
 import { Language, LanguagePackage } from "@ledgerhq/types-live";
-import { LanguageInstallRefusedOnDevice } from "../errors";
 import ManagerAPI from "../manager/api";
 import attemptToQuitApp, { AttemptToQuitAppEvent } from "./attemptToQuitApp";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
+++ b/libs/ledger-live-common/src/hw/isCounterfeitError.test.ts
@@ -1,5 +1,5 @@
 import { isCounterfeitError } from "./isCounterfeitError";
-import { DeviceSocketFail } from "@ledgerhq/errors";
+import { DeviceSocketFail } from "../errors";
 
 describe("isCounterfeitError", () => {
   it("should return true if the error is a DeviceSocketFail", () => {

--- a/libs/ledger-live-common/src/hw/signMessage/index.ts
+++ b/libs/ledger-live-common/src/hw/signMessage/index.ts
@@ -1,4 +1,4 @@
-import { UserRefusedAddress } from "@ledgerhq/errors";
+import { UserRefusedAddress } from "@ledgerhq/ledger-wallet-framework/errors";
 import { log } from "@ledgerhq/logs";
 import invariant from "invariant";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.test.ts
@@ -1,4 +1,5 @@
-import { StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { command as uninstallAllApps } from "./uninstallAllApps";
 import Transport from "@ledgerhq/hw-transport";
 

--- a/libs/ledger-live-common/src/hw/uninstallAllApps.ts
+++ b/libs/ledger-live-common/src/hw/uninstallAllApps.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, StatusCodes, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from, of } from "rxjs";
 import { withDevice } from "./deviceAccess";

--- a/libs/ledger-live-common/src/hw/uninstallApp.ts
+++ b/libs/ledger-live-common/src/hw/uninstallApp.ts
@@ -1,6 +1,6 @@
 import { ignoreElements, catchError } from "rxjs/operators";
 import { Observable, throwError } from "rxjs";
-import { ManagerAppDepUninstallRequired } from "@ledgerhq/errors";
+import { ManagerAppDepUninstallRequired } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import ManagerAPI from "../manager/api";
 import type { App, ApplicationVersion } from "@ledgerhq/types-live";

--- a/libs/ledger-live-common/src/intents/signMessageIntent/__tests__/job.test.ts
+++ b/libs/ledger-live-common/src/intents/signMessageIntent/__tests__/job.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { TransportStatusError, UserRefusedAddress, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedAddress, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getMainAccount } from "../../../account/index";
 import { signMessageExec } from "../../../hw/signMessage/index";
 import type { Result } from "../../../hw/signMessage/types";

--- a/libs/ledger-live-common/src/intents/signMessageIntent/job.ts
+++ b/libs/ledger-live-common/src/intents/signMessageIntent/job.ts
@@ -1,4 +1,5 @@
-import { TransportStatusError, UserRefusedAddress, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedAddress, UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import type { DeviceConnectionResult, Job } from "@ledgerhq/device-intent";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import { Observable, type Subscription } from "rxjs";

--- a/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
+++ b/libs/ledger-live-common/src/intents/signTransactionIntent/__tests__/job.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { TransportStatusError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getMainAccount } from "../../../account/index";
 import { getAccountBridge } from "../../../bridge/index";
@@ -28,7 +29,7 @@ const parentAccount = { id: "parent-account-1" } as Account;
 const mainAccount = {
   id: "main-account-1",
   currency: getCryptoCurrencyById("ethereum"),
-} as unknown as Account;
+} as Account;
 const transaction = { family: "evm" } as SignTransactionIntentInput["transaction"];
 const signedOperation = { operation: { id: "operation-1" } } as SignedOperation;
 

--- a/libs/ledger-live-common/src/manager/api.ts
+++ b/libs/ledger-live-common/src/manager/api.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { NetworkDown } from "@ledgerhq/live-network/errors";
 import {
   DeviceOnDashboardExpected,
   FirmwareNotRecognized,
@@ -6,9 +7,8 @@ import {
   ManagerDeviceLockedError,
   ManagerFirmwareNotEnoughSpaceError,
   ManagerNotEnoughSpaceError,
-  NetworkDown,
   UserRefusedFirmwareUpdate,
-} from "@ledgerhq/errors";
+} from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 import { makeLRUCache } from "@ledgerhq/live-network/cache";
 import network from "@ledgerhq/live-network/network";

--- a/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
+++ b/libs/ledger-live-common/src/wallet-api/ACRE/server.ts
@@ -31,7 +31,7 @@ import {
   getWalletAPITransactionSignFlowInfos,
 } from "../converters";
 import { getAccountBridge } from "../../bridge";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getEnv } from "@shared/env";
 import BigNumber from "bignumber.js";
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.test.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.test.ts
@@ -1,4 +1,5 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { EthAppPleaseEnableContractData } from "@ledgerhq/live-signer-evm/errors";
 import { mapDmkSignerError } from "./mapDmkSignerError";
 

--- a/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.ts
+++ b/libs/ledger-live-common/src/wallet-api/Exchange/intents/shared/mapDmkSignerError.ts
@@ -1,4 +1,5 @@
-import { LockedDeviceError, UserRefusedOnDevice } from "@ledgerhq/errors";
+import { LockedDeviceError } from "@ledgerhq/hw-transport/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { EthAppPleaseEnableContractData } from "@ledgerhq/live-signer-evm/errors";
 
 function isObjectLike(value: unknown): value is Record<string, unknown> {

--- a/libs/ledger-live-common/src/wallet-api/react.ts
+++ b/libs/ledger-live-common/src/wallet-api/react.ts
@@ -7,7 +7,7 @@ import { WalletHandlers, ServerConfig, WalletAPIServer } from "@ledgerhq/wallet-
 import { Transport, Permission } from "@ledgerhq/wallet-api-core";
 import { first } from "rxjs/operators";
 import { getEnv } from "@shared/env";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { WalletState } from "@ledgerhq/live-wallet/store";
 import { cryptoAssetsApi } from "@domain/api-currency-token";
 import { ThunkDispatch, UnknownAction } from "@reduxjs/toolkit";
@@ -24,6 +24,7 @@ import {
   setWalletApiIdForAccountId,
   resolveWalletApiSpendableBalance,
 } from "./converters";
+import { AccountPublicKeyUnavailable } from "../errors";
 import { isWalletAPISupportedCurrency } from "./helpers";
 import {
   WalletAPICurrency,
@@ -1256,10 +1257,14 @@ export function useWalletAPIServer({
       try {
         return await accountGetPublicKeyLogic({ manifest, accounts, tracking }, accountId);
       } catch (error) {
-        // Surface a native message, then let the RPC reject as before. Match by name so it holds
-        // even if the error loses its prototype (e.g. serialized across a transport).
+        // Surface a native message, then let the RPC reject as before. Match by name (not just
+        // instanceof, per createCustomErrorClass) so it holds even if the error loses its
+        // prototype (e.g. serialized to a plain object across a transport).
         const isPublicKeyUnavailable =
-          (error as { name?: string } | null | undefined)?.name === "AccountPublicKeyUnavailable";
+          error instanceof AccountPublicKeyUnavailable ||
+          (typeof error === "object" &&
+            error !== null &&
+            (error as { name?: unknown }).name === "AccountPublicKeyUnavailable");
         if (isPublicKeyUnavailable && uiAccountPublicKeyUnavailable) {
           try {
             const localAccountId = getAccountIdFromWalletAccountId(accountId);

--- a/libs/ledger-wallet-framework/src/account/support.ts
+++ b/libs/ledger-wallet-framework/src/account/support.ts
@@ -1,4 +1,4 @@
-import { AccountNotSupported } from "@ledgerhq/errors";
+import { AccountNotSupported } from "../errors";
 import { getEnv } from "@ledgerhq/live-env";
 import { getAllDerivationModes, getDerivationModesForCurrency } from "../derivation";
 import type { CryptoCurrency } from "../types";


### PR DESCRIPTION
### 📝 Description

Removes direct imports of @ledgerhq/errors in libs/ledger-live-common, replacing them with native error classes from @ledgerhq/ledger-wallet-framework/errors, @ledgerhq/hw-transport/errors, or local modules.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35182](https://ledgerhq.atlassian.net/browse/LIVE-35182)
- **ADR** (if any): N/A

[LIVE-35182]: https://ledgerhq.atlassian.net/browse/LIVE-35182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ