### PR TITLE
fix(wallet-cli): print amounts with an ascii space

### DIFF
--- a/apps/wallet-cli/src/wallet/README.md
+++ b/apps/wallet-cli/src/wallet/README.md
@@ -17,13 +17,18 @@ wallet/
   models.ts          ← serializable types + Zod schemas
   index.ts           ← WalletAdapter (routing)
   intents/           ← TransactionIntent schemas (bitcoin, evm, solana)
-  formatter/         ← HumanFormatter and JsonFormatter
+  formatter/         ← HumanFormatter, JsonFormatter, and currency.ts
   compatibility/
     bridge.ts        ← BridgeAdapter (full sync via live-common bridge)
     coinframework.ts ← CoinFrameworkAdapter (direct Coin Module API — currently unused for ops)
 ```
 
 `compatibility/` is an internal implementation detail — do not import it directly from outside `wallet/`.
+
+Every amount string goes through `formatter/currency.ts`, never through live-common's
+`formatCurrencyUnit` directly: the shared helper separates the value from its code with a
+non-breaking space, which is invisible in a terminal but breaks `grep`, `awk`, `cut` and anything
+consuming `--output json`.
 
 ## Integration
 

--- a/apps/wallet-cli/src/wallet/compatibility/bridge.ts
+++ b/apps/wallet-cli/src/wallet/compatibility/bridge.ts
@@ -3,7 +3,7 @@
 import { Observable, firstValueFrom, lastValueFrom } from "rxjs";
 import type { Subscriber, Subscription } from "rxjs";
 import { filter, map, reduce } from "rxjs/operators";
-import { getCryptoCurrencyById, formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import { getAccountBridge, getCurrencyBridge } from "@ledgerhq/live-common/bridge/index";
 import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/bridge/cache";
@@ -20,6 +20,7 @@ import type { AccountDescriptor, Balance, Operation, SendEvent } from "../models
 import type { EarnSolanaStake } from "../earn/types";
 import type { TransactionIntent } from "../intents";
 import { parseAmountWithTicker } from "../intents/parse-amount";
+import { formatCliCurrencyUnit } from "../formatter/currency";
 
 type SendOptions = { deviceId: string; deviceModelId: DeviceModelId };
 
@@ -310,8 +311,8 @@ export class BridgeAdapter {
     return {
       // formatted summary (used by prepareSend and the "prepared" event in send)
       recipient: intent.recipient,
-      amount: formatCurrencyUnit(amountUnit, status.amount, { showCode: true }),
-      fees: formatCurrencyUnit(nativeUnit, status.estimatedFees, { showCode: true }),
+      amount: formatCliCurrencyUnit(amountUnit, status.amount, { showCode: true }),
+      fees: formatCliCurrencyUnit(nativeUnit, status.estimatedFees, { showCode: true }),
       // raw objects needed by send to proceed to signing
       bridge,
       tx,

--- a/apps/wallet-cli/src/wallet/formatter/currency.test.ts
+++ b/apps/wallet-cli/src/wallet/formatter/currency.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { BigNumber } from "bignumber.js";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
+import { formatCliCurrencyUnit, toAsciiSpaces } from "./currency";
+
+const NBSP = "\u00A0";
+const NARROW_NBSP = "\u202F";
+
+const ethUnit = getCryptoCurrencyById("ethereum").units[0];
+
+describe("toAsciiSpaces", () => {
+  it("should replace a non-breaking space with U+0020", () => {
+    expect(toAsciiSpaces(`1.234${NBSP}ETH`)).toBe("1.234 ETH");
+  });
+
+  it("should replace a narrow no-break space with U+0020", () => {
+    expect(toAsciiSpaces(`1${NARROW_NBSP}234${NBSP}ETH`)).toBe("1 234 ETH");
+  });
+
+  it("should leave a string that already uses ASCII spaces untouched", () => {
+    expect(toAsciiSpaces("1,234.5 ETH")).toBe("1,234.5 ETH");
+  });
+});
+
+describe("formatCliCurrencyUnit", () => {
+  it("should separate the value from its code with U+0020, not U+00A0", () => {
+    const formatted = formatCliCurrencyUnit(ethUnit, new BigNumber("1234000000000000000"), {
+      showCode: true,
+    });
+    // Assert on the codepoint: `toContain("1.234 ETH")` typed with a regular space is exactly the
+    // assertion that let the non-breaking space ship unnoticed.
+    expect(formatted).not.toContain(NBSP);
+    expect(formatted.split(" ")).toEqual(["1.234", "ETH"]);
+  });
+
+  it("should emit no non-ASCII space anywhere, including in grouped thousands", () => {
+    const formatted = formatCliCurrencyUnit(ethUnit, new BigNumber("12345000000000000000000"), {
+      showCode: true,
+    });
+    expect(formatted).not.toMatch(new RegExp(`[${NBSP}${NARROW_NBSP}]`));
+    expect(formatted.endsWith(" ETH")).toBe(true);
+  });
+
+  it("should keep formatting a zero amount pipe-safe", () => {
+    const formatted = formatCliCurrencyUnit(ethUnit, new BigNumber(0), { showCode: true });
+    expect(formatted).not.toContain(NBSP);
+    expect(formatted).toBe("0 ETH");
+  });
+});

--- a/apps/wallet-cli/src/wallet/formatter/currency.ts
+++ b/apps/wallet-cli/src/wallet/formatter/currency.ts
@@ -1,0 +1,34 @@
+/**
+ * CLI boundary for live-common's currency formatting.
+ *
+ * `formatCurrencyUnit` joins the value and its code with a NON-BREAKING SPACE (U+00A0), and some
+ * locales group thousands with a NARROW NO-BREAK SPACE (U+202F). Both are the right call for the
+ * desktop/mobile GUIs, which is why the shared helper is left alone — but they are wrong for a CLI:
+ * they are invisible in a terminal, yet `grep " ETH"`, `awk`, `cut` and anything consuming
+ * `--output json` all fail to match on them.
+ *
+ * Every wallet-cli amount string must go through here rather than calling `formatCurrencyUnit`
+ * directly.
+ */
+
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { formatCurrencyUnitOptions } from "@ledgerhq/live-common/currencies/index";
+import type { BigNumber } from "bignumber.js";
+import type { Unit } from "@domain/entity-currency-unit";
+
+/** Unicode spaces live-common can emit inside a formatted amount: NBSP and narrow NBSP. */
+const UNICODE_SPACES = /[\u00A0\u202F]/g;
+
+/** Replace every non-ASCII space in a formatted amount with U+0020. */
+export function toAsciiSpaces(formatted: string): string {
+  return formatted.replace(UNICODE_SPACES, " ");
+}
+
+/** `formatCurrencyUnit` with terminal- and pipe-safe spacing. */
+export function formatCliCurrencyUnit(
+  unit: Unit,
+  value: BigNumber,
+  options?: formatCurrencyUnitOptions,
+): string {
+  return toAsciiSpaces(formatCurrencyUnit(unit, value, options));
+}

--- a/apps/wallet-cli/src/wallet/formatter/human.test.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.test.ts
@@ -9,6 +9,8 @@ import { USDT_TOKEN_INFO } from "../../test/helpers/cal-fixtures";
 
 const stubStore = {} as CryptoAssetsStore;
 
+const NBSP = "\u00A0";
+
 const btcDiscovered: DiscoveredAccount = {
   descriptor: {
     purpose: "account",
@@ -179,6 +181,12 @@ describe("HumanFormatter.formatAmount", () => {
     expect(result).toContain("ETH");
   });
 
+  it("separates the value from the ticker with U+0020 so the output survives grep/awk/cut", async () => {
+    const result = await formatter.formatAmount("1000000000000000000", "ethereum");
+    expect(result).not.toContain(NBSP);
+    expect(result.split(" ")).toEqual(["1", "ETH"]);
+  });
+
   it("throws for unknown assetId", async () => {
     const storeWithNoToken = {
       findTokenById: async () => undefined,
@@ -219,6 +227,13 @@ describe("HumanFormatter.formatBalance", () => {
     );
     expect(result).toContain("ETH");
   });
+
+  it("renders the amount with an ASCII space", async () => {
+    const result = await formatter.formatBalance(
+      BalanceSchema.parse({ assetId: "ethereum", balance: "1000000000000000000" }),
+    );
+    expect(result).not.toContain(NBSP);
+  });
 });
 
 describe("HumanFormatter.formatOperation", () => {
@@ -257,6 +272,12 @@ describe("HumanFormatter.formatOperation", () => {
   it("formats an IN operation", async () => {
     const result = await formatter.formatOperation({ ...op, type: "IN" }, "ethereum");
     expect(result).toContain("IN");
+  });
+
+  it("renders the value and the fee with ASCII spaces", async () => {
+    const result = await formatter.formatOperation(op, "ethereum");
+    expect(result).not.toContain(NBSP);
+    expect(result).toContain("0.5 ETH");
   });
 });
 

--- a/apps/wallet-cli/src/wallet/formatter/human.ts
+++ b/apps/wallet-cli/src/wallet/formatter/human.ts
@@ -1,8 +1,9 @@
 import { BigNumber } from "bignumber.js";
-import { findCryptoCurrencyById, formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import { findCryptoCurrencyById } from "@ledgerhq/live-common/currencies/index";
 import type { Unit } from "@domain/entity-currency-unit";
 import type { CryptoAssetsStore, OperationType } from "@ledgerhq/types-live";
 import { colors } from "../../shared/ui";
+import { formatCliCurrencyUnit } from "./currency";
 import type {
   AccountDescriptor,
   Balance,
@@ -36,7 +37,7 @@ export class HumanFormatter {
 
   async formatAmount(rawDecimal: string, assetId: string): Promise<string> {
     const unit = await this.resolveUnit(assetId);
-    return formatCurrencyUnit(unit, new BigNumber(rawDecimal), { showCode: true });
+    return formatCliCurrencyUnit(unit, new BigNumber(rawDecimal), { showCode: true });
   }
 
   /** @deprecated Use formatDiscoveredAccount — kept for any internal callers during migration. */
@@ -89,8 +90,8 @@ export class HumanFormatter {
       this.resolveUnit(op.assetId),
       this.resolveUnit(nativeCurrencyId),
     ]);
-    const value = formatCurrencyUnit(valueUnit, new BigNumber(op.value), { showCode: true });
-    const fee = formatCurrencyUnit(feeUnit, new BigNumber(op.fee), { showCode: true });
+    const value = formatCliCurrencyUnit(valueUnit, new BigNumber(op.value), { showCode: true });
+    const fee = formatCliCurrencyUnit(feeUnit, new BigNumber(op.fee), { showCode: true });
     const date = colors.dim(formatDate(new Date(op.date)));
     const block =
       op.blockHeight == null ? colors.yellow("pending") : colors.dim(`#${op.blockHeight}`);


