### PR TITLE
test(wallet-cli): add the release regression harness and plan

### DIFF
--- a/apps/wallet-cli/README.md
+++ b/apps/wallet-cli/README.md
@@ -105,6 +105,15 @@ pnpm start -- <command> [args]
 
 If `USER_ID` is unset, it defaults to `wallet-cli` so DMK firmware distribution salt stays stable for this CLI (`env-setup.ts`).
 
+## Regression testing
+
+Before a release, work through the [regression plan](docs/regression/README.md). Cases that
+need no device are automated (`bun scripts/regression/run.ts`); the rest need a Ledger on USB
+and a person to confirm on-screen. Per-release focus lives in
+[`docs/regression/releases/`](docs/regression/releases/).
+
+Adding or changing a command? Update the matching case table in the same PR.
+
 ## Relation to `ledger-live` CLI
 
 This package is DMK-focused and is separate from `@ledgerhq/live-cli` ([`apps/cli`](../cli)), which is now an internal, Speculos-only tool used by the monorepo's e2e suites and CI. For human/manual hardware-wallet flows, use this `wallet-cli` (or the Ledger Live desktop/mobile app).

--- a/apps/wallet-cli/docs/regression/README.md
+++ b/apps/wallet-cli/docs/regression/README.md
@@ -1,0 +1,93 @@
+# wallet-cli regression plan
+
+A living regression plan for `@ledgerhq/wallet-cli`. It is kept next to the code so it
+evolves with it: **when you add or change a command, add or update its cases here in the
+same PR.**
+
+Cases are split by one thing only — whether the command needs a Ledger on USB:
+
+| Where | What | Who runs it |
+| --- | --- | --- |
+| [`no-device.md`](./no-device.md) | Repo gates, `skill`, the first-run nudge, and every command that reads or dry-runs without a device | `scripts/regression/run.ts`, unattended |
+| [`with-device.md`](./with-device.md) | `account discover`, `receive`, `send`, `genuine-check`, `swap execute`, `earn deposit/withdraw`, `ring` | a person, device connected and unlocked |
+
+There is no way to automate the second file: the harness drives the real CLI, so a command
+that talks to the device needs the device. wallet-cli has **no Speculos support** — the
+transport is USB/DMK only.
+
+Per-release focus lives in [`releases/`](./releases/) — one short file per version listing
+what changed and which cases it puts at risk. Start there when planning a campaign.
+
+## What CI already covers (don't re-test by hand)
+
+`pnpm test` (bun, in `apps/wallet-cli`) runs on every PR and already covers a lot that
+looks device-shaped, using an in-process mock DMK (`src/test/helpers/cli-runner.ts`, driven
+by `WALLET_CLI_MOCK_DMK*`) plus HTTP interception:
+
+- device-state → message → exit-code mapping (`src/device/device-state.test.ts`,
+  `classify-device-error.test.ts`, `wallet-cli-device-error.test.ts`);
+- `genuine-check`: genuine, locked, timeout, non-genuine, truncated stream;
+- `receive`: `--verify` / `--verify=false` / `--no-verify` equivalence;
+- `swap execute`: envelope shape, provider validation, currency/chain mismatches, the DIE
+  pipeline incl. legacy fallback — and the display-unit conversion of `amountExpectedTo`
+  (`src/commands/swap/cli-swap-pipeline.test.ts`);
+- `earn deposit/withdraw`: dry-run envelopes, guard errors, the ETH vault approve→deposit
+  pipeline and its Kiln app dependency.
+
+That mock is **only reachable in-process from bun tests**, never from the shipped binary,
+so it can't be used by the harness. Its value here is negative scope: if a behaviour is
+covered there, the device pass only needs one confirmation on real hardware rather than a
+matrix. Gaps worth closing as tests rather than as manual steps are listed at the end of
+[`with-device.md`](./with-device.md).
+
+## Prerequisites
+
+| Item | Notes |
+| --- | --- |
+| Build | `pnpm build` in `apps/wallet-cli`, then test `dist/<platform>/cli` — required for anything `skill`-related, since skills are embedded in the binary |
+| From source | `pnpm --silent wallet-cli start <cmd>` from the repo root (`run.ts --source`) |
+| Device | Unlocked Ledger on USB; Ethereum, Bitcoin, Solana, Exchange and Kiln apps installed; firmware current |
+| Funds | A dedicated regression wallet: ETH (gas) + a funded ERC-20, BTC, ≥2 SOL, and a small swap budget |
+| Network | Unrestricted egress. Sandboxed shells must be bypassed for USB and OS-keychain commands |
+| Tools | `bun` only — the harness shells out to nothing else |
+| Isolation | Every hermetic case gets a throwaway state dir (session + first-run marker) and home dir, on every OS |
+
+## Running the no-device cases
+
+```bash
+cd apps/wallet-cli
+pnpm build                                                 # skill cases need the binary
+bun scripts/regression/run.ts                              # skill, nudge, device-free commands
+bun scripts/regression/run.ts --suite b                    # one area
+bun scripts/regression/run.ts --with-gates --with-build    # + repo gates, build, pack, npm smoke
+bun scripts/regression/run.ts --source                     # run from source instead of the binary
+bun scripts/regression/run.ts --suite d --session <dir>    # suite D against a pinned session, not yours
+```
+
+`--bin <path>` picks a specific binary; the default is `dist/<platform>/cli` for the host
+(`darwin-arm64`, `linux-arm64`, `linux-x64`, `windows-x64`). `CASE_TIMEOUT` (240s) and
+`GATE_TIMEOUT` (2400s) bound each case and each Suite A gate.
+
+Case ids printed by the script match the tables in [`no-device.md`](./no-device.md). Every
+invocation, stdout, stderr and exit code is logged; the path is printed at the end.
+
+The script never signs and never broadcasts. It uses your **real session** for read cases
+(so `account discover` must have run at least once, unless you point `--session` at a pinned
+one) and throwaway state for `skill` and nudge cases. With no readable session the read cases
+are skipped with a reason rather than failing.
+
+## Running the device cases
+
+Read [`with-device.md`](./with-device.md) — it defines the protocol (one command per case,
+`--output json` so the exit code and device-state stream are the oracle, and what evidence
+to record), then work through the tables. Start the Solana undelegate case on day one: its
+`--finalize` step can only run after the deactivation epoch boundary (~2–3 days).
+
+## Priorities
+
+1. **Blocking:** repo gates; `skill` and nudge cases; every `--dry-run` and validation case;
+   `genuine-check`; `receive` address verification; one real `send`; one real `swap execute`.
+2. **Release quality:** the rest of the no-device tables, remaining `send`/`swap`/`earn`
+   device cases, packaging and npm smoke.
+3. **Opportunistic:** `ring` edge cases (rotation, ejection), the platform matrix, and the
+   multi-day Solana finalize.

--- a/apps/wallet-cli/docs/regression/no-device.md
+++ b/apps/wallet-cli/docs/regression/no-device.md
@@ -1,0 +1,214 @@
+# Regression cases — no device required
+
+Runnable unattended by `scripts/regression/run.ts`. Every numbered id below is one the script
+prints, in the order it prints it; each suite ends with a **not yet automated** table of cases
+that still need a person. Nothing here signs or broadcasts. See [README](./README.md) for
+prerequisites and flags.
+
+Suite A uses the repo, B and C are hermetic (throwaway cwd, home and state dir), and D uses
+a real session plus live backends.
+
+## Suite A — repo & artifact gates
+
+`run.ts --with-gates` (add `--with-build` for A7–A9). Run these first: a stale
+`src/skills/manifest.gen.ts` invalidates every Suite B result.
+
+| ID | Command (in `apps/wallet-cli`) | Expected |
+| --- | --- | --- |
+| A1 | `pnpm test` | green |
+| A2 | `pnpm typecheck` | clean |
+| A3 | `pnpm lint:ci` | clean |
+| A4 | `pnpm format:check` | clean (separate CI gate from lint) |
+| A5 | `pnpm check:skills` | every shipped skill found in `.agents/skills/` |
+| A6 | `pnpm check:notices` | `THIRD_PARTY_NOTICES.md` in sync |
+| A7 | `pnpm build` | binaries for all four platforms in `dist/` |
+| A8 | `pnpm pack:check` | tarball layout (bin/, LICENSE, notices, README, CHANGELOG) |
+| A9 | `pnpm smoke:npm` | packs + installs into a temp dir, runs `wallet-cli --version` |
+
+### not yet automated
+
+| Case | Expected |
+| --- | --- |
+| `git status` after a run | only generated files untracked; nothing else dirty |
+
+## Suite B — `skill` command group
+
+Run against the **binary**: the point of the feature is that skills ship inside it.
+
+### list / retrieve
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B1 | `skill list` | names `ledger-wallet-cli` |
+| B2 | `skill list --output json` | `status:success`, `command:"skill list"`, `skills[].name/description` |
+| B3 | `skill retrieve` | prints `SKILL.md` |
+| B4 | `skill retrieve --file references/business-logic.md` | prints the reference doc |
+| B5 | `skill retrieve --file no-such.md` | exit 1, lists available files |
+
+### install
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B6 | `skill install --agent claude` in an empty dir | `SKILL.md`, `references/business-logic.md`, `.wallet-cli-skill.json` |
+| B7 | sidecar contents | `name`, `cliVersion` = binary version, 64-hex `contentHash` matching the files on disk, per-file `files{}`, ISO `installedAt` |
+| B8 | install again, no `--force` | exit 1, "Refusing to overwrite", files untouched |
+| B9 | `--force` | exit 0, `installedAt` refreshed |
+| B10 | delete both skill files, keep the sidecar, install without `--force` | succeeds (sidecar excluded from the clash check) |
+| B11 | `--agent cursor` / `codex` / `agents` | `.cursor/skills`, `.codex/skills`, `.agents/skills` |
+| B12 | bare `skill install` | defaults to `.claude/skills` |
+| B13 | `--dir ./custom` | writes there; no `.claude/` created |
+| B14 | `--global` | installs under `$HOME`, not cwd |
+| B15 | `--all` | every embedded skill installed |
+| B16 | `install --output json` | `cliVersion`, `root`, `skills[]`, `contentHashes{}`, `installed[]` |
+| B17 | `--agent bogus` (human + json) | exit 1, lists `claude, cursor, codex, agents`, suggests `--dir`; json → `{ok:false,error:{command,message}}` |
+| B18 | unknown skill name | exit 1, "not found", points at `skill list` |
+
+### doctor
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| B19 | after a fresh install | `up-to-date`, exit 0 |
+| B20 | `--output json` | `results[]` with `status`/`installedVersion`/`installedHash`/`diskHash`/`shippedVersion`/`shippedHash`; `fixed` and `remainingDrift` empty |
+| B21 | edit the installed `SKILL.md` | `modified-locally`, "still drifting", hints `--fix --force`, exit 1 |
+| B22 | `--fix` on that | still drifting, exit 1, **local edit preserved** |
+| B23 | `--fix --force` | "Fixed 1 skill(s)", `up-to-date`, exit 0, edit gone |
+| B24 | delete a tracked reference file | drift detected; `--fix --force` restores it |
+| B25 | nothing installed | `missing`, "installed none", exit 1 |
+| B26 | `--fix` on `missing` | installs it **without** `--force`, exit 0 |
+| B27 | simulate an older install (content edited, sidecar rewritten to agree with disk but recording an older `cliVersion`) | `outdated`; plain `--fix` heals it and rewrites the sidecar |
+| B28 | remove the sidecar, content untouched | `up-to-date`, "installed none" — legacy/manual installs tolerated |
+| B29 | remove the sidecar **and** edit content | `modified-locally`; `--fix` alone must not overwrite |
+| B30 | `--dir ./elsewhere` | scans only that dir; the default scan then reports `missing` |
+| B31 | `--global` | also scans `$HOME` agent dirs; both roots appear in `results[].root` |
+| B32 | a regular file named `ledger-wallet-cli` in `.claude/skills` | reported `missing`, not mistaken for an install |
+
+### not yet automated
+
+| Case | Expected |
+| --- | --- |
+| `--dir` on an unwritable path | clean error, non-zero, no partial write |
+| `--global` run from `$HOME` | roots de-duplicated; no skill listed or fixed twice |
+| installed for two agents, then `doctor` | one diagnosis per (root, skill), each with its own `root` |
+| binary copied outside the repo, `skill install --agent claude` | works with no repo and no prior setup |
+| `skill retrieve` vs `.agents/skills/ledger-wallet-cli/SKILL.md` | byte-identical — the shipped skill can't drift from source |
+
+## Suite C — first-run nudge
+
+Each case needs a pristine state dir; `session view` is the cheapest real command. C3 and C11
+assert POSIX file modes and are skipped on Windows and as root. C8 runs once per non-command
+invocation, so it prints two ids.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| C1 | fresh state, `CLAUDECODE=1` | stderr shows `skill install --agent claude` + "Claude Code"; stdout untouched |
+| C2 | run again | silent |
+| C3 | marker | `first-run.json` under the state dir, dir `0700`, file `0600`, `version` = CLI version |
+| C4 | `--output json` on fresh state | stderr empty, marker **not** written; a later human run still shows the hint |
+| C5 | `WALLET_CLI_NO_NUDGE=1` | silent, no marker |
+| C6 | no agent env, stderr not a TTY | silent, no marker |
+| C7 | `CURSOR_AGENT` → cursor; `CODEX_ENABLED` → codex; `GEMINI_CLI` / `OPENCODE` / `AMP_CURRENT_THREAD_ID` → `agents` | each hint names the right agent and label |
+| C8help | `--help` | no hint, marker not consumed; next real command shows it |
+| C8version | `--version` | no hint, marker not consumed; next real command shows it |
+| C9 | any `skill *` command | no hint, marker not consumed |
+| C10 | a failing command on fresh state | hint shown **and** the exit code unchanged |
+| C11 | read-only state dir | command succeeds, no crash |
+
+### not yet automated
+
+| Case | Expected |
+| --- | --- |
+| bare invocation (no args) on fresh state | no hint, marker not consumed |
+| corrupt marker file | never crashes (shown once more at worst) |
+| no agent env, real interactive TTY | generic `wallet-cli skill install`, no `--agent` — needs a terminal |
+
+## Suite D — commands that need no device
+
+Uses discovered session accounts. `send`/`earn` cases are `--dry-run` only. Account lookup is
+mainnet-only (`ethereum-<n>`, `solana-<n>`, `bitcoin-<derivation>-<n>`), so a session holding
+only testnet accounts skips the cases that need them rather than asserting mainnet
+expectations against testnet.
+
+### session, balances, operations, assets
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D1 | `session view` | labels + descriptors |
+| D2 | `session view --output json` | `accounts[].label/descriptor`; no xprv anywhere |
+| D3 | `balances <eth>` | native + token rows, `ETH` present |
+| D4 | `balances <eth> --output json` | `{asset, amount}` rows, `network:"ethereum:main"`, exactly one native ETH row |
+| D5 | `balances <sol> --output json` | exactly one SOL-denominated row |
+| D6 | `balances <btc> --output json` | exactly one BTC-denominated row |
+| D7 | unknown label | exit 1, "No account labeled …", points at `account discover` |
+| D8 | a raw descriptor as an argument | rejected |
+| D9 | `operations <eth> --limit 3` | rows printed |
+| D10 | `operations <eth> --limit 3 --output json` | `command:"operations"`, `operations` is an array |
+| D11 | `operations --cursor <cursor>` | page advances — skipped unless a session account has >1 page of history |
+| D12 | `assets token ethereum 0xdac17f95…` | USDT, id `ethereum/erc20/usd_tether__erc20_` |
+| D13 | `assets token-by-id` with that id | same token (`ticker:"USDT"` in the envelope) |
+| D14 | unknown contract | non-zero, "not found" |
+| D15 | `assets token solana <SPL mint>` | resolved — the mint is the **positional** address |
+| D15b | `assets token solana` (no address) | `Usage: assets token <network> <address>`, non-zero, no stack trace |
+
+### earn read paths
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D16 | `earn yields` | supported networks with `ledgerlive://` deeplinks |
+| D17 | `earn yields -n solana` | "Deposit targets" with `--product`, Ledger validators surfaced |
+| D18 | `earn yields -n ethereum --output json` | ERC-4626 vault ids as `--product` (`vaultId` in json) |
+| D19 | `earn yields -n solana --limit 3`, then `earn yields --all` | both accepted |
+| D20 | `earn positions <sol> --output json` | `command:"earn positions"`, `positions` is an array |
+| D21 | `earn positions <sol> --fresh` | accepted, non-blocking |
+| D22 | `earn positions <eth> --output json` | vault positions or empty, valid envelope |
+
+### send / earn dry runs
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D23 | `send <eth> --to <own addr> --amount '0.0001 ETH' --dry-run` | amount + Fees shown, no `hash:` line |
+| D24 | same with a funded ERC-20 ticker | token resolved by ticker |
+| D25 | `--amount '0.0001'` (no ticker) | "must include a ticker" |
+| D26 | `--amount '1 UNKN'` | "not found in account. Available: …" |
+| D27 | amount above balance | `NotEnoughBalance` |
+| D28 | invalid recipient, ethereum | `InvalidAddress` |
+| D29 | invalid recipient, bitcoin (also with `--fee-per-byte`/`--rbf`) | `InvalidAddress`, flags parse |
+| D30 | invalid recipient, solana, then `send <sol> --to <own addr> --memo …` | `InvalidAddress`; memo accepted, nothing broadcast |
+| D31 | `earn deposit <sol> --product <validator> --amount '0.5 SOL' --dry-run` | validated, no signature, nothing broadcast |
+| D32 | `earn deposit <eth> --product <vaultId> --amount '1 USDC' --dry-run` | flags parse, nothing broadcast |
+| D33 | `earn withdraw <eth> --dry-run` with no target | non-zero validation error |
+
+D28–D30 are the coverage for address validation going through the `CoinModuleApi` instance:
+keep one case per family.
+
+### swap quote / status
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D34 | `swap quote` ETH→BTC, sensible amount | provider fan-out; rates, or "No quotes available" |
+| D35 | the same quote `--output json` | `command:"swap quote"` |
+| D36 | token id as `--from` | accepted |
+| D37 | missing `--to-account` | clean validation error, never `[object Object]` |
+| D38 | `--from not-a-currency` | clean error, never `[object Object]` |
+| D39 | `swap status --swap-id <unknown> --provider changelly` | `UNKNOWN`, exit 0, never `[object Object]` |
+| D39b | `swap status` without `--provider` | clean validation error |
+
+### cross-cutting
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| D40 | `--version`, then `--help` | version matches `package.json`; `--help` lists every command group, incl. `skill`, `earn`, `ring` |
+
+### not yet automated
+
+| Area | Case | Expected |
+| --- | --- | --- |
+| earn | deeplink shape | ERC-20 grow rows target the token sub-account id; SOL rows use `earn?action=stake-account` |
+| earn | `earn positions <sol>` detail | `stakes[]` with `→ --stake-account`, `state`, `withdrawable`; `(stale)` markers |
+| earn | `earn deposit <eth>` first ever deposit, then once an allowance exists | approve validated, deposit `not-simulated` with the documented reason; the deposit leg simulates on the second run |
+| earn | `earn withdraw <eth> --product <vaultId> --dry-run`, no `--amount` | full exit (`amount:"max"`) |
+| swap | amount below provider minimums | `amount_off_limits` per provider, exit 0, no crash |
+| swap | a session label passed to `--from` | rejected, message points at `--from-account` |
+| help | `<group> --help` for each group | every group documents its own sub-commands |
+| streams | every `--output json` command piped to `jq` | valid JSON (or NDJSON), never mixed with human text |
+| streams | human mode with stdout piped | progress on stderr, payload on stdout |
+| concurrency | two no-device commands in parallel | both succeed |

