### PR TITLE
[LWDM] fix(coin-modules): add coverageProvider babel to coin-canton and coin-concordium

### DIFF
--- a/libs/coin-modules/coin-canton/jest.config.js
+++ b/libs/coin-modules/coin-canton/jest.config.js
@@ -23,6 +23,7 @@ module.exports = {
   coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
   testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integ\\.test\\.[tj]s"],
   workerThreads: true,
+  coverageProvider: "babel",
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),

--- a/libs/coin-modules/coin-concordium/jest.config.js
+++ b/libs/coin-modules/coin-concordium/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
   testPathIgnorePatterns: ["lib/", "lib-es/", ".*\\.integ\\.test\\.[tj]s"],
   transformIgnorePatterns: ["node_modules/(?!(@walletconnect)/)"],
   workerThreads: true,
+  coverageProvider: "babel",
   reporters: [
     "default",
     ...(process.env.CI ? ["github-actions"] : []),


### PR DESCRIPTION
`workerThreads: true` causes `generateEmptyCoverage` in jest 30 to produce V8-format coverage output instead of Istanbul format, crashing `addFileCoverage` with "Invalid file coverage object, missing keys, found:data". Adding explicit `coverageProvider: "babel"` fixes this.