### PR TITLE
feat(analytics-consent): add consent entity package

### DIFF
--- a/.changeset/bright-lions-agree.md
+++ b/.changeset/bright-lions-agree.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-analytics-consent": minor
+---
+
+Add analytics consent entity with policyVersion value object and stored consent schema

--- a/domain/entity/analytics-consent/README.md
+++ b/domain/entity/analytics-consent/README.md
@@ -1,0 +1,30 @@
+# @domain/entity-analytics-consent
+
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the analytics consent renewal feature.
+
+Canonical data model for analytics consent: the privacy policy version value object and the
+stored consent state (`consentDate` + `privacyPolicyVersion`).
+
+Policy versions carry major/minor semantics — a major bump means analytics consent must be
+renewed, a minor bump means the privacy policy only needs an acknowledgement. See
+[ADR: Analytics Consent Renewal](https://ledgerhq.atlassian.net/wiki/spaces/Engagement/pages/7249592355).
+
+## Exports
+
+- `parsePolicyVersion` — `unknown` → `{ major, minor, normalized }` or `null` when invalid
+- `policyVersionSchema` — accepts `1`, `"1"`, `"1.0"`, `"2.10"`; rejects `1.2`, `"01.2"`, `"1.2.3"`, `"v1.2"`
+- `parseStoredPolicyVersion` — same, but tolerates the decimal numbers (`1.4`) that clients released before LIVE-29593 wrote after coercing a `"<major>.<minor>"` flag value. Use it for stored state, `parsePolicyVersion` for remote config
+- `comparePolicyVersions` — major before minor, numeric minor ordering
+- `parseConsentDate` — `unknown` → `Date` or `null`; strict RFC 3339 (via `@shared/schema-primitives`) so a corrupted date cannot pass as a valid consent
+- `analyticsConsentInfoSchema` / `AnalyticsConsentInfo` / `defaultAnalyticsConsentInfo` — stored consent state; `privacyPolicyVersion` accepts legacy numbers and normalized strings so no migration is needed
+- `mockAnalyticsConsentInfo` (via `@domain/entity-analytics-consent/schema.mock`)
+
+The consent decision itself lives in `@features/flow-analytics-consent`.
+
+## Testing
+
+```sh
+pnpm test
+pnpm typecheck
+```

--- a/domain/entity/analytics-consent/jest.config.js
+++ b/domain/entity/analytics-consent/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/analytics-consent/package.json
+++ b/domain/entity/analytics-consent/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@domain/entity-analytics-consent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Domain entity for analytics consent: privacy policy version value object and stored consent state",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema.mock": "./src/schema.mock.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/analytics-consent"
+  },
+  "dependencies": {
+    "@shared/schema-primitives": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/analytics-consent/project.json
+++ b/domain/entity/analytics-consent/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/analytics-consent/src/index.ts
+++ b/domain/entity/analytics-consent/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./schema";

--- a/domain/entity/analytics-consent/src/schema.mock.ts
+++ b/domain/entity/analytics-consent/src/schema.mock.ts
@@ -1,0 +1,7 @@
+import { defaultAnalyticsConsentInfo, type AnalyticsConsentInfo } from "./schema";
+
+export function mockAnalyticsConsentInfo(
+  overrides?: Partial<AnalyticsConsentInfo>,
+): AnalyticsConsentInfo {
+  return { ...defaultAnalyticsConsentInfo, ...overrides };
+}

--- a/domain/entity/analytics-consent/src/schema.test.ts
+++ b/domain/entity/analytics-consent/src/schema.test.ts
@@ -1,0 +1,138 @@
+import {
+  analyticsConsentInfoSchema,
+  comparePolicyVersions,
+  parseConsentDate,
+  parsePolicyVersion,
+  parseStoredPolicyVersion,
+  type PolicyVersion,
+} from "./schema";
+import { mockAnalyticsConsentInfo } from "./schema.mock";
+
+describe("parsePolicyVersion", () => {
+  it.each([
+    { value: 1, expected: { major: 1, minor: 0, normalized: "1.0" } },
+    { value: "1", expected: { major: 1, minor: 0, normalized: "1.0" } },
+    { value: "1.0", expected: { major: 1, minor: 0, normalized: "1.0" } },
+    { value: "1.2", expected: { major: 1, minor: 2, normalized: "1.2" } },
+    { value: "2", expected: { major: 2, minor: 0, normalized: "2.0" } },
+    { value: "2.10", expected: { major: 2, minor: 10, normalized: "2.10" } },
+    { value: 20260531, expected: { major: 20260531, minor: 0, normalized: "20260531.0" } },
+  ])("reads $value as $expected.normalized", ({ value, expected }) => {
+    expect(parsePolicyVersion(value)).toEqual(expected);
+  });
+
+  it.each([
+    { value: 1.2 },
+    { value: 0 },
+    { value: -1 },
+    { value: "01.2" },
+    { value: "1.02" },
+    { value: "1.2.3" },
+    { value: "v1.2" },
+    { value: "0.1" },
+    { value: "1." },
+    { value: ".1" },
+    { value: "" },
+    { value: " 1.2 " },
+    { value: null },
+    { value: undefined },
+    { value: {} },
+    { value: true },
+    { value: Number.NaN },
+    { value: Number.POSITIVE_INFINITY },
+  ])("rejects $value", ({ value }) => {
+    expect(parsePolicyVersion(value)).toBeNull();
+  });
+});
+
+describe("parseStoredPolicyVersion", () => {
+  it.each([
+    { value: 1.4, expected: { major: 1, minor: 4, normalized: "1.4" } },
+    { value: 2.1, expected: { major: 2, minor: 1, normalized: "2.1" } },
+  ])("reads the coerced float $value as $expected.normalized", ({ value, expected }) => {
+    expect(parseStoredPolicyVersion(value)).toEqual(expected);
+  });
+
+  it.each([
+    { value: "1.4", expected: { major: 1, minor: 4, normalized: "1.4" } },
+    { value: 1, expected: { major: 1, minor: 0, normalized: "1.0" } },
+  ])("still reads $value written by a current client", ({ value, expected }) => {
+    expect(parseStoredPolicyVersion(value)).toEqual(expected);
+  });
+
+  it.each([{ value: 0 }, { value: -1.4 }, { value: 1e21 }, { value: Number.NaN }, { value: null }])(
+    "rejects $value",
+    ({ value }) => {
+      expect(parseStoredPolicyVersion(value)).toBeNull();
+    },
+  );
+});
+
+describe("comparePolicyVersions", () => {
+  const version = (value: string): PolicyVersion => {
+    const parsed = parsePolicyVersion(value);
+    if (!parsed) throw new Error(`unparseable test version ${value}`);
+    return parsed;
+  };
+
+  it("orders by major before minor", () => {
+    expect(comparePolicyVersions(version("1.9"), version("2.0"))).toBeLessThan(0);
+    expect(comparePolicyVersions(version("2.0"), version("1.9"))).toBeGreaterThan(0);
+  });
+
+  it("compares minor numerically rather than lexicographically", () => {
+    expect(comparePolicyVersions(version("2.9"), version("2.10"))).toBeLessThan(0);
+  });
+
+  it("treats an implicit minor as zero", () => {
+    expect(comparePolicyVersions(version("2"), version("2.0"))).toBe(0);
+  });
+});
+
+describe("parseConsentDate", () => {
+  it("reads what the app writes", () => {
+    const written = new Date("2026-01-31T12:00:00.123Z").toISOString();
+    expect(parseConsentDate(written)?.toISOString()).toBe(written);
+  });
+
+  it.each([
+    { value: "2026-01-31T12:00:00Z" },
+    { value: "2026-01-31T12:00:00+05:30" },
+    { value: "2026-01-31T12:00:00.123Z" },
+  ])("accepts the RFC 3339 instant $value", ({ value }) => {
+    expect(parseConsentDate(value)).toEqual(new Date(value));
+  });
+
+  it.each([
+    { value: "Jan 15, 2026" },
+    { value: "2026-1-5" },
+    { value: "2026/01/31" },
+    { value: "2026-01-31" },
+    { value: "2026-01-31T12:00:00" },
+    { value: "" },
+    { value: null },
+    { value: undefined },
+    { value: 1_769_860_800_000 },
+  ])("rejects $value", ({ value }) => {
+    expect(parseConsentDate(value)).toBeNull();
+  });
+});
+
+describe("analyticsConsentInfoSchema", () => {
+  it.each([
+    mockAnalyticsConsentInfo(),
+    mockAnalyticsConsentInfo({ consentDate: "2026-01-01T00:00:00.000Z", privacyPolicyVersion: 1 }),
+    mockAnalyticsConsentInfo({
+      consentDate: "2026-01-01T00:00:00.000Z",
+      privacyPolicyVersion: "2.1",
+    }),
+  ])("accepts stored consent %p", info => {
+    expect(analyticsConsentInfoSchema.parse(info)).toEqual(info);
+  });
+
+  it("rejects a consent date that is not a string", () => {
+    expect(() =>
+      analyticsConsentInfoSchema.parse({ consentDate: 0, privacyPolicyVersion: 1 }),
+    ).toThrow();
+  });
+});

--- a/domain/entity/analytics-consent/src/schema.ts
+++ b/domain/entity/analytics-consent/src/schema.ts
@@ -1,8 +1,7 @@
 import { DateTimeIsoSchema } from "@shared/schema-primitives";
 import { z } from "zod";
 
-/** `<major>` or `<major>.<minor>`, no leading zeros, no patch segment. */
-const POLICY_VERSION_STRING = /^[1-9]\d*(\.(0|[1-9]\d*))?$/;
+const POLICY_VERSION_REGEX = /^[1-9]\d*(\.(0|[1-9]\d*))?$/;
 
 export type PolicyVersion = {
   major: number;
@@ -10,54 +9,31 @@ export type PolicyVersion = {
   normalized: string;
 };
 
-function toPolicyVersion(value: number | string): PolicyVersion {
-  const [major, minor = "0"] = String(value).split(".");
-  return { major: Number(major), minor: Number(minor), normalized: `${major}.${minor}` };
-}
-
-/**
- * Accepts `1`, `"1"`, `"1.0"`, `"2.10"`. Rejects decimal numbers such as `1.2`,
- * leading zeros, patch segments and decorated versions.
- */
 export const policyVersionSchema = z
-  .union([z.number().int().positive(), z.string().regex(POLICY_VERSION_STRING)])
-  .transform(toPolicyVersion);
+  .union([z.number().int().positive(), z.string().regex(POLICY_VERSION_REGEX)])
+  .transform(value => {
+    const [major, minor = "0"] = String(value).split(".");
+    return { major: Number(major), minor: Number(minor), normalized: `${major}.${minor}` };
+  });
 
 export function parsePolicyVersion(value: unknown): PolicyVersion | null {
   const result = policyVersionSchema.safeParse(value);
   return result.success ? result.data : null;
 }
 
-/**
- * Reads a version previously written to storage, which clients released before LIVE-29593 wrote
- * through `z.coerce.number()`: a remote `"1.4"` reached them as the float `1.4`. Stored numbers are
- * therefore read via their decimal form so those users are not asked to reconsent after updating.
- * `"2.10"` coerced to `2.1` under-reads the minor and costs one extra acknowledgement, which is the
- * milder failure of the two.
- */
 export function parseStoredPolicyVersion(value: unknown): PolicyVersion | null {
-  if (typeof value === "number") {
-    return parsePolicyVersion(String(value));
-  }
-  return parsePolicyVersion(value);
+  return parsePolicyVersion(typeof value === "number" ? String(value) : value);
 }
 
 export function comparePolicyVersions(a: PolicyVersion, b: PolicyVersion): number {
   return a.major - b.major || a.minor - b.minor;
 }
 
-/**
- * Consent dates are written with `Date.prototype.toISOString`, so anything that is not a valid
- * RFC 3339 instant is corrupted state. Validating rather than relying on `Date.parse` — which
- * accepts implementation-defined formats such as `"Jan 15, 2026"` — keeps a garbage date from
- * passing as a valid consent.
- */
 export function parseConsentDate(value: unknown): Date | null {
   const result = DateTimeIsoSchema.safeParse(value);
   return result.success ? new Date(result.data) : null;
 }
 
-/** Legacy state holds a bare number; acknowledgements since LIVE-29593 hold a normalized string. */
 export const storedPolicyVersionSchema = z.union([z.number(), z.string()]).nullable();
 
 export const analyticsConsentInfoSchema = z.object({

--- a/domain/entity/analytics-consent/src/schema.ts
+++ b/domain/entity/analytics-consent/src/schema.ts
@@ -1,0 +1,73 @@
+import { DateTimeIsoSchema } from "@shared/schema-primitives";
+import { z } from "zod";
+
+/** `<major>` or `<major>.<minor>`, no leading zeros, no patch segment. */
+const POLICY_VERSION_STRING = /^[1-9]\d*(\.(0|[1-9]\d*))?$/;
+
+export type PolicyVersion = {
+  major: number;
+  minor: number;
+  normalized: string;
+};
+
+function toPolicyVersion(value: number | string): PolicyVersion {
+  const [major, minor = "0"] = String(value).split(".");
+  return { major: Number(major), minor: Number(minor), normalized: `${major}.${minor}` };
+}
+
+/**
+ * Accepts `1`, `"1"`, `"1.0"`, `"2.10"`. Rejects decimal numbers such as `1.2`,
+ * leading zeros, patch segments and decorated versions.
+ */
+export const policyVersionSchema = z
+  .union([z.number().int().positive(), z.string().regex(POLICY_VERSION_STRING)])
+  .transform(toPolicyVersion);
+
+export function parsePolicyVersion(value: unknown): PolicyVersion | null {
+  const result = policyVersionSchema.safeParse(value);
+  return result.success ? result.data : null;
+}
+
+/**
+ * Reads a version previously written to storage, which clients released before LIVE-29593 wrote
+ * through `z.coerce.number()`: a remote `"1.4"` reached them as the float `1.4`. Stored numbers are
+ * therefore read via their decimal form so those users are not asked to reconsent after updating.
+ * `"2.10"` coerced to `2.1` under-reads the minor and costs one extra acknowledgement, which is the
+ * milder failure of the two.
+ */
+export function parseStoredPolicyVersion(value: unknown): PolicyVersion | null {
+  if (typeof value === "number") {
+    return parsePolicyVersion(String(value));
+  }
+  return parsePolicyVersion(value);
+}
+
+export function comparePolicyVersions(a: PolicyVersion, b: PolicyVersion): number {
+  return a.major - b.major || a.minor - b.minor;
+}
+
+/**
+ * Consent dates are written with `Date.prototype.toISOString`, so anything that is not a valid
+ * RFC 3339 instant is corrupted state. Validating rather than relying on `Date.parse` — which
+ * accepts implementation-defined formats such as `"Jan 15, 2026"` — keeps a garbage date from
+ * passing as a valid consent.
+ */
+export function parseConsentDate(value: unknown): Date | null {
+  const result = DateTimeIsoSchema.safeParse(value);
+  return result.success ? new Date(result.data) : null;
+}
+
+/** Legacy state holds a bare number; acknowledgements since LIVE-29593 hold a normalized string. */
+export const storedPolicyVersionSchema = z.union([z.number(), z.string()]).nullable();
+
+export const analyticsConsentInfoSchema = z.object({
+  consentDate: z.string().nullable(),
+  privacyPolicyVersion: storedPolicyVersionSchema,
+});
+
+export type AnalyticsConsentInfo = z.infer<typeof analyticsConsentInfoSchema>;
+
+export const defaultAnalyticsConsentInfo: AnalyticsConsentInfo = {
+  consentDate: null,
+  privacyPolicyVersion: null,
+};

--- a/domain/entity/analytics-consent/tsconfig.json
+++ b/domain/entity/analytics-consent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3693,6 +3693,31 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/analytics-consent:
+    dependencies:
+      '@shared/schema-primitives':
+        specifier: workspace:*
+        version: link:../../../shared/schema-primitives
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/client-identity:
     dependencies:
       '@reduxjs/toolkit':


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - New `@domain/entity-analytics-consent` package (policyVersion value object + consent schema)
  - No app wiring yet; consumed by later stack PRs

### 📝 Description

Analytics consent renewal needs a shared model for privacy policy versions and stored consent state.

Adds `@domain/entity-analytics-consent` with Zod schemas, a policyVersion value object (major/minor semantics), unit tests, and package scaffolding. Apps do not depend on it yet.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29593](https://ledgerhq.atlassian.net/browse/LIVE-29593)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29593]: https://ledgerhq.atlassian.net/browse/LIVE-29593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