--- a/apps/wallet-cli/docs/regression/releases/2.1.0.md
+++ b/apps/wallet-cli/docs/regression/releases/2.1.0.md
@@ -1,0 +1,51 @@
+# Release focus — 2.1.0
+
+Previous published version: **2.0.1**. Full entries in
+[`CHANGELOG.md`](../../../CHANGELOG.md).
+
+## What changed, and what it puts at risk
+
+| Change | Risk | Cases |
+| --- | --- | --- |
+| New `skill` group (`list`, `retrieve`, `install`) with skills embedded in the binary | New surface that writes into the user's project | B1–B18, plus Suite B's not-yet-automated rows |
+| New `skill doctor` + `.wallet-cli-skill.json` provenance sidecar, hashes in the install envelope | New surface that can overwrite user files | B19–B32 |
+| One-time agent-aware first-run nudge | Runs on **every** command's startup path and writes to stderr | C1–C11, and Suite D's not-yet-automated stream-hygiene rows |
+| `swap execute`: `amountExpectedTo` now in display units, atomic value moved to `amountExpectedToAtomic` | **Breaking for script consumers**; money-facing | G1, G2 |
+| `swap_completed` analytics gains `provider` | Analytics only | G11 |
+| `validateAddress` consumed through the `CoinModuleApi` instance | Recipient validation on every send/earn/swap build, all families | D28–D30, F1–F4 |
+| Remaining `@ledgerhq/cryptoassets` value-barrel imports repointed to `@domain/entity-currency-crypto` / `-fiat` | Currency, token, fiat and unit resolution everywhere: balances, tickers, token ids, fee display | D3–D6, D12–D15b, D23–D27, D34–D36 |
+
+The last two rows are why this release needs a broad pass rather than only testing the new
+`skill` and nudge surface: they sit underneath every amount, ticker and address in the CLI.
+
+## Suggested campaign
+
+1. Suite A (gates) — a stale generated skill manifest invalidates all of Suite B.
+2. Suites B and C via `scripts/regression/run.ts` — the new surface.
+3. Suite D via the same script — the regression net for the two refactors above.
+4. Device pass: E (basics) → F (send) → G1–G3 (the display-unit change) → H → I as budget allows.
+   Kick off H3 early so H4's epoch boundary passes during the campaign.
+
+## Open questions raised while writing this plan
+
+Product decisions, not pass/fail cases:
+
+1. **`balances --output json` amounts are display strings.** Rows are `{asset, amount}` with
+   `amount` like `"2,000 BXX"` — thousands separators, ticker suffix, no separate numeric or
+   atomic field. Machine consumers have to parse locale-formatted text. Given 2.1.0 split
+   `amountExpectedTo` / `amountExpectedToAtomic` in swap for exactly this reason, should
+   balances follow?
+2. **`swap status` on an unknown id exits 0** and prints `[?] UNKNOWN <id>`. Intended (it's a
+   status read, not a failure), or should an unknown id be non-zero?
+3. **The embedded skill documents `assets token` wrongly.** It says to pass `--identifier` for
+   non-EVM chains, but the address is a required positional and `--identifier` is an extra hint
+   for MultiversX/Cardano/Algorand/Stellar; a Solana mint goes in the positional. The skill now
+   ships inside the binary, so this wording ships too.
+4. **The embedded skill's frontmatter description lists only the pre-2.0 commands** — no `earn`,
+   no `skill`. Agents select skills on that description, which makes the newer features harder
+   to discover.
+5. **`operations` pagination has no reliable fixture.** D11 needs an account with more than one
+   page of history; a dedicated fixture account would make it always exercised.
+6. **Provider IP restrictions read as failures.** `swap quote` returns
+   `failed_to_get_quote_error - IP address not supported by cic_v2` from some regions. Worth
+   distinguishing from a real provider failure in the output.

--- a/apps/wallet-cli/docs/regression/with-device.md
+++ b/apps/wallet-cli/docs/regression/with-device.md
@@ -1,0 +1,132 @@
+# Regression cases — device required
+
+Every case here drives a command that talks to the Ledger, so it needs the device connected
+and unlocked and a person to confirm on-screen. Nothing automates this: wallet-cli speaks
+USB/DMK only and has **no Speculos support**.
+
+## Protocol
+
+- **One command per case.** Run it, confirm on the device, record the result before moving on.
+- **Always `--output json`.** The exit code plus the `device-state` events (`awaiting_approval`
+  with its `reason`, terminal states) are the oracle — not "it looked fine".
+- **Exit codes are the contract** (`src/device/device-state.ts`): `0` success, `2` rejected,
+  `3` disconnected, `4` wrong app, `5` app not installed, `6` timeout/locked.
+- **Never run two device commands at once** — concurrent APDU traffic garbles the session.
+- **Batch by device app** (all Ethereum cases, then Bitcoin, then Solana) to cut app switching.
+- **Use the dedicated regression wallet**, with the amounts written in the case. Don't improvise
+  with real funds.
+- **Record per case:** command, exit code, the JSON envelope, what the device screen showed,
+  and the tx hash where one is produced.
+- **Start E9 (Solana undelegate) on day one** — its finalize step needs the deactivation epoch
+  boundary to pass (~2–3 days).
+
+## Suite E — device basics
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| E1 | `genuine-check`, device on the dashboard | genuine, exit 0 |
+| E2 | `genuine-check` with a currency app open | `[✖] Wrong app. Open Ledger dashboard.`, exit 4 |
+| E3 | `genuine-check` with the host offline | clean network error, no crash |
+| E4 | `account discover ethereum` / `bitcoin` / `solana` | accounts found, labels `<network>[-derivation]-<n>`, persisted; no raw V1 descriptor in the output |
+| E5 | `account discover ethereum:sepolia` / `bitcoin:testnet` / `solana:devnet` | testnet labels (e.g. `ethereum-sepolia-1`); discovery only |
+| E6 | `receive <acct>` | **terminal address matches the device screen character for character** |
+| E7 | `receive <acct> --no-verify` | no device prompt, same address as E6 |
+| E8 | `receive` on each bitcoin derivation (native/taproot/segwit/legacy) | correct address format per derivation |
+| E9 | device locked when a command starts | `awaiting_approval`, `reason: unlock`; resumes after PIN, no spurious timeout |
+| E10 | app not installed for the target network | exit 5 with an install hint |
+| E11 | unplug mid-command | exit 3, clean DMK teardown; the next command works without replugging twice |
+
+## Suite F — send
+
+| ID | Case | Amount | Expected |
+| --- | --- | --- | --- |
+| F1 | native ETH | 0.0001 ETH | device shows amount/recipient/fees; `hash:` on stdout; appears in `operations` |
+| F2 | ERC-20 | 0.01 USDC | clear-signed token transfer, correct decimals and symbol |
+| F3 | BTC with `--fee-per-byte` + `--rbf` | dust-safe minimum | fee rate respected, RBF flagged |
+| F4 | SOL with `--memo` | 0.001 SOL | memo instruction present on-chain |
+| F5 | reject on device | — | exit 2, "No action taken", nothing broadcast |
+| F6 | approve, then unplug before broadcast | — | clean error; no half-broadcast state |
+
+## Suite G — swap execute
+
+Small amounts. G1 is the check for 2.1.0's display-unit change; the conversion itself is
+unit-tested, so one hardware confirmation per output mode is enough.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| G1 | small swap, legacy provider, `--output json` | `amountExpectedTo` in **display units**, `amountExpectedToAtomic` alongside it, `magnitudeAwareRate` unchanged (atomic/atomic) |
+| G2 | same run, human output | "Amount expected to:" in display units with the right magnitude |
+| G3 | legacy pipeline ETH→BTC end to end | nonce → payload → complete exchange → sign → broadcast; Exchange app session stays open throughout; `hash:` emitted |
+| G4 | DEX provider (`uniswap`) ETH→USDT, EVM source | embedded coin-app flow: `Open <app>` prompts, approval/permit2/swap signatures, broadcast |
+| G5 | DEX provider with a non-EVM source account | falls back to the legacy pipeline |
+| G6 | a quote that resolves to an RFQ plan | `falling back to legacy Exchange-app pipeline`, then legacy flow |
+| G7 | reject on device | exit 2, nothing broadcast |
+| G8 | `--fee-strategy slow` vs `fast` | refund-chain fee differs accordingly |
+| G9 | swap into a token account that doesn't exist yet | succeeds (destination account created) |
+| G10 | `swap status --swap-id <from G3> --provider <same>` | real status progression |
+| G11 | analytics for a completed swap (Segment debug) | `swap_completed` carries `provider`, `fromCurrency`, `toCurrency`, and `toAmount` in display units |
+
+## Suite H — earn deposit / withdraw
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| H1 | `earn deposit <sol> --product <Ledger validator> --amount '1 SOL'` | `stake.createAccount` creates **and** delegates in one tx |
+| H2 | `earn positions <sol>` after H1 | the new stake account listed with `→ --stake-account`, state `activating` |
+| H3 | `earn withdraw <sol> --stake-account <addr>` | undelegate signed; state → `deactivating` |
+| H4 | `earn withdraw <sol> --stake-account <addr> --finalize` after the epoch boundary | lamports back on the main account; `--amount` ignored |
+| H5 | `earn deposit <eth> --product <vaultId> --amount '1 USDC'`, first deposit | Ethereum app opens with the **Kiln** clear-signing dependency; `approve` then `deposit`; on-chain status polled |
+| H6 | `earn withdraw <eth> --product <vaultId>` with no `--amount` | full exit, no dust left |
+| H7 | reject either leg of H5 on device | exit 2; the approve tx state is reported accurately |
+
+## Suite I — ring (LKRP)
+
+Password comes from the OS keychain via command substitution
+(`WALLET_PASS=$(security find-generic-password …)`). Never type a literal, not even a
+throwaway. `ring decrypt` output is secret — pipe it to a file or the clipboard, never to a
+terminal or a log.
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| I1 | `ring init --name <machine>` with `WALLET_PASS` injected | provisioned via the device; trustchain meta recorded in the session |
+| I2 | `ring encrypt --key k -i f -o f.enc`, then `ring decrypt` | round-trips, **no device** after init |
+| I3 | stdin/stdout round-trip | text round-trips |
+| I4 | decrypt with the wrong `--key` | fails, mentions wrong key / corruption / rotation |
+| I5 | `ring keys` | lists the key names used on this machine |
+| I6 | encrypt/decrypt with the host offline | clear error (LKRP restore needs network) |
+| I7 | `ring destroy` with a wrong password | aborts, no changes |
+| I8 | `ring destroy` with `WALLET_PASS` set but empty | aborts (treated as a failed keychain lookup) |
+| I9 | `echo destroy | ring destroy` with the right password | remote application closed, local credentials wiped |
+| I10 | decrypt data encrypted before a ring rotation | `⚠ Ledger Key Ring rotated` warning + actionable error |
+| I11 | encrypt after the wallet-cli application was deactivated on the ring | actionable guidance, not a raw SDK error |
+
+## Suite J — platform matrix
+
+Per platform, at minimum: `--version`, `skill install --agent claude`, `session view`, and one
+device command (`receive`).
+
+| ID | Case | Expected |
+| --- | --- | --- |
+| J1 | each built binary (`darwin-arm64`, `linux-x64`, `linux-arm64`, `windows-x64`) | `--version` correct |
+| J2 | after publish, `npm i -g @ledgerhq/wallet-cli@<version>` on a clean machine | right platform package resolved; commands work |
+| J3 | Linux without USB build deps | actionable error naming `libudev-dev` / `libusb-1.0-0-dev` |
+| J4 | Windows | `skill install` writes `.claude\skills\…`; `--file references\business-logic.md` resolves |
+| J5 | `USER_ID` unset | defaults to `wallet-cli` (stable DMK salt) |
+
+## Gaps worth closing as tests, not as manual steps
+
+These are device-shaped behaviours the in-process mock DMK could assert (see
+[README](./README.md)), but that no test covers today. Turning them into `bun test` cases
+would take them off the manual pass permanently:
+
+- **Per-command wiring of terminal device states.** The state → exit-code mapping is
+  unit-tested, but only `genuine-check` asserts it end to end. `send`, `swap execute`,
+  `earn deposit/withdraw` and `receive` have no case for rejected (2), disconnected (3),
+  wrong app (4), app-not-installed (5) or locked/timeout (6).
+- **`send` beyond dry-run.** No mocked sign-and-broadcast case: the `hash:` stdout contract
+  and the operation-serialisation path are only exercised on hardware today.
+- **`earn deposit/withdraw` signing dispatch.** Pipeline-level tests exist, but not the
+  command-level path from flags through signing to broadcast.
+- **Fee strategy.** `--fee-strategy slow|medium|fast` has no assertion that the choice
+  reaches the built transaction.
+- **Mid-flow interruption.** No case for a device disappearing between signature and
+  broadcast, which is exactly where a partial state would be worst.

