### PR TITLE
[LWD] chore(desktop): remove legacy translation keys (LIVE-34001)

### DIFF
--- a/.changeset/legacy-translations-cleanup-desktop.md
+++ b/.changeset/legacy-translations-cleanup-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Remove legacy translation keys orphaned by the Wallet 4.0 Q1 cleanup (sidebar/topbar rewrite, legacy dashboard & empty states, Help modal, receive step-options and the sync activity indicator).

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -100,7 +100,6 @@
     "selectNoResults": "No results found matching \"{{query}}\"",
     "sortBy": "Sort by",
     "save": "Save",
-    "lock": "Lock",
     "showMore": "Show more",
     "backToMatchingURL": "Back to {{appName}}",
     "back": "Back",
@@ -139,11 +138,8 @@
       "syncing": "Synchronizing...",
       "upToDate": "Synchronized",
       "outdated": "Paused",
-      "error": "Synchronization error",
       "refresh": "Refresh",
-      "devTools": "Dev tools",
-      "failingSync_one": "Account failing to sync:",
-      "failingSync_other": "Accounts failing to sync:"
+      "devTools": "Dev tools"
     },
     "exchange": "Exchange",
     "info": "Info",
@@ -306,24 +302,14 @@
   "sidebar": {
     "card": "Card",
     "paytab": "Pay",
-    "menu": "Menu",
-    "stars": "Starred accounts",
     "accounts": "Accounts",
-    "manager": "My Ledger",
-    "earn": "Earn",
-    "exchange": "Buy / Sell",
     "swap": "Swap",
-    "perps": "Perpetuals",
-    "borrow": "Borrow",
     "home": "Home",
     "refer": "Refer a friend",
-    "lend": "Lend",
     "catalog": "Discover",
-    "market": "Market",
     "recover": "[L] Recover"
   },
   "stars": {
-    "placeholder": "Star an account to display it here.",
     "tooltip": "Star account"
   },
   "bridge": {
@@ -1153,18 +1139,9 @@
     }
   },
   "help": {
-    "title": "Help & Support",
-    "gettingStarted": {
-      "title": "Getting started",
-      "desc": "Start here"
-    },
     "status": {
       "title": "Ledger Status",
       "desc": "Check our system status"
-    },
-    "helpCenter": {
-      "title": "Ledger Support",
-      "desc": "Get help"
     },
     "ledgerAcademy": {
       "title": "Ledger Academy",
@@ -1531,7 +1508,6 @@
     "titleAccount": "WalletConnect"
   },
   "dashboard": {
-    "title": "Portfolio",
     "header": "Portfolio balance",
     "emptyAccountTile": {
       "desc": "Add accounts to manage other crypto assets",
@@ -1540,21 +1516,6 @@
     "recentActivity": "Latest operations",
     "totalBalance": "Total balance",
     "transactionsPendingConfirmation": "Some transactions are not confirmed yet. These will be reflected in your balance and useable after being confirmed.",
-    "featuredButtons": {
-      "buySell": {
-        "title": "Buy / Sell",
-        "description": "Buy and sell with our trusted providers"
-      },
-      "swap": {
-        "title": "Swap",
-        "description": "Convert crypto to crypto",
-        "label": "Popular"
-      },
-      "earn": {
-        "title": "Stake",
-        "description": "Get rewards on your crypto"
-      }
-    },
     "recoverBanner": {
       "subscribeDone": {
         "title": "Reminder: Finish subscribing to Ledger Recover",
@@ -1604,25 +1565,6 @@
     "taprootWarning": "Make sure the sender supports taproot",
     "dashStakingWarning": "Please make sure you don't use this address for receiving staking rewards",
     "utxoWarning": "For privacy reasons, a new address is generated for every transaction. The previous ones do remain valid."
-  },
-  "emptyState": {
-    "dashboard": {
-      "title": "Install apps on your device",
-      "desc": "Go to My Ledger to install apps on your device. You can add accounts once you have apps on your device.",
-      "buttons": {
-        "installApp": "Go to My Ledger",
-        "help": "Help"
-      }
-    },
-    "accounts": {
-      "title": "Add an account to get started",
-      "desc": "Add an account to start managing your crypto assets. You must have the app for your crypto asset installed on your device.",
-      "buttons": {
-        "addAccount": "Add account",
-        "installApp": "Go to My Ledger to install apps",
-        "help": "Help"
-      }
-    }
   },
   "genuinecheck": {
     "deviceInBootloader": "Device in Bootloader mode. Click on <1>Continue</1> to update it."
@@ -2335,16 +2277,6 @@
     "successTitle": "Address shared securely",
     "connectToNoah": "Connecting you to Noah",
     "steps": {
-      "options": {
-        "fromBank": {
-          "title": "Via bank transfer",
-          "description": "Receive stablecoin via Cash-to-Stablecoin account. Registration needed."
-        },
-        "fromCrypto": {
-          "title": "Via crypto address",
-          "description": "Receive crypto from another wallet."
-        }
-      },
       "chooseAccount": {
         "title": "Account",
         "label": "Account to credit",
@@ -5021,7 +4953,6 @@
   "settings": {
     "title": "Settings",
     "discreet": "Toggle discreet mode",
-    "helpButton": "Help",
     "tabs": {
       "display": "General",
       "currencies": "Crypto assets",
@@ -5690,9 +5621,6 @@
     }
   },
   "informationCenter": {
-    "tooltip": "Information center",
-    "ongoingIncidentsTooltip": "There is {{count}} ongoing incident",
-    "ongoingIncidentsTooltip_other": "There are {{count}} ongoing incidents",
     "tabs": {
       "announcements": "News",
       "announcementsUnseen": "News ({{unseenCount}})",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _No tests needed — dead-key removal only; every removed key was verified to have zero references in `src` and `tests`, with no dynamic key construction targeting them._
- [x] **Impact of the changes:**
      - No user-facing impact expected: only unused translation keys were removed.
      - Sanity-check the left sidebar labels, the Help drawer, the dashboard, the empty states, the Receive flow and the sync status indicator still render correctly.

### 📝 Description

Following the Wallet 4.0 Q1 cleanup epic ([LIVE-32982](https://ledgerhq.atlassian.net/browse/LIVE-32982)), a number of translation keys in `apps/ledger-live-desktop/static/i18n/en/app.json` became orphaned once the legacy screens, feature flags and components were removed (sidebar/topbar rewrite, legacy dashboard & empty states, Help modal, receive step-options, sync activity indicator).

This PR removes those dead keys. The set was derived by tracing the 8 LWD epic PRs to the 35 deleted files, extracting their translation keys, then running a namespace-level scan of every rewritten area to also catch keys orphaned by *modified* files. Each removed key was confirmed to have **zero references** in desktop `src` + `tests`, with dynamic (`viewModel.earnLabel` resolves via a separate hook, not `sidebar.earn`) and i18next plural forms ruled out.

Removed groups:
- **`sidebar`** — `menu`, `stars`, `manager`, `earn`, `exchange`, `perps`, `borrow`, `lend`, `market` (kept the labels the new `SideBarView` renders).
- **`common`** — `lock`, `sync.error`, `sync.failingSync_one/_other` (kept `sync.devTools`, still used by the LiveApp web-player top bars, and `sync.refresh/syncing/upToDate/outdated`).
- **`help`** — `title`, `gettingStarted.*`, `helpCenter.*` (kept status/ledgerAcademy/facebook/twitter/github).
- **`dashboard`** — `title`, whole `featuredButtons`.
- **`emptyState`** — whole top-level namespace.
- **`receive.steps`** — whole `options` (fromBank/fromCrypto).
- **`settings`** — `helpButton`.
- **`stars`** — `placeholder` (kept `tooltip`).
- **`informationCenter`** — `tooltip`, `ongoingIncidentsTooltip(+_other)`.

Net: **73 deletions**, no behaviour change.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-34001](https://ledgerhq.atlassian.net/browse/LIVE-34001)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-32982]: https://ledgerhq.atlassian.net/browse/LIVE-32982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34001]: https://ledgerhq.atlassian.net/browse/LIVE-34001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