### PR TITLE
feat(analytics-consent): add consent decision flow package

### DIFF
--- a/.changeset/brave-pandas-policy.md
+++ b/.changeset/brave-pandas-policy.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Widen analyticsOptIn policyVersion to number | string for major/minor semantics

--- a/.changeset/swift-foxes-consent.md
+++ b/.changeset/swift-foxes-consent.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-analytics-consent": minor
+---
+
+Add analytics consent decision flow package with policyVersion major/minor semantics

--- a/features/flow/analytics-consent/README.md
+++ b/features/flow/analytics-consent/README.md
@@ -1,0 +1,37 @@
+# @features/flow-analytics-consent
+
+> [!CAUTION]
+> **Status: UNSTABLE** — In active development as part of the analytics consent renewal feature.
+
+Decides whether Ledger Wallet must ask for analytics consent again, only ask the user to
+acknowledge a new privacy policy, or stay silent. Implements
+[ADR: Analytics Consent Renewal](https://ledgerhq.atlassian.net/wiki/spaces/Engagement/pages/7249592355):
+`analyticsOptIn.params.policyVersion` carries major/minor semantics.
+
+Renewal is version-driven only. A stored consent never expires on a timer, so
+`analyticsOptIn.params.consentValidityDays` is not read here — it remains for desktop, which
+still runs its own rolling window through `libs/ledger-live-common`.
+
+One verdict drives both the consent drawer and the tracking gate, so optional analytics is
+disabled exactly while a fresh choice is pending.
+
+## Exports
+
+- `getAnalyticsConsentDecision` — `{ kind: "renewal" | "privacy" | "none", reason }`
+  - `renewal` — consent date missing/invalid, stored version missing/invalid, or a major bump
+  - `privacy` — same major, newer minor, consent otherwise valid
+  - `none` — up to date, stored version newer than current (remote-config rollback), or current version invalid
+- `useAnalyticsConsentDecision` — reads the `analyticsOptIn` flag and returns the verdict plus the version to persist
+- `resolveAnalyticsOptInParams` — strict flag params; an invalid `policyVersion` resolves to `null` (version checks off) and warns once instead of defaulting
+- `resolveAnalyticsConsentPhase` — maps a verdict to the drawer/dialog phase
+- `getConsentDateState` — `"missing" | "invalid" | "valid"`, for QA diagnostics
+
+Renewal outranks privacy acknowledgement. An invalid current version disables version checks
+but never the check that a consent was recorded at all.
+
+## Testing
+
+```sh
+pnpm test
+pnpm typecheck
+```

--- a/features/flow/analytics-consent/jest.config.js
+++ b/features/flow/analytics-consent/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/flow/analytics-consent/package.json
+++ b/features/flow/analytics-consent/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@features/flow-analytics-consent",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Analytics consent decision engine: policy version major/minor semantics plus rolling consent expiry",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W features/flow/analytics-consent"
+  },
+  "dependencies": {
+    "@domain/entity-analytics-consent": "workspace:*",
+    "@features/platform-feature-flags": "workspace:^"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "react": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/flow/analytics-consent/project.json
+++ b/features/flow/analytics-consent/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/flow-analytics-consent",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/flow/analytics-consent/src/decision/getAnalyticsConsentDecision.test.ts
+++ b/features/flow/analytics-consent/src/decision/getAnalyticsConsentDecision.test.ts
@@ -1,0 +1,136 @@
+import { parsePolicyVersion, type AnalyticsConsentInfo } from "@domain/entity-analytics-consent";
+import { mockAnalyticsConsentInfo } from "@domain/entity-analytics-consent/schema.mock";
+import { getAnalyticsConsentDecision } from "./getAnalyticsConsentDecision";
+import type { AnalyticsConsentDecision } from "../types";
+
+const NOW = new Date("2026-07-29T10:00:00.000Z");
+const MS_PER_DAY = 86_400_000;
+
+const daysAgo = (days: number) => new Date(NOW.getTime() - days * MS_PER_DAY).toISOString();
+
+const consent = (
+  privacyPolicyVersion: number | string | null,
+  consentDate: string | null = daysAgo(10),
+) => mockAnalyticsConsentInfo({ consentDate, privacyPolicyVersion });
+
+const decide = (
+  stored: AnalyticsConsentInfo,
+  currentPolicyVersion: number | string | null,
+): AnalyticsConsentDecision =>
+  getAnalyticsConsentDecision(stored, {
+    currentPolicyVersion:
+      currentPolicyVersion === null ? null : parsePolicyVersion(currentPolicyVersion),
+  });
+
+describe("getAnalyticsConsentDecision", () => {
+  describe("full analytics renewal", () => {
+    it("renews when no consent was ever given", () => {
+      expect(decide(consent(null, null), "1.0")).toEqual({
+        kind: "renewal",
+        reason: "consent_date_missing",
+      });
+    });
+
+    it("renews when the consent date is not a parseable date", () => {
+      expect(decide(consent(1, "not-a-date"), "1.0")).toEqual({
+        kind: "renewal",
+        reason: "consent_date_invalid",
+      });
+    });
+
+    it("renews when the major version is newer than the stored one", () => {
+      expect(decide(consent("1.5"), "2.0")).toEqual({ kind: "renewal", reason: "major_bump" });
+    });
+
+    it("reads a stored legacy number as a major version", () => {
+      expect(decide(consent(1), "2")).toEqual({ kind: "renewal", reason: "major_bump" });
+    });
+
+    it("renews when the stored version is missing but the consent date is valid", () => {
+      expect(decide(consent(null), "1.0")).toEqual({
+        kind: "renewal",
+        reason: "stored_version_missing",
+      });
+    });
+
+    it("renews when the stored version cannot be parsed", () => {
+      expect(decide(consent("v1.2"), "1.0")).toEqual({
+        kind: "renewal",
+        reason: "stored_version_invalid",
+      });
+    });
+
+    it("prefers renewal over privacy acknowledgement when the stored date is corrupted", () => {
+      expect(decide(consent("2.0", "not-a-date"), "2.1")).toEqual({
+        kind: "renewal",
+        reason: "consent_date_invalid",
+      });
+    });
+  });
+
+  describe("privacy acknowledgement only", () => {
+    it("asks for acknowledgement on a minor bump", () => {
+      expect(decide(consent("2.0"), "2.1")).toEqual({ kind: "privacy", reason: "minor_bump" });
+    });
+
+    it("compares minor versions numerically", () => {
+      expect(decide(consent("2.9"), "2.10")).toEqual({ kind: "privacy", reason: "minor_bump" });
+    });
+
+    it("asks for acknowledgement when a legacy stored number gains a minor version", () => {
+      expect(decide(consent(1), "1.1")).toEqual({ kind: "privacy", reason: "minor_bump" });
+    });
+
+    it("asks for acknowledgement rather than renewal when a coerced float lags behind", () => {
+      expect(decide(consent(1.4), "1.5")).toEqual({ kind: "privacy", reason: "minor_bump" });
+    });
+  });
+
+  describe("no prompt", () => {
+    it("stays silent when the stored version matches the current one", () => {
+      expect(decide(consent("2.1"), "2.1")).toEqual({ kind: "none", reason: "up_to_date" });
+    });
+
+    it("treats a stored legacy number as the implicit minor zero", () => {
+      expect(decide(consent(1), "1.0")).toEqual({ kind: "none", reason: "up_to_date" });
+    });
+
+    it("stays silent for a user who acknowledged 1.4 on a client that coerced it to a float", () => {
+      expect(decide(consent(1.4), "1.4")).toEqual({ kind: "none", reason: "up_to_date" });
+    });
+
+    it("stays silent however old the consent date is, since renewal is version-driven", () => {
+      expect(decide(consent(1, daysAgo(3650)), "1.0")).toEqual({
+        kind: "none",
+        reason: "up_to_date",
+      });
+    });
+
+    it.each([{ current: 1.2 }, { current: "1.02" }, { current: "v2" }, { current: null }])(
+      "disables version checks when the current version $current is invalid",
+      ({ current }) => {
+        expect(decide(consent(1), current as number | string | null)).toEqual({
+          kind: "none",
+          reason: "current_version_invalid",
+        });
+      },
+    );
+
+    it("still renews on a missing consent date when the current version is invalid", () => {
+      expect(decide(consent(1, null), null)).toEqual({
+        kind: "renewal",
+        reason: "consent_date_missing",
+      });
+    });
+
+    it.each([{ stored: "3.0" }, { stored: "2.2" }])(
+      "allows a remote-config rollback with stored version $stored newer than current 2.1",
+      ({ stored }) => {
+        expect(decide(consent(stored), "2.1")).toEqual({
+          kind: "none",
+          reason: "stored_version_newer",
+        });
+      },
+    );
+  });
+});

--- a/features/flow/analytics-consent/src/decision/getAnalyticsConsentDecision.ts
+++ b/features/flow/analytics-consent/src/decision/getAnalyticsConsentDecision.ts
@@ -1,0 +1,56 @@
+import {
+  comparePolicyVersions,
+  parseStoredPolicyVersion,
+  type AnalyticsConsentInfo,
+} from "@domain/entity-analytics-consent";
+import { getConsentDateState } from "../utils/getConsentDateState";
+import type {
+  AnalyticsConsentContext,
+  AnalyticsConsentDecision,
+  AnalyticsConsentRenewalReason,
+} from "../types";
+
+const RENEWAL_REASON_BY_DATE_STATE = {
+  missing: "consent_date_missing",
+  invalid: "consent_date_invalid",
+} as const satisfies Record<string, AnalyticsConsentRenewalReason>;
+
+/**
+ * Single verdict shared by the consent drawer and the tracking gate.
+ * Renewal outranks privacy acknowledgement; an invalid current version disables version checks.
+ */
+export function getAnalyticsConsentDecision(
+  { consentDate, privacyPolicyVersion }: AnalyticsConsentInfo,
+  { currentPolicyVersion }: AnalyticsConsentContext,
+): AnalyticsConsentDecision {
+  const dateState = getConsentDateState(consentDate);
+  if (dateState !== "valid") {
+    return { kind: "renewal", reason: RENEWAL_REASON_BY_DATE_STATE[dateState] };
+  }
+
+  if (currentPolicyVersion === null) {
+    return { kind: "none", reason: "current_version_invalid" };
+  }
+
+  const storedVersion = parseStoredPolicyVersion(privacyPolicyVersion);
+  if (storedVersion === null) {
+    return {
+      kind: "renewal",
+      reason: privacyPolicyVersion == null ? "stored_version_missing" : "stored_version_invalid",
+    };
+  }
+
+  if (storedVersion.major < currentPolicyVersion.major) {
+    return { kind: "renewal", reason: "major_bump" };
+  }
+
+  if (comparePolicyVersions(storedVersion, currentPolicyVersion) > 0) {
+    return { kind: "none", reason: "stored_version_newer" };
+  }
+
+  if (storedVersion.minor < currentPolicyVersion.minor) {
+    return { kind: "privacy", reason: "minor_bump" };
+  }
+
+  return { kind: "none", reason: "up_to_date" };
+}

--- a/features/flow/analytics-consent/src/decision/resolveAnalyticsConsentPhase.test.ts
+++ b/features/flow/analytics-consent/src/decision/resolveAnalyticsConsentPhase.test.ts
@@ -1,0 +1,28 @@
+import { resolveAnalyticsConsentPhase } from "./resolveAnalyticsConsentPhase";
+import type { AnalyticsConsentDecision } from "../types";
+
+const renewal: AnalyticsConsentDecision = { kind: "renewal", reason: "major_bump" };
+const privacy: AnalyticsConsentDecision = { kind: "privacy", reason: "minor_bump" };
+const none: AnalyticsConsentDecision = { kind: "none", reason: "up_to_date" };
+
+describe("resolveAnalyticsConsentPhase", () => {
+  it("asks a user who shares analytics to reconfirm", () => {
+    expect(resolveAnalyticsConsentPhase("closed", renewal, true)).toBe("consentReconfirm");
+  });
+
+  it("asks a user who does not share analytics for a fresh choice", () => {
+    expect(resolveAnalyticsConsentPhase("closed", renewal, false)).toBe("consentFresh");
+  });
+
+  it("shows the privacy sheet on a minor bump", () => {
+    expect(resolveAnalyticsConsentPhase("closed", privacy, true)).toBe("privacy");
+  });
+
+  it("stays closed when nothing is required", () => {
+    expect(resolveAnalyticsConsentPhase("closed", none, true)).toBe("closed");
+  });
+
+  it("keeps the phase the user is already in", () => {
+    expect(resolveAnalyticsConsentPhase("privacy", renewal, false)).toBe("privacy");
+  });
+});

--- a/features/flow/analytics-consent/src/decision/resolveAnalyticsConsentPhase.ts
+++ b/features/flow/analytics-consent/src/decision/resolveAnalyticsConsentPhase.ts
@@ -1,0 +1,14 @@
+import type { AnalyticsConsentDecision, AnalyticsConsentPhase } from "../types";
+
+export function resolveAnalyticsConsentPhase(
+  currentPhase: AnalyticsConsentPhase,
+  decision: AnalyticsConsentDecision,
+  analyticsSharingEnabled: boolean,
+): AnalyticsConsentPhase {
+  if (currentPhase !== "closed") return currentPhase;
+  if (decision.kind === "renewal") {
+    return analyticsSharingEnabled ? "consentReconfirm" : "consentFresh";
+  }
+  if (decision.kind === "privacy") return "privacy";
+  return "closed";
+}

--- a/features/flow/analytics-consent/src/hooks/useAnalyticsConsentDecision.ts
+++ b/features/flow/analytics-consent/src/hooks/useAnalyticsConsentDecision.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+import { useFeature } from "@features/platform-feature-flags";
+import type { AnalyticsConsentInfo, PolicyVersion } from "@domain/entity-analytics-consent";
+import { getAnalyticsConsentDecision } from "../decision/getAnalyticsConsentDecision";
+import { resolveAnalyticsOptInParams } from "../utils/resolveAnalyticsOptInParams";
+import type { AnalyticsConsentDecision } from "../types";
+
+export type UseAnalyticsConsentDecisionResult = {
+  isFeatureEnabled: boolean;
+  decision: AnalyticsConsentDecision;
+  /** Version to persist on a fresh consent choice or a privacy acknowledgement. */
+  currentPolicyVersion: PolicyVersion | null;
+};
+
+export function useAnalyticsConsentDecision(
+  storedConsentInfo: AnalyticsConsentInfo,
+): UseAnalyticsConsentDecisionResult {
+  const feature = useFeature("analyticsOptIn");
+  const { currentPolicyVersion } = resolveAnalyticsOptInParams(feature);
+  const normalizedPolicyVersion = currentPolicyVersion?.normalized ?? null;
+
+  return useMemo(
+    () => ({
+      isFeatureEnabled: Boolean(feature?.enabled),
+      currentPolicyVersion,
+      decision: getAnalyticsConsentDecision(storedConsentInfo, { currentPolicyVersion }),
+    }),
+    // currentPolicyVersion is re-parsed on every render, so its normalized form keys the memo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [feature?.enabled, normalizedPolicyVersion, storedConsentInfo],
+  );
+}

--- a/features/flow/analytics-consent/src/index.ts
+++ b/features/flow/analytics-consent/src/index.ts
@@ -1,0 +1,7 @@
+export type { AnalyticsConsentInfo, PolicyVersion } from "@domain/entity-analytics-consent";
+export * from "./types";
+export * from "./decision/getAnalyticsConsentDecision";
+export * from "./decision/resolveAnalyticsConsentPhase";
+export * from "./hooks/useAnalyticsConsentDecision";
+export * from "./utils/resolveAnalyticsOptInParams";
+export * from "./utils/getConsentDateState";

--- a/features/flow/analytics-consent/src/types.ts
+++ b/features/flow/analytics-consent/src/types.ts
@@ -1,0 +1,32 @@
+import type { PolicyVersion } from "@domain/entity-analytics-consent";
+
+export type AnalyticsConsentRenewalReason =
+  | "consent_date_missing"
+  | "consent_date_invalid"
+  | "stored_version_missing"
+  | "stored_version_invalid"
+  | "major_bump";
+
+export type AnalyticsConsentNoneReason =
+  | "up_to_date"
+  | "current_version_invalid"
+  | "stored_version_newer";
+
+/**
+ * `renewal` requires a fresh analytics choice and disables optional analytics meanwhile.
+ * `privacy` only asks the user to acknowledge the new privacy policy.
+ */
+export type AnalyticsConsentDecision =
+  | { kind: "renewal"; reason: AnalyticsConsentRenewalReason }
+  | { kind: "privacy"; reason: "minor_bump" }
+  | { kind: "none"; reason: AnalyticsConsentNoneReason };
+
+export type AnalyticsConsentContext = {
+  currentPolicyVersion: PolicyVersion | null;
+};
+
+export type AnalyticsOptInParams = {
+  currentPolicyVersion: PolicyVersion | null;
+};
+
+export type AnalyticsConsentPhase = "closed" | "privacy" | "consentFresh" | "consentReconfirm";

--- a/features/flow/analytics-consent/src/utils/getConsentDateState.ts
+++ b/features/flow/analytics-consent/src/utils/getConsentDateState.ts
@@ -1,0 +1,12 @@
+import { parseConsentDate } from "@domain/entity-analytics-consent";
+
+export type ConsentDateState = "missing" | "invalid" | "valid";
+
+/**
+ * A stored consent date never goes stale on its own: renewal is driven by `policyVersion` bumps,
+ * so the date only tells us whether a consent choice was ever recorded and stored intact.
+ */
+export function getConsentDateState(consentDateIso: string | null): ConsentDateState {
+  if (consentDateIso == null || consentDateIso === "") return "missing";
+  return parseConsentDate(consentDateIso) === null ? "invalid" : "valid";
+}

--- a/features/flow/analytics-consent/src/utils/resolveAnalyticsOptInParams.test.ts
+++ b/features/flow/analytics-consent/src/utils/resolveAnalyticsOptInParams.test.ts
@@ -1,0 +1,50 @@
+import { resolveAnalyticsOptInParams } from "./resolveAnalyticsOptInParams";
+
+describe("resolveAnalyticsOptInParams", () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("parses a major/minor string version", () => {
+    expect(resolveAnalyticsOptInParams({ params: { policyVersion: "2.1" } })).toEqual({
+      currentPolicyVersion: { major: 2, minor: 1, normalized: "2.1" },
+    });
+  });
+
+  it("reads a legacy number version as major only", () => {
+    expect(resolveAnalyticsOptInParams({ params: { policyVersion: 2 } })).toEqual({
+      currentPolicyVersion: { major: 2, minor: 0, normalized: "2.0" },
+    });
+  });
+
+  it("ignores params the mobile decision no longer reads", () => {
+    expect(
+      resolveAnalyticsOptInParams({ params: { policyVersion: 2, consentValidityDays: 730 } }),
+    ).toEqual({ currentPolicyVersion: { major: 2, minor: 0, normalized: "2.0" } });
+  });
+
+  it.each([
+    { feature: null },
+    { feature: undefined },
+    { feature: {} },
+    { feature: { params: "nope" } },
+    { feature: { params: { policyVersion: 1.2 } } },
+    { feature: { params: { policyVersion: "01.2" } } },
+  ])("resolves no current version for $feature instead of defaulting", ({ feature }) => {
+    expect(resolveAnalyticsOptInParams(feature).currentPolicyVersion).toBeNull();
+  });
+
+  it("warns once per invalid value so a remote-config mistake is visible", () => {
+    resolveAnalyticsOptInParams({ params: { policyVersion: "v2" } });
+    resolveAnalyticsOptInParams({ params: { policyVersion: "v2" } });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("policyVersion");
+  });
+});

