### PR TITLE
[LWDM] perf(modular-drawer): forward network filters to DADA

### DIFF
--- a/.changeset/dada-network-ids.md
+++ b/.changeset/dada-network-ids.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Forward Modular Asset Drawer network filters to DADA asset requests.

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
@@ -91,7 +91,7 @@ describe("useModularDialogData filters", () => {
     mockedUseAssetsData.mockImplementation(actualUseAssetsData);
   });
 
-  it("should not forward network ids as exact DADA currency ids", () => {
+  it("should forward network ids without treating them as exact currency ids", () => {
     renderHook(() => useModularDialogData(), {
       initialState: {
         modularDialog: {
@@ -112,6 +112,7 @@ describe("useModularDialogData filters", () => {
     expect(mockedUseAssetsData).toHaveBeenCalledWith(
       expect.objectContaining({
         currencyIds: undefined,
+        networkIds: ["ethereum"],
         areCurrenciesFiltered: false,
       }),
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/__tests__/useModularDialogData.test.ts
@@ -142,4 +142,31 @@ describe("useModularDialogData filters", () => {
       }),
     );
   });
+
+  it("should preserve the exact currency filter when network ids are empty", () => {
+    renderHook(() => useModularDialogData(), {
+      initialState: {
+        modularDialog: {
+          searchedValue: undefined,
+          isDebuggingDuplicates: false,
+          flow: "",
+          source: "",
+          isOpen: true,
+          dialogParams: {
+            networkIds: [],
+            currencies: ["bitcoin"],
+            areCurrenciesFiltered: true,
+          },
+        },
+      },
+    });
+
+    expect(mockedUseAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currencyIds: ["bitcoin"],
+        networkIds: undefined,
+        areCurrenciesFiltered: true,
+      }),
+    );
+  });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
@@ -26,17 +26,18 @@ export function useModularDialogData() {
 
   const currencyIds = useSelector(modularDialogCurrenciesSelector);
   const networkIds = useSelector(modularDialogNetworkIdsSelector);
+  const resolvedNetworkIds = networkIds?.length ? networkIds : undefined;
   const useCase = useSelector(modularDialogUseCaseSelector);
   const areCurrenciesFiltered = useSelector(modularDialogAreCurrenciesFilteredSelector);
 
   const { data, isLoading, isSuccess, error, errorInfo, loadNext, refetch } = useAssetsData({
     search: searchedValue,
-    currencyIds: networkIds === undefined ? currencyIds : undefined,
-    networkIds,
+    currencyIds: resolvedNetworkIds === undefined ? currencyIds : undefined,
+    networkIds: resolvedNetworkIds,
     product: "lld",
     version: __APP_VERSION__,
     useCase,
-    areCurrenciesFiltered: networkIds === undefined ? areCurrenciesFiltered : false,
+    areCurrenciesFiltered: resolvedNetworkIds === undefined ? areCurrenciesFiltered : false,
     isStaging,
     includeTestNetworks: devMode,
   });
@@ -46,10 +47,10 @@ export function useModularDialogData() {
       data
         ? buildAssetsSorted(data, {
             includeMetaCurrencyId: true,
-            networkIds,
+            networkIds: resolvedNetworkIds,
           })
         : undefined,
-    [data, networkIds],
+    [data, resolvedNetworkIds],
   );
 
   const loadingStatus: LoadingStatus = getLoadingStatus({ isLoading, isSuccess, error });

--- a/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/ModularDialog/hooks/useModularDialogData.ts
@@ -32,6 +32,7 @@ export function useModularDialogData() {
   const { data, isLoading, isSuccess, error, errorInfo, loadNext, refetch } = useAssetsData({
     search: searchedValue,
     currencyIds: networkIds === undefined ? currencyIds : undefined,
+    networkIds,
     product: "lld",
     version: __APP_VERSION__,
     useCase,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
@@ -101,4 +101,39 @@ describe("useAssets", () => {
       expect.objectContaining({ networkIds: ["ethereum", "tron"] }),
     );
   });
+
+  it("preserves the exact currency filter when network ids are empty", () => {
+    mockedUseAssetsData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetchingNextPage: false,
+      isSuccess: true,
+      isError: false,
+      error: undefined,
+      errorInfo: {
+        hasError: false,
+        isNetworkError: false,
+        isApiError: false,
+        apiStatus: undefined,
+      },
+      loadNext: undefined,
+      refetch: jest.fn(),
+    });
+
+    renderHook(() =>
+      useAssets({
+        currencyIds: ["bitcoin"],
+        networkIds: [],
+        areCurrenciesFiltered: true,
+      }),
+    );
+
+    expect(mockedUseAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currencyIds: ["bitcoin"],
+        networkIds: undefined,
+        areCurrenciesFiltered: true,
+      }),
+    );
+  });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
@@ -1,39 +1,33 @@
 import { renderHook, waitFor } from "@tests/test-renderer";
+import { http, HttpResponse, server } from "@tests/server";
 import { useAssets } from "../useAssets";
-import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
-import { expectedAssetsSorted as expectedAssetsSortedFromMock } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
+import {
+  expectedAssetsSorted as expectedAssetsSortedFromMock,
+  mockData,
+} from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
 import { LoadingStatus } from "@ledgerhq/live-common/deposit/type";
-
-jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => {
-  const actual = jest.requireActual<
-    typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
-  >("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
-
-  return {
-    ...actual,
-    useAssetsData: jest.fn(actual.useAssetsData),
-  };
-});
-
-const mockedUseAssetsData = jest.mocked(useAssetsData);
-const actualUseAssetsData = jest.requireActual<
-  typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
->("@ledgerhq/live-common/dada-client/hooks/useAssetsData").useAssetsData;
 
 jest.mock("@ledgerhq/live-common/coin-modules/registry", () => ({
   ...jest.requireActual("@ledgerhq/live-common/coin-modules/registry"),
   isCurrencySupported: jest.fn(() => true),
 }));
 
+function captureDadaRequests(): string[] {
+  const requests: string[] = [];
+  const handler = ({ request }: { request: Request }) => {
+    requests.push(request.url);
+    return HttpResponse.json(mockData);
+  };
+
+  server.use(
+    http.get("https://dada.api.ledger-test.com/v1/assets", handler),
+    http.get("https://dada.api.ledger.com/v1/assets", handler),
+  );
+
+  return requests;
+}
+
 describe("useAssets", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  afterEach(() => {
-    mockedUseAssetsData.mockImplementation(actualUseAssetsData);
-  });
-
   it("transforms data into assetsSorted and sortedCryptoCurrencies", async () => {
     const { result } = renderHook(() => useAssets({}));
 
@@ -77,50 +71,9 @@ describe("useAssets", () => {
     ).toBe(true);
   });
 
-  it("forwards network ids to DADA", () => {
-    mockedUseAssetsData.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isFetchingNextPage: false,
-      isSuccess: true,
-      isError: false,
-      error: undefined,
-      errorInfo: {
-        hasError: false,
-        isNetworkError: false,
-        isApiError: false,
-        apiStatus: undefined,
-      },
-      loadNext: undefined,
-      refetch: jest.fn(),
-    });
-
-    renderHook(() => useAssets({ networkIds: ["ethereum", "tron"] }));
-
-    expect(mockedUseAssetsData).toHaveBeenCalledWith(
-      expect.objectContaining({ networkIds: ["ethereum", "tron"] }),
-    );
-  });
-
-  it("preserves the exact currency filter when network ids are empty", () => {
-    mockedUseAssetsData.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      isFetchingNextPage: false,
-      isSuccess: true,
-      isError: false,
-      error: undefined,
-      errorInfo: {
-        hasError: false,
-        isNetworkError: false,
-        isApiError: false,
-        apiStatus: undefined,
-      },
-      loadNext: undefined,
-      refetch: jest.fn(),
-    });
-
-    renderHook(() =>
+  it("keeps the exact currency filter when network ids are empty", async () => {
+    const requests = captureDadaRequests();
+    const { result } = renderHook(() =>
       useAssets({
         currencyIds: ["bitcoin"],
         networkIds: [],
@@ -128,12 +81,10 @@ describe("useAssets", () => {
       }),
     );
 
-    expect(mockedUseAssetsData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        currencyIds: ["bitcoin"],
-        networkIds: undefined,
-        areCurrenciesFiltered: true,
-      }),
-    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const searchParams = new URL(requests[0]).searchParams;
+    expect(searchParams.get("currencyIds")).toBe("bitcoin");
+    expect(searchParams.has("networkIds")).toBe(false);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useAssets.test.ts
@@ -1,7 +1,24 @@
 import { renderHook, waitFor } from "@tests/test-renderer";
 import { useAssets } from "../useAssets";
+import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
 import { expectedAssetsSorted as expectedAssetsSortedFromMock } from "@ledgerhq/live-common/modularDrawer/__mocks__/dada.mock";
 import { LoadingStatus } from "@ledgerhq/live-common/deposit/type";
+
+jest.mock("@ledgerhq/live-common/dada-client/hooks/useAssetsData", () => {
+  const actual = jest.requireActual<
+    typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
+  >("@ledgerhq/live-common/dada-client/hooks/useAssetsData");
+
+  return {
+    ...actual,
+    useAssetsData: jest.fn(actual.useAssetsData),
+  };
+});
+
+const mockedUseAssetsData = jest.mocked(useAssetsData);
+const actualUseAssetsData = jest.requireActual<
+  typeof import("@ledgerhq/live-common/dada-client/hooks/useAssetsData")
+>("@ledgerhq/live-common/dada-client/hooks/useAssetsData").useAssetsData;
 
 jest.mock("@ledgerhq/live-common/coin-modules/registry", () => ({
   ...jest.requireActual("@ledgerhq/live-common/coin-modules/registry"),
@@ -11,6 +28,10 @@ jest.mock("@ledgerhq/live-common/coin-modules/registry", () => ({
 describe("useAssets", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockedUseAssetsData.mockImplementation(actualUseAssetsData);
   });
 
   it("transforms data into assetsSorted and sortedCryptoCurrencies", async () => {
@@ -54,5 +75,30 @@ describe("useAssets", () => {
         ),
       ),
     ).toBe(true);
+  });
+
+  it("forwards network ids to DADA", () => {
+    mockedUseAssetsData.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetchingNextPage: false,
+      isSuccess: true,
+      isError: false,
+      error: undefined,
+      errorInfo: {
+        hasError: false,
+        isNetworkError: false,
+        isApiError: false,
+        apiStatus: undefined,
+      },
+      loadNext: undefined,
+      refetch: jest.fn(),
+    });
+
+    renderHook(() => useAssets({ networkIds: ["ethereum", "tron"] }));
+
+    expect(mockedUseAssetsData).toHaveBeenCalledWith(
+      expect.objectContaining({ networkIds: ["ethereum", "tron"] }),
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
@@ -26,6 +26,7 @@ export function useAssets({
   const isAcceptedCurrency = useAcceptedCurrency();
   const modularDrawerFeature = useFeature("llmModularDrawer");
   const devMode = useEnv("MANAGER_DEV_MODE");
+  const resolvedNetworkIds = networkIds?.length ? networkIds : undefined;
 
   const isStaging = useMemo(
     () => modularDrawerFeature?.params?.backendEnvironment === "STAGING",
@@ -34,19 +35,19 @@ export function useAssets({
 
   const { data, isLoading, isSuccess, isError, error, refetch, loadNext } = useAssetsData({
     search: searchedValue,
-    currencyIds: networkIds === undefined ? currencyIds : undefined,
-    networkIds,
+    currencyIds: resolvedNetworkIds === undefined ? currencyIds : undefined,
+    networkIds: resolvedNetworkIds,
     product: "llm",
     version: VersionNumber.appVersion,
     useCase,
-    areCurrenciesFiltered: networkIds === undefined ? areCurrenciesFiltered : false,
+    areCurrenciesFiltered: resolvedNetworkIds === undefined ? areCurrenciesFiltered : false,
     isStaging,
     includeTestNetworks: devMode,
   });
 
   const assetsSorted = useMemo(
-    () => (data ? buildAssetsSorted(data, { networkIds }) : undefined),
-    [data, networkIds],
+    () => (data ? buildAssetsSorted(data, { networkIds: resolvedNetworkIds }) : undefined),
+    [data, resolvedNetworkIds],
   );
 
   const loadingStatus: LoadingStatus = getLoadingStatus({ isLoading, isSuccess, error });

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useAssets.ts
@@ -35,6 +35,7 @@ export function useAssets({
   const { data, isLoading, isSuccess, isError, error, refetch, loadNext } = useAssetsData({
     search: searchedValue,
     currencyIds: networkIds === undefined ? currencyIds : undefined,
+    networkIds,
     product: "llm",
     version: VersionNumber.appVersion,
     useCase,

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
@@ -221,21 +221,4 @@ describe("useAssetsData", () => {
       expect.objectContaining({ pollingInterval: undefined }),
     );
   });
-
-  it("should forward network ids to the underlying query", () => {
-    mockuseGetAssetsDataInfiniteQuery.mockReturnValue({ ...defaultMockValues });
-
-    renderHook(() =>
-      useAssetsData({
-        product: "lld",
-        version: "1.0.0",
-        networkIds: ["ethereum", "tron"],
-      }),
-    );
-
-    expect(mockuseGetAssetsDataInfiniteQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ networkIds: ["ethereum", "tron"] }),
-      expect.anything(),
-    );
-  });
 });

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetsData.test.ts
@@ -221,4 +221,21 @@ describe("useAssetsData", () => {
       expect.objectContaining({ pollingInterval: undefined }),
     );
   });
+
+  it("should forward network ids to the underlying query", () => {
+    mockuseGetAssetsDataInfiniteQuery.mockReturnValue({ ...defaultMockValues });
+
+    renderHook(() =>
+      useAssetsData({
+        product: "lld",
+        version: "1.0.0",
+        networkIds: ["ethereum", "tron"],
+      }),
+    );
+
+    expect(mockuseGetAssetsDataInfiniteQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ networkIds: ["ethereum", "tron"] }),
+      expect.anything(),
+    );
+  });
 });

--- a/libs/ledger-live-common/src/dada-client/hooks/useAssetsData.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/useAssetsData.ts
@@ -7,6 +7,7 @@ import { mergeAssetsDataPages } from "../utils/mergeAssetsDataPages";
 export function useAssetsData({
   search,
   currencyIds,
+  networkIds,
   useCase,
   areCurrenciesFiltered,
   product,
@@ -37,6 +38,7 @@ export function useAssetsData({
       search,
       useCase,
       currencyIds: areCurrenciesFiltered ? currencyIds : undefined,
+      networkIds: networkIds?.length ? networkIds : undefined,
       product,
       version,
       isStaging,

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/api.test.ts
@@ -79,6 +79,19 @@ describe("buildAssetsQueryParams", () => {
     expect(buildAssetsQueryParams(baseQueryArg).currencyIds).toBeUndefined();
   });
 
+  it("should serialize networkIds as a comma-separated string", () => {
+    const input = ["ethereum", "tron"];
+
+    expect(buildAssetsQueryParams({ ...baseQueryArg, networkIds: input }).networkIds).toBe(
+      "ethereum,tron",
+    );
+  });
+
+  it("should omit networkIds when empty or not provided", () => {
+    expect(buildAssetsQueryParams({ ...baseQueryArg, networkIds: [] }).networkIds).toBeUndefined();
+    expect(buildAssetsQueryParams(baseQueryArg).networkIds).toBeUndefined();
+  });
+
   it("should serialize categories as a comma-separated string", () => {
     expect(
       buildAssetsQueryParams({ ...baseQueryArg, categories: [AssetCategory.Stocks] }).categories,

--- a/libs/ledger-live-common/src/dada-client/state-manager/api.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/api.ts
@@ -119,6 +119,10 @@ export function buildAssetsQueryParams(
       queryArg.currencyIds.length > 0 && {
         currencyIds: queryArg.currencyIds,
       }),
+    ...(queryArg.networkIds &&
+      queryArg.networkIds.length > 0 && {
+        networkIds: queryArg.networkIds.join(","),
+      }),
     ...(queryArg.categories &&
       queryArg.categories.length > 0 && {
         categories: queryArg.categories.join(","),

--- a/libs/ledger-live-common/src/dada-client/state-manager/types.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/types.ts
@@ -17,6 +17,7 @@ export enum AssetCategory {
 export interface GetAssetsDataParams {
   search?: string;
   currencyIds?: string[];
+  networkIds?: readonly string[];
   categories?: AssetCategory[];
   useCase?: string;
   product: "llm" | "lld";


### PR DESCRIPTION
### ✅ Checklist

- [x] npx changeset was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile and Desktop Modular Asset Drawer asset loading
  - DADA asset query filtering and caching
  - Contacts currency selection on eligible networks

### 📝 Description

This PR adds optional network ID filtering to the shared DADA asset query flow used by the Modular Asset Drawer.

Mobile and Desktop now forward their resolved network IDs to DADA when loading assets. The client serializes the value as `networkIds=ethereum,tron`, while retaining the existing local filtering as a defensive safeguard.

### ❓ Context

- **JIRA or GitHub link**: Not provided

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)