### PR TITLE
[LWDM] fix(aleo): incorrect asset type in tx intent

### DIFF
--- a/.changeset/clean-cows-type.md
+++ b/.changeset/clean-cows-type.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-aleo": minor
+---
+
+fix(aleo): incorrect asset type in tx intent

--- a/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.test.ts
@@ -1634,6 +1634,22 @@ describe("createTransactionIntent", () => {
     },
   );
 
+  it.each(supportedPublicTransactionModes)(
+    "should keep the native asset for %s even with a stale subAccountId from a previous token selection",
+    mode => {
+      const tokenSubAccount = getMockedTokenAccount();
+      const account = getMockedAccount({ subAccounts: [tokenSubAccount] });
+      const transaction = getMockedTransaction({
+        mode,
+        subAccountId: tokenSubAccount.id,
+      });
+
+      const result = createTransactionIntent({ account, transaction });
+
+      expect(result.asset).toEqual({ type: "native" });
+    },
+  );
+
   it("should include useAllAmount when set to true", () => {
     const transaction = getMockedTransaction({
       mode: TRANSACTION_TYPE.TRANSFER_PUBLIC,
@@ -1746,7 +1762,12 @@ describe("createTransactionIntent", () => {
 
     expect(result).toEqual({
       intentType: "transaction",
-      asset: { type: "native" },
+      asset: {
+        type: tokenSubAccount.token.tokenType,
+        assetReference: tokenSubAccount.token.contractAddress,
+        name: tokenSubAccount.token.name,
+        unit: tokenSubAccount.token.units[0],
+      },
       type: mode,
       amount: BigInt(transaction.amount.toString()),
       recipient: transaction.recipient,
@@ -1805,6 +1826,12 @@ describe("createTransactionIntent", () => {
 
       expect(result).toMatchObject({
         type: mode,
+        asset: {
+          type: tokenAccount.token.tokenType,
+          assetReference: tokenAccount.token.contractAddress,
+          name: tokenAccount.token.name,
+          unit: tokenAccount.token.units[0],
+        },
         data: {
           type: mode,
           programId: tokenAccount.token.contractAddress,

--- a/libs/coin-modules/coin-aleo/src/logic/utils.ts
+++ b/libs/coin-modules/coin-aleo/src/logic/utils.ts
@@ -815,6 +815,7 @@ function resolveDecryptedAmountRecordsFromCommitments({
 function buildTransactionIntentBase(
   account: AleoAccount,
   transaction: Transaction,
+  tokenAccount: AleoTokenAccount | undefined,
 ): Pick<
   AleoTransactionIntent,
   "intentType" | "amount" | "asset" | "recipient" | "sender" | "type" | "useAllAmount"
@@ -822,22 +823,19 @@ function buildTransactionIntentBase(
   return {
     intentType: "transaction",
     amount: BigInt(transaction.amount.toString()),
-    asset: { type: "native" },
+    asset: tokenAccount
+      ? {
+          type: tokenAccount.token.tokenType,
+          assetReference: tokenAccount.token.contractAddress,
+          name: tokenAccount.token.name,
+          unit: tokenAccount.token.units[0],
+        }
+      : { type: "native" },
     recipient: transaction.recipient,
     sender: account.freshAddress,
     type: transaction.mode,
     ...(transaction.useAllAmount && { useAllAmount: true }),
   };
-}
-
-function getRequiredTokenProgramId(
-  account: AleoAccount,
-  subAccountId: string | null | undefined,
-): string {
-  const tokenAccount = getAleoSubAccount(account, subAccountId);
-  invariant(tokenAccount, `aleo: token account is missing (${subAccountId})`);
-
-  return tokenAccount.token.contractAddress;
 }
 
 export function createTransactionIntent({
@@ -847,7 +845,10 @@ export function createTransactionIntent({
   account: AleoAccount;
   transaction: Transaction;
 }): AleoTransactionIntent {
-  const base = buildTransactionIntentBase(account, transaction);
+  const tokenAccount = isTokenTransaction(transaction)
+    ? getAleoSubAccount(account, transaction.subAccountId)
+    : undefined;
+  const base = buildTransactionIntentBase(account, transaction, tokenAccount);
 
   switch (transaction.mode) {
     case TRANSACTION_TYPE.TRANSFER_PUBLIC:
@@ -871,17 +872,18 @@ export function createTransactionIntent({
 
     case TRANSACTION_TYPE.TRANSFER_TOKEN_PUBLIC:
     case TRANSACTION_TYPE.CONVERT_TOKEN_PUBLIC_TO_PRIVATE:
+      invariant(tokenAccount, `aleo: token account is missing (${transaction.subAccountId})`);
+
       return {
         ...base,
         data: {
           type: transaction.mode,
-          programId: getRequiredTokenProgramId(account, transaction.subAccountId),
+          programId: tokenAccount.token.contractAddress,
         },
       };
 
     case TRANSACTION_TYPE.TRANSFER_TOKEN_PRIVATE:
     case TRANSACTION_TYPE.CONVERT_TOKEN_PRIVATE_TO_PUBLIC: {
-      const tokenAccount = getAleoSubAccount(account, transaction.subAccountId);
       invariant(tokenAccount, `aleo: token account is missing (${transaction.subAccountId})`);
 
       return {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Aleo transaction intents always hardcoded `asset: { type: "native" }`, even for token transfers, so the intent's asset never matched the sub-account actually being spent from. `buildTransactionIntentBase` now resolves the real token asset when the transaction targets a token sub-account, with the token account looked up once and threaded through instead of three redundant lookups.

`AleoTransactionIntent.asset` isn't read by any consumer today - mapTransactionIntentToSdkIntent and everything downstream (craftTransaction, signing) only use .type, .recipient, .amount, and .data. So this is a correctness cleanup of dead metadata, not a functional bug fix.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-35174
