### PR TITLE
refactor(e2e): extract e2e slack report into a shared composite

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1320,156 +1320,46 @@ jobs:
     needs: [determine-builds, allure-report-android, allure-report-ios]
     if: ${{ !cancelled() && (needs.allure-report-ios.outputs.finalStatus || needs.allure-report-android.outputs.finalStatus) }}
     env:
-      IOS_STATUS: ${{ needs.allure-report-ios.outputs.finalStatus }}
-      IOS_REPORT_URL: ${{ needs.allure-report-ios.outputs.report-url }}
-      IOS_MISSING_SHARDS: ${{ needs.allure-report-ios.outputs.missingShards }}
-      ANDROID_STATUS: ${{ needs.allure-report-android.outputs.finalStatus }}
-      ANDROID_REPORT_URL: ${{ needs.allure-report-android.outputs.report-url }}
-      ANDROID_MISSING_SHARDS: ${{ needs.allure-report-android.outputs.missingShards }}
-      TESTS_TYPE: ${{ inputs.tests_type }}
+      REF: ${{ inputs.ref || github.ref_name }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      HEADER_DEVICES: "iOS:${{ needs.determine-builds.outputs.ios_device }} / Android:${{ needs.determine-builds.outputs.android_device }}"
+      # A platform's label is blanked out when tests_type excludes it; the e2e-slack-report
+      # composite then drops that row entirely (and its status stops driving the color).
+      IOS_LABEL: ${{ inputs.tests_type != 'Android Only' && 'iOS' || '' }}
+      ANDROID_LABEL: ${{ inputs.tests_type != 'iOS Only' && 'Android' || '' }}
     steps:
-      - name: format message
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        id: message
-        env:
-          REF_NAME: ${{ inputs.ref || github.ref_name }}
-          IOS_DEVICE: ${{ needs.determine-builds.outputs.ios_device }}
-          ANDROID_DEVICE: ${{ needs.determine-builds.outputs.android_device }}
-          SMOKE_TESTS_SUFFIX: ${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}
-          IOS_SUMMARY: ${{ needs.allure-report-ios.outputs.summary_message || 'No test results' }}
-          ANDROID_SUMMARY: ${{ needs.allure-report-android.outputs.summary_message || 'No test results' }}
-          SERVER_URL: ${{ github.server_url }}
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
+      - name: Report e2e results to Slack
+        uses: LedgerHQ/ledger-live/tools/actions/composites/e2e-slack-report@develop
         with:
-          script: |
-            const fs = require("fs");
-            const text = "Ledger Live Mobile E2E tests finished";
-            const header = [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": `:ledger-logo: Ledger Live Mobile E2E tests results on ${process.env.REF_NAME} - iOS:${process.env.IOS_DEVICE} / Android:${process.env.ANDROID_DEVICE}${process.env.SMOKE_TESTS_SUFFIX}`,
-                  "emoji": true
-                }
-              },
-              {
-                "type": "divider"
-              }
-            ];
-
-            const iOSResult = [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": `🍏 iOS · FF '${process.env.IOS_FEATURE_FLAGS}' · ${process.env.IOS_DEVICE} : ${process.env.IOS_SUMMARY}`
-                }
-              }
-            ];
-
-            const androidResult = [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": `🤖 Android · FF '${process.env.ANDROID_FEATURE_FLAGS}' · ${process.env.ANDROID_DEVICE} : ${process.env.ANDROID_SUMMARY}`
-                }
-              }
-            ];
-
-            const iOSInfo = [
-              {
-                "type": "mrkdwn",
-                "text": process.env.IOS_REPORT_URL ? `*Allure Report iOS*\n<${process.env.IOS_REPORT_URL}|Allure Report iOS>` : '*Allure Report iOS*\nNo Allure Report'
-              }
-            ];
-
-            const androidInfo = [
-              {
-                "type": "mrkdwn",
-                "text": process.env.ANDROID_REPORT_URL ? `*Allure Report Android*\n<${process.env.ANDROID_REPORT_URL}|Allure Report Android>` : '*Allure Report Android*\nNo Allure Report'
-              }
-            ];
-
-            const infoFields = []
-              .concat(process.env.TESTS_TYPE === 'Android Only' ? [] : iOSInfo)
-              .concat(process.env.TESTS_TYPE === 'iOS Only' ? [] : androidInfo)
-              .concat([
-              {
-                "type": "mrkdwn",
-                "text": `*Workflow*\n<${process.env.SERVER_URL}/${process.env.REPOSITORY}/actions/runs/${process.env.RUN_ID}|Workflow run>`
-              }
-            ]);
-
-            const infoBlock = [
-              {
-                "type": "divider"
-              },
-              {
-                "type": "section",
-                "fields": infoFields
-              }
-            ];
-
-            // Warning block for failed shards
-            const warningBlocks = [];
-            if (process.env.IOS_MISSING_SHARDS) {
-              warningBlocks.push({
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": `⚠️ *Warning*: iOS - Missing results for shard(s): ${process.env.IOS_MISSING_SHARDS}.`
-                }
-              });
-            }
-            if (process.env.ANDROID_MISSING_SHARDS) {
-              warningBlocks.push({
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": `⚠️ *Warning*: Android - Missing results for shard(s): ${process.env.ANDROID_MISSING_SHARDS}.`
-                }
-              });
-            }
-
-            const blocks = []
-              .concat(header)
-              .concat(process.env.TESTS_TYPE === 'Android Only' ? [] : iOSResult)
-              .concat(process.env.TESTS_TYPE === 'iOS Only' ? [] : androidResult)
-              .concat(warningBlocks.length > 0 ? warningBlocks : [])
-              .concat(infoBlock);
-
-            const result = {
-                text: " ",
-                attachments: [
-                  {
-                    color: process.env.ANDROID_STATUS !== 'success' || (process.env.IOS_STATUS !== 'success' && process.env.ANDROID_ONLY == 'false')
-                      ? "#FF333C"
-                      : "#33FF39",
-                    fallback: text,
-                    blocks,
-                  },
-                ],
-              };
-
-            fs.writeFileSync(`./payload-slack-content.json`, JSON.stringify({ ...result, channel: "CTMQ0S5SB" }, null, 2));
-            fs.writeFileSync(`./payload-slack-content-alt.json`, JSON.stringify({ ...result, channel: "C05FKJ7DFAP" }, null, 2));
-      - name: post to a Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
-        with:
-          method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          payload-file-path: "./payload-slack-content.json"
-      - name: post to a Slack channel
-        if: ${{ inputs.slack_notif || github.event_name == 'schedule' }}
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
-          payload-file-path: "./payload-slack-content-alt.json"
+          channel: CTMQ0S5SB
+          # Second channel only on scheduled runs / opt-in.
+          secondary_channel: ${{ (inputs.slack_notif || github.event_name == 'schedule') && 'C05FKJ7DFAP' || '' }}
+          product: "Ledger Live Mobile E2E"
+          ref: ${{ env.REF }}
+          smoke_tests: ${{ inputs.smoke_tests }}
+          header_devices: ${{ env.HEADER_DEVICES }}
+          run_url: ${{ env.RUN_URL }}
+          row1_emoji: "🍏"
+          row1_label: ${{ env.IOS_LABEL }}
+          row1_flags: ${{ env.IOS_FEATURE_FLAGS }}
+          row1_device: ${{ needs.determine-builds.outputs.ios_device }}
+          row1_summary: ${{ needs.allure-report-ios.outputs.summary_message }}
+          row1_report_url: ${{ needs.allure-report-ios.outputs.report-url }}
+          row1_report_title: "Allure Report iOS"
+          row1_report_link_text: "Allure Report iOS"
+          row1_status: ${{ needs.allure-report-ios.outputs.finalStatus }}
+          row1_missing_shards: ${{ needs.allure-report-ios.outputs.missingShards }}
+          row2_emoji: "🤖"
+          row2_label: ${{ env.ANDROID_LABEL }}
+          row2_flags: ${{ env.ANDROID_FEATURE_FLAGS }}
+          row2_device: ${{ needs.determine-builds.outputs.android_device }}
+          row2_summary: ${{ needs.allure-report-android.outputs.summary_message }}
+          row2_report_url: ${{ needs.allure-report-android.outputs.report-url }}
+          row2_report_title: "Allure Report Android"
+          row2_report_link_text: "Allure Report Android"
+          row2_status: ${{ needs.allure-report-android.outputs.finalStatus }}
+          row2_missing_shards: ${{ needs.allure-report-android.outputs.missingShards }}
 
   merge-ios-timings:
     name: Merge iOS Timing Files

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -414,7 +414,7 @@ jobs:
     runs-on: [ledger-live-medium]
     needs: [prepare-devices, e2e-tests]
     outputs:
