### PR TITLE
[LWDM] feat(lwdm): a/b testing show recent banner

### DIFF
--- a/.changeset/poor-rocks-rush.md
+++ b/.changeset/poor-rocks-rush.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@shared/feature-flags": minor
+"ledger-live-desktop-e2e-tests": minor
+"ledger-live-mobile-e2e-tests": minor
+---
+
+feat(lwdm): a/b testing show recent banner

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -2,6 +2,7 @@ import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recip
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import { Subheader, SubheaderRow, SubheaderTitle } from "@ledgerhq/lumen-ui-react";
+import { useFeature } from "@features/platform-feature-flags";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { useFormatRelativeDate } from "../hooks/useFormatRelativeDate";
@@ -27,6 +28,8 @@ export function AddressMatchedSection({
 }: AddressMatchedSectionProps) {
   const { t } = useTranslation();
   const formatRelativeDate = useFormatRelativeDate();
+  const isFirstInteractionBannerEnabled =
+    useFeature("newSendFlowFirstInteractionBanner")?.enabled ?? false;
 
   const { accountName, matchedAccounts, ensName, matchedRecentAddress, status, resolvedAddress } =
     searchResult;
@@ -137,7 +140,8 @@ export function AddressMatchedSection({
           />
         )}
 
-        {searchResult.isFirstInteraction &&
+        {isFirstInteractionBannerEnabled &&
+          searchResult.isFirstInteraction &&
           !isSanctioned &&
           !hasBridgeError &&
           isAddressComplete && <RecentHistoryWarningCard />}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -2,74 +2,47 @@
  * @jest-environment jsdom
  */
 import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
-import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import React from "react";
-import { render, screen } from "tests/testSetup";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
 import {
   createMockAccount,
   createMockCurrency,
 } from "../../__integrations__/__fixtures__/accounts";
 import { AddressMatchedSection } from "../AddressMatchedSection";
 
-jest.mock("@ledgerhq/live-common/utils/addressUtils", () => ({
-  formatAddress: jest.fn(),
-}));
+const FIXED_NOW = new Date("2026-07-31T10:00:00.000Z");
+const address = "0x95f98055ag77xe7csuz15e36";
+const formattedAddress = "0x95f980...suz15e36";
 
-jest.mock("react-i18next", () => ({
-  ...jest.requireActual("react-i18next"),
-  useTranslation: () => ({
-    t: (key: string, values?: Record<string, string>) => {
-      if (key === "newSendFlow.addressMatched") return "Address matched";
-      if (key === "newSendFlow.sendTo") return `Send to ${values?.address}`;
-      if (key === "newSendFlow.alreadyUsed") return `Already used · ${values?.date}`;
-      return key;
-    },
-  }),
-}));
-
-jest.mock("../../hooks/useFormatRelativeDate", () => ({
-  useFormatRelativeDate: () => () => "3 min ago",
-}));
-
-jest.mock("@ledgerhq/lumen-ui-react", () => {
-  return {
-    ...jest.requireActual("@ledgerhq/lumen-ui-react"),
-    ListItem: ({
-      children,
-      ...props
-    }: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => (
-      <div {...props}>{children}</div>
-    ),
-    ListItemContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    ListItemDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    ListItemLeading: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    ListItemTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    ListItemTrailing: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    Spot: () => <div />,
-    Subheader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    SubheaderRow: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-    SubheaderTitle: ({
-      children,
-      ...props
-    }: React.PropsWithChildren<React.HTMLAttributes<HTMLDivElement>>) => (
-      <div {...props}>{children}</div>
-    ),
-  };
-});
-
-jest.mock("@ledgerhq/lumen-ui-react/symbols", () => ({
-  ChevronRight: () => <span />,
-  LedgerLogo: () => null,
-  Wallet: () => null,
-}));
-
-const mockedFormatAddress = jest.mocked(formatAddress);
+function renderAddressMatchedSection(
+  searchResult: AddressSearchResult,
+  options?: {
+    featureFlagOverrides?: Parameters<typeof withFlagOverrides>[0];
+  },
+) {
+  return render(
+    <AddressMatchedSection
+      searchResult={searchResult}
+      searchValue={address}
+      onSelect={jest.fn()}
+      isAddressComplete
+    />,
+    options?.featureFlagOverrides
+      ? { initialState: withFlagOverrides(options.featureFlagOverrides) }
+      : undefined,
+  );
+}
 
 describe("AddressMatchedSection", () => {
-  it("displays the matched account name with the already used subtitle", () => {
-    const address = "0x95f98055ag77xe7csuz15e36";
-    mockedFormatAddress.mockReturnValue("0x95f...15e36");
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(FIXED_NOW);
+  });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("displays the matched account name with the already used subtitle", () => {
     const searchResult: AddressSearchResult = {
       status: "valid",
       error: null,
@@ -83,7 +56,7 @@ describe("AddressMatchedSection", () => {
       matchedRecentAddress: {
         address,
         currency: createMockCurrency({ id: "ethereum", name: "Ethereum", ticker: "ETH" }),
-        lastUsedAt: new Date("2026-03-01T10:00:00.000Z"),
+        lastUsedAt: new Date("2026-07-31T09:57:00.000Z"),
         name: address,
         isLedgerAccount: true,
         accountId: "account_2",
@@ -101,24 +74,14 @@ describe("AddressMatchedSection", () => {
       hasBridgeValidationResult: true,
     };
 
-    render(
-      <AddressMatchedSection
-        searchResult={searchResult}
-        searchValue={address}
-        onSelect={jest.fn()}
-        isAddressComplete
-      />,
-    );
+    renderAddressMatchedSection(searchResult);
 
-    expect(screen.getByText("Address matched")).toBeInTheDocument();
+    expect(screen.getByTestId("send-address-matched-title")).toHaveTextContent("Address matched");
     expect(screen.getByText("Send to Ethereum 2")).toBeInTheDocument();
     expect(screen.getByText("Already used · 3 min ago")).toBeInTheDocument();
   });
 
   it("displays the formatted address subtitle when the matched account was not already used", () => {
-    const address = "0x95f98055ag77xe7csuz15e36";
-    mockedFormatAddress.mockReturnValue("0x95f...15e36");
-
     const searchResult: AddressSearchResult = {
       status: "valid",
       error: null,
@@ -143,16 +106,34 @@ describe("AddressMatchedSection", () => {
       hasBridgeValidationResult: true,
     };
 
-    render(
-      <AddressMatchedSection
-        searchResult={searchResult}
-        searchValue={address}
-        onSelect={jest.fn()}
-        isAddressComplete
-      />,
-    );
+    renderAddressMatchedSection(searchResult);
 
     expect(screen.getByText("Send to Ethereum 2")).toBeInTheDocument();
-    expect(screen.getByText("0x95f...15e36")).toBeInTheDocument();
+    expect(screen.getByText(formattedAddress)).toBeInTheDocument();
+  });
+
+  it("does not display the first interaction banner when the feature flag is disabled", () => {
+    const searchResult: AddressSearchResult = {
+      status: "valid",
+      error: null,
+      resolvedAddress: address,
+      ensName: undefined,
+      isLedgerAccount: false,
+      accountName: undefined,
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: true,
+      matchedRecentAddress: undefined,
+      matchedAccounts: [],
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      featureFlagOverrides: { newSendFlowFirstInteractionBanner: { enabled: false } },
+    });
+
+    expect(screen.queryByTestId("send-recent-history-warning")).not.toBeInTheDocument();
   });
 });

--- a/apps/ledger-live-desktop/tests/specs/send/newSendFlow.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/send/newSendFlow.spec.ts
@@ -1,4 +1,5 @@
 import test from "../../fixtures/common";
+import { FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED } from "tests/utils/featureFlagUtils";
 import { expect, Page } from "@playwright/test";
 import { AccountPage } from "../../page/account.page";
 import { AccountsPage } from "../../page/accounts.page";
@@ -47,6 +48,7 @@ test.use({
   userdata:
     "1AccountBTC1AccountETH1AccountARB1AccountSOL1AccountXTZ1AccountXLM1AccountALGO1AccountXRP",
   featureFlags: {
+    ...FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED,
     newSendFlow: {
       enabled: true,
       params: {

--- a/apps/ledger-live-desktop/tests/utils/featureFlagUtils.ts
+++ b/apps/ledger-live-desktop/tests/utils/featureFlagUtils.ts
@@ -1,0 +1,5 @@
+import type { OptionalFeatureMap } from "@shared/feature-flags";
+
+export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
+  newSendFlowFirstInteractionBanner: { enabled: true },
+} satisfies OptionalFeatureMap;

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
+import { useFeature } from "@features/platform-feature-flags";
 import React, { useCallback } from "react";
 import { Keyboard } from "react-native";
 import { useTranslation } from "~/context/Locale";
@@ -40,6 +41,8 @@ export function AddressMatchedSection({
 }: AddressMatchedSectionProps) {
   const { t } = useTranslation();
   const formatRelativeDate = useFormatRelativeDate();
+  const isFirstInteractionBannerEnabled =
+    useFeature("newSendFlowFirstInteractionBanner")?.enabled ?? false;
   const helpSheetRef = useBottomSheetRef();
   const openHelpSheet = useCallback(() => {
     Keyboard.dismiss();
@@ -157,7 +160,8 @@ export function AddressMatchedSection({
         )}
       </Box>
       <Box lx={{ flexDirection: "column", marginVertical: "s16", marginHorizontal: "s8" }}>
-        {searchResult.isFirstInteraction &&
+        {isFirstInteractionBannerEnabled &&
+          searchResult.isFirstInteraction &&
           !isSanctioned &&
           !hasBridgeError &&
           isAddressComplete && (

--- a/e2e/desktop/tests/utils/featureFlagUtils.ts
+++ b/e2e/desktop/tests/utils/featureFlagUtils.ts
@@ -144,6 +144,10 @@ export const FF_NEW_SEND_FLOW_DISABLED = {
   },
 } satisfies OptionalFeatureMap;
 
+export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
+  newSendFlowFirstInteractionBanner: { enabled: true },
+} satisfies OptionalFeatureMap;
+
 export const getMergedFeatureFlags = ({
   testFlags,
 }: { testFlags?: OptionalFeatureMap } = {}): OptionalFeatureMap => {
@@ -178,6 +182,7 @@ export const getMergedFeatureFlags = ({
     },
     // default flags for wallet 4.0
     ...FF_LWD_WALLET_40_Q2,
+    ...FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED,
     // any flags from env variable (if set)
     ...ffPresetMap[process.env.E2E_DESKTOP_FEATURE_FLAGS || ""],
   };

--- a/e2e/desktop/tests/utils/newSendFlowUtils.ts
+++ b/e2e/desktop/tests/utils/newSendFlowUtils.ts
@@ -6,6 +6,7 @@ import { addBugLink, addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers";
 import { liveDataWithRecipientAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import { FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED } from "tests/utils/featureFlagUtils";
 import { Currency } from "@ledgerhq/live-e2e-shared/enum/Currency";
 import { buildTags } from "tests/utils/tagsUtils";
 
@@ -80,6 +81,7 @@ export function registerNewSendFlowTests(entries: NewSendFlowEntry[]) {
         speculosApp: tx.accountToDebit.currency.speculosApp,
         cliCommands: [liveDataWithRecipientAddressCommand(tx)],
         featureFlags: {
+          ...FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED,
           newSendFlow: {
             enabled: true,
             params: { families: NEW_SEND_FLOW_FAMILIES },

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -43,6 +43,10 @@ export const FF_LWM_WALLET_40_Q2 = {
   },
 } satisfies OptionalFeatureMap;
 
+export const FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED = {
+  newSendFlowFirstInteractionBanner: { enabled: true },
+} satisfies OptionalFeatureMap;
+
 export const FF_NEW_SEND_FLOW_ENABLED = {
   newSendFlow: {
     enabled: true,
@@ -52,6 +56,7 @@ export const FF_NEW_SEND_FLOW_ENABLED = {
     },
   },
   useDeviceActionSignatureSend: { enabled: true }, // Note: Prevent usage of DIE, which is not Speculos ready yet.
+  ...FF_NEW_SEND_FLOW_FIRST_INTERACTION_BANNER_ENABLED,
 } satisfies OptionalFeatureMap;
 
 export const getMergedFeatureFlags = ({

--- a/shared/feature-flags/src/flags/team-coin-integration/index.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/index.ts
@@ -110,6 +110,7 @@ export * from "./llmMemoTag";
 export * from "./llmTezosStaking";
 export * from "./llmWebviewManifestDomainCheck";
 export * from "./newSendFlow";
+export * from "./newSendFlowFirstInteractionBanner";
 export * from "./useDeviceActionSignatureSend";
 export * from "./web3hub";
 export * from "./zcashShielded";

--- a/shared/feature-flags/src/flags/team-coin-integration/newSendFlowFirstInteractionBanner.ts
+++ b/shared/feature-flags/src/flags/team-coin-integration/newSendFlowFirstInteractionBanner.ts
@@ -1,0 +1,4 @@
+import { flag } from "../../define";
+
+/** A/B test flag for the "first interaction" banner in the new send flow recipient step. */
+export const newSendFlowFirstInteractionBanner = flag({ enabled: true });


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Create the `newSendFlowFirstInteractionBanner` FF for A/B testing the recent address banner in the new send flow recipient step

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34435)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
