### PR TITLE
[LWM] feat(analytics-consent): revamp consent QA debug screen

### DIFF
--- a/.changeset/quiet-moths-debug.md
+++ b/.changeset/quiet-moths-debug.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-analytics-consent": minor
+"live-mobile": minor
+---
+
+Add shared analytics consent QA debug helpers and revamp mobile QA screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/SettingsNavigator.tsx
@@ -245,7 +245,7 @@ export default function SettingsNavigator() {
         name={ScreenName.DebugAnalyticsConsentQA}
         component={DebugAnalyticsConsentQA}
         options={{
-          title: "Analytics opt-in consent — QA",
+          title: "Analytics consent QA",
         }}
       />
       <Stack.Screen

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
@@ -1,253 +1,678 @@
-import React, { useMemo } from "react";
-import { Box, Button, Text } from "@ledgerhq/lumen-ui-rnative";
-import { parseStoredPolicyVersion } from "@domain/entity-analytics-consent";
-import { useFeature } from "@features/platform-feature-flags";
+import React, { useEffect, useState } from "react";
+import { Alert, TouchableOpacity } from "react-native";
 import {
-  needsConsentRenewal,
-  needsPrivacyPolicyAck,
+  Box,
+  Button,
+  Divider,
+  SegmentedControl,
+  SegmentedControlButton,
+  Switch,
+  Tag,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+import { useFeature } from "@features/platform-feature-flags";
+import { setOverride } from "@shared/feature-flags";
+import {
+  parseConsentDate,
+  parseStoredPolicyVersion,
+  type AnalyticsConsentInfo,
+  type PolicyVersion,
+} from "@domain/entity-analytics-consent";
+import {
+  getConsentDateState,
   resolveAnalyticsConsentPhase,
-  resolveAnalyticsOptInParams,
-} from "@ledgerhq/live-common/analyticsConsent/index";
+  useAnalyticsConsentDecision,
+} from "@features/flow-analytics-consent";
+import {
+  mapDecisionToQaExpectation,
+  QA_SCENARIOS,
+  REASON_LABEL,
+  resolveBaselinePolicyVersion,
+  resolveScenarioConsentDate,
+  resolveScenarioVersions,
+  SCENARIO_GROUPS,
+  SYNTHETIC_BASELINE,
+  VERDICT_META,
+  type QaExpectation,
+  type QaScenario,
+} from "@features/flow-analytics-consent/debug";
 import { useDispatch, useSelector } from "~/context/hooks";
 import {
   analyticsConsentInfoSelector,
   analyticsEnabledSelector,
   hasCompletedOnboardingSelector,
+  hasSeenAnalyticsOptInPromptSelector,
   personalizedRecommendationsEnabledSelector,
+  trackingEnabledSelector,
 } from "~/reducers/settings";
 import {
   setAnalytics,
   setAnalyticsConsentInfo,
+  setHasSeenAnalyticsOptInPrompt,
   setPersonalizedRecommendations,
 } from "~/actions/settings";
-import SettingsNavigationScrollView from "../../SettingsNavigationScrollView";
+import { AnalyticsConsentDrawer } from "LLM/features/AnalyticsConsentDrawer";
+import NavigationScrollView from "~/components/NavigationScrollView";
 import { TrackScreen } from "~/analytics";
-import { useTranslation } from "~/context/Locale";
 
-function valueLxColor(ok: boolean): "success" | "error" {
-  return ok ? "success" : "error";
+const FLAG_KEY = "analyticsOptIn";
+
+type TabId = "scenarios" | "inspect";
+
+type FieldTone = "success" | "error" | "warning" | "gray";
+
+type InspectorField = {
+  label: string;
+  /** Large primary value the tester should read first. */
+  value: string;
+  /** Small secondary line, typically the raw stored form. */
+  raw?: string;
+  /** Tag shown next to the label: Valid, Invalid, Missing, On, Off… */
+  status: { label: string; tone: FieldTone };
+};
+
+type ToggleField = {
+  label: string;
+  value: boolean;
+  note?: string;
+  onChange: (v: boolean) => void;
+};
+
+type StoredConsentInfo = Readonly<AnalyticsConsentInfo>;
+
+type BlockedReason = keyof typeof BLOCKED_META;
+
+const BLOCKED_META: Record<string, { hint: string; previewHint: string }> = {
+  "analyticsOptIn flag is off": {
+    hint: "Feature flag off. Turn on Feature flag enabled in Inspect.",
+    previewHint: "Enable feature flag in Inspect first.",
+  },
+  "onboarding incomplete": {
+    hint: "Onboarding incomplete. Finish onboarding first.",
+    previewHint: "Finish onboarding first.",
+  },
+};
+
+function confirm(title: string, message: string, confirmLabel: string, onConfirm: () => void) {
+  Alert.alert(title, message, [
+    { text: "Cancel", style: "cancel" },
+    { text: confirmLabel, onPress: onConfirm },
+  ]);
 }
 
-/** Map stored string|number|null into the legacy numeric helper used by this debug screen. */
-function toLegacyStoredVersion(value: string | number | null): number | null {
-  const parsed = parseStoredPolicyVersion(value);
-  if (parsed == null) return null;
-  return Number(parsed.normalized);
+function scenarioConfirmMessage(scenario: QaScenario): string {
+  return `Applies this preset.\n\n${scenario.summary}\n\nExpected: ${VERDICT_META[scenario.expected].title}.`;
+}
+
+function formatConsentDate(iso: string | null): string | null {
+  const date = parseConsentDate(iso);
+  if (date === null) return null;
+  return date.toLocaleString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatBareValue(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  return JSON.stringify(value);
+}
+
+function buildInspectorFields(
+  consentInfo: StoredConsentInfo,
+  storedVersion: PolicyVersion | null,
+  formattedConsentDate: string | null,
+  consentDateState: ReturnType<typeof getConsentDateState>,
+  currentPolicyVersion: PolicyVersion | null,
+  rawPolicyVersion: unknown,
+): Readonly<{ storedFields: InspectorField[]; policyVersionField: InspectorField }> {
+  let storedPolicyValue: string;
+  if (storedVersion) {
+    storedPolicyValue = `Version ${storedVersion.major}.${storedVersion.minor}`;
+  } else if (consentInfo.privacyPolicyVersion === null) {
+    storedPolicyValue = "Missing";
+  } else {
+    storedPolicyValue = "Invalid";
+  }
+
+  let storedPolicyStatus: InspectorField["status"];
+  if (consentInfo.privacyPolicyVersion === null) {
+    storedPolicyStatus = { label: "Missing", tone: "error" };
+  } else if (storedVersion) {
+    storedPolicyStatus = { label: "Valid", tone: "success" };
+  } else {
+    storedPolicyStatus = { label: "Invalid", tone: "error" };
+  }
+
+  let consentDateValue: string;
+  if (formattedConsentDate) {
+    consentDateValue = formattedConsentDate;
+  } else if (consentDateState === "missing") {
+    consentDateValue = "Missing";
+  } else {
+    consentDateValue = "Invalid";
+  }
+
+  let consentDateStatus: InspectorField["status"];
+  if (consentDateState === "valid") {
+    consentDateStatus = { label: "Valid", tone: "success" };
+  } else if (consentDateState === "missing") {
+    consentDateStatus = { label: "Missing", tone: "error" };
+  } else {
+    consentDateStatus = { label: "Invalid", tone: "error" };
+  }
+
+  return {
+    storedFields: [
+      {
+        label: "Saved policy version",
+        value: storedPolicyValue,
+        raw: `privacyPolicyVersion: ${formatBareValue(consentInfo.privacyPolicyVersion)}`,
+        status: storedPolicyStatus,
+      },
+      {
+        label: "Consent date",
+        value: consentDateValue,
+        raw: consentInfo.consentDate
+          ? `consentDate: ${formatBareValue(consentInfo.consentDate)}`
+          : "consentDate: null",
+        status: consentDateStatus,
+      },
+    ],
+    policyVersionField: {
+      label: "Remote policy version",
+      value: currentPolicyVersion
+        ? `Version ${currentPolicyVersion.major}.${currentPolicyVersion.minor}`
+        : "Invalid — checks off",
+      raw: `policyVersion: ${formatBareValue(rawPolicyVersion)}`,
+      status: currentPolicyVersion
+        ? { label: "Valid", tone: "success" }
+        : { label: "Invalid", tone: "error" },
+    },
+  };
+}
+
+function InspectorRow({ field }: Readonly<{ field: InspectorField }>) {
+  return (
+    <Box
+      lx={{
+        paddingHorizontal: "s8",
+        paddingVertical: "s12",
+        borderRadius: "sm",
+        marginBottom: "s8",
+        gap: "s8",
+        borderWidth: "s1",
+        borderColor: "muted",
+      }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "s8",
+        }}
+      >
+        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
+          {field.label}
+        </Text>
+        <Tag label={field.status.label} size="sm" appearance={field.status.tone} />
+      </Box>
+      <Text typography="body2SemiBold" lx={{ color: "base" }} selectable>
+        {field.value}
+      </Text>
+      {field.raw ? (
+        <Text typography="body3" lx={{ color: "muted" }} selectable>
+          {field.raw}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function ToggleRow({ field }: Readonly<{ field: ToggleField }>) {
+  return (
+    <Box
+      lx={{
+        paddingHorizontal: "s8",
+        paddingVertical: "s12",
+        borderRadius: "sm",
+        marginBottom: "s8",
+        gap: "s8",
+        borderWidth: "s1",
+        borderColor: "muted",
+      }}
+    >
+      <Box
+        lx={{
+          flexDirection: "row",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "s8",
+        }}
+      >
+        <Text typography="body2SemiBold" lx={{ color: "base", flex: 1 }}>
+          {field.label}
+        </Text>
+        <Tag
+          label={field.value ? "On" : "Off"}
+          size="sm"
+          appearance={field.value ? "success" : "gray"}
+        />
+      </Box>
+      <Box lx={{ flexDirection: "row", justifyContent: "flex-end" }}>
+        <Switch checked={field.value} onCheckedChange={field.onChange} />
+      </Box>
+      {field.note ? (
+        <Text typography="body3" lx={{ color: "warning" }}>
+          {field.note}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function GroupLabel({
+  expectation,
+  first,
+}: Readonly<{ expectation: QaExpectation; first?: boolean }>) {
+  const meta = VERDICT_META[expectation];
+  return (
+    <Box
+      lx={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: "s8",
+        marginTop: first ? undefined : "s16",
+        marginBottom: "s8",
+      }}
+    >
+      <Tag label={meta.title} size="sm" appearance={meta.tone} />
+      <Text typography="body3" lx={{ color: "muted", flex: 1 }}>
+        {meta.hint}
+      </Text>
+    </Box>
+  );
+}
+
+function QaTabSection({
+  tab,
+  onTabChange,
+  isAlreadyReset,
+  onResetAll,
+  onApplyScenario,
+  storedFields,
+  policyVersionField,
+  toggleFields,
+  featureEnabled,
+  onFlagEnabledChange,
+}: Readonly<{
+  tab: TabId;
+  onTabChange: (tab: TabId) => void;
+  isAlreadyReset: boolean;
+  onResetAll: () => void;
+  onApplyScenario: (scenario: QaScenario) => void;
+  storedFields: InspectorField[];
+  policyVersionField: InspectorField;
+  toggleFields: ToggleField[];
+  featureEnabled: boolean;
+  onFlagEnabledChange: (enabled: boolean) => void;
+}>) {
+  return (
+    <Box lx={{ gap: "s8" }}>
+      <Box lx={{ flexDirection: "row", alignItems: "center", gap: "s8" }}>
+        <Box lx={{ flex: 1 }}>
+          <SegmentedControl
+            selectedValue={tab}
+            onSelectedChange={onTabChange}
+            tabLayout="fit"
+            accessibilityLabel="Analytics consent QA sections"
+          >
+            <SegmentedControlButton value="scenarios">Scenarios</SegmentedControlButton>
+            <SegmentedControlButton value="inspect">Inspect</SegmentedControlButton>
+          </SegmentedControl>
+        </Box>
+        <Button
+          appearance="no-background"
+          size="sm"
+          disabled={isAlreadyReset}
+          onPress={() =>
+            confirm(
+              "Reset all",
+              "Clears saved consent and analytics preferences, and removes the local test override.",
+              "Reset",
+              onResetAll,
+            )
+          }
+        >
+          Reset all
+        </Button>
+      </Box>
+
+      {tab === "scenarios" ? (
+        <Box>
+          {SCENARIO_GROUPS.map((expected: QaExpectation, index: number) => {
+            const meta = VERDICT_META[expected];
+            return (
+              <Box key={expected}>
+                <GroupLabel expectation={expected} first={index === 0} />
+                <Box lx={{ flexDirection: "row", flexWrap: "wrap", gap: "s8" }}>
+                  {QA_SCENARIOS.filter(
+                    (scenario: QaScenario) => scenario.expected === expected,
+                  ).map((scenario: QaScenario) => (
+                    <TouchableOpacity
+                      key={scenario.id}
+                      activeOpacity={0.7}
+                      style={{ flexBasis: "47%", flexGrow: 1 }}
+                      onPress={() =>
+                        confirm(scenario.name, scenarioConfirmMessage(scenario), "Apply", () =>
+                          onApplyScenario(scenario),
+                        )
+                      }
+                    >
+                      <Box
+                        lx={{
+                          gap: "s8",
+                          padding: "s12",
+                          borderRadius: "sm",
+                          borderWidth: "s1",
+                          borderColor: "muted",
+                          backgroundColor: "baseTransparent",
+                        }}
+                      >
+                        <Tag label={meta.title} size="sm" appearance={meta.tone} />
+                        <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                          {scenario.name}
+                        </Text>
+                        <Text typography="body3" lx={{ color: "muted" }}>
+                          {scenario.summary}
+                        </Text>
+                      </Box>
+                    </TouchableOpacity>
+                  ))}
+                </Box>
+              </Box>
+            );
+          })}
+        </Box>
+      ) : (
+        <Box>
+          <Text typography="body3SemiBold" lx={{ color: "muted", marginBottom: "s4" }}>
+            Stored on this device
+          </Text>
+          {storedFields.map(field => (
+            <InspectorRow key={field.label} field={field} />
+          ))}
+          <Text
+            typography="body3SemiBold"
+            lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+          >
+            From remote config
+          </Text>
+          <ToggleRow
+            field={{
+              label: "Feature flag enabled",
+              value: featureEnabled,
+              onChange: onFlagEnabledChange,
+            }}
+          />
+          <InspectorRow field={policyVersionField} />
+          <Text
+            typography="body3SemiBold"
+            lx={{ color: "muted", marginTop: "s16", marginBottom: "s4" }}
+          >
+            User preferences
+          </Text>
+          {toggleFields.map(field => (
+            <ToggleRow key={field.label} field={field} />
+          ))}
+        </Box>
+      )}
+    </Box>
+  );
 }
 
 export default function DebugAnalyticsConsentQA() {
-  const { t } = useTranslation();
   const dispatch = useDispatch();
-  const feature = useFeature("analyticsOptIn");
-  const { policyVersion, consentValidityDays } = resolveAnalyticsOptInParams(feature);
+  const feature = useFeature(FLAG_KEY);
+  const rawPolicyVersion = feature?.params?.policyVersion;
+
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const analyticsEnabled = useSelector(analyticsEnabledSelector);
   const personalizedEnabled = useSelector(personalizedRecommendationsEnabledSelector);
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const hasSeenPrompt = useSelector(hasSeenAnalyticsOptInPromptSelector);
+  const trackingEnabled = useSelector(trackingEnabledSelector);
+  const hasAnalyticsOptInOverride = useSelector(
+    state => state.featureFlags.overrides[FLAG_KEY] !== undefined,
+  );
 
-  const storedLegacyVersion = toLegacyStoredVersion(consentInfo.privacyPolicyVersion);
-  const storedVersionOk = !needsPrivacyPolicyAck(storedLegacyVersion, policyVersion);
-  const consentDateOk = !needsConsentRenewal(consentInfo.consentDate, consentValidityDays);
+  const { decision, currentPolicyVersion } = useAnalyticsConsentDecision(consentInfo);
+  const storedVersion = parseStoredPolicyVersion(consentInfo.privacyPolicyVersion);
+  const consentDateState = getConsentDateState(consentInfo.consentDate);
 
-  const expectation = useMemo(() => {
-    const analyticsOptInFeatureEnabled = Boolean(feature?.enabled);
-    if (!analyticsOptInFeatureEnabled) {
-      return { shouldOffer: false as const, phase: null, reason: "featureOff" as const };
-    }
-    if (!hasCompletedOnboarding) {
-      return { shouldOffer: false as const, phase: null, reason: "onboardingIncomplete" as const };
-    }
-    const needsUpdatePrivacy = needsPrivacyPolicyAck(storedLegacyVersion, policyVersion);
-    const needsRenewal = needsConsentRenewal(consentInfo.consentDate, consentValidityDays);
-    if (!needsUpdatePrivacy && !needsRenewal) {
-      return { shouldOffer: false as const, phase: null, reason: "nothingToRenew" as const };
-    }
-    const phase = resolveAnalyticsConsentPhase(
-      "closed",
-      needsRenewal,
-      needsUpdatePrivacy,
-      analyticsEnabled,
-    );
-    if (phase === "closed") {
-      return { shouldOffer: false as const, phase: null, reason: "nothingToRenew" as const };
-    }
-    return { shouldOffer: true as const, phase };
-  }, [
-    analyticsEnabled,
-    feature?.enabled,
-    hasCompletedOnboarding,
-    consentInfo.consentDate,
-    storedLegacyVersion,
-    policyVersion,
-    consentValidityDays,
-  ]);
+  const [tab, setTab] = useState<TabId>("scenarios");
+  // Remote policyVersion without a local override — refreshed on mount and after Reset all.
+  const [baselinePolicyVersion, setBaselinePolicyVersion] =
+    useState<PolicyVersion>(SYNTHETIC_BASELINE);
+  // Remounting the drawer is what re-opens it, since it closes itself by setting its own phase.
+  const [previewKey, setPreviewKey] = useState(0);
+  // Kept mounted only until the next state change: a mounted drawer re-opens itself on every
+  // decision change, which would pop it over the screen each time a scenario is applied.
+  const [isPreviewMounted, setPreviewMounted] = useState(false);
 
-  const expectedModalLines = useMemo(() => {
-    if (!expectation.shouldOffer) {
-      const lines: string[] = ["No modal on portfolio (home) in this state."];
-      if (expectation.reason === "featureOff") {
-        lines.push("Reason: analytics opt-in feature flag is off.");
-      } else if (expectation.reason === "onboardingIncomplete") {
-        lines.push("Reason: onboarding is not complete.");
-      } else {
-        lines.push("Reason: policy version and consent date do not require a prompt.");
-      }
-      return lines;
+  useEffect(() => {
+    if (!hasAnalyticsOptInOverride) {
+      setBaselinePolicyVersion(resolveBaselinePolicyVersion(feature?.params?.policyVersion));
     }
-    const titles: Record<typeof expectation.phase, string> = {
-      consentFresh: "First-time consent sheet (AnalyticsConsentDrawer — consent fresh).",
-      consentReconfirm: "Reconfirm consent sheet (AnalyticsConsentDrawer — reconfirm).",
-      privacy: "Privacy update sheet (AnalyticsConsentDrawer — policy update).",
-    };
-    return [titles[expectation.phase]];
-  }, [expectation]);
+  }, [hasAnalyticsOptInOverride, feature?.params?.policyVersion]);
 
-  const onOutdateVersion = () => {
-    const outdated = Math.max(0, policyVersion - 1);
+  let blockedReason: BlockedReason | null = null;
+  if (!feature?.enabled) blockedReason = "analyticsOptIn flag is off";
+  else if (!hasCompletedOnboarding) blockedReason = "onboarding incomplete";
+
+  const phase = resolveAnalyticsConsentPhase("closed", decision, analyticsEnabled);
+  const isEligibleForDrawer = blockedReason === null && phase !== "closed";
+  const verdict = mapDecisionToQaExpectation(decision, analyticsEnabled, blockedReason);
+  const verdictMeta = VERDICT_META[verdict];
+  const verdictReason = blockedReason ?? decision.reason;
+
+  const blocked = blockedReason !== null ? BLOCKED_META[blockedReason] : null;
+  const headline = blocked ? "Blocked — no drawer" : verdictMeta.title;
+  const headlineHint = blocked ? blocked.hint : verdictMeta.hint;
+  const previewHint = blocked ? blocked.previewHint : verdictMeta.previewHint;
+
+  const isAlreadyReset =
+    !hasAnalyticsOptInOverride &&
+    consentInfo.consentDate === null &&
+    consentInfo.privacyPolicyVersion === null &&
+    !analyticsEnabled &&
+    !personalizedEnabled &&
+    !hasSeenPrompt;
+
+  const overrideConfigVersion = (policyVersion: number | string | undefined) => {
+    setPreviewMounted(false);
     dispatch(
-      setAnalyticsConsentInfo({
-        consentDate: consentInfo.consentDate,
-        privacyPolicyVersion: outdated,
+      setOverride({
+        key: FLAG_KEY,
+        value:
+          policyVersion === undefined
+            ? undefined
+            : {
+                ...feature,
+                enabled: feature?.enabled ?? true,
+                params: { ...feature?.params, policyVersion },
+              },
       }),
     );
   };
 
-  const onRemoveDate = () => {
+  const overrideFlagEnabled = (enabled: boolean) => {
+    setPreviewMounted(false);
     dispatch(
-      setAnalyticsConsentInfo({
-        consentDate: null,
-        privacyPolicyVersion: consentInfo.privacyPolicyVersion,
+      setOverride({
+        key: FLAG_KEY,
+        value: {
+          ...feature,
+          enabled,
+          params: feature?.params ?? {},
+        },
       }),
     );
   };
 
-  const commitConsentDate = (date: Date) => {
+  const applyScenario = (scenario: QaScenario) => {
+    const { policyVersion, storedVersion } = resolveScenarioVersions(
+      scenario,
+      baselinePolicyVersion,
+    );
+    overrideConfigVersion(policyVersion);
     dispatch(
       setAnalyticsConsentInfo({
-        consentDate: date.toISOString(),
-        privacyPolicyVersion: consentInfo.privacyPolicyVersion,
+        consentDate: resolveScenarioConsentDate(scenario.consentDate, new Date()),
+        // `undefined` from resolveScenarioVersions means leave the saved version as-is.
+        privacyPolicyVersion:
+          storedVersion === undefined ? consentInfo.privacyPolicyVersion : storedVersion,
       }),
     );
+    dispatch(setAnalytics(scenario.analyticsEnabled));
+    dispatch(setPersonalizedRecommendations(scenario.analyticsEnabled));
+    dispatch(setHasSeenAnalyticsOptInPrompt(scenario.hasSeenPrompt));
+    setPreviewMounted(false);
   };
 
-  const onSetConsentOneYearAgo = () => {
-    const d = new Date();
-    d.setUTCFullYear(d.getUTCFullYear() - 1);
-    commitConsentDate(d);
-  };
-
-  const onResetConsentFresh = () => {
-    dispatch(
-      setAnalyticsConsentInfo({
-        consentDate: null,
-        privacyPolicyVersion: null,
-      }),
-    );
+  const onResetAll = () => {
+    overrideConfigVersion(undefined);
+    dispatch(setAnalyticsConsentInfo({ consentDate: null, privacyPolicyVersion: null }));
     dispatch(setAnalytics(false));
     dispatch(setPersonalizedRecommendations(false));
+    dispatch(setHasSeenAnalyticsOptInPrompt(false));
+    setPreviewMounted(false);
   };
 
-  const expectedModalLxColor = expectation.shouldOffer ? "error" : "success";
+  const onPreviewDrawer = () => {
+    setPreviewKey(key => key + 1);
+    setPreviewMounted(true);
+  };
+
+  const formattedConsentDate = formatConsentDate(consentInfo.consentDate);
+  const { storedFields, policyVersionField } = buildInspectorFields(
+    consentInfo,
+    storedVersion,
+    formattedConsentDate,
+    consentDateState,
+    currentPolicyVersion,
+    rawPolicyVersion,
+  );
+
+  const toggleFields: ToggleField[] = [
+    {
+      label: "Analytics enabled",
+      value: analyticsEnabled,
+      onChange: value => {
+        setPreviewMounted(false);
+        dispatch(setAnalytics(value));
+      },
+    },
+    {
+      label: "Personalized recommendations",
+      value: personalizedEnabled,
+      onChange: value => {
+        setPreviewMounted(false);
+        dispatch(setPersonalizedRecommendations(value));
+      },
+    },
+    {
+      label: "Has seen consent prompt",
+      value: hasSeenPrompt,
+      note: hasSeenPrompt ? undefined : "Never answered consent prompt",
+      onChange: value => {
+        setPreviewMounted(false);
+        dispatch(setHasSeenAnalyticsOptInPrompt(value));
+      },
+    },
+  ];
 
   return (
-    <SettingsNavigationScrollView>
+    <Box lx={{ flex: 1 }}>
       <TrackScreen category="Settings" name="DebugAnalyticsConsentQA" />
-      <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s16" }}>
-        <Text
-          typography="body2SemiBold"
-          lx={{ color: "muted", marginBottom: "s12" }}
-          style={{ textTransform: "uppercase" }}
-        >
-          Analytics opt-in consent — QA
-        </Text>
+      {isPreviewMounted ? <AnalyticsConsentDrawer key={previewKey} /> : null}
+      <NavigationScrollView
+        key={tab}
+        contentContainerStyle={{ paddingBottom: 64 }}
+        style={{ flex: 1 }}
+      >
+        <Box lx={{ paddingHorizontal: "s24", paddingBottom: "s24", paddingTop: "s16", gap: "s16" }}>
+          <Box lx={{ backgroundColor: "muted", borderRadius: "md", padding: "s16", gap: "s12" }}>
+            <Box lx={{ gap: "s4" }}>
+              <Text
+                typography="heading3SemiBold"
+                lx={{ color: blockedReason !== null ? "warning" : verdictMeta.tone }}
+              >
+                {headline}
+              </Text>
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {headlineHint}
+              </Text>
+            </Box>
 
-        <Text typography="heading5SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
-          Current settings
-        </Text>
+            <Box lx={{ gap: "s8" }}>
+              <Box lx={{ gap: "s2" }}>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  Reason
+                </Text>
+                <Text typography="body2SemiBold" lx={{ color: "base" }}>
+                  {REASON_LABEL[verdictReason] ?? verdictReason}
+                </Text>
+              </Box>
+              <Box lx={{ gap: "s2" }}>
+                <Text typography="body3" lx={{ color: "muted" }}>
+                  Analytics tracking
+                </Text>
+                <Text
+                  typography="body2SemiBold"
+                  lx={{ color: trackingEnabled ? "success" : "error" }}
+                >
+                  {trackingEnabled ? "On" : "Off"}
+                  {!trackingEnabled && verdict === "Re-ask" ? " · paused until answered" : ""}
+                </Text>
+              </Box>
+            </Box>
 
-        <Text typography="body2" lx={{ color: "base", marginBottom: "s8" }}>
-          {t("settings.display.analytics")}: {analyticsEnabled ? "On" : "Off"}
-        </Text>
-        <Text typography="body2" lx={{ color: "base", marginBottom: "s16" }}>
-          {t("settings.display.personalizedRecommendations")}: {personalizedEnabled ? "On" : "Off"}
-        </Text>
+            <Divider />
 
-        <Text typography="body3" lx={{ color: "muted", marginBottom: "s4" }}>
-          App privacy policy version (config)
-        </Text>
-        <Text typography="body2SemiBold" lx={{ color: "base", marginBottom: "s16" }}>
-          {String(policyVersion)}
-        </Text>
-
-        <Box
-          lx={{
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: "s8",
-          }}
-        >
-          <Box lx={{ flex: 1, marginRight: "s12" }}>
-            <Text typography="body3" lx={{ color: "muted" }}>
-              Stored privacy policy version
-            </Text>
-            <Text typography="body2SemiBold" lx={{ color: valueLxColor(storedVersionOk) }}>
-              {consentInfo.privacyPolicyVersion === null
-                ? "null"
-                : String(consentInfo.privacyPolicyVersion)}
-            </Text>
+            <Box lx={{ gap: "s8" }}>
+              <Button
+                appearance="accent"
+                size="sm"
+                disabled={!isEligibleForDrawer}
+                onPress={onPreviewDrawer}
+              >
+                Preview drawer
+              </Button>
+              <Text typography="body3" lx={{ color: "muted" }}>
+                {previewHint}
+              </Text>
+            </Box>
           </Box>
-          <Button appearance="accent" size="sm" onPress={onOutdateVersion}>
-            Outdate version
-          </Button>
+
+          <QaTabSection
+            tab={tab}
+            onTabChange={setTab}
+            isAlreadyReset={isAlreadyReset}
+            onResetAll={onResetAll}
+            onApplyScenario={applyScenario}
+            storedFields={storedFields}
+            policyVersionField={policyVersionField}
+            toggleFields={toggleFields}
+            featureEnabled={Boolean(feature?.enabled)}
+            onFlagEnabledChange={overrideFlagEnabled}
+          />
         </Box>
-
-        <Box lx={{ marginBottom: "s16" }}>
-          <Text typography="body3" lx={{ color: "muted", marginBottom: "s4" }}>
-            Consent date (raw)
-          </Text>
-          <Text typography="body2SemiBold" lx={{ color: valueLxColor(consentDateOk) }} selectable>
-            {consentInfo.consentDate === null ? "null" : consentInfo.consentDate}
-          </Text>
-          <Box
-            lx={{
-              display: "flex",
-              flexDirection: "row",
-              width: "full",
-              gap: "s8",
-              marginTop: "s12",
-            }}
-          >
-            <Button appearance="accent" size="sm" onPress={onSetConsentOneYearAgo}>
-              Set to one year ago
-            </Button>
-            <Button appearance="accent" size="sm" onPress={onRemoveDate}>
-              Remove date
-            </Button>
-          </Box>
-        </Box>
-
-        <Text typography="heading5SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
-          Expected modal on portfolio (home)
-        </Text>
-        {expectedModalLines.map(line => (
-          <Text
-            key={line}
-            typography="body2"
-            lx={{ color: expectedModalLxColor, marginBottom: "s4" }}
-          >
-            {line}
-          </Text>
-        ))}
-        <Text typography="body3" lx={{ color: "muted", marginBottom: "s16", marginTop: "s8" }}>
-          Open portfolio (home) while this screen is closed — the drawer uses the same rules as in
-          production.
-        </Text>
-
-        <Button appearance="red" onPress={onResetConsentFresh} isFull lx={{ marginBottom: "s24" }}>
-          Reset for consent fresh
-        </Button>
-      </Box>
-    </SettingsNavigationScrollView>
+      </NavigationScrollView>
+    </Box>
   );
 }

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/index.tsx
@@ -92,8 +92,8 @@ export default function DebugSettings({
         onPress={() => navigate(ScreenName.DebugDevTools)}
       />
       <SettingsRow
-        title="Analytics opt-in consent — QA"
-        desc="Inspect consent state and simulate portfolio drawer scenarios"
+        title="Analytics consent QA"
+        desc="Policy bumps, consent state, drawer preview"
         iconLeft={<IconsLegacy.ChartNetworkMedium size={24} color="black" />}
         onPress={() => navigate(ScreenName.DebugAnalyticsConsentQA)}
       />

--- a/features/flow/analytics-consent/package.json
+++ b/features/flow/analytics-consent/package.json
@@ -7,6 +7,7 @@
   "types": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./debug": "./src/debug/index.ts",
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/features/flow/analytics-consent/src/debug/index.ts
+++ b/features/flow/analytics-consent/src/debug/index.ts
@@ -1,0 +1,21 @@
+export {
+  INVALID_CONSENT_DATE,
+  INVALID_POLICY_VERSION,
+  QA_SCENARIOS,
+  resolveBaselinePolicyVersion,
+  resolveScenarioConsentDate,
+  resolveScenarioVersions,
+  SYNTHETIC_BASELINE,
+  type QaExpectation,
+  type QaScenario,
+  type RemotePolicyRef,
+  type StoredPolicyRef,
+} from "./scenarios";
+export {
+  mapDecisionToQaExpectation,
+  REASON_LABEL,
+  SCENARIO_GROUPS,
+  VERDICT_META,
+  type VerdictMeta,
+  type VerdictTone,
+} from "./verdict";

--- a/features/flow/analytics-consent/src/debug/scenarios.test.ts
+++ b/features/flow/analytics-consent/src/debug/scenarios.test.ts
@@ -1,0 +1,251 @@
+import {
+  INVALID_CONSENT_DATE,
+  INVALID_POLICY_VERSION,
+  QA_SCENARIOS,
+  resolveScenarioConsentDate,
+  resolveScenarioVersions,
+  SYNTHETIC_BASELINE,
+  type QaExpectation,
+  type QaScenario,
+  type RemotePolicyRef,
+  type StoredPolicyRef,
+} from "./scenarios";
+
+const CUSTOM_BASELINE = { major: 2, minor: 3, normalized: "2.3" } as const;
+
+describe("QA_SCENARIOS", () => {
+  const catalogInvariants: Array<{
+    id: string;
+    name: string;
+    expected: QaExpectation;
+    remotePolicy: RemotePolicyRef;
+    storedPolicy: StoredPolicyRef;
+    consentDateKind: QaScenario["consentDate"]["kind"];
+    analyticsEnabled: boolean;
+    hasSeenPrompt: boolean;
+  }> = [
+    {
+      id: "up-to-date",
+      name: "Up to date",
+      expected: "Quiet",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "minor-bump",
+      name: "Minor update",
+      expected: "Ack only",
+      remotePolicy: "nextMinor",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "major-bump",
+      name: "Major update",
+      expected: "Re-ask",
+      remotePolicy: "nextMajor",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "first-time",
+      name: "No consent",
+      expected: "Re-ask",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "keep",
+      consentDateKind: "null",
+      analyticsEnabled: false,
+      hasSeenPrompt: false,
+    },
+    {
+      id: "old-date",
+      name: "Old consent",
+      expected: "Quiet",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "date-corrupt",
+      name: "Bad date",
+      expected: "Re-ask",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "invalid",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "stored-corrupt",
+      name: "Bad version",
+      expected: "Re-ask",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "corrupt",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "config-invalid",
+      name: "Bad config",
+      expected: "Quiet",
+      remotePolicy: "invalid",
+      storedPolicy: "matchBaseline",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "stored-ahead",
+      name: "Device ahead",
+      expected: "Quiet",
+      remotePolicy: "matchBaseline",
+      storedPolicy: "nextMajor",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+    {
+      id: "legacy-float",
+      name: "Legacy format",
+      expected: "Quiet",
+      remotePolicy: "nextMinor",
+      storedPolicy: "legacyFloat",
+      consentDateKind: "daysAgo",
+      analyticsEnabled: true,
+      hasSeenPrompt: true,
+    },
+  ];
+
+  it("contains every catalog scenario with stable ids and verdicts", () => {
+    expect(QA_SCENARIOS).toHaveLength(catalogInvariants.length);
+    expect(new Set(QA_SCENARIOS.map(scenario => scenario.id)).size).toBe(catalogInvariants.length);
+  });
+
+  it.each(catalogInvariants)(
+    "scenario $id exposes the expected QA shape",
+    ({
+      id,
+      name,
+      expected,
+      remotePolicy,
+      storedPolicy,
+      consentDateKind,
+      analyticsEnabled,
+      hasSeenPrompt,
+    }) => {
+      const scenario = QA_SCENARIOS.find(entry => entry.id === id);
+
+      expect(scenario).toMatchObject({
+        id,
+        name,
+        expected,
+        remotePolicy,
+        storedPolicy,
+        analyticsEnabled,
+        hasSeenPrompt,
+      });
+      expect(scenario?.summary.length).toBeGreaterThan(0);
+      expect(scenario?.consentDate.kind).toBe(consentDateKind);
+    },
+  );
+
+  it("uses keep storedPolicy and null consent date only for first-time", () => {
+    expect(QA_SCENARIOS.filter(scenario => scenario.storedPolicy === "keep")).toEqual([
+      expect.objectContaining({ id: "first-time" }),
+    ]);
+    expect(QA_SCENARIOS.filter(scenario => scenario.consentDate.kind === "null")).toEqual([
+      expect.objectContaining({ id: "first-time" }),
+    ]);
+  });
+});
+
+describe("resolveScenarioVersions", () => {
+  it.each([
+    {
+      remotePolicy: "matchBaseline" as const,
+      expectedPolicyVersion: CUSTOM_BASELINE.normalized,
+    },
+    { remotePolicy: "nextMinor" as const, expectedPolicyVersion: "2.4" },
+    { remotePolicy: "nextMajor" as const, expectedPolicyVersion: "3.3" },
+    { remotePolicy: "invalid" as const, expectedPolicyVersion: INVALID_POLICY_VERSION },
+  ])(
+    "remotePolicy $remotePolicy resolves policyVersion",
+    ({ remotePolicy, expectedPolicyVersion }) => {
+      expect(
+        resolveScenarioVersions({ remotePolicy, storedPolicy: "matchBaseline" }, CUSTOM_BASELINE)
+          .policyVersion,
+      ).toBe(expectedPolicyVersion);
+    },
+  );
+
+  it.each([
+    { storedPolicy: "keep" as const, expectedStoredVersion: undefined },
+    { storedPolicy: "matchBaseline" as const, expectedStoredVersion: CUSTOM_BASELINE.normalized },
+    { storedPolicy: "nextMajor" as const, expectedStoredVersion: "3.3" },
+    { storedPolicy: "corrupt" as const, expectedStoredVersion: "v2" },
+    { storedPolicy: "legacyFloat" as const, expectedStoredVersion: 2.4 },
+  ])(
+    "storedPolicy $storedPolicy resolves storedVersion",
+    ({ storedPolicy, expectedStoredVersion }) => {
+      expect(
+        resolveScenarioVersions({ remotePolicy: "matchBaseline", storedPolicy }, CUSTOM_BASELINE)
+          .storedVersion,
+      ).toBe(expectedStoredVersion);
+    },
+  );
+
+  it("leaves storedVersion undefined when storedPolicy is keep", () => {
+    expect(
+      resolveScenarioVersions(
+        { remotePolicy: "matchBaseline", storedPolicy: "keep" },
+        SYNTHETIC_BASELINE,
+      ),
+    ).toEqual({
+      policyVersion: "1.0",
+      storedVersion: undefined,
+    });
+  });
+
+  it("resolves an explicit stored policy version", () => {
+    expect(
+      resolveScenarioVersions(
+        { remotePolicy: "nextMinor", storedPolicy: "matchBaseline" },
+        SYNTHETIC_BASELINE,
+      ),
+    ).toEqual({
+      policyVersion: "1.1",
+      storedVersion: "1.0",
+    });
+  });
+});
+
+describe("resolveScenarioConsentDate", () => {
+  const now = new Date("2026-07-31T12:00:00.000Z");
+
+  it("returns null for the null kind", () => {
+    expect(resolveScenarioConsentDate({ kind: "null" }, now)).toBeNull();
+  });
+
+  it("returns the invalid sentinel for the invalid kind", () => {
+    expect(resolveScenarioConsentDate({ kind: "invalid" }, now)).toBe(INVALID_CONSENT_DATE);
+  });
+
+  it.each([
+    { days: 0, expected: "2026-07-31T12:00:00.000Z" },
+    { days: 1, expected: "2026-07-30T12:00:00.000Z" },
+    { days: 28, expected: "2026-07-03T12:00:00.000Z" },
+    { days: 400, expected: "2025-06-26T12:00:00.000Z" },
+  ])("daysAgo $days resolves against the provided clock", ({ days, expected }) => {
+    expect(resolveScenarioConsentDate({ kind: "daysAgo", days }, now)).toBe(expected);
+  });
+});

--- a/features/flow/analytics-consent/src/debug/scenarios.ts
+++ b/features/flow/analytics-consent/src/debug/scenarios.ts
@@ -1,0 +1,218 @@
+import {
+  parsePolicyVersion,
+  type AnalyticsConsentInfo,
+  type PolicyVersion,
+} from "@domain/entity-analytics-consent";
+
+export const INVALID_POLICY_VERSION = "not-a-version";
+
+/** Fallback when live remote policyVersion is missing or invalid. */
+export const SYNTHETIC_BASELINE: PolicyVersion = {
+  major: 1,
+  minor: 0,
+  normalized: "1.0",
+};
+
+export type QaExpectation = "Re-ask" | "Ack only" | "Quiet";
+
+export type RemotePolicyRef = "matchBaseline" | "nextMinor" | "nextMajor" | "invalid";
+/** `"keep"` leaves the device's saved policy version untouched when applying the scenario. */
+export type StoredPolicyRef = "matchBaseline" | "nextMajor" | "corrupt" | "legacyFloat" | "keep";
+
+export type QaScenario = {
+  id: string;
+  name: string;
+  expected: QaExpectation;
+  /** Short card + confirm copy; versions are relative to live remote baseline. */
+  summary: string;
+  remotePolicy: RemotePolicyRef;
+  storedPolicy: StoredPolicyRef;
+  /** `daysAgo` is resolved against the current clock; the other kinds cover corrupted state. */
+  consentDate: { kind: "daysAgo"; days: number } | { kind: "null" } | { kind: "invalid" };
+  analyticsEnabled: boolean;
+  hasSeenPrompt: boolean;
+};
+
+export const QA_SCENARIOS: QaScenario[] = [
+  {
+    id: "up-to-date",
+    name: "Up to date",
+    expected: "Quiet",
+    summary: "Policy matches consent → no drawer",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "minor-bump",
+    name: "Minor update",
+    expected: "Ack only",
+    summary: "Small policy change → privacy ack",
+    remotePolicy: "nextMinor",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "major-bump",
+    name: "Major update",
+    expected: "Re-ask",
+    summary: "Big policy change → full reconsent",
+    remotePolicy: "nextMajor",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "first-time",
+    name: "No consent",
+    expected: "Re-ask",
+    summary: "Clears consent date only → full reconsent",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "keep",
+    consentDate: { kind: "null" },
+    analyticsEnabled: false,
+    hasSeenPrompt: false,
+  },
+  {
+    // Consent no longer expires on a timer, so an old date must stay silent.
+    id: "old-date",
+    name: "Old consent",
+    expected: "Quiet",
+    summary: "Old date, same policy → no drawer",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "daysAgo", days: 400 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "date-corrupt",
+    name: "Bad date",
+    expected: "Re-ask",
+    summary: "Unreadable date → full reconsent",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "invalid" },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "stored-corrupt",
+    name: "Bad version",
+    expected: "Re-ask",
+    summary: "Unreadable saved version → full reconsent",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "corrupt",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "config-invalid",
+    name: "Bad config",
+    expected: "Quiet",
+    summary: "Invalid server version → no drawer",
+    remotePolicy: "invalid",
+    storedPolicy: "matchBaseline",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "stored-ahead",
+    name: "Device ahead",
+    expected: "Quiet",
+    summary: "Device newer than server → no drawer",
+    remotePolicy: "matchBaseline",
+    storedPolicy: "nextMajor",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+  {
+    id: "legacy-float",
+    name: "Legacy format",
+    expected: "Quiet",
+    summary: "Number stored as version → no drawer",
+    remotePolicy: "nextMinor",
+    storedPolicy: "legacyFloat",
+    consentDate: { kind: "daysAgo", days: 28 },
+    analyticsEnabled: true,
+    hasSeenPrompt: true,
+  },
+];
+
+export const INVALID_CONSENT_DATE = "yesterday";
+const MS_PER_DAY = 86_400_000;
+
+export function resolveBaselinePolicyVersion(rawRemote: unknown): PolicyVersion {
+  return parsePolicyVersion(rawRemote) ?? SYNTHETIC_BASELINE;
+}
+
+function bumpMinor(version: PolicyVersion): PolicyVersion {
+  const minor = version.minor + 1;
+  return { major: version.major, minor, normalized: `${version.major}.${minor}` };
+}
+
+function bumpMajor(version: PolicyVersion): PolicyVersion {
+  const major = version.major + 1;
+  return { major, minor: version.minor, normalized: `${major}.${version.minor}` };
+}
+
+export function resolveScenarioVersions(
+  scenario: Pick<QaScenario, "remotePolicy" | "storedPolicy">,
+  baseline: PolicyVersion,
+): {
+  policyVersion: number | string;
+  /** `undefined` means leave the device's saved policy version unchanged. */
+  storedVersion: AnalyticsConsentInfo["privacyPolicyVersion"] | undefined;
+} {
+  const policyVersion = (() => {
+    switch (scenario.remotePolicy) {
+      case "matchBaseline":
+        return baseline.normalized;
+      case "nextMinor":
+        return bumpMinor(baseline).normalized;
+      case "nextMajor":
+        return bumpMajor(baseline).normalized;
+      case "invalid":
+        return INVALID_POLICY_VERSION;
+    }
+  })();
+
+  const storedVersion = (() => {
+    switch (scenario.storedPolicy) {
+      case "keep":
+        return undefined;
+      case "matchBaseline":
+        return baseline.normalized;
+      case "nextMajor":
+        return bumpMajor(baseline).normalized;
+      case "corrupt":
+        return "v2";
+      case "legacyFloat":
+        return Number(bumpMinor(baseline).normalized);
+    }
+  })();
+
+  return { policyVersion, storedVersion };
+}
+
+export function resolveScenarioConsentDate(
+  consentDate: QaScenario["consentDate"],
+  now: Date,
+): string | null {
+  switch (consentDate.kind) {
+    case "null":
+      return null;
+    case "invalid":
+      return INVALID_CONSENT_DATE;
+    case "daysAgo":
+      return new Date(now.getTime() - consentDate.days * MS_PER_DAY).toISOString();
+  }
+}

--- a/features/flow/analytics-consent/src/debug/verdict.test.ts
+++ b/features/flow/analytics-consent/src/debug/verdict.test.ts
@@ -1,0 +1,25 @@
+import { mapDecisionToQaExpectation } from "./verdict";
+import type { AnalyticsConsentDecision } from "../types";
+
+describe("mapDecisionToQaExpectation", () => {
+  const renewal: AnalyticsConsentDecision = { kind: "renewal", reason: "major_bump" };
+  const privacy: AnalyticsConsentDecision = { kind: "privacy", reason: "minor_bump" };
+  const none: AnalyticsConsentDecision = { kind: "none", reason: "up_to_date" };
+
+  it("returns Quiet when blocked", () => {
+    expect(mapDecisionToQaExpectation(renewal, false, "analyticsOptIn flag is off")).toBe("Quiet");
+  });
+
+  it("maps renewal to Re-ask", () => {
+    expect(mapDecisionToQaExpectation(renewal, true)).toBe("Re-ask");
+    expect(mapDecisionToQaExpectation(renewal, false)).toBe("Re-ask");
+  });
+
+  it("maps privacy to Ack only", () => {
+    expect(mapDecisionToQaExpectation(privacy, true)).toBe("Ack only");
+  });
+
+  it("maps none to Quiet", () => {
+    expect(mapDecisionToQaExpectation(none, true)).toBe("Quiet");
+  });
+});

--- a/features/flow/analytics-consent/src/debug/verdict.ts
+++ b/features/flow/analytics-consent/src/debug/verdict.ts
@@ -1,0 +1,68 @@
+import { resolveAnalyticsConsentPhase } from "../decision/resolveAnalyticsConsentPhase";
+import type { AnalyticsConsentDecision } from "../types";
+import type { QaExpectation } from "./scenarios";
+
+/** Semantic tone only — apps map this to design-system colors. */
+export type VerdictTone = "error" | "warning" | "success";
+
+export type VerdictMeta = {
+  title: string;
+  hint: string;
+  previewHint: string;
+  tone: VerdictTone;
+};
+
+/** Loudest verdict first. */
+export const SCENARIO_GROUPS: QaExpectation[] = ["Re-ask", "Ack only", "Quiet"];
+
+export const VERDICT_META: Record<QaExpectation, VerdictMeta> = {
+  "Re-ask": {
+    title: "Full reconsent",
+    hint: "Full consent drawer. Tracking pauses until answered.",
+    previewHint: "Preview full consent drawer.",
+    tone: "error",
+  },
+  "Ack only": {
+    title: "Privacy only",
+    hint: "Privacy ack drawer. Analytics choice unchanged.",
+    previewHint: "Preview privacy ack drawer.",
+    tone: "warning",
+  },
+  Quiet: {
+    title: "No drawer",
+    hint: "No drawer needed. Tracking unchanged.",
+    previewHint: "Nothing to preview.",
+    tone: "success",
+  },
+};
+
+/** Machine reason → plain label. Keep raw codes out of UI. */
+export const REASON_LABEL: Record<string, string> = {
+  up_to_date: "Consent matches policy",
+  minor_bump: "Minor policy update",
+  major_bump: "Major policy update",
+  consent_date_missing: "No consent date saved",
+  consent_date_invalid: "Consent date unreadable",
+  stored_version_missing: "No saved policy version",
+  stored_version_invalid: "Saved version unreadable",
+  stored_version_newer: "Device ahead of server",
+  current_version_invalid: "Server version invalid",
+  "analyticsOptIn flag is off": "Feature flag disabled",
+  "onboarding incomplete": "Onboarding incomplete",
+};
+
+/**
+ * Map production decision (+ optional app gate) to the QA expectation triad.
+ * `blockedReason` covers app-only gates (feature off, onboarding incomplete).
+ */
+export function mapDecisionToQaExpectation(
+  decision: AnalyticsConsentDecision,
+  analyticsSharingEnabled: boolean,
+  blockedReason: string | null = null,
+): QaExpectation {
+  if (blockedReason !== null) return "Quiet";
+  const phase = resolveAnalyticsConsentPhase("closed", decision, analyticsSharingEnabled);
+  if (phase === "closed") return "Quiet";
+  if (phase === "privacy") return "Ack only";
+  return "Re-ask";
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Analytics Consent QA debug screen
  - Adaptive scenarios from live FF `policyVersion` (incl. no-consent clears `consentDate` only)
  - Inspect tab and shared `@features/flow-analytics-consent/debug` helpers

### 📝 Description

QA and engineers need a deterministic way to exercise analytics consent renewal without waiting on remote config or real dates. This PR is the mobile debug layer for that (LIVE-29595).

**What changed**

- Shared QA helpers live under `features/flow/analytics-consent/src/debug`, exported as `@features/flow-analytics-consent/debug` (scenarios, adaptive version/date helpers, verdict mapping).
- Mobile Analytics Consent QA screen consumes that package. UI, Redux wiring, and alerts stay in the app.
- Scenarios adapt to the live feature-flag `policyVersion`.
- No-consent scenario keeps the stored privacy policy version and only nulls `consentDate` (so "no choice made" does not wipe policy state).

**Stack**

- Depends on mobile [#20211](https://github.com/LedgerHQ/ledger-live/pull/20211) (and layers below).
- Ticket is [LIVE-29595](https://ledgerhq.atlassian.net/browse/LIVE-29595), not LIVE-29593.
- Desktop is not migrated in this PR.


https://github.com/user-attachments/assets/59eb093f-7019-4c8f-ac6e-aed52e71e6e7



### ❓ Context

- **JIRA or GitHub link**: [LIVE-29595](https://ledgerhq.atlassian.net/browse/LIVE-29595)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29595]: https://ledgerhq.atlassian.net/browse/LIVE-29595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