### PR TITLE
[LWM] feat(mobile): align Earn deposit canvas background (LIVE-35191)

### DIFF
--- a/.changeset/align-earn-deposit-canvas-background.md
+++ b/.changeset/align-earn-deposit-canvas-background.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Align Earn deposit flow header and webview shell with the live-app canvas when swapToEarn is enabled

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -192,6 +192,8 @@ export default function BaseNavigator() {
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector) && isAccountsEmpty;
   const web3hub = useFeature("web3hub");
   const llmAccountListUI = useFeature("llmAccountListUI");
+  const swapToEarnFlag = useFeature("swapToEarn");
+  const isSwapToEarnEnabled = swapToEarnFlag?.enabled ?? false;
 
   return (
     <>
@@ -596,7 +598,12 @@ export default function BaseNavigator() {
           // `useEarnIntentFlowPresentation` becomes the live owner and overrides this imperatively
           // via `getParent(BASE_NAVIGATOR_ID).setOptions` as the webview route changes.
           options={props =>
-            getEarnScreenOptions(props.route?.params?.params?.intent, t, liveAppCanvasColor)
+            getEarnScreenOptions(
+              props.route?.params?.params?.intent,
+              t,
+              liveAppCanvasColor,
+              isSwapToEarnEnabled,
+            )
           }
         />
         <Stack.Screen

--- a/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/BaseNavigator.tsx
@@ -104,7 +104,7 @@ import AssetsListNavigator from "LLM/features/Assets/Navigator";
 import AnalyticsNavigator from "LLM/features/Analytics/Navigator";
 import OperationsHistoryNavigator from "LLM/features/OperationsHistory/Navigator";
 import FeesNavigator from "./FeesNavigator";
-import { getEarnScreenOptions } from "./getEarnScreenOptions";
+import { getEarnScreenOptions, getEarnScreenOptionsFromRouteParams } from "./getEarnScreenOptions";
 import SignRawTransactionNavigator from "./SignRawTransactionNavigator";
 import LiveAppModalScreen from "LLM/features/LiveAppModal";
 
@@ -598,8 +598,8 @@ export default function BaseNavigator() {
           // `useEarnIntentFlowPresentation` becomes the live owner and overrides this imperatively
           // via `getParent(BASE_NAVIGATOR_ID).setOptions` as the webview route changes.
           options={props =>
-            getEarnScreenOptions(
-              props.route?.params?.params?.intent,
+            getEarnScreenOptionsFromRouteParams(
+              props.route?.params?.params,
               t,
               liveAppCanvasColor,
               isSwapToEarnEnabled,

--- a/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/getEarnScreenOptions.test.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/getEarnScreenOptions.test.ts
@@ -10,20 +10,44 @@ const CANVAS = "#000000";
 
 describe("getEarnScreenOptions", () => {
   it.each(["deposit", "withdraw"])(
-    "shows the locale stake header without canvas styling for the %s intent",
+    "shows the locale stake header without canvas styling for the %s intent when swapToEarn is off",
     intent => {
-      const options = getEarnScreenOptions(intent, t, CANVAS);
+      const options = getEarnScreenOptions(intent, t, CANVAS, false);
 
       expect(options).toMatchObject({
         headerShown: true,
         closable: false,
         headerTitle: "account.earn",
       });
-      // deposit / withdraw keep the default background (canvas styling is simulate-only).
       expect(options.headerStyle).toBeUndefined();
       expect(options.contentStyle).toBeUndefined();
     },
   );
+
+  it("paints the deposit intent header and content on the live-app canvas when swapToEarn is on", () => {
+    const options = getEarnScreenOptions("deposit", t, CANVAS, true);
+
+    expect(options).toMatchObject({
+      headerShown: true,
+      closable: false,
+      headerTitle: "account.earn",
+      headerShadowVisible: false,
+      headerStyle: { backgroundColor: CANVAS },
+      contentStyle: { backgroundColor: CANVAS },
+    });
+  });
+
+  it("keeps withdraw without canvas styling when swapToEarn is on", () => {
+    const options = getEarnScreenOptions("withdraw", t, CANVAS, true);
+
+    expect(options).toMatchObject({
+      headerShown: true,
+      closable: false,
+      headerTitle: "account.earn",
+    });
+    expect(options.headerStyle).toBeUndefined();
+    expect(options.contentStyle).toBeUndefined();
+  });
 
   it("paints the simulator full-screen on the live-app canvas", () => {
     const options = getEarnScreenOptions("simulate", t, CANVAS);

--- a/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/getEarnScreenOptions.test.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/__tests__/getEarnScreenOptions.test.ts
@@ -1,5 +1,9 @@
 import type { TFunction } from "i18next";
-import { getEarnScreenOptions } from "../getEarnScreenOptions";
+import {
+  getEarnScreenOptions,
+  getEarnScreenOptionsFromRouteParams,
+  shouldDisplayEarnBackgroundCanvas,
+} from "../getEarnScreenOptions";
 
 jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
   getStakeLabelLocaleBased: () => "account.earn",
@@ -68,5 +72,28 @@ describe("getEarnScreenOptions", () => {
 
   it("hides the header for an unknown intent", () => {
     expect(getEarnScreenOptions("something-else", t, CANVAS)).toEqual({ headerShown: false });
+  });
+});
+
+describe("shouldDisplayEarnBackgroundCanvas", () => {
+  it.each([
+    { intent: "simulate", isSwapToEarnEnabled: false, expected: true },
+    { intent: "deposit", isSwapToEarnEnabled: true, expected: true },
+    { intent: "deposit", isSwapToEarnEnabled: false, expected: false },
+    { intent: "withdraw", isSwapToEarnEnabled: true, expected: false },
+  ])(
+    "returns $expected for intent=$intent and swapToEarn=$isSwapToEarnEnabled",
+    ({ intent, isSwapToEarnEnabled, expected }) => {
+      expect(shouldDisplayEarnBackgroundCanvas(intent, isSwapToEarnEnabled)).toBe(expected);
+    },
+  );
+});
+
+describe("getEarnScreenOptionsFromRouteParams", () => {
+  it("forwards nested route params to getEarnScreenOptions", () => {
+    const options = getEarnScreenOptionsFromRouteParams({ intent: "deposit" }, t, CANVAS, true);
+
+    expect(options.headerStyle).toEqual({ backgroundColor: CANVAS });
+    expect(options.contentStyle).toEqual({ backgroundColor: CANVAS });
   });
 });

--- a/apps/ledger-live-mobile/src/components/RootNavigator/getEarnScreenOptions.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/getEarnScreenOptions.ts
@@ -6,9 +6,19 @@ export type EarnScreenOptions = Partial<NativeStackNavigationOptions> & { closab
 
 const renderNullHeaderRight = () => null;
 
+const liveAppCanvasScreenStyles = (
+  canvasColor: string,
+): Pick<EarnScreenOptions, "headerStyle" | "headerShadowVisible" | "contentStyle"> => ({
+  headerStyle: { backgroundColor: canvasColor },
+  headerShadowVisible: false,
+  contentStyle: { backgroundColor: canvasColor },
+});
+
 /**
  * Resolves the Base-stack screen options for the Earn live-app screen from the deeplink intent:
- * - `deposit` / `withdraw`: native header titled with the locale-based stake label.
+ * - `deposit`: native header titled with the locale-based stake label; when `swapToEarn` is enabled,
+ *   header and content use the live-app canvas (same as the webview shell).
+ * - `withdraw`: native header titled with the locale-based stake label (default stack styling).
  * - `simulate`: full-screen Rewards simulator painted on the live-app canvas (no header shadow,
  *   canvas background on both the header and the content so there is no gray flash before the
  *   webview paints).
@@ -18,8 +28,19 @@ export const getEarnScreenOptions = (
   intent: string | undefined,
   t: TFunction,
   canvasColor: string,
+  isSwapToEarnEnabled = false,
 ): EarnScreenOptions => {
-  if (intent === "deposit" || intent === "withdraw") {
+  if (intent === "deposit") {
+    return {
+      headerShown: true,
+      closable: false,
+      headerTitle: t(getStakeLabelLocaleBased()),
+      headerRight: renderNullHeaderRight,
+      ...(isSwapToEarnEnabled ? liveAppCanvasScreenStyles(canvasColor) : {}),
+    };
+  }
+
+  if (intent === "withdraw") {
     return {
       headerShown: true,
       closable: false,
@@ -34,9 +55,7 @@ export const getEarnScreenOptions = (
       closable: false,
       headerTitle: t("earn.simulator.title"),
       headerRight: renderNullHeaderRight,
-      headerStyle: { backgroundColor: canvasColor },
-      headerShadowVisible: false,
-      contentStyle: { backgroundColor: canvasColor },
+      ...liveAppCanvasScreenStyles(canvasColor),
     };
   }
 

--- a/apps/ledger-live-mobile/src/components/RootNavigator/getEarnScreenOptions.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/getEarnScreenOptions.ts
@@ -61,3 +61,20 @@ export const getEarnScreenOptions = (
 
   return { headerShown: false };
 };
+
+/** Whether the Earn V2 webview shell should use the live-app canvas background. */
+export const shouldDisplayEarnBackgroundCanvas = (
+  intent: string | undefined,
+  isSwapToEarnEnabled: boolean,
+): boolean => (isSwapToEarnEnabled && intent === "deposit") || intent === "simulate";
+
+type EarnScreenRouteParams = { intent?: string } | undefined;
+
+/** Resolves Base-stack options from nested Earn navigator route params. */
+export const getEarnScreenOptionsFromRouteParams = (
+  routeParams: EarnScreenRouteParams,
+  t: TFunction,
+  canvasColor: string,
+  isSwapToEarnEnabled: boolean,
+): EarnScreenOptions =>
+  getEarnScreenOptions(routeParams?.intent, t, canvasColor, isSwapToEarnEnabled);

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -295,7 +295,6 @@ describe("EarnV2Webview", () => {
         manifest={STUB_MANIFEST}
         appManifestNotFoundError={ERROR}
         inputs={{ intent: "simulate" }}
-        shouldDisplayBackgroundCanvas
       />,
       {
         overrideInitialState: withFlagOverrides({
@@ -314,7 +313,6 @@ describe("EarnV2Webview", () => {
         manifest={STUB_MANIFEST}
         appManifestNotFoundError={ERROR}
         inputs={{ intent: "deposit" }}
-        shouldDisplayBackgroundCanvas={false}
       />,
       {
         overrideInitialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -307,7 +307,7 @@ describe("EarnV2Webview", () => {
     expect(flattened.backgroundColor).toEqual(expect.any(String));
   });
 
-  it("does not override the screen background outside the simulate intent", () => {
+  it("does not override the screen background for deposit when swapToEarn is disabled", () => {
     render(
       <EarnV2Webview
         manifest={STUB_MANIFEST}
@@ -317,11 +317,31 @@ describe("EarnV2Webview", () => {
       {
         overrideInitialState: withFlagOverrides({
           ptxEarnUi: { enabled: true, params: { value: "v2" } },
+          swapToEarn: { enabled: false },
         }),
       },
     );
 
     const flattened = StyleSheet.flatten(screen.getByTestId("earn-screen").props.style);
     expect(flattened.backgroundColor).toBeUndefined();
+  });
+
+  it("paints the live-app canvas behind the webview for deposit when swapToEarn is enabled", () => {
+    render(
+      <EarnV2Webview
+        manifest={STUB_MANIFEST}
+        appManifestNotFoundError={ERROR}
+        inputs={{ intent: "deposit" }}
+      />,
+      {
+        overrideInitialState: withFlagOverrides({
+          ptxEarnUi: { enabled: true, params: { value: "v2" } },
+          swapToEarn: { enabled: true },
+        }),
+      },
+    );
+
+    const flattened = StyleSheet.flatten(screen.getByTestId("earn-screen").props.style);
+    expect(flattened.backgroundColor).toEqual(expect.any(String));
   });
 });

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/__tests__/EarnV2Webview.test.tsx
@@ -295,6 +295,7 @@ describe("EarnV2Webview", () => {
         manifest={STUB_MANIFEST}
         appManifestNotFoundError={ERROR}
         inputs={{ intent: "simulate" }}
+        shouldDisplayBackgroundCanvas
       />,
       {
         overrideInitialState: withFlagOverrides({
@@ -313,6 +314,7 @@ describe("EarnV2Webview", () => {
         manifest={STUB_MANIFEST}
         appManifestNotFoundError={ERROR}
         inputs={{ intent: "deposit" }}
+        shouldDisplayBackgroundCanvas={false}
       />,
       {
         overrideInitialState: withFlagOverrides({

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -23,6 +23,7 @@ type Props = {
   isLwm40Enabled?: boolean;
   hideMainNavigator?: boolean;
   appManifestNotFoundError: Error;
+  shouldDisplayBackgroundCanvas: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -36,15 +37,17 @@ export const EarnV2Webview = ({
   isLwm40Enabled,
   hideMainNavigator,
   appManifestNotFoundError,
+  shouldDisplayBackgroundCanvas,
 }: Props) => {
   const { state: remoteLiveAppState } = useRemoteLiveAppContext();
   const insets = useSafeAreaInsets();
   const { theme: lumenTheme } = useLumenTheme();
   const canvasColor = lumenTheme.colors.bg.canvas;
-  const isSimulateIntent = inputs?.intent === "simulate";
   const { topBarHeight, bottomBarHeight } = useNavigationBarHeights();
   const { shouldDisplayEarnUpselling, shouldDisplayEarnSimulator } =
     useWalletFeaturesConfig("mobile");
+
+  const isSwapToEarnEnabled = useFeature("swapToEarn")?.enabled ?? false;
 
   const earnUiVersion = useFeature("ptxEarnUi")?.params?.value ?? "v2";
 
@@ -76,6 +79,7 @@ export const EarnV2Webview = ({
     webviewUrl,
     webviewUrlRef,
     canvasColor,
+    isSwapToEarnEnabled,
   });
 
   const inIntentFlow = !!hideMainNavigator && intentFlowState !== false;
@@ -96,7 +100,7 @@ export const EarnV2Webview = ({
   return (
     <View
       testID="earn-screen"
-      style={[styles.container, isSimulateIntent && { backgroundColor: canvasColor }]}
+      style={[styles.container, shouldDisplayBackgroundCanvas && { backgroundColor: canvasColor }]}
     >
       {showsBackground && <LiveAppBackground type="earn" scrollY={scrollY} />}
       <View style={styles.contentContainer} pointerEvents="box-none">

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -23,7 +23,7 @@ type Props = {
   isLwm40Enabled?: boolean;
   hideMainNavigator?: boolean;
   appManifestNotFoundError: Error;
-  shouldDisplayBackgroundCanvas: boolean;
+  shouldDisplayBackgroundCanvas?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -85,6 +85,10 @@ export const EarnV2Webview = ({
   const inIntentFlow = !!hideMainNavigator && intentFlowState !== false;
   const showsBackground = isPtxUiMinV2 && !inIntentFlow;
 
+  const displayBackgroundCanvas =
+    shouldDisplayBackgroundCanvas ??
+    ((isSwapToEarnEnabled && inputs?.intent === "deposit") || inputs?.intent === "simulate");
+
   const webviewInputs = {
     ...inputs,
     safeAreaTop: insets.top.toString(),
@@ -100,7 +104,7 @@ export const EarnV2Webview = ({
   return (
     <View
       testID="earn-screen"
-      style={[styles.container, shouldDisplayBackgroundCanvas && { backgroundColor: canvasColor }]}
+      style={[styles.container, displayBackgroundCanvas && { backgroundColor: canvasColor }]}
     >
       {showsBackground && <LiveAppBackground type="earn" scrollY={scrollY} />}
       <View style={styles.contentContainer} pointerEvents="box-none">

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/EarnV2Webview/index.tsx
@@ -16,6 +16,7 @@ import { useTheme as useLumenTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { computeEarnUiVersion } from "@ledgerhq/live-common/domain/computeEarnUiVersion";
 import type { WebviewState } from "~/components/Web3AppWebview/types";
 import { useEarnIntentFlowPresentation } from "../useEarnIntentFlowPresentation";
+import { shouldDisplayEarnBackgroundCanvas } from "~/components/RootNavigator/getEarnScreenOptions";
 
 type Props = {
   manifest?: LiveAppManifest;
@@ -87,7 +88,7 @@ export const EarnV2Webview = ({
 
   const displayBackgroundCanvas =
     shouldDisplayBackgroundCanvas ??
-    ((isSwapToEarnEnabled && inputs?.intent === "deposit") || inputs?.intent === "simulate");
+    shouldDisplayEarnBackgroundCanvas(inputs?.intent, isSwapToEarnEnabled);
 
   const webviewInputs = {
     ...inputs,

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { render, withFlagOverrides } from "@tests/test-renderer";
+import {
+  useRemoteLiveAppContext,
+  useRemoteLiveAppManifest,
+} from "@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index";
+import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
+import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
+import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
+import { EarnScreen } from "../index";
+import type { EarnV2Webview } from "../EarnV2Webview";
+
+type EarnV2WebviewProps = React.ComponentProps<typeof EarnV2Webview>;
+
+const capturedProps: { current: EarnV2WebviewProps | undefined } = { current: undefined };
+
+// Mock the child to assert wiring only; canvas logic is covered in getEarnScreenOptions.test.ts.
+jest.mock("../EarnV2Webview", () => ({
+  EarnV2Webview: (props: EarnV2WebviewProps) => {
+    capturedProps.current = props;
+    return null;
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/platform/providers/RemoteLiveAppProvider/index", () => ({
+  useRemoteLiveAppManifest: jest.fn(),
+  useRemoteLiveAppContext: jest.fn(),
+}));
+
+jest.mock("@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index", () => ({
+  useLocalLiveAppManifest: jest.fn(),
+}));
+
+jest.mock("LLM/hooks/useStake/useVersionedStakePrograms", () => ({
+  useVersionedStakePrograms: jest.fn(),
+}));
+
+jest.mock("~/helpers/getStakeLabelLocaleBased", () => ({
+  getCountryLocale: jest.fn().mockReturnValue("US"),
+}));
+
+const STUB_MANIFEST: LiveAppManifest = {
+  id: "earn-test",
+  name: "Earn Test",
+  url: "https://earn.test",
+  homepageUrl: "https://earn.test",
+  platforms: ["ios", "android"],
+  apiVersion: "2.0.0",
+  manifestVersion: "2",
+  branch: "stable",
+  permissions: [],
+  domains: [],
+  categories: [],
+  currencies: "*",
+  visibility: "complete",
+  content: {
+    shortDescription: { en: "test" },
+    description: { en: "test" },
+  },
+};
+
+const makeProps = (intent: "deposit" | "simulate") =>
+  ({
+    navigation: {} as never,
+    route: { params: { intent } },
+  }) as React.ComponentProps<typeof EarnScreen>;
+
+const renderEarnScreen = (
+  intent: "deposit" | "simulate",
+  flags: Parameters<typeof withFlagOverrides>[0],
+) =>
+  render(<EarnScreen {...makeProps(intent)} />, {
+    overrideInitialState: withFlagOverrides(flags),
+  });
+
+describe("EarnScreen canvas background wiring", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedProps.current = undefined;
+    jest.mocked(useLocalLiveAppManifest).mockReturnValue(undefined);
+    jest.mocked(useRemoteLiveAppManifest).mockReturnValue(STUB_MANIFEST);
+    jest.mocked(useRemoteLiveAppContext).mockReturnValue({
+      state: { isLoading: false },
+    } as ReturnType<typeof useRemoteLiveAppContext>);
+    jest.mocked(useVersionedStakePrograms).mockReturnValue(null);
+  });
+
+  it("should pass shouldDisplayBackgroundCanvas true when deposit intent and swapToEarn is enabled", () => {
+    renderEarnScreen("deposit", {
+      lwmWallet40: { enabled: true },
+      swapToEarn: { enabled: true },
+    });
+
+    expect(capturedProps.current).toBeDefined();
+    expect(capturedProps.current?.shouldDisplayBackgroundCanvas).toBe(true);
+  });
+
+  it("should pass shouldDisplayBackgroundCanvas false when deposit intent and swapToEarn is disabled", () => {
+    renderEarnScreen("deposit", {
+      lwmWallet40: { enabled: true },
+      swapToEarn: { enabled: false },
+    });
+
+    expect(capturedProps.current).toBeDefined();
+    expect(capturedProps.current?.shouldDisplayBackgroundCanvas).toBe(false);
+  });
+
+  it("should pass shouldDisplayBackgroundCanvas true when simulate intent regardless of swapToEarn", () => {
+    renderEarnScreen("simulate", {
+      lwmWallet40: { enabled: true },
+      swapToEarn: { enabled: false },
+    });
+
+    expect(capturedProps.current).toBeDefined();
+    expect(capturedProps.current?.shouldDisplayBackgroundCanvas).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/__tests__/index.test.tsx
@@ -7,6 +7,7 @@ import {
 import { useLocalLiveAppManifest } from "@ledgerhq/live-common/wallet-api/LocalLiveAppProvider/index";
 import type { LiveAppManifest } from "@ledgerhq/live-common/platform/types";
 import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
+import { ScreenName } from "~/const";
 import { EarnScreen } from "../index";
 import type { EarnV2Webview } from "../EarnV2Webview";
 
@@ -62,8 +63,8 @@ const STUB_MANIFEST: LiveAppManifest = {
 const makeProps = (intent: "deposit" | "simulate") =>
   ({
     navigation: {} as never,
-    route: { params: { intent } },
-  }) as React.ComponentProps<typeof EarnScreen>;
+    route: { key: "earn", name: ScreenName.Earn, params: { intent } },
+  }) as unknown as React.ComponentProps<typeof EarnScreen>;
 
 const renderEarnScreen = (
   intent: "deposit" | "simulate",

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -29,6 +29,7 @@ import { counterValueCurrencySelector, discreetModeSelector } from "~/reducers/s
 import { EarnWebview } from "./EarnWebview";
 import { useVersionedStakePrograms } from "LLM/hooks/useStake/useVersionedStakePrograms";
 import { EarnV2Webview } from "./EarnV2Webview";
+import { shouldDisplayEarnBackgroundCanvas } from "~/components/RootNavigator/getEarnScreenOptions";
 import { buildEarnGoToURL } from "./buildEarnGoToURL";
 
 export type Props = StackNavigatorProps<EarnLiveAppNavigatorParamList, ScreenName.Earn>;
@@ -95,8 +96,7 @@ function Earn({ route }: Props) {
   );
 
   const shouldDisplayBackgroundCanvas = useMemo(
-    () =>
-      (swapToEarnFlag?.enabled && params?.intent === "deposit") || params?.intent === "simulate",
+    () => shouldDisplayEarnBackgroundCanvas(params?.intent, swapToEarnFlag?.enabled ?? false),
     [swapToEarnFlag, params?.intent],
   );
 

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/index.tsx
@@ -94,6 +94,12 @@ function Earn({ route }: Props) {
     [swapToEarnFlag],
   );
 
+  const shouldDisplayBackgroundCanvas = useMemo(
+    () =>
+      (swapToEarnFlag?.enabled && params?.intent === "deposit") || params?.intent === "simulate",
+    [swapToEarnFlag, params?.intent],
+  );
+
   if (!remoteLiveAppState.isLoading && !manifest) {
     console.error(appManifestNotFoundError);
   }
@@ -155,6 +161,7 @@ function Earn({ route }: Props) {
         isLwm40Enabled={isLwm40Enabled}
         hideMainNavigator={hideMainNavigator}
         appManifestNotFoundError={appManifestNotFoundError}
+        shouldDisplayBackgroundCanvas={shouldDisplayBackgroundCanvas}
       />
     );
   }

--- a/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.ts
+++ b/apps/ledger-live-mobile/src/screens/PTX/Earn/useEarnIntentFlowPresentation.ts
@@ -23,6 +23,7 @@ type Params = {
   webviewUrl?: string;
   webviewUrlRef: React.MutableRefObject<string | undefined>;
   canvasColor: string;
+  isSwapToEarnEnabled?: boolean;
 };
 
 /**
@@ -37,6 +38,7 @@ export function useEarnIntentFlowPresentation({
   webviewUrl,
   webviewUrlRef,
   canvasColor,
+  isSwapToEarnEnabled = false,
 }: Params) {
   const navigation = useNavigation<EarnBaseNavigation>();
   const { t } = useTranslation();
@@ -62,7 +64,7 @@ export function useEarnIntentFlowPresentation({
     if (webviewIntent) {
       navigation
         .getParent(BASE_NAVIGATOR_ID)
-        ?.setOptions(getEarnScreenOptions(webviewIntent, t, canvasColor));
+        ?.setOptions(getEarnScreenOptions(webviewIntent, t, canvasColor, isSwapToEarnEnabled));
     }
   }, [
     hideMainNavigator,
@@ -71,6 +73,7 @@ export function useEarnIntentFlowPresentation({
     navigation,
     t,
     canvasColor,
+    isSwapToEarnEnabled,
     webviewUrlRef,
   ]);
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Earn deposit flow native header background (Base stack)
  - Earn V2 webview shell background on deposit intent
  - Behavior when `swapToEarn` is enabled vs disabled
  - Withdraw and simulate flows (must remain unchanged)

### 📝 Description

**Problem**: On mobile, the Earn deposit flow could show a gray flash or mismatched background between the native header and the Earn live-app webview when `swapToEarn` is enabled.

**Solution**: When `swapToEarn` is on and the intent is `deposit`, paint the Base-stack header/content and the Earn V2 webview shell with the live-app canvas color. Withdraw keeps default stack styling; simulate keeps its existing full-canvas presentation.

| Before |
<img width="726" height="1278" alt="image" src="https://github.com/user-attachments/assets/384da8cb-7248-4104-accf-67f9b814fddc" />


| After |
<img width="694" height="1195" alt="image" src="https://github.com/user-attachments/assets/4fdde462-8520-4a25-88d0-83d8b5c88fe3" />

| _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35191](https://ledgerhq.atlassian.net/browse/LIVE-35191)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35191]: https://ledgerhq.atlassian.net/browse/LIVE-35191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