### PR TITLE
[LWM] chore(mobile): remove legacy translation keys (LIVE-33737)

### DIFF
--- a/.changeset/legacy-translations-cleanup.md
+++ b/.changeset/legacy-translations-cleanup.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Remove legacy translation keys orphaned by the Wallet 4.0 Q1 cleanup (navigation collapse, graph rework, legacy Portfolio screen and Transfer drawer removal).

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1548,10 +1548,6 @@
     }
   },
   "graph": {
-    "week": "1W",
-    "month": "1M",
-    "year": "1Y",
-    "all": "ALL",
     "graphNotSupported": "The graph is not available for this token"
   },
   "carousel": {
@@ -1697,10 +1693,8 @@
     "cta": "Buy your Ledger now",
     "footer": "I already have a Ledger, set it up",
     "bannerTitle": "Top-notch security for your crypto and NFTs",
-    "bannerTitle2": "You will need a Ledger to be able to trade",
     "bannerSubtitle": "with a Ledger Flex",
     "bannerButtonTitle": "Discover the Flex",
-    "bannerButtonTitle2": "Buy a Ledger",
     "setupCta": "I already have a Ledger, set it up"
   },
   "rebornBuyDevice": {
@@ -2829,44 +2823,18 @@
       "skipCTA": "Maybe later"
     }
   },
-  "tabs": {
-    "accounts": "Accounts",
-    "transfer": "Transfer",
-    "manager": "My Ledger",
-    "myWallet": "My wallet",
-    "settings": "Settings",
-    "platform": "Live Apps",
-    "discover": "Discover",
-    "nanoX": "Nano X",
-    "market": "Market",
-    "earn": "Earn",
-    "card": "Card",
-    "swap": "Swap"
-  },
   "portfolio": {
     "totalBalance": "Total balance",
-    "syncError": "Sync error",
-    "syncFailed": "Synchronization failed",
     "syncPending": "Synchronizing...",
     "transactionsPendingConfirmation": {
       "title": "Unsynchronized balance",
       "desc": "Some transactions are not confirmed yet. These will be reflected in your balance and useable after being confirmed."
     },
     "emptyState": {
-      "noAppsTitle": "Install an app on my device",
-      "noAppsDesc": "Install apps on your device before adding accounts in Ledger Wallet. Go to My Ledger to install apps.",
-      "noAccountsTitle": "You don't have any accounts…",
-      "noAccountsDesc": "Please add accounts to your Portfolio.",
       "buttons": {
         "import": "Add asset",
-        "buy": "Buy",
         "manager": "Install apps",
         "managerSecondary": "Install apps on my device"
-      },
-      "addAccounts": {
-        "addAccounts": "Add asset",
-        "title": "Get started",
-        "description": "You can either purchase crypto from our partners or setup your wallet"
       }
     },
     "noOpState": {
@@ -2887,14 +2855,6 @@
       "cardDescription": "Borrow at competitive rates",
       "cta": "Explore"
     },
-    "recommended": {
-      "title": "Recommended"
-    },
-    "topGainers": {
-      "title": "Market gainers (24H)",
-      "seeMarket": "See all"
-    },
-    "walletBalance": "Wallet balance",
     "balance": {
       "noSigner": "Your secure\ncrypto wallet",
       "noAccounts": "Start by funding\nyour wallet"
@@ -2927,8 +2887,7 @@
       "sell": "Sell",
       "swap": "Swap",
       "send": "Send",
-      "deposit": "Receive",
-      "stake": "Stake"
+      "deposit": "Receive"
     },
     "quickActionsCtas": {
       "transfer": "Transfer",
@@ -3866,8 +3825,7 @@
       "learnMore": "Learn more about Tag/Memo"
     },
     "send": {
-      "title": "Send",
-      "description": "Send crypto to another wallet."
+      "title": "Send"
     },
     "fees": {
       "title": "Edit fees"
@@ -4000,21 +3958,12 @@
       "title": "Buy",
       "description": "Buy crypto securely with cash."
     },
-    "sell": {
-      "title": "Sell",
-      "description": "Sell crypto securely for cash."
-    },
     "exchange": {
       "title": "Buy / Sell",
       "connectingTo": "Connecting you to {{provider}}"
     },
-    "stake": {
-      "title": "Stake",
-      "description": "Get rewards on your crypto."
-    },
     "swap": {
       "title": "Swap",
-      "description": "Exchange crypto to crypto.",
       "selectDevice": "Select your device",
       "broadcasting": "Broadcasting swap",
       "loadingFees": "Loading network fees...",
@@ -4494,11 +4443,6 @@
     "walletConnect": {
       "title": "WalletConnect",
       "description": "Connect your wallet to dapps"
-    },
-    "recover": {
-      "title": "Ledger Recover",
-      "description": "Wallet recovery made easy",
-      "tag": "One month free"
     }
   },
   "signMessage": {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _No tests needed — dead-key removal only; every removed key was verified to have zero references in `src` and `e2e`, and no dynamic/plural key construction targets them._
- [x] **Impact of the changes:**
      - No user-facing impact expected: only unused translation keys were removed.
      - Sanity-check the reworked Portfolio, the balance graph range selector, the Transfer/Send/Swap/Receive flows and the "Buy a Ledger" banner still render their labels correctly.

### 📝 Description

Following the Wallet 4.0 Q1 cleanup epic ([LIVE-32982](https://ledgerhq.atlassian.net/browse/LIVE-32982)), a number of translation keys became orphaned once the legacy screens, feature flags and components were removed (navigation collapse, graph rework, legacy Portfolio screen, `TabBar`/`TransferDrawer`, Lumen/graph debug tools).

This PR removes those dead keys from `apps/ledger-live-mobile/src/locales/en/common.json`. Each removed key was cross-checked against the current codebase (`src` + `e2e`) and confirmed to have **zero references**, while intentionally keeping siblings that are still used, including dynamically-built (`currencyPriceChange.${range}`) and i18next plural (`count_one`/`count_other`) keys.

Removed groups:
- **`tabs`** — whole block (old bottom navigation, removed by the nav collapse / `mainNavigation` FF cleanup).
- **`graph`** — `week` / `month` / `year` / `all` range labels (graph rework); kept `graphNotSupported`.
- **`buyDevice`** — `bannerTitle2` / `bannerButtonTitle2` (legacy Portfolio empty state).
- **`portfolio`** — `syncError`, `syncFailed`, `walletBalance`, `recommended`, `topGainers`, `quickActions.stake`, and the legacy `emptyState` entries (`noApps*`, `noAccounts*`, `addAccounts.*`, `buttons.buy`).
- **`transfer`** menu — `recover.*`, `sell.*`, `stake.*`, `send.description`, `swap.description` (Transfer drawer removal); kept still-used titles and the large `transfer.swap.*` flow namespace.

Net: **58 deletions**, no behaviour change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33737](https://ledgerhq.atlassian.net/browse/LIVE-33737)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32982]: https://ledgerhq.atlassian.net/browse/LIVE-32982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33737]: https://ledgerhq.atlassian.net/browse/LIVE-33737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