--- a/apps/wallet-cli/scripts/regression/cases-gates.ts
+++ b/apps/wallet-cli/scripts/regression/cases-gates.ts
@@ -1,0 +1,49 @@
+// Suite A — repo / artifact gates. Slow; opt in with --with-gates.
+// These are the same checks CI runs, plus the packaging smoke tests that matter
+// for a release. No device, no session.
+
+import type { Harness } from "./lib";
+
+async function gate(h: Harness, id: string, desc: string, ...argv: string[]): Promise<void> {
+  h.caseStart(id, desc);
+  h.setEnv({});
+  h.log(`$ ${argv.join(" ")}`);
+  const { out, err, rc, timedOut } = await h.spawn(argv, {
+    cwd: h.config.walletCliDir,
+    timeoutMs: h.config.gateTimeoutMs,
+  });
+  const output = out + err;
+  const lines = output.split("\n");
+  h.log(`--- rc=${rc}`);
+  h.log(lines.slice(-100).join("\n"));
+  if (timedOut) {
+    h.failCase(`timed out after ${h.config.gateTimeoutMs / 1000}s`);
+  } else if (rc !== 0) {
+    const tail = lines
+      .filter(l => l.trim() !== "")
+      .slice(-3)
+      .join(" ")
+      .slice(0, 300);
+    h.failCase(`exit ${rc} — see ${h.config.logFile} (tail: ${tail})`);
+  }
+  h.caseEnd();
+}
+
+export async function suiteA(h: Harness): Promise<void> {
+  await gate(h, "A1", "unit tests (bun test src/)", "pnpm", "test");
+  await gate(h, "A2", "typecheck (tsc --noEmit)", "pnpm", "typecheck");
+  await gate(h, "A3", "lint (oxlint --quiet)", "pnpm", "lint:ci");
+  await gate(h, "A4", "format check (oxfmt --check)", "pnpm", "format:check");
+  await gate(h, "A5", "embedded skill generation (check:skills)", "pnpm", "check:skills");
+  await gate(h, "A6", "third-party notices up to date", "pnpm", "check:notices");
+
+  if (h.config.withBuild) {
+    await gate(h, "A7", "build all platform binaries", "pnpm", "build");
+    await gate(h, "A8", "npm tarball layout (pack:check)", "pnpm", "pack:check");
+    await gate(h, "A9", "install-and-run smoke (smoke:npm)", "pnpm", "smoke:npm");
+  } else {
+    h.caseSkip("A7", "build all platform binaries", "pass --with-build");
+    h.caseSkip("A8", "npm tarball layout", "pass --with-build");
+    h.caseSkip("A9", "install-and-run smoke", "pass --with-build");
+  }
+}

--- a/apps/wallet-cli/scripts/regression/cases-nudge.ts
+++ b/apps/wallet-cli/scripts/regression/cases-nudge.ts
@@ -1,0 +1,179 @@
+// Suite C — the one-time, agent-aware first-run nudge (introduced in 2.1.0).
+// Every case gets a pristine state dir so the "once per user" marker is never
+// inherited. `session view` is used as the cheapest "real command".
+
+import { chmodSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  asString,
+  isolatedEnv,
+  jsonAt,
+  modeAssertionsUnsupported,
+  stateAppDir,
+  type Harness,
+} from "./lib";
+
+const MARKER_FILE = "first-run.json";
+
+// Agent signals the developer's own shell may already carry: unset them so each
+// case only sees the one it opts back into.
+const AGENT_SIGNALS = [
+  "WALLET_CLI_NO_NUDGE",
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "CURSOR_AGENT",
+  "CODEX_ENABLED",
+  "GEMINI_CLI",
+  "OPENCODE",
+  "AMP_CURRENT_THREAD_ID",
+  "AGENT",
+];
+
+export async function suiteC(h: Harness): Promise<void> {
+  const nudgeEnv = (stateHome: string, extra: Record<string, string> = {}): void =>
+    h.setEnv({ ...isolatedEnv(stateHome, h.config.isoHome), ...extra }, AGENT_SIGNALS);
+  const marker = (stateHome: string): string => join(stateAppDir(stateHome), MARKER_FILE);
+
+  // ---- C1: shown once for a detected agent ----------------------------------
+  let s = h.freshState();
+  h.caseStart("C1", "first real command prints the Claude Code nudge on stderr only");
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("session", "view");
+  h.assertRc(0);
+  h.assertHas(h.err, "wallet-cli skill install --agent claude", "stderr");
+  h.assertHas(h.err, "Claude Code", "stderr");
+  h.assertLacks(h.out, "skill install", "stdout");
+  h.caseEnd();
+
+  // ---- C2: never shown twice ------------------------------------------------
+  h.caseStart("C2", "the nudge is not repeated on the next command");
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("session", "view");
+  h.assertRc(0);
+  h.assertLacks(h.err, "skill install", "stderr");
+  h.caseEnd();
+
+  // ---- C3: marker file ------------------------------------------------------
+  const c3Desc = "the marker is persisted under the state dir with 0600/0700 perms";
+  const unsupported = modeAssertionsUnsupported();
+  if (unsupported) {
+    h.caseSkip("C3", c3Desc, unsupported);
+  } else {
+    h.caseStart("C3", c3Desc);
+    h.assertFile(marker(s));
+    h.assertMode(marker(s), 0o600);
+    h.assertMode(stateAppDir(s), 0o700);
+    if (existsSync(marker(s))) {
+      const parsed = h.assertJson(readFileSync(marker(s), "utf8"), "marker");
+      h.assertField(parsed, "version", h.config.expectedVersion, "marker.version");
+      h.assertThat(
+        /^\d{4}-/.test(asString(jsonAt(parsed, "nudgeShownAt")) ?? ""),
+        "marker.nudgeShownAt is not an ISO timestamp",
+      );
+    }
+    h.caseEnd();
+  }
+
+  // ---- C4: silent under --output json, and not consumed ---------------------
+  s = h.freshState();
+  h.caseStart("C4", "--output json is nudge-free and does not consume the one-time hint");
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("session", "view", "--output", "json");
+  h.assertRc(0);
+  h.assertEmpty(h.err, "stderr");
+  h.assertJson(h.out);
+  h.assertNoFile(marker(s));
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("session", "view");
+  h.assertHas(h.err, "skill install", "stderr (after a json run)");
+  h.caseEnd();
+
+  // ---- C5: opt-out ----------------------------------------------------------
+  s = h.freshState();
+  h.caseStart("C5", "WALLET_CLI_NO_NUDGE=1 suppresses the nudge and writes no marker");
+  nudgeEnv(s, { CLAUDECODE: "1", WALLET_CLI_NO_NUDGE: "1" });
+  await h.cli("session", "view");
+  h.assertRc(0);
+  h.assertLacks(h.err, "skill install", "stderr");
+  h.assertNoFile(marker(s));
+  h.caseEnd();
+
+  // ---- C6: quiet in plain pipes ---------------------------------------------
+  s = h.freshState();
+  h.caseStart("C6", "no agent env and a non-TTY stderr stays silent");
+  nudgeEnv(s);
+  await h.cli("session", "view");
+  h.assertRc(0);
+  h.assertLacks(h.err, "skill install", "stderr");
+  h.assertNoFile(marker(s));
+  h.caseEnd();
+
+  // ---- C7: per-agent tailoring ----------------------------------------------
+  h.caseStart("C7", "each detected agent maps to its own --agent value");
+  const agents = [
+    { signal: "CURSOR_AGENT", value: "1", expect: "--agent cursor", label: "Cursor" },
+    { signal: "CODEX_ENABLED", value: "1", expect: "--agent codex", label: "Codex" },
+    { signal: "GEMINI_CLI", value: "1", expect: "--agent agents", label: "Gemini CLI" },
+    { signal: "OPENCODE", value: "1", expect: "--agent agents", label: "opencode" },
+    { signal: "AMP_CURRENT_THREAD_ID", value: "x", expect: "--agent agents", label: "amp" },
+  ];
+  for (const agent of agents) {
+    nudgeEnv(h.freshState(), { [agent.signal]: agent.value });
+    await h.cli("session", "view");
+    h.assertHas(h.err, `wallet-cli skill install ${agent.expect}`, `stderr for ${agent.signal}`);
+    h.assertHas(h.err, agent.label, `stderr label for ${agent.signal}`);
+  }
+  h.caseEnd();
+
+  // ---- C8: non-command invocations do not consume the nudge -----------------
+  for (const invocation of ["--help", "--version"]) {
+    s = h.freshState();
+    h.caseStart(
+      `C8${invocation.replaceAll("-", "")}`,
+      `${invocation} does not consume the one-time nudge`,
+    );
+    nudgeEnv(s, { CLAUDECODE: "1" });
+    await h.cli(invocation);
+    h.assertNoFile(marker(s));
+    h.assertLacks(h.err, "skill install", `stderr of ${invocation}`);
+    nudgeEnv(s, { CLAUDECODE: "1" });
+    await h.cli("session", "view");
+    h.assertHas(h.err, "skill install", "stderr of the following real command");
+    h.caseEnd();
+  }
+
+  // ---- C9: skill commands are exempt ----------------------------------------
+  s = h.freshState();
+  h.caseStart("C9", "skill * commands never show the nudge nor consume it");
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("skill", "list");
+  h.assertRc(0);
+  h.assertLacks(h.err, "Tip: install", "stderr");
+  h.assertNoFile(marker(s));
+  h.caseEnd();
+
+  // ---- C10: exit codes are untouched ----------------------------------------
+  s = h.freshState();
+  h.caseStart("C10", "the nudge does not alter a failing command's exit code");
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("balances", "no-such-label-9");
+  h.assertRc(1);
+  h.assertHas(h.err, "skill install", "stderr");
+  h.caseEnd();
+
+  // ---- C11: hostile state dir -----------------------------------------------
+  const c11Desc = "a read-only state dir never breaks the command";
+  if (unsupported) {
+    h.caseSkip("C11", c11Desc, unsupported);
+    return;
+  }
+  s = h.freshState();
+  h.caseStart("C11", c11Desc);
+  chmodSync(s, 0o500);
+  nudgeEnv(s, { CLAUDECODE: "1" });
+  await h.cli("session", "view", "--output", "json");
+  h.assertRc(0);
+  h.assertJson(h.out);
+  chmodSync(s, 0o700);
+  h.caseEnd();
+}

