### PR TITLE
docs(architecture): document sibling flow deps in features/flow

### DIFF
--- a/features/flow/README.md
+++ b/features/flow/README.md
@@ -21,7 +21,8 @@ User-facing feature packages shared across desktop and mobile apps. Each subdire
 - Package name: `@features/flow-<name>`
 - Directory name: `features/flow/<name>/`
 - `package.json` must have `"private": true`
-- May depend on `type:feature-platform`, `scope:domain`, and `scope:shared`
+- May depend on sibling flows (`type:feature-flow`), `type:feature-platform`, `scope:domain`, and `scope:shared`
+- A flow may orchestrate sub-flows: depending on another `@features/flow-*` package is allowed, so a parent flow can compose smaller ones
 - Nx tag inferred automatically: `type:feature-flow`
 - Platform-specific files use `.web.tsx` / `.native.tsx` suffixes; shared logic uses `.ts` / `.tsx`
 - Barrel export via `src/index.ts`


### PR DESCRIPTION
## Why

`features/flow/README.md` listed the allowed dependencies of a `type:feature-flow` package as `type:feature-platform`, `scope:domain` and `scope:shared` — omitting `type:feature-flow` itself.

The boundary validator has always allowed sibling flow dependencies, and does so deliberately:

- `tools/nx-plugins/enforce-boundaries/constraints.js` lists `type:feature-flow` in its own `onlyDependOnLibsWithTags`
- `tools/nx-plugins/enforce-boundaries/validate.test.js` locks the behaviour in: *"feature-flow -> feature-flow is allowed (sibling flows can compose)"*
- `.agents/skills/ddd-structure-flow/SKILL.md` already documents `features/flow` → `features/flow` in its boundary table

So the README was the only artifact out of sync. Reading it as authoritative would make a reviewer reject a legitimate parent-flow / sub-flow composition that CI happily accepts.

## What

Docs only — no behaviour change, no package touched.

- Add `type:feature-flow` to the documented allowlist
- State explicitly that a flow may orchestrate sub-flows, which is the motivating case (splitting a large flow into smaller composable ones)

## Test plan

Nothing to run: markdown-only change to a directory README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
