### PR TITLE
docs(wallet-cli): add regression plan and no-device harness

### DIFF
--- a/.changeset/quiet-doors-testify.md
+++ b/.changeset/quiet-doors-testify.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/wallet-cli": patch
+---
+
+Add a living regression plan under `docs/regression/`, split by whether a case needs a Ledger on USB, plus an automated harness (`scripts/regression/run.sh`) for the no-device cases: repo gates, the `skill` command group, the first-run nudge, and every read/dry-run command path

--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -105,6 +105,15 @@ pnpm start -- <command> [args]
 
 If `USER_ID` is unset, it defaults to `wallet-cli` so DMK firmware distribution salt stays stable for this CLI (`env-setup.ts`).
 
+## Regression testing
+
+Before a release, work through the [regression plan](docs/regression/README.md). Cases that
+need no device are automated (`./scripts/regression/run.sh`); the rest need a Ledger on USB
+and a person to confirm on-screen. Per-release focus lives in
+[`docs/regression/releases/`](docs/regression/releases/).
+
+Adding or changing a command? Update the matching case table in the same PR.
+
 ## Relation to `ledger-live` CLI
 
 This package is DMK-focused and is separate from `@ledgerhq/live-cli` ([`apps/cli`](../cli)), which is now an internal, Speculos-only tool used by the monorepo's e2e suites and CI. For human/manual hardware-wallet flows, use this `wallet-cli` (or the Ledger Live desktop/mobile app).

--- a/apps/wallet-cli/docs/regression/README.md
+++ b/apps/wallet-cli/docs/regression/README.md
@@ -1,0 +1,87 @@
+# wallet-cli regression plan
+
+A living regression plan for `@ledgerhq/wallet-cli`. It is kept next to the code so it
+evolves with it: **when you add or change a command, add or update its cases here in the
+same PR.**
+
+Cases are split by one thing only — whether the command needs a Ledger on USB:
+
+| Where | What | Who runs it |
+| --- | --- | --- |
+| [`no-device.md`](./no-device.md) | Repo gates, `skill`, the first-run nudge, and every command that reads or dry-runs without a device | `scripts/regression/run.sh`, unattended |
+| [`with-device.md`](./with-device.md) | `account discover`, `receive`, `send`, `genuine-check`, `swap execute`, `earn deposit/withdraw`, `ring` | a person, device connected and unlocked |
+
+There is no way to automate the second file: the harness drives the real CLI, so a command
+that talks to the device needs the device. wallet-cli has **no Speculos support** — the
+transport is USB/DMK only.
+
+Per-release focus lives in [`releases/`](./releases/) — one short file per version listing
+what changed and which cases it puts at risk. Start there when planning a campaign.
+
+## What CI already covers (don't re-test by hand)
+
+`pnpm test` (bun, in `apps/wallet-cli`) runs on every PR and already covers a lot that
+looks device-shaped, using an in-process mock DMK (`src/test/helpers/cli-runner.ts`, driven
+by `WALLET_CLI_MOCK_DMK*`) plus HTTP interception:
+
+- device-state → message → exit-code mapping (`src/device/device-state.test.ts`,
+  `classify-device-error.test.ts`, `wallet-cli-device-error.test.ts`);
+- `genuine-check`: genuine, locked, timeout, non-genuine, truncated stream;
+- `receive`: `--verify` / `--verify=false` / `--no-verify` equivalence;
+- `swap execute`: envelope shape, provider validation, currency/chain mismatches, the DIE
+  pipeline incl. legacy fallback — and the display-unit conversion of `amountExpectedTo`
+  (`src/commands/swap/cli-swap-pipeline.test.ts`);
+- `earn deposit/withdraw`: dry-run envelopes, guard errors, the ETH vault approve→deposit
+  pipeline and its Kiln app dependency.
+
+That mock is **only reachable in-process from bun tests**, never from the shipped binary,
+so it can't be used by the harness. Its value here is negative scope: if a behaviour is
+covered there, the device pass only needs one confirmation on real hardware rather than a
+matrix. Gaps worth closing as tests rather than as manual steps are listed at the end of
+[`with-device.md`](./with-device.md).
+
+## Prerequisites
+
+| Item | Notes |
+| --- | --- |
+| Build | `pnpm build` in `apps/wallet-cli`, then test `dist/<platform>/cli` — required for anything `skill`-related, since skills are embedded in the binary |
+| From source | `pnpm --silent wallet-cli start <cmd>` from the repo root (`run.sh --source`) |
+| Device | Unlocked Ledger on USB; Ethereum, Bitcoin, Solana, Exchange and Kiln apps installed; firmware current |
+| Funds | A dedicated regression wallet: ETH (gas) + a funded ERC-20, BTC, ≥2 SOL, and a small swap budget |
+| Network | Unrestricted egress. Sandboxed shells must be bypassed for USB and OS-keychain commands |
+| Tools | `bash`, `jq`, `node`, `timeout` (coreutils) for the harness |
+| Isolation | `XDG_STATE_HOME=<tmp>` gives a throwaway session + first-run marker; `HOME=<tmp>` for `--global` cases |
+
+## Running the no-device cases
+
+```bash
+cd apps/wallet-cli
+pnpm build                        # skill cases must run against the binary
+./scripts/regression/run.sh       # skill, nudge and device-free command cases
+./scripts/regression/run.sh --suite b            # one area
+./scripts/regression/run.sh --with-gates --with-build   # + repo gates, build, pack, npm smoke
+./scripts/regression/run.sh --source             # run from source instead of the binary
+```
+
+Case ids printed by the script match the tables in [`no-device.md`](./no-device.md). Every
+invocation, stdout, stderr and exit code is logged; the path is printed at the end.
+
+The script never signs and never broadcasts. It uses your **real session** for read cases
+(so `account discover` must have run at least once) and throwaway state for `skill` and
+nudge cases.
+
+## Running the device cases
+
+Read [`with-device.md`](./with-device.md) — it defines the protocol (one command per case,
+`--output json` so the exit code and device-state stream are the oracle, and what evidence
+to record), then work through the tables. Start the Solana undelegate case on day one: its
+`--finalize` step can only run after the deactivation epoch boundary (~2–3 days).
+
+## Priorities
+
+1. **Blocking:** repo gates; `skill` and nudge cases; every `--dry-run` and validation case;
+   `genuine-check`; `receive` address verification; one real `send`; one real `swap execute`.
+2. **Release quality:** the rest of the no-device tables, remaining `send`/`swap`/`earn`
+   device cases, packaging and npm smoke.
+3. **Opportunistic:** `ring` edge cases (rotation, ejection), the platform matrix, and the
+   multi-day Solana finalize.

