### PR TITLE
test(aleo): e2e public transfer

### DIFF
--- a/.changeset/weak-spoons-fold.md
+++ b/.changeset/weak-spoons-fold.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-e2e-shared": minor
+"ledger-live-desktop-e2e-tests": minor
+---
+
+test(aleo): e2e public transfer

--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -10,6 +10,7 @@ import {
   liveDataWithRecipientAddressCommand,
   liveDataCommand,
 } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import { shareViewKeyCommand } from "@ledgerhq/live-e2e-shared/families/aleo";
 import { Addresses } from "@ledgerhq/live-e2e-shared/enum/Addresses";
 import { FF_NEW_SEND_FLOW_DISABLED } from "tests/utils/featureFlagUtils";
 import { buildTags, shouldSkipLNSTag } from "tests/utils/tagsUtils";
@@ -252,6 +253,11 @@ const transactionE2E = [
     transaction: new Transaction(Account.ICP_1, Account.ICP_2, "0.001"),
     xrayTicket: "B2CQA-4742",
   },
+  {
+    transaction: new Transaction(Account.ALEO_1, Account.ALEO_2, "0.000001"),
+    xrayTicket: "B2CQA-4731",
+    extraCliCommands: [shareViewKeyCommand(Account.ALEO_1)],
+  },
 ];
 
 test.describe("Send flows", () => {
@@ -261,7 +267,10 @@ test.describe("Send flows", () => {
         teamOwner: Team.COIN_INTEGRATION,
         userdata: "skip-onboarding-with-last-seen-device",
         speculosApp: transaction.transaction.accountToDebit.currency.speculosApp,
-        cliCommands: [liveDataWithRecipientAddressCommand(transaction.transaction)],
+        cliCommands: [
+          liveDataWithRecipientAddressCommand(transaction.transaction),
+          ...(transaction.extraCliCommands ?? []),
+        ],
         env: transaction.disableBroadcast ? { DISABLE_TRANSACTION_BROADCAST: "1" } : {},
         featureFlags: {
           ...FF_NEW_SEND_FLOW_DISABLED,

--- a/e2e/desktop/tests/utils/tagsUtils.ts
+++ b/e2e/desktop/tests/utils/tagsUtils.ts
@@ -3,7 +3,12 @@ import { getFamilyByCurrencyId } from "@ledgerhq/live-common/currencies/helpers"
 
 export const DEVICE_TAGS = ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5"] as const;
 
-const LNS_UNSUPPORTED_CURRENCIES = new Set([Currency.SUI.id, Currency.VET.id, Currency.HBAR.id]);
+const LNS_UNSUPPORTED_CURRENCIES = new Set([
+  Currency.SUI.id,
+  Currency.VET.id,
+  Currency.HBAR.id,
+  Currency.ALEO.id,
+]);
 
 export function shouldSkipLNSTag(currencyId: string): boolean {
   return LNS_UNSUPPORTED_CURRENCIES.has(currencyId);

--- a/libs/live-e2e-shared/package.json
+++ b/libs/live-e2e-shared/package.json
@@ -23,6 +23,7 @@
     "@ledgerhq/ledger-wallet-framework": "workspace:^",
     "@ledgerhq/live-common": "workspace:^",
     "@ledgerhq/live-dmk-speculos": "workspace:^",
+    "@ledgerhq/live-signer-aleo": "workspace:^",
     "@ledgerhq/live-signer-evm": "workspace:^",
     "@ledgerhq/logs": "workspace:^",
     "@ledgerhq/speculos-device-controller": "catalog:",

--- a/libs/live-e2e-shared/src/data/deviceLabelsData.ts
+++ b/libs/live-e2e-shared/src/data/deviceLabelsData.ts
@@ -193,6 +193,7 @@ export const DEVICE_LABELS_CONFIG: DeviceLabelsConfig = {
       [AppInfos.BITCOIN_CASH.name]: DeviceLabels.ACCEPT,
       [AppInfos.CONCORDIUM.name]: DeviceLabels.SIGN_TRANSACTION,
       [AppInfos.CONCORDIUM_TESTNET.name]: DeviceLabels.SIGN_TRANSACTION,
+      [AppInfos.ALEO.name]: DeviceLabels.SIGN_TRANSACTION,
       default: DeviceLabels.CAPS_APPROVE,
     },
   },

--- a/libs/live-e2e-shared/src/enum/Account.ts
+++ b/libs/live-e2e-shared/src/enum/Account.ts
@@ -18,6 +18,25 @@ export class Account {
   static readonly ADA_1 = new Account(Currency.ADA, "Cardano 1", 0, "1852'/1815'/0'/0/3");
   static readonly ADA_2 = new Account(Currency.ADA, "Cardano 2", 1, "1852'/1815'/1'/0/2");
 
+  static readonly ALEO_1 = new Account(
+    Currency.ALEO,
+    "Aleo 1",
+    0,
+    "44'/683'/0'/0'",
+    undefined,
+    undefined,
+    "aleo",
+  );
+  static readonly ALEO_2 = new Account(
+    Currency.ALEO,
+    "Aleo 2",
+    1,
+    "44'/683'/1'/0'",
+    undefined,
+    undefined,
+    "aleo",
+  );
+
   static readonly ALGO_1 = new Account(Currency.ALGO, "Algorand 1", 0, "44'/283'/0'/0/0");
   static readonly ALGO_2 = new Account(Currency.ALGO, "Algorand 2", 1, "44'/283'/1'/0/0");
   // Algorand account without ASA (tokens) for specific scenarios

--- a/libs/live-e2e-shared/src/families/aleo.ts
+++ b/libs/live-e2e-shared/src/families/aleo.ts
@@ -1,0 +1,74 @@
+import fs from "fs";
+import invariant from "invariant";
+import {
+  encodeAccountId,
+  decodeAccountId,
+} from "@ledgerhq/ledger-wallet-framework/account/accountId";
+import { DeviceManagementKitTransportSpeculos } from "@ledgerhq/live-dmk-speculos";
+import { DmkSignerAleo } from "@ledgerhq/live-signer-aleo";
+import { getEnv } from "@shared/env";
+import type { AccountRaw } from "@ledgerhq/types-live";
+import { getSendEvents, shareViewKey } from "../speculos";
+import { isTouchDevice } from "../speculosAppVersion";
+import { DeviceLabels } from "../enum/DeviceLabels";
+import { longPressAndRelease } from "../deviceInteraction/TouchDeviceSimulator";
+import { Transaction } from "../models/Transaction";
+import { Account } from "../enum/Account";
+import { withDeviceController } from "../deviceInteraction/DeviceController";
+
+export const sendAleo = withDeviceController(
+  ({ getButtonsController }) =>
+    async (tx: Transaction) => {
+      const buttons = getButtonsController();
+
+      await getSendEvents(tx);
+      if (isTouchDevice()) {
+        await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
+      } else {
+        await buttons.both();
+      }
+    },
+);
+
+async function fetchViewKey(path: string): Promise<string> {
+  const transport = await DeviceManagementKitTransportSpeculos.open({
+    apiPort: String(getEnv("SPECULOS_API_PORT")),
+  });
+
+  try {
+    const signer = new DmkSignerAleo(transport.dmk, transport.sessionId);
+    const [{ viewKey }] = await Promise.all([signer.getViewKey(path), shareViewKey()]);
+    return viewKey;
+  } finally {
+    // transport.close() keeps the session in the static `byBase` cache; a same-port relaunch would reuse it.
+    await DeviceManagementKitTransportSpeculos.disconnectAll();
+  }
+}
+
+/**
+ * Aleo accounts need a view key in the account id (`customData`) — `extractViewKey` throws
+ * without it, on sync as well as signing. `liveData` cannot produce it; in the app it comes
+ * from a device confirmation, so this reads it from Speculos and re-encodes the seeded id.
+ */
+export const shareViewKeyCommand = (account: Account) => async (userdataPath?: string) => {
+  invariant(userdataPath, "aleo: shareViewKeyCommand requires a userdataPath");
+
+  const viewKey = await fetchViewKey(account.accountPath);
+
+  const raw = fs.readFileSync(userdataPath, "utf-8");
+  const accounts = JSON.parse(raw).data?.accounts;
+  invariant(Array.isArray(accounts), "aleo: no decrypted accounts array in %s", userdataPath);
+  const entry = accounts.find((e: { data: AccountRaw }) => {
+    return (
+      e.data.currencyId === account.currency.id && e.data.freshAddressPath === account.accountPath
+    );
+  });
+  invariant(
+    entry,
+    `aleo: no ${account.currency.id} account at ${account.accountPath} in ${userdataPath}`,
+  );
+
+  // operation and sub-account ids embed the account id, so replace it as text everywhere
+  const newId = encodeAccountId({ ...decodeAccountId(entry.data.id), customData: viewKey });
+  fs.writeFileSync(userdataPath, raw.replaceAll(entry.data.id, newId), "utf-8");
+};

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -62,6 +62,7 @@ import { getDeviceCoordinates } from "./deviceCoordinates";
 import { sendInternetComputer } from "./families/internet_computer";
 import { sleep } from "./index";
 import { delegateMina } from "./families/mina";
+import { sendAleo } from "./families/aleo";
 
 const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
 const SCREEN_POLL_INTERVAL_MS = 500;
@@ -966,6 +967,9 @@ export async function signSendTransaction(tx: Transaction) {
       break;
     case Currency.CCD_TESTNET.id:
       await sendConcordium(tx);
+      break;
+    case Currency.ALEO.id:
+      await sendAleo(tx);
       break;
     default:
       throw new Error(`Unsupported currency: ${tx.accountToDebit.currency.ticker}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11961,6 +11961,9 @@ importers:
       '@ledgerhq/live-dmk-speculos':
         specifier: workspace:^
         version: link:../live-dmk-speculos
+      '@ledgerhq/live-signer-aleo':
+        specifier: workspace:^
+        version: link:../live-signer-aleo
       '@ledgerhq/live-signer-evm':
         specifier: workspace:^
         version: link:../live-signer-evm


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR adds an E2E test for Aleo public transfers in the desktop send flow. Since Aleo accounts require a view key embedded in their account id before signing or syncing can work, and that key normally only becomes available via a device confirmation, this adds a CLI step (`shareViewKeyCommand`) that fetches the view key from Speculos and re-encodes it into the seeded test account's id before the transaction runs.

It also wires up the Aleo device-confirmation flow (sendAleo) in speculos.ts, adds two seeded Aleo test accounts, and marks Aleo as an LNS-unsupported currency for tagging purposes.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-27411

### 📝 Allure reports

- [nanoSP](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/e5a3db80-4929-410a-acdf-bd24b7a79f1e/)
- [nanoX](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/56d131dd-e16a-4ec1-9e6e-04cc38b5391e/)
- [stax](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/5ed1dfb9-67ef-48d1-b85d-19f743eb9ebd/)
- [flex](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/d2350aea-20aa-4360-8274-0eeed49094fb/)
- [nanoGen5](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/577ef6c6-3525-4195-bb8b-8d11f1826d7d/)
