### PR TITLE
[LWD] fix(lwd): clear notification dot on center open (LIVE-32093)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/LogContentCardWrapper.tsx
@@ -67,8 +67,8 @@ const LogContentCardWrapper: React.FC<LogContentCardWrapperProps> = ({
             const cardId = currentCard.id;
             if (!cardId) return;
 
-            const expiresAt = currentCard.expiresAt?.getTime();
-            if (expiresAt !== undefined && anonymousUserNotifications[cardId] !== expiresAt) {
+            const expiresAt = currentCard.expiresAt?.getTime() ?? Date.now();
+            if (anonymousUserNotifications[cardId] !== expiresAt) {
               notificationTimerRef.current = setTimeout(() => {
                 dispatch(
                   updateAnonymousUserNotifications({

--- a/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/TopBar/NotificationIndicator/AnnouncementPanel.tsx
@@ -13,6 +13,7 @@ import Text from "~/renderer/components/Text";
 import { useDeepLinkHandler } from "~/renderer/hooks/useDeeplinking/useDeepLinkHandler";
 import { closeInformationCenter } from "~/renderer/actions/UI";
 import { useNotifications } from "~/renderer/hooks/useNotifications";
+import { useMarkNotificationsAsReadOnOpen } from "~/renderer/hooks/useMarkNotificationsAsReadOnOpen";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { urls } from "~/config/urls";
 import { useDateFormatted } from "~/renderer/hooks/useDateFormatter";
@@ -248,6 +249,7 @@ const Separator = styled.div`
 
 export function AnnouncementPanel() {
   const { notificationsCards, groupNotifications, onClickNotif } = useNotifications();
+  useMarkNotificationsAsReadOnOpen();
   const groups = useMemo(
     () => groupNotifications(notificationsCards),
     // oxlint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useMarkNotificationsAsReadOnOpen.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useMarkNotificationsAsReadOnOpen.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from "tests/testSetup";
+import { setNotificationsCards } from "~/renderer/actions/dynamicContent";
+import { LocationContentCard, type NotificationContentCard } from "~/types/dynamicContent";
+import { useMarkNotificationsAsReadOnOpen } from "../useMarkNotificationsAsReadOnOpen";
+
+jest.mock("LLD/features/LNSUpsell", () => ({
+  useLNSUpsellBannerState: jest.fn(() => ({ isShown: false })),
+}));
+
+const mockUseLNSUpsellBannerState = jest.requireMock("LLD/features/LNSUpsell")
+  .useLNSUpsellBannerState as jest.Mock;
+
+const NOTIF: NotificationContentCard = {
+  id: "notif-1",
+  title: "Update available",
+  description: "Please update",
+  cta: "Learn more",
+  viewed: false,
+  created: new Date("2026-01-01"),
+  location: LocationContentCard.NotificationCenter,
+};
+
+describe("useMarkNotificationsAsReadOnOpen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLNSUpsellBannerState.mockReturnValue({ isShown: false });
+  });
+
+  it("should mark notification cards as viewed in Redux on mount", () => {
+    const { store } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [NOTIF] },
+        settings: { shareAnalytics: true, sharePersonalizedRecommandations: false },
+      },
+    });
+
+    expect(store.getState().dynamicContent.notificationsCards[0]?.viewed).toBe(true);
+  });
+
+  it("should persist anonymous read state when tracking is disabled", () => {
+    const { store } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [NOTIF] },
+        settings: {
+          shareAnalytics: false,
+          sharePersonalizedRecommandations: false,
+          anonymousUserNotifications: {},
+        },
+      },
+    });
+
+    expect(store.getState().settings.anonymousUserNotifications[NOTIF.id]).toEqual(
+      expect.any(Number),
+    );
+  });
+
+  it("should mark LNS upsell notification as read when shown in notification center", () => {
+    mockUseLNSUpsellBannerState.mockReturnValue({ isShown: true });
+
+    const { store } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [NOTIF] },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: false,
+          anonymousUserNotifications: {},
+        },
+      },
+    });
+
+    expect(store.getState().settings.anonymousUserNotifications.LNSUpsell).toEqual(
+      expect.any(Number),
+    );
+  });
+
+  it("should do nothing when there are no notification cards", () => {
+    const { store } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [] },
+        settings: { shareAnalytics: true, sharePersonalizedRecommandations: false },
+      },
+    });
+
+    expect(store.getState().dynamicContent.notificationsCards).toEqual([]);
+  });
+
+  it("should mark cards as read when they arrive after mount", () => {
+    const { store, rerender } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [] },
+        settings: { shareAnalytics: true, sharePersonalizedRecommandations: false },
+      },
+    });
+
+    expect(store.getState().dynamicContent.notificationsCards).toEqual([]);
+
+    act(() => {
+      store.dispatch(setNotificationsCards([NOTIF]));
+    });
+    rerender();
+
+    expect(store.getState().dynamicContent.notificationsCards[0]?.viewed).toBe(true);
+  });
+
+  it("should not re-dispatch when all cards are already viewed", () => {
+    const viewedNotif = { ...NOTIF, viewed: true };
+    const { store, rerender } = renderHook(() => useMarkNotificationsAsReadOnOpen(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [viewedNotif] },
+        settings: { shareAnalytics: true, sharePersonalizedRecommandations: false },
+      },
+    });
+
+    rerender();
+
+    expect(store.getState().dynamicContent.notificationsCards[0]?.viewed).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useUnseenNotificationsCount.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useUnseenNotificationsCount.test.ts
@@ -1,0 +1,57 @@
+import { renderHook } from "tests/testSetup";
+import { LocationContentCard, type NotificationContentCard } from "~/types/dynamicContent";
+import { useUnseenNotificationsCount } from "../useUnseenNotificationsCount";
+
+jest.mock("LLD/features/LNSUpsell", () => ({
+  useLNSUpsellBannerState: jest.fn(() => ({ isShown: false })),
+}));
+
+const mockUseLNSUpsellBannerState = jest.requireMock("LLD/features/LNSUpsell")
+  .useLNSUpsellBannerState as jest.Mock;
+
+const unreadNotif: NotificationContentCard = {
+  id: "notif-1",
+  title: "Title",
+  description: "Description",
+  cta: "CTA",
+  viewed: false,
+  created: new Date("2026-01-01"),
+  location: LocationContentCard.NotificationCenter,
+};
+
+const readNotif: NotificationContentCard = { ...unreadNotif, id: "notif-2", viewed: true };
+
+describe("useUnseenNotificationsCount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLNSUpsellBannerState.mockReturnValue({ isShown: false });
+  });
+
+  it("should count unviewed notification cards", () => {
+    const { result } = renderHook(() => useUnseenNotificationsCount(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [unreadNotif, readNotif] },
+        settings: { shareAnalytics: true, sharePersonalizedRecommandations: false },
+      },
+    });
+
+    expect(result.current).toBe(1);
+  });
+
+  it("should include LNS upsell banner when shown and not yet read", () => {
+    mockUseLNSUpsellBannerState.mockReturnValue({ isShown: true });
+
+    const { result } = renderHook(() => useUnseenNotificationsCount(), {
+      initialState: {
+        dynamicContent: { notificationsCards: [] },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: false,
+          anonymousUserNotifications: {},
+        },
+      },
+    });
+
+    expect(result.current).toBe(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useMarkNotificationsAsReadOnOpen.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useMarkNotificationsAsReadOnOpen.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { useLNSUpsellBannerState } from "LLD/features/LNSUpsell";
+import { setNotificationsCards } from "~/renderer/actions/dynamicContent";
+import { updateAnonymousUserNotifications } from "~/renderer/actions/settings";
+import { notificationsContentCardSelector } from "~/renderer/reducers/dynamicContent";
+import {
+  anonymousUserNotificationsSelector,
+  trackingEnabledSelector,
+} from "~/renderer/reducers/settings";
+
+/** Marks notification center cards read on open — mirrors mobile NotificationCenter mount behavior. */
+export function useMarkNotificationsAsReadOnOpen() {
+  const dispatch = useDispatch();
+  const notificationsCards = useSelector(notificationsContentCardSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
+  const anonymousUserNotifications = useSelector(anonymousUserNotificationsSelector);
+  const isLNSNotifShown = useLNSUpsellBannerState("notification_center").isShown;
+
+  useEffect(() => {
+    const unviewedCards = notificationsCards?.filter(n => !n.viewed) ?? [];
+    const hasUnreadLnsUpsell = isLNSNotifShown && !anonymousUserNotifications.LNSUpsell;
+
+    if (unviewedCards.length === 0 && !hasUnreadLnsUpsell) {
+      return;
+    }
+
+    if (unviewedCards.length > 0) {
+      dispatch(
+        setNotificationsCards(
+          notificationsCards!.map(n => (n.viewed ? n : { ...n, viewed: true })),
+        ),
+      );
+
+      if (!isTrackedUser) {
+        const unreadAnonymousNotifications = Object.fromEntries(
+          unviewedCards
+            .filter(n => anonymousUserNotifications[n.id] === undefined)
+            .map(n => [n.id, Date.now()] as const),
+        );
+        if (Object.keys(unreadAnonymousNotifications).length > 0) {
+          dispatch(
+            updateAnonymousUserNotifications({ notifications: unreadAnonymousNotifications }),
+          );
+        }
+      }
+    }
+
+    if (hasUnreadLnsUpsell) {
+      dispatch(updateAnonymousUserNotifications({ notifications: { LNSUpsell: Date.now() } }));
+    }
+  }, [notificationsCards, isTrackedUser, anonymousUserNotifications, isLNSNotifShown, dispatch]);
+}


### PR DESCRIPTION
## Summary

Fixes [LIVE-32093](https://ledgerhq.atlassian.net/browse/LIVE-32093): the desktop notification red dot (My Wallet avatar / bell badge) never clears after the user opens the Information Center.

On mobile, opening the notification center marks all cards as read on mount. Desktop previously relied on Braze SDK callbacks, `IntersectionObserver` visibility, and an anonymous-user path that required `expiresAt` — so the badge could stay visible even after the user had seen their notifications.

- Add `useMarkNotificationsAsReadOnOpen` to mark notification cards as read when the announcement panel opens (Redux `viewed: true`, plus anonymous read-state persistence and LNS upsell badge clearing)
- Wire the hook into `AnnouncementPanel`
- Fix `LogContentCardWrapper` so anonymous users without `expiresAt` fall back to `Date.now()` when persisting read state
- Add unit tests for the new hook and `useUnseenNotificationsCount`

## Test plan

- [ ] Open Ledger Wallet Desktop with at least one unread Braze notification (red dot visible on avatar/bell)
- [ ] Open Information Center → Announcements tab
- [ ] Confirm red dot disappears immediately after opening (without clicking individual notifications)
- [ ] Close and reopen Information Center — dot should stay cleared
- [ ] Repeat with analytics/tracking **disabled** (anonymous user path) — dot should still clear
- [ ] If LNS upsell banner is shown in notification center, confirm it no longer contributes to unseen count after open
- [x] Unit tests pass:
  ```bash
  pnpm desktop test:jest "useMarkNotificationsAsReadOnOpen|useUnseenNotificationsCount"
  ```

[LIVE-32093]: https://ledgerhq.atlassian.net/browse/LIVE-32093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