-      status_color: ${{ steps.summary.outputs.status_color }}
+      status: ${{ steps.summary.outputs.status }}
       summary_message: ${{ steps.summary.outputs.summary_message }}
       report-url: ${{ steps.allure-server.outputs.report-url }}
     if: ${{ !cancelled() }}
@@ -459,7 +459,7 @@ jobs:
     needs: [prepare-devices, e2e-tests]
     if: ${{ !cancelled() && needs.prepare-devices.outputs.is_dual == 'true' }}
     outputs:
-      status_color: ${{ steps.summary.outputs.status_color }}
+      status: ${{ steps.summary.outputs.status }}
       summary_message: ${{ steps.summary.outputs.summary_message }}
       report-url: ${{ steps.allure-server.outputs.report-url }}
     env:
@@ -594,133 +594,42 @@ jobs:
     runs-on: [ledger-live-medium]
     needs: [prepare-devices, report-to-allure, report-to-allure-device2]
     if: ${{ always() && (inputs.slack_notif || github.event_name == 'schedule') }}
+    env:
+      IS_DUAL: ${{ needs.prepare-devices.outputs.is_dual }}
+      DEVICE_1: ${{ needs.prepare-devices.outputs.device_1 || 'nanoSP' }}
+      DEVICE_2: ${{ needs.prepare-devices.outputs.device_2 }}
+      REF: ${{ inputs.ref || github.ref_name }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        name: Prepare Slack payload
-        id: status
-        env:
-          IS_DUAL: ${{ needs.prepare-devices.outputs.is_dual }}
-          DEVICE_1: ${{ needs.prepare-devices.outputs.device_1 }}
-          DEVICE_2: ${{ needs.prepare-devices.outputs.device_2 }}
-          EXPORT_TO_XRAY: ${{ inputs.export_to_xray }}
-          TEST_EXECUTION: ${{ github.event.inputs.test_execution }}
+      - name: Report e2e results to Slack
+        uses: LedgerHQ/ledger-live/tools/actions/composites/e2e-slack-report@develop
         with:
-          script: |
-            const fs = require("fs");
-            const isDual = process.env.IS_DUAL === "true";
-            const device1 = process.env.DEVICE_1 || "nanoSP";
-            const device2 = process.env.DEVICE_2;
-            let blocks;
-            if (isDual) {
-              blocks = [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${device1} + ${device2}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
-                    "emoji": true
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `🐧 linux (${device1}) · FF '${{ env.E2E_DESKTOP_FEATURE_FLAGS }}' : ${{ needs.report-to-allure.outputs.summary_message || 'No test results' }}`
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `🐧 linux (${device2}) · FF '${{ env.E2E_DESKTOP_FEATURE_FLAGS }}' : ${{ needs.report-to-allure-device2.outputs.summary_message || 'No test results' }}`
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Allure Report (${device1})*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-${device1}>`
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Allure Report (${device2})*\n<${{ needs.report-to-allure-device2.outputs.report-url }}|allure-results-${device2}>`
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
-                    }
-                  ]
-                }
-              ];
-            } else {
-              blocks = [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": `:ledger-logo: Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }} - ${device1}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
-                    "emoji": true
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": `🐧 linux · FF '${{ env.E2E_DESKTOP_FEATURE_FLAGS }}' : ${{ needs.report-to-allure.outputs.summary_message || 'No test results' }}`
-                  }
-                },
-                { "type": "divider" },
-                {
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Allure Report*\n<${{ needs.report-to-allure.outputs.report-url }}|allure-results-linux>"
-                    },
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Workflow*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
-                    }
-                  ]
-                }
-              ];
-              if (process.env.EXPORT_TO_XRAY === 'true') {
-                blocks.push({
-                  "type": "section",
-                  "fields": [
-                    {
-                      "type": "mrkdwn",
-                      "text": `*Xray Link*\n<https://ledgerhq.atlassian.net/browse/${process.env.TEST_EXECUTION}|Test Execution>`
-                    }
-                  ]
-                });
-              }
-            }
-            const d1Color = "${{ needs.report-to-allure.outputs.status_color }}";
-            const d2Color = "${{ needs.report-to-allure-device2.outputs.status_color }}";
-            const color = isDual
-              ? (d1Color === "#33FF39" && d2Color === "#33FF39" ? "#33FF39" : "#FF333C")
-              : (d1Color || "#808080");
-            const slackPayload = {
-              "text": " ",
-              "attachments": [
-                {
-                  "color": color,
-                  "fallback": `Ledger Live Desktop E2E tests results on ${{ inputs.ref || github.ref_name }}${{ inputs.smoke_tests && ' (Smoke Tests)' || '' }}`,
-                  blocks
-                }
-              ]
-            };
-            fs.writeFileSync("payload-slack-content.json", JSON.stringify({ ...slackPayload, channel: "C05FKJ7DFAP" }), "utf-8");
-
-      - name: Post to Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
-        with:
-          method: chat.postMessage
           token: ${{ secrets.SLACK_LIVE_CI_BOT_TOKEN }}