--- a/features/flow/analytics-consent/src/utils/resolveAnalyticsOptInParams.ts
+++ b/features/flow/analytics-consent/src/utils/resolveAnalyticsOptInParams.ts
@@ -1,0 +1,34 @@
+import { parsePolicyVersion } from "@domain/entity-analytics-consent";
+import type { AnalyticsOptInParams } from "../types";
+
+const warnedPolicyVersions = new Set<string>();
+
+function warnOnceAboutPolicyVersion(rawPolicyVersion: unknown): void {
+  const key = `${typeof rawPolicyVersion}:${String(rawPolicyVersion)}`;
+  if (warnedPolicyVersions.has(key)) return;
+  warnedPolicyVersions.add(key);
+  console.warn(
+    `[analyticsConsent] analyticsOptIn.params.policyVersion ${JSON.stringify(
+      rawPolicyVersion,
+    )} is invalid, policy version checks are disabled. Expected an integer or a "<major>.<minor>" string.`,
+  );
+}
+
+/**
+ * An invalid `policyVersion` resolves to `null` rather than a default: a remote-config
+ * mistake must never prompt or silently suppress a prompt.
+ */
+export function resolveAnalyticsOptInParams(
+  feature: { params?: unknown } | null | undefined,
+): AnalyticsOptInParams {
+  const rawParams = feature?.params;
+  const params: Record<string, unknown> =
+    rawParams && typeof rawParams === "object" ? (rawParams as Record<string, unknown>) : {};
+  const currentPolicyVersion = parsePolicyVersion(params.policyVersion);
+
+  if (currentPolicyVersion === null) {
+    warnOnceAboutPolicyVersion(params.policyVersion);
+  }
+
+  return { currentPolicyVersion };
+}

