### PR TITLE
feat(feature-flags): widen analyticsOptIn policyVersion

### DIFF
--- a/.changeset/brave-pandas-policy.md
+++ b/.changeset/brave-pandas-policy.md
@@ -1,0 +1,5 @@
+---
+"@shared/feature-flags": minor
+---
+
+Widen analyticsOptIn policyVersion to number | string for major/minor semantics

--- a/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
+++ b/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { flagWith } from "../../define";
 
 const analyticsOptInParamsShape = {
-  policyVersion: z.number().positive().default(1),
+  /** Major/minor privacy policy version: `1`, `"1"`, `"1.0"`, `"2.10"`. Validated by `@domain/entity-analytics-consent`. */
+  policyVersion: z.union([z.number(), z.string()]).default(1),
+  /** Desktop only: mobile renews from `policyVersion` bumps and ignores this window. */
   consentValidityDays: z.number().int().positive().default(365),
 } satisfies z.ZodRawShape;
 

--- a/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
+++ b/shared/feature-flags/src/flags/team-engagement/analyticsOptIn.ts
@@ -2,9 +2,7 @@ import { z } from "zod";
 import { flagWith } from "../../define";
 
 const analyticsOptInParamsShape = {
-  /** Major/minor privacy policy version: `1`, `"1"`, `"1.0"`, `"2.10"`. Validated by `@domain/entity-analytics-consent`. */
   policyVersion: z.union([z.number(), z.string()]).default(1),
-  /** Desktop only: mobile renews from `policyVersion` bumps and ignores this window. */
   consentValidityDays: z.number().int().positive().default(365),
 } satisfies z.ZodRawShape;
 


### PR DESCRIPTION
## Summary
- Widens `analyticsOptIn.params.policyVersion` from `number` to `number | string` so major/minor forms (`1`, `"1.0"`, `"2.10"`) validate.
- Keeps `consentValidityDays` (desktop still uses the rolling window; mobile ignores it).
- Changeset for `@shared/feature-flags`.

## Test plan
- [ ] Confirm flag schema accepts string and number policyVersion defaults
- [ ] No removal of `consentValidityDays` in this PR


Made with [Cursor](https://cursor.com)