-          payload-file-path: ${{ github.workspace }}/payload-slack-content.json
+          channel: C05FKJ7DFAP
+          product: "Ledger Live Desktop E2E"
+          ref: ${{ env.REF }}
+          smoke_tests: ${{ inputs.smoke_tests }}
+          header_devices: ${{ env.IS_DUAL == 'true' && format('{0} + {1}', env.DEVICE_1, env.DEVICE_2) || env.DEVICE_1 }}
+          run_url: ${{ env.RUN_URL }}
+          row1_emoji: "🐧"
+          # Dual runs put the device in the label ("linux (nanoSP)"); single runs use plain "linux".
+          row1_label: ${{ env.IS_DUAL == 'true' && format('linux ({0})', env.DEVICE_1) || 'linux' }}
+          row1_flags: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}
+          row1_summary: ${{ needs.report-to-allure.outputs.summary_message }}
+          row1_report_url: ${{ needs.report-to-allure.outputs.report-url }}
+          row1_report_title: ${{ env.IS_DUAL == 'true' && format('Allure Report ({0})', env.DEVICE_1) || 'Allure Report' }}
+          row1_report_link_text: ${{ env.IS_DUAL == 'true' && format('allure-results-{0}', env.DEVICE_1) || 'allure-results-linux' }}
+          row1_status: ${{ needs.report-to-allure.outputs.status }}
+          # Row 2 only renders on dual-device runs (empty label = dropped).
+          row2_emoji: "🐧"
+          row2_label: ${{ env.IS_DUAL == 'true' && format('linux ({0})', env.DEVICE_2) || '' }}
+          row2_flags: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}
+          row2_summary: ${{ needs.report-to-allure-device2.outputs.summary_message }}
+          row2_report_url: ${{ needs.report-to-allure-device2.outputs.report-url }}
+          row2_report_title: ${{ env.IS_DUAL == 'true' && format('Allure Report ({0})', env.DEVICE_2) || '' }}
+          row2_report_link_text: ${{ env.IS_DUAL == 'true' && format('allure-results-{0}', env.DEVICE_2) || '' }}
+          row2_status: ${{ needs.report-to-allure-device2.outputs.status }}
+          # Xray link: single-device runs with export_to_xray only (matches previous behavior).
+          extra_field_title: ${{ (env.IS_DUAL != 'true' && inputs.export_to_xray) && 'Xray Link' || '' }}
+          extra_field_url: "https://ledgerhq.atlassian.net/browse/${{ github.event.inputs.test_execution }}"
+          extra_field_link_text: "Test Execution"

