### PR TITLE
[LWD] feat(contacts): render Me contact detail on Desktop

### DIFF
--- a/.changeset/lwd-me-contact-detail.md
+++ b/.changeset/lwd-me-contact-detail.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": minor
+"@domain/entity-contact": minor
+"ledger-live-desktop": minor
+---
+
+Render Desktop Me contact detail by default with Me display-name formatting and external address CTA.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -194,7 +194,8 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-page")).toBeVisible();
     expect(screen.getByTestId("contacts-page-header")).toBeVisible();
     expect(screen.getByTestId("contacts-list-pane")).toBeVisible();
-    expect(screen.getByTestId("contacts-detail-pane")).toBeEmptyDOMElement();
+    expect(screen.getByTestId("contacts-detail-pane")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
     expect(screen.queryByTestId("contacts-ledger-sync-list-loading")).not.toBeInTheDocument();
     expect(screen.queryByTestId("contacts-ledger-sync-detail-loading")).not.toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
@@ -244,11 +245,16 @@ describe("Contacts integration", () => {
     expect(screen.getByTestId("contacts-add-contact-header")).toBeVisible();
     expect(screen.getByTestId("contacts-section-A")).toBeVisible();
     expect(screen.getByTestId("contacts-section-B")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-C")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-D")).toBeVisible();
     expect(screen.getByTestId("contacts-section-O")).toBeVisible();
 
     expect(screen.getByTestId("contacts-me-row")).toHaveTextContent("Me");
+    expect(screen.getByTestId("contacts-me-row")).toHaveTextContent("3 addresses");
     expect(screen.getByTestId("contacts-saved-row-contact-ada")).toHaveTextContent("Ada");
     expect(screen.getByTestId("contacts-saved-row-contact-ben")).toHaveTextContent("Ben");
+    expect(screen.getByTestId("contacts-saved-row-contact-charlie")).toHaveTextContent("Charlie");
+    expect(screen.getByTestId("contacts-saved-row-contact-diana")).toHaveTextContent("Diana");
     expect(screen.getByTestId("contacts-saved-row-contact-olive")).toHaveTextContent("Olive");
   });
 
@@ -381,8 +387,37 @@ describe("Contacts integration", () => {
     expect(store.getState().settings.hasDismissedContactsFeatureIntroduction).toBe(false);
   });
 
