### PR TITLE
test(e2e): derive delegate team owner from currency (QAA-1438)

### DIFF
--- a/e2e/desktop/tests/specs/delegate.spec.ts
+++ b/e2e/desktop/tests/specs/delegate.spec.ts
@@ -1,5 +1,5 @@
 import { test } from "tests/fixtures/common";
-import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { delegateTeamOwner } from "@ledgerhq/live-e2e-shared/data/delegateTeamOwner";
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
@@ -89,7 +89,7 @@ const liveApps = [
 for (const account of e2eDelegationAccounts) {
   test.describe("Delegate", () => {
     test.use({
-      teamOwner: Team.EARN,
+      teamOwner: delegateTeamOwner(account.delegate.account.currency.id),
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: account.delegate.account.currency.speculosApp,
       cliCommands: [liveDataCommand(account.delegate.account)],
@@ -152,7 +152,7 @@ test.describe("Delegate without Broadcasting", () => {
   const account = new Delegate(Account.ADA_1, "0.01", "Ledger by Figment 3");
   setupEnv(true);
   test.use({
-    teamOwner: Team.EARN,
+    teamOwner: delegateTeamOwner(account.account.currency.id),
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.account.currency.speculosApp,
     cliCommands: [liveDataCommand(account.account)],
@@ -190,7 +190,7 @@ test.describe("Delegate without Broadcasting", () => {
   const account = new Delegate(Account.MULTIVERS_X_1, "1", "Figment");
   setupEnv(true);
   test.use({
-    teamOwner: Team.EARN,
+    teamOwner: delegateTeamOwner(account.account.currency.id),
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.account.currency.speculosApp,
     cliCommands: [liveDataCommand(account.account)],
@@ -235,7 +235,7 @@ test.describe("Delegate without Broadcasting", () => {
   const account = new Delegate(Account.SOL_2, "1", "Ledger by Figment");
   setupEnv(true);
   test.use({
-    teamOwner: Team.EARN,
+    teamOwner: delegateTeamOwner(account.account.currency.id),
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.account.currency.speculosApp,
     cliCommands: [liveDataCommand(account.account)],
@@ -277,7 +277,7 @@ test.describe("Delegate without Broadcasting", () => {
 test.describe("e2e delegation - Celo", () => {
   const account = new Delegate(Account.CELO_1, "0.001", "N/A");
   test.use({
-    teamOwner: Team.EARN,
+    teamOwner: delegateTeamOwner(account.account.currency.id),
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: account.account.currency.speculosApp,
     cliCommands: [liveDataCommand(account.account)],
@@ -350,7 +350,7 @@ test.describe("e2e delegation - Celo", () => {
 for (const validator of validators) {
   test.describe("Select a validator", () => {
     test.use({
-      teamOwner: Team.EARN,
+      teamOwner: delegateTeamOwner(validator.delegate.account.currency.id),
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: validator.delegate.account.currency.speculosApp,
       cliCommands: [liveDataCommand(validator.delegate.account)],
@@ -403,7 +403,7 @@ for (const validator of validators) {
 test.describe("Staking flow from different entry point", () => {
   const delegateAccount = new Delegate(Account.ATOM_1, "0.001", "Ledger by Bitwise");
   test.use({
-    teamOwner: Team.EARN,
+    teamOwner: delegateTeamOwner(delegateAccount.account.currency.id),
     userdata: "skip-onboarding-with-last-seen-device",
     speculosApp: delegateAccount.account.currency.speculosApp,
     cliCommands: [liveDataCommand(delegateAccount.account)],
@@ -447,7 +447,7 @@ test.describe("Staking flow from different entry point", () => {
 for (const currency of liveApps) {
   test.describe("LiveApp delegate", () => {
     test.use({
-      teamOwner: Team.EARN,
+      teamOwner: delegateTeamOwner(currency.delegate.account.currency.id),
       userdata: "skip-onboarding-with-last-seen-device",
       speculosApp: currency.delegate.account.currency.speculosApp,
       cliCommands: [liveDataCommand(currency.delegate.account)],

--- a/e2e/mobile/specs/delegate/delegate.ts
+++ b/e2e/mobile/specs/delegate/delegate.ts
@@ -1,11 +1,9 @@
 import { setEnv } from "@shared/env";
 import { DelegateType } from "@ledgerhq/live-e2e-shared/models/Delegate";
-import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { delegateTeamOwner } from "@ledgerhq/live-e2e-shared/data/delegateTeamOwner";
 import { verifyAppValidationStakeInfo, verifyStakeOperationDetailsInfo } from "../../models/stake";
 import { getCurrencyManagerApp } from "../../models/currencies";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
-
-const BST_DELEGATE_CURRENCIES = new Set(["cardano", "near"]);
 
 const beforeAllFunction = async (delegation: DelegateType) => {
   await app.init({
@@ -17,9 +15,7 @@ const beforeAllFunction = async (delegation: DelegateType) => {
 };
 
 export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
-  setTeamOwner(
-    BST_DELEGATE_CURRENCIES.has(delegation.account.currency.id) ? Team.BST : Team.COIN_INTEGRATION,
-  );
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Delegate", () => {
@@ -68,7 +64,7 @@ export function runDelegateTest(delegation: DelegateType, tmsLinks: string[], ta
 }
 
 export function runSuiDelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
-  setTeamOwner(Team.COIN_INTEGRATION);
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Delegate", () => {
@@ -99,7 +95,7 @@ export function runSuiDelegateTest(delegation: DelegateType, tmsLinks: string[],
 }
 
 export function runSuiUndelegateTest(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
-  setTeamOwner(Team.COIN_INTEGRATION);
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe("Undelegate", () => {
@@ -127,7 +123,7 @@ export function runSuiUndelegateTest(delegation: DelegateType, tmsLinks: string[
 }
 
 export function runLockCelo(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
-  setTeamOwner(Team.COIN_INTEGRATION);
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe(`Lock flow on CELO`, () => {
@@ -159,7 +155,7 @@ export function runLockCelo(delegation: DelegateType, tmsLinks: string[], tags: 
 }
 
 export function runVoteCelo(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
-  setTeamOwner(Team.COIN_INTEGRATION);
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   tags.forEach(tag => $Tag(tag));
   describe(`Vote flow on CELO`, () => {
@@ -196,7 +192,7 @@ export function runVoteCelo(delegation: DelegateType, tmsLinks: string[], tags: 
 
 export function runDelegateTezos(delegation: DelegateType, tmsLinks: string[], tags: string[]) {
   setEnv("DISABLE_TRANSACTION_BROADCAST", true);
-  setTeamOwner(Team.BST);
+  setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
   tags.forEach(tag => $Tag(tag));
   tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
   describe(`Delegate flow on TEZOS`, () => {

--- a/e2e/mobile/specs/delegate/delegateSEI.spec.ts
+++ b/e2e/mobile/specs/delegate/delegateSEI.spec.ts
@@ -1,6 +1,6 @@
 import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
 import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
-import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { delegateTeamOwner } from "@ledgerhq/live-e2e-shared/data/delegateTeamOwner";
 import { Delegate } from "@ledgerhq/live-e2e-shared/models/Delegate";
 import { setEnv } from "@shared/env";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
@@ -14,7 +14,7 @@ const delegation = new Delegate(Account.SEI_EVM_1, DELEGATION_AMOUNT, "first-ava
 const tmsLinks: string[] = ["B2CQA-5740"];
 const tags = ["@NanoSP", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@sei_evm", "@family-evm"];
 
-setTeamOwner(Team.COIN_INTEGRATION);
+setTeamOwner(delegateTeamOwner(delegation.account.currency.id));
 tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
 tags.forEach(tag => $Tag(tag));
 describe("Delegate", () => {

--- a/libs/live-e2e-shared/src/data/delegateTeamOwner.ts
+++ b/libs/live-e2e-shared/src/data/delegateTeamOwner.ts
@@ -1,0 +1,14 @@
+import { Currency } from "../enum/Currency";
+import { Team } from "../enum/Team";
+
+const BST_DELEGATE_CURRENCIES = new Set([
+  Currency.ADA.id,
+  Currency.CELO.id,
+  Currency.NEAR.id,
+  Currency.SUI.id,
+  Currency.XTZ.id,
+]);
+
+export function delegateTeamOwner(currencyId: string): Team {
+  return BST_DELEGATE_CURRENCIES.has(currencyId) ? Team.BST : Team.COIN_INTEGRATION;
+}


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable: the change touches only E2E test-support code. `libs/live-e2e-shared` is a private package and recent commits touching it (e.g. `43ac2b39`, `7170b398`) carry no changeset. The `Changeset Validation` job only validates the format of existing changeset files and does not compare against the base branch._
- [ ] **Covered by automatic tests.** _This changes Allure **reporting metadata** only — there is no runtime behaviour to assert. Verified instead by: `nx lint,typecheck` clean on both e2e projects, `oxfmt --check` clean, `playwright test --list` confirming all 19 delegate tests still register with unchanged titles, and an ad-hoc assertion run of all 19 ticket rows plus all 13 mobile flows through the real `Account`/`Currency` objects (0 failures)._
- [x] **Impact of the changes:**
  - Allure report `owner` / `parentSuite` / `feature` labels for the delegate & staking E2E tests (Desktop) and `owner` / `parentSuite` (Mobile).
  - No change to test titles, tags, TMS/Xray annotations, test bodies, or execution behaviour — so no impact on which tests run or on pass/fail outcomes.
  - Report filtering by team is what changes: delegate failures now route to `Coin-integration` / `BST` instead of `Earn`.

### 📝 Description

**Problem.** 19 LWD delegate/staking E2E tests were attributed to the `Earn` team in the Allure report, but Earn does not own them, so report filtering by owner sent failures to the wrong people. QAA-1438 lists the 19 tests and their correct team.

**Observation.** The ticket's table is a purely **per-coin** rule with no per-flow exceptions:

- `BST` → Cardano, Celo, NEAR, Sui (and Tezos, see below)
- `Coin-integration` → Cosmos, Injective, Osmosis, MultiversX, Solana, Polkadot, Tron

Mobile already encoded this same rule as a currency `Set`, but its copy had drifted to only `{cardano, near}` — so mobile's **Sui** and **Celo** delegate flows were reporting `Coin-integration` when they should have been `BST`. Rather than duplicate the rule a third time, this PR promotes it to a single shared definition consumed by both platforms, so the two cannot drift again.

**Solution.** New `libs/live-e2e-shared/src/data/delegateTeamOwner.ts`:

```ts
const BST_DELEGATE_CURRENCIES = new Set([
  Currency.ADA.id,
  Currency.CELO.id,
  Currency.NEAR.id,
  Currency.SUI.id,
  Currency.XTZ.id,
]);

export function delegateTeamOwner(currencyId: string): Team {
  return BST_DELEGATE_CURRENCIES.has(currencyId) ? Team.BST : Team.COIN_INTEGRATION;
}
```

- **Desktop** — `delegate.spec.ts`: all 8 `teamOwner: Team.EARN` sites now call `delegateTeamOwner(<currencyId>)`. The three parametrized loops already declare `test.describe` inside the `for`, so `test.use()` was already per-test-case and no restructuring was needed. `Team.EARN` no longer appears in the file.
- **Mobile** — `delegate.ts` / `delegateSEI.spec.ts`: the stale local `Set` is removed and all 7 `setTeamOwner` sites route through the helper. No hardcoded `Team.*` literal remains in the mobile delegate suite.

**Note for reviewers — this extends slightly beyond the `[LWD]` ticket title.** The mobile side is included deliberately, agreed with the ticket assignee:

| Mobile flow | Before | After | Why |
| --- | --- | --- | --- |
| `runSuiDelegateTest` | `Coin-integration` | **`BST`** | Fixes the drift; matches ticket row "[Sui] Delegate" |
| `runLockCelo` | `Coin-integration` | **`BST`** | Matches ticket row "Celo Delegation" |
| `runVoteCelo` | `Coin-integration` | **`BST`** | Matches ticket row "Celo Vote" |
| `runSuiUndelegateTest` | `Coin-integration` | **`BST`** | Not in the ticket; moved so ownership consistently follows the coin |
| `runDelegateTezos` | `BST` | `BST` (unchanged) | Routed through the helper; `Currency.XTZ.id` added to the set so Tezos is **preserved** rather than silently flipped to `Coin-integration` |
| `delegateSEI.spec` | `Coin-integration` | `Coin-integration` (unchanged) | `sei_evm` falls through the set; preserved |
| `runDelegateTest` (ADA/ATOM/EGLD/INJ/NEAR/OSMO/SOL) | — | unchanged | Behaviour-identical; only the duplicated `Set` was removed |

Two things intentionally left alone: desktop `undelegate.spec.ts` stays `Team.EARN` (not in the ticket), and the `B2CQA-3289` occurrence in `buySell.spec.ts` stays `Team.BUY_AND_SELL` — the ticket identifies rows by test name, and that test's current team is not `Earn`.

`Team.EARN` remains legitimately in use by `borrow.spec.ts`, `earn.v2.spec.ts`, `undelegate.spec.ts` and mobile `earnV2.ts`, so the enum member is kept.

### ❓ Context

- **JIRA or GitHub link**: [QAA-1438](https://ledgerhq.atlassian.net/browse/QAA-1438)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[QAA-1438]: https://ledgerhq.atlassian.net/browse/QAA-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