### PR TITLE
[LWDM] fix: update zenrock lcd to zenrock.api.m.anode.team

### DIFF
--- a/.changeset/young-news-joke.md
+++ b/.changeset/young-news-joke.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-cosmos": minor
+---
+
+fix: update zenrock lcd to https://zenrock.api.m.anode.team (stavr.tech returns 502)

--- a/libs/coin-modules/coin-cosmos/src/config.ts
+++ b/libs/coin-modules/coin-cosmos/src/config.ts
@@ -172,7 +172,7 @@ export const cosmosConfig: CosmosConfig = {
   config_currency_zenrock: {
     type: "object",
     default: {
-      lcd: "https://zenrock.api.m.stavr.tech",
+      lcd: "https://zenrock.api.m.anode.team",
       minGasPrice: 2.5,
       status: {
         type: "active",

--- a/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/injective.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/cosmos/datasets/__snapshots__/injective.integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`injective currency bridge scanAccounts injective seed 1 1`] = `
 [
   {
-    "balance": "607564000016396",
+    "balance": "643420137173618",
     "currencyId": "injective",
     "derivationMode": "",
     "freshAddress": "inj1hn46zvx43mxq47vsecvw84k5chjhuhwp6d62dt",
@@ -12,7 +12,7 @@ exports[`injective currency bridge scanAccounts injective seed 1 1`] = `
     "index": 0,
     "pendingOperations": [],
     "seedIdentifier": "03f8e9b05b4de510b0b7d970060eac6a0f76d3c4eb07e11418c0747bc593c91c7d",
-    "spendableBalance": "506664000000021",
+    "spendableBalance": "542520137157243",
     "swapHistory": [],
     "syncHash": undefined,
     "used": true,


### PR DESCRIPTION
### 📝 Description

`zenrock.api.m.stavr.tech` (the zenrock LCD default in `coin-cosmos/src/config.ts`) now returns HTTP 502. The `zenrock.integration.test.ts` suite reads this default, so it fails on every run.

Fix: point the default at `https://zenrock.api.m.anode.team`, which currently responds 200 on both the `blocks/latest` and `staking/validators` endpoints the test exercises. Same shape as #16725 (`diamond` → `stavr`).

### 🔗 Context

- **JIRA / GitHub issue**: _n/a
- **ADR** (if any): _n/a_

https://ledger.slack.com/archives/C02LACPH3U3/p1785418489768269?thread_ts=1776949318.712449&cid=C02LACPH3U3