--- a/apps/wallet-cli/scripts/regression/cases-readonly.ts
+++ b/apps/wallet-cli/scripts/regression/cases-readonly.ts
@@ -1,0 +1,703 @@
+// Suite D — regression of every path that needs NO device: session, balances,
+// operations, assets, earn read paths, swap quote, and all `--dry-run` builders.
+// Runs against a REAL session (labels are discovered dynamically), reads live
+// backends, and never signs or broadcasts.
+
+import { asArray, asString, colors, jsonAt, objectsDeep, parseJson, type Harness } from "./lib";
+
+const QUOTE_ETH_BTC = [
+  "swap",
+  "quote",
+  "--from",
+  "ethereum",
+  "--to",
+  "bitcoin",
+  "--amount",
+  "0.05",
+] as const;
+
+type Discovered = {
+  /** Set when the session cannot be used at all; every session-bound case skips with it. */
+  readonly unavailable: string | undefined;
+  readonly labels: readonly string[];
+  readonly ethLabel: string | undefined;
+  readonly solLabel: string | undefined;
+  readonly btcLabel: string | undefined;
+  readonly ethAddr: string;
+  readonly addressOf: (label: string | undefined) => string;
+};
+
+/** Descriptors are `account:1:address:<net>:main:<address>:<path>`; the address is field 6. */
+function descriptorAddress(descriptor: string | undefined): string {
+  return descriptor?.split(":")[5] ?? "";
+}
+
+async function discover(h: Harness): Promise<Discovered> {
+  const empty = {
+    labels: [],
+    ethLabel: undefined,
+    solLabel: undefined,
+    btcLabel: undefined,
+    ethAddr: "",
+    addressOf: () => "",
+  };
+
+  h.realEnv();
+  await h.cli("session", "view", "--output", "json");
+  const json = h.rc === 0 ? parseJson(h.out) : undefined;
+  if (json === undefined) {
+    return { ...empty, unavailable: "cannot read the session — run `account discover` first" };
+  }
+
+  const accounts = asArray(jsonAt(json, "accounts"));
+  if (accounts.length === 0) {
+    return { ...empty, unavailable: "no accounts in the session — run `account discover` first" };
+  }
+
+  const descriptorOf = (label: string | undefined): string =>
+    asString(
+      jsonAt(
+        accounts.find(account => jsonAt(account, "label") === label),
+        "descriptor",
+      ),
+    ) ?? "";
+
+  const labels = accounts
+    .map(account => asString(jsonAt(account, "label")))
+    .filter((label): label is string => Boolean(label));
+  const ethLabel = labels.find(label => /^ethereum-\d+$/.test(label));
+  const solLabel = labels.find(label => /^solana-\d+$/.test(label));
+  const btcLabel = labels.find(label => /^bitcoin-[a-z0-9]+-\d+$/.test(label));
+
+  // A safe dry-run recipient: one of our own ethereum addresses, so even a
+  // mis-typed real send would only be a self-transfer. `session view` exposes
+  // descriptors, not addresses, so the address is read out of a *different*
+  // ethereum account's descriptor.
+  const otherEth = accounts.find(
+    account =>
+      jsonAt(account, "label") !== ethLabel &&
+      (asString(jsonAt(account, "descriptor")) ?? "").includes(":address:ethereum:main:"),
+  );
+  const ethAddr =
+    descriptorAddress(asString(jsonAt(otherEth, "descriptor"))) ||
+    descriptorAddress(descriptorOf(ethLabel));
+
+  return {
+    unavailable: undefined,
+    labels,
+    ethLabel,
+    solLabel,
+    btcLabel,
+    ethAddr,
+    addressOf: label => descriptorAddress(descriptorOf(label)),
+  };
+}
+
+type Page = { readonly label: string; readonly cursor: string; readonly firstHash: string };
+
+// Pagination needs an account whose history is longer than the page size; with a
+// short history the backend legitimately returns no cursor, so pick the account
+// with the most operations and skip (not fail) when none paginates.
+async function findPaginatingAccount(h: Harness, labels: readonly string[]): Promise<Page> {
+  for (const candidate of labels) {
+    if (!/^(ethereum|solana|bitcoin)-/.test(candidate)) continue;
+    await h.cli("operations", candidate, "--limit", "2", "--output", "json");
+    if (h.rc !== 0) continue;
+    const json = parseJson(h.out);
+    const cursor = asString(jsonAt(json, "nextCursor")) ?? "";
+    if (cursor) {
+      const firstHash = asString(jsonAt(json, "operations.0.hash")) ?? "";
+      return { label: candidate, cursor, firstHash };
+    }
+  }
+  return { label: "", cursor: "", firstHash: "" };
+}
+
+export async function suiteD(h: Harness): Promise<void> {
+  const session = await discover(h);
+  h.realEnv();
+
+  const { unavailable, ethLabel, solLabel, btcLabel, ethAddr } = session;
+  const eth = ethLabel ?? "";
+  const sol = solLabel ?? "";
+  const btc = btcLabel ?? "";
+
+  if (unavailable) {
+    h.print(`  ${colors.dim}${unavailable}${colors.off}`);
+  } else {
+    h.print(
+      `  ${colors.dim}session labels: eth=${eth} sol=${sol} btc=${btc} recipient=${ethAddr}${colors.off}`,
+    );
+  }
+
+  const missing = (label: string | undefined, reason: string): string | undefined =>
+    unavailable ?? (label ? undefined : reason);
+  const noEth = missing(ethLabel, "no ethereum account in session");
+  const noSol = missing(solLabel, "no solana account");
+  const noBtc = missing(btcLabel, "no mainnet bitcoin account");
+
+  const run = async (
+    id: string,
+    desc: string,
+    reason: string | undefined,
+    body: () => Promise<void>,
+  ): Promise<void> => {
+    if (reason) {
+      h.caseSkip(id, desc, reason);
+      return;
+    }
+    h.caseStart(id, desc);
+    await body();
+    h.caseEnd();
+  };
+
+  // ---- D1/D2: session view --------------------------------------------------
+  await run("D1", "session view lists labels and descriptors", noEth, async () => {
+    await h.cli("session", "view");
+    h.assertRc(0);
+    h.assertHas(h.out, eth, "stdout");
+    h.assertHas(h.out, "account:1:", "stdout");
+  });
+
+  await run("D2", "session view --output json envelope", unavailable, async () => {
+    await h.cli("session", "view", "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    h.assertField(json, "status", "success");
+    h.assertField(json, "command", "session view");
+    h.assertThat(asArray(jsonAt(json, "accounts")).length > 0, "accounts[] is empty");
+    const first = asArray(jsonAt(json, "accounts"))[0];
+    h.assertThat(
+      jsonAt(first, "label") !== undefined && jsonAt(first, "descriptor") !== undefined,
+      "accounts[0] lacks label or descriptor",
+    );
+    // v1 hardening: no raw xprv/extended private keys ever surface
+    h.assertLacks(h.out, "xprv", "stdout");
+  });
+
+  // ---- D3..D6: balances -----------------------------------------------------
+  await run("D3", "balances (ethereum) prints native + token balances", noEth, async () => {
+    await h.cli("balances", eth);
+    h.assertRc(0);
+    h.assertHas(h.out, "ETH", "stdout");
+  });
+
+  await run("D4", "balances --output json shape ({asset, amount} rows)", noEth, async () => {
+    await h.cli("balances", eth, "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    h.assertField(json, "status", "success");
+    h.assertField(json, "command", "balances");
+    h.assertField(json, "network", "ethereum:main");
+    const balances = asArray(jsonAt(json, "balances"));
+    h.assertThat(balances.length >= 1, "balances[] is empty");
+    h.assertThat(
+      jsonAt(balances[0], "asset") !== undefined && jsonAt(balances[0], "amount") !== undefined,
+      "balances[0] lacks asset or amount",
+    );
+    const native = balances.filter(row => jsonAt(row, "asset") === "ethereum");
+    h.assertThat(native.length === 1, "expected exactly one native ethereum row");
+    h.assertThat(
+      (asString(jsonAt(native[0], "amount")) ?? "").endsWith(" ETH"),
+      "the native row's amount is not denominated in ETH",
+    );
+  });
+
+  await run("D5", "balances (solana) works for a non-EVM account", noSol, async () => {
+    await h.cli("balances", sol, "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    const native = asArray(jsonAt(json, "balances")).filter(row =>
+      (asString(jsonAt(row, "amount")) ?? "").endsWith(" SOL"),
+    );
+    h.assertThat(native.length === 1, "expected exactly one SOL-denominated row");
+  });
+
+  await run("D6", "balances (bitcoin) works for a UTXO account", noBtc, async () => {
+    await h.cli("balances", btc, "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    const native = asArray(jsonAt(json, "balances")).filter(row =>
+      (asString(jsonAt(row, "amount")) ?? "").endsWith(" BTC"),
+    );
+    h.assertThat(native.length === 1, "expected exactly one BTC-denominated row");
+  });
+
+  await run("D7", "unknown session label fails with actionable guidance", undefined, async () => {
+    await h.cli("balances", "no-such-label-9");
+    h.assertRc(1);
+    h.assertHas(h.out + h.err, "No account labeled");
+    h.assertHas(h.out + h.err, "account discover");
+  });
+
+  await run("D8", "raw account descriptors are rejected as arguments", undefined, async () => {
+    await h.cli(
+      "balances",
+      "account:1:address:ethereum:main:0x0000000000000000000000000000000000000000:m/44h/60h/0h/0/0",
+    );
+    h.assertRcNonZero();
+  });
+
+  // ---- D9..D11: operations --------------------------------------------------
+  await run("D9", "operations --limit returns rows and a pagination cursor", noEth, async () => {
+    await h.cli("operations", eth, "--limit", "3");
+    h.assertRc(0);
+    h.assertNonEmpty(h.out + h.err);
+  });
+
+  await run("D10", "operations --output json exposes nextCursor", noEth, async () => {
+    await h.cli("operations", eth, "--limit", "3", "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    h.assertField(json, "command", "operations");
+    h.assertThat(Array.isArray(jsonAt(json, "operations")), "operations is not an array");
+  });
+
+  const page = unavailable
+    ? { label: "", cursor: "", firstHash: "" }
+    : await findPaginatingAccount(h, session.labels);
+  await run(
+    "D11",
+    page.label
+      ? `operations pagination: --cursor advances the page (${page.label})`
+      : "operations pagination",
+    unavailable ??
+      (page.label ? undefined : "no session account has more than one page of history"),
+    async () => {
+      await h.cli(
+        "operations",
+        page.label,
+        "--limit",
+        "2",
+        "--cursor",
+        page.cursor,
+        "--output",
+        "json",
+      );
+      h.assertRc(0);
+      const json = h.assertJson(h.out);
+      const secondHash = asString(jsonAt(json, "operations.0.hash")) ?? "";
+      h.assertThat(
+        secondHash !== "" && page.firstHash !== secondHash,
+        `cursor page did not advance (${page.firstHash} vs ${secondHash})`,
+      );
+    },
+  );
+
+  // ---- D12..D15: assets -----------------------------------------------------
+  await run("D12", "assets token resolves USDT by contract address", undefined, async () => {
+    await h.cli("assets", "token", "ethereum", "0xdac17f958d2ee523a2206206994597c13d831ec7");
+    h.assertRc(0);
+    h.assertHas(h.out, "USDT", "stdout");
+    h.assertHas(h.out, "ethereum/erc20/usd_tether__erc20_", "stdout");
+  });
+
+  await run("D13", "assets token-by-id round-trips the same id", undefined, async () => {
+    await h.cli("assets", "token-by-id", "ethereum/erc20/usd_tether__erc20_", "--output", "json");
+    h.assertRc(0);
+    const json = h.assertJson(h.out);
+    h.assertThat(
+      objectsDeep(json).some(node => node.ticker === "USDT"),
+      "no object in the envelope carries ticker USDT",
+    );
+  });
+
+  await run("D14", "assets token for an unknown contract exits non-zero", undefined, async () => {
+    await h.cli("assets", "token", "ethereum", "0x0000000000000000000000000000000000000001");
+    h.assertRcNonZero();
+    h.assertHas(h.out + h.err, "not found");
+  });
+
+  await run(
+    "D15",
+    "assets token resolves a non-EVM (solana) mint by address",
+    undefined,
+    async () => {
+      await h.cli("assets", "token", "solana", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+      h.assertRc(0);
+      h.assertHas(h.out, "USDC", "stdout");
+    },
+  );
+
+  await run(
+    "D15b",
+    "assets token with a missing positional prints usage, not a stack trace",
+    undefined,
+    async () => {
+      await h.cli("assets", "token", "solana");
+      h.assertRcNonZero();
+      h.assertHas(h.out + h.err, "Usage: assets token <network> <address>");
+    },
+  );
+
+  // ---- D16..D20: earn read paths --------------------------------------------
+  await run(
+    "D16",
+    "earn yields (no network) lists supported networks with deeplinks",
+    undefined,
+    async () => {
+      await h.cli("earn", "yields");
+      h.assertRc(0);
+      h.assertHas(h.out, "ledgerlive://", "stdout");
+    },
+  );
+
+  await run(
+    "D17",
+    "earn yields -n solana surfaces --product validator targets",
+    undefined,
+    async () => {
+      await h.cli("earn", "yields", "-n", "solana");
+      h.assertRc(0);
+      h.assertHas(h.out, "Deposit targets", "stdout");
+      h.assertHas(h.out, "--product", "stdout");
+      h.assertHas(h.out, "Ledger by", "stdout");
+    },
+  );
+
+  await run(
+    "D18",
+    "earn yields -n ethereum surfaces vault ids as --product",
+    undefined,
+    async () => {
+      await h.cli("earn", "yields", "-n", "ethereum", "--output", "json");
+      h.assertRc(0);
+      const json = h.assertJson(h.out);
+      h.assertThat(
+        objectsDeep(json).some(node => "vaultId" in node),
+        "no vaultId anywhere in the envelope",
+      );
+    },
+  );
+
+  await run("D19", "earn yields --limit and --all are accepted", undefined, async () => {
+    await h.cli("earn", "yields", "-n", "solana", "--limit", "3");
+    h.assertRc(0);
+    await h.cli("earn", "yields", "--all");
+    h.assertRc(0);
+  });
+
+  await run(
+    "D20",
+    "earn positions (solana) returns positions and/or on-chain stakes",
+    noSol,
+    async () => {
+      await h.cli("earn", "positions", sol, "--output", "json");
+      h.assertRc(0);
+      const json = h.assertJson(h.out);
+      h.assertField(json, "command", "earn positions");
+      h.assertThat(Array.isArray(jsonAt(json, "positions")), "positions is not an array");
+    },
+  );
+
+  await run("D21", "earn positions --fresh is accepted and stays non-blocking", noSol, async () => {
+    await h.cli("earn", "positions", sol, "--fresh");
+    h.assertRc(0);
+  });
+
+  await run("D22", "earn positions (ethereum) works", noEth, async () => {
+    await h.cli("earn", "positions", eth, "--output", "json");
+    h.assertRc(0);
+    h.assertJson(h.out);
+  });
+
+  // ---- D23..D30: send --dry-run (no device, nothing broadcast) --------------
+  await run(
+    "D23",
+    "send --dry-run (native ETH) builds a transaction and shows fees",
+    noEth,
+    async () => {
+      await h.cli("send", eth, "--to", ethAddr, "--amount", "0.0001 ETH", "--dry-run");
+      h.assertRc(0);
+      h.assertHas(h.out + h.err, "0.0001 ETH");
+      h.assertHas(h.out + h.err, "Fees");
+      h.assertLacks(h.out + h.err, "hash:", "output (nothing may be broadcast in a dry run)");
+    },
+  );
+
+  await run("D24", "send --dry-run (ERC-20) resolves the token by ticker", noEth, async () => {
+    await h.cli("balances", eth, "--output", "json");
+    // `amount` is a display string ("8.0232 USDC"): take the ticker of the first
+    // non-native row whose numeric part is > 0.
+    const token = asArray(jsonAt(parseJson(h.out), "balances"))
+      .filter(row => jsonAt(row, "asset") !== "ethereum")
+      .map(row => (asString(jsonAt(row, "amount")) ?? "").split(" "))
+      .find(parts => Number((parts[0] ?? "").replaceAll(",", "")) > 0)?.[1];
+    if (token) {
+      await h.cli("send", eth, "--to", ethAddr, "--amount", `0.01 ${token}`, "--dry-run");
+      h.assertRc(0);
+      h.assertHas(h.out + h.err, token);
+    } else {
+      h.failCase(`no funded ERC-20 in ${eth} — run this case on a token-funded account`);
+    }
+  });
+
+  await run("D25", "send --amount without a ticker is rejected", noEth, async () => {
+    await h.cli("send", eth, "--to", ethAddr, "--amount", "0.0001", "--dry-run");
+    h.assertRcNonZero();
+    h.assertHas(h.out + h.err, "must include a ticker");
+  });
+
+  await run("D26", "send with an unknown ticker lists the account's tickers", noEth, async () => {
+    await h.cli("send", eth, "--to", ethAddr, "--amount", "1 UNKN", "--dry-run");
+    h.assertRcNonZero();
+    h.assertHas(h.out + h.err, "not found in account");
+    h.assertHas(h.out + h.err, "Available:");
+  });
+
+  await run("D27", "send above balance surfaces NotEnoughBalance", noEth, async () => {
+    await h.cli("send", eth, "--to", ethAddr, "--amount", "999999 ETH", "--dry-run");
+    h.assertRcNonZero();
+    h.assertHas(h.out + h.err, "NotEnoughBalance");
+  });
+
+  // Address validation now goes through the CoinModuleApi instance (2.1.0 change):
+  // exercise it once per family.
+  await run(
+    "D28",
+    "invalid recipient is rejected (ethereum) — validateAddress via CoinModuleApi",
+    noEth,
+    async () => {
+      await h.cli("send", eth, "--to", "0xnotanaddress", "--amount", "0.0001 ETH", "--dry-run");
+      h.assertRcNonZero();
+      h.assertHas(h.out + h.err, "InvalidAddress");
+    },
+  );
+
+  // A UTXO descriptor carries an xpub, not a spendable address, so the positive
+  // bitcoin dry run (with --fee-per-byte/--rbf) lives in the manual suite, where
+  // `receive` has produced a real address. Here we cover validation + flag parsing.
+  await run(
+    "D29",
+    "invalid recipient is rejected (bitcoin) and fee flags parse",
+    noBtc,
+    async () => {
+      await h.cli("send", btc, "--to", "bc1qinvalidaddress", "--amount", "0.0001 BTC", "--dry-run");
+      h.assertRcNonZero();
+      h.assertHas(h.out + h.err, "InvalidAddress");
+      await h.cli(
+        "send",
+        btc,
+        "--to",
+        "bc1qinvalidaddress",
+        "--amount",
+        "0.0001 BTC",
+        "--fee-per-byte",
+        "5",
+        "--rbf",
+        "--dry-run",
+      );
+      h.assertHas(h.out + h.err, "InvalidAddress");
+      h.assertLacks(h.out + h.err, "Unknown option");
+    },
+  );
+
+  await run(
+    "D30",
+    "invalid recipient is rejected (solana) + --memo accepted in a dry run",
+    noSol,
+    async () => {
+      await h.cli("send", sol, "--to", "notasolanaaddress", "--amount", "0.001 SOL", "--dry-run");
+      h.assertRcNonZero();
+      h.assertHas(h.out + h.err, "InvalidAddress");
+      await h.cli(
+        "send",
+        sol,
+        "--to",
+        session.addressOf(solLabel),
+        "--amount",
+        "0.0001 SOL",
+        "--memo",
+        "nr-2.1.0",
+        "--dry-run",
+      );
+      h.assertLacks(h.out + h.err, "Unknown option");
+      h.assertLacks(h.out + h.err, "hash:", "output (dry run must not broadcast)");
+    },
+  );
+
+  // ---- D31..D33: earn dry runs ----------------------------------------------
+  await run(
+    "D31",
+    "earn deposit --dry-run (solana stake) validates without signing",
+    noSol,
+    async () => {
+      await h.cli("earn", "yields", "-n", "solana", "--output", "json");
+      const validator = objectsDeep(parseJson(h.out))
+        .map(node => asString(node.validator))
+        .find(Boolean);
+      if (!validator) {
+        h.failCase("no validator returned by earn yields -n solana");
+        return;
+      }
+      await h.cli(
+        "earn",
+        "deposit",
+        sol,
+        "--product",
+        validator,
+        "--amount",
+        "0.5 SOL",
+        "--dry-run",
+      );
+      h.assertLacks(h.out + h.err, "Unknown option");
+      h.assertLacks(h.out + h.err, "hash:", "output (dry run must not broadcast)");
+    },
+  );
+
+  await run(
+    "D32",
+    "earn deposit --dry-run (ethereum vault) reports the approve/deposit split",
+    noEth,
+    async () => {
+      await h.cli("earn", "yields", "-n", "ethereum", "--output", "json");
+      const vault = objectsDeep(parseJson(h.out))
+        .map(node => asString(node.vaultId))
+        .find(Boolean);
+      if (!vault) {
+        h.failCase("no vaultId returned by earn yields -n ethereum");
+        return;
+      }
+      await h.cli("earn", "deposit", eth, "--product", vault, "--amount", "1 USDC", "--dry-run");
+      h.assertLacks(h.out + h.err, "Unknown option");
+      h.assertLacks(h.out + h.err, "hash:", "output (dry run must not broadcast)");
+    },
+  );
+
+  await run("D33", "earn withdraw --dry-run rejects a missing target", noEth, async () => {
+    await h.cli("earn", "withdraw", eth, "--dry-run");
+    h.assertRcNonZero();
+  });
+
+  // ---- D34..D38: swap quote -------------------------------------------------
+  await run(
+    "D34",
+    "swap quote (ETH -> BTC) queries providers and reports per-provider outcomes",
+    noEth,
+    async () => {
+      if (!btcLabel) {
+        h.failCase("no mainnet bitcoin account for the ETH->BTC quote");
+        return;
+      }
+      await h.cli(...QUOTE_ETH_BTC, "--from-account", eth, "--to-account", btc);
+      h.assertRc(0);
+      h.assertNonEmpty(h.out + h.err);
+      h.assertThat(
+        /rate|no quotes available/i.test(h.out + h.err),
+        "no rate lines and no explicit 'No quotes available'",
+      );
+    },
+  );
+
+  await run("D35", "swap quote --output json shape", noEth, async () => {
+    await h.cli(...QUOTE_ETH_BTC, "--from-account", eth, "--to-account", btc, "--output", "json");
+    h.assertRc(0);
+    h.assertField(h.assertJson(h.out), "command", "swap quote");
+  });
+
+  await run("D36", "swap quote accepts a token currency id", noEth, async () => {
+    const usdt = "ethereum/erc20/usd_tether__erc20_";
+    await h.cli(
+      "swap",
+      "quote",
+      "--from",
+      usdt,
+      "--to",
+      "ethereum",
+      "--amount",
+      "50",
+      "--from-account",
+      eth,
+      "--to-account",
+      eth,
+      "--output",
+      "json",
+    );
+    h.assertRc(0);
+    h.assertJson(h.out);
+  });
+
+  await run("D37", "swap quote with a missing required flag fails cleanly", noEth, async () => {
+    await h.cli(...QUOTE_ETH_BTC, "--from-account", eth);
+    h.assertRcNonZero();
+    h.assertLacks(h.out + h.err, "[object Object]");
+  });
+
+  await run("D38", "swap quote with an unknown currency id fails cleanly", noEth, async () => {
+    await h.cli(
+      "swap",
+      "quote",
+      "--from",
+      "not-a-currency",
+      "--to",
+      "bitcoin",
+      "--amount",
+      "0.05",
+      "--from-account",
+      eth,
+      "--to-account",
+      btc,
+    );
+    h.assertRcNonZero();
+    h.assertLacks(h.out + h.err, "[object Object]");
+  });
+
+  // Documented behaviour: an id the provider does not know is reported as UNKNOWN
+  // with exit 0 (it is a status read, not a failure). What must not happen is a
+  // crash or an unrendered error object.
+  await run(
+    "D39",
+    "swap status reports UNKNOWN for an unknown swap id without crashing",
+    undefined,
+    async () => {
+      await h.cli(
+        "swap",
+        "status",
+        "--swap-id",
+        "nr-2-1-0-does-not-exist",
+        "--provider",
+        "changelly",
+      );
+      h.assertRc(0);
+      h.assertHas(h.out, "UNKNOWN", "stdout");
+      h.assertLacks(h.out + h.err, "[object Object]");
+    },
+  );
+
+  await run("D39b", "swap status with a missing --provider fails cleanly", undefined, async () => {
+    await h.cli("swap", "status", "--swap-id", "nr-2-1-0-does-not-exist");
+    h.assertRcNonZero();
+    h.assertLacks(h.out + h.err, "[object Object]");
+  });
+
+  // ---- D40: version / help surface ------------------------------------------
+  const groups = [
+    "account",
+    "session",
+    "balances",
+    "operations",
+    "receive",
+    "send",
+    "swap",
+    "earn",
+    "ring",
+    "skill",
+    "genuine-check",
+    "assets",
+  ];
+  await run(
+    "D40",
+    `--version reports ${h.config.expectedVersion} and --help lists every command group`,
+    undefined,
+    async () => {
+      await h.cli("--version");
+      h.assertRc(0);
+      h.assertHas(h.out, h.config.expectedVersion, "stdout");
+      await h.cli("--help");
+      h.assertRc(0);
+      for (const group of groups) {
+        h.assertHas(h.out + h.err, group, `--help output (missing ${group})`);
+      }
+    },
+  );
+}

--- a/apps/wallet-cli/scripts/regression/cases-skill.ts
+++ b/apps/wallet-cli/scripts/regression/cases-skill.ts
@@ -1,0 +1,480 @@
+// Suite B — the `skill` command group (introduced in 2.1.0) (list / retrieve / install / doctor).
+// No device, no network. Every case runs in a throwaway cwd with an isolated home
+// and state dir so nothing touches the developer's real agent directories.
+
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import { hashOne, hashSkillFiles } from "../../src/skills/hash";
+import { asArray, asRecord, asString, isolatedEnv, jsonAt, type Harness } from "./lib";
+
+const SKILL_FILES = ["SKILL.md", "references/business-logic.md"] as const;
+
+/**
+ * Canonical skill content hash of the files on disk, using the very
+ * implementation under test (src/skills/hash.ts) so the harness cannot drift
+ * from it. Used to forge a provenance sidecar for the `outdated` case, which
+ * otherwise needs a genuinely older binary.
+ */
+function skillDiskHash(
+  root: string,
+  files: readonly string[],
+): { contentHash: string; files: Record<string, string> } {
+  const contents = files.map(path => ({ path, content: readFileSync(`${root}/${path}`, "utf8") }));
+  const perFile: Record<string, string> = {};
+  for (const { path, content } of contents) perFile[path] = hashOne(content);
+  return { contentHash: hashSkillFiles(contents), files: perFile };
+}
+
+export async function suiteB(h: Harness): Promise<void> {
+  const { expectedVersion } = h.config;
+
+  // ---- B1: skill list (human) -----------------------------------------------
+  let w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  h.caseStart("B1", "skill list names the embedded skill");
+  await h.cli("skill", "list");
+  h.assertRc(0);
+  h.assertHas(h.out, "ledger-wallet-cli", "stdout");
+  h.caseEnd();
+
+  // ---- B2: skill list --output json -----------------------------------------
+  h.caseStart("B2", "skill list --output json emits a valid envelope");
+  await h.cli("skill", "list", "--output", "json");
+  h.assertRc(0);
+  let json = h.assertJson(h.out);
+  h.assertField(json, "status", "success");
+  h.assertField(json, "command", "skill list");
+  h.assertThat(
+    asArray(jsonAt(json, "skills")).some(s => jsonAt(s, "name") === "ledger-wallet-cli"),
+    "skills[] does not list ledger-wallet-cli",
+  );
+  h.assertThat(
+    (asString(jsonAt(json, "skills.0.description")) ?? "").length > 20,
+    "skills[0].description is too short to be a real description",
+  );
+  h.caseEnd();
+
+  // ---- B3: skill retrieve (default file) ------------------------------------
+  h.caseStart("B3", "skill retrieve prints SKILL.md from the binary");
+  await h.cli("skill", "retrieve");
+  h.assertRc(0);
+  h.assertHas(h.out, "name: ledger-wallet-cli", "stdout");
+  h.assertHas(h.out, "account discover", "stdout");
+  h.caseEnd();
+
+  // ---- B4: skill retrieve --file --------------------------------------------
+  h.caseStart("B4", "skill retrieve --file returns a reference doc");
+  await h.cli("skill", "retrieve", "--file", "references/business-logic.md");
+  h.assertRc(0);
+  h.assertNonEmpty(h.out, "stdout");
+  h.assertHas(h.out, "business logic", "stdout");
+  h.caseEnd();
+
+  // ---- B5: skill retrieve unknown file --------------------------------------
+  h.caseStart("B5", "skill retrieve --file <unknown> fails and lists available files");
+  await h.cli("skill", "retrieve", "--file", "no-such.md");
+  h.assertRc(1);
+  h.assertHas(h.err + h.out, "Available files:");
+  h.assertHas(h.err + h.out, "SKILL.md");
+  h.caseEnd();
+
+  // ---- B6: install --agent claude -------------------------------------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  h.caseStart("B6", "skill install --agent claude writes SKILL.md, references and sidecar");
+  await h.cli("skill", "install", "--agent", "claude");
+  h.assertRc(0);
+  let skillroot = `${w}/.claude/skills/ledger-wallet-cli`;
+  h.assertFile(`${skillroot}/SKILL.md`);
+  h.assertFile(`${skillroot}/references/business-logic.md`);
+  h.assertFile(`${skillroot}/.wallet-cli-skill.json`);
+  h.caseEnd();
+
+  // ---- B7: sidecar provenance content ---------------------------------------
+  h.caseStart("B7", "provenance sidecar records name, cliVersion and content hashes");
+  const sidecar = h.assertJson(
+    readFileSync(`${skillroot}/.wallet-cli-skill.json`, "utf8"),
+    "sidecar",
+  );
+  h.assertField(sidecar, "name", "ledger-wallet-cli", "sidecar.name");
+  h.assertField(sidecar, "cliVersion", expectedVersion, "sidecar.cliVersion");
+  h.assertThat(
+    /^[0-9a-f]{64}$/.test(asString(jsonAt(sidecar, "contentHash")) ?? ""),
+    "sidecar.contentHash is not a 64-hex digest",
+  );
+  const sidecarFiles = asRecord(jsonAt(sidecar, "files")) ?? {};
+  h.assertThat(
+    SKILL_FILES.every(file => file in sidecarFiles),
+    "sidecar.files does not cover both shipped files",
+  );
+  h.assertThat(
+    /^\d{4}-/.test(asString(jsonAt(sidecar, "installedAt")) ?? ""),
+    "sidecar.installedAt is not an ISO timestamp",
+  );
+  // the recorded hash must equal the hash of what is actually on disk
+  h.assertField(
+    sidecar,
+    "contentHash",
+    skillDiskHash(skillroot, SKILL_FILES).contentHash,
+    "sidecar hash vs disk",
+  );
+  h.caseEnd();
+
+  // ---- B8: install refuses to clobber ---------------------------------------
+  h.caseStart("B8", "second skill install without --force refuses to overwrite");
+  await h.cli("skill", "install", "--agent", "claude");
+  h.assertRc(1);
+  h.assertHas(h.err + h.out, "Refusing to overwrite");
+  h.assertHas(h.err + h.out, "--force");
+  h.caseEnd();
+
+  // ---- B9: install --force --------------------------------------------------
+  h.caseStart("B9", "skill install --force overwrites and refreshes the sidecar");
+  const sidecarPath = `${skillroot}/.wallet-cli-skill.json`;
+  const before = jsonAt(h.assertJson(readFileSync(sidecarPath, "utf8"), "sidecar"), "installedAt");
+  await Bun.sleep(1000);
+  await h.cli("skill", "install", "--agent", "claude", "--force");
+  h.assertRc(0);
+  const after = jsonAt(h.assertJson(readFileSync(sidecarPath, "utf8"), "sidecar"), "installedAt");
+  h.assertThat(before !== after, "sidecar installedAt not refreshed under --force");
+  h.caseEnd();
+
+  // ---- B10: sidecar never blocks a first install ----------------------------
+  h.caseStart(
+    "B10",
+    "install succeeds when only the sidecar remains (sidecar excluded from clash check)",
+  );
+  rmSync(`${skillroot}/SKILL.md`, { force: true });
+  rmSync(`${skillroot}/references/business-logic.md`, { force: true });
+  await h.cli("skill", "install", "--agent", "claude");
+  h.assertRc(0);
+  h.assertFile(`${skillroot}/SKILL.md`);
+  h.caseEnd();
+
+  // ---- B11: every supported agent maps to its own directory -----------------
+  h.caseStart("B11", "--agent cursor/codex/agents install into .cursor/.codex/.agents");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  for (const agent of ["cursor", "codex", "agents"]) {
+    await h.cli("skill", "install", "--agent", agent);
+    h.assertRc(0);
+    h.assertFile(`${w}/.${agent}/skills/ledger-wallet-cli/SKILL.md`);
+  }
+  h.caseEnd();
+
+  // ---- B12: default agent is claude -----------------------------------------
+  h.caseStart("B12", "bare skill install defaults to the claude directory");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install");
+  h.assertRc(0);
+  h.assertFile(`${w}/.claude/skills/ledger-wallet-cli/SKILL.md`);
+  h.caseEnd();
+
+  // ---- B13: --dir overrides -------------------------------------------------
+  h.caseStart("B13", "skill install --dir writes to an explicit directory");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install", "--dir", "./custom-skills");
+  h.assertRc(0);
+  h.assertFile(`${w}/custom-skills/ledger-wallet-cli/SKILL.md`);
+  h.assertNoFile(`${w}/.claude`);
+  h.caseEnd();
+
+  // ---- B14: --global installs under HOME ------------------------------------
+  h.caseStart("B14", "skill install --global installs under the home directory");
+  w = h.freshDir();
+  h.cwd = w;
+  const globalHome = h.freshDir();
+  h.setEnv({ WALLET_CLI_NO_NUDGE: "1", ...isolatedEnv(h.config.isoState, globalHome) });
+  await h.cli("skill", "install", "--agent", "claude", "--global");
+  h.assertRc(0);
+  h.assertFile(`${globalHome}/.claude/skills/ledger-wallet-cli/SKILL.md`);
+  h.assertNoFile(`${w}/.claude`);
+  h.caseEnd();
+
+  // ---- B15: --all -----------------------------------------------------------
+  h.caseStart("B15", "skill install --all installs every embedded skill");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "list", "--output", "json");
+  const names = asArray(jsonAt(h.assertJson(h.out), "skills"))
+    .map(s => asString(jsonAt(s, "name")))
+    .filter((name): name is string => Boolean(name));
+  await h.cli("skill", "install", "--all", "--agent", "claude");
+  h.assertRc(0);
+  for (const name of names) h.assertFile(`${w}/.claude/skills/${name}/SKILL.md`);
+  h.caseEnd();
+
+  // ---- B16: install --output json envelope ----------------------------------
+  h.caseStart("B16", "skill install --output json surfaces version, hashes and paths");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install", "--agent", "claude", "--output", "json");
+  h.assertRc(0);
+  json = h.assertJson(h.out);
+  h.assertField(json, "status", "success");
+  h.assertField(json, "command", "skill install");
+  h.assertField(json, "cliVersion", expectedVersion, "envelope.cliVersion");
+  h.assertThat(
+    (asString(jsonAt(json, "root")) ?? "").replaceAll("\\", "/").endsWith(".claude/skills"),
+    "envelope.root does not end with .claude/skills",
+  );
+  h.assertThat(
+    asArray(jsonAt(json, "skills")).includes("ledger-wallet-cli"),
+    "envelope.skills does not list ledger-wallet-cli",
+  );
+  h.assertThat(
+    /^[0-9a-f]{64}$/.test(asString(jsonAt(json, "contentHashes.ledger-wallet-cli")) ?? ""),
+    "envelope.contentHashes[ledger-wallet-cli] is not a 64-hex digest",
+  );
+  h.assertThat(
+    asArray(jsonAt(json, "installed")).length >= 2,
+    "envelope.installed has < 2 entries",
+  );
+  h.caseEnd();
+
+  // ---- B17: unknown agent ---------------------------------------------------
+  h.caseStart("B17", "unknown --agent fails with the supported list (human + json)");
+  await h.cli("skill", "install", "--agent", "bogus");
+  h.assertRc(1);
+  h.assertHas(h.err + h.out, 'Unknown agent "bogus"');
+  h.assertHas(h.err + h.out, "claude, cursor, codex, agents");
+  await h.cli("skill", "install", "--agent", "bogus", "--output", "json");
+  h.assertRc(1);
+  json = h.assertJson(h.out);
+  h.assertField(json, "ok", "false");
+  h.assertField(json, "error.command", "skill install");
+  h.caseEnd();
+
+  // ---- B18: unknown skill name ----------------------------------------------
+  h.caseStart("B18", "unknown skill name fails and points at skill list");
+  await h.cli("skill", "install", "definitely-not-a-skill", "--agent", "claude");
+  h.assertRc(1);
+  h.assertHas(h.err + h.out, "not found");
+  h.assertHas(h.err + h.out, "skill list");
+  h.caseEnd();
+
+  // ---- B19: doctor up-to-date -----------------------------------------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install", "--agent", "claude");
+  skillroot = `${w}/.claude/skills/ledger-wallet-cli`;
+  h.caseStart("B19", "skill doctor reports up-to-date after a fresh install (exit 0)");
+  await h.cli("skill", "doctor");
+  h.assertRc(0);
+  h.assertHas(h.out, "up-to-date", "stdout");
+  h.assertHas(h.out, "All skills up-to-date.", "stdout");
+  h.caseEnd();
+
+  // ---- B20: doctor json shape -----------------------------------------------
+  h.caseStart("B20", "skill doctor --output json exposes results/fixed/remainingDrift");
+  await h.cli("skill", "doctor", "--output", "json");
+  h.assertRc(0);
+  json = h.assertJson(h.out);
+  h.assertField(json, "command", "skill doctor");
+  h.assertThat(asArray(jsonAt(json, "fixed")).length === 0, "doctor.fixed is not empty");
+  h.assertThat(
+    asArray(jsonAt(json, "remainingDrift")).length === 0,
+    "doctor.remainingDrift is not empty",
+  );
+  h.assertField(json, "results.0.status", "up-to-date");
+  h.assertField(json, "results.0.installedVersion", expectedVersion);
+  h.assertField(json, "results.0.shippedVersion", expectedVersion);
+  h.assertThat(
+    jsonAt(json, "results.0.diskHash") === jsonAt(json, "results.0.shippedHash"),
+    "results[0].diskHash differs from results[0].shippedHash",
+  );
+  h.caseEnd();
+
+  // ---- B21: modified-locally ------------------------------------------------
+  h.caseStart("B21", "local edit is reported modified-locally and exits non-zero");
+  appendFileSync(`${skillroot}/SKILL.md`, "\n<!-- local edit -->\n");
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "modified-locally", "stdout");
+  h.assertHas(h.out, "still drifting", "stdout");
+  h.assertHas(h.out, "--fix --force", "stdout");
+  h.caseEnd();
+
+  // ---- B22: --fix leaves local edits alone ----------------------------------
+  h.caseStart("B22", "skill doctor --fix does NOT overwrite a locally modified skill");
+  await h.cli("skill", "doctor", "--fix");
+  h.assertRc(1);
+  h.assertHas(h.out, "modified-locally", "stdout");
+  h.assertFileContains(
+    `${skillroot}/SKILL.md`,
+    "local edit",
+    "local edit was overwritten by --fix without --force",
+  );
+  h.caseEnd();
+
+  // ---- B23: --fix --force heals ---------------------------------------------
+  h.caseStart("B23", "skill doctor --fix --force restores the shipped content");
+  await h.cli("skill", "doctor", "--fix", "--force");
+  h.assertRc(0);
+  h.assertHas(h.out, "Fixed 1 skill(s).", "stdout");
+  h.assertHas(h.out, "All skills up-to-date.", "stdout");
+  h.assertFileLacks(`${skillroot}/SKILL.md`, "local edit", "local edit survived --fix --force");
+  h.caseEnd();
+
+  // ---- B24: deleted tracked file counts as drift ----------------------------
+  h.caseStart("B24", "a deleted tracked file is detected as drift and healed by --fix --force");
+  rmSync(`${skillroot}/references/business-logic.md`, { force: true });
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "modified-locally", "stdout");
+  await h.cli("skill", "doctor", "--fix", "--force");
+  h.assertRc(0);
+  h.assertFile(`${skillroot}/references/business-logic.md`);
+  h.caseEnd();
+
+  // ---- B25: missing ---------------------------------------------------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  h.caseStart("B25", "skill doctor reports missing when nothing is installed (exit 1)");
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "missing", "stdout");
+  h.assertHas(h.out, "installed none", "stdout");
+  h.caseEnd();
+
+  // ---- B26: missing + --fix -------------------------------------------------
+  h.caseStart("B26", "skill doctor --fix installs a missing skill without --force");
+  await h.cli("skill", "doctor", "--fix");
+  h.assertRc(0);
+  h.assertHas(h.out, "Fixed 1 skill(s).", "stdout");
+  h.assertFile(`${w}/.claude/skills/ledger-wallet-cli/SKILL.md`);
+  h.assertFile(`${w}/.claude/skills/ledger-wallet-cli/.wallet-cli-skill.json`);
+  h.caseEnd();
+
+  // ---- B27: outdated (forged older-version sidecar) -------------------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install", "--agent", "claude");
+  skillroot = `${w}/.claude/skills/ledger-wallet-cli`;
+  h.caseStart(
+    "B27",
+    "an install from an older wallet-cli is reported outdated and healed by --fix",
+  );
+  // Simulate "installed by 2.0.0": edit the content, then make the sidecar agree
+  // with what is on disk (so it is provenance-consistent) but disagree with the
+  // binary's shipped hash — exactly the outdated signature.
+  appendFileSync(`${skillroot}/SKILL.md`, "\n<!-- shipped by an older cli -->\n");
+  const forged = skillDiskHash(skillroot, SKILL_FILES);
+  writeFileSync(
+    `${skillroot}/.wallet-cli-skill.json`,
+    JSON.stringify({
+      name: "ledger-wallet-cli",
+      cliVersion: "2.0.0",
+      contentHash: forged.contentHash,
+      files: forged.files,
+      installedAt: "2026-01-01T00:00:00.000Z",
+    }),
+  );
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "outdated", "stdout");
+  h.assertHas(h.out, "installed 2.0.0@", "stdout");
+  await h.cli("skill", "doctor", "--fix");
+  h.assertRc(0);
+  h.assertHas(h.out, "Fixed 1 skill(s).", "stdout");
+  h.assertField(
+    h.assertJson(readFileSync(`${skillroot}/.wallet-cli-skill.json`, "utf8"), "sidecar"),
+    "cliVersion",
+    expectedVersion,
+    "healed sidecar version",
+  );
+  h.caseEnd();
+
+  // ---- B28: sidecar-less install that matches shipped content ---------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  await h.cli("skill", "install", "--agent", "claude");
+  skillroot = `${w}/.claude/skills/ledger-wallet-cli`;
+  h.caseStart("B28", "a manual install with no sidecar but matching content is up-to-date");
+  rmSync(`${skillroot}/.wallet-cli-skill.json`, { force: true });
+  await h.cli("skill", "doctor");
+  h.assertRc(0);
+  h.assertHas(h.out, "up-to-date", "stdout");
+  h.assertHas(h.out, "installed none", "stdout");
+  h.caseEnd();
+
+  // ---- B29: sidecar-less install that differs is conservative ---------------
+  h.caseStart("B29", "a sidecar-less install whose content differs is treated as modified-locally");
+  appendFileSync(`${skillroot}/SKILL.md`, "\n<!-- hand edit -->\n");
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "modified-locally", "stdout");
+  await h.cli("skill", "doctor", "--fix");
+  h.assertRc(1);
+  h.assertFileContains(
+    `${skillroot}/SKILL.md`,
+    "hand edit",
+    "--fix overwrote a sidecar-less install without --force",
+  );
+  h.caseEnd();
+
+  // ---- B30: doctor --dir ----------------------------------------------------
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  h.caseStart("B30", "skill doctor --dir scans an explicit directory only");
+  await h.cli("skill", "install", "--dir", "./elsewhere");
+  await h.cli("skill", "doctor", "--dir", "./elsewhere");
+  h.assertRc(0);
+  h.assertHas(h.out, "up-to-date", "stdout");
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "missing", "stdout");
+  h.caseEnd();
+
+  // ---- B31: doctor --global -------------------------------------------------
+  h.caseStart("B31", "skill doctor --global also scans the home directory");
+  w = h.freshDir();
+  h.cwd = w;
+  const doctorHome = h.freshDir();
+  h.setEnv({ WALLET_CLI_NO_NUDGE: "1", ...isolatedEnv(h.config.isoState, doctorHome) });
+  await h.cli("skill", "install", "--agent", "claude", "--global");
+  await h.cli("skill", "doctor", "--global", "--output", "json");
+  h.assertRc(0);
+  json = h.assertJson(h.out);
+  // Compare on the home dir's basename: macOS resolves /var -> /private/var, so a
+  // full-path prefix match would fail for reasons unrelated to --global.
+  const results = asArray(jsonAt(json, "results"));
+  h.assertThat(
+    results.some(r => (asString(jsonAt(r, "root")) ?? "").includes(basename(doctorHome))),
+    "no results[].root under the home directory",
+  );
+  h.assertThat(
+    results.some(r => jsonAt(r, "status") === "up-to-date"),
+    "no results[] with status up-to-date",
+  );
+  h.caseEnd();
+
+  // ---- B32: a regular file where a skill dir is expected --------------------
+  h.caseStart("B32", "a regular file at the skill path is not mistaken for an install");
+  w = h.freshDir();
+  h.cwd = w;
+  h.isoEnv();
+  const impostor = `${w}/.claude/skills/ledger-wallet-cli`;
+  mkdirSync(dirname(impostor), { recursive: true });
+  writeFileSync(impostor, "not a skill\n");
+  await h.cli("skill", "doctor");
+  h.assertRc(1);
+  h.assertHas(h.out, "missing", "stdout");
+  h.caseEnd();
+
+  h.cwd = h.config.repoRoot;
+}

