### PR TITLE
[LWDM] chore(auth): change Keycloak staging URL to Gravitee

### DIFF
--- a/.changeset/green-gates-route.md
+++ b/.changeset/green-gates-route.md
@@ -1,0 +1,5 @@
+---
+"@shared/env": patch
+---
+
+Update the staging Keycloak base URL to use the Gravitee gateway

--- a/docs/services.md
+++ b/docs/services.md
@@ -116,7 +116,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | NFT metadata | `nft.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Wallet icons / avatars CDN | `lw-icons.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Sanctioned addresses (compliance) | `compliance.ledger.com` | [env](/libs/env/src/env.ts) | prod |
-| Ledger API authentication (Keycloak) | `global.api.prd.ledger.com`<br>path: `/keycloak`; staging: `keycloak.api.live.aws.stg.ldg-tech.com` | [env](/shared/env/src/definitions/team-platform/index.ts) | prod / staging |
+| Ledger API authentication (Keycloak) | `global.api.prd.ledger.com`<br>path: `/keycloak`; staging: `global.api.stg.ledger-test.com` | [env](/shared/env/src/definitions/team-platform/index.ts) | prod / staging |
 | Ledger Button tracking | `ledgerb.api.ledger.com` | [code](/libs/ledger-live-common/src/wallet-api/utils/ledgerButtonTracking.ts) | prod |
 | **Live Devices** | | | |
 | Manager API | `manager.api.live.ledger.com` | [env](/libs/env/src/env.ts) | prod |

--- a/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
+++ b/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
@@ -14,7 +14,7 @@ import { readMemberCredentials } from "./utils/readMemberCredentials";
  *   - LEDGER_AUTH_CLIENT_ID
  */
 const KEYCLOAK_BASE_URL =
-  process.env.LEDGER_AUTH_KEYCLOAK_BASE_URL ?? "https://keycloak.api.live.aws.stg.ldg-tech.com";
+  process.env.LEDGER_AUTH_KEYCLOAK_BASE_URL ?? "https://global.api.stg.ledger-test.com/keycloak";
 const KEYCLOAK_REALM = process.env.LEDGER_AUTH_KEYCLOAK_REALM ?? "ledger-bc-customers";
 const CLIENT_ID = process.env.LEDGER_AUTH_CLIENT_ID ?? "ledger-keycloak";
 

--- a/shared/env/src/definitions/team-platform/index.ts
+++ b/shared/env/src/definitions/team-platform/index.ts
@@ -98,7 +98,7 @@ const teamPlatform = {
     desc: "Trustchain API Prod",
   },
   LEDGER_AUTH_KEYCLOAK_BASE_URL_STAGING: {
-    def: "https://keycloak.api.live.aws.stg.ldg-tech.com",
+    def: "https://global.api.stg.ledger-test.com/keycloak",
     parser: stringParser,
     desc: "Keycloak base URL for Ledger authenticated APIs (staging)",
   },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Use the staging Gravitee base URL

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
