### PR TITLE
Revert "test(e2e): hardcode HBAR to XRP swap amount to 500"

### DIFF
--- a/.changeset/quiet-hbars-fixed.md
+++ b/.changeset/quiet-hbars-fixed.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+"ledger-live-mobile-e2e-tests": patch
+---
+
+Revert temporary hardcoded HBAR to XRP swap amount workaround (LIVE-33611); provider-side minimum amount bug is now fixed.

--- a/e2e/desktop/tests/specs/send.swap.spec.ts
+++ b/e2e/desktop/tests/specs/send.swap.spec.ts
@@ -145,9 +145,6 @@ const swaps = [
     toAccount: Account.XRP_1,
     xrayTicket: "B2CQA-3753",
     tag: [...deviceTagsWithoutLNS(), "@hedera", "@ripple", "@family-xrp", "@family-hedera"],
-    // TODO(LIVE-33611): remove hardcoded amount once the swap "min amount for quotes" bug is fixed
-    // https://ledgerhq.atlassian.net/browse/LIVE-33611
-    amount: "500",
   },
   {
     fromAccount: TokenAccount.SUI_USDC_1,
@@ -174,7 +171,7 @@ const swaps = [
   // },
 ];
 
-for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
+for (const { fromAccount, toAccount, xrayTicket, tag } of swaps) {
   test.describe("Swap - Accepted (without tx broadcast)", () => {
     setupEnv(true);
 
@@ -222,7 +219,7 @@ for (const { fromAccount, toAccount, xrayTicket, tag, amount } of swaps) {
       async ({ app, speculos }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        const minAmount = amount ?? (await app.swap.getMinimumAmount(fromAccount, toAccount));
+        const minAmount = await app.swap.getMinimumAmount(fromAccount, toAccount);
         const swap = new Swap(fromAccount, toAccount, minAmount);
 
         await performSwapUntilQuoteSelectionStep(app, swap, minAmount);

--- a/e2e/mobile/specs/swap/swap.ts
+++ b/e2e/mobile/specs/swap/swap.ts
@@ -32,7 +32,6 @@ export function runSwapTest(
   tmsLinks: string[],
   tags: string[],
   fee: Fee = Fee.MEDIUM,
-  hardcodedAmount?: string,
 ) {
   // The amount is resolved at runtime from the provider minimum and set on `swap` inside the test.
   const swap = new Swap(accountToDebit, accountToCredit, "", undefined, fee);
@@ -46,13 +45,8 @@ export function runSwapTest(
     tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
     tags.forEach(tag => $Tag(tag));
     it(`Swap ${accountToDebit.currency.name} to ${accountToCredit.currency.name}`, async () => {
-      let swapAmount: string;
-      if (hardcodedAmount) {
-        swapAmount = hardcodedAmount;
-      } else {
-        const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
-        swapAmount = minAmount ? truncateSwapAmount(minAmount) : minAmount;
-      }
+      const minAmount = await app.swapLiveApp.getMinimumAmount(accountToDebit, accountToCredit);
+      const swapAmount = minAmount ? truncateSwapAmount(minAmount) : minAmount;
       swap.amount = swapAmount;
 
       await performSwapUntilQuoteSelectionStep(accountToDebit, accountToCredit, swapAmount);

--- a/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
+++ b/e2e/mobile/specs/swap/swapHBAR_XRP.spec.ts
@@ -1,5 +1,4 @@
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
-import { Fee } from "@ledgerhq/live-e2e-shared/enum/Fee";
 import { runSwapTest } from "./swap";
 
 runSwapTest(
@@ -18,8 +17,4 @@ runSwapTest(
     "@ripple",
     "@family-xrp",
   ],
-  Fee.MEDIUM,
-  // TODO(LIVE-33611): remove hardcoded amount once the swap "min amount for quotes" bug is fixed
-  // https://ledgerhq.atlassian.net/browse/LIVE-33611
-  "500",
 );


### PR DESCRIPTION
## Summary
- Reverts #19888, which temporarily hardcoded the HBAR → XRP swap E2E amount to 500 on Desktop and Mobile as a workaround for LIVE-33611.
- The provider-side "minimum amount for quotes" bug is now fixed, so the HBAR → XRP pair goes back to resolving its amount dynamically via `getMinimumAmount`, like every other swap pair.

## Test plan
- [x] CI: [Desktop `send.swap.spec.ts` HBAR → XRP case passes with the dynamically fetched minimum amount](https://github.com/LedgerHQ/ledger-live/actions/runs/30526939489)
- [x] CI: Mobile [`swapHBAR_XRP.spec.ts` passes without the hardcoded amount](https://github.com/LedgerHQ/ledger-live/actions/runs/30527536796)