--- a/apps/wallet-cli/scripts/regression/lib.ts
+++ b/apps/wallet-cli/scripts/regression/lib.ts
@@ -1,0 +1,380 @@
+// Shared harness plumbing for the wallet-cli regression suites.
+// Imported by run.ts — not runnable on its own.
+
+import {
+  accessSync,
+  appendFileSync,
+  constants,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { extname, join } from "node:path";
+
+export const APP_NAME = "ledger-wallet-cli";
+
+const GREEN = "\u001B[32m";
+const RED = "\u001B[31m";
+const YELLOW = "\u001B[33m";
+const DIM = "\u001B[2m";
+const OFF = "\u001B[0m";
+
+export const colors = { green: GREEN, red: RED, yellow: YELLOW, dim: DIM, off: OFF } as const;
+
+export type RunConfig = {
+  readonly repoRoot: string;
+  readonly walletCliDir: string;
+  readonly expectedVersion: string;
+  /** argv of the CLI under test: a built binary, or `pnpm … wallet-cli start`. */
+  readonly binArgv: readonly string[];
+  readonly binLabel: string;
+  readonly caseTimeoutMs: number;
+  readonly gateTimeoutMs: number;
+  readonly tmpRoot: string;
+  readonly logFile: string;
+  readonly isoState: string;
+  readonly isoHome: string;
+  /** Pinned state dir for Suite D (--session); undefined means the developer's real one. */
+  readonly sessionDir: string | undefined;
+  readonly withBuild: boolean;
+};
+
+type EnvSpec = {
+  readonly set: Readonly<Record<string, string>>;
+  readonly unset: readonly string[];
+};
+
+export type SpawnResult = { out: string; err: string; rc: number; timedOut: boolean };
+
+/**
+ * Environment that keeps the developer's real state, agent dirs and home out of
+ * the way. `XDG_STATE_HOME`/`HOME` cover POSIX; win32 needs `LOCALAPPDATA`
+ * (what @bunli/utils `stateDir` reads there) and `USERPROFILE` (what
+ * `os.homedir()` reads — it ignores `HOME`).
+ */
+export function isolatedEnv(stateHome: string, home: string): Record<string, string> {
+  const env: Record<string, string> = { XDG_STATE_HOME: stateHome, HOME: home };
+  if (process.platform === "win32") {
+    env.USERPROFILE = home;
+    env.LOCALAPPDATA = stateHome;
+    env.APPDATA = join(home, "AppData", "Roaming");
+  }
+  return env;
+}
+
+/** Same redirection as isolatedEnv, but for the state dir only (home is left alone). */
+export function isolatedStateEnv(stateHome: string): Record<string, string> {
+  const env: Record<string, string> = { XDG_STATE_HOME: stateHome };
+  if (process.platform === "win32") env.LOCALAPPDATA = stateHome;
+  return env;
+}
+
+/** Where @bunli/utils `stateDir(APP_NAME)` lands for a given isolated state home. */
+export function stateAppDir(stateHome: string): string {
+  return process.platform === "win32"
+    ? join(stateHome, APP_NAME, "State")
+    : join(stateHome, APP_NAME);
+}
+
+/** pnpm on Windows is a `.cmd` shim, which CreateProcess cannot exec directly. */
+export function commandArgv(argv: readonly string[]): string[] {
+  if (process.platform !== "win32") return [...argv];
+  const [command, ...rest] = argv;
+  if (/[\\/]/.test(command) || extname(command) !== "") return [...argv];
+  return ["cmd.exe", "/d", "/s", "/c", command, ...rest];
+}
+
+// --- JSON accessors ----------------------------------------------------------
+
+/** Reads a dotted path (`results.0.status`) out of a parsed JSON value. */
+export function jsonAt(value: unknown, path: string): unknown {
+  let current = value;
+  for (const key of path.split(".")) {
+    if (Array.isArray(current)) current = current[Number(key)];
+    else if (typeof current === "object" && current !== null)
+      current = (current as Record<string, unknown>)[key];
+    else return undefined;
+    if (current === undefined) return undefined;
+  }
+  return current;
+}
+
+export function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Every object anywhere in the tree — the equivalent of jq's `.. | objects`. */
+export function objectsDeep(value: unknown): Record<string, unknown>[] {
+  const found: Record<string, unknown>[] = [];
+  const walk = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    const record = asRecord(node);
+    if (!record) return;
+    found.push(record);
+    for (const item of Object.values(record)) walk(item);
+  };
+  walk(value);
+  return found;
+}
+
+export function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export class Harness {
+  passCount = 0;
+  failCount = 0;
+  skipCount = 0;
+  readonly failedIds: string[] = [];
+
+  out = "";
+  err = "";
+  rc = 0;
+  cwd: string;
+
+  private currentId = "";
+  private currentDesc = "";
+  private caseErrors: string[] = [];
+  private env: EnvSpec = { set: {}, unset: [] };
+
+  constructor(readonly config: RunConfig) {
+    this.cwd = config.repoRoot;
+  }
+
+  log(line: string): void {
+    appendFileSync(this.config.logFile, `${line}\n`);
+  }
+
+  print(line: string): void {
+    process.stdout.write(`${line}\n`);
+  }
+
+  // --- case lifecycle --------------------------------------------------------
+
+  caseStart(id: string, desc: string): void {
+    this.currentId = id;
+    this.currentDesc = desc;
+    this.caseErrors = [];
+    this.log("");
+    this.log(`=== ${id} — ${desc} ===`);
+  }
+
+  caseEnd(): void {
+    if (this.caseErrors.length === 0) {
+      this.passCount++;
+      this.print(`${GREEN}[PASS]${OFF} ${this.currentId.padEnd(5)} ${this.currentDesc}`);
+      return;
+    }
+    this.failCount++;
+    this.failedIds.push(this.currentId);
+    this.print(`${RED}[FAIL]${OFF} ${this.currentId.padEnd(5)} ${this.currentDesc}`);
+    for (const error of this.caseErrors) {
+      this.print(`       ${DIM}${error}${OFF}`);
+      this.log(`  FAILURE: ${error}`);
+    }
+  }
+
+  caseSkip(id: string, desc: string, reason: string): void {
+    this.skipCount++;
+    this.print(`${YELLOW}[SKIP]${OFF} ${id.padEnd(5)} ${desc} ${DIM}(${reason})${OFF}`);
+    this.log(`=== ${id} — SKIPPED: ${reason} ===`);
+  }
+
+  failCase(message: string): void {
+    this.caseErrors.push(message);
+  }
+
+  // --- assertions ------------------------------------------------------------
+
+  assertRc(expected: number): void {
+    if (this.rc !== expected) this.failCase(`exit code: expected ${expected}, got ${this.rc}`);
+  }
+
+  assertRcNonZero(): void {
+    if (this.rc === 0) this.failCase("exit code: expected non-zero, got 0");
+  }
+
+  assertHas(haystack: string, needle: string, label = "output"): void {
+    if (!haystack.includes(needle)) this.failCase(`${label} does not contain: ${needle}`);
+  }
+
+  assertLacks(haystack: string, needle: string, label = "output"): void {
+    if (haystack.includes(needle)) this.failCase(`${label} unexpectedly contains: ${needle}`);
+  }
+
+  assertEmpty(text: string, label = "output"): void {
+    if (text.trim() !== "") this.failCase(`${label} expected empty, got: ${text.slice(0, 200)}`);
+  }
+
+  assertNonEmpty(text: string, label = "output"): void {
+    if (text.trim() === "") this.failCase(`${label} expected non-empty`);
+  }
+
+  assertFile(path: string): void {
+    if (!existsSync(path) || !statSync(path).isFile()) this.failCase(`missing file: ${path}`);
+  }
+
+  assertNoFile(path: string): void {
+    if (existsSync(path)) this.failCase(`file should not exist: ${path}`);
+  }
+
+  assertMode(path: string, expected: number): void {
+    try {
+      const mode = statSync(path).mode & 0o777;
+      if (mode !== expected)
+        this.failCase(`mode of ${path}: expected ${expected.toString(8)}, got ${mode.toString(8)}`);
+    } catch {
+      this.failCase(`mode of ${path}: cannot stat`);
+    }
+  }
+
+  /** Parses `text` as JSON, recording a failure (and returning undefined) when it is not. */
+  assertJson(text: string, label = "output"): unknown {
+    const value = parseJson(text);
+    if (value === undefined) this.failCase(`${label} is not valid JSON`);
+    return value;
+  }
+
+  assertField(value: unknown, path: string, expected: string, label?: string): void {
+    const got = jsonAt(value, path);
+    const rendered = typeof got === "string" ? got : JSON.stringify(got);
+    if (rendered !== expected)
+      this.failCase(`${label ?? path}: expected '${expected}', got '${rendered}'`);
+  }
+
+  assertThat(condition: boolean, message: string): void {
+    if (!condition) this.failCase(message);
+  }
+
+  assertFileContains(path: string, needle: string, message: string): void {
+    if (!readFileSync(path, "utf8").includes(needle)) this.failCase(message);
+  }
+
+  assertFileLacks(path: string, needle: string, message: string): void {
+    if (readFileSync(path, "utf8").includes(needle)) this.failCase(message);
+  }
+
+  // --- environment -----------------------------------------------------------
+
+  setEnv(set: Readonly<Record<string, string>>, unset: readonly string[] = []): void {
+    this.env = { set, unset };
+  }
+
+  /** Default env for non-nudge cases: isolated state dir and home, nudge muted. */
+  isoEnv(): void {
+    this.setEnv({
+      WALLET_CLI_NO_NUDGE: "1",
+      ...isolatedEnv(this.config.isoState, this.config.isoHome),
+    });
+  }
+
+  /** Env that keeps a real session (the developer's, or the one pinned by --session). */
+  realEnv(): void {
+    const { sessionDir } = this.config;
+    this.setEnv({
+      WALLET_CLI_NO_NUDGE: "1",
+      ...(sessionDir ? isolatedStateEnv(sessionDir) : {}),
+    });
+  }
+
+  // --- CLI invocation --------------------------------------------------------
+
+  /** Runs the CLI under test, capturing stdout/stderr/exit code into out/err/rc. */
+  async cli(...args: string[]): Promise<void> {
+    const label = [
+      ...this.env.unset.map(name => `-u ${name}`),
+      ...Object.entries(this.env.set).map(([key, value]) => `${key}=${value}`),
+    ].join(" ");
+    this.log(`$ ${label} ${this.config.binLabel} ${args.join(" ")}`);
+
+    const result = await this.spawn([...this.config.binArgv, ...args], {
+      cwd: this.cwd,
+      timeoutMs: this.config.caseTimeoutMs,
+    });
+    this.out = result.out;
+    this.err = result.err;
+    this.rc = result.rc;
+    this.log(`--- rc=${this.rc}`);
+    this.log("--- stdout");
+    this.log(this.out);
+    this.log("--- stderr");
+    this.log(this.err);
+    if (result.timedOut) this.failCase(`timed out after ${this.config.caseTimeoutMs / 1000}s`);
+  }
+
+  async spawn(
+    argv: readonly string[],
+    options: { cwd: string; timeoutMs: number },
+  ): Promise<SpawnResult> {
+    // Unset first: a case that opts back into a signal it just cleared (Suite C)
+    // must keep the value it set.
+    const env: Record<string, string | undefined> = { ...process.env };
+    for (const name of this.env.unset) delete env[name];
+    Object.assign(env, this.env.set);
+
+    const proc = Bun.spawn({
+      cmd: commandArgv(argv),
+      cwd: options.cwd,
+      env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: options.timeoutMs,
+    });
+    const [out, err] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    await proc.exited;
+    // The harness never signals its children, so a null exit code means the
+    // spawn timeout killed it. 124 is the conventional `timeout` exit code.
+    const timedOut = proc.exitCode === null;
+    return { out, err, rc: proc.exitCode ?? 124, timedOut };
+  }
+
+  // --- scratch space ---------------------------------------------------------
+
+  freshState(): string {
+    return mkdtempSync(join(this.config.tmpRoot, "state."));
+  }
+
+  freshDir(): string {
+    return mkdtempSync(join(this.config.tmpRoot, "work."));
+  }
+}
+
+/** Why file-mode assertions are meaningless here, if they are: NTFS has no mode bits, root ignores them. */
+export function modeAssertionsUnsupported(): string | undefined {
+  if (process.platform === "win32") return "file modes are not meaningful on Windows";
+  if (process.getuid?.() === 0) return "running as root, which ignores mode bits";
+  return undefined;
+}
+
+export function isExecutableFile(path: string): boolean {
+  if (!existsSync(path) || !statSync(path).isFile()) return false;
+  if (process.platform === "win32") return true;
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/wallet-cli/scripts/regression/run.ts
+++ b/apps/wallet-cli/scripts/regression/run.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+// Automated regression harness for the wallet-cli cases that need no device.
+// Case ids match ../../docs/regression/no-device.md.
+//
+//   bun scripts/regression/run.ts                 # suites B, C, D (skill group, first-run nudge, read/dry-run)
+//   bun scripts/regression/run.ts --suite b       # one suite (a|b|c|d, repeatable)
+//   bun scripts/regression/run.ts --with-gates    # add suite A (repo gates); --with-build adds build/pack/smoke
+//   bun scripts/regression/run.ts --bin ./cli     # a specific binary (default: dist/<platform>/cli)
+//   bun scripts/regression/run.ts --source        # run from source via `pnpm wallet-cli start`
+//   bun scripts/regression/run.ts --session <dir> # suite D against a pinned state dir, not yours
+//   bun scripts/regression/run.ts --timeout <s>   # per-case timeout (default 240s)
+//
+// Suites B and C are hermetic (throwaway cwd, home and state dir).
+// Suite D reads a real session and live backends; it never signs or broadcasts.
+// Device-touching cases live in the docs, not here.
+//
+// Requires: bun, and a built binary or pnpm. Env: CASE_TIMEOUT, GATE_TIMEOUT, REPO_ROOT.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Harness, isExecutableFile, type RunConfig } from "./lib";
+import { suiteA } from "./cases-gates";
+import { suiteB } from "./cases-skill";
+import { suiteC } from "./cases-nudge";
+import { suiteD } from "./cases-readonly";
+
+const USAGE = `Automated regression harness for the wallet-cli cases that need no device.
+Case ids match apps/wallet-cli/docs/regression/no-device.md.
+
+  bun scripts/regression/run.ts                 # suites B, C, D (skill group, first-run nudge, read/dry-run)
+  bun scripts/regression/run.ts --suite b       # one suite (a|b|c|d, repeatable)
+  bun scripts/regression/run.ts --with-gates    # add suite A (repo gates); --with-build adds build/pack/smoke
+  bun scripts/regression/run.ts --bin ./cli     # a specific binary (default: dist/<platform>/cli)
+  bun scripts/regression/run.ts --source        # run from source via \`pnpm wallet-cli start\`
+  bun scripts/regression/run.ts --session <dir> # suite D against a pinned state dir, not yours
+  bun scripts/regression/run.ts --timeout <s>   # per-case timeout (default 240s)
+
+Suites B and C are hermetic (throwaway cwd, home and state dir).
+Suite D reads a real session and live backends; it never signs or broadcasts.
+Device-touching cases live in the docs, not here.
+
+Requires: bun, and a built binary or pnpm. Env: CASE_TIMEOUT, GATE_TIMEOUT, REPO_ROOT.`;
+
+const SUITES = {
+  a: { title: "Suite A — repo & artifact gates", run: suiteA },
+  b: { title: "Suite B — skill command group", run: suiteB },
+  c: { title: "Suite C — first-run nudge", run: suiteC },
+  d: { title: "Suite D — device-free regression", run: suiteD },
+} as const;
+
+type SuiteKey = keyof typeof SUITES;
+
+// bunli.config.ts builds exactly these four targets.
+const BINARY_BY_HOST: Record<string, string> = {
+  "darwin-arm64": join("darwin-arm64", "cli"),
+  "linux-arm64": join("linux-arm64", "cli"),
+  "linux-x64": join("linux-x64", "cli"),
+  "win32-x64": join("windows-x64", "cli.exe"),
+};
+
+function die(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(2);
+}
+
+function parseArgs(argv: string[]) {
+  const suites: SuiteKey[] = [];
+  let withBuild = false;
+  let binOverride = "";
+  let useSource = false;
+  let sessionDir: string | undefined;
+  let caseTimeout = Number(process.env.CASE_TIMEOUT ?? 240);
+
+  const next = (index: number, flag: string): string => {
+    const value = argv[index + 1];
+    if (value === undefined) die(`${flag} needs a value`);
+    return value;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--suite": {
+        const name = next(i++, arg).toLowerCase();
+        if (!(name in SUITES)) die(`unknown suite: ${name}`);
+        suites.push(name as SuiteKey);
+        break;
+      }
+      case "--with-gates":
+        suites.push("a");
+        break;
+      case "--with-build":
+        withBuild = true;
+        break;
+      case "--bin":
+        binOverride = next(i++, arg);
+        break;
+      case "--source":
+        useSource = true;
+        break;
+      case "--session":
+        sessionDir = resolve(next(i++, arg));
+        break;
+      case "--timeout":
+        caseTimeout = Number(next(i++, arg));
+        break;
+      case "-h":
+      case "--help":
+        process.stdout.write(`${USAGE}\n`);
+        process.exit(0);
+        break;
+      default:
+        die(`unknown flag: ${arg}`);
+    }
+  }
+
+  return {
+    suites: suites.length > 0 ? suites : (["b", "c", "d"] as SuiteKey[]),
+    withBuild,
+    binOverride,
+    useSource,
+    sessionDir,
+    caseTimeout,
+  };
+}
+
+function resolveCli(
+  args: ReturnType<typeof parseArgs>,
+  repoRoot: string,
+  walletCliDir: string,
+): { binArgv: string[]; binLabel: string } {
+  if (args.useSource) {
+    return {
+      binArgv: ["pnpm", "--dir", repoRoot, "--silent", "wallet-cli", "start"],
+      binLabel: "pnpm wallet-cli start",
+    };
+  }
+  const host = `${process.platform}-${process.arch}`;
+  const fallback = BINARY_BY_HOST[host];
+  if (!args.binOverride && !fallback) die(`no default binary for ${host}; pass --bin or --source`);
+  const bin = args.binOverride || join(walletCliDir, "dist", fallback);
+  if (!isExecutableFile(bin)) {
+    process.stderr.write(`binary not found: ${bin}\n`);
+    die(`build it with: (cd ${walletCliDir} && pnpm build)   — or run with --source`);
+  }
+  return { binArgv: [bin], binLabel: bin };
+}
+
+const args = parseArgs(process.argv.slice(2));
+const here = import.meta.dir;
+const repoRoot = process.env.REPO_ROOT ?? resolve(here, "..", "..", "..", "..");
+const walletCliDir = join(repoRoot, "apps", "wallet-cli");
+const packageJson = JSON.parse(readFileSync(join(walletCliDir, "package.json"), "utf8")) as {
+  version: string;
+};
+const { binArgv, binLabel } = resolveCli(args, repoRoot, walletCliDir);
+
+const runId = new Date()
+  .toISOString()
+  .replace(/[-:]/g, "")
+  .replace(/\.\d+Z$/, "")
+  .replace("T", "-");
+const tmpRoot = mkdtempSync(join(tmpdir(), `wallet-cli-regression.${runId}.`));
+const logFile = join(tmpRoot, "run.log");
+writeFileSync(logFile, "");
+
+const config: RunConfig = {
+  repoRoot,
+  walletCliDir,
+  expectedVersion: packageJson.version,
+  binArgv,
+  binLabel,
+  caseTimeoutMs: args.caseTimeout * 1000,
+  gateTimeoutMs: Number(process.env.GATE_TIMEOUT ?? 2400) * 1000,
+  tmpRoot,
+  logFile,
+  isoState: mkdtempSync(join(tmpRoot, "iso-state.")),
+  isoHome: mkdtempSync(join(tmpRoot, "iso-home.")),
+  sessionDir: args.sessionDir,
+  withBuild: args.withBuild,
+};
+
+const harness = new Harness(config);
+
+harness.print(`wallet-cli regression run ${runId}`);
+harness.print(`  version under test : ${config.expectedVersion}`);
+harness.print(`  cli                : ${config.binLabel}`);
+harness.print(`  suites             : ${args.suites.join(" ")}`);
+if (config.sessionDir) harness.print(`  session            : ${config.sessionDir}`);
+harness.print(`  log                : ${config.logFile}`);
+harness.print("");
+
+const start = Date.now();
+for (const key of args.suites) {
+  const suite = SUITES[key];
+  harness.print(`── ${suite.title} ──`);
+  await suite.run(harness);
+  harness.print("");
+}
+const seconds = Math.round((Date.now() - start) / 1000);
+
+const total = harness.passCount + harness.failCount;
+harness.print("──────────────────────────────────────────────");
+harness.print(
+  `passed ${harness.passCount}/${total}   failed ${harness.failCount}   skipped ${harness.skipCount}   (${seconds}s)`,
+);
+if (harness.failCount > 0) {
+  harness.print(`failed cases: ${harness.failedIds.join(" ")}`);
+  harness.print(`full log: ${config.logFile}`);
+  process.exit(1);
+}
+harness.print(`log: ${config.logFile}`);

