### PR TITLE
[LWDM] feat(contacts): render desktop address label (LIVE-33919)

### DIFF
--- a/.changeset/calm-ravens-smile.md
+++ b/.changeset/calm-ravens-smile.md
@@ -1,0 +1,6 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+---
+
+Add address label validation and flow

--- a/.changeset/live-33919-desktop-address-label.md
+++ b/.changeset/live-33919-desktop-address-label.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Render the Desktop Contacts address label step

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -39,6 +39,15 @@ jest.mock("~/renderer/store", () => ({
   resetStore: jest.fn(),
 }));
 
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  ...jest.requireActual<typeof import("@ledgerhq/live-common/bridge/index")>(
+    "@ledgerhq/live-common/bridge/index",
+  ),
+  getAccountBridgeByFamily: jest.fn().mockResolvedValue({
+    validateAddress: jest.fn().mockResolvedValue(true),
+  }),
+}));
+
 const contextMenuValue = {
   close: mockClose,
   view: CONTEXT_MENU_VIEW.myWallet,
@@ -541,6 +550,68 @@ describe("Contacts integration", () => {
     expect(confirmationButton).toBeDisabled();
     expect(confirmationButton.querySelector("svg")).not.toBeNull();
     expect(dialog.querySelector('[data-slot="dialog-body"]')).toHaveClass("!mb-0");
+  });
+
+  it("should render the address and its prefilled name together before review", async () => {
+    const { store, user } = render(
+      <MemoryRouter initialEntries={["/contacts"]}>
+        <Routes>
+          <Route path="/contacts" element={<ContactsScreen />} />
+        </Routes>
+      </MemoryRouter>,
+      {
+        skipRouter: true,
+        initialState: contactsPageInitialState(),
+      },
+    );
+
+    await user.click(screen.getByTestId("contacts-me-row"));
+    await user.click(screen.getByTestId("contacts-detail-add-address"));
+
+    const dialog = screen.getByRole("dialog");
+    act(() => {
+      store
+        .getState()
+        .modularDialog.dialogParams?.onAssetSelected?.(getCryptoCurrencyById("ethereum"));
+    });
+
+    const addressInput = await screen.findByTestId("contacts-add-address-input");
+    const addressNameInput = screen.getByTestId("contacts-add-address-name-input");
+    expect(screen.getByRole("dialog")).toBe(dialog);
+    expect(addressNameInput).toHaveValue("Ethereum");
+    expect(addressNameInput).toHaveAttribute("maxlength", "32");
+    expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
+
+    fireEvent.change(addressInput, {
+      target: { value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034" },
+    });
+
+    const confirmationButton = screen.getByTestId("contacts-add-address-confirm");
+    await waitFor(() => expect(confirmationButton).toBeEnabled());
+
+    await user.clear(addressNameInput);
+    await user.type(addressNameInput, "Ethereum 💎");
+
+    expect(screen.getByText("Special characters are not allowed.")).toBeVisible();
+    expect(confirmationButton).toBeDisabled();
+
+    await user.clear(addressNameInput);
+    await user.type(addressNameInput, "Exchange");
+    await user.click(confirmationButton);
+
+    expect(screen.getByRole("dialog")).toBe(dialog);
+    expect(screen.getByTestId("contacts-add-address-review")).toBeVisible();
+
+    await user.click(
+      screen.getByRole("button", { name: "components.dialogHeader.goBackAriaLabel" }),
+    );
+    expect(screen.getByTestId("contacts-add-address-input")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Exchange");
+
+    await user.click(screen.getByTestId("contacts-add-address-confirm"));
+    await user.click(screen.getByTestId("contacts-add-address-review-continue"));
+
+    expect(screen.getByTestId("contacts-add-address-success")).toBeVisible();
   });
 
   it("should expose the Add Address session started for Me", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -3,12 +3,31 @@ import { DialogFlow, type DialogFlowScreenRegistry } from "LLD/components/Dialog
 import { ModularDialogFlow } from "LLD/features/ModularDialog/ModularDialogFlow";
 import {
   ContactsAddAddressEntry,
+  ContactsAddAddressCompletion,
+  ContactsAddAddressName,
   type AddAddressFlowState,
   type ContactsAddAddressEntryLabels,
+  type ContactsAddAddressNameLabels,
 } from "@features/flow-contacts";
-import type { ContactsAddAddressFlowDialogProps } from "./types";
+import type { ContactsAddAddressFlowDialogProps, ContactsAddAddressReviewLabels } from "./types";
 
-type ContactsAddAddressDialogStep = "currency" | "address";
+type ContactsAddAddressDialogStep = "currency" | "address" | "name" | "review" | "success";
+
+function resolveCurrentStep(state: AddAddressFlowState): ContactsAddAddressDialogStep {
+  switch (state.status) {
+    case "enteringAddress":
+      return "address";
+    case "namingAddress":
+      return "name";
+    case "reviewingAddress":
+      return "review";
+    case "success":
+      return "success";
+    case "selectingCurrency":
+    case "closed":
+      return "currency";
+  }
+}
 
 function isEnteringAddress(
   state: AddAddressFlowState,
@@ -19,21 +38,75 @@ function isEnteringAddress(
 function createAddressContent(
   state: Extract<AddAddressFlowState, { status: "enteringAddress" }>,
   labels: ContactsAddAddressEntryLabels,
+  nameLabels: ContactsAddAddressNameLabels,
   onAddressChange: ContactsAddAddressFlowDialogProps["onAddressChange"],
+  onAddressLabelChange: ContactsAddAddressFlowDialogProps["onAddressLabelChange"],
+  onContinueFromAddressDetails: ContactsAddAddressFlowDialogProps["onContinueFromAddressDetails"],
 ): React.JSX.Element {
   return (
     <ContactsAddAddressEntry
       addressEntry={state.addressEntry}
+      addressLabel={state.addressLabel}
       labels={labels}
+      nameLabels={nameLabels}
       onAddressChange={onAddressChange}
+      onAddressLabelChange={onAddressLabelChange}
+      onConfirm={onContinueFromAddressDetails}
+    />
+  );
+}
+
+function isNamingAddress(
+  state: AddAddressFlowState,
+): state is Extract<AddAddressFlowState, { status: "namingAddress" }> {
+  return state.status === "namingAddress";
+}
+
+function createNameContent(
+  state: Extract<AddAddressFlowState, { status: "namingAddress" }>,
+  labels: ContactsAddAddressNameLabels,
+  onAddressLabelChange: ContactsAddAddressFlowDialogProps["onAddressLabelChange"],
+  onContinueFromName: ContactsAddAddressFlowDialogProps["onContinueFromName"],
+): React.JSX.Element {
+  return (
+    <ContactsAddAddressName
+      addressEntry={state.addressEntry}
+      addressLabel={state.addressLabel}
+      labels={labels}
+      onAddressLabelChange={onAddressLabelChange}
+      onContinue={onContinueFromName}
+    />
+  );
+}
+
+function createCompletionContent(
+  state: Extract<AddAddressFlowState, { status: "reviewingAddress" | "success" }>,
+  labels: ContactsAddAddressReviewLabels,
+  onContinueFromReview: ContactsAddAddressFlowDialogProps["onContinueFromReview"],
+  onClose: ContactsAddAddressFlowDialogProps["onClose"],
+): React.JSX.Element {
+  const isReviewingAddress = state.status === "reviewingAddress";
+
+  return (
+    <ContactsAddAddressCompletion
+      buttonLabel={isReviewingAddress ? labels.continue : labels.close}
+      onContinue={isReviewingAddress ? onContinueFromReview : onClose}
+      testID={isReviewingAddress ? "contacts-add-address-review" : "contacts-add-address-success"}
+      title={isReviewingAddress ? labels.title : labels.successTitle}
     />
   );
 }
 
 export function ContactsAddAddressFlowDialog({
   state,
-  labels,
+  entryLabels,
+  nameLabels,
+  reviewLabels,
   onAddressChange,
+  onContinueFromAddressDetails,
+  onAddressLabelChange,
+  onContinueFromName,
+  onContinueFromReview,
   onBack,
   onClose,
 }: ContactsAddAddressFlowDialogProps): React.JSX.Element | null {
@@ -45,7 +118,10 @@ export function ContactsAddAddressFlowDialog({
     <ModularDialogFlow onClose={onClose}>
       {modularDialog => {
         const isAddressEntry = isEnteringAddress(state);
-        const currentStep: ContactsAddAddressDialogStep = isAddressEntry ? "address" : "currency";
+        const isAddressNaming = isNamingAddress(state);
+        const isReviewingAddress = state.status === "reviewingAddress";
+        const isSuccess = state.status === "success";
+        const currentStep = resolveCurrentStep(state);
         const screens: DialogFlowScreenRegistry<ContactsAddAddressDialogStep> = {
           currency: {
             content: modularDialog.content,
@@ -60,11 +136,47 @@ export function ContactsAddAddressFlowDialog({
           },
           address: {
             content: isAddressEntry
-              ? createAddressContent(state, labels, onAddressChange)
+              ? createAddressContent(
+                  state,
+                  entryLabels,
+                  nameLabels,
+                  onAddressChange,
+                  onAddressLabelChange,
+                  onContinueFromAddressDetails,
+                )
               : modularDialog.content,
             options: {
-              dialogHeaderProps: { density: "expanded", title: labels.title },
+              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
               hasBackButton: true,
+            },
+          },
+          name: {
+            content: isAddressNaming
+              ? createNameContent(state, nameLabels, onAddressLabelChange, onContinueFromName)
+              : modularDialog.content,
+            options: {
+              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              hasBackButton: true,
+            },
+          },
+          review: {
+            content:
+              isReviewingAddress || isSuccess
+                ? createCompletionContent(state, reviewLabels, onContinueFromReview, onClose)
+                : modularDialog.content,
+            options: {
+              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              hasBackButton: true,
+            },
+          },
+          success: {
+            content:
+              isReviewingAddress || isSuccess
+                ? createCompletionContent(state, reviewLabels, onContinueFromReview, onClose)
+                : modularDialog.content,
+            options: {
+              dialogHeaderProps: { density: "expanded", title: entryLabels.title },
+              hasBackButton: false,
             },
           },
         };
@@ -77,7 +189,11 @@ export function ContactsAddAddressFlowDialog({
               dialogContentProps: { className: "w-400 bg-canvas-sheet pb-0" },
             }}
             isOpen
-            onBack={isAddressEntry ? onBack : modularDialog.onBack}
+            onBack={
+              isAddressEntry || isAddressNaming || isReviewingAddress
+                ? onBack
+                : modularDialog.onBack
+            }
             onClose={onClose}
             screens={screens}
           />

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/index.ts
@@ -1,2 +1,2 @@
 export { ContactsAddAddressFlowDialog } from "./ContactsAddAddressFlowDialog";
-export type { ContactsAddAddressFlowDialogProps } from "./types";
+export type { ContactsAddAddressFlowDialogProps, ContactsAddAddressReviewLabels } from "./types";

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -2,12 +2,26 @@ import type {
   AddAddressFlowState,
   AddAddressInputSource,
   ContactsAddAddressEntryLabels,
+  ContactsAddAddressNameLabels,
 } from "@features/flow-contacts";
+
+export type ContactsAddAddressReviewLabels = Readonly<{
+  title: string;
+  continue: string;
+  successTitle: string;
+  close: string;
+}>;
 
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
-  labels: ContactsAddAddressEntryLabels;
+  entryLabels: ContactsAddAddressEntryLabels;
+  nameLabels: ContactsAddAddressNameLabels;
+  reviewLabels: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
+  onContinueFromAddressDetails: () => void;
+  onAddressLabelChange: (value: string) => void;
+  onContinueFromName: () => void;
+  onContinueFromReview: () => void;
   onBack: () => void;
   onClose: () => void;
 }>;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
-import type { ContactId } from "@domain/entity-contact";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  type ContactId,
+} from "@domain/entity-contact";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
   createContactsListViewModel,
@@ -15,6 +20,7 @@ import {
   type AddAddressContact,
   type AddAddressFlowState,
   type ContactsAddAddressEntryLabels,
+  type ContactsAddAddressNameLabels,
   type ContactAddressDetailDialogProps,
   type ContactsLedgerSyncStatus,
   type ContactsListViewLabels,
@@ -25,7 +31,10 @@ import { useContactsFeatureIntroductionPreference } from "../../hooks/useContact
 import { useContactsCurrencySelectionAdapter } from "../../hooks/useContactsCurrencySelectionAdapter";
 import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddressValidationAdapter";
 import { useContactDetailPaneAdapter } from "./useContactDetailPaneAdapter";
-import type { ContactsAddAddressFlowDialogProps } from "./components/ContactsAddAddressFlowDialog";
+import type {
+  ContactsAddAddressFlowDialogProps,
+  ContactsAddAddressReviewLabels,
+} from "./components/ContactsAddAddressFlowDialog";
 
 export type ContactsPageViewModel = Omit<ContactsListViewProps, "onAddContact"> &
   Readonly<{
@@ -54,6 +63,10 @@ export function useContactsViewModel(): ContactsPageViewModel {
     completeCurrencySelection,
     goBack: goBackAddAddress,
     updateAddress,
+    updateAddressLabel,
+    continueFromAddressDetails,
+    continueFromName,
+    continueFromReview,
     close: closeAddAddress,
   } = useAddAddressFlowViewModel({ addressValidation });
   const selectCurrencyForContact = useCallback(
@@ -82,6 +95,14 @@ export function useContactsViewModel(): ContactsPageViewModel {
     closeAddAddress();
   }, [cancelCurrencySelection, closeAddAddress]);
   const onBackAddAddress = useCallback(() => {
+    if (
+      addAddressFlowState.status === "namingAddress" ||
+      addAddressFlowState.status === "reviewingAddress"
+    ) {
+      goBackAddAddress();
+      return;
+    }
+
     if (addAddressFlowState.status !== "enteringAddress") {
       return;
     }
@@ -104,22 +125,56 @@ export function useContactsViewModel(): ContactsPageViewModel {
     }),
     [t],
   );
+  const addAddressNameLabels = useMemo<ContactsAddAddressNameLabels>(
+    () => ({
+      inputLabel: t("contacts.addAddressName.inputLabel"),
+      continueToReview: t("contacts.addAddressName.continueToReview"),
+      validAddress: t("contacts.addAddressEntry.validAddress"),
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.invalidLabel"),
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t("contacts.addAddressName.tooLongLabel"),
+      },
+    }),
+    [t],
+  );
+  const addAddressReviewLabels = useMemo<ContactsAddAddressReviewLabels>(
+    () => ({
+      title: t("contacts.addAddressReview.title"),
+      continue: t("contacts.addAddressReview.continue"),
+      successTitle: t("contacts.addAddressReview.successTitle"),
+      close: t("contacts.addAddressReview.close"),
+    }),
+    [t],
+  );
   const addAddressFlowDialog = useMemo<ContactsAddAddressFlowDialogProps>(
     () => ({
       state: addAddressFlowState,
-      labels: addAddressEntryLabels,
+      entryLabels: addAddressEntryLabels,
+      nameLabels: addAddressNameLabels,
+      reviewLabels: addAddressReviewLabels,
       onAddressChange: (address, inputMethod) => {
         void updateAddress(address, inputMethod);
       },
+      onContinueFromAddressDetails: continueFromAddressDetails,
+      onAddressLabelChange: updateAddressLabel,
+      onContinueFromName: continueFromName,
+      onContinueFromReview: continueFromReview,
       onBack: onBackAddAddress,
       onClose: onCloseAddAddress,
     }),
     [
       addAddressEntryLabels,
+      addAddressNameLabels,
+      addAddressReviewLabels,
       addAddressFlowState,
       onBackAddAddress,
       onCloseAddAddress,
       updateAddress,
+      updateAddressLabel,
+      continueFromAddressDetails,
+      continueFromName,
+      continueFromReview,
     ],
   );
   const { detail, addressDetailDialog, onOpenMe, onOpenContact } =

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9305,6 +9305,19 @@
       "validationUnavailable": "Address validation is temporarily unavailable.",
       "ensDisclaimer": "This ENS name resolves to the address shown above."
     },
+    "addAddressName": {
+      "inputLabel": "Address name",
+      "continueToReview": "Continue to review",
+      "invalidLabel": "Special characters are not allowed.",
+      "duplicateLabel": "This address name is already used for this contact.",
+      "tooLongLabel": "Address names must be 32 characters or fewer."
+    },
+    "addAddressReview": {
+      "title": "Review address",
+      "continue": "Confirm address",
+      "successTitle": "Address saved",
+      "close": "Close"
+    },
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10212,7 +10212,8 @@
       "namingDisclaimer": "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
       "continueToReview": "Continue to review",
       "invalidLabel": "Special characters are not allowed.",
-      "duplicateLabel": "This address name is already used for this contact."
+      "duplicateLabel": "This address name is already used for this contact.",
+      "labelTooLong": "This address name is too long."
     },
     "addAddressFlow": {
       "review": "Validation",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,5 +1,6 @@
 import { Platform } from "react-native";
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
@@ -91,6 +92,9 @@ export function useContactsAddAddressFlowDrawerViewModel({
                 ),
                 [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
                   "contacts.addAddressName.duplicateLabel",
+                ),
+                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
+                  "contacts.addAddressName.labelTooLong",
                 ),
               },
             },

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -19,9 +19,12 @@ export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME = "InvalidContactAddressLa
 
 export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME = "DuplicateContactAddressLabelError";
 
+export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME = "ContactAddressLabelTooLongError";
+
 export type ContactAddressLabelValidationErrorName =
   | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
+  | typeof CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 
 export class InvalidContactAddressLabelError extends ContactError {
   override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
@@ -29,4 +32,8 @@ export class InvalidContactAddressLabelError extends ContactError {
 
 export class DuplicateContactAddressLabelError extends ContactError {
   override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+}
+
+export class ContactAddressLabelTooLongError extends ContactError {
+  override name = CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -98,6 +98,10 @@ describe("ContactAddressSchema", () => {
     expect(() => ContactAddressLabelSchema.parse("Ethereum 1\uFE0F\u20E3")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum\nWallet")).toThrow();
   });
+
+  it("rejects address labels longer than 32 characters", () => {
+    expect(() => ContactAddressLabelSchema.parse("a".repeat(33))).toThrow();
+  });
 });
 
 describe("contact mock factories", () => {

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -13,12 +13,16 @@ const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;
 const ContactAddressLabelPattern = /^(?=.*[\p{L}\p{N}])[\p{L}\p{Mn}\p{Mc}\p{N}\p{P}\p{Zs}]+$/u;
 
+export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;
+
 export const ContactNameSchema = NonEmptyStringSchema.regex(
   ContactNamePattern,
   "Expected letters, spaces, apostrophes, or hyphens",
 );
 
-export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern);
+export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern).max(
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+);
 
 export const ContactAddressValueSchema = NonEmptyStringSchema;
 

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,4 +1,6 @@
 import {
+  ContactAddressLabelTooLongError,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DuplicateContactAddressLabelError,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   InvalidContactAddressLabelError,
@@ -53,11 +55,21 @@ describe("contact address label validation", () => {
     expect(isValidContactAddressLabel("")).toBe(false);
   });
 
-  it("accepts a valid draft label without imposing a length limit", () => {
+  it("rejects an address label longer than 32 characters", () => {
     const longLabel = "Ethereum ".repeat(50);
 
     expect(getContactAddressLabelValidationError("Ethereum")).toBeNull();
-    expect(isValidContactAddressLabel(longLabel)).toBe(true);
+    expect(getContactAddressLabelValidationError(longLabel)).toBe(
+      CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+    );
+    expect(isValidContactAddressLabel(longLabel)).toBe(false);
+  });
+
+  it("ignores surrounding whitespace when checking the address label length", () => {
+    const labelWithWhitespace = `  ${"a".repeat(32)}  `;
+
+    expect(getContactAddressLabelValidationError(labelWithWhitespace)).toBeNull();
+    expect(parseContactAddressLabel(labelWithWhitespace)).toBe("a".repeat(32));
   });
 
   it("reports invalid characters for a non-empty invalid draft label", () => {
@@ -97,6 +109,9 @@ describe("contact address label validation", () => {
     expect(() => parseContactAddressLabel("Ethereum 💎")).toThrow(InvalidContactAddressLabelError);
     expect(() => parseContactAddressLabel("ethereum", existingLabels)).toThrow(
       DuplicateContactAddressLabelError,
+    );
+    expect(() => parseContactAddressLabel("Ethereum ".repeat(50))).toThrow(
+      ContactAddressLabelTooLongError,
     );
   });
 });

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,5 +1,7 @@
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
@@ -8,7 +10,11 @@ import {
   type ContactAddressLabelValidationErrorName,
   type ContactNameValidationErrorName,
 } from "./errors";
-import { ContactAddressLabelSchema, ContactNameSchema } from "./schema";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  ContactAddressLabelSchema,
+  ContactNameSchema,
+} from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
 export function getContactNameValidationError(
@@ -47,10 +53,16 @@ export function getContactAddressLabelValidationError(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = [],
 ): ContactAddressLabelValidationErrorName | null {
-  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+  const trimmedDraftLabel = draftLabel.trim();
+
+  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
+    return CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
+  }
+
+  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
 
   if (!parsed.success) {
-    return draftLabel.trim().length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+    return trimmedDraftLabel.length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
   }
 
   const comparisonLabel = normalizeContactAddressLabelForComparison(parsed.data);
@@ -75,7 +87,13 @@ export function parseContactAddressLabel(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = [],
 ): ContactAddressLabel {
-  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+  const trimmedDraftLabel = draftLabel.trim();
+
+  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
+    throw new ContactAddressLabelTooLongError();
+  }
+
+  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
 
   if (!parsed.success) {
     throw new InvalidContactAddressLabelError();

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.web.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressLabelSchema,
+  ContactAddressValueSchema,
+} from "@domain/entity-contact";
+import { ContactsAddAddressName } from "./ContactsAddAddressName.web";
+import type { ContactsAddAddressNameProps } from "./types";
+
+const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
+  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+);
+
+function createProps(
+  overrides: Partial<ContactsAddAddressNameProps> = {},
+): ContactsAddAddressNameProps {
+  return {
+    addressEntry: {
+      status: "valid",
+      value: RESOLVED_ADDRESS,
+      resolvedAddress: RESOLVED_ADDRESS,
+      inputMethod: "manual",
+    },
+    addressLabel: {
+      status: "valid",
+      value: "Ethereum",
+      label: ContactAddressLabelSchema.parse("Ethereum"),
+      validationError: null,
+    },
+    labels: {
+      inputLabel: "Address name",
+      continueToReview: "Continue to review",
+      validAddress: "Valid address",
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
+          "This address name is already used for this contact.",
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]:
+          "Address names must be 32 characters or fewer.",
+      },
+    },
+    onAddressLabelChange: jest.fn(),
+    onContinue: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactsAddAddressName", () => {
+  it("should render the confirmed address and prefilled label with the 32-character limit", () => {
+    render(<ContactsAddAddressName {...createProps()} />);
+
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
+      "value",
+      RESOLVED_ADDRESS,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "maxlength",
+      "32",
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
+  });
+
+  it("should forward address-label edits", () => {
+    const onAddressLabelChange = jest.fn();
+    render(<ContactsAddAddressName {...createProps({ onAddressLabelChange })} />);
+
+    fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
+      target: { value: "Exchange" },
+    });
+
+    expect(onAddressLabelChange).toHaveBeenCalledWith("Exchange");
+  });
+
+  it.each([
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME, "Special characters are not allowed."],
+    [
+      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      "This address name is already used for this contact.",
+    ],
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME, "Address names must be 32 characters or fewer."],
+  ] as const)("should render the shared %s validation error", (validationError, message) => {
+    render(
+      <ContactsAddAddressName
+        {...createProps({
+          addressLabel: {
+            status: "invalid",
+            value: "Ethereum",
+            label: null,
+            validationError,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "helpertext",
+      message,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+
+  it("should continue only with a valid address label", () => {
+    const onContinue = jest.fn();
+    const { rerender } = render(<ContactsAddAddressName {...createProps({ onContinue })} />);
+
+    fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ContactsAddAddressName
+        {...createProps({
+          onContinue,
+          addressLabel: { status: "empty", value: "", label: null, validationError: null },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.web.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import type { ContactsAddAddressNameProps } from "./types";
+import { ContactsAddAddressNameView } from "./ContactsAddAddressNameView.web";
+import { useContactsAddAddressNameViewModel } from "./useContactsAddAddressNameViewModel.web";
+
+export function ContactsAddAddressName(props: ContactsAddAddressNameProps): React.JSX.Element {
+  return <ContactsAddAddressNameView {...useContactsAddAddressNameViewModel(props)} />;
+}

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  ContactAddressLabelSchema,
+  ContactAddressValueSchema,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import { ContactsAddAddressNameView } from "./ContactsAddAddressNameView.web";
+import type { ContactsAddAddressNameViewProps } from "./types";
+
+const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
+  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+);
+
+function createProps(
+  overrides: Partial<ContactsAddAddressNameViewProps> = {},
+): ContactsAddAddressNameViewProps {
+  return {
+    address: RESOLVED_ADDRESS,
+    addressLabel: {
+      status: "valid",
+      value: "Ethereum",
+      label: ContactAddressLabelSchema.parse("Ethereum"),
+      validationError: null,
+    },
+    labels: {
+      inputLabel: "Address name",
+      continueToReview: "Continue to review",
+      validAddress: "Valid address",
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
+          "This address name is already used for this contact.",
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
+      },
+    },
+    isContinueEnabled: true,
+    onAddressLabelChange: jest.fn(),
+    onContinue: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactsAddAddressNameView", () => {
+  it("should render the address details and forward input actions", () => {
+    const onAddressLabelChange = jest.fn();
+    const onContinue = jest.fn();
+
+    render(<ContactsAddAddressNameView {...createProps({ onAddressLabelChange, onContinue })} />);
+
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
+      "value",
+      RESOLVED_ADDRESS,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+
+    fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
+      target: { value: "Exchange" },
+    });
+    fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
+
+    expect(onAddressLabelChange).toHaveBeenCalledTimes(1);
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("should display an invalid label and disable continuation", () => {
+    render(
+      <ContactsAddAddressNameView
+        {...createProps({
+          addressLabel: {
+            status: "invalid",
+            value: "Ethereum 💎",
+            label: null,
+            validationError: "InvalidContactAddressLabelError",
+          },
+          validationMessage: "Special characters are not allowed.",
+          isContinueEnabled: false,
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "helpertext",
+      "Special characters are not allowed.",
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { AddressInput, Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import type { ContactsAddAddressNameViewProps } from "./types";
+
+export function ContactsAddAddressNameView({
+  address,
+  addressLabel,
+  labels,
+  validationMessage,
+  isContinueEnabled,
+  onAddressLabelChange,
+  onContinue,
+}: ContactsAddAddressNameViewProps): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-24">
+      <AddressInput
+        autoComplete="off"
+        autoCorrect="off"
+        data-testid="contacts-add-address-confirmed-input"
+        helperText={labels.validAddress}
+        hideClearButton
+        prefix=""
+        readOnly
+        spellCheck={false}
+        status="success"
+        value={address}
+      />
+      <TextInput
+        autoComplete="off"
+        autoCorrect="off"
+        data-testid="contacts-add-address-name-input"
+        helperText={validationMessage}
+        label={labels.inputLabel}
+        maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+        maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+        onChange={onAddressLabelChange}
+        spellCheck={false}
+        status={addressLabel.status === "invalid" ? "error" : undefined}
+        value={addressLabel.value}
+      />
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid="contacts-add-address-name-continue"
+        disabled={!isContinueEnabled}
+        icon={LedgerLogo}
+        onClick={onContinue}
+        size="lg"
+      >
+        {labels.continueToReview}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
@@ -1,0 +1,28 @@
+import type { ChangeEvent } from "react";
+import type { ContactAddressLabelValidationErrorName } from "@domain/entity-contact";
+import type { AddAddressLabelState, ValidAddAddressEntryState } from "../types";
+
+export type ContactsAddAddressNameLabels = Readonly<{
+  inputLabel: string;
+  continueToReview: string;
+  validAddress: string;
+  validationErrors: Record<ContactAddressLabelValidationErrorName, string>;
+}>;
+
+export type ContactsAddAddressNameProps = Readonly<{
+  addressEntry: ValidAddAddressEntryState;
+  addressLabel: AddAddressLabelState;
+  labels: ContactsAddAddressNameLabels;
+  onAddressLabelChange: (value: string) => void;
+  onContinue: () => void;
+}>;
+
+export type ContactsAddAddressNameViewProps = Readonly<{
+  address: string;
+  addressLabel: AddAddressLabelState;
+  labels: ContactsAddAddressNameLabels;
+  validationMessage?: string;
+  isContinueEnabled: boolean;
+  onAddressLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onContinue: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -1,0 +1,32 @@
+import { useCallback, useMemo, type ChangeEvent } from "react";
+import type { ContactsAddAddressNameProps, ContactsAddAddressNameViewProps } from "./types";
+
+export function useContactsAddAddressNameViewModel({
+  addressEntry,
+  addressLabel,
+  labels,
+  onAddressLabelChange,
+  onContinue,
+}: ContactsAddAddressNameProps): ContactsAddAddressNameViewProps {
+  const validationMessage = useMemo(
+    () =>
+      addressLabel.validationError
+        ? labels.validationErrors[addressLabel.validationError]
+        : undefined,
+    [addressLabel.validationError, labels.validationErrors],
+  );
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onAddressLabelChange(event.target.value),
+    [onAddressLabelChange],
+  );
+
+  return {
+    address: addressEntry.value,
+    addressLabel,
+    labels,
+    validationMessage,
+    isContinueEnabled: addressLabel.status === "valid",
+    onAddressLabelChange: onChange,
+    onContinue,
+  };
+}

--- a/features/flow/contacts/src/steps/AddAddress/Completion/ContactsAddAddressCompletion.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Completion/ContactsAddAddressCompletion.web.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { AddAddressPlaceholderViewProps } from "../types";
+
+export function ContactsAddAddressCompletion({
+  title,
+  buttonLabel,
+  testID,
+  onContinue,
+}: AddAddressPlaceholderViewProps): React.JSX.Element {
+  return (
+    <div className="flex min-h-256 flex-col justify-between gap-24" data-testid={testID}>
+      <div className="flex flex-1 items-center justify-center">
+        <h2 className="heading-3-semi-bold text-base">{title}</h2>
+      </div>
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid={`${testID}-continue`}
+        onClick={onContinue}
+        size="lg"
+      >
+        {buttonLabel}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
@@ -1,10 +1,19 @@
 import type { ChangeEvent, ClipboardEvent } from "react";
-import type { AddAddressEntryLabels, AddAddressEntryState, AddAddressInputSource } from "./types";
+import type { ContactsAddAddressNameLabels } from "./AddressName/types";
+import type {
+  AddAddressEntryLabels,
+  AddAddressEntryState,
+  AddAddressInputSource,
+  AddAddressLabelState,
+} from "./types";
 
 export type ContactsAddAddressEntryWebProps = Readonly<{
   addressEntry: AddAddressEntryState;
   labels: AddAddressEntryLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
+  addressLabel?: AddAddressLabelState;
+  nameLabels?: ContactsAddAddressNameLabels;
+  onAddressLabelChange?: (value: string) => void;
   onConfirm?: () => void;
 }>;
 
@@ -14,8 +23,12 @@ export type ContactsAddAddressEntryWebViewProps = Readonly<{
   inputStatus?: "error" | "success";
   helperText?: string;
   showEnsDisclaimer: boolean;
+  addressLabel?: AddAddressLabelState;
+  nameLabels?: ContactsAddAddressNameLabels;
+  nameValidationMessage?: string;
   isConfirmEnabled: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
+  onAddressLabelChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   onConfirm?: () => void;
 }>;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { AddressInput, Banner, Button } from "@ledgerhq/lumen-ui-react";
+import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
 
 export function ContactsAddAddressEntryView({
@@ -9,9 +10,13 @@ export function ContactsAddAddressEntryView({
   inputStatus,
   helperText,
   showEnsDisclaimer,
+  addressLabel,
+  nameLabels,
+  nameValidationMessage,
   isConfirmEnabled,
   onChange,
   onPaste,
+  onAddressLabelChange,
   onConfirm,
 }: ContactsAddAddressEntryWebViewProps): React.JSX.Element {
   return (
@@ -35,6 +40,21 @@ export function ContactsAddAddressEntryView({
           appearance="info"
           data-testid="contacts-add-address-ens-disclaimer"
           description={labels.ensDisclaimer}
+        />
+      ) : null}
+      {addressLabel && nameLabels && onAddressLabelChange ? (
+        <TextInput
+          autoComplete="off"
+          autoCorrect="off"
+          data-testid="contacts-add-address-name-input"
+          helperText={nameValidationMessage}
+          label={nameLabels.inputLabel}
+          maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+          maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+          onChange={onAddressLabelChange}
+          spellCheck={false}
+          status={addressLabel.status === "invalid" ? "error" : undefined}
+          value={addressLabel.value}
         />
       ) : null}
       <Button

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressLabelSchema,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
@@ -18,6 +19,7 @@ const labels: AddAddressNameLabels = {
     [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
     [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
       "This address name is already used for this contact.",
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
   },
 };
 

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -99,7 +99,11 @@ export type AddAddressFlowState =
     }>
   | (AddAddressSession & Readonly<{ status: "enteringAddress" }>)
   | (ConfirmedAddAddressSession & Readonly<{ status: "namingAddress" }>)
-  | (NamedAddAddressSession & Readonly<{ status: "reviewingAddress" }>)
+  | (NamedAddAddressSession &
+      Readonly<{
+        status: "reviewingAddress";
+        origin: "addressDetails" | "addressName";
+      }>)
   | (NamedAddAddressSession & Readonly<{ status: "success" }>);
 
 export type AddAddressFlowViewModel = Readonly<{
@@ -109,6 +113,7 @@ export type AddAddressFlowViewModel = Readonly<{
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
   updateAddressLabel: (label: string) => void;
   confirmAddress: () => void;
+  continueFromAddressDetails: () => void;
   continueFromName: () => void;
   continueFromReview: () => void;
   goBack: () => void;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -256,7 +256,7 @@ export function useAddAddressFlowViewModel({
   );
   const updateAddressLabel = useCallback((value: string) => {
     setState(currentState => {
-      if (currentState.status !== "namingAddress") {
+      if (currentState.status !== "enteringAddress" && currentState.status !== "namingAddress") {
         return currentState;
       }
 
@@ -302,15 +302,41 @@ export function useAddAddressFlowViewModel({
         selectedCurrencyId: currentState.selectedCurrencyId,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
+        origin: "addressName",
       };
     });
   }, []);
+  const continueFromAddressDetails = useCallback(() => {
+    cancelAddressValidation();
+    setState(currentState => {
+      if (
+        currentState.status !== "enteringAddress" ||
+        currentState.addressEntry.status !== "valid" ||
+        currentState.addressLabel.status !== "valid"
+      ) {
+        return currentState;
+      }
+
+      return {
+        status: "reviewingAddress",
+        selectedContactId: currentState.selectedContactId,
+        existingAddressLabels: currentState.existingAddressLabels,
+        selectedCurrencyId: currentState.selectedCurrencyId,
+        addressEntry: currentState.addressEntry,
+        addressLabel: currentState.addressLabel,
+        origin: "addressDetails",
+      };
+    });
+  }, [cancelAddressValidation]);
   const continueFromReview = useCallback(() => {
-    setState(currentState =>
-      currentState.status === "reviewingAddress"
-        ? { ...currentState, status: "success" }
-        : currentState,
-    );
+    setState(currentState => {
+      if (currentState.status !== "reviewingAddress") {
+        return currentState;
+      }
+
+      const { origin, ...session } = currentState;
+      return { ...session, status: "success" };
+    });
   }, []);
   const goBack = useCallback(() => {
     cancelAddressValidation();
@@ -328,8 +354,12 @@ export function useAddAddressFlowViewModel({
           };
         case "namingAddress":
           return { ...currentState, status: "enteringAddress" };
-        case "reviewingAddress":
-          return { ...currentState, status: "namingAddress" };
+        case "reviewingAddress": {
+          const { origin, ...session } = currentState;
+          return origin === "addressDetails"
+            ? { ...session, status: "enteringAddress" }
+            : { ...session, status: "namingAddress" };
+        }
         case "success":
           return currentState;
       }
@@ -348,6 +378,7 @@ export function useAddAddressFlowViewModel({
     updateAddress,
     updateAddressLabel,
     confirmAddress,
+    continueFromAddressDetails,
     continueFromName,
     continueFromReview,
     goBack,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -326,6 +326,44 @@ describe("useAddAddressFlowViewModel", () => {
     });
   });
 
+  it("should continue directly from address details to review when both inputs are valid", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    act(() => result.current.updateAddressLabel("Exchange"));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.continueFromAddressDetails());
+
+    expect(result.current.state).toMatchObject({
+      status: "reviewingAddress",
+      origin: "addressDetails",
+      addressLabel: { label: "Exchange", status: "valid" },
+    });
+
+    act(() => result.current.goBack());
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      addressLabel: { label: "Exchange", status: "valid" },
+    });
+  });
+
+  it("should prevent direct review when either address detail is invalid", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    act(() => result.current.updateAddressLabel("Ethereum 💎"));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.continueFromAddressDetails());
+
+    expect(result.current.state.status).toBe("enteringAddress");
+  });
+
   it("should expose invalid characters and prevent review", async () => {
     const contact = mockContact();
     const addressValidation = createValidationPort();

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ClipboardEvent } from "react";
-import { ContactAddressValueSchema } from "@domain/entity-contact";
+import {
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressValueSchema,
+} from "@domain/entity-contact";
+import type { ContactsAddAddressNameLabels } from "./AddressName/types";
 import type { ContactsAddAddressEntryWebProps } from "./ContactsAddAddressEntry.web.types";
 import type { AddAddressEntryLabels } from "./types";
 import { useContactsAddAddressEntryViewModel } from "./useContactsAddAddressEntryViewModel.web";
@@ -19,6 +23,16 @@ const labels: AddAddressEntryLabels = {
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
   "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
 );
+const nameLabels: ContactsAddAddressNameLabels = {
+  inputLabel: "Address name",
+  continueToReview: "Continue to review",
+  validAddress: "Valid address",
+  validationErrors: {
+    InvalidContactAddressLabelError: "Special characters are not allowed.",
+    DuplicateContactAddressLabelError: "Duplicate address name.",
+    ContactAddressLabelTooLongError: "Address name is too long.",
+  },
+};
 
 function renderViewModel(overrides: Partial<ContactsAddAddressEntryWebProps> = {}) {
   const onAddressChange = jest.fn();
@@ -109,5 +123,37 @@ describe("useContactsAddAddressEntryViewModel", () => {
     });
 
     expect(result.current.isConfirmEnabled).toBe(false);
+  });
+
+  it("should require a valid address label for the combined Desktop form", () => {
+    const onAddressLabelChange = jest.fn();
+    const { result } = renderViewModel({
+      addressEntry: {
+        status: "valid",
+        value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        resolvedAddress: RESOLVED_ADDRESS,
+        inputMethod: "manual",
+      },
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum 💎",
+        label: null,
+        validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      },
+      nameLabels,
+      onAddressLabelChange,
+      onConfirm: jest.fn(),
+    });
+
+    expect(result.current.isConfirmEnabled).toBe(false);
+    expect(result.current.nameValidationMessage).toBe("Special characters are not allowed.");
+
+    act(() => {
+      result.current.onAddressLabelChange?.({
+        target: { value: "Exchange" },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(onAddressLabelChange).toHaveBeenCalledWith("Exchange");
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -58,6 +58,9 @@ export function useContactsAddAddressEntryViewModel({
   addressEntry,
   labels,
   onAddressChange,
+  addressLabel,
+  nameLabels,
+  onAddressLabelChange,
   onConfirm,
 }: ContactsAddAddressEntryWebProps): ContactsAddAddressEntryWebViewProps {
   const presentation = useMemo(
@@ -75,14 +78,30 @@ export function useContactsAddAddressEntryViewModel({
     },
     [addressEntry.value, onAddressChange],
   );
+  const onNameChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onAddressLabelChange?.(event.target.value),
+    [onAddressLabelChange],
+  );
+  const nameValidationMessage = useMemo(
+    () =>
+      addressLabel?.validationError
+        ? nameLabels?.validationErrors[addressLabel.validationError]
+        : undefined,
+    [addressLabel?.validationError, nameLabels?.validationErrors],
+  );
+  const isNameValid = addressLabel === undefined || addressLabel.status === "valid";
 
   return {
     value: addressEntry.value,
     labels,
     ...presentation,
-    isConfirmEnabled: presentation.isConfirmEnabled && onConfirm !== undefined,
+    addressLabel,
+    nameLabels,
+    nameValidationMessage,
+    isConfirmEnabled: presentation.isConfirmEnabled && isNameValid && onConfirm !== undefined,
     onChange,
     onPaste,
+    onAddressLabelChange: onAddressLabelChange ? onNameChange : undefined,
     onConfirm,
   };
 }

--- a/features/flow/contacts/src/steps/AddAddress/web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/web.ts
@@ -1,3 +1,9 @@
 export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.web";
 export type { ContactsAddAddressEntryWebProps as ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.web.types";
 export type { AddAddressEntryLabels as ContactsAddAddressEntryLabels } from "./types";
+export { ContactsAddAddressName } from "./AddressName/ContactsAddAddressName.web";
+export { ContactsAddAddressCompletion } from "./Completion/ContactsAddAddressCompletion.web";
+export type {
+  ContactsAddAddressNameLabels,
+  ContactsAddAddressNameProps,
+} from "./AddressName/types";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Desktop Contacts add-address dialog padding and layout
  - Address and label validation, including the shared 32-character limit
  - Navigation from the double-input form to review and success states

### 📝 Description

Contacts on Desktop did not compose the address-label state exposed by the shared flow, so users could not enter the address and its name together before review.

This PR displays the editable address and prefilled address-name inputs together in the Desktop dialog immediately after asset selection. The single Continue to review CTA is enabled only when both fields are valid, and the 32-character maximum is enforced in the shared domain model and input. Review and success states remain in the same dialog.


https://github.com/user-attachments/assets/037606ae-262c-40d9-bf2a-bc4ed48d1819


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33919](https://ledgerhq.atlassian.net/browse/LIVE-33919)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33919]: https://ledgerhq.atlassian.net/browse/LIVE-33919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