--- a/features/flow/analytics-consent/tsconfig.json
+++ b/features/flow/analytics-consent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4321,6 +4321,37 @@ importers:
         specifier: 1.51.0
         version: 1.51.0
 
+  features/flow/analytics-consent:
+    dependencies:
+      '@domain/entity-analytics-consent':
+        specifier: workspace:*
+        version: link:../../../domain/entity/analytics-consent
+      '@features/platform-feature-flags':
+        specifier: workspace:^
+        version: link:../../platform/feature-flags
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   features/flow/card:
     dependencies:
       '@domain/api-pay-card':
@@ -41385,6 +41416,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-private-methods@7.27.1':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.27.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41424,13 +41424,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-methods@7.27.1':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5

--- a/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
+++ b/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { flagWith } from "../../define";
 
 const analyticsOptInParamsShape = {
-  policyVersion: z.number().positive().default(1),
+  /** Major/minor privacy policy version: `1`, `"1"`, `"1.0"`, `"2.10"`. Validated by `@domain/entity-analytics-consent`. */
+  policyVersion: z.union([z.number(), z.string()]).default(1),
+  /** Desktop only: mobile renews from `policyVersion` bumps and ignores this window. */
   consentValidityDays: z.number().int().positive().default(365),
 } satisfies z.ZodRawShape;
 

--- a/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
+++ b/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
@@ -2,9 +2,7 @@ import { z } from "zod";
 import { flagWith } from "../../define";
 
 const analyticsOptInParamsShape = {
-  /** Major/minor privacy policy version: `1`, `"1"`, `"1.0"`, `"2.10"`. Validated by `@domain/entity-analytics-consent`. */
   policyVersion: z.union([z.number(), z.string()]).default(1),
-  /** Desktop only: mobile renews from `policyVersion` bumps and ignores this window. */
   consentValidityDays: z.number().int().positive().default(365),
 } satisfies z.ZodRawShape;
 


### PR DESCRIPTION
## Summary
- Adds `@features/flow-analytics-consent` with production decision engine (`getAnalyticsConsentDecision`, phase resolver, hook, opt-in params).
- Shared package for mobile (and later desktop) consent renewal from policyVersion major/minor semantics.
- Changeset for `@features/flow-analytics-consent` only.

## Test plan
- [x] `pnpm --filter @features/flow-analytics-consent test` (37 production tests)
- [ ] CI typecheck/test for the new package


Made with [Cursor](https://cursor.com)