-  it("should render the Me empty detail state when Me is selected", async () => {
-    const { user } = render(
+  it("should render populated Me detail on load when populated contacts are persisted", () => {
+    render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({
+          contacts: { contacts: mockPopulatedContacts() },
+        }),
+      },
+    );
+
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Me");
+    expect(
+      within(screen.getByTestId("contacts-detail-screen")).getByText("3 addresses"),
+    ).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-address-list")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-network-group-arbitrum")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-network-group-base")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-network-group-ethereum")).toBeVisible();
+    expect(
+      screen.getByTestId("contacts-detail-address-row-address-me-arbitrum-usdc"),
+    ).toBeVisible();
+    expect(screen.queryByTestId("contacts-detail-empty-state")).not.toBeInTheDocument();
+  });
+
+  it("should render the default Me detail state on load", () => {
+    render(
       <MemoryRouter initialEntries={["/contacts"]}>
         <Routes>
           <Route path="/contacts" element={<ContactsScreen />} />
@@ -394,15 +429,35 @@ describe("Contacts integration", () => {
       },
     );
 
-    await user.click(screen.getByTestId("contacts-me-row"));
-
     expect(screen.getByTestId("contacts-detail-screen")).toBeVisible();
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Me");
+    expect(screen.getByText("Add external address")).toBeVisible();
     expect(screen.getByText("No saved addresses for you")).toBeVisible();
-    expect(
-      screen.getByText("Save your wallet addresses to receive crypto by name next time."),
-    ).toBeVisible();
-    expect(screen.getByTestId("contacts-detail-add-address")).toBeVisible();
+  });
+
+  it("should render the Me empty detail state when Me is selected after another contact", async () => {
+    const { user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState({
+          contacts: {
+            contacts: mockPopulatedContacts(),
+          },
+        }),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ada"));
+    await user.click(screen.getByTestId("contacts-me-row"));
+
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Me");
+    expect(screen.queryByText("No saved addresses for Ada")).not.toBeInTheDocument();
   });
 
   it("should render a saved contact empty detail state when an empty contact is selected", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { ContactId } from "@domain/entity-contact";
 import {
   type AddAddressContact,
+  useContactsMeContact,
   useEmptyContactDetail,
   usePopulatedContactDetail,
   useContactAddressDetailDialog,
@@ -24,8 +25,9 @@ export function useContactDetailPaneAdapter(
   onOpenContact: ContactsListViewProps["onOpenContact"];
 }> {
   const { t } = useTranslation();
+  const meContact = useContactsMeContact();
   const currencyPort = useContactsAddressCurrencyAdapter();
-  const [detailContactId, setDetailContactId] = useState<ContactId | undefined>();
+  const [detailContactId, setDetailContactId] = useState<ContactId | undefined>(meContact.id);
   const emptyContact = useEmptyContactDetail(detailContactId);
   const populatedContactDetail = usePopulatedContactDetail(detailContactId, currencyPort);
   const {
@@ -38,10 +40,12 @@ export function useContactDetailPaneAdapter(
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
+      addExternalAddress: t("contacts.addExternalAddress"),
       emptyMeTitle: t("contacts.detail.emptyState.meTitle"),
       emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
       emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
       emptyContactDescription: () => t("contacts.detail.emptyState.contactDescription"),
+      formatMeDisplayName: name => t("contacts.detail.meDisplayName", { name }),
       formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
@@ -94,7 +98,7 @@ export function useContactDetailPaneAdapter(
   const addressDetailDialog = useMemo<ContactAddressDetailDialogProps>(
     () => ({
       isOpen,
-      contactName: populatedContactDetail?.contact.name ?? "",
+      contactName: populatedContactDetail?.contact.name ?? emptyContact?.name ?? "",
       row: selection?.row,
       network: selection?.network,
       labels: addressDetailDialogLabels,
@@ -102,6 +106,7 @@ export function useContactDetailPaneAdapter(
     }),
     [
       addressDetailDialogLabels,
+      emptyContact?.name,
       isOpen,
       onCloseAddressDetail,
       populatedContactDetail?.contact.name,

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/ContactsDevTool/hooks/__tests__/useContactsDevToolViewModel.test.ts
@@ -168,13 +168,16 @@ describe("useContactsDevToolViewModel", () => {
       result.current.handleLoadPopulatedContacts();
     });
 
-    expect(store.getState().contacts.contacts).toHaveLength(4);
+    expect(store.getState().contacts.contacts).toHaveLength(6);
     expect(store.getState().contacts.contacts.map(contact => contact.name)).toEqual([
       "Me",
       "Ada",
       "Ben",
+      "Charlie",
+      "Diana",
       "Olive",
     ]);
+    expect(store.getState().contacts.contacts[0]?.addresses).toHaveLength(3);
   });
 
   it("should reset contacts to the default Me contact", () => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9293,6 +9293,7 @@
     "title": "Contacts",
     "addContact": "Add contact",
     "addAddress": "Add address",
+    "addExternalAddress": "Add external address",
     "addAddressEntry": {
       "title": "Enter address",
       "addressPlaceholder": "Address or ENS",
@@ -9318,6 +9319,7 @@
       "name": "Me"
     },
     "detail": {
+      "meDisplayName": "{{name}} (Me)",
       "emptyState": {
         "meTitle": "No saved addresses for you",
         "contactTitle": "No saved addresses for {{name}}",

--- a/domain/entity/contact/src/schema.mock.ts
+++ b/domain/entity/contact/src/schema.mock.ts
@@ -21,6 +21,32 @@ export function mockMeContact(overrides?: Partial<ContactInput>): Contact {
   });
 }
 
+export function mockMeContactWithAddresses(overrides?: Partial<ContactInput>): Contact {
+  return mockMeContact({
+    addresses: [
+      mockContactAddress({
+        id: "address-me-arbitrum-usdc",
+        currencyId: "arbitrum/erc20/usd_coin",
+        label: "USDC",
+        address: "0x1234ABCD1234567890123456789012345678901234",
+      }),
+      mockContactAddress({
+        id: "address-me-base-usdt",
+        currencyId: "base/erc20/tether_usd",
+        label: "USDT",
+        address: "0x9F8E7D6C5B4A392817161514131211100908070605",
+      }),
+      mockContactAddress({
+        id: "address-me-ethereum",
+        currencyId: "ethereum",
+        label: "Ethereum",
+        address: "0xdD3F8f1234567890123456789012345678901234",
+      }),
+    ],
+    ...overrides,
+  });
+}
+
 export function mockContact(overrides?: Partial<ContactInput>): Contact {
   return contact({
     id: "contact-ben",
@@ -59,9 +85,11 @@ export function mockEmptyContacts(): Contact[] {
 
 export function mockPopulatedContacts(): Contact[] {
   return [
-    mockMeContact(),
+    mockMeContactWithAddresses(),
     mockContact({ id: "contact-ada", name: "Ada" }),
-    mockContactWithMultipleAddresses(),
+    mockContactWithMultipleAddresses({ id: "contact-ben", name: "Ben" }),
+    mockContactWithAddress({ id: "contact-charlie", name: "Charlie" }),
+    mockContact({ id: "contact-diana", name: "Diana" }),
     mockContact({ id: "contact-olive", name: "Olive" }),
   ];
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -121,7 +121,15 @@ describe("contact mock factories", () => {
 
     const contacts = mockPopulatedContacts();
 
-    expect(contacts.map(contact => contact.name)).toEqual(["Me", "Ada", "Ben", "Olive"]);
+    expect(contacts.map(contact => contact.name)).toEqual([
+      "Me",
+      "Ada",
+      "Ben",
+      "Charlie",
+      "Diana",
+      "Olive",
+    ]);
+    expect(contacts[0]?.addresses).toHaveLength(3);
     expect(contacts[2]?.addresses).toHaveLength(2);
   });
 });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -12,10 +12,12 @@ import { ContactDetailView } from "./ContactDetailView.web";
 
 const labels: ContactDetailLabels = {
   addAddress: "Add address",
+  addExternalAddress: "Add external address",
   emptyMeTitle: "No saved addresses for you",
   emptyContactTitle: name => `No saved addresses for ${name}`,
   emptyMeDescription: "Save your wallet addresses to receive crypto by name next time.",
   emptyContactDescription: () => "Save their wallet addresses to send to them by name next time.",
+  formatMeDisplayName: name => `${name} (Me)`,
   formatAddressCount: count => `${count} address`,
 };
 
@@ -32,10 +34,23 @@ describe("ContactDetailView", () => {
     render(<ContactDetailView {...defaultProps} contact={mockMeContact()} />);
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeInTheDocument();
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Me");
+    expect(screen.getByText("Add external address")).toBeInTheDocument();
     expect(screen.getByText("No saved addresses for you")).toBeInTheDocument();
     expect(
       screen.getByText("Save your wallet addresses to receive crypto by name next time."),
     ).toBeInTheDocument();
+  });
+
+  it("should render a custom Me display name with the Me suffix", () => {
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockMeContact({ name: "Maxime" })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent("Maxime (Me)");
   });
 
   it("should render a saved contact empty state", () => {

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { Plus } from "@ledgerhq/lumen-ui-react/symbols";
+import { resolveMeContactDisplayName } from "../../../utils";
 import type { ContactDetailViewProps } from "../types";
 import { ContactDetailAvatar } from "./ContactDetailAvatar.web";
 
@@ -15,12 +16,22 @@ export function ContactDetailHeader({
   meAvatarSrc,
   onAddAddress,
 }: ContactDetailHeaderProps): React.ReactNode {
+  const displayName = resolveMeContactDisplayName(
+    contact,
+    labels.formatMeDisplayName ?? (name => name),
+  );
+  const addAddressLabel = contact.isMe
+    ? (labels.addExternalAddress ?? labels.addAddress)
+    : labels.addAddress;
+
   return (
     <div className="flex flex-col items-center gap-24 pt-24">
       <div className="flex flex-col items-center gap-16">
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
         <div className="flex flex-col items-center gap-4">
-          <h2 className="heading-3-semi-bold text-base">{contact.name}</h2>
+          <h2 className="heading-3-semi-bold text-base" data-testid="contacts-detail-name">
+            {displayName}
+          </h2>
           <p className="body-2 text-muted">
             {labels.formatAddressCount(contact.addresses.length)}
           </p>
@@ -33,7 +44,7 @@ export function ContactDetailHeader({
         onClick={onAddAddress}
         data-testid="contacts-detail-add-address"
       >
-        {labels.addAddress}
+        {addAddressLabel}
       </Button>
     </div>
   );

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -56,6 +56,7 @@ export type PopulatedContactDetailViewModel = Readonly<{
 
 export type ContactDetailLabels = Readonly<{
   addAddress: string;
+  addExternalAddress?: string;
   addYourAddress?: string;
   emptyMeTitle: string;
   emptyContactTitle: (name: string) => string;
@@ -63,6 +64,7 @@ export type ContactDetailLabels = Readonly<{
   emptyContactDescription: (name: string) => string;
   ledgerWalletAddresses?: string;
   myAddresses?: string;
+  formatMeDisplayName?: (name: string) => string;
   formatAddressCount: (count: number) => string;
 }>;
 

--- a/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
+++ b/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
@@ -133,11 +133,16 @@ describe("ContactsPage", () => {
 
     expect(screen.getByTestId("contacts-section-A")).toBeVisible();
     expect(screen.getByTestId("contacts-section-B")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-C")).toBeVisible();
+    expect(screen.getByTestId("contacts-section-D")).toBeVisible();
     expect(screen.getByTestId("contacts-section-O")).toBeVisible();
     expect(contactsList).toHaveTextContent("Ada");
     expect(contactsList).toHaveTextContent("0 address");
     expect(contactsList).toHaveTextContent("Ben");
     expect(contactsList).toHaveTextContent("2 address");
+    expect(contactsList).toHaveTextContent("Charlie");
+    expect(contactsList).toHaveTextContent("1 address");
+    expect(contactsList).toHaveTextContent("Diana");
     expect(contactsList).toHaveTextContent("Olive");
     expect(screen.getByTestId("contacts-saved-avatar-contact-ada")).toHaveTextContent("A");
     expect(contactsList).toHaveTextContent("Add contact");

--- a/features/flow/contacts/src/utils/constants.ts
+++ b/features/flow/contacts/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ME_CONTACT_NAME = "Me";

--- a/features/flow/contacts/src/utils/index.ts
+++ b/features/flow/contacts/src/utils/index.ts
@@ -1,1 +1,3 @@
+export { DEFAULT_ME_CONTACT_NAME } from "./constants";
 export { getContactInitial } from "./getContactInitial";
+export { resolveMeContactDisplayName } from "./resolveMeContactDisplayName";

--- a/features/flow/contacts/src/utils/resolveMeContactDisplayName.ts
+++ b/features/flow/contacts/src/utils/resolveMeContactDisplayName.ts
@@ -1,0 +1,17 @@
+import type { Contact } from "@domain/entity-contact";
+import { DEFAULT_ME_CONTACT_NAME } from "./constants";
+
+export function resolveMeContactDisplayName(
+  contact: Contact,
+  formatWithMeSuffix: (name: string) => string,
+): string {
+  if (!contact.isMe) {
+    return contact.name;
+  }
+
+  if (contact.name === DEFAULT_ME_CONTACT_NAME) {
+    return DEFAULT_ME_CONTACT_NAME;
+  }
+
+  return formatWithMeSuffix(contact.name);
+}

--- a/features/flow/contacts/src/utils/resolveMeContactDisplayName.web.test.ts
+++ b/features/flow/contacts/src/utils/resolveMeContactDisplayName.web.test.ts
@@ -1,0 +1,22 @@
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { resolveMeContactDisplayName } from "./resolveMeContactDisplayName";
+
+const formatWithMeSuffix = (name: string) => `${name} (Me)`;
+
+describe("resolveMeContactDisplayName", () => {
+  it("should return the contact name for saved contacts", () => {
+    expect(
+      resolveMeContactDisplayName(mockContact({ name: "Ada" }), formatWithMeSuffix),
+    ).toBe("Ada");
+  });
+
+  it("should return Me when the self contact still uses the default name", () => {
+    expect(resolveMeContactDisplayName(mockMeContact(), formatWithMeSuffix)).toBe("Me");
+  });
+
+  it("should append the Me suffix when the self contact has a custom name", () => {
+    expect(
+      resolveMeContactDisplayName(mockMeContact({ name: "Maxime" }), formatWithMeSuffix),
+    ).toBe("Maxime (Me)");
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->


Wire Desktop Contacts to show Me as the default detail pane with
external-address CTAs, rename support, Ledger Wallet accounts entry,
and shared Me display-name formatting from @features/flow-contacts.

- Render **Me** as the default Desktop contact detail on load, consuming shared `@features/flow-contacts` state and Desktop adapters
- Add Me-specific detail UI: **Add external address** CTA, **Ledger Wallet accounts** row, and `<name> (Me)` display when renamed
- Allow renaming Me via a shared rename dialog; hide delete for Me while keeping delete for saved contacts
- Redirect **Ledger Wallet accounts** to the existing Desktop accounts area (`/accounts` or `/cryptos` depending on feature flag)
- Render external addresses saved on Me with the same populated detail behavior as other contacts; address count reflects external addresses only

## Shared (`@features/flow-contacts`)

- `resolveMeContactDisplayName` utility for default `Me` vs custom `<name> (Me)`
- Web detail updates: header actions, `LedgerWalletAccountsCard`, rename/delete dialogs
- New `EditContact` step for rename flow (reuses contact name validation)

## Desktop

- `useContactDetailPaneAdapter`: default Me selection, labels, accounts navigation
- `useRenameContactDialogAdapter` / `useDeleteContactDialogAdapter`: Redux-backed edit/delete wiring
- i18n keys for external address CTA, Me suffix, Ledger Wallet accounts, rename/delete copy


https://github.com/user-attachments/assets/e1ac598c-2a1a-4441-9f5b-20b990032c2f




### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

[LIVE-33997](https://ledgerhq.atlassian.net/browse/LIVE-33997)

[LIVE-33997]: https://ledgerhq.atlassian.net/browse/LIVE-33997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