### PR TITLE
[LWM] feat(contacts): render address label input (LIVE-33920)

### DIFF
--- a/.changeset/nice-labels-render.md
+++ b/.changeset/nice-labels-render.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Render the Contacts address name input in the Mobile add-address flow

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10206,8 +10206,15 @@
       "validationUnavailable": "Address validation is temporarily unavailable",
       "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing."
     },
+    "addAddressName": {
+      "title": "Name address",
+      "inputLabel": "Address name",
+      "namingDisclaimer": "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
+      "continueToReview": "Continue to review",
+      "invalidLabel": "Special characters are not allowed.",
+      "duplicateLabel": "This address name is already used for this contact."
+    },
     "addAddressFlow": {
-      "name": "Name",
       "review": "Validation",
       "success": "Success"
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -645,7 +645,7 @@ describe("Contacts integration", () => {
     });
   });
 
-  it("should keep one Add Address drawer through QR, placeholders and success", async () => {
+  it("should keep one Add Address drawer through QR, naming and success", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: contactDetailNavigationState,
       overrideInitialState: withContactsPageReadyState({
@@ -682,9 +682,21 @@ describe("Contacts integration", () => {
     });
 
     await user.press(screen.getByTestId("contacts-add-address-confirm"));
-    expect(await screen.findByTestId("contacts-add-address-name-screen-continue")).toBeVisible();
+    const addressNameInput = await screen.findByTestId("contacts-add-address-name-input");
+    expect(addressNameInput).toHaveProp("value", mockEthCryptoCurrency.name);
+    expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Name address");
+    expect(
+      screen.getByText(
+        "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
 
-    await user.press(screen.getByTestId("contacts-add-address-name-screen-continue"));
+    await user.clear(addressNameInput);
+    await user.type(addressNameInput, "Exchange");
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveProp("value", "Exchange");
+
+    await user.press(screen.getByTestId("contacts-add-address-name-continue"));
     expect(await screen.findByTestId("contacts-add-address-review-screen-continue")).toBeVisible();
 
     await user.press(screen.getByTestId("contacts-add-address-review-screen-continue"));

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -684,6 +684,8 @@ describe("Contacts integration", () => {
     await user.press(screen.getByTestId("contacts-add-address-confirm"));
     const addressNameInput = await screen.findByTestId("contacts-add-address-name-input");
     expect(addressNameInput).toHaveProp("value", mockEthCryptoCurrency.name);
+    expect(addressNameInput).toHaveProp("maxLength", 32);
+    expect(screen.getByTestId("contacts-add-address-name-count")).toHaveTextContent("8/32");
     expect(screen.getByTestId("bottom-sheet-header-title")).toHaveTextContent("Name address");
     expect(
       screen.getByText(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/ContactsAddAddressFlowContentView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View } from "react-native";
 import {
   ContactsAddAddressEntry,
+  ContactsAddAddressName,
   ContactsAddAddressPlaceholderView,
 } from "@features/flow-contacts";
 import {
@@ -37,13 +38,13 @@ function ContactsAddAddressStepFrame({ children }: React.PropsWithChildren): Rea
 
 export function ContactsAddAddressFlowContentView({
   addressEntryProps,
+  addressNameProps,
   currencyShell,
   currentStep,
   isOpen,
   labels,
   onBack,
   onClose,
-  onContinueFromName,
   onContinueFromReview,
   onFinish,
 }: ContactsAddAddressFlowContentViewModel): React.JSX.Element {
@@ -64,16 +65,11 @@ export function ContactsAddAddressFlowContentView({
       options: LOCKED_STEP_OPTIONS,
     },
     name: {
-      content: (
+      content: addressNameProps ? (
         <ContactsAddAddressStepFrame>
-          <ContactsAddAddressPlaceholderView
-            title={labels.name}
-            buttonLabel={labels.continue}
-            testID="contacts-add-address-name-screen"
-            onContinue={onContinueFromName}
-          />
+          <ContactsAddAddressName {...addressNameProps} />
         </ContactsAddAddressStepFrame>
-      ),
+      ) : null,
       options: LOCKED_STEP_OPTIONS,
     },
     review: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/types.ts
@@ -8,6 +8,7 @@ export type ContactsAddAddressFlowDrawerProps = Readonly<{
   state: AddAddressFlowState;
   eligibleNetworkIds: readonly string[];
   onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
+  onAddressNameChange: (value: string) => void;
   onAddressConfirm: () => void;
   onBack: () => void;
   onClose: () => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,4 +1,8 @@
 import { Platform } from "react-native";
+import {
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 import { useTranslation } from "~/context/Locale";
 import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { useContactsCurrencySelectionAdapter } from "../../../../hooks/useContactsCurrencySelectionAdapter";
@@ -81,8 +85,14 @@ export function useContactsAddAddressFlowDrawerViewModel({
               inputLabel: t("contacts.addAddressName.inputLabel"),
               namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
               continueToReview: t("contacts.addAddressName.continueToReview"),
-              invalidLabel: t("contacts.addAddressName.invalidLabel"),
-              duplicateLabel: t("contacts.addAddressName.duplicateLabel"),
+              validationErrors: {
+                [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.invalidLabel",
+                ),
+                [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
+                  "contacts.addAddressName.duplicateLabel",
+                ),
+              },
             },
             bottomOffset,
             onChangeText: onAddressNameChange,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -26,6 +26,7 @@ export function useContactsAddAddressFlowDrawerViewModel({
   state,
   eligibleNetworkIds,
   onAddressChange,
+  onAddressNameChange,
   onAddressConfirm,
   onBack,
   onClose,
@@ -71,18 +72,33 @@ export function useContactsAddAddressFlowDrawerViewModel({
             onQrCodeClick,
           }
         : null,
+    addressNameProps:
+      state.status === "namingAddress"
+        ? {
+            addressLabel: state.addressLabel,
+            labels: {
+              title: t("contacts.addAddressName.title"),
+              inputLabel: t("contacts.addAddressName.inputLabel"),
+              namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+              continueToReview: t("contacts.addAddressName.continueToReview"),
+              invalidLabel: t("contacts.addAddressName.invalidLabel"),
+              duplicateLabel: t("contacts.addAddressName.duplicateLabel"),
+            },
+            bottomOffset,
+            onChangeText: onAddressNameChange,
+            onContinue: onContinueFromName,
+          }
+        : null,
     currencySelection,
     currentStep: resolveDrawerStep(state.status),
     isOpen: state.status !== "closed",
     labels: {
-      name: t("contacts.addAddressFlow.name"),
       review: t("contacts.addAddressFlow.review"),
       success: t("contacts.addAddressFlow.success"),
       continue: t("common.continue"),
       done: t("common.done"),
     },
     onBack,
-    onContinueFromName,
     onContinueFromReview,
     onFinish: onClose,
   } as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -52,6 +52,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     start: startAddAddress,
     completeCurrencySelection,
     updateAddress,
+    updateAddressLabel,
     confirmAddress,
     continueFromName,
     continueFromReview,
@@ -86,6 +87,12 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       void updateAddress(value, inputMethod);
     },
     [updateAddress],
+  );
+  const onAddressNameChange = useCallback(
+    (value: string) => {
+      updateAddressLabel(value);
+    },
+    [updateAddressLabel],
   );
   const onQrCodeClick = useCallback(() => {
     navigation.navigate(ScreenName.ScanRecipient, {
@@ -131,6 +138,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       state: addAddressFlowState,
       eligibleNetworkIds,
       onAddressChange,
+      onAddressNameChange,
       onAddressConfirm: confirmAddress,
       onBack: goBackAddAddress,
       onClose: closeAddAddress,

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -32,7 +32,7 @@ After a successful selection, the session retains the selected contact and final
 identifiers and moves to `enteringAddress`. It also retains the selected contact's existing address
 labels so the naming step can reject a duplicate for that contact. Labels are compared after
 trimming, Unicode normalization, and case folding, while the user's casing is preserved for the
-saved value. An empty label has no validation error but cannot continue. The `AddAddress` step owns
+saved value. Native address-label input is limited to 32 characters. An empty label has no validation error but cannot continue. The `AddAddress` step owns
 its injected validation port, currency and token resolution, domain orchestration, input methods,
 asynchronous validation state, resolved-address storage, and stale-result protection. Consuming
 apps adapt coin bridges, domain services, token stores, and other app-owned or platform-specific

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -38,10 +38,10 @@ asynchronous validation state, resolved-address storage, and stale-result protec
 apps adapt coin bridges, domain services, token stores, and other app-owned or platform-specific
 integrations.
 
-The native Add Address views render the shared address-entry states and temporary Name, Validation,
-and Success steps as composable Lumen bottom-sheet content. The Flow owns their order, back
-transitions, resolved-address session and valid-only confirmation. Mobile owns the single queued
-bottom-sheet container, currency-selection adapter, translations, keyboard behavior, scanner
+The native Add Address views render the shared address-entry and address-name states plus temporary
+Validation and Success steps as composable Lumen bottom-sheet content. The Flow owns their order,
+back transitions, resolved-address session and valid-only confirmation. Mobile owns the single
+queued bottom-sheet container, currency-selection adapter, translations, keyboard behavior, scanner
 routing and safe-area inset. Native paste events are classified without reading the clipboard
 proactively, while manual validation can be debounced without delaying paste or QR validation.
 

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { ContactAddressLabelSchema } from "@domain/entity-contact";
+import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
+import { ContactsAddAddressName } from "./ContactsAddAddressName.native";
+
+const labels: AddAddressNameLabels = {
+  title: "Name address",
+  inputLabel: "Address name",
+  namingDisclaimer: "Only you can see this name.",
+  continueToReview: "Continue to review",
+  invalidLabel: "Special characters are not allowed.",
+  duplicateLabel: "This address name is already used for this contact.",
+};
+
+describe("ContactsAddAddressName", () => {
+  it("should render the default label with an enabled review action", () => {
+    const onChangeText = jest.fn();
+    const onContinue = jest.fn();
+
+    render(
+      <ContactsAddAddressName
+        addressLabel={{
+          status: "valid",
+          value: "Ethereum",
+          label: ContactAddressLabelSchema.parse("Ethereum"),
+          validationError: null,
+        }}
+        labels={labels}
+        onChangeText={onChangeText}
+        onContinue={onContinue}
+      />,
+    );
+
+    expect(screen.UNSAFE_getByProps({ title: "Name address" }).props.title).toBe("Name address");
+    expect(screen.getByTestId("contacts-add-address-name-input").props).toMatchObject({
+      label: "Address name",
+      value: "Ethereum",
+    });
+    expect(screen.getByTestId("contacts-add-address-name-disclaimer").props.description).toBe(
+      "Only you can see this name.",
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
+
+    fireEvent.changeText(screen.getByTestId("contacts-add-address-name-input"), "Exchange");
+    fireEvent.press(screen.getByTestId("contacts-add-address-name-continue"));
+
+    expect(onChangeText).toHaveBeenCalledWith("Exchange");
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "invalid characters",
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum 💎",
+        label: null,
+        validationError: "InvalidContactAddressLabelError",
+      },
+      helperText: "Special characters are not allowed.",
+    },
+    {
+      name: "duplicate label",
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum",
+        label: null,
+        validationError: "DuplicateContactAddressLabelError",
+      },
+      helperText: "This address name is already used for this contact.",
+    },
+    {
+      name: "empty label",
+      addressLabel: {
+        status: "empty",
+        value: "",
+        label: null,
+        validationError: null,
+      },
+      helperText: undefined,
+    },
+  ] satisfies ReadonlyArray<{
+    name: string;
+    addressLabel: AddAddressLabelState;
+    helperText: string | undefined;
+  }>)("should block the $name state", ({ addressLabel, helperText }) => {
+    render(
+      <ContactsAddAddressName
+        addressLabel={addressLabel}
+        labels={labels}
+        onChangeText={jest.fn()}
+        onContinue={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-input").props).toMatchObject({
+      value: addressLabel.value,
+      ...(helperText === undefined ? {} : { helperText, status: "error" }),
+    });
+    expect(screen.getByTestId("contacts-add-address-name-continue").props.disabled).toBe(true);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
@@ -5,6 +5,7 @@ import {
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
 import { ContactsAddAddressName } from "./ContactsAddAddressName.native";
 
@@ -42,12 +43,17 @@ describe("ContactsAddAddressName", () => {
     expect(screen.UNSAFE_getByProps({ title: "Name address" }).props.title).toBe("Name address");
     expect(screen.getByTestId("contacts-add-address-name-input").props).toMatchObject({
       label: "Address name",
+      maxLength: CONTACT_ADDRESS_LABEL_MAX_LENGTH,
       value: "Ethereum",
     });
+    expect(screen.getByTestId("contacts-add-address-name-count")).toHaveTextContent("8/32");
     expect(screen.getByTestId("contacts-add-address-name-disclaimer").props.description).toBe(
       "Only you can see this name.",
     );
     expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
+    expect(screen.getByTestId("contacts-add-address-name-continue").props.icon).toEqual(
+      expect.any(Function),
+    );
 
     fireEvent.changeText(screen.getByTestId("contacts-add-address-name-input"), "Exchange");
     fireEvent.press(screen.getByTestId("contacts-add-address-name-continue"));

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
-import { ContactAddressLabelSchema } from "@domain/entity-contact";
+import {
+  ContactAddressLabelSchema,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
 import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
 import { ContactsAddAddressName } from "./ContactsAddAddressName.native";
 
@@ -9,8 +13,11 @@ const labels: AddAddressNameLabels = {
   inputLabel: "Address name",
   namingDisclaimer: "Only you can see this name.",
   continueToReview: "Continue to review",
-  invalidLabel: "Special characters are not allowed.",
-  duplicateLabel: "This address name is already used for this contact.",
+  validationErrors: {
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
+    [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
+      "This address name is already used for this contact.",
+  },
 };
 
 describe("ContactsAddAddressName", () => {
@@ -56,7 +63,7 @@ describe("ContactsAddAddressName", () => {
         status: "invalid",
         value: "Ethereum 💎",
         label: null,
-        validationError: "InvalidContactAddressLabelError",
+        validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
       helperText: "Special characters are not allowed.",
     },
@@ -66,7 +73,7 @@ describe("ContactsAddAddressName", () => {
         status: "invalid",
         value: "Ethereum",
         label: null,
-        validationError: "DuplicateContactAddressLabelError",
+        validationError: DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },
       helperText: "This address name is already used for this contact.",
     },

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
@@ -5,8 +5,11 @@ import {
   BottomSheetView,
   Box,
   Button,
+  Text,
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
 
 export function ContactsAddAddressName({
@@ -28,16 +31,29 @@ export function ContactsAddAddressName({
       <BottomSheetHeader density="expanded" title={labels.title} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
         <Box lx={{ gap: "s16" }}>
-          <TextInput
-            testID="contacts-add-address-name-input"
-            autoFocus
-            autoCorrect={false}
-            label={labels.inputLabel}
-            value={addressLabel.value}
-            helperText={validationMessage}
-            status={addressLabel.status === "invalid" ? "error" : undefined}
-            onChangeText={onChangeText}
-          />
+          <Box lx={{ gap: "s8" }}>
+            <TextInput
+              testID="contacts-add-address-name-input"
+              autoFocus
+              autoCorrect={false}
+              label={labels.inputLabel}
+              value={addressLabel.value}
+              helperText={validationMessage}
+              maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+              status={addressLabel.status === "invalid" ? "error" : undefined}
+              onChangeText={onChangeText}
+            />
+            <Box lx={{ flexDirection: "row", justifyContent: "flex-end" }}>
+              <Text
+                testID="contacts-add-address-name-count"
+                typography="body3"
+                accessibilityLiveRegion="polite"
+                lx={{ color: "muted" }}
+              >
+                {`${addressLabel.value.length}/${CONTACT_ADDRESS_LABEL_MAX_LENGTH}`}
+              </Text>
+            </Box>
+          </Box>
           <Banner
             testID="contacts-add-address-name-disclaimer"
             appearance="info"
@@ -50,6 +66,7 @@ export function ContactsAddAddressName({
           size="lg"
           isFull
           disabled={addressLabel.status !== "valid"}
+          icon={LedgerLogo}
           onPress={onContinue}
         >
           {labels.continueToReview}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
@@ -9,20 +9,6 @@ import {
 } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
 
-function getValidationMessage({
-  addressLabel,
-  labels,
-}: Pick<ContactsAddAddressNameProps, "addressLabel" | "labels">): string | undefined {
-  switch (addressLabel.validationError) {
-    case "InvalidContactAddressLabelError":
-      return labels.invalidLabel;
-    case "DuplicateContactAddressLabelError":
-      return labels.duplicateLabel;
-    case null:
-      return undefined;
-  }
-}
-
 export function ContactsAddAddressName({
   addressLabel,
   labels,
@@ -30,7 +16,9 @@ export function ContactsAddAddressName({
   onChangeText,
   onContinue,
 }: ContactsAddAddressNameProps): React.JSX.Element {
-  const validationMessage = getValidationMessage({ addressLabel, labels });
+  const validationMessage = addressLabel.validationError
+    ? labels.validationErrors[addressLabel.validationError]
+    : undefined;
 
   return (
     <BottomSheetView

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  Banner,
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  TextInput,
+} from "@ledgerhq/lumen-ui-rnative";
+import type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
+
+function getValidationMessage({
+  addressLabel,
+  labels,
+}: Pick<ContactsAddAddressNameProps, "addressLabel" | "labels">): string | undefined {
+  switch (addressLabel.validationError) {
+    case "InvalidContactAddressLabelError":
+      return labels.invalidLabel;
+    case "DuplicateContactAddressLabelError":
+      return labels.duplicateLabel;
+    case null:
+      return undefined;
+  }
+}
+
+export function ContactsAddAddressName({
+  addressLabel,
+  labels,
+  bottomOffset = 0,
+  onChangeText,
+  onContinue,
+}: ContactsAddAddressNameProps): React.JSX.Element {
+  const validationMessage = getValidationMessage({ addressLabel, labels });
+
+  return (
+    <BottomSheetView
+      testID="contacts-add-address-name-screen"
+      style={{ bottom: bottomOffset, paddingBottom: 32 }}
+    >
+      <BottomSheetHeader density="expanded" title={labels.title} />
+      <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>
+        <Box lx={{ gap: "s16" }}>
+          <TextInput
+            testID="contacts-add-address-name-input"
+            autoFocus
+            autoCorrect={false}
+            label={labels.inputLabel}
+            value={addressLabel.value}
+            helperText={validationMessage}
+            status={addressLabel.status === "invalid" ? "error" : undefined}
+            onChangeText={onChangeText}
+          />
+          <Banner
+            testID="contacts-add-address-name-disclaimer"
+            appearance="info"
+            description={labels.namingDisclaimer}
+          />
+        </Box>
+        <Button
+          testID="contacts-add-address-name-continue"
+          appearance="base"
+          size="lg"
+          isFull
+          disabled={addressLabel.status !== "valid"}
+          onPress={onContinue}
+        >
+          {labels.continueToReview}
+        </Button>
+      </Box>
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.types.ts
@@ -1,0 +1,9 @@
+import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
+
+export type ContactsAddAddressNameProps = Readonly<{
+  addressLabel: AddAddressLabelState;
+  labels: AddAddressNameLabels;
+  bottomOffset?: number;
+  onChangeText: (value: string) => void;
+  onContinue: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -3,6 +3,7 @@ export type {
   ContactsAddressValidationResult,
   ContactsCurrencySelectionPort,
 } from "./model/ports";
+export { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 export {
   createContactsAddressValidationDependencies,
   createContactsAddressValidationService,

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -29,6 +29,7 @@ export type {
   AddAddressInputMethod,
   AddAddressInputSource,
   AddAddressLabelState,
+  AddAddressNameLabels,
   AddAddressPlaceholderViewProps,
   ValidAddAddressEntryState,
   ValidAddAddressLabelState,

--- a/features/flow/contacts/src/steps/AddAddress/model/constants.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/constants.ts
@@ -1,0 +1,1 @@
+export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;

--- a/features/flow/contacts/src/steps/AddAddress/native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/native.ts
@@ -1,3 +1,5 @@
 export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.native";
 export type { ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.types";
+export { ContactsAddAddressName } from "./ContactsAddAddressName.native";
+export type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
 export { ContactsAddAddressPlaceholderView } from "./ContactsAddAddressPlaceholderView.native";

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -127,6 +127,15 @@ export type AddAddressEntryLabels = Readonly<{
   ensDisclaimer: string;
 }>;
 
+export type AddAddressNameLabels = Readonly<{
+  title: string;
+  inputLabel: string;
+  namingDisclaimer: string;
+  continueToReview: string;
+  invalidLabel: string;
+  duplicateLabel: string;
+}>;
+
 export type AddAddressPlaceholderViewProps = Readonly<{
   title: string;
   buttonLabel: string;

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -132,8 +132,7 @@ export type AddAddressNameLabels = Readonly<{
   inputLabel: string;
   namingDisclaimer: string;
   continueToReview: string;
-  invalidLabel: string;
-  duplicateLabel: string;
+  validationErrors: Readonly<Record<ContactAddressLabelValidationErrorName, string>>;
 }>;
 
 export type AddAddressPlaceholderViewProps = Readonly<{

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -6,6 +6,7 @@ import {
   type ContactAddressLabel,
   type ContactId,
 } from "@domain/entity-contact";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import type {
   AddAddressContact,
@@ -71,6 +72,10 @@ function createAddressLabelState(
     label: parseContactAddressLabel(value, existingAddressLabels),
     validationError: null,
   };
+}
+
+function limitAddressLabelLength(value: string): string {
+  return value.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH);
 }
 
 function resolveAddressEntryState(
@@ -187,7 +192,7 @@ export function useAddAddressFlowViewModel({
           selectedCurrencyId: selection.currencyId,
           addressEntry: EMPTY_ADD_ADDRESS_ENTRY_STATE,
           addressLabel: createAddressLabelState(
-            selection.assetDisplayName,
+            limitAddressLabelLength(selection.assetDisplayName),
             currentState.existingAddressLabels,
           ),
         };
@@ -257,7 +262,10 @@ export function useAddAddressFlowViewModel({
 
       return {
         ...currentState,
-        addressLabel: createAddressLabelState(value, currentState.existingAddressLabels),
+        addressLabel: createAddressLabelState(
+          limitAddressLabelLength(value),
+          currentState.existingAddressLabels,
+        ),
       };
     });
   }, []);

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@domain/entity-contact";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import { useAddAddressFlowViewModel } from "./useAddAddressFlowViewModel";
 
@@ -287,6 +288,42 @@ describe("useAddAddressFlowViewModel", () => {
 
     act(() => result.current.continueFromName());
     expect(result.current.state.status).toBe("reviewingAddress");
+  });
+
+  it("should limit default and edited address labels to 32 characters", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+    const longDefaultLabel = "A".repeat(CONTACT_ADDRESS_LABEL_MAX_LENGTH + 1);
+    const longEditedLabel = "B".repeat(CONTACT_ADDRESS_LABEL_MAX_LENGTH + 1);
+
+    act(() => result.current.start(contact));
+    act(() =>
+      result.current.completeCurrencySelection(contact.id, {
+        currencyId: ETHEREUM_CURRENCY_ID,
+        assetDisplayName: longDefaultLabel,
+      }),
+    );
+
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      addressLabel: {
+        status: "valid",
+        value: longDefaultLabel.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH),
+      },
+    });
+
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+    act(() => result.current.updateAddressLabel(longEditedLabel));
+
+    expect(result.current.state).toMatchObject({
+      status: "namingAddress",
+      addressLabel: {
+        status: "valid",
+        value: longEditedLabel.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH),
+      },
+    });
   });
 
   it("should expose invalid characters and prevent review", async () => {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Flow component and Mobile Contacts integration cover valid, empty, invalid and duplicate address labels.
- [x] **Impact of the changes:**
      The Mobile Contacts add-address drawer now renders the address-name step with the default label, custom edits, validation feedback and keyboard-aware layout.

### 📝 Description

Renders the shared Contacts address-name input in the Mobile add-address flow, following the existing address-entry layout.


https://github.com/user-attachments/assets/071b7e1c-5b31-4389-87fc-8bc0512c90ff

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-07-31 at 10 46 34" src="https://github.com/user-attachments/assets/00e07276-1c70-4406-93bf-1751280a3b92" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33920

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)