--- a/tools/actions/composites/e2e-slack-report/action.yml
+++ b/tools/actions/composites/e2e-slack-report/action.yml
@@ -1,0 +1,189 @@
+name: "E2E Slack report"
+description: "Build and post the Slack test-results message for an e2e run (mobile or desktop) to one or two channels."
+
+inputs:
+  token:
+    description: "Slack bot token used to post the message."
+    required: true
+  channel:
+    description: "Slack channel ID to post to."
+    required: true
+  secondary_channel:
+    description: "Optional second channel ID to also post the same message to. Leave empty to post once."
+    required: false
+    default: ""
+  product:
+    description: 'Product label in the header, e.g. "Ledger Live Mobile E2E".'
+    required: true
+  ref:
+    description: "Git ref under test (shown in the header)."
+    required: true
+  smoke_tests:
+    description: "'true' to append the ' (Smoke Tests)' suffix to the header."
+    required: false
+    default: "false"
+  header_devices:
+    description: 'Device portion of the header, e.g. "iOS:nanoX / Android:pixel" or "nanoSP + stax".'
+    required: true
+  run_url:
+    description: "Full URL of the workflow run (for the Workflow link)."
+    required: true
+
+  # --- Result rows. A row is included only when its label is non-empty. ---
+  # Row 1 (mobile: iOS · desktop: device 1)
+  row1_emoji:
+    required: false
+    default: ""
+  row1_label:
+    description: 'Row label, e.g. "iOS" or "linux" or "linux (nanoSP)". Empty = omit this row.'
+    required: false
+    default: ""
+  row1_flags:
+    description: "Feature-flag set shown in the result line."
+    required: false
+    default: ""
+  row1_device:
+    description: 'Rendered as " · <device>" after the flags (mobile). Leave empty on desktop.'
+    required: false
+    default: ""
+  row1_summary:
+    description: "Allure summary message; falls back to 'No test results' when empty."
+    required: false
+    default: ""
+  row1_report_url:
+    required: false
+    default: ""
+  row1_report_title:
+    description: 'Bold label of the Allure field, e.g. "Allure Report iOS".'
+    required: false
+    default: ""
+  row1_report_link_text:
+    description: "Link text of the Allure field."
+    required: false
+    default: ""
+  row1_status:
+    description: "'success' when the row passed; any other non-empty value counts as failed."
+    required: false
+    default: ""
+  row1_missing_shards:
+    description: "Comma-separated shard ids that produced no results (adds a warning block)."
+    required: false
+    default: ""
+
+  # Row 2 (mobile: Android · desktop: device 2)
+  row2_emoji:
+    required: false
+    default: ""
+  row2_label:
+    required: false
+    default: ""
+  row2_flags:
+    required: false
+    default: ""
+  row2_device:
+    required: false
+    default: ""
+  row2_summary:
+    required: false
+    default: ""
+  row2_report_url:
+    required: false
+    default: ""
+  row2_report_title:
+    required: false
+    default: ""
+  row2_report_link_text:
+    required: false
+    default: ""
+  row2_status:
+    required: false
+    default: ""
+  row2_missing_shards:
+    required: false
+    default: ""
+
+  # --- Optional extra field, appended as its own section (e.g. desktop Xray link). ---
+  extra_field_title:
+    required: false
+    default: ""
+  extra_field_url:
+    required: false
+    default: ""
+  extra_field_link_text:
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build Slack payload
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        PAYLOAD_PATH: ${{ runner.temp }}/e2e-slack-payload.json
+        SECONDARY_PAYLOAD_PATH: ${{ runner.temp }}/e2e-slack-payload-secondary.json
+        CHANNEL: ${{ inputs.channel }}
+        SECONDARY_CHANNEL: ${{ inputs.secondary_channel }}
+        PRODUCT: ${{ inputs.product }}
+        REF: ${{ inputs.ref }}
+        SMOKE_TESTS: ${{ inputs.smoke_tests }}
+        HEADER_DEVICES: ${{ inputs.header_devices }}
+        RUN_URL: ${{ inputs.run_url }}
+        ROW1_EMOJI: ${{ inputs.row1_emoji }}
+        ROW1_LABEL: ${{ inputs.row1_label }}
+        ROW1_FLAGS: ${{ inputs.row1_flags }}
+        ROW1_DEVICE: ${{ inputs.row1_device }}
+        ROW1_SUMMARY: ${{ inputs.row1_summary }}
+        ROW1_REPORT_URL: ${{ inputs.row1_report_url }}
+        ROW1_REPORT_TITLE: ${{ inputs.row1_report_title }}
+        ROW1_REPORT_LINK_TEXT: ${{ inputs.row1_report_link_text }}
+        ROW1_STATUS: ${{ inputs.row1_status }}
+        ROW1_MISSING_SHARDS: ${{ inputs.row1_missing_shards }}
+        ROW2_EMOJI: ${{ inputs.row2_emoji }}
+        ROW2_LABEL: ${{ inputs.row2_label }}
+        ROW2_FLAGS: ${{ inputs.row2_flags }}
+        ROW2_DEVICE: ${{ inputs.row2_device }}
+        ROW2_SUMMARY: ${{ inputs.row2_summary }}
+        ROW2_REPORT_URL: ${{ inputs.row2_report_url }}
+        ROW2_REPORT_TITLE: ${{ inputs.row2_report_title }}
+        ROW2_REPORT_LINK_TEXT: ${{ inputs.row2_report_link_text }}
+        ROW2_STATUS: ${{ inputs.row2_status }}
+        ROW2_MISSING_SHARDS: ${{ inputs.row2_missing_shards }}
+        EXTRA_FIELD_TITLE: ${{ inputs.extra_field_title }}
+        EXTRA_FIELD_URL: ${{ inputs.extra_field_url }}
+        EXTRA_FIELD_LINK_TEXT: ${{ inputs.extra_field_link_text }}
+      with:
+        script: |
+          const path = require("path");
+          const fs = require("fs");
+          const { modelFromEnv, buildSlackPayload } = require(
+            path.join(process.env.ACTION_PATH, "build-slack-payload.js"),
+          );
+          const payload = buildSlackPayload(modelFromEnv(process.env));
+          fs.writeFileSync(
+            process.env.PAYLOAD_PATH,
+            JSON.stringify({ ...payload, channel: process.env.CHANNEL }),
+            "utf-8",
+          );
+          if (process.env.SECONDARY_CHANNEL) {
+            fs.writeFileSync(
+              process.env.SECONDARY_PAYLOAD_PATH,
+              JSON.stringify({ ...payload, channel: process.env.SECONDARY_CHANNEL }),
+              "utf-8",
+            );
+          }
+
+    - name: Post to Slack channel
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.token }}
+        payload-file-path: ${{ runner.temp }}/e2e-slack-payload.json
+
+    - name: Post to secondary Slack channel
+      if: ${{ inputs.secondary_channel != '' }}
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.token }}
+        payload-file-path: ${{ runner.temp }}/e2e-slack-payload-secondary.json