--- a/apps/wallet-cli/docs/regression/no-device.md
+++ b/apps/wallet-cli/docs/regression/no-device.md
@@ -1,0 +1,182 @@
+# Regression cases — no device required
+
+Runnable unattended by `scripts/regression/run.sh`; ids match the script output. Nothing
+here signs or broadcasts. See [README](./README.md) for prerequisites and flags.
+
+Suite A uses the repo, B and C are hermetic (throwaway cwd, `HOME`, `XDG_STATE_HOME`), and
+D uses your real session plus live backends.
+
+## Suite A — repo & artifact gates
+
+`./run.sh --with-gates` (add `--with-build` for A7–A9). Run these first: a stale
+`src/skills/manifest.gen.ts` invalidates every Suite B result.
+
+| ID | Command (in `apps/wallet-cli`) | Expected |
+| --- | --- | --- |
+| A1 | `pnpm test` | green |
+| A2 | `pnpm typecheck` | clean |
+| A3 | `pnpm lint:ci` | clean |
+| A4 | `pnpm format:check` | clean (separate CI gate from lint) |
+| A5 | `pnpm check:skills` | every shipped skill found in `.agents/skills/` |
+| A6 | `pnpm check:notices` | `THIRD_PARTY_NOTICES.md` in sync |
+| A7 | `pnpm build` | binaries for all four platforms in `dist/` |
+| A8 | `pnpm pack:check` | tarball layout (bin/, LICENSE, notices, README, CHANGELOG) |
+| A9 | `pnpm smoke:npm` | packs + installs into a temp dir, runs `wallet-cli --version` |
+| A10 | `git status` afterwards | only generated files untracked; nothing else dirty |
+
+## Suite B — `skill` command group
+
+Run against the **binary**: the point of the feature is that skills ship inside it.
+
+### list / retrieve
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B1 | `skill list` | names `ledger-wallet-cli` |
+| B2 | `skill list --output json` | `status:success`, `command:"skill list"`, `skills[].name/description` |
+| B3 | `skill retrieve` | prints `SKILL.md` |
+| B4 | `skill retrieve --file references/business-logic.md` | prints the reference doc |
+| B5 | `skill retrieve --file no-such.md` | exit 1, lists available files |
+
+### install
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B6 | `skill install --agent claude` in an empty dir | `SKILL.md`, `references/business-logic.md`, `.wallet-cli-skill.json` |
+| B7 | sidecar contents | `name`, `cliVersion` = binary version, 64-hex `contentHash` matching the files on disk, per-file `files{}`, ISO `installedAt` |
+| B8 | install again, no `--force` | exit 1, "Refusing to overwrite", files untouched |
+| B9 | `--force` | exit 0, `installedAt` refreshed |
+| B10 | delete both skill files, keep the sidecar, install without `--force` | succeeds (sidecar excluded from the clash check) |
+| B11 | `--agent cursor` / `codex` / `agents` | `.cursor/skills`, `.codex/skills`, `.agents/skills` |
+| B12 | bare `skill install` | defaults to `.claude/skills` |
+| B13 | `--dir ./custom` | writes there; no `.claude/` created |
+| B14 | `--global` | installs under `$HOME`, not cwd |
+| B15 | `--all` | every embedded skill installed |
+| B16 | `install --output json` | `cliVersion`, `root`, `skills[]`, `contentHashes{}`, `installed[]` |
+| B17 | `--agent bogus` (human + json) | exit 1, lists `claude, cursor, codex, agents`, suggests `--dir`; json → `{ok:false,error:{command,message}}` |
+| B18 | unknown skill name | exit 1, "not found", points at `skill list` |
+| B19 | `--dir` on an unwritable path | clean error, non-zero, no partial write |
+
+### doctor
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B20 | after a fresh install | `up-to-date`, exit 0 |
+| B21 | `--output json` | `results[]` with `status`/`installedVersion`/`installedHash`/`diskHash`/`shippedVersion`/`shippedHash`; `fixed` and `remainingDrift` empty |
+| B22 | edit the installed `SKILL.md` | `modified-locally`, "still drifting", hints `--fix --force`, exit 1 |
+| B23 | `--fix` on that | still drifting, exit 1, **local edit preserved** |
+| B24 | `--fix --force` | "Fixed 1 skill(s)", `up-to-date`, exit 0, edit gone |
+| B25 | delete a tracked reference file | drift detected; `--fix --force` restores it |
+| B26 | nothing installed | `missing`, "installed none", exit 1 |
+| B27 | `--fix` on `missing` | installs it **without** `--force`, exit 0 |
+| B28 | simulate an older install (content edited, sidecar rewritten to agree with disk but recording an older `cliVersion`) | `outdated`; plain `--fix` heals it and rewrites the sidecar |
+| B29 | remove the sidecar, content untouched | `up-to-date`, "installed none" — legacy/manual installs tolerated |
+| B30 | remove the sidecar **and** edit content | `modified-locally`; `--fix` alone must not overwrite |
+| B31 | `--dir ./elsewhere` | scans only that dir; the default scan then reports `missing` |
+| B32 | `--global` | also scans `$HOME` agent dirs; both roots appear in `results[].root` |
+| B33 | a regular file named `ledger-wallet-cli` in `.claude/skills` | reported `missing`, not mistaken for an install |
+| B34 | `--global` run from `$HOME` | roots de-duplicated; no skill listed or fixed twice |
+| B35 | installed for two agents, then `doctor` | one diagnosis per (root, skill), each with its own `root` |
+| B36 | binary copied outside the repo, `skill install --agent claude` | works with no repo and no prior setup |
+| B37 | `skill retrieve` vs `.agents/skills/ledger-wallet-cli/SKILL.md` | byte-identical — the shipped skill can't drift from source |
+
+## Suite C — first-run nudge
+
+Each case needs a pristine `XDG_STATE_HOME`; `session view` is the cheapest real command.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| C1 | fresh state, `CLAUDECODE=1` | stderr shows `skill install --agent claude` + "Claude Code"; stdout untouched |
+| C2 | run again | silent |
+| C3 | marker | `$XDG_STATE_HOME/ledger-wallet-cli/first-run.json`, dir `0700`, file `0600`, `version` = CLI version |
+| C4 | `--output json` on fresh state | stderr empty, marker **not** written; a later human run still shows the hint |
+| C5 | `WALLET_CLI_NO_NUDGE=1` | silent, no marker |
+| C6 | no agent env, stderr not a TTY | silent, no marker |
+| C7 | `CURSOR_AGENT` → cursor; `CODEX_ENABLED` → codex; `GEMINI_CLI` / `OPENCODE` / `AMP_CURRENT_THREAD_ID` → `agents` | each hint names the right agent and label |
+| C8 | `--help`, `--version`, bare invocation | no hint, marker not consumed; next real command shows it |
+| C9 | any `skill *` command | no hint, marker not consumed |
+| C10 | a failing command on fresh state | hint shown **and** the exit code unchanged |
+| C11 | read-only state dir | command succeeds, no crash |
+| C12 | corrupt marker file | never crashes (shown once more at worst) |
+| C13 | no agent env, real interactive TTY | generic `wallet-cli skill install`, no `--agent` — **needs a terminal, so run by hand** |
+
+## Suite D — commands that need no device
+
+Uses discovered session accounts. `send`/`earn` cases are `--dry-run` only.
+
+### session, balances, operations, assets
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D1 | `session view` | labels + descriptors |
+| D2 | `session view --output json` | `accounts[].label/descriptor`; no xprv anywhere |
+| D3 | unknown label | exit 1, "No account labeled …", points at `account discover` |
+| D4 | a raw descriptor as an argument | rejected |
+| D5 | `balances <eth>` (human + json) | native + token rows; json rows are `{asset, amount}`, `network: "ethereum:main"` |
+| D6 | `balances` for solana and each bitcoin derivation | correct native ticker per family |
+| D7 | `operations <eth> --limit 3` (human + json) | typed rows; `nextCursor` when more pages exist |
+| D8 | `operations --cursor <cursor>` | page advances — needs an account with >1 page of history |
+| D9 | `assets token ethereum 0xdac17f95…` | USDT, id `ethereum/erc20/usd_tether__erc20_`, 6 decimals |
+| D10 | `assets token-by-id` with that id | same token |
+| D11 | unknown contract | non-zero, "Token not found" |
+| D12 | `assets token solana <SPL mint>` | resolved — the mint is the **positional** address |
+| D13 | `assets token solana` (no address) | usage message, non-zero, no stack trace |
+
+### earn read paths
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D14 | `earn yields` | only CLI-supported networks, narrowed to discovered accounts, `ledgerlive://` deeplinks |
+| D15 | `earn yields --all` | account filter bypassed |
+| D16 | `earn yields -n solana` | "Deposit targets" with `→ --product <voteAccount>`, Ledger validators surfaced, Net APY |
+| D17 | `earn yields -n ethereum` | ERC-4626 vault ids as `--product` (`vaultId` in json) |
+| D18 | `earn yields -n solana --limit 3` | limit honoured |
+| D19 | `earn positions <sol>` | positions array; `stakes[]` with `→ --stake-account`, `state`, `withdrawable` when stakes exist; `(stale)` markers |
+| D20 | `earn positions <sol> --fresh` | accepted, non-blocking; refreshed data appears on a re-run |
+| D21 | `earn positions <eth>` | vault positions or empty, valid envelope |
+| D22 | deeplink shape | ERC-20 grow rows target the token sub-account id; SOL rows use `earn?action=stake-account` |
+
+### send / earn dry runs
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D23 | `send <eth> --to <own addr> --amount '0.0001 ETH' --dry-run` | To/Amount/Fees shown, no `hash:` line |
+| D24 | same with a funded ERC-20 ticker | token resolved by ticker, fees in ETH |
+| D25 | `--amount '0.0001'` (no ticker) | "Amount must include a ticker" |
+| D26 | `--amount '1 UNKN'` | "Ticker … not found in account. Available: …" |
+| D27 | amount above balance | `NotEnoughBalance` |
+| D28 | invalid recipient, ethereum | `InvalidAddress` |
+| D29 | invalid recipient, bitcoin (also with `--fee-per-byte`/`--rbf`) | `InvalidAddress`, flags parse |
+| D30 | invalid recipient, solana | `InvalidAddress` |
+| D31 | `send <sol> --to <own addr> --memo …` | memo accepted, nothing broadcast |
+| D32 | `earn deposit <sol> --product <validator> --amount '0.5 SOL' --dry-run` | validated, no signature |
+| D33 | `earn deposit <eth> --product <vaultId> --amount '1 USDC' --dry-run`, first ever deposit | approve validated, deposit `not-simulated` with the documented reason — **not** a balance error |
+| D34 | same once an allowance exists | deposit leg simulates |
+| D35 | `earn withdraw` missing `--product` / `--stake-account` | clean validation error |
+| D36 | `earn withdraw <eth> --product <vaultId> --dry-run`, no `--amount` | full exit (`amount:"max"`) |
+
+D28–D30 are the coverage for address validation going through the `CoinModuleApi` instance:
+keep one case per family.
+
+### swap quote / status
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D37 | `swap quote` ETH→BTC, sensible amount (human + json) | provider fan-out; rates, or "No quotes available" with a reason per provider |
+| D38 | token id as `--from` | accepted |
+| D39 | amount below provider minimums | `amount_off_limits` per provider, exit 0, no crash |
+| D40 | missing `--to-account` | clean validation error, never `[object Object]` |
+| D41 | `--from not-a-currency` | clean error |
+| D42 | a session label passed to `--from` | rejected, message points at `--from-account` |
+| D43 | `swap status --swap-id <unknown> --provider changelly` | `[?] UNKNOWN <id>`, exit 0 |
+| D44 | `swap status` without `--provider` | clean validation error |
+
+### cross-cutting
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D45 | `--version` | matches `package.json` |
+| D46 | `--help` and `<group> --help` | all groups documented, incl. `skill`, `earn`, `ring` |
+| D47 | every `--output json` command piped to `jq` | valid JSON (or NDJSON), never mixed with human text |
+| D48 | human mode with stdout piped | progress on stderr, payload on stdout |
+| D49 | two no-device commands in parallel | both succeed |

--- a/apps/wallet-cli/docs/regression/releases/2.1.0.md
+++ b/apps/wallet-cli/docs/regression/releases/2.1.0.md
@@ -1,0 +1,51 @@
+# Release focus — 2.1.0
+
+Previous published version: **2.0.1**. Full entries in
+[`CHANGELOG.md`](../../../CHANGELOG.md).
+
+## What changed, and what it puts at risk
+
+| Change | Risk | Cases |
+| --- | --- | --- |
+| New `skill` group (`list`, `retrieve`, `install`) with skills embedded in the binary | New surface that writes into the user's project | B1–B19, B36–B37 |
+| New `skill doctor` + `.wallet-cli-skill.json` provenance sidecar, hashes in the install envelope | New surface that can overwrite user files | B20–B35 |
+| One-time agent-aware first-run nudge | Runs on **every** command's startup path and writes to stderr | C1–C13, and D47/D48 for stream hygiene |
+| `swap execute`: `amountExpectedTo` now in display units, atomic value moved to `amountExpectedToAtomic` | **Breaking for script consumers**; money-facing | G1, G2 |
+| `swap_completed` analytics gains `provider` | Analytics only | G11 |
+| `validateAddress` consumed through the `CoinModuleApi` instance | Recipient validation on every send/earn/swap build, all families | D28–D30, F1–F4 |
+| Remaining `@ledgerhq/cryptoassets` value-barrel imports repointed to `@domain/entity-currency-crypto` / `-fiat` | Currency, token, fiat and unit resolution everywhere: balances, tickers, token ids, fee display | D5–D13, D23–D27, D37–D38 |
+
+The last two rows are why this release needs a broad pass rather than only testing the new
+`skill` and nudge surface: they sit underneath every amount, ticker and address in the CLI.
+
+## Suggested campaign
+
+1. Suite A (gates) — a stale generated skill manifest invalidates all of Suite B.
+2. Suites B and C via `scripts/regression/run.sh` — the new surface.
+3. Suite D via the same script — the regression net for the two refactors above.
+4. Device pass: E (basics) → F (send) → G1–G3 (the display-unit change) → H → I as budget allows.
+   Kick off H3 early so H4's epoch boundary passes during the campaign.
+
+## Open questions raised while writing this plan
+
+Product decisions, not pass/fail cases:
+
+1. **`balances --output json` amounts are display strings.** Rows are `{asset, amount}` with
+   `amount` like `"2,000 BXX"` — thousands separators, ticker suffix, no separate numeric or
+   atomic field. Machine consumers have to parse locale-formatted text. Given 2.1.0 split
+   `amountExpectedTo` / `amountExpectedToAtomic` in swap for exactly this reason, should
+   balances follow?
+2. **`swap status` on an unknown id exits 0** and prints `[?] UNKNOWN <id>`. Intended (it's a
+   status read, not a failure), or should an unknown id be non-zero?
+3. **The embedded skill documents `assets token` wrongly.** It says to pass `--identifier` for
+   non-EVM chains, but the address is a required positional and `--identifier` is an extra hint
+   for MultiversX/Cardano/Algorand/Stellar; a Solana mint goes in the positional. The skill now
+   ships inside the binary, so this wording ships too.
+4. **The embedded skill's frontmatter description lists only the pre-2.0 commands** — no `earn`,
+   no `skill`. Agents select skills on that description, which makes the newer features harder
+   to discover.
+5. **`operations` pagination has no reliable fixture.** D8 needs an account with more than one
+   page of history; a dedicated fixture account would make it always exercised.
+6. **Provider IP restrictions read as failures.** `swap quote` returns
+   `failed_to_get_quote_error - IP address not supported by cic_v2` from some regions. Worth
+   distinguishing from a real provider failure in the output.

