### PR TITLE
docs(agents): add gh cli default for github interactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ For general test, build and check recipes see [/docs/repo-commands.md](/docs/rep
 
 When a task includes Jira or Confluence links, use Atlassian MCP to fetch and read the referenced ticket or page by default before summarizing, planning, or implementing.
 
+When a task involves GitHub — pull requests, issues, CI checks, or releases — use the `gh` CLI by default.
+
 ## Validate Before Finishing
 
 Always follow the [validate-before-finishing](/docs/validate-before-finishing.md) instructions before completing code changes.


### PR DESCRIPTION
## Summary

- Adds an instruction to `AGENTS.md` telling agents to use the `gh` CLI by default when a task involves GitHub (pull requests, issues, CI checks, or releases).
- This mirrors the existing Atlassian MCP instruction for Jira/Confluence links, making the two external work link patterns consistent.