--- a/tools/actions/composites/e2e-slack-report/build-slack-payload.js
+++ b/tools/actions/composites/e2e-slack-report/build-slack-payload.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * Build the Slack `chat.postMessage` payload for an E2E test report (mobile or desktop).
+ *
+ * Shared by the mobile (`report-on-slack`) and desktop (`notify-to-slack`) e2e workflows.
+ * `modelFromEnv` reads the flat scalar inputs the composite forwards via `env:`; a row is
+ * included only when its `label` is non-empty (that is how callers drop a platform, e.g.
+ * mobile `tests_type: iOS Only` or desktop single-device runs). `buildSlackPayload` turns
+ * the model into the Slack Block Kit attachment.
+ *
+ * Run locally: node build-slack-payload.js   (prints a sample payload built from the env)
+ * From actions/github-script: require this file, call buildSlackPayload(modelFromEnv(process.env)).
+ */
+
+const GREEN = "#33FF39";
+const RED = "#FF333C";
+const GREY = "#808080";
+
+/**
+ * Build the list of result rows from ROW{1,2}_* env vars. A row with an empty label is skipped.
+ * @param {NodeJS.ProcessEnv} env
+ */
+function rowsFromEnv(env) {
+  const rows = [];
+  for (const i of [1, 2]) {
+    const label = env[`ROW${i}_LABEL`];
+    if (!label) continue;
+    rows.push({
+      emoji: env[`ROW${i}_EMOJI`] || "",
+      label,
+      flags: env[`ROW${i}_FLAGS`] || "",
+      // Rendered as " · <device>" after the feature flags (mobile). Desktop leaves this empty
+      // and bakes the device into the label instead (e.g. "linux (nanoSP)").
+      device: env[`ROW${i}_DEVICE`] || "",
+      summary: env[`ROW${i}_SUMMARY`] || "No test results",
+      reportUrl: env[`ROW${i}_REPORT_URL`] || "",
+      reportTitle: env[`ROW${i}_REPORT_TITLE`] || "Allure Report",
+      reportLinkText: env[`ROW${i}_REPORT_LINK_TEXT`] || "Allure Report",
+      status: env[`ROW${i}_STATUS`] || "",
+      missingShards: env[`ROW${i}_MISSING_SHARDS`] || "",
+    });
+  }
+  return rows;
+}
+
+/**
+ * Assemble the message model from the flat env vars forwarded by the composite.
+ * @param {NodeJS.ProcessEnv} env
+ */
+function modelFromEnv(env) {
+  const smokeSuffix = env.SMOKE_TESTS === "true" ? " (Smoke Tests)" : "";
+  const extraField = env.EXTRA_FIELD_TITLE
+    ? {
+        title: env.EXTRA_FIELD_TITLE,
+        url: env.EXTRA_FIELD_URL || "",
+        linkText: env.EXTRA_FIELD_LINK_TEXT || env.EXTRA_FIELD_TITLE,
+      }
+    : null;
+  return {
+    product: env.PRODUCT || "",
+    ref: env.REF || "",
+    smokeSuffix,
+    headerDevices: env.HEADER_DEVICES || "",
+    runUrl: env.RUN_URL || "",
+    rows: rowsFromEnv(env),
+    extraField,
+  };
+}
+
+/** `<emoji> <label> · FF '<flags>'[ · <device>] : <summary>` */
+function resultLine(row) {
+  const deviceMid = row.device ? ` · ${row.device}` : "";
+  return `${row.emoji} ${row.label} · FF '${row.flags}'${deviceMid} : ${row.summary}`;
+}
+
+/** Allure link field, with a "No Allure Report" fallback when no URL is available. */
+function allureField(row) {
+  const text = row.reportUrl
+    ? `*${row.reportTitle}*\n<${row.reportUrl}|${row.reportLinkText}>`
+    : `*${row.reportTitle}*\nNo Allure Report`;
+  return { type: "mrkdwn", text };
+}
+
+/**
+ * Green only when every included row succeeded. Red when any included row did not — a failure
+ * OR a missing status (e.g. a dual run where one device produced no results): a rendered row that
+ * reports nothing must not be able to leave the bar green. Grey only when no included row reported
+ * any status at all (e.g. a single-device desktop run with no results).
+ */
+function attachmentColor(rows) {
+  if (rows.length === 0 || rows.every(r => !r.status)) return GREY;
+  return rows.every(r => r.status === "success") ? GREEN : RED;
+}
+
+/**
+ * @param {ReturnType<typeof modelFromEnv>} model
+ * @returns {{ text: string, attachments: Array<object> }} Slack payload without `channel`.
+ */
+function buildSlackPayload(model) {
+  const { product, ref, smokeSuffix, headerDevices, runUrl, rows, extraField } = model;
+
+  const blocks = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `:ledger-logo: ${product} tests results on ${ref} - ${headerDevices}${smokeSuffix}`,
+        emoji: true,
+      },
+    },
+    { type: "divider" },
+  ];
+
+  for (const row of rows) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: resultLine(row) },
+    });
+  }
+
+  for (const row of rows) {
+    if (!row.missingShards) continue;
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `⚠️ *Warning*: ${row.label} - Missing results for shard(s): ${row.missingShards}.`,
+      },
+    });
+  }
+
+  const infoFields = rows.map(allureField);
+  infoFields.push({
+    type: "mrkdwn",
+    text: `*Workflow*\n<${runUrl}|Workflow run>`,
+  });
+  blocks.push({ type: "divider" });
+  blocks.push({ type: "section", fields: infoFields });
+
+  if (extraField) {
+    blocks.push({
+      type: "section",
+      fields: [
+        {
+          type: "mrkdwn",
+          text: `*${extraField.title}*\n<${extraField.url}|${extraField.linkText}>`,
+        },
+      ],
+    });
+  }
+
+  return {
+    text: " ",
+    attachments: [
+      {
+        color: attachmentColor(rows),
+        fallback: `${product} tests results on ${ref}${smokeSuffix}`,
+        blocks,
+      },
+    ],
+  };
+}
+
+module.exports = { modelFromEnv, buildSlackPayload };
+
+if (require.main === module) {
+  const payload = buildSlackPayload(modelFromEnv(process.env));
+  console.log(JSON.stringify(payload, null, 2));
+}