--- a/apps/wallet-cli/docs/regression/with-device.md
+++ b/apps/wallet-cli/docs/regression/with-device.md
@@ -1,0 +1,132 @@
+# Regression cases — device required
+
+Every case here drives a command that talks to the Ledger, so it needs the device connected
+and unlocked and a person to confirm on-screen. Nothing automates this: wallet-cli speaks
+USB/DMK only and has **no Speculos support**.
+
+## Protocol
+
+- **One command per case.** Run it, confirm on the device, record the result before moving on.
+- **Always `--output json`.** The exit code plus the `device-state` events (`awaiting_approval`
+  with its `reason`, terminal states) are the oracle — not "it looked fine".
+- **Exit codes are the contract** (`src/device/device-state.ts`): `0` success, `2` rejected,
+  `3` disconnected, `4` wrong app, `5` app not installed, `6` timeout/locked.
+- **Never run two device commands at once** — concurrent APDU traffic garbles the session.
+- **Batch by device app** (all Ethereum cases, then Bitcoin, then Solana) to cut app switching.
+- **Use the dedicated regression wallet**, with the amounts written in the case. Don't improvise
+  with real funds.
+- **Record per case:** command, exit code, the JSON envelope, what the device screen showed,
+  and the tx hash where one is produced.
+- **Start E9 (Solana undelegate) on day one** — its finalize step needs the deactivation epoch
+  boundary to pass (~2–3 days).
+
+## Suite E — device basics
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| E1 | `genuine-check`, device on the dashboard | genuine, exit 0 |
+| E2 | `genuine-check` with a currency app open | `[✖] Wrong app. Open Ledger dashboard.`, exit 4 |
+| E3 | `genuine-check` with the host offline | clean network error, no crash |
+| E4 | `account discover ethereum` / `bitcoin` / `solana` | accounts found, labels `<network>[-derivation]-<n>`, persisted; no raw V1 descriptor in the output |
+| E5 | `account discover ethereum:sepolia` / `bitcoin:testnet` / `solana:devnet` | testnet labels (e.g. `ethereum-sepolia-1`); discovery only |
+| E6 | `receive <acct>` | **terminal address matches the device screen character for character** |
+| E7 | `receive <acct> --no-verify` | no device prompt, same address as E6 |
+| E8 | `receive` on each bitcoin derivation (native/taproot/segwit/legacy) | correct address format per derivation |
+| E9 | device locked when a command starts | `awaiting_approval`, `reason: unlock`; resumes after PIN, no spurious timeout |
+| E10 | app not installed for the target network | exit 5 with an install hint |
+| E11 | unplug mid-command | exit 3, clean DMK teardown; the next command works without replugging twice |
+
+## Suite F — send
+
+| ID | Case | Amount | Expected |
+| --- | --- | --- | --- |
+| F1 | native ETH | 0.0001 ETH | device shows amount/recipient/fees; `hash:` on stdout; appears in `operations` |
+| F2 | ERC-20 | 0.01 USDC | clear-signed token transfer, correct decimals and symbol |
+| F3 | BTC with `--fee-per-byte` + `--rbf` | dust-safe minimum | fee rate respected, RBF flagged |
+| F4 | SOL with `--memo` | 0.001 SOL | memo instruction present on-chain |
+| F5 | reject on device | — | exit 2, "No action taken", nothing broadcast |
+| F6 | approve, then unplug before broadcast | — | clean error; no half-broadcast state |
+
+## Suite G — swap execute
+
+Small amounts. G1 is the check for 2.1.0's display-unit change; the conversion itself is
+unit-tested, so one hardware confirmation per output mode is enough.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| G1 | small swap, legacy provider, `--output json` | `amountExpectedTo` in **display units**, `amountExpectedToAtomic` alongside it, `magnitudeAwareRate` unchanged (atomic/atomic) |
+| G2 | same run, human output | "Amount expected to:" in display units with the right magnitude |
+| G3 | legacy pipeline ETH→BTC end to end | nonce → payload → complete exchange → sign → broadcast; Exchange app session stays open throughout; `hash:` emitted |
+| G4 | DEX provider (`uniswap`) ETH→USDT, EVM source | embedded coin-app flow: `Open <app>` prompts, approval/permit2/swap signatures, broadcast |
+| G5 | DEX provider with a non-EVM source account | falls back to the legacy pipeline |
+| G6 | a quote that resolves to an RFQ plan | `falling back to legacy Exchange-app pipeline`, then legacy flow |
+| G7 | reject on device | exit 2, nothing broadcast |
+| G8 | `--fee-strategy slow` vs `fast` | refund-chain fee differs accordingly |
+| G9 | swap into a token account that doesn't exist yet | succeeds (destination account created) |
+| G10 | `swap status --swap-id <from G3> --provider <same>` | real status progression |
+| G11 | analytics for a completed swap (Segment debug) | `swap_completed` carries `provider`, `fromCurrency`, `toCurrency`, and `toAmount` in display units |
+
+## Suite H — earn deposit / withdraw
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| H1 | `earn deposit <sol> --product <Ledger validator> --amount '1 SOL'` | `stake.createAccount` creates **and** delegates in one tx |
+| H2 | `earn positions <sol>` after H1 | the new stake account listed with `→ --stake-account`, state `activating` |
+| H3 | `earn withdraw <sol> --stake-account <addr>` | undelegate signed; state → `deactivating` |
+| H4 | `earn withdraw <sol> --stake-account <addr> --finalize` after the epoch boundary | lamports back on the main account; `--amount` ignored |
+| H5 | `earn deposit <eth> --product <vaultId> --amount '1 USDC'`, first deposit | Ethereum app opens with the **Kiln** clear-signing dependency; `approve` then `deposit`; on-chain status polled |
+| H6 | `earn withdraw <eth> --product <vaultId>` with no `--amount` | full exit, no dust left |
+| H7 | reject either leg of H5 on device | exit 2; the approve tx state is reported accurately |
+
+## Suite I — ring (LKRP)
+
+Password comes from the OS keychain via command substitution
+(`WALLET_PASS=$(security find-generic-password …)`). Never type a literal, not even a
+throwaway. `ring decrypt` output is secret — pipe it to a file or the clipboard, never to a
+terminal or a log.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| I1 | `ring init --name <machine>` with `WALLET_PASS` injected | provisioned via the device; trustchain meta recorded in the session |
+| I2 | `ring encrypt --key k -i f -o f.enc`, then `ring decrypt` | round-trips, **no device** after init |
+| I3 | stdin/stdout round-trip | text round-trips |
+| I4 | decrypt with the wrong `--key` | fails, mentions wrong key / corruption / rotation |
+| I5 | `ring keys` | lists the key names used on this machine |
+| I6 | encrypt/decrypt with the host offline | clear error (LKRP restore needs network) |
+| I7 | `ring destroy` with a wrong password | aborts, no changes |
+| I8 | `ring destroy` with `WALLET_PASS` set but empty | aborts (treated as a failed keychain lookup) |
+| I9 | `echo destroy | ring destroy` with the right password | remote application closed, local credentials wiped |
+| I10 | decrypt data encrypted before a ring rotation | `⚠ Ledger Key Ring rotated` warning + actionable error |
+| I11 | encrypt after the wallet-cli application was deactivated on the ring | actionable guidance, not a raw SDK error |
+
+## Suite J — platform matrix
+
+Per platform, at minimum: `--version`, `skill install --agent claude`, `session view`, and one
+device command (`receive`).
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| J1 | each built binary (`darwin-arm64`, `linux-x64`, `linux-arm64`, `windows-x64`) | `--version` correct |
+| J2 | after publish, `npm i -g @ledgerhq/wallet-cli@<version>` on a clean machine | right platform package resolved; commands work |
+| J3 | Linux without USB build deps | actionable error naming `libudev-dev` / `libusb-1.0-0-dev` |
+| J4 | Windows | `skill install` writes `.claude\skills\…`; `--file references\business-logic.md` resolves |
+| J5 | `USER_ID` unset | defaults to `wallet-cli` (stable DMK salt) |
+
+## Gaps worth closing as tests, not as manual steps
+
+These are device-shaped behaviours the in-process mock DMK could assert (see
+[README](./README.md)), but that no test covers today. Turning them into `bun test` cases
+would take them off the manual pass permanently:
+
+- **Per-command wiring of terminal device states.** The state → exit-code mapping is
+  unit-tested, but only `genuine-check` asserts it end to end. `send`, `swap execute`,
+  `earn deposit/withdraw` and `receive` have no case for rejected (2), disconnected (3),
+  wrong app (4), app-not-installed (5) or locked/timeout (6).
+- **`send` beyond dry-run.** No mocked sign-and-broadcast case: the `hash:` stdout contract
+  and the operation-serialisation path are only exercised on hardware today.
+- **`earn deposit/withdraw` signing dispatch.** Pipeline-level tests exist, but not the
+  command-level path from flags through signing to broadcast.
+- **Fee strategy.** `--fee-strategy slow|medium|fast` has no assertion that the choice
+  reaches the built transaction.
+- **Mid-flow interruption.** No case for a device disappearing between signature and
+  broadcast, which is exactly where a partial state would be worst.

--- a/apps/wallet-cli/scripts/regression/cases-gates.sh
+++ b/apps/wallet-cli/scripts/regression/cases-gates.sh
@@ -1,0 +1,35 @@
+# Suite A — repo / artifact gates. Slow; opt in with --with-gates.
+# These are the same checks CI runs, plus the packaging smoke tests that matter
+# for a release. No device, no session.
+
+gate() { # gate <ID> <desc> <cmd...>
+  case_start "$1" "$2"
+  local id="$1" desc="$2"; shift 2
+  log "\$ $*"
+  local outf; outf=$(mktemp "$TMP_ROOT/gate.XXXXXX")
+  ( cd "$WALLET_CLI_DIR" && timeout "$GATE_TIMEOUT" "$@" ) >"$outf" 2>&1
+  local rc=$?
+  log "--- rc=$rc"; log "$(tail -100 "$outf")"
+  if [ "$rc" = 124 ]; then fail_case "timed out after ${GATE_TIMEOUT}s"
+  elif [ "$rc" != 0 ]; then fail_case "exit $rc — see $LOG_FILE (tail: $(tail -3 "$outf" | tr '\n' ' ' | head -c 300))"; fi
+  case_end
+}
+
+suite_a() {
+  gate A1 "unit tests (bun test src/)"            pnpm test
+  gate A2 "typecheck (tsc --noEmit)"              pnpm typecheck
+  gate A3 "lint (oxlint --quiet)"                 pnpm lint:ci
+  gate A4 "format check (oxfmt --check)"          pnpm format:check
+  gate A5 "embedded skill generation (check:skills)" pnpm check:skills
+  gate A6 "third-party notices up to date"        pnpm check:notices
+
+  if [ "$WITH_BUILD" = 1 ]; then
+    gate A7 "build all platform binaries"         pnpm build
+    gate A8 "npm tarball layout (pack:check)"     pnpm pack:check
+    gate A9 "install-and-run smoke (smoke:npm)"   pnpm smoke:npm
+  else
+    case_skip A7 "build all platform binaries" "pass --with-build"
+    case_skip A8 "npm tarball layout"          "pass --with-build"
+    case_skip A9 "install-and-run smoke"       "pass --with-build"
+  fi
+}

