### PR TITLE
[LWDM] chore(lint): ban wallet-framework currency types outside coin-modules (LIVE-35206)

### DIFF
--- a/apps/ledger-live-desktop/.oxlintrc.json
+++ b/apps/ledger-live-desktop/.oxlintrc.json
@@ -64,6 +64,30 @@
             "name": "react-redux",
             "importNames": ["useSelector", "useDispatch", "useStore"],
             "message": "Import typed hooks from 'LLD/hooks/redux' instead of 'react-redux' to ensure proper TypeScript typing."
+          },
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/types",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+          },
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/api",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
           }
         ],
         "patterns": [

--- a/apps/ledger-live-mobile/.oxlintrc.json
+++ b/apps/ledger-live-mobile/.oxlintrc.json
@@ -64,6 +64,30 @@
             "name": "react-i18next",
             "importNames": ["useTranslation", "Trans"],
             "message": "Use the locale hooks from '~/context/Locale' instead of 'react-i18next' to ensure correct injection of the i18n instance."
+          },
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/types",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+          },
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/api",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
           }
         ],
         "patterns": [
@@ -154,7 +178,33 @@
         "eslint/no-restricted-imports": [
           "error",
           {
-            "paths": ["lodash"],
+            "paths": [
+              "lodash",
+              {
+                "name": "@ledgerhq/ledger-wallet-framework/types",
+                "importNames": [
+                  "CryptoCurrency",
+                  "TokenCurrency",
+                  "Currency",
+                  "Unit",
+                  "FiatCurrency",
+                  "ExplorerView"
+                ],
+                "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+              },
+              {
+                "name": "@ledgerhq/ledger-wallet-framework/api",
+                "importNames": [
+                  "CryptoCurrency",
+                  "TokenCurrency",
+                  "Currency",
+                  "Unit",
+                  "FiatCurrency",
+                  "ExplorerView"
+                ],
+                "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+              }
+            ],
             "patterns": [
               {
                 "group": [

--- a/libs/ledger-live-common/.oxlintrc.json
+++ b/libs/ledger-live-common/.oxlintrc.json
@@ -49,7 +49,33 @@
     "eslint/no-restricted-imports": [
       "error",
       {
-        "paths": ["lodash"],
+        "paths": [
+          "lodash",
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/types",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+          },
+          {
+            "name": "@ledgerhq/ledger-wallet-framework/api",
+            "importNames": [
+              "CryptoCurrency",
+              "TokenCurrency",
+              "Currency",
+              "Unit",
+              "FiatCurrency",
+              "ExplorerView"
+            ],
+            "message": "Wallet-framework currency types are for coin-modules. Import from @domain/entity-currency-* (unions from @domain/entity-currency)."
+          }
+        ],
         "patterns": [
           {
             "group": [

--- a/libs/ledger-live-common/src/families/vechain/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/vechain/bridge/api.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import type { TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { CryptoAssetsStore } from "@ledgerhq/types-live";
 import vechainBridge, { getAssetFromToken, getTokenFromAsset } from "./api";
 

--- a/libs/ledger-live-common/src/families/vechain/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/vechain/bridge/api.ts
@@ -1,7 +1,8 @@
 import type { AssetInfo } from "@ledgerhq/coin-module-framework/api/types";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
 import { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/ledger-wallet-framework/types";
+import type { CryptoCurrency } from "@domain/entity-currency-crypto";
+import type { TokenCurrency } from "@domain/entity-currency-token";
 
 /**
  * VeChain's only in-module token is VTHO (see `@ledgerhq/coin-vechain/logic/account/getBalance`,


### PR DESCRIPTION
## Context

[LIVE-35206](https://ledgerhq.atlassian.net/browse/LIVE-35206)

`@ledgerhq/ledger-wallet-framework` re-declares the currency types (`CryptoCurrency`, `TokenCurrency`, `Currency`, `Unit`, `FiatCurrency`, `ExplorerView`) for **coin-module** consumption. The app and live-common layers must not import them from there — they use `@domain/entity-currency-*` (unions from `@domain/entity-currency`).

This PR locks that in with oxlint, using the `no-restricted-imports` + `importNames` pattern already established in these configs (e.g. the `react-redux` / `reselect` / `react-i18next` bans).

## Changes

**Guard** — two `paths` entries added to `eslint/no-restricted-imports` in:

- `apps/ledger-live-desktop/.oxlintrc.json`
- `apps/ledger-live-mobile/.oxlintrc.json`
- `libs/ledger-live-common/.oxlintrc.json`

banning the six currency type names from `@ledgerhq/ledger-wallet-framework/types` and `@ledgerhq/ledger-wallet-framework/api`, with a message pointing at the domain packages. Type-only imports are caught by default (`allowTypeImports` deliberately unset).

**One real violation fixed** — `libs/ledger-live-common/src/families/vechain/bridge/api.ts` (+ its test) still sourced `CryptoCurrency` / `TokenCurrency` from the framework. Every sibling family (`solana`, `tron`, `cardano`, `evm`, `celo`, `stellar`, `tezos`, `multiversx`) already uses `@domain/entity-currency-crypto` / `-token`, so this is repointed to match rather than carved out. No `package.json` change needed — live-common already declares both domain deps.

## Notes for reviewers

- **`/api` is defensive, not currently reachable.** `@ledgerhq/ledger-wallet-framework/api` re-exports `./types` — but that resolves to `src/api/types.ts` (`BridgeApi`, `ChainSpecificRules`, …), which *imports* the currency types without re-exporting them. `src/types.ts` is therefore the only live leak path today; the `/api` entry guards against a future `export *` widening it. Kept intentionally.
- **Mobile's test/debug override.** `apps/ledger-live-mobile/.oxlintrc.json` has an override that re-declares the whole rule for `src/**/*.test.*`, the Debug/FeatureFlags/Experimental screens and `**/*Mock*`, which would have left the guard off in exactly those files. The two entries are added there too — one of the two violations found on `develop` was a *test* file, so the hole was real, not theoretical.
- **Pre-existing carve-out left alone:** desktop's `src/renderer/families/**` override turns `no-restricted-imports` off wholesale, so the guard does not apply there. Narrowing that is out of scope for this PR.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter ledger-live-desktop lint` | 0 errors (760 pre-existing warnings) |
| `pnpm --filter live-mobile lint` | 0 errors (311 pre-existing warnings) |
| `pnpm --filter @ledgerhq/live-common lint` | 0 errors (2731 pre-existing warnings) |
| Rule actually fires | scratch `import { CryptoCurrency } from ".../types"` + `{ TokenCurrency } from ".../api"` errored in all three projects — and in mobile's override-covered `*.test.ts` path — with the guidance message; scratch files removed |
| Repo-wide scan | 0 remaining imports of the six names from framework `/types` or `/api` across the three project sources |
| `pnpm --filter @ledgerhq/live-common typecheck` | no new errors — 8 pre-existing failures (unbuilt self-referencing `@ledgerhq/live-common/*` artifacts), byte-identical with and without this change |
| `jest src/families/vechain/bridge/api.test.ts` | 6/6 pass |

Two unrelated suites (`families/solana/signer.test.ts`, `coin-modules/loaders.test.ts`) fail locally on a missing `@ledgerhq/context-module` build artifact — environmental, present without this change.

---

Supersedes #20250 (closed automatically when its head branch was renamed to strip a stray em dash; commits are identical).


[LIVE-35206]: https://ledgerhq.atlassian.net/browse/LIVE-35206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