--- a/apps/wallet-cli/tsconfig.json
+++ b/apps/wallet-cli/tsconfig.json
@@ -8,5 +8,5 @@
     "moduleResolution": "Bundler",
     "module": "ESNext"
   },
-  "include": ["src/**/*.ts", "bunli.config.ts"]
+  "include": ["src/**/*.ts", "scripts/regression/*.ts", "bunli.config.ts"]
 }


### PR DESCRIPTION
> **Stacked on #20241** — this PR targets `fix/wallet-cli-ascii-space-amounts`, not `develop`. Review and merge #20241 first.

## Summary

Adds the wallet-cli release regression plan, and the harness that automates the part of it needing no device:

- `docs/regression/README.md` — entry point: what CI already covers, prerequisites, how to run a campaign.
- `docs/regression/no-device.md` — the case tables the harness automates.
- `docs/regression/with-device.md` — the cases a person has to run with a Ledger on USB (wallet-cli is USB/DMK only, no Speculos support).
- `docs/regression/releases/2.1.0.md` — per-release focus: what changed and which cases it puts at risk.
- `scripts/regression/*.ts` — the harness itself, suites A–D, in bun/TypeScript.

The harness needs only bun — no `jq`, no `bash`, no GNU `timeout`, the last of which stock macOS does not ship — so it runs on any contributor's machine, on macOS, Linux and Windows alike. Case ids it prints match the tables in `docs/regression/no-device.md`.

Windows specifics handled:

- Binary resolution covers `dist/windows-x64/cli.exe`.
- Env isolation also overrides `USERPROFILE`/`LOCALAPPDATA`/`APPDATA`, since `stateDir` from `@bunli/utils` reads `%LOCALAPPDATA%` on win32 and ignores `XDG_STATE_HOME`.
- The POSIX file-mode cases skip with a reason on Windows and as root.

Also:

- A `--session <dir>` flag to pin suite D at a specific session directory instead of the developer's real one.
- A missing session degrades to per-case skips instead of aborting the suite.
- `tsconfig.json` adds `scripts/regression/*.ts` to `include` so the harness is typechecked.

The cases were first prototyped as bash scripts that were never committed — which is why the case ids look pre-established, and why the parity numbers below are evidence rather than a self-comparison.

## Test plan

- [x] Hermetic suites B and C: `passed 44/44 failed 0 skipped 0`, identical to the bash prototype on the same machine
- [x] Suite D: `passed 41/41 failed 0 skipped 1` once #20241 is applied. Without it, suite D shows five NBSP-related failures (D4, D5, D6, D23, D24) — hence the stacking.

## Notes

No changeset: `@ledgerhq/wallet-cli` is `private: true` and nothing under `libs/` changed.
