### PR TITLE
chore(codeowners): own analytics consent packages (LIVE-29593)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -154,6 +154,8 @@ libs/ledgerjs/packages/types-live/src/lnsUpsell.ts       @ledgerhq/engagement
 libs/ledgerjs/packages/types-live/src/postOnboarding.ts  @ledgerhq/engagement
 domain/entity/large-screen-upsell-modal/                 @ledgerhq/engagement
 features/flow/large-screen-upsell/                       @ledgerhq/engagement
+domain/entity/analytics-consent/                         @ledgerhq/engagement
+features/flow/analytics-consent/                         @ledgerhq/engagement
 
 ### ... market/altcoins sentiment => @ledgerhq/wallet-xp ... ###
 domain/entity/market-sentiment/                          @ledgerhq/wallet-xp


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached. _CODEOWNERS only — no package changeset_
- [ ] **Covered by automatic tests.** _Ownership metadata only_
- [x] **Impact of the changes:**
  - CODEOWNERS routing for new analytics consent packages
  - No runtime or product behavior change

### 📝 Description

New analytics consent packages need clear owners before the domain and mobile work lands.

This PR only adds CODEOWNERS entries for those packages. No app or package code.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29593](https://ledgerhq.atlassian.net/browse/LIVE-29593)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29593]: https://ledgerhq.atlassian.net/browse/LIVE-29593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