--- a/tools/actions/composites/get-allure-summary/action.yml
+++ b/tools/actions/composites/get-allure-summary/action.yml
@@ -8,9 +8,9 @@ inputs:
     description: "Path to allure files"
     required: true
 outputs:
-  status_color:
-    value: ${{ steps.get-summary.outputs.status_color }}
-    description: "Slack Status color"
+  status:
+    value: ${{ steps.get-summary.outputs.status }}
+    description: "Test outcome: 'success' or 'failed'"
   summary_message:
     value: ${{ steps.get-summary.outputs.summary_message }}
     description: "Formatted summary line, e.g. '❌ 19 passed, 7 failed, 0 broken, 12 skipped, 38 total'"
@@ -29,10 +29,10 @@ runs:
         skippedTests=$(jq '.statistic.skipped' summary.json)
         totalTests=$(jq '.statistic.total' summary.json)
         if [ "$failedTests" -gt 0 ] || [ "$brokenTests" -gt 0 ]; then
-          echo "status_color=#FF333C" >> "$GITHUB_OUTPUT";
+          echo "status=failed" >> "$GITHUB_OUTPUT";
           echo "summary_message=❌ $passedTests passed, $failedTests failed, $brokenTests broken, $skippedTests skipped, $totalTests total" >> "$GITHUB_OUTPUT";
         else