### PR DESCRIPTION
## Summary

wallet-cli printed every amount with a non-breaking space (U+00A0) between the value and the ticker, inherited from live-common's `formatCurrencyUnit` (`libs/live-currency-format/src/formatCurrencyUnit.ts:7`, joined into the suffix at line 211).

NBSP is the right choice for the desktop and mobile GUIs, so the shared helper is deliberately left untouched. Instead, a new CLI boundary `formatCliCurrencyUnit` in `src/wallet/formatter/currency.ts` normalizes U+00A0 and U+202F to a plain space, and all five of wallet-cli's direct `formatCurrencyUnit` call sites now go through it.

The character is invisible in a terminal but breaks `grep`, `awk`, `cut` and anything consuming `--output json`.

Affected surfaces:

- `balances` (human and JSON)
- `operations` (human and JSON)
- `earn positions`
- `send --dry-run` and the `send` "prepared" event
- the earn deposit/withdraw dry runs

`swap quote` was already clean.

## Test plan

- [x] `pnpm test` in `apps/wallet-cli`: 827 pass, 0 fail
- [x] Typecheck, lint and format all clean
- [x] Device-free regression suite D went from `passed 36/41 failed 5 skipped 1` (failing D4, D5, D6, D23, D24) to `passed 41/41 failed 0 skipped 1`, verified by stashing the fix and re-running against the same session and network

## Notes

No changeset: `@ledgerhq/wallet-cli` is `private: true` and nothing under `libs/` changed.