### PR TITLE
[LWDM] test(cosmos): run zenrock integration test weekly (flaky node)

### DIFF
--- a/.changeset/twelve-pugs-knock.md
+++ b/.changeset/twelve-pugs-knock.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore(llc): run the zenrock cosmos integration test weekly (flaky public node)

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -24,6 +24,7 @@ const weeklyIntegrationTests = [
   "src/families/cosmos/datasets/stargaze.integration.test.ts",
   "src/families/cosmos/datasets/quicksilver.integration.test.ts",
   "src/families/cosmos/datasets/xion.integration.test.ts",
+  "src/families/cosmos/datasets/zenrock.integration.test.ts",
   "src/families/mina/bridge.integration.test.ts",
 ];
 


### PR DESCRIPTION
### 📝 Description

`zenrock.integration.test.ts` fails every per-PR/daily Integration Tests run — 22× `API HTTP 502` from its public LCD `zenrock.api.m.stavr.tech`. zenrock has no paid node provider and `zenrock.coin.ledger.com` is being removed, so there is no stable endpoint to point at.

Safe quick fix to unblock affected PR's.

### 🔗 Context

- **JIRA / GitHub issue**: _n/a_ 
- **ADR** (if any): _n/a_