### PR TITLE
[LWDM] feat(contacts): model address labels (LIVE-33918)

### DIFF
--- a/.changeset/kind-labels-model.md
+++ b/.changeset/kind-labels-model.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Model contact address labels with asset defaults and per-contact uniqueness

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -20,11 +20,15 @@ describe("useContactsCurrencySelectionAdapter", () => {
     jest.mocked(useOpenCurrencyFlow).mockReturnValue({ openCurrencyFlow, cancelCurrencyFlow });
   });
 
-  it("should pass the exact network ids and return the selected currency id", async () => {
-    openCurrencyFlow.mockResolvedValue(getCryptoCurrencyById("ethereum"));
+  it("should pass the exact network ids and return the selected currency details", async () => {
+    const ethereum = getCryptoCurrencyById("ethereum");
+    openCurrencyFlow.mockResolvedValue(ethereum);
     const { result } = renderHook(() => useContactsCurrencySelectionAdapter());
 
-    await expect(result.current.selectCurrency([ethereumId, bitcoinId])).resolves.toBe(ethereumId);
+    await expect(result.current.selectCurrency([ethereumId, bitcoinId])).resolves.toEqual({
+      currencyId: ethereumId,
+      assetDisplayName: ethereum.name,
+    });
     expect(openCurrencyFlow).toHaveBeenCalledWith([ethereumId, bitcoinId], {
       presentation: "embedded",
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,17 +1,25 @@
 import { useMemo } from "react";
-import { ContactCurrencyIdSchema, type ContactAddress } from "@domain/entity-contact";
-import type { ContactsCurrencySelectionPort } from "@features/flow-contacts";
+import { ContactCurrencyIdSchema } from "@domain/entity-contact";
+import type {
+  AddAddressCurrencySelection,
+  ContactsCurrencySelectionPort,
+} from "@features/flow-contacts";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import {
   type OpenCurrencyFlow,
   useOpenCurrencyFlow,
 } from "../../ModularDialog/hooks/useOpenCurrencyFlow";
 
-function resolveContactCurrencyId(
+function resolveContactCurrencySelection(
   currency: CryptoOrTokenCurrency | null,
-): ContactAddress["currencyId"] | null {
+): AddAddressCurrencySelection | null {
   const parsedCurrencyId = ContactCurrencyIdSchema.safeParse(currency?.id);
-  return parsedCurrencyId.success ? parsedCurrencyId.data : null;
+  return parsedCurrencyId.success && currency
+    ? {
+        currencyId: parsedCurrencyId.data,
+        assetDisplayName: currency.name,
+      }
+    : null;
 }
 
 function createCurrencySelectionPort(
@@ -19,7 +27,9 @@ function createCurrencySelectionPort(
 ): ContactsCurrencySelectionPort {
   return {
     selectCurrency: async networkIds =>
-      resolveContactCurrencyId(await openCurrencyFlow(networkIds, { presentation: "embedded" })),
+      resolveContactCurrencySelection(
+        await openCurrencyFlow(networkIds, { presentation: "embedded" }),
+      ),
   };
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ContactId } from "@domain/entity-contact";
 import {
+  type AddAddressContact,
   useEmptyContactDetail,
   usePopulatedContactDetail,
   useContactAddressDetailDialog,
@@ -15,7 +16,7 @@ import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/User
 import { useContactsAddressCurrencyAdapter } from "../../hooks/useContactsAddressCurrencyAdapter";
 
 export function useContactDetailPaneAdapter(
-  onAddAddress: (contactId: ContactId) => void,
+  onAddAddress: (contact: AddAddressContact) => void,
 ): Readonly<{
   detail: ContactDetailViewProps | undefined;
   addressDetailDialog: ContactAddressDetailDialogProps;
@@ -74,7 +75,7 @@ export function useContactDetailPaneAdapter(
       return {
         ...baseDetail,
         contact: populatedContactDetail.contact,
-        onAddAddress: () => onAddAddress(populatedContactDetail.contact.id),
+        onAddAddress: () => onAddAddress(populatedContactDetail.contact),
         addressGroups: populatedContactDetail.addressGroups,
         onAddressRowPress,
       };
@@ -87,7 +88,7 @@ export function useContactDetailPaneAdapter(
     return {
       ...baseDetail,
       contact: emptyContact,
-      onAddAddress: () => onAddAddress(emptyContact.id),
+      onAddAddress: () => onAddAddress(emptyContact),
     };
   }, [emptyContact, labels, onAddAddress, onAddressRowPress, populatedContactDetail]);
   const addressDetailDialog = useMemo<ContactAddressDetailDialogProps>(

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
-import type { ContactId } from "@domain/entity-contact";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   createContactsListViewModel,
@@ -12,6 +11,7 @@ import {
   useContacts,
   useContactsFeatureIntroductionState,
   useContactsMeContact,
+  type AddAddressContact,
   type AddAddressFlowState,
   type ContactsAddAddressEntryLabels,
   type ContactAddressDetailDialogProps,
@@ -60,7 +60,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       void selectCurrency()
         .then(result => {
           if (result.status === "selected") {
-            completeCurrencySelection(contactId, result.currencyId);
+            completeCurrencySelection(contactId, result.selection);
           } else if (result.status === "cancelled" || result.status === "unavailable") {
             closeAddAddress();
           }
@@ -70,9 +70,9 @@ export function useContactsViewModel(): ContactsPageViewModel {
     [closeAddAddress, completeCurrencySelection, selectCurrency],
   );
   const onAddAddress = useCallback(
-    (contactId: ContactId) => {
-      startAddAddress(contactId);
-      selectCurrencyForContact(contactId);
+    (contact: AddAddressContact) => {
+      startAddAddress(contact);
+      selectCurrencyForContact(contact.id);
     },
     [selectCurrencyForContact, startAddAddress],
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
+import type { ContactId } from "@domain/entity-contact";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   createContactsListViewModel,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -196,7 +196,10 @@ function ContactDetailViewModelProbe() {
           <Pressable
             testID="contacts-select-currency"
             onPress={() =>
-              viewModel.addAddressFlowProps.onCurrencySelected(mockEthCryptoCurrency.id)
+              viewModel.addAddressFlowProps.onCurrencySelected({
+                currencyId: mockEthCryptoCurrency.id,
+                assetDisplayName: mockEthCryptoCurrency.name,
+              })
             }
           >
             <Text>Select currency</Text>

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.test.tsx
@@ -69,7 +69,7 @@ describe("useContactsCurrencySelectionAdapter", () => {
     });
   });
 
-  it("should return a valid selected currency id", () => {
+  it("should return the selected currency id and display name", () => {
     const onCurrencySelected = jest.fn();
     renderHook(() =>
       useContactsCurrencySelectionAdapter({
@@ -83,7 +83,10 @@ describe("useContactsCurrencySelectionAdapter", () => {
     const onMadCurrencySelected = openDrawer.mock.calls[0]?.[0].onCurrencySelected;
     act(() => onMadCurrencySelected(mockEthCryptoCurrency));
 
-    expect(onCurrencySelected).toHaveBeenCalledWith(mockEthCryptoCurrency.id);
+    expect(onCurrencySelected).toHaveBeenCalledWith({
+      currencyId: mockEthCryptoCurrency.id,
+      assetDisplayName: mockEthCryptoCurrency.name,
+    });
   });
 
   it.each([null, { ...mockEthCryptoCurrency, id: "" }])(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactsCurrencySelectionAdapter.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { ContactCurrencyIdSchema, type ContactAddress } from "@domain/entity-contact";
+import { ContactCurrencyIdSchema } from "@domain/entity-contact";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import type { AddAddressCurrencySelection } from "@features/flow-contacts";
 import { ScreenName } from "~/const";
 import {
   type ModularDrawerFlowProps,
@@ -12,7 +13,7 @@ const FLOW = "contacts_add_address";
 type UseContactsCurrencySelectionAdapterOptions = Readonly<{
   isOpen: boolean;
   networkIds: readonly string[];
-  onCurrencySelected: (currencyId: ContactAddress["currencyId"]) => void;
+  onCurrencySelected: (selection: AddAddressCurrencySelection) => void;
   onSelectionCancelled: () => void;
 }>;
 
@@ -20,11 +21,16 @@ export type ContactsCurrencySelectionAdapter = Readonly<{
   flowProps: Omit<ModularDrawerFlowProps, "children">;
 }>;
 
-function resolveContactCurrencyId(
+function resolveContactCurrencySelection(
   currency: CryptoOrTokenCurrency | null,
-): ContactAddress["currencyId"] | null {
+): AddAddressCurrencySelection | null {
   const parsedCurrencyId = ContactCurrencyIdSchema.safeParse(currency?.id);
-  return parsedCurrencyId.success ? parsedCurrencyId.data : null;
+  return parsedCurrencyId.success && currency
+    ? {
+        currencyId: parsedCurrencyId.data,
+        assetDisplayName: currency.name,
+      }
+    : null;
 }
 
 export function useContactsCurrencySelectionAdapter({
@@ -50,9 +56,9 @@ export function useContactsCurrencySelectionAdapter({
   } = useModularDrawerController();
   const completeSelection = useCallback(
     (currency: CryptoOrTokenCurrency | null) => {
-      const currencyId = resolveContactCurrencyId(currency);
-      if (currencyId) {
-        onCurrencySelected(currencyId);
+      const selection = resolveContactCurrencySelection(currency);
+      if (selection) {
+        onCurrencySelected(selection);
       } else {
         onSelectionCancelled();
       }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
@@ -1,5 +1,8 @@
-import type { AddAddressFlowState, AddAddressInputSource } from "@features/flow-contacts";
-import type { ContactAddress } from "@domain/entity-contact";
+import type {
+  AddAddressCurrencySelection,
+  AddAddressFlowState,
+  AddAddressInputSource,
+} from "@features/flow-contacts";
 
 export type ContactsAddAddressFlowDrawerProps = Readonly<{
   state: AddAddressFlowState;
@@ -10,7 +13,7 @@ export type ContactsAddAddressFlowDrawerProps = Readonly<{
   onClose: () => void;
   onContinueFromName: () => void;
   onContinueFromReview: () => void;
-  onCurrencySelected: (currencyId: ContactAddress["currencyId"]) => void;
+  onCurrencySelected: (selection: AddAddressCurrencySelection) => void;
   onQrCodeClick: () => void;
 }>;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -63,12 +63,12 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   });
   const onAddAddress = useCallback(() => {
     if (!contact || eligibleNetworkIds.length === 0) return;
-    startAddAddress(contact.id);
+    startAddAddress(contact);
   }, [contact, eligibleNetworkIds.length, startAddAddress]);
   const onCurrencySelected = useCallback<ContactsAddAddressFlowDrawerProps["onCurrencySelected"]>(
-    currencyId => {
+    selection => {
       if (addAddressFlowState.status === "selectingCurrency") {
-        completeCurrencySelection(addAddressFlowState.selectedContactId, currencyId);
+        completeCurrencySelection(addAddressFlowState.selectedContactId, selection);
       }
     },
     [addAddressFlowState, completeCurrencySelection],

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -16,10 +16,10 @@ This package describes what Contacts flows manipulate:
 
 `currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to later flow or integration adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
 
-Address labels accept letters, numbers, punctuation, and spaces without a maximum length. The
-domain validation helpers treat a blank draft as incomplete without surfacing an error and can
-reject labels already used by the same contact. Duplicate comparison trims surrounding spaces,
-normalizes Unicode, and ignores casing.
+Address labels must contain at least one letter or number, and may also include punctuation and
+spaces, without a maximum length. The domain validation helpers treat a blank draft as incomplete
+without surfacing an error and can reject labels already used by the same contact. Duplicate
+comparison trims surrounding spaces, normalizes Unicode, and ignores casing.
 
 It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, or UI.
 

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -16,6 +16,11 @@ This package describes what Contacts flows manipulate:
 
 `currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to later flow or integration adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
 
+Address labels accept letters, numbers, punctuation, and spaces without a maximum length. The
+domain validation helpers treat a blank draft as incomplete without surfacing an error and can
+reject labels already used by the same contact. Duplicate comparison trims surrounding spaces,
+normalizes Unicode, and ignores casing.
+
 It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, or UI.
 
 ## Usage

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -15,20 +15,18 @@ export type ContactNameValidationErrorName = "InvalidContactNameError";
 export const INVALID_CONTACT_NAME_ERROR_NAME =
   "InvalidContactNameError" satisfies ContactNameValidationErrorName;
 
+export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME = "InvalidContactAddressLabelError";
+
+export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME = "DuplicateContactAddressLabelError";
+
+export type ContactAddressLabelValidationErrorName =
+  | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
+  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+
 export class InvalidContactAddressLabelError extends ContactError {
-  override name = "InvalidContactAddressLabelError";
+  override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
 }
 
 export class DuplicateContactAddressLabelError extends ContactError {
-  override name = "DuplicateContactAddressLabelError";
+  override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
 }
-
-export type ContactAddressLabelValidationErrorName =
-  | "InvalidContactAddressLabelError"
-  | "DuplicateContactAddressLabelError";
-
-export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "InvalidContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
-
-export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "DuplicateContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -17,18 +17,10 @@ export const INVALID_CONTACT_NAME_ERROR_NAME =
 
 export class InvalidContactAddressLabelError extends ContactError {
   override name = "InvalidContactAddressLabelError";
-
-  constructor() {
-    super("Expected at least one letter or number; punctuation and spaces are also allowed");
-  }
 }
 
 export class DuplicateContactAddressLabelError extends ContactError {
   override name = "DuplicateContactAddressLabelError";
-
-  constructor() {
-    super("Expected a unique address label for the contact");
-  }
 }
 
 export type ContactAddressLabelValidationErrorName =

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -14,3 +14,29 @@ export type ContactNameValidationErrorName = "InvalidContactNameError";
 
 export const INVALID_CONTACT_NAME_ERROR_NAME =
   "InvalidContactNameError" satisfies ContactNameValidationErrorName;
+
+export class InvalidContactAddressLabelError extends ContactError {
+  override name = "InvalidContactAddressLabelError";
+
+  constructor() {
+    super("Expected letters, numbers, punctuation, or spaces");
+  }
+}
+
+export class DuplicateContactAddressLabelError extends ContactError {
+  override name = "DuplicateContactAddressLabelError";
+
+  constructor() {
+    super("Expected a unique address label for the contact");
+  }
+}
+
+export type ContactAddressLabelValidationErrorName =
+  | "InvalidContactAddressLabelError"
+  | "DuplicateContactAddressLabelError";
+
+export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "InvalidContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+
+export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "DuplicateContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -19,7 +19,7 @@ export class InvalidContactAddressLabelError extends ContactError {
   override name = "InvalidContactAddressLabelError";
 
   constructor() {
-    super("Expected letters, numbers, punctuation, or spaces");
+    super("Expected at least one letter or number; punctuation and spaces are also allowed");
   }
 }
 

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -20,7 +20,7 @@ export const ContactNameSchema = NonEmptyStringSchema.regex(
 
 export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(
   ContactAddressLabelPattern,
-  "Expected letters, numbers, punctuation, or spaces",
+  "Expected at least one letter or number; punctuation and spaces are also allowed",
 );
 
 export const ContactAddressValueSchema = NonEmptyStringSchema;

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -18,10 +18,7 @@ export const ContactNameSchema = NonEmptyStringSchema.regex(
   "Expected letters, spaces, apostrophes, or hyphens",
 );
 
-export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(
-  ContactAddressLabelPattern,
-  "Expected at least one letter or number; punctuation and spaces are also allowed",
-);
+export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern);
 
 export const ContactAddressValueSchema = NonEmptyStringSchema;
 

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,5 +1,21 @@
-import { InvalidContactNameError, INVALID_CONTACT_NAME_ERROR_NAME } from "./errors";
-import { getContactNameValidationError, isValidContactName, parseContactName } from "./validation";
+import {
+  DuplicateContactAddressLabelError,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  InvalidContactAddressLabelError,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  InvalidContactNameError,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "./errors";
+import { ContactAddressLabelSchema } from "./schema";
+import {
+  getContactAddressLabelValidationError,
+  getContactNameValidationError,
+  isValidContactAddressLabel,
+  isValidContactName,
+  normalizeContactAddressLabelForComparison,
+  parseContactAddressLabel,
+  parseContactName,
+} from "./validation";
 
 describe("contact name validation", () => {
   it("does not report an error for an empty draft name", () => {
@@ -27,5 +43,60 @@ describe("contact name validation", () => {
 
   it("parseContactName returns a parsed name for a valid draft name", () => {
     expect(parseContactName("  Ben  ")).toBe("Ben");
+  });
+});
+
+describe("contact address label validation", () => {
+  it("does not report an error for an empty draft label", () => {
+    expect(getContactAddressLabelValidationError("")).toBeNull();
+    expect(getContactAddressLabelValidationError("   ")).toBeNull();
+    expect(isValidContactAddressLabel("")).toBe(false);
+  });
+
+  it("accepts a valid draft label without imposing a length limit", () => {
+    const longLabel = "Ethereum ".repeat(50);
+
+    expect(getContactAddressLabelValidationError("Ethereum")).toBeNull();
+    expect(isValidContactAddressLabel(longLabel)).toBe(true);
+  });
+
+  it("reports invalid characters for a non-empty invalid draft label", () => {
+    expect(getContactAddressLabelValidationError("Ethereum 💎")).toBe(
+      INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+    );
+    expect(isValidContactAddressLabel("Ethereum 💎")).toBe(false);
+  });
+
+  it("reports a duplicate within the existing labels", () => {
+    const existingLabels = [ContactAddressLabelSchema.parse("Ethereum")];
+
+    expect(getContactAddressLabelValidationError(" ethereum ", existingLabels)).toBe(
+      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+    );
+    expect(isValidContactAddressLabel("ETHEREUM", existingLabels)).toBe(false);
+  });
+
+  it("treats canonically equivalent Unicode labels as duplicates", () => {
+    const existingLabels = [ContactAddressLabelSchema.parse("Ethér")];
+
+    expect(getContactAddressLabelValidationError("Ethe\u0301r", existingLabels)).toBe(
+      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+    );
+    expect(normalizeContactAddressLabelForComparison(" Ethér ")).toBe(
+      normalizeContactAddressLabelForComparison("ETHE\u0301R"),
+    );
+  });
+
+  it("parses and normalizes a valid address label", () => {
+    expect(parseContactAddressLabel("  Ethe\u0301r  ")).toBe("Ethér");
+  });
+
+  it("throws the matching domain error for invalid and duplicate labels", () => {
+    const existingLabels = [ContactAddressLabelSchema.parse("Ethereum")];
+
+    expect(() => parseContactAddressLabel("Ethereum 💎")).toThrow(InvalidContactAddressLabelError);
+    expect(() => parseContactAddressLabel("ethereum", existingLabels)).toThrow(
+      DuplicateContactAddressLabelError,
+    );
   });
 });

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,10 +1,15 @@
 import {
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  DuplicateContactAddressLabelError,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
+  InvalidContactAddressLabelError,
   InvalidContactNameError,
+  type ContactAddressLabelValidationErrorName,
   type ContactNameValidationErrorName,
 } from "./errors";
-import { ContactNameSchema } from "./schema";
-import type { ContactName } from "./types";
+import { ContactAddressLabelSchema, ContactNameSchema } from "./schema";
+import type { ContactAddressLabel, ContactName } from "./types";
 
 export function getContactNameValidationError(
   draftName: string,
@@ -32,4 +37,53 @@ export function parseContactName(draftName: string): ContactName {
   }
 
   return parsed.data;
+}
+
+export function normalizeContactAddressLabelForComparison(label: string): string {
+  return label.trim().normalize("NFC").toLocaleLowerCase("en-US");
+}
+
+export function getContactAddressLabelValidationError(
+  draftLabel: string,
+  existingLabels: readonly ContactAddressLabel[] = [],
+): ContactAddressLabelValidationErrorName | null {
+  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+
+  if (!parsed.success) {
+    return draftLabel.trim().length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  }
+
+  const comparisonLabel = normalizeContactAddressLabelForComparison(parsed.data);
+  return existingLabels.some(
+    label => normalizeContactAddressLabelForComparison(label) === comparisonLabel,
+  )
+    ? DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
+    : null;
+}
+
+export function isValidContactAddressLabel(
+  draftLabel: string,
+  existingLabels: readonly ContactAddressLabel[] = [],
+): boolean {
+  return (
+    draftLabel.trim().length > 0 &&
+    getContactAddressLabelValidationError(draftLabel, existingLabels) === null
+  );
+}
+
+export function parseContactAddressLabel(
+  draftLabel: string,
+  existingLabels: readonly ContactAddressLabel[] = [],
+): ContactAddressLabel {
+  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+
+  if (!parsed.success) {
+    throw new InvalidContactAddressLabelError();
+  }
+
+  if (getContactAddressLabelValidationError(parsed.data, existingLabels) !== null) {
+    throw new DuplicateContactAddressLabelError();
+  }
+
+  return ContactAddressLabelSchema.parse(parsed.data.normalize("NFC"));
 }

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -14,7 +14,7 @@ Shared Contacts flow package for Desktop and Mobile.
 - Contact address detail view model (selected address payload, QR payload string, and not-found state)
 - Contact address detail quick-action scenario state (send, edit, and delete intents with delete lifecycle)
 - `useAddContactViewModel` and `useContactsFeatureIntroductionState` (app wiring injects ports)
-- Add Address session and address-entry validation state
+- Add Address session, address-entry validation state, and address-label state
 - Add Address network eligibility and final currency selection state (MAD integration uses an
   injected selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
@@ -24,15 +24,19 @@ App layers own routing, screen composition, i18n, and analytics.
 
 For Add Address, the Flow resolves ordered production network IDs from
 `eligibleAddressFamilies` and sends only those IDs to MAD. The consuming adapter filters MAD content
-by native network ID or token parent network ID. The Flow stores only the final crypto-or-token
-`currencyId` returned after asset and optional network selection. MAD is not opened when no
-production network matches the feature-flag families.
+by native network ID or token parent network ID. The Flow stores the final crypto-or-token
+`currencyId` and uses its display name as the default address label after asset and optional network
+selection. MAD is not opened when no production network matches the feature-flag families.
 
 After a successful selection, the session retains the selected contact and final currency
-identifiers and moves to `enteringAddress`. The `AddAddress` step owns its injected validation
-port, currency and token resolution, domain orchestration, input methods, asynchronous validation
-state, resolved-address storage, and stale-result protection. Consuming apps adapt coin bridges,
-domain services, token stores, and other app-owned or platform-specific integrations.
+identifiers and moves to `enteringAddress`. It also retains the selected contact's existing address
+labels so the naming step can reject a duplicate for that contact. Labels are compared after
+trimming, Unicode normalization, and case folding, while the user's casing is preserved for the
+saved value. An empty label has no validation error but cannot continue. The `AddAddress` step owns
+its injected validation port, currency and token resolution, domain orchestration, input methods,
+asynchronous validation state, resolved-address storage, and stale-result protection. Consuming
+apps adapt coin bridges, domain services, token stores, and other app-owned or platform-specific
+integrations.
 
 The native Add Address views render the shared address-entry states and temporary Name, Validation,
 and Success steps as composable Lumen bottom-sheet content. The Flow owns their order, back

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -20,14 +20,18 @@ export {
   type UseAddAddressCurrencySelectionViewModelOptions,
 } from "./useAddAddressCurrencySelectionViewModel";
 export type {
+  AddAddressContact,
+  AddAddressCurrencySelection,
   AddAddressEntryLabels,
   AddAddressEntryState,
   AddAddressFlowState,
   AddAddressFlowViewModel,
   AddAddressInputMethod,
   AddAddressInputSource,
+  AddAddressLabelState,
   AddAddressPlaceholderViewProps,
   ValidAddAddressEntryState,
+  ValidAddAddressLabelState,
 } from "./types";
 export {
   useAddAddressFlowViewModel,

--- a/features/flow/contacts/src/steps/AddAddress/model/ports.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/ports.ts
@@ -1,5 +1,5 @@
-import type { ContactAddress } from "@domain/entity-contact";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { AddAddressCurrencySelection } from "../types";
 export type {
   ContactsAddressValidationPort,
   ContactsAddressValidationResult,
@@ -8,5 +8,5 @@ export type {
 export type ContactsCurrencySelectionPort = Readonly<{
   selectCurrency(
     networkIds: readonly CryptoCurrency["id"][],
-  ): Promise<ContactAddress["currencyId"] | null>;
+  ): Promise<AddAddressCurrencySelection | null>;
 }>;

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -1,7 +1,20 @@
-import type { ContactAddress, ContactId } from "@domain/entity-contact";
+import type {
+  Contact,
+  ContactAddress,
+  ContactAddressLabel,
+  ContactAddressLabelValidationErrorName,
+  ContactId,
+} from "@domain/entity-contact";
 
 export type AddAddressInputMethod = "manual" | "paste" | "qr_code" | "ens";
 export type AddAddressInputSource = Exclude<AddAddressInputMethod, "ens">;
+
+export type AddAddressContact = Pick<Contact, "id" | "addresses">;
+
+export type AddAddressCurrencySelection = Readonly<{
+  currencyId: ContactAddress["currencyId"];
+  assetDisplayName: string;
+}>;
 
 export type AddAddressEntryState =
   | Readonly<{
@@ -36,12 +49,35 @@ export type AddAddressEntryState =
       inputMethod: AddAddressInputSource;
     }>;
 
+export type AddAddressLabelState =
+  | Readonly<{
+      status: "empty";
+      value: string;
+      label: null;
+      validationError: null;
+    }>
+  | Readonly<{
+      status: "invalid";
+      value: string;
+      label: null;
+      validationError: ContactAddressLabelValidationErrorName;
+    }>
+  | Readonly<{
+      status: "valid";
+      value: string;
+      label: ContactAddressLabel;
+      validationError: null;
+    }>;
+
 export type ValidAddAddressEntryState = Extract<AddAddressEntryState, { status: "valid" }>;
+export type ValidAddAddressLabelState = Extract<AddAddressLabelState, { status: "valid" }>;
 
 type AddAddressSession = Readonly<{
   selectedContactId: ContactId;
+  existingAddressLabels: readonly ContactAddress["label"][];
   selectedCurrencyId: ContactAddress["currencyId"];
   addressEntry: AddAddressEntryState;
+  addressLabel: AddAddressLabelState;
 }>;
 
 type ConfirmedAddAddressSession = Omit<AddAddressSession, "addressEntry"> &
@@ -49,25 +85,29 @@ type ConfirmedAddAddressSession = Omit<AddAddressSession, "addressEntry"> &
     addressEntry: ValidAddAddressEntryState;
   }>;
 
+type NamedAddAddressSession = Omit<ConfirmedAddAddressSession, "addressLabel"> &
+  Readonly<{
+    addressLabel: ValidAddAddressLabelState;
+  }>;
+
 export type AddAddressFlowState =
   | Readonly<{ status: "closed" }>
   | Readonly<{
       status: "selectingCurrency";
       selectedContactId: ContactId;
+      existingAddressLabels: readonly ContactAddress["label"][];
     }>
   | (AddAddressSession & Readonly<{ status: "enteringAddress" }>)
   | (ConfirmedAddAddressSession & Readonly<{ status: "namingAddress" }>)
-  | (ConfirmedAddAddressSession & Readonly<{ status: "reviewingAddress" }>)
-  | (ConfirmedAddAddressSession & Readonly<{ status: "success" }>);
+  | (NamedAddAddressSession & Readonly<{ status: "reviewingAddress" }>)
+  | (NamedAddAddressSession & Readonly<{ status: "success" }>);
 
 export type AddAddressFlowViewModel = Readonly<{
   state: AddAddressFlowState;
-  start: (contactId: ContactId) => void;
-  completeCurrencySelection: (
-    contactId: ContactId,
-    currencyId: ContactAddress["currencyId"],
-  ) => void;
+  start: (contact: AddAddressContact) => void;
+  completeCurrencySelection: (contactId: ContactId, selection: AddAddressCurrencySelection) => void;
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
+  updateAddressLabel: (label: string) => void;
   confirmAddress: () => void;
   continueFromName: () => void;
   continueFromReview: () => void;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.ts
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import type { ContactAddress } from "@domain/entity-contact";
 import { useContactsFeature, type ContactsFeaturePlatform } from "../../featureFlags";
 import type { ContactsCurrencySelectionPort } from "./model/ports";
 import { resolveEligibleAddressCurrencyIds } from "./model/resolveEligibleAddressCurrencyIds";
+import type { AddAddressCurrencySelection } from "./types";
 
 export type UseAddAddressCurrencySelectionViewModelOptions = Readonly<{
   platform: ContactsFeaturePlatform;
@@ -12,14 +12,14 @@ export type UseAddAddressCurrencySelectionViewModelOptions = Readonly<{
 export type AddAddressCurrencySelectionResult =
   | Readonly<{
       status: "selected";
-      currencyId: ContactAddress["currencyId"];
+      selection: AddAddressCurrencySelection;
     }>
   | Readonly<{ status: "cancelled" }>
   | Readonly<{ status: "unavailable" }>
   | Readonly<{ status: "busy" }>;
 
 export type AddAddressCurrencySelectionViewModel = Readonly<{
-  selectedCurrencyId: ContactAddress["currencyId"] | null;
+  selectedCurrency: AddAddressCurrencySelection | null;
   selectCurrency: () => Promise<AddAddressCurrencySelectionResult>;
 }>;
 
@@ -33,7 +33,7 @@ export function useAddAddressCurrencySelectionViewModel({
     [eligibleAddressFamilies],
   );
   const isSelectingRef = useRef(false);
-  const [selectedCurrencyId, setSelectedCurrencyId] = useState<ContactAddress["currencyId"] | null>(
+  const [selectedCurrency, setSelectedCurrency] = useState<AddAddressCurrencySelection | null>(
     null,
   );
   const selectCurrency = useCallback(async () => {
@@ -47,14 +47,14 @@ export function useAddAddressCurrencySelectionViewModel({
     isSelectingRef.current = true;
 
     try {
-      const currencyId = await currencySelection.selectCurrency(eligibleNetworkIds);
+      const selection = await currencySelection.selectCurrency(eligibleNetworkIds);
 
-      if (currencyId === null) {
+      if (selection === null) {
         return { status: "cancelled" } as const;
       }
 
-      setSelectedCurrencyId(currencyId);
-      return { status: "selected", currencyId } as const;
+      setSelectedCurrency(selection);
+      return { status: "selected", selection } as const;
     } catch {
       return { status: "cancelled" } as const;
     } finally {
@@ -63,7 +63,7 @@ export function useAddAddressCurrencySelectionViewModel({
   }, [currencySelection, eligibleNetworkIds]);
 
   return {
-    selectedCurrencyId,
+    selectedCurrency,
     selectCurrency,
   };
 }

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressCurrencySelectionViewModel.web.test.tsx
@@ -16,6 +16,10 @@ import {
 } from "./useAddAddressCurrencySelectionViewModel";
 
 const ETHEREUM_CURRENCY_ID = getCryptoCurrencyById("ethereum").id;
+const ETHEREUM_SELECTION = {
+  currencyId: ETHEREUM_CURRENCY_ID,
+  assetDisplayName: "Ethereum",
+} as const;
 
 function makeWrapper(contactsFeature?: Features["lwdContacts"]) {
   const resolved: Features = {
@@ -69,8 +73,12 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
     expect(selectionResult).toEqual({ status: "cancelled" });
   });
 
-  it("stores the final eligible crypto-or-token currency id selected by MAD", async () => {
-    const selectCurrency = jest.fn().mockResolvedValue("ethereum/erc20/usd-tether");
+  it("stores the final eligible crypto-or-token currency selected by MAD", async () => {
+    const selection = {
+      currencyId: "ethereum/erc20/usd-tether",
+      assetDisplayName: "Tether USD",
+    } as const;
+    const selectCurrency = jest.fn().mockResolvedValue(selection);
     const { result } = renderViewModel(
       { selectCurrency },
       {
@@ -91,15 +99,18 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
     });
 
     expect(selectCurrency).toHaveBeenCalledWith(expectedNetworkIds);
-    expect(result.current.selectedCurrencyId).toBe("ethereum/erc20/usd-tether");
+    expect(result.current.selectedCurrency).toEqual(selection);
     expect(selectionResult).toEqual({
       status: "selected",
-      currencyId: "ethereum/erc20/usd-tether",
+      selection,
     });
   });
 
-  it("preserves the selected currency id when MAD is cancelled", async () => {
-    const selectCurrency = jest.fn().mockResolvedValueOnce("ethereum").mockResolvedValueOnce(null);
+  it("preserves the selected currency when MAD is cancelled", async () => {
+    const selectCurrency = jest
+      .fn()
+      .mockResolvedValueOnce(ETHEREUM_SELECTION)
+      .mockResolvedValueOnce(null);
     const { result } = renderViewModel({ selectCurrency });
 
     await act(async () => {
@@ -107,7 +118,7 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
       expect(await result.current.selectCurrency()).toEqual({ status: "cancelled" });
     });
 
-    expect(result.current.selectedCurrencyId).toBe("ethereum");
+    expect(result.current.selectedCurrency).toEqual(ETHEREUM_SELECTION);
   });
 
   it("does not open MAD when no production network matches the eligible families", async () => {
@@ -133,10 +144,10 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
   });
 
   it("ignores concurrent selection requests while MAD is open", async () => {
-    let resolveSelection: (currencyId: typeof ETHEREUM_CURRENCY_ID) => void = () => undefined;
+    let resolveSelection: (selection: typeof ETHEREUM_SELECTION) => void = () => undefined;
     const selectCurrency = jest.fn(
       () =>
-        new Promise<typeof ETHEREUM_CURRENCY_ID>(resolve => {
+        new Promise<typeof ETHEREUM_SELECTION>(resolve => {
           resolveSelection = resolve;
         }),
     );
@@ -147,31 +158,31 @@ describe("useAddAddressCurrencySelectionViewModel", () => {
     await act(async () => {
       firstSelection = result.current.selectCurrency();
       concurrentSelectionResult = await result.current.selectCurrency();
-      resolveSelection(ETHEREUM_CURRENCY_ID);
+      resolveSelection(ETHEREUM_SELECTION);
       await firstSelection;
     });
 
     expect(selectCurrency).toHaveBeenCalledTimes(1);
     expect(concurrentSelectionResult).toEqual({ status: "busy" });
-    expect(result.current.selectedCurrencyId).toBe("ethereum");
+    expect(result.current.selectedCurrency).toEqual(ETHEREUM_SELECTION);
   });
 
   it("returns a cancelled result and allows retrying when the selection port rejects", async () => {
     const selectCurrency = jest
       .fn()
       .mockRejectedValueOnce(new Error("MAD unavailable"))
-      .mockResolvedValueOnce(ETHEREUM_CURRENCY_ID);
+      .mockResolvedValueOnce(ETHEREUM_SELECTION);
     const { result } = renderViewModel({ selectCurrency });
 
     await act(async () => {
       expect(await result.current.selectCurrency()).toEqual({ status: "cancelled" });
       expect(await result.current.selectCurrency()).toEqual({
         status: "selected",
-        currencyId: ETHEREUM_CURRENCY_ID,
+        selection: ETHEREUM_SELECTION,
       });
     });
 
     expect(selectCurrency).toHaveBeenCalledTimes(2);
-    expect(result.current.selectedCurrencyId).toBe(ETHEREUM_CURRENCY_ID);
+    expect(result.current.selectedCurrency).toEqual(ETHEREUM_SELECTION);
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -68,7 +68,7 @@ function createAddressLabelState(
   return {
     status: "valid",
     value,
-    label: parseContactAddressLabel(value),
+    label: parseContactAddressLabel(value, existingAddressLabels),
     validationError: null,
   };
 }

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -1,11 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ContactAddress, ContactId } from "@domain/entity-contact";
+import {
+  getContactAddressLabelValidationError,
+  parseContactAddressLabel,
+  type ContactAddress,
+  type ContactAddressLabel,
+  type ContactId,
+} from "@domain/entity-contact";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import type {
+  AddAddressContact,
+  AddAddressCurrencySelection,
   AddAddressEntryState,
   AddAddressFlowState,
   AddAddressFlowViewModel,
   AddAddressInputSource,
+  AddAddressLabelState,
 } from "./types";
 
 const CLOSED_ADD_ADDRESS_FLOW_STATE = {
@@ -30,6 +39,38 @@ export type UseAddAddressFlowViewModelOptions = Readonly<{
 
 function wait(delayMs: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, delayMs));
+}
+
+function createAddressLabelState(
+  value: string,
+  existingAddressLabels: readonly ContactAddressLabel[],
+): AddAddressLabelState {
+  const validationError = getContactAddressLabelValidationError(value, existingAddressLabels);
+
+  if (value.trim().length === 0) {
+    return {
+      status: "empty",
+      value,
+      label: null,
+      validationError: null,
+    };
+  }
+
+  if (validationError) {
+    return {
+      status: "invalid",
+      value,
+      label: null,
+      validationError,
+    };
+  }
+
+  return {
+    status: "valid",
+    value,
+    label: parseContactAddressLabel(value),
+    validationError: null,
+  };
 }
 
 function resolveAddressEntryState(
@@ -119,17 +160,18 @@ export function useAddAddressFlowViewModel({
     validationRequestId.current += 1;
   }, []);
   const start = useCallback(
-    (selectedContactId: ContactId) => {
+    (contact: AddAddressContact) => {
       cancelAddressValidation();
       setState({
         status: "selectingCurrency",
-        selectedContactId,
+        selectedContactId: contact.id,
+        existingAddressLabels: contact.addresses.map(address => address.label),
       });
     },
     [cancelAddressValidation],
   );
   const completeCurrencySelection = useCallback(
-    (selectedContactId: ContactId, selectedCurrencyId: ContactAddress["currencyId"]) => {
+    (selectedContactId: ContactId, selection: AddAddressCurrencySelection) => {
       setState(currentState => {
         if (
           currentState.status !== "selectingCurrency" ||
@@ -141,8 +183,13 @@ export function useAddAddressFlowViewModel({
         return {
           status: "enteringAddress",
           selectedContactId,
-          selectedCurrencyId,
+          existingAddressLabels: currentState.existingAddressLabels,
+          selectedCurrencyId: selection.currencyId,
           addressEntry: EMPTY_ADD_ADDRESS_ENTRY_STATE,
+          addressLabel: createAddressLabelState(
+            selection.assetDisplayName,
+            currentState.existingAddressLabels,
+          ),
         };
       });
     },
@@ -202,6 +249,18 @@ export function useAddAddressFlowViewModel({
     },
     [addressValidation, manualValidationDebounceMs, state],
   );
+  const updateAddressLabel = useCallback((value: string) => {
+    setState(currentState => {
+      if (currentState.status !== "namingAddress") {
+        return currentState;
+      }
+
+      return {
+        ...currentState,
+        addressLabel: createAddressLabelState(value, currentState.existingAddressLabels),
+      };
+    });
+  }, []);
   const confirmAddress = useCallback(() => {
     cancelAddressValidation();
     setState(currentState => {
@@ -215,17 +274,28 @@ export function useAddAddressFlowViewModel({
       return {
         status: "namingAddress",
         selectedContactId: currentState.selectedContactId,
+        existingAddressLabels: currentState.existingAddressLabels,
         selectedCurrencyId: currentState.selectedCurrencyId,
         addressEntry: currentState.addressEntry,
+        addressLabel: currentState.addressLabel,
       };
     });
   }, [cancelAddressValidation]);
   const continueFromName = useCallback(() => {
-    setState(currentState =>
-      currentState.status === "namingAddress"
-        ? { ...currentState, status: "reviewingAddress" }
-        : currentState,
-    );
+    setState(currentState => {
+      if (currentState.status !== "namingAddress" || currentState.addressLabel.status !== "valid") {
+        return currentState;
+      }
+
+      return {
+        status: "reviewingAddress",
+        selectedContactId: currentState.selectedContactId,
+        existingAddressLabels: currentState.existingAddressLabels,
+        selectedCurrencyId: currentState.selectedCurrencyId,
+        addressEntry: currentState.addressEntry,
+        addressLabel: currentState.addressLabel,
+      };
+    });
   }, []);
   const continueFromReview = useCallback(() => {
     setState(currentState =>
@@ -246,6 +316,7 @@ export function useAddAddressFlowViewModel({
           return {
             status: "selectingCurrency",
             selectedContactId: currentState.selectedContactId,
+            existingAddressLabels: currentState.existingAddressLabels,
           };
         case "namingAddress":
           return { ...currentState, status: "enteringAddress" };
@@ -267,6 +338,7 @@ export function useAddAddressFlowViewModel({
     start,
     completeCurrencySelection,
     updateAddress,
+    updateAddressLabel,
     confirmAddress,
     continueFromName,
     continueFromReview,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -162,14 +162,15 @@ describe("useAddAddressFlowViewModel", () => {
     const addressValidation = createValidationPort();
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
     act(() => result.current.goBack());
 
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: contactId,
+      existingAddressLabels: [],
     });
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -1,12 +1,24 @@
 import { act, renderHook } from "@testing-library/react";
-import { ContactAddressValueSchema } from "@domain/entity-contact";
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  ContactAddressValueSchema,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import { useAddAddressFlowViewModel } from "./useAddAddressFlowViewModel";
 
 const ETHEREUM_CURRENCY_ID = getCryptoCurrencyById("ethereum").id;
 const BITCOIN_CURRENCY_ID = getCryptoCurrencyById("bitcoin").id;
+const ETHEREUM_SELECTION = {
+  currencyId: ETHEREUM_CURRENCY_ID,
+  assetDisplayName: "Ethereum",
+} as const;
+const BITCOIN_SELECTION = {
+  currencyId: BITCOIN_CURRENCY_ID,
+  assetDisplayName: "Bitcoin",
+} as const;
 const RAW_ADDRESS = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
 const VALID_ADDRESS = ContactAddressValueSchema.parse(RAW_ADDRESS);
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
@@ -36,6 +48,10 @@ function createDeferredValidation() {
   return { promise, resolve };
 }
 
+function contactWithoutAddresses(contactId: ReturnType<typeof mockContact>["id"]) {
+  return { id: contactId, addresses: [] };
+}
+
 describe("useAddAddressFlowViewModel", () => {
   it("should be closed initially", () => {
     const { result } = renderHook(() => useAddAddressFlowViewModel());
@@ -47,11 +63,12 @@ describe("useAddAddressFlowViewModel", () => {
     const contactId = mockMeContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(contactId));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
 
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: contactId,
+      existingAddressLabels: [],
     });
   });
 
@@ -60,12 +77,13 @@ describe("useAddAddressFlowViewModel", () => {
     const nextContactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(firstContactId));
-    act(() => result.current.start(nextContactId));
+    act(() => result.current.start(contactWithoutAddresses(firstContactId)));
+    act(() => result.current.start(contactWithoutAddresses(nextContactId)));
 
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: nextContactId,
+      existingAddressLabels: [],
     });
   });
 
@@ -73,18 +91,25 @@ describe("useAddAddressFlowViewModel", () => {
     const contactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     expect(result.current.state).toEqual({
       status: "enteringAddress",
       selectedContactId: contactId,
+      existingAddressLabels: [],
       selectedCurrencyId: ETHEREUM_CURRENCY_ID,
       addressEntry: {
         status: "empty",
         value: "",
         resolvedAddress: null,
         inputMethod: null,
+      },
+      addressLabel: {
+        status: "valid",
+        value: "Ethereum",
+        label: "Ethereum",
+        validationError: null,
       },
     });
   });
@@ -94,13 +119,14 @@ describe("useAddAddressFlowViewModel", () => {
     const nextContactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(firstContactId));
-    act(() => result.current.start(nextContactId));
-    act(() => result.current.completeCurrencySelection(firstContactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(firstContactId)));
+    act(() => result.current.start(contactWithoutAddresses(nextContactId)));
+    act(() => result.current.completeCurrencySelection(firstContactId, ETHEREUM_SELECTION));
 
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: nextContactId,
+      existingAddressLabels: [],
     });
   });
 
@@ -109,13 +135,14 @@ describe("useAddAddressFlowViewModel", () => {
     const nextContactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(firstContactId));
-    act(() => result.current.completeCurrencySelection(firstContactId, ETHEREUM_CURRENCY_ID));
-    act(() => result.current.start(nextContactId));
+    act(() => result.current.start(contactWithoutAddresses(firstContactId)));
+    act(() => result.current.completeCurrencySelection(firstContactId, ETHEREUM_SELECTION));
+    act(() => result.current.start(contactWithoutAddresses(nextContactId)));
 
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: nextContactId,
+      existingAddressLabels: [],
     });
   });
 
@@ -123,9 +150,9 @@ describe("useAddAddressFlowViewModel", () => {
     const contactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(contactId));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
     act(() => result.current.close());
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     expect(result.current.state).toEqual({ status: "closed" });
   });
@@ -149,7 +176,7 @@ describe("useAddAddressFlowViewModel", () => {
   it("should remain closed when closed repeatedly", () => {
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(mockContact().id));
+    act(() => result.current.start(mockContact()));
     act(() => result.current.close());
     act(() => result.current.close());
 
@@ -163,8 +190,8 @@ describe("useAddAddressFlowViewModel", () => {
       const addressValidation = createValidationPort();
       const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-      act(() => result.current.start(contactId));
-      act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+      act(() => result.current.start(contactWithoutAddresses(contactId)));
+      act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
       await act(() => result.current.updateAddress(RAW_ADDRESS, inputMethod));
 
       expect(addressValidation.validateAddress).toHaveBeenCalledWith({
@@ -192,8 +219,8 @@ describe("useAddAddressFlowViewModel", () => {
     });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("ledger.eth", "manual"));
 
     expect(result.current.state).toMatchObject({
@@ -216,8 +243,8 @@ describe("useAddAddressFlowViewModel", () => {
     });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("ledger.eth", "manual"));
     act(() => result.current.confirmAddress());
 
@@ -236,13 +263,137 @@ describe("useAddAddressFlowViewModel", () => {
     expect(result.current.state.status).toBe("success");
   });
 
+  it("should allow a custom address label before review", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.updateAddressLabel("Exchange"));
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressLabel: {
+        status: "valid",
+        value: "Exchange",
+        label: "Exchange",
+        validationError: null,
+      },
+    });
+
+    act(() => result.current.continueFromName());
+    expect(result.current.state.status).toBe("reviewingAddress");
+  });
+
+  it("should expose invalid characters and prevent review", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.updateAddressLabel("Ethereum 💎"));
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum 💎",
+        label: null,
+        validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      },
+    });
+
+    act(() => result.current.continueFromName());
+    expect(result.current.state.status).toBe("namingAddress");
+  });
+
+  it("should keep an empty draft free of errors and prevent review", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.updateAddressLabel("   "));
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressLabel: {
+        status: "empty",
+        value: "   ",
+        label: null,
+        validationError: null,
+      },
+    });
+
+    act(() => result.current.continueFromName());
+    expect(result.current.state.status).toBe("namingAddress");
+  });
+
+  it("should reject an address label already used by the selected contact", async () => {
+    const contact = mockContact({
+      addresses: [mockContactAddress({ label: "Ethereum" })],
+    });
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum",
+        label: null,
+        validationError: DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      },
+    });
+  });
+
+  it("should reset a custom address label after the selected asset changes", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.updateAddressLabel("Exchange"));
+    act(() => result.current.goBack());
+    act(() => result.current.goBack());
+    act(() => result.current.completeCurrencySelection(contact.id, BITCOIN_SELECTION));
+
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      selectedCurrencyId: BITCOIN_CURRENCY_ID,
+      addressLabel: {
+        status: "valid",
+        value: "Bitcoin",
+        label: "Bitcoin",
+        validationError: null,
+      },
+    });
+  });
+
   it("should not confirm an invalid address", async () => {
     const contactId = mockContact().id;
     const addressValidation = createValidationPort({ status: "invalid_format" });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("invalid", "manual"));
     act(() => result.current.confirmAddress());
 
@@ -254,8 +405,8 @@ describe("useAddAddressFlowViewModel", () => {
     const addressValidation = createValidationPort();
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
     act(() => result.current.confirmAddress());
     act(() => result.current.continueFromName());
@@ -270,6 +421,7 @@ describe("useAddAddressFlowViewModel", () => {
     expect(result.current.state).toEqual({
       status: "selectingCurrency",
       selectedContactId: contactId,
+      existingAddressLabels: [],
     });
 
     act(() => result.current.goBack());
@@ -284,8 +436,8 @@ describe("useAddAddressFlowViewModel", () => {
     const addressValidation = createValidationPort({ status: error });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("invalid", "manual"));
 
     expect(result.current.state).toMatchObject({
@@ -308,8 +460,8 @@ describe("useAddAddressFlowViewModel", () => {
     });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("ledger.eth", "manual"));
 
     expect(result.current.state).toMatchObject({
@@ -328,8 +480,8 @@ describe("useAddAddressFlowViewModel", () => {
     const contactId = mockContact().id;
     const { result } = renderHook(() => useAddAddressFlowViewModel());
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
 
     expect(result.current.state).toMatchObject({
@@ -349,8 +501,8 @@ describe("useAddAddressFlowViewModel", () => {
     addressValidation.validateAddress.mockRejectedValue(new Error("validation unavailable"));
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
 
     expect(result.current.state).toMatchObject({
@@ -366,8 +518,8 @@ describe("useAddAddressFlowViewModel", () => {
     addressValidation.validateAddress.mockReturnValue(deferredValidation.promise);
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     let update = Promise.resolve();
     act(() => {
@@ -405,8 +557,8 @@ describe("useAddAddressFlowViewModel", () => {
         }),
       );
 
-      act(() => result.current.start(contactId));
-      act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+      act(() => result.current.start(contactWithoutAddresses(contactId)));
+      act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
       let firstUpdate = Promise.resolve();
       let secondUpdate = Promise.resolve();
@@ -446,8 +598,8 @@ describe("useAddAddressFlowViewModel", () => {
       }),
     );
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "paste"));
 
     expect(addressValidation.validateAddress).toHaveBeenCalledTimes(1);
@@ -458,8 +610,8 @@ describe("useAddAddressFlowViewModel", () => {
     const addressValidation = createValidationPort();
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress("   ", "paste"));
 
     expect(addressValidation.validateAddress).not.toHaveBeenCalled();
@@ -484,8 +636,8 @@ describe("useAddAddressFlowViewModel", () => {
       .mockReturnValueOnce(secondValidation.promise);
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     let firstUpdate = Promise.resolve();
     let secondUpdate = Promise.resolve();
@@ -524,15 +676,15 @@ describe("useAddAddressFlowViewModel", () => {
     addressValidation.validateAddress.mockReturnValue(deferredValidation.promise);
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     let update = Promise.resolve();
     act(() => {
       update = result.current.updateAddress(RAW_ADDRESS, "manual");
     });
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, BITCOIN_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, BITCOIN_SELECTION));
     await act(async () => {
       deferredValidation.resolve({
         status: "valid",
@@ -557,14 +709,14 @@ describe("useAddAddressFlowViewModel", () => {
     addressValidation.validateAddress.mockReturnValue(deferredValidation.promise);
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     let update = Promise.resolve();
     act(() => {
       update = result.current.updateAddress(RAW_ADDRESS, "manual");
     });
-    act(() => result.current.completeCurrencySelection(staleContactId, BITCOIN_CURRENCY_ID));
+    act(() => result.current.completeCurrencySelection(staleContactId, BITCOIN_SELECTION));
     await act(async () => {
       deferredValidation.resolve({
         status: "valid",
@@ -591,8 +743,8 @@ describe("useAddAddressFlowViewModel", () => {
     addressValidation.validateAddress.mockReturnValue(deferredValidation.promise);
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
-    act(() => result.current.start(contactId));
-    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_CURRENCY_ID));
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
 
     let update = Promise.resolve();
     act(() => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Shared Add Address label lifecycle and validation
  - Desktop and Mobile asset-selection adapters
  - Per-contact label uniqueness, including case and Unicode normalization

### 📝 Description

The shared Add Address flow needed to retain and validate the address label before its mobile UI is introduced.

This stacked PR adds domain label validation and shared flow state. It initializes the label from the selected asset display name, supports custom values, blocks empty or invalid labels from advancing, resets the default after an asset change, and rejects duplicate labels within the selected contact. Desktop and Mobile adapters now return the asset display name together with the selected currency ID.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33918](https://ledgerhq.atlassian.net/browse/LIVE-33918)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33918]: https://ledgerhq.atlassian.net/browse/LIVE-33918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