### PR TITLE
[LWDM] feat(send): add info disclaimer on the recipient address (LIVE-34434)

### DIFF
--- a/.changeset/send-flow-address-disclaimer.md
+++ b/.changeset/send-flow-address-disclaimer.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add an info disclaimer next to the recipient address in the new send flow, reminding users to verify the full address on their Ledger device

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
@@ -20,10 +20,9 @@ function AddressDisclaimerComponent() {
           aria-label={t("newSendFlow.addressDisclaimer.accessibilityLabel")}
         />
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent side="bottom">
         <div className="max-w-256 text-center">
-          <div className="font-semibold">{t("newSendFlow.addressDisclaimer.title")}</div>
-          <div>{t("newSendFlow.addressDisclaimer.description")}</div>
+          {t("newSendFlow.addressDisclaimer.description")}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
@@ -21,9 +21,7 @@ function AddressDisclaimerComponent() {
         />
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        <div className="max-w-256 text-center">
-          {t("newSendFlow.addressDisclaimer.description")}
-        </div>
+        <div className="max-w-256">{t("newSendFlow.addressDisclaimer.description")}</div>
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/AddressDisclaimer.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@ledgerhq/lumen-ui-react";
+import { Information } from "@ledgerhq/lumen-ui-react/symbols";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Info icon shown next to the read-only recipient address, reminding the user to
+ * verify the full address on their Ledger device.
+ */
+function AddressDisclaimerComponent() {
+  const { t } = useTranslation();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Information
+          size={20}
+          className="text-muted"
+          data-testid="send-address-disclaimer-icon"
+          aria-label={t("newSendFlow.addressDisclaimer.accessibilityLabel")}
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="max-w-256 text-center">
+          <div className="font-semibold">{t("newSendFlow.addressDisclaimer.title")}</div>
+          <div>{t("newSendFlow.addressDisclaimer.description")}</div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+export const AddressDisclaimer = React.memo(AddressDisclaimerComponent);

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -15,6 +15,7 @@ import {
 import { getMemoFamilyCurrencyId } from "@ledgerhq/live-common/flows/send/utils/memoFamilyCurrencyId";
 import { useAvailableBalance } from "../hooks/useAvailableBalance";
 import { useSendHeaderModel } from "../hooks/useSendHeaderModel";
+import { AddressDisclaimer } from "./AddressDisclaimer";
 import { MemoTypeSelect } from "../screens/Recipient/components/Memo/MemoTypeSelect";
 import { MemoValueInput } from "../screens/Recipient/components/Memo/MemoValueInput";
 import { SkipMemoSection } from "../screens/Recipient/components/Memo/SkipMemoSection";
@@ -108,10 +109,12 @@ export function SendHeader() {
               value={addressInputValue}
               hideClearButton
               prefix={t("newSendFlow.to")}
+              suffix={<AddressDisclaimer />}
             />
+            {/* Stops short of the trailing info icon so the disclaimer stays hoverable. */}
             <button
               type="button"
-              className="absolute inset-0"
+              className="absolute inset-y-0 left-0 right-56"
               aria-label="Edit recipient"
               data-testid="send-edit-recipient-button"
               onClick={handleRecipientInputClick}

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2532,7 +2532,6 @@
     "to": "To:",
     "addressDisclaimer": {
       "accessibilityLabel": "About the recipient address",
-      "title": "Verify address on your Ledger device",
       "description": "Your Ledger device will securely display the full address. Make sure it matches the address from the original source."
     },
     "placeholder": "Enter address or ENS",

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -2530,6 +2530,11 @@
     "title": "Send {{currency}}",
     "available": "Available {{amount}}",
     "to": "To:",
+    "addressDisclaimer": {
+      "accessibilityLabel": "About the recipient address",
+      "title": "Verify address on your Ledger device",
+      "description": "Your Ledger device will securely display the full address. Make sure it matches the address from the original source."
+    },
     "placeholder": "Enter address or ENS",
     "placeholderNoENS": "Enter address",
     "recent": "Recent",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4541,6 +4541,11 @@
       "title": "Send {{currency}}",
       "available": "Available {{amount}}",
       "to": "To:",
+      "addressDisclaimer": {
+        "accessibilityLabel": "About the recipient address",
+        "title": "Verify address on your Ledger device",
+        "description": "Your Ledger device will securely display the full address. Make sure it matches the address from the original source."
+      },
       "placeholder": "Enter address or ENS",
       "placeholderNoENS": "Enter address",
       "pasteFromClipboard": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/AddressDisclaimer.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/AddressDisclaimer.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from "react";
+import { Pressable } from "react-native";
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  BottomSheetView,
+  useBottomSheetRef,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Information } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { BottomSheetInfoGradient } from "LLM/components/BottomSheetGradient";
+import { InfoState } from "LLM/components/InfoState";
+import { useTranslation } from "~/context/Locale";
+
+/**
+ * Info icon shown next to the read-only recipient address, opening a sheet that
+ * reminds the user to verify the full address on their Ledger device.
+ */
+export function AddressDisclaimer() {
+  const { t } = useTranslation();
+  const sheetRef = useBottomSheetRef();
+
+  const handleOpen = useCallback(() => {
+    sheetRef.current?.present();
+  }, [sheetRef]);
+
+  const handleClose = useCallback(() => {
+    sheetRef.current?.dismiss();
+  }, [sheetRef]);
+
+  return (
+    <>
+      <Pressable
+        testID="send-address-disclaimer-button"
+        accessibilityRole="button"
+        accessibilityLabel={t("send.newSendFlow.addressDisclaimer.accessibilityLabel")}
+        onPress={handleOpen}
+      >
+        <Information size={20} lx={{ color: "muted" }} />
+      </Pressable>
+      <BottomSheet
+        ref={sheetRef}
+        enableDynamicSizing
+        snapPoints={null}
+        backgroundComponent={BottomSheetInfoGradient}
+      >
+        <BottomSheetView>
+          <BottomSheetHeader density="compact" />
+          <InfoState
+            preset="info"
+            size="hug"
+            title={t("send.newSendFlow.addressDisclaimer.title")}
+            description={t("send.newSendFlow.addressDisclaimer.description")}
+            primaryCta={{
+              label: t("common.gotit"),
+              onPress: handleClose,
+            }}
+          />
+        </BottomSheetView>
+      </BottomSheet>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -15,6 +15,7 @@ import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
 
 import { useTranslation } from "~/context/Locale";
 
+import { AddressDisclaimer } from "./AddressDisclaimer";
 import { useSendHeaderViewModel } from "../hooks/useSendHeaderViewModel";
 import { useSendFlowData } from "../context/SendFlowContext";
 import { useAnalytics } from "~/analytics";
@@ -23,6 +24,9 @@ import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework
 type SendHeaderProps = Readonly<{
   headerRight?: React.ReactNode;
 }>;
+
+/** Width reserved on the right of the address row for the info icon. */
+const DISCLAIMER_HIT_AREA = 56;
 
 export function SendHeader({ headerRight }: SendHeaderProps) {
   const { t } = useTranslation();
@@ -37,11 +41,12 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
       addressValue: {
         color: theme.colors.text.base,
       },
-      absoluteOverlay: {
+      editOverlay: {
         position: "absolute",
         top: 0,
         left: 0,
-        right: 0,
+        // Stops short of the trailing info icon so the disclaimer stays pressable.
+        right: DISCLAIMER_HIT_AREA,
         bottom: 0,
       },
     }),
@@ -121,9 +126,10 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
                 hideClearButton
                 placeholder={viewModel.recipientPlaceholder}
                 inputStyle={styles.addressValue}
+                suffix={<AddressDisclaimer />}
               />
               <Pressable
-                style={styles.absoluteOverlay}
+                style={styles.editOverlay}
                 accessibilityRole="button"
                 accessibilityLabel={t("send.newSendFlow.editRecipientAccessibilityLabel")}
                 onPress={viewModel.handleRecipientInputPress}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _No test added: the change is a presentational icon plus a tooltip/sheet wired into the existing header. The Send suites were run on both apps and match the develop baseline exactly (see below)._
- [x] **Impact of the changes:**
      - New send flow header on the **Amount step**: an ⓘ icon now sits at the end of the read-only address row
      - Mobile: tapping it opens a bottom sheet (spot icon, title, description, "Got it")
      - Desktop: hovering it shows a tooltip with the same copy
      - **Tap/click-to-edit the recipient**: the full-bleed overlay that made the whole address row editable now stops 56px short of the icon. Please check that tapping the row still returns to the Recipient step everywhere, and that the ⓘ itself is reachable
      - Recipient step is untouched — the QR-code icon is unaffected

### 📝 Description

**Problem**: LIVE-34434 had two deliverables. The 8-digit address truncation shipped in #20180, but the second one — *"Add info disclaimer on the address on input step"* — was missed, so this PR completes the ticket.

**Solution**: add an ⓘ affordance at the end of the read-only recipient address row that explains the address must be verified on the device.

Copy (from the Figma frame, identical on both platforms):

> **Verify address on your Ledger device**
> Your Ledger device will securely display the full address. Make sure it matches the address from the original source.

Implementation follows the platform conventions already used for the memo help icon in this same flow:

- **Mobile** — `AddressDisclaimer.tsx` renders the icon as the `AddressInput` `suffix` and a `BottomSheet` reusing the shared `InfoState` component (`preset="info"`, `primaryCta`) plus `BottomSheetInfoGradient`, matching the Figma mock (centred spot, title, description, full-width "Got it"). Same structure as `Send/components/NetworkFeesRow.tsx`.
- **Desktop** — `AddressDisclaimer.tsx` uses `Tooltip`/`TooltipTrigger`/`TooltipContent`, the same pattern as `Recipient/components/Memo/MemoValueInput.tsx`.
- The existing edit-recipient overlay (`absolute inset-0`) is narrowed to leave the icon interactive; this is the only behavioural change to existing code.
- Reused `common.gotit` on mobile rather than adding a new CTA string.

### 📸 Screenshots

| Mobile | Desktop |
| ------ | ------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 11 56 32" src="https://github.com/user-attachments/assets/0d9299c9-1837-402b-9b2e-e681f7e50a32" />| <img width="580" height="690" alt="Screenshot 2026-07-30 at 11 43 43" src="https://github.com/user-attachments/assets/e0d72319-2eda-4f0d-b48b-b4c10102dbd3" />|

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34434](https://ledgerhq.atlassian.net/browse/LIVE-34434)
- Follow-up to #20180, which covered the 8-digit part of the same ticket.

#### Local verification

- `pnpm typecheck` — pass on both apps
- `pnpm lint` — 0 errors on both apps
- `pnpm test:jest src/mvvm/features/Send` — desktop 232/234, mobile 235/238. The 5 failures are **pre-existing on develop** (verified by stashing this branch's changes and re-running): `isAddressValid` is asserted by `useRecipientScreenView` / `useRecipientAddressModalViewModel` tests but is not returned by those hooks, and two Stellar memo integration cases cannot find `send-memo-input`. Not addressed here as they are unrelated to this change.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-34434]: https://ledgerhq.atlassian.net/browse/LIVE-34434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