-          echo "status_color=#33FF39" >> "$GITHUB_OUTPUT";
+          echo "status=success" >> "$GITHUB_OUTPUT";
           echo "summary_message=✅ $passedTests passed, $failedTests failed, $brokenTests broken, $skippedTests skipped, $totalTests total" >> "$GITHUB_OUTPUT";
         fi
       shell: bash


### PR DESCRIPTION
## What

Replaces the large inline `github-script` Slack-notification blocks in the mobile and desktop e2e workflows with a shared `tools/actions/composites/e2e-slack-report` composite, backed by `build-slack-payload.js`.

## Why

- The message-building code was duplicated across both workflows and hard to follow; the desktop one interpolated `${{ }}` expressions straight into JS source (fragile against quotes/special chars). Everything now flows through `env:`, and the Block Kit logic lives in one place.
- Fixes a latent bug in the **mobile** attachment color: the old logic read an undefined `ANDROID_ONLY`, so the iOS clause was dead code. Color is now driven off the *included* rows, and a missing per-row status counts as a failure — so e.g. a **dual-device** desktop run where one device produced no results can no longer render green.

## Also in this PR

- Adds a `status` output to the shared `get-allure-summary` composite and reads it directly in the desktop notifier, replacing a fragile `status_color == '#33FF39'` hex string-match. `status_color` had no remaining consumers, so it's removed.
- **Reviewer note:** this touches a shared composite (`get-allure-summary`, used by both e2e workflows). The change is additive/behavior-preserving and merges atomically with the workflow edits, so `develop` stays consistent.

## Behavior-preserving

Same channels (mobile `CTMQ0S5SB` + conditional `C05FKJ7DFAP`; desktop `C05FKJ7DFAP`), tokens, triggers, and gating. The only intended message change is the corrected color.

## Testing

Validated on live runs (composites temporarily branch-pinned, posting to a private test channel — pins reverted before this PR):

- Desktop single (nanoSP) — ✅ green, `status` output flowed through
- Mobile iOS & Android — ✅ green, two-row message
- Desktop dual (nanoSP + stax) — ✅ green, both device statuses populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