--- a/apps/wallet-cli/scripts/regression/cases-nudge.sh
+++ b/apps/wallet-cli/scripts/regression/cases-nudge.sh
@@ -1,0 +1,142 @@
+# Suite C — the one-time, agent-aware first-run nudge (introduced in 2.1.0).
+# Every case gets a pristine XDG_STATE_HOME so the "once per user" marker is
+# never inherited. `session view` is used as the cheapest "real command".
+
+MARKER_REL="ledger-wallet-cli/first-run.json"
+
+nudge_env() { # nudge_env <stateDir> [extra VAR=val ...]
+  # `env` requires its -u options before any VAR=value assignment, so unset the
+  # inherited agent/opt-out signals first and let callers opt back in.
+  local s="$1"; shift
+  CLI_ENV=(-u WALLET_CLI_NO_NUDGE -u CLAUDECODE -u CLAUDE_CODE -u CURSOR_AGENT -u CODEX_ENABLED \
+           -u GEMINI_CLI -u OPENCODE -u AMP_CURRENT_THREAD_ID -u AGENT \
+           "XDG_STATE_HOME=$s" "HOME=$ISO_HOME" "$@")
+}
+
+suite_c() {
+  local s
+
+  # ---- C1: shown once for a detected agent -----------------------------------
+  s=$(fresh_state)
+  case_start C1 "first real command prints the Claude Code nudge on stderr only"
+  nudge_env "$s" CLAUDECODE=1
+  cli session view
+  assert_rc 0 "$RC"
+  assert_has "$ERR" "wallet-cli skill install --agent claude" "stderr"
+  assert_has "$ERR" "Claude Code" "stderr"
+  assert_lacks "$OUT" "skill install" "stdout"
+  case_end
+
+  # ---- C2: never shown twice --------------------------------------------------
+  case_start C2 "the nudge is not repeated on the next command"
+  nudge_env "$s" CLAUDECODE=1
+  cli session view
+  assert_rc 0 "$RC"
+  assert_lacks "$ERR" "skill install" "stderr"
+  case_end
+
+  # ---- C3: marker file --------------------------------------------------------
+  case_start C3 "the marker is persisted under XDG_STATE_HOME with 0600/0700 perms"
+  assert_file "$s/$MARKER_REL"
+  assert_mode "$s/$MARKER_REL" 600
+  assert_mode "$s/ledger-wallet-cli" 700
+  assert_jq "$(cat "$s/$MARKER_REL")" '.version' "$EXPECTED_VERSION" "marker.version"
+  assert_jq_true "$(cat "$s/$MARKER_REL")" '.nudgeShownAt | test("^[0-9]{4}-")'
+  case_end
+
+  # ---- C4: silent under --output json, and not consumed ----------------------
+  s=$(fresh_state)
+  case_start C4 "--output json is nudge-free and does not consume the one-time hint"
+  nudge_env "$s" CLAUDECODE=1
+  cli session view --output json
+  assert_rc 0 "$RC"
+  assert_empty "$ERR" "stderr"
+  assert_json "$OUT"
+  assert_no_file "$s/$MARKER_REL"
+  nudge_env "$s" CLAUDECODE=1
+  cli session view
+  assert_has "$ERR" "skill install" "stderr (after a json run)"
+  case_end
+
+  # ---- C5: opt-out ------------------------------------------------------------
+  s=$(fresh_state)
+  case_start C5 "WALLET_CLI_NO_NUDGE=1 suppresses the nudge and writes no marker"
+  nudge_env "$s" CLAUDECODE=1 WALLET_CLI_NO_NUDGE=1
+  cli session view
+  assert_rc 0 "$RC"
+  assert_lacks "$ERR" "skill install" "stderr"
+  assert_no_file "$s/$MARKER_REL"
+  case_end
+
+  # ---- C6: quiet in plain pipes ----------------------------------------------
+  s=$(fresh_state)
+  case_start C6 "no agent env and a non-TTY stderr stays silent"
+  nudge_env "$s"
+  cli session view
+  assert_rc 0 "$RC"
+  assert_lacks "$ERR" "skill install" "stderr"
+  assert_no_file "$s/$MARKER_REL"
+  case_end
+
+  # ---- C7: per-agent tailoring -----------------------------------------------
+  case_start C7 "each detected agent maps to its own --agent value"
+  local pairs=("CURSOR_AGENT=1:--agent cursor:Cursor"
+               "CODEX_ENABLED=1:--agent codex:Codex"
+               "GEMINI_CLI=1:--agent agents:Gemini CLI"
+               "OPENCODE=1:--agent agents:opencode"
+               "AMP_CURRENT_THREAD_ID=x:--agent agents:amp")
+  local p envvar expect label
+  for p in "${pairs[@]}"; do
+    envvar=${p%%:*}; rest=${p#*:}; expect=${rest%%:*}; label=${rest#*:}
+    s=$(fresh_state)
+    nudge_env "$s" "$envvar"
+    cli session view
+    assert_has "$ERR" "wallet-cli skill install $expect" "stderr for $envvar"
+    assert_has "$ERR" "$label" "stderr label for $envvar"
+  done
+  case_end
+
+  # ---- C8: non-command invocations do not consume the nudge ------------------
+  for inv in --help --version; do
+    s=$(fresh_state)
+    case_start "C8${inv//-/}" "$inv does not consume the one-time nudge"
+    nudge_env "$s" CLAUDECODE=1
+    cli "$inv"
+    assert_no_file "$s/$MARKER_REL"
+    assert_lacks "$ERR" "skill install" "stderr of $inv"
+    nudge_env "$s" CLAUDECODE=1
+    cli session view
+    assert_has "$ERR" "skill install" "stderr of the following real command"
+    case_end
+  done
+
+  # ---- C9: skill commands are exempt -----------------------------------------
+  s=$(fresh_state)
+  case_start C9 "skill * commands never show the nudge nor consume it"
+  nudge_env "$s" CLAUDECODE=1
+  cli skill list
+  assert_rc 0 "$RC"
+  assert_lacks "$ERR" "Tip: install" "stderr"
+  assert_no_file "$s/$MARKER_REL"
+  case_end
+
+  # ---- C10: exit codes are untouched -----------------------------------------
+  s=$(fresh_state)
+  case_start C10 "the nudge does not alter a failing command's exit code"
+  nudge_env "$s" CLAUDECODE=1
+  cli balances no-such-label-9
+  assert_rc 1 "$RC"
+  assert_has "$ERR" "skill install" "stderr"
+  case_end
+
+  # ---- C11: hostile state dir -------------------------------------------------
+  s=$(fresh_state)
+  case_start C11 "a read-only state dir never breaks the command"
+  chmod 500 "$s"
+  nudge_env "$s" CLAUDECODE=1
+  cli session view --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  chmod 700 "$s"
+  case_end
+}

--- a/apps/wallet-cli/scripts/regression/cases-readonly.sh
+++ b/apps/wallet-cli/scripts/regression/cases-readonly.sh
@@ -1,0 +1,408 @@
+# Suite D — regression of every path that needs NO device: session, balances,
+# operations, assets, earn read paths, swap quote, and all `--dry-run` builders.
+# Runs against the developer's REAL session (labels are discovered dynamically),
+# reads live backends, and never signs or broadcasts.
+
+# Filled by suite_d_prepare from `session view --output json`.
+ETH_LABEL=""; SOL_LABEL=""; BTC_LABEL=""
+ETH_ADDR=""
+
+suite_d_prepare() {
+  real_env
+  cli session view --output json
+  if [ "$RC" != 0 ] || ! printf '%s' "$OUT" | jq -e . >/dev/null 2>&1; then
+    echo "${c_red}Cannot read the session — Suite D needs discovered accounts.${c_off}" >&2
+    return 1
+  fi
+  local labels; labels=$(printf '%s' "$OUT" | jq -r '.accounts[].label')
+  ETH_LABEL=$(printf '%s\n' "$labels" | grep -E '^ethereum-[0-9]+$'   | head -1)
+  SOL_LABEL=$(printf '%s\n' "$labels" | grep -E '^solana-[0-9]+$'     | head -1)
+  BTC_LABEL=$(printf '%s\n' "$labels" | grep -E '^bitcoin-.*[0-9]+$'  | head -1)
+  # A safe dry-run recipient: one of our own ethereum addresses, so even a
+  # mis-typed real send would only be a self-transfer. `session view` exposes
+  # descriptors (`account:1:address:<net>:main:<address>:<path>`), not addresses,
+  # so the address is taken from field 5 of a *different* ethereum account.
+  ETH_ADDR=$(printf '%s' "$OUT" | jq -r --arg l "$ETH_LABEL" \
+    '[.accounts[] | select(.label != $l) | select(.descriptor | test(":address:ethereum:main:")) | .descriptor][0] // empty' \
+    | cut -d: -f6)
+  [ -n "$ETH_ADDR" ] || ETH_ADDR=$(printf '%s' "$OUT" | jq -r --arg l "$ETH_LABEL" \
+    '[.accounts[] | select(.label == $l) | .descriptor][0]' | cut -d: -f6)
+  ADDR_OF() { # ADDR_OF <label> — address embedded in that account's descriptor
+    printf '%s' "$SESSION_JSON" | jq -r --arg l "$1" \
+      '[.accounts[] | select(.label == $l) | .descriptor][0] // empty' | cut -d: -f6
+  }
+  SESSION_JSON="$OUT"
+  echo "  ${c_dim}session labels: eth=$ETH_LABEL sol=$SOL_LABEL btc=$BTC_LABEL recipient=$ETH_ADDR${c_off}"
+}
+
+suite_d() {
+  suite_d_prepare || return 1
+  real_env
+
+  # ---- D1/D2: session view ----------------------------------------------------
+  case_start D1 "session view lists labels and descriptors"
+  cli session view
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "$ETH_LABEL" "stdout"
+  assert_has "$OUT" "account:1:" "stdout"
+  case_end
+
+  case_start D2 "session view --output json envelope"
+  cli session view --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.status' 'success'
+  assert_jq "$OUT" '.command' 'session view'
+  assert_jq_true "$OUT" '.accounts | length > 0'
+  assert_jq_true "$OUT" '.accounts[0] | has("label") and has("descriptor")'
+  # v1 hardening: no raw xprv/extended private keys ever surface
+  assert_lacks "$OUT" "xprv" "stdout"
+  case_end
+
+  # ---- D3..D6: balances -------------------------------------------------------
+  case_start D3 "balances (ethereum) prints native + token balances"
+  cli balances "$ETH_LABEL"
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "ETH" "stdout"
+  case_end
+
+  case_start D4 "balances --output json shape ({asset, amount} rows)"
+  cli balances "$ETH_LABEL" --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.status' 'success'
+  assert_jq "$OUT" '.command' 'balances'
+  assert_jq "$OUT" '.network' 'ethereum:main'
+  assert_jq_true "$OUT" '.balances | length >= 1'
+  assert_jq_true "$OUT" '.balances[0] | has("asset") and has("amount")'
+  assert_jq_true "$OUT" '[.balances[] | select(.asset == "ethereum")] | length == 1'
+  assert_jq_true "$OUT" '.balances[] | select(.asset == "ethereum") | .amount | test(" ETH$")'
+  case_end
+
+  if [ -n "$SOL_LABEL" ]; then
+    case_start D5 "balances (solana) works for a non-EVM account"
+    cli balances "$SOL_LABEL" --output json
+    assert_rc 0 "$RC"; assert_json "$OUT"
+    assert_jq_true "$OUT" '[.balances[] | select(.amount | test(" SOL$"))] | length == 1'
+    case_end
+  else case_skip D5 "balances (solana)" "no solana account in session"; fi
+
+  if [ -n "$BTC_LABEL" ]; then
+    case_start D6 "balances (bitcoin) works for a UTXO account"
+    cli balances "$BTC_LABEL" --output json
+    assert_rc 0 "$RC"; assert_json "$OUT"
+    assert_jq_true "$OUT" '[.balances[] | select(.amount | test(" BTC$"))] | length == 1'
+    case_end
+  else case_skip D6 "balances (bitcoin)" "no bitcoin account in session"; fi
+
+  case_start D7 "unknown session label fails with actionable guidance"
+  cli balances no-such-label-9
+  assert_rc 1 "$RC"
+  assert_has "$OUT$ERR" "No account labeled" "output"
+  assert_has "$OUT$ERR" "account discover" "output"
+  case_end
+
+  case_start D8 "raw account descriptors are rejected as arguments"
+  cli balances "account:1:address:ethereum:main:0x0000000000000000000000000000000000000000:m/44h/60h/0h/0/0"
+  assert_rc_nonzero "$RC"
+  case_end
+
+  # ---- D9..D11: operations ----------------------------------------------------
+  case_start D9 "operations --limit returns rows and a pagination cursor"
+  cli operations "$ETH_LABEL" --limit 3
+  assert_rc 0 "$RC"
+  assert_nonempty "$OUT$ERR" "output"
+  case_end
+
+  case_start D10 "operations --output json exposes nextCursor"
+  cli operations "$ETH_LABEL" --limit 3 --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.command' 'operations'
+  assert_jq_true "$OUT" '.operations | type == "array"'
+  case_end
+
+  # Pagination needs an account whose history is longer than the page size; with a
+  # short history the backend legitimately returns no cursor, so pick the account
+  # with the most operations and skip (not fail) when none paginates.
+  local page_label="" cur="" first=""
+  for cand in $(printf '%s' "$SESSION_JSON" | jq -r '.accounts[].label'); do
+    case "$cand" in ethereum-*|solana-*|bitcoin-*) : ;; *) continue ;; esac
+    cli operations "$cand" --limit 2 --output json
+    [ "$RC" = 0 ] || continue
+    cur=$(printf '%s' "$OUT" | jq -r '.nextCursor // empty')
+    if [ -n "$cur" ]; then
+      page_label="$cand"; first=$(printf '%s' "$OUT" | jq -r '.operations[0].hash // empty'); break
+    fi
+  done
+  if [ -n "$page_label" ]; then
+    case_start D11 "operations pagination: --cursor advances the page ($page_label)"
+    cli operations "$page_label" --limit 2 --cursor "$cur" --output json
+    assert_rc 0 "$RC"; assert_json "$OUT"
+    local second; second=$(printf '%s' "$OUT" | jq -r '.operations[0].hash // empty')
+    [ -n "$second" ] && [ "$first" != "$second" ] || fail_case "cursor page did not advance ($first vs $second)"
+    case_end
+  else
+    case_skip D11 "operations pagination" "no session account has more than one page of history"
+  fi
+
+  # ---- D12..D15: assets -------------------------------------------------------
+  case_start D12 "assets token resolves USDT by contract address"
+  cli assets token ethereum 0xdac17f958d2ee523a2206206994597c13d831ec7
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "USDT" "stdout"
+  assert_has "$OUT" "ethereum/erc20/usd_tether__erc20_" "stdout"
+  case_end
+
+  case_start D13 "assets token-by-id round-trips the same id"
+  cli assets token-by-id ethereum/erc20/usd_tether__erc20_ --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq_true "$OUT" '.. | objects | select(has("ticker")) | .ticker == "USDT"'
+  case_end
+
+  case_start D14 "assets token for an unknown contract exits non-zero"
+  cli assets token ethereum 0x0000000000000000000000000000000000000001
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "not found" "output"
+  case_end
+
+  case_start D15 "assets token resolves a non-EVM (solana) mint by address"
+  cli assets token solana EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "USDC" "stdout"
+  case_end
+
+  case_start D15b "assets token with a missing positional prints usage, not a stack trace"
+  cli assets token solana
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "Usage: assets token <network> <address>" "output"
+  case_end
+
+  # ---- D16..D20: earn read paths ---------------------------------------------
+  case_start D16 "earn yields (no network) lists supported networks with deeplinks"
+  cli earn yields
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "ledgerlive://" "stdout"
+  case_end
+
+  case_start D17 "earn yields -n solana surfaces --product validator targets"
+  cli earn yields -n solana
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "Deposit targets" "stdout"
+  assert_has "$OUT" "--product" "stdout"
+  assert_has "$OUT" "Ledger by" "stdout"
+  case_end
+
+  case_start D18 "earn yields -n ethereum surfaces vault ids as --product"
+  cli earn yields -n ethereum --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq_true "$OUT" '[.. | objects | select(has("vaultId")) | .vaultId] | length > 0'
+  case_end
+
+  case_start D19 "earn yields --limit and --all are accepted"
+  cli earn yields -n solana --limit 3
+  assert_rc 0 "$RC"
+  cli earn yields --all
+  assert_rc 0 "$RC"
+  case_end
+
+  if [ -n "$SOL_LABEL" ]; then
+    case_start D20 "earn positions (solana) returns positions and/or on-chain stakes"
+    cli earn positions "$SOL_LABEL" --output json
+    assert_rc 0 "$RC"
+    assert_json "$OUT"
+    assert_jq "$OUT" '.command' 'earn positions'
+    assert_jq_true "$OUT" '(.positions | type == "array")'
+    case_end
+
+    case_start D21 "earn positions --fresh is accepted and stays non-blocking"
+    cli earn positions "$SOL_LABEL" --fresh
+    assert_rc 0 "$RC"
+    case_end
+  else
+    case_skip D20 "earn positions (solana)" "no solana account"
+    case_skip D21 "earn positions --fresh" "no solana account"
+  fi
+
+  case_start D22 "earn positions (ethereum) works"
+  cli earn positions "$ETH_LABEL" --output json
+  assert_rc 0 "$RC"; assert_json "$OUT"
+  case_end
+
+  # ---- D23..D30: send --dry-run (no device, nothing broadcast) ---------------
+  case_start D23 "send --dry-run (native ETH) builds a transaction and shows fees"
+  cli send "$ETH_LABEL" --to "$ETH_ADDR" --amount "0.0001 ETH" --dry-run
+  assert_rc 0 "$RC"
+  assert_has "$OUT$ERR" "0.0001 ETH" "output"
+  assert_has "$OUT$ERR" "Fees" "output"
+  assert_lacks "$OUT$ERR" "hash:" "output (nothing may be broadcast in a dry run)"
+  case_end
+
+  case_start D24 "send --dry-run (ERC-20) resolves the token by ticker"
+  cli balances "$ETH_LABEL" --output json
+  # `amount` is a display string ("8.0232 USDC"): take the ticker of the first
+  # non-native row whose numeric part is > 0.
+  local tok; tok=$(printf '%s' "$OUT" | jq -r '
+    [.balances[] | select(.asset != "ethereum")
+      | (.amount | split(" ")) as $p
+      | select((($p[0] | gsub(",";"")) | tonumber? // 0) > 0)
+      | $p[1]][0] // empty')
+  if [ -n "$tok" ]; then
+    cli send "$ETH_LABEL" --to "$ETH_ADDR" --amount "0.01 $tok" --dry-run
+    assert_rc 0 "$RC"
+    assert_has "$OUT$ERR" "$tok" "output"
+  else
+    fail_case "no funded ERC-20 in $ETH_LABEL — run this case on a token-funded account"
+  fi
+  case_end
+
+  case_start D25 "send --amount without a ticker is rejected"
+  cli send "$ETH_LABEL" --to "$ETH_ADDR" --amount "0.0001" --dry-run
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "must include a ticker" "output"
+  case_end
+
+  case_start D26 "send with an unknown ticker lists the account's tickers"
+  cli send "$ETH_LABEL" --to "$ETH_ADDR" --amount "1 UNKN" --dry-run
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "not found in account" "output"
+  assert_has "$OUT$ERR" "Available:" "output"
+  case_end
+
+  case_start D27 "send above balance surfaces NotEnoughBalance"
+  cli send "$ETH_LABEL" --to "$ETH_ADDR" --amount "999999 ETH" --dry-run
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "NotEnoughBalance" "output"
+  case_end
+
+  # Address validation now goes through the CoinModuleApi instance (2.1.0 change):
+  # exercise it once per family.
+  case_start D28 "invalid recipient is rejected (ethereum) — validateAddress via CoinModuleApi"
+  cli send "$ETH_LABEL" --to 0xnotanaddress --amount "0.0001 ETH" --dry-run
+  assert_rc_nonzero "$RC"
+  assert_has "$OUT$ERR" "InvalidAddress" "output"
+  case_end
+
+  if [ -n "$BTC_LABEL" ]; then
+    # A UTXO descriptor carries an xpub, not a spendable address, so the positive
+    # bitcoin dry run (with --fee-per-byte/--rbf) lives in the manual suite, where
+    # `receive` has produced a real address. Here we cover validation + flag parsing.
+    case_start D29 "invalid recipient is rejected (bitcoin) and fee flags parse"
+    cli send "$BTC_LABEL" --to bc1qinvalidaddress --amount "0.0001 BTC" --dry-run
+    assert_rc_nonzero "$RC"
+    assert_has "$OUT$ERR" "InvalidAddress" "output"
+    cli send "$BTC_LABEL" --to bc1qinvalidaddress --amount "0.0001 BTC" --fee-per-byte 5 --rbf --dry-run
+    assert_has "$OUT$ERR" "InvalidAddress" "output"
+    assert_lacks "$OUT$ERR" "Unknown option" "output"
+    case_end
+  else case_skip D29 "bitcoin validation + fee flags" "no bitcoin account"; fi
+
+  if [ -n "$SOL_LABEL" ]; then
+    case_start D30 "invalid recipient is rejected (solana) + --memo accepted in a dry run"
+    cli send "$SOL_LABEL" --to notasolanaaddress --amount "0.001 SOL" --dry-run
+    assert_rc_nonzero "$RC"
+    assert_has "$OUT$ERR" "InvalidAddress" "output"
+    local soladdr; soladdr=$(ADDR_OF "$SOL_LABEL")
+    cli send "$SOL_LABEL" --to "$soladdr" --amount "0.0001 SOL" --memo "nr-2.1.0" --dry-run
+    assert_lacks "$OUT$ERR" "Unknown option" "output"
+    assert_lacks "$OUT$ERR" "hash:" "output (dry run must not broadcast)"
+    case_end
+  else case_skip D30 "solana validation + --memo" "no solana account"; fi
+
+  # ---- D31..D33: earn dry runs ------------------------------------------------
+  if [ -n "$SOL_LABEL" ]; then
+    case_start D31 "earn deposit --dry-run (solana stake) validates without signing"
+    cli earn yields -n solana --output json
+    local validator; validator=$(printf '%s' "$OUT" | jq -r '[.. | objects | select(has("validator")) | .validator][0] // empty')
+    if [ -n "$validator" ]; then
+      cli earn deposit "$SOL_LABEL" --product "$validator" --amount "0.5 SOL" --dry-run
+      assert_lacks "$OUT$ERR" "Unknown option" "output"
+      assert_lacks "$OUT$ERR" "hash:" "output (dry run must not broadcast)"
+    else
+      fail_case "no validator returned by earn yields -n solana"
+    fi
+    case_end
+  else case_skip D31 "earn deposit --dry-run (solana)" "no solana account"; fi
+
+  case_start D32 "earn deposit --dry-run (ethereum vault) reports the approve/deposit split"
+  cli earn yields -n ethereum --output json
+  local vault; vault=$(printf '%s' "$OUT" | jq -r '[.. | objects | select(has("vaultId")) | .vaultId][0] // empty')
+  if [ -n "$vault" ]; then
+    cli earn deposit "$ETH_LABEL" --product "$vault" --amount "1 USDC" --dry-run
+    assert_lacks "$OUT$ERR" "Unknown option" "output"
+    assert_lacks "$OUT$ERR" "hash:" "output (dry run must not broadcast)"
+  else
+    fail_case "no vaultId returned by earn yields -n ethereum"
+  fi
+  case_end
+
+  case_start D33 "earn withdraw --dry-run rejects a missing target"
+  cli earn withdraw "$ETH_LABEL" --dry-run
+  assert_rc_nonzero "$RC"
+  case_end
+
+  # ---- D34..D38: swap quote ---------------------------------------------------
+  case_start D34 "swap quote (ETH -> BTC) queries providers and reports per-provider outcomes"
+  if [ -n "$BTC_LABEL" ]; then
+    cli swap quote --from ethereum --to bitcoin --amount 0.05 --from-account "$ETH_LABEL" --to-account "$BTC_LABEL"
+    assert_rc 0 "$RC"
+    assert_nonempty "$OUT$ERR" "output"
+    printf '%s' "$OUT$ERR" | grep -qiE "rate|no quotes available" || fail_case "no rate lines and no explicit 'No quotes available'"
+  else fail_case "no bitcoin account for the ETH->BTC quote"; fi
+  case_end
+
+  case_start D35 "swap quote --output json shape"
+  cli swap quote --from ethereum --to bitcoin --amount 0.05 --from-account "$ETH_LABEL" --to-account "$BTC_LABEL" --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.command' 'swap quote'
+  case_end
+
+  case_start D36 "swap quote accepts a token currency id"
+  cli swap quote --from ethereum/erc20/usd_tether__erc20_ --to ethereum --amount 50 --from-account "$ETH_LABEL" --to-account "$ETH_LABEL" --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  case_end
+
+  case_start D37 "swap quote with a missing required flag fails cleanly"
+  cli swap quote --from ethereum --to bitcoin --amount 0.05 --from-account "$ETH_LABEL"
+  assert_rc_nonzero "$RC"
+  assert_lacks "$OUT$ERR" "[object Object]" "output"
+  case_end
+
+  case_start D38 "swap quote with an unknown currency id fails cleanly"
+  cli swap quote --from not-a-currency --to bitcoin --amount 0.05 --from-account "$ETH_LABEL" --to-account "$BTC_LABEL"
+  assert_rc_nonzero "$RC"
+  assert_lacks "$OUT$ERR" "[object Object]" "output"
+  case_end
+
+  # Documented behaviour: an id the provider does not know is reported as UNKNOWN
+  # with exit 0 (it is a status read, not a failure). What must not happen is a
+  # crash or an unrendered error object.
+  case_start D39 "swap status reports UNKNOWN for an unknown swap id without crashing"
+  cli swap status --swap-id nr-2-1-0-does-not-exist --provider changelly
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "UNKNOWN" "stdout"
+  assert_lacks "$OUT$ERR" "[object Object]" "output"
+  case_end
+
+  case_start D39b "swap status with a missing --provider fails cleanly"
+  cli swap status --swap-id nr-2-1-0-does-not-exist
+  assert_rc_nonzero "$RC"
+  assert_lacks "$OUT$ERR" "[object Object]" "output"
+  case_end
+
+  # ---- D40: version / help surface -------------------------------------------
+  case_start D40 "--version reports $EXPECTED_VERSION and --help lists every command group"
+  cli --version
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "$EXPECTED_VERSION" "stdout"
+  cli --help
+  assert_rc 0 "$RC"
+  for grp in account session balances operations receive send swap earn ring skill genuine-check assets; do
+    assert_has "$OUT$ERR" "$grp" "--help output (missing $grp)"
+  done
+  case_end
+}

--- a/apps/wallet-cli/scripts/regression/cases-skill.sh
+++ b/apps/wallet-cli/scripts/regression/cases-skill.sh
@@ -1,0 +1,374 @@
+# Suite B — the `skill` command group (introduced in 2.1.0) (list / retrieve / install / doctor).
+# No device, no network. Every case runs in a throwaway cwd with an isolated HOME
+# and XDG_STATE_HOME so nothing touches the developer's real agent directories.
+
+# Recompute the canonical skill content hash over the files on disk, mirroring
+# src/skills/hash.ts (sha256 over `path\0sha256(content)\n`, files sorted by path).
+# Used to forge a provenance sidecar for the `outdated` case, which otherwise
+# needs a genuinely older binary.
+skill_disk_hash() { # skill_disk_hash <skillRoot> <relpath...>
+  local root="$1"; shift
+  node -e '
+    const { createHash } = require("node:crypto");
+    const { readFileSync } = require("node:fs");
+    const [root, ...files] = process.argv.slice(1);
+    const one = c => createHash("sha256").update(c, "utf8").digest("hex");
+    const sorted = [...files].sort();
+    const h = createHash("sha256");
+    const per = {};
+    for (const f of sorted) {
+      const c = readFileSync(require("node:path").join(root, f), "utf8");
+      per[f] = one(c);
+      h.update(`${f}\0${per[f]}\n`, "utf8");
+    }
+    console.log(JSON.stringify({ contentHash: h.digest("hex"), files: per }));
+  ' "$root" "$@"
+}
+
+suite_b() {
+  local w skillroot sidecar json
+
+  # ---- B1: skill list (human) -------------------------------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  case_start B1 "skill list names the embedded skill"
+  cli skill list
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "ledger-wallet-cli" "stdout"
+  case_end
+
+  # ---- B2: skill list --output json ------------------------------------------
+  case_start B2 "skill list --output json emits a valid envelope"
+  cli skill list --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.status' 'success'
+  assert_jq "$OUT" '.command' 'skill list'
+  assert_jq_true "$OUT" '.skills | map(.name) | index("ledger-wallet-cli") != null'
+  assert_jq_true "$OUT" '.skills[0].description | length > 20'
+  case_end
+
+  # ---- B3: skill retrieve (default file) --------------------------------------
+  case_start B3 "skill retrieve prints SKILL.md from the binary"
+  cli skill retrieve
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "name: ledger-wallet-cli" "stdout"
+  assert_has "$OUT" "account discover" "stdout"
+  case_end
+
+  # ---- B4: skill retrieve --file ---------------------------------------------
+  case_start B4 "skill retrieve --file returns a reference doc"
+  cli skill retrieve --file references/business-logic.md
+  assert_rc 0 "$RC"
+  assert_nonempty "$OUT" "stdout"
+  assert_has "$OUT" "business logic" "stdout"
+  case_end
+
+  # ---- B5: skill retrieve unknown file ---------------------------------------
+  case_start B5 "skill retrieve --file <unknown> fails and lists available files"
+  cli skill retrieve --file no-such.md
+  assert_rc 1 "$RC"
+  assert_has "$ERR$OUT" "Available files:" "output"
+  assert_has "$ERR$OUT" "SKILL.md" "output"
+  case_end
+
+  # ---- B6: install --agent claude --------------------------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  case_start B6 "skill install --agent claude writes SKILL.md, references and sidecar"
+  cli skill install --agent claude
+  assert_rc 0 "$RC"
+  skillroot="$w/.claude/skills/ledger-wallet-cli"
+  assert_file "$skillroot/SKILL.md"
+  assert_file "$skillroot/references/business-logic.md"
+  assert_file "$skillroot/.wallet-cli-skill.json"
+  case_end
+
+  # ---- B7: sidecar provenance content ----------------------------------------
+  case_start B7 "provenance sidecar records name, cliVersion and content hashes"
+  sidecar=$(cat "$skillroot/.wallet-cli-skill.json")
+  assert_json "$sidecar" "sidecar"
+  assert_jq "$sidecar" '.name' 'ledger-wallet-cli' "sidecar.name"
+  assert_jq "$sidecar" '.cliVersion' "$EXPECTED_VERSION" "sidecar.cliVersion"
+  assert_jq_true "$sidecar" '.contentHash | test("^[0-9a-f]{64}$")'
+  assert_jq_true "$sidecar" '.files | has("SKILL.md") and has("references/business-logic.md")'
+  assert_jq_true "$sidecar" '.installedAt | test("^[0-9]{4}-")'
+  # the recorded hash must equal the hash of what is actually on disk
+  local disk
+  disk=$(skill_disk_hash "$skillroot" SKILL.md references/business-logic.md)
+  assert_jq "$sidecar" '.contentHash' "$(printf '%s' "$disk" | jq -r .contentHash)" "sidecar hash vs disk"
+  case_end
+
+  # ---- B8: install refuses to clobber ----------------------------------------
+  case_start B8 "second skill install without --force refuses to overwrite"
+  cli skill install --agent claude
+  assert_rc 1 "$RC"
+  assert_has "$ERR$OUT" "Refusing to overwrite" "output"
+  assert_has "$ERR$OUT" "--force" "output"
+  case_end
+
+  # ---- B9: install --force ---------------------------------------------------
+  case_start B9 "skill install --force overwrites and refreshes the sidecar"
+  local before after
+  before=$(jq -r .installedAt "$skillroot/.wallet-cli-skill.json")
+  sleep 1
+  cli skill install --agent claude --force
+  assert_rc 0 "$RC"
+  after=$(jq -r .installedAt "$skillroot/.wallet-cli-skill.json")
+  [ "$before" != "$after" ] || fail_case "sidecar installedAt not refreshed under --force"
+  case_end
+
+  # ---- B10: sidecar never blocks a first install -----------------------------
+  case_start B10 "install succeeds when only the sidecar remains (sidecar excluded from clash check)"
+  rm -f "$skillroot/SKILL.md" "$skillroot/references/business-logic.md"
+  cli skill install --agent claude
+  assert_rc 0 "$RC"
+  assert_file "$skillroot/SKILL.md"
+  case_end
+
+  # ---- B11: every supported agent maps to its own directory ------------------
+  case_start B11 "--agent cursor/codex/agents install into .cursor/.codex/.agents"
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --agent cursor;  assert_rc 0 "$RC"; assert_file "$w/.cursor/skills/ledger-wallet-cli/SKILL.md"
+  cli skill install --agent codex;   assert_rc 0 "$RC"; assert_file "$w/.codex/skills/ledger-wallet-cli/SKILL.md"
+  cli skill install --agent agents;  assert_rc 0 "$RC"; assert_file "$w/.agents/skills/ledger-wallet-cli/SKILL.md"
+  case_end
+
+  # ---- B12: default agent is claude -----------------------------------------
+  case_start B12 "bare skill install defaults to the claude directory"
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install
+  assert_rc 0 "$RC"
+  assert_file "$w/.claude/skills/ledger-wallet-cli/SKILL.md"
+  case_end
+
+  # ---- B13: --dir overrides -------------------------------------------------
+  case_start B13 "skill install --dir writes to an explicit directory"
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --dir ./custom-skills
+  assert_rc 0 "$RC"
+  assert_file "$w/custom-skills/ledger-wallet-cli/SKILL.md"
+  assert_no_file "$w/.claude"
+  case_end
+
+  # ---- B14: --global installs under HOME ------------------------------------
+  case_start B14 "skill install --global installs under the home directory"
+  w=$(fresh_dir); cd "$w"
+  local ghome; ghome=$(fresh_dir)
+  CLI_ENV=(WALLET_CLI_NO_NUDGE=1 "XDG_STATE_HOME=$ISO_STATE" "HOME=$ghome")
+  cli skill install --agent claude --global
+  assert_rc 0 "$RC"
+  assert_file "$ghome/.claude/skills/ledger-wallet-cli/SKILL.md"
+  assert_no_file "$w/.claude"
+  case_end
+
+  # ---- B15: --all ------------------------------------------------------------
+  case_start B15 "skill install --all installs every embedded skill"
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill list --output json; local names
+  names=$(printf '%s' "$OUT" | jq -r '.skills[].name')
+  cli skill install --all --agent claude
+  assert_rc 0 "$RC"
+  while IFS= read -r n; do [ -n "$n" ] && assert_file "$w/.claude/skills/$n/SKILL.md"; done <<<"$names"
+  case_end
+
+  # ---- B16: install --output json envelope ----------------------------------
+  case_start B16 "skill install --output json surfaces version, hashes and paths"
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --agent claude --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.status' 'success'
+  assert_jq "$OUT" '.command' 'skill install'
+  assert_jq "$OUT" '.cliVersion' "$EXPECTED_VERSION" "envelope.cliVersion"
+  assert_jq_true "$OUT" '.root | test("\\.claude/skills$")'
+  assert_jq_true "$OUT" '.skills | index("ledger-wallet-cli") != null'
+  assert_jq_true "$OUT" '.contentHashes["ledger-wallet-cli"] | test("^[0-9a-f]{64}$")'
+  assert_jq_true "$OUT" '.installed | length >= 2'
+  case_end
+
+  # ---- B17: unknown agent ----------------------------------------------------
+  case_start B17 "unknown --agent fails with the supported list (human + json)"
+  cli skill install --agent bogus
+  assert_rc 1 "$RC"
+  assert_has "$ERR$OUT" 'Unknown agent "bogus"' "output"
+  assert_has "$ERR$OUT" "claude, cursor, codex, agents" "output"
+  cli skill install --agent bogus --output json
+  assert_rc 1 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.ok' 'false'
+  assert_jq "$OUT" '.error.command' 'skill install'
+  case_end
+
+  # ---- B18: unknown skill name ----------------------------------------------
+  case_start B18 "unknown skill name fails and points at skill list"
+  cli skill install definitely-not-a-skill --agent claude
+  assert_rc 1 "$RC"
+  assert_has "$ERR$OUT" "not found" "output"
+  assert_has "$ERR$OUT" "skill list" "output"
+  case_end
+
+  # ---- B19: doctor up-to-date ------------------------------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --agent claude >/dev/null
+  skillroot="$w/.claude/skills/ledger-wallet-cli"
+  case_start B19 "skill doctor reports up-to-date after a fresh install (exit 0)"
+  cli skill doctor
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "up-to-date" "stdout"
+  assert_has "$OUT" "All skills up-to-date." "stdout"
+  case_end
+
+  # ---- B20: doctor json shape ------------------------------------------------
+  case_start B20 "skill doctor --output json exposes results/fixed/remainingDrift"
+  cli skill doctor --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  assert_jq "$OUT" '.command' 'skill doctor'
+  assert_jq "$OUT" '.fixed | length' '0'
+  assert_jq "$OUT" '.remainingDrift | length' '0'
+  assert_jq "$OUT" '.results[0].status' 'up-to-date'
+  assert_jq "$OUT" '.results[0].installedVersion' "$EXPECTED_VERSION"
+  assert_jq "$OUT" '.results[0].shippedVersion' "$EXPECTED_VERSION"
+  assert_jq_true "$OUT" '.results[0].diskHash == .results[0].shippedHash'
+  case_end
+
+  # ---- B21: modified-locally -------------------------------------------------
+  case_start B21 "local edit is reported modified-locally and exits non-zero"
+  printf '\n<!-- local edit -->\n' >>"$skillroot/SKILL.md"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "modified-locally" "stdout"
+  assert_has "$OUT" "still drifting" "stdout"
+  assert_has "$OUT" "--fix --force" "stdout"
+  case_end
+
+  # ---- B22: --fix leaves local edits alone -----------------------------------
+  case_start B22 "skill doctor --fix does NOT overwrite a locally modified skill"
+  cli skill doctor --fix
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "modified-locally" "stdout"
+  grep -q "local edit" "$skillroot/SKILL.md" || fail_case "local edit was overwritten by --fix without --force"
+  case_end
+
+  # ---- B23: --fix --force heals ---------------------------------------------
+  case_start B23 "skill doctor --fix --force restores the shipped content"
+  cli skill doctor --fix --force
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "Fixed 1 skill(s)." "stdout"
+  assert_has "$OUT" "All skills up-to-date." "stdout"
+  grep -q "local edit" "$skillroot/SKILL.md" && fail_case "local edit survived --fix --force"
+  case_end
+
+  # ---- B24: deleted tracked file counts as drift ----------------------------
+  case_start B24 "a deleted tracked file is detected as drift and healed by --fix --force"
+  rm -f "$skillroot/references/business-logic.md"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "modified-locally" "stdout"
+  cli skill doctor --fix --force
+  assert_rc 0 "$RC"
+  assert_file "$skillroot/references/business-logic.md"
+  case_end
+
+  # ---- B25: missing ----------------------------------------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  case_start B25 "skill doctor reports missing when nothing is installed (exit 1)"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "missing" "stdout"
+  assert_has "$OUT" "installed none" "stdout"
+  case_end
+
+  # ---- B26: missing + --fix --------------------------------------------------
+  case_start B26 "skill doctor --fix installs a missing skill without --force"
+  cli skill doctor --fix
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "Fixed 1 skill(s)." "stdout"
+  assert_file "$w/.claude/skills/ledger-wallet-cli/SKILL.md"
+  assert_file "$w/.claude/skills/ledger-wallet-cli/.wallet-cli-skill.json"
+  case_end
+
+  # ---- B27: outdated (forged older-version sidecar) -------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --agent claude >/dev/null
+  skillroot="$w/.claude/skills/ledger-wallet-cli"
+  case_start B27 "an install from an older wallet-cli is reported outdated and healed by --fix"
+  # Simulate "installed by 2.0.0": edit the content, then make the sidecar agree
+  # with what is on disk (so it is provenance-consistent) but disagree with the
+  # binary's shipped hash — exactly the outdated signature.
+  printf '\n<!-- shipped by an older cli -->\n' >>"$skillroot/SKILL.md"
+  local forged
+  forged=$(skill_disk_hash "$skillroot" SKILL.md references/business-logic.md)
+  jq -n --argjson h "$forged" '{name:"ledger-wallet-cli", cliVersion:"2.0.0", contentHash:$h.contentHash, files:$h.files, installedAt:"2026-01-01T00:00:00.000Z"}' \
+    >"$skillroot/.wallet-cli-skill.json"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "outdated" "stdout"
+  assert_has "$OUT" "installed 2.0.0@" "stdout"
+  cli skill doctor --fix
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "Fixed 1 skill(s)." "stdout"
+  assert_jq "$(cat "$skillroot/.wallet-cli-skill.json")" '.cliVersion' "$EXPECTED_VERSION" "healed sidecar version"
+  case_end
+
+  # ---- B28: sidecar-less install that matches shipped content ---------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  cli skill install --agent claude >/dev/null
+  skillroot="$w/.claude/skills/ledger-wallet-cli"
+  case_start B28 "a manual install with no sidecar but matching content is up-to-date"
+  rm -f "$skillroot/.wallet-cli-skill.json"
+  cli skill doctor
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "up-to-date" "stdout"
+  assert_has "$OUT" "installed none" "stdout"
+  case_end
+
+  # ---- B29: sidecar-less install that differs is conservative ---------------
+  case_start B29 "a sidecar-less install whose content differs is treated as modified-locally"
+  printf '\n<!-- hand edit -->\n' >>"$skillroot/SKILL.md"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "modified-locally" "stdout"
+  cli skill doctor --fix
+  assert_rc 1 "$RC"
+  grep -q "hand edit" "$skillroot/SKILL.md" || fail_case "--fix overwrote a sidecar-less install without --force"
+  case_end
+
+  # ---- B30: doctor --dir -----------------------------------------------------
+  w=$(fresh_dir); cd "$w"; iso_env
+  case_start B30 "skill doctor --dir scans an explicit directory only"
+  cli skill install --dir ./elsewhere >/dev/null
+  cli skill doctor --dir ./elsewhere
+  assert_rc 0 "$RC"
+  assert_has "$OUT" "up-to-date" "stdout"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "missing" "stdout"
+  case_end
+
+  # ---- B31: doctor --global --------------------------------------------------
+  case_start B31 "skill doctor --global also scans the home directory"
+  w=$(fresh_dir); cd "$w"
+  local ghome2; ghome2=$(fresh_dir)
+  CLI_ENV=(WALLET_CLI_NO_NUDGE=1 "XDG_STATE_HOME=$ISO_STATE" "HOME=$ghome2")
+  cli skill install --agent claude --global >/dev/null
+  cli skill doctor --global --output json
+  assert_rc 0 "$RC"
+  assert_json "$OUT"
+  # Compare on the home dir's basename: macOS resolves /var -> /private/var, so a
+  # full-path prefix match would fail for reasons unrelated to --global.
+  assert_jq_true "$OUT" "[.results[].root] | map(test(\"$(basename "$ghome2")\")) | any"
+  assert_jq_true "$OUT" '[.results[].status] | map(. == "up-to-date") | any'
+  case_end
+
+  # ---- B32: a regular file where a skill dir is expected --------------------
+  case_start B32 "a regular file at the skill path is not mistaken for an install"
+  w=$(fresh_dir); cd "$w"; iso_env
+  mkdir -p "$w/.claude/skills"
+  printf 'not a skill\n' >"$w/.claude/skills/ledger-wallet-cli"
+  cli skill doctor
+  assert_rc 1 "$RC"
+  assert_has "$OUT" "missing" "stdout"
+  case_end
+
+  cd "$REPO_ROOT"
+}

--- a/apps/wallet-cli/scripts/regression/lib.sh
+++ b/apps/wallet-cli/scripts/regression/lib.sh
@@ -1,0 +1,132 @@
+# Shared harness plumbing for the wallet-cli 2.1.0 non-regression suites.
+# Sourced by run-nr.sh — not executable on its own.
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+FAILED_IDS=()
+CURRENT_ID=""
+CURRENT_DESC=""
+CASE_ERRORS=()
+
+c_green=$'\033[32m'; c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_dim=$'\033[2m'; c_off=$'\033[0m'
+
+log() { printf '%s\n' "$*" >>"$LOG_FILE"; }
+
+case_start() {
+  CURRENT_ID="$1"; CURRENT_DESC="$2"; CASE_ERRORS=()
+  log ""; log "=== $CURRENT_ID — $CURRENT_DESC ==="
+}
+
+case_end() {
+  if [ ${#CASE_ERRORS[@]} -eq 0 ]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    printf '%s[PASS]%s %-5s %s\n' "$c_green" "$c_off" "$CURRENT_ID" "$CURRENT_DESC"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1)); FAILED_IDS+=("$CURRENT_ID")
+    printf '%s[FAIL]%s %-5s %s\n' "$c_red" "$c_off" "$CURRENT_ID" "$CURRENT_DESC"
+    for e in "${CASE_ERRORS[@]}"; do
+      printf '       %s%s%s\n' "$c_dim" "$e" "$c_off"
+      log "  FAILURE: $e"
+    done
+  fi
+}
+
+case_skip() {
+  SKIP_COUNT=$((SKIP_COUNT + 1))
+  printf '%s[SKIP]%s %-5s %s %s(%s)%s\n' "$c_yellow" "$c_off" "$1" "$2" "$c_dim" "$3" "$c_off"
+  log "=== $1 — SKIPPED: $3 ==="
+}
+
+fail_case() { CASE_ERRORS+=("$1"); }
+
+# --- assertions -------------------------------------------------------------
+
+assert_rc() { # assert_rc <expected> <actual>
+  [ "$2" = "$1" ] || fail_case "exit code: expected $1, got $2"
+}
+
+assert_rc_nonzero() {
+  [ "$1" != "0" ] || fail_case "exit code: expected non-zero, got 0"
+}
+
+assert_has() { # assert_has <haystack> <needle> [label]
+  case "$1" in
+    *"$2"*) : ;;
+    *) fail_case "${3:-output} does not contain: $2" ;;
+  esac
+}
+
+assert_lacks() {
+  case "$1" in
+    *"$2"*) fail_case "${3:-output} unexpectedly contains: $2" ;;
+    *) : ;;
+  esac
+}
+
+assert_empty() {
+  [ -z "${1//[[:space:]]/}" ] || fail_case "${2:-output} expected empty, got: $(printf '%s' "$1" | head -c 200)"
+}
+
+assert_nonempty() {
+  [ -n "${1//[[:space:]]/}" ] || fail_case "${2:-output} expected non-empty"
+}
+
+assert_file() { [ -f "$1" ] || fail_case "missing file: $1"; }
+assert_no_file() { [ ! -e "$1" ] || fail_case "file should not exist: $1"; }
+assert_dir() { [ -d "$1" ] || fail_case "missing dir: $1"; }
+
+assert_json() { # assert_json <text> [label]
+  printf '%s' "$1" | jq -e . >/dev/null 2>&1 || fail_case "${2:-output} is not valid JSON"
+}
+
+assert_jq() { # assert_jq <json> <filter> <expected> [label]
+  local got
+  got=$(printf '%s' "$1" | jq -r "$2" 2>/dev/null)
+  [ "$got" = "$3" ] || fail_case "${4:-jq $2}: expected '$3', got '$got'"
+}
+
+assert_jq_true() { # assert_jq_true <json> <filter>
+  printf '%s' "$1" | jq -e "$2" >/dev/null 2>&1 || fail_case "jq assertion false: $2"
+}
+
+assert_mode() { # assert_mode <path> <expected octal>
+  local got
+  got=$(stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1" 2>/dev/null)
+  [ "$got" = "$2" ] || fail_case "mode of $1: expected $2, got $got"
+}
+
+# --- CLI invocation ---------------------------------------------------------
+
+# Run the CLI capturing stdout/stderr separately into OUT/ERR/RC.
+# Extra env is passed as VAR=value pairs before the subcommand via CLI_ENV array.
+cli() {
+  local outf errf
+  outf=$(mktemp "$TMP_ROOT/out.XXXXXX"); errf=$(mktemp "$TMP_ROOT/err.XXXXXX")
+  log "\$ ${CLI_ENV[*]:-} $BIN_LABEL $*"
+  if [ ${#CLI_ENV[@]} -gt 0 ]; then
+    timeout "$CASE_TIMEOUT" env "${CLI_ENV[@]}" "${BIN_ARR[@]}" "$@" >"$outf" 2>"$errf"
+  else
+    timeout "$CASE_TIMEOUT" env "${BIN_ARR[@]}" "$@" >"$outf" 2>"$errf"
+  fi
+  RC=$?
+  OUT=$(cat "$outf"); ERR=$(cat "$errf")
+  log "--- rc=$RC"
+  log "--- stdout"; log "$OUT"
+  log "--- stderr"; log "$ERR"
+  [ "$RC" = 124 ] && fail_case "timed out after ${CASE_TIMEOUT}s"
+  return 0
+}
+
+# Default env for non-nudge cases: isolated state dir, nudge muted.
+iso_env() {
+  CLI_ENV=(WALLET_CLI_NO_NUDGE=1 "XDG_STATE_HOME=$ISO_STATE" "HOME=$ISO_HOME")
+}
+
+# Env that keeps the developer's real session (needed for read commands).
+real_env() {
+  CLI_ENV=(WALLET_CLI_NO_NUDGE=1)
+}
+
+fresh_state() { mktemp -d "$TMP_ROOT/state.XXXXXX"; }
+fresh_dir() { mktemp -d "$TMP_ROOT/work.XXXXXX"; }

--- a/apps/wallet-cli/scripts/regression/run.sh
+++ b/apps/wallet-cli/scripts/regression/run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Automated regression harness for the wallet-cli cases that need no device.
+# Case ids match ../../docs/regression/no-device.md.
+#
+#   ./run.sh                       # suites B, C, D (skill group, first-run nudge, read/dry-run)
+#   ./run.sh --suite b             # one suite (a|b|c|d, repeatable)
+#   ./run.sh --with-gates          # add suite A (repo gates); --with-build adds build/pack/smoke
+#   ./run.sh --bin ./path/to/cli   # a specific binary (default: dist/<platform>/cli)
+#   ./run.sh --source              # run from source via `pnpm wallet-cli start`
+#
+# Suites B and C are hermetic (throwaway cwd, HOME and XDG_STATE_HOME).
+# Suite D reads the developer's real session and live backends; it never signs
+# or broadcasts. Device-touching cases live in the docs, not here.
+#
+# Requires: bash, jq, node, timeout (coreutils), and a built binary or pnpm.
+
+set -uo pipefail
+
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=${REPO_ROOT:-$(git -C "$HERE" rev-parse --show-toplevel)}
+WALLET_CLI_DIR="$REPO_ROOT/apps/wallet-cli"
+EXPECTED_VERSION=$(jq -r .version "$WALLET_CLI_DIR/package.json")
+
+for tool in jq node timeout; do
+  command -v "$tool" >/dev/null || { echo "missing required tool: $tool" >&2; exit 2; }
+done
+
+SUITES=()
+WITH_GATES=0
+WITH_BUILD=0
+BIN_OVERRIDE=""
+USE_SOURCE=0
+CASE_TIMEOUT=${CASE_TIMEOUT:-240}
+GATE_TIMEOUT=${GATE_TIMEOUT:-2400}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --suite) SUITES+=("$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"); shift 2 ;;
+    --with-gates) WITH_GATES=1; SUITES+=(a); shift ;;
+    --with-build) WITH_BUILD=1; shift ;;
+    --bin) BIN_OVERRIDE="$2"; shift 2 ;;
+    --source) USE_SOURCE=1; shift ;;
+    --timeout) CASE_TIMEOUT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+[ ${#SUITES[@]} -eq 0 ] && SUITES=(b c d)
+
+# --- CLI under test ---------------------------------------------------------
+if [ "$USE_SOURCE" = 1 ]; then
+  BIN_ARR=(pnpm --dir "$REPO_ROOT" --silent wallet-cli start)
+  BIN_LABEL="pnpm wallet-cli start"
+else
+  if [ -n "$BIN_OVERRIDE" ]; then
+    BIN="$BIN_OVERRIDE"
+  else
+    case "$(uname -s)-$(uname -m)" in
+      Darwin-arm64) BIN="$WALLET_CLI_DIR/dist/darwin-arm64/cli" ;;
+      Linux-x86_64) BIN="$WALLET_CLI_DIR/dist/linux-x64/cli" ;;
+      Linux-aarch64) BIN="$WALLET_CLI_DIR/dist/linux-arm64/cli" ;;
+      *) echo "no default binary for $(uname -s)-$(uname -m); pass --bin or --source" >&2; exit 2 ;;
+    esac
+  fi
+  if [ ! -x "$BIN" ]; then
+    echo "binary not found: $BIN" >&2
+    echo "build it with: (cd $WALLET_CLI_DIR && pnpm build)   — or run with --source" >&2
+    exit 2
+  fi
+  BIN_ARR=("$BIN")
+  BIN_LABEL="$BIN"
+fi
+
+# --- scratch space ----------------------------------------------------------
+RUN_ID=$(date +%Y%m%d-%H%M%S)
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/wallet-cli-regression.$RUN_ID.XXXXXX")
+LOG_FILE="$TMP_ROOT/run.log"
+ISO_STATE=$(mktemp -d "$TMP_ROOT/iso-state.XXXXXX")
+ISO_HOME=$(mktemp -d "$TMP_ROOT/iso-home.XXXXXX")
+CLI_ENV=()
+OUT=""; ERR=""; RC=0
+: >"$LOG_FILE"
+
+# shellcheck source=lib.sh
+source "$HERE/lib.sh"
+source "$HERE/cases-gates.sh"
+source "$HERE/cases-skill.sh"
+source "$HERE/cases-nudge.sh"
+source "$HERE/cases-readonly.sh"
+
+echo "wallet-cli regression run $RUN_ID"
+echo "  version under test : $EXPECTED_VERSION"
+echo "  cli                : $BIN_LABEL"
+echo "  suites             : ${SUITES[*]}"
+echo "  log                : $LOG_FILE"
+echo
+
+START=$(date +%s)
+for s in "${SUITES[@]}"; do
+  case "$s" in
+    a) echo "── Suite A — repo & artifact gates ──"; suite_a ;;
+    b) echo "── Suite B — skill command group ──"; suite_b ;;
+    c) echo "── Suite C — first-run nudge ──"; suite_c ;;
+    d) echo "── Suite D — device-free regression ──"; suite_d ;;
+    *) echo "unknown suite: $s" >&2; exit 2 ;;
+  esac
+  echo
+done
+END=$(date +%s)
+
+TOTAL=$((PASS_COUNT + FAIL_COUNT))
+echo "──────────────────────────────────────────────"
+printf 'passed %s/%s   failed %s   skipped %s   (%ss)\n' "$PASS_COUNT" "$TOTAL" "$FAIL_COUNT" "$SKIP_COUNT" "$((END - START))"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf 'failed cases: %s\n' "${FAILED_IDS[*]}"
+  echo "full log: $LOG_FILE"
+  exit 1
+fi
+echo "log: $LOG_FILE"


### PR DESCRIPTION
## Why

wallet-cli had no written regression plan. This adds one that lives next to the code so it evolves with it, plus a script for the part that can actually be automated.

## What

- `apps/wallet-cli/docs/regression/` — the plan, split by the only distinction that matters in practice: whether a case needs a Ledger on USB.
  - `no-device.md` — repo gates (A), the `skill` group (B), the first-run nudge (C), and every read/dry-run command path (D). Script-runnable.
  - `with-device.md` — `account discover`, `receive`, `send`, `swap execute`, `earn deposit/withdraw`, `ring`, platform matrix. Run by a person with the device in hand; includes the protocol (one command per case, `--output json` so exit codes and device-state events are the oracle, what evidence to record).
  - `releases/2.1.0.md` — what changed in this release and which cases it puts at risk.
- `apps/wallet-cli/scripts/regression/` — the harness for the no-device cases. Case ids match `no-device.md`; isolates `HOME`/`XDG_STATE_HOME` for the `skill`/nudge cases, uses the real session for read cases, never signs or broadcasts.

No Speculos: the transport is USB/DMK only, so device cases are not automatable. The in-process mock DMK used by `bun test` is not reachable from the shipped binary — `with-device.md` ends with a list of device-shaped behaviours that mock *could* cover but doesn't today, so they can be moved off the manual pass as tests.

## Notes for review

- The plan is the deliverable; the harness is a convenience. Suites B (37 cases) and C (13) were verified green against a locally built `dist/darwin-arm64/cli`; suite D was verified against a real session with 5 cases left needing a funded ERC-20 or a longer-history account — those are noted in the tables rather than hidden.
- `releases/2.1.0.md` ends with 6 open questions found while writing this (JSON balance amounts as locale-formatted display strings, `swap status` exit code on unknown ids, and two inaccuracies in the skill that now ships inside the binary). They want product answers, not test runs.

## Test plan

- `bash -n` on the harness scripts.
- `./scripts/regression/run.sh --suite b` / `--suite c` against a built binary.