### PR TITLE
test(dada-client): characterize the untested surface (LIVE-35224)

### DIFF
--- a/.changeset/lucky-mirrors-observe.md
+++ b/.changeset/lucky-mirrors-observe.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Add characterization tests for the previously untested dada-client cache selectors, query hooks and API transforms

--- a/libs/ledger-live-common/src/dada-client/entities/__tests__/interestRateSelectors.test.ts
+++ b/libs/ledger-live-common/src/dada-client/entities/__tests__/interestRateSelectors.test.ts
@@ -1,0 +1,46 @@
+import { selectInterestRateByCurrency } from "../interestRateSelectors";
+import type { ApiState } from "../selectorUtils";
+import type { InterestRate } from "..";
+
+const bitcoinRate: InterestRate = {
+  currencyId: "bitcoin",
+  rate: 4.2,
+  type: "APY",
+  fetchAt: "2026-07-31T00:00:00.000Z",
+};
+
+function stateWith(pages: Record<string, unknown>[]): ApiState {
+  return { assetsDataApi: { queries: { a: { data: { pages } } } } } as ApiState;
+}
+
+describe("selectInterestRateByCurrency", () => {
+  it("reads from the interestRates collection", () => {
+    const state = stateWith([{ interestRates: { bitcoin: bitcoinRate } }]);
+
+    expect(selectInterestRateByCurrency(state, "bitcoin")).toEqual(bitcoinRate);
+  });
+
+  it("returns undefined when the currency has no rate", () => {
+    const state = stateWith([{ interestRates: { bitcoin: bitcoinRate } }]);
+
+    expect(selectInterestRateByCurrency(state, "ethereum")).toBeUndefined();
+  });
+
+  it("does not read from the markets collection", () => {
+    const state = stateWith([{ markets: { bitcoin: { price: 100 } } }]);
+
+    expect(selectInterestRateByCurrency(state, "bitcoin")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty state", () => {
+    expect(selectInterestRateByCurrency({}, "bitcoin")).toBeUndefined();
+  });
+
+  it("preserves every field of the stored rate", () => {
+    const state = stateWith([{ interestRates: { bitcoin: bitcoinRate } }]);
+
+    expect(selectInterestRateByCurrency(state, "bitcoin")).toEqual(
+      expect.objectContaining({ currencyId: "bitcoin", rate: 4.2, type: "APY" }),
+    );
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/entities/__tests__/marketSelectors.test.ts
+++ b/libs/ledger-live-common/src/dada-client/entities/__tests__/marketSelectors.test.ts
@@ -1,0 +1,42 @@
+import { selectMarketByCurrency } from "../marketSelectors";
+import type { ApiState } from "../selectorUtils";
+
+const bitcoinMarket = {
+  price: 65000.42,
+  priceChangePercentage24h: 1.2345,
+  marketCap: 1_280_000_000_000,
+};
+
+function stateWith(pages: Record<string, unknown>[]): ApiState {
+  return { assetsDataApi: { queries: { a: { data: { pages } } } } } as ApiState;
+}
+
+describe("selectMarketByCurrency", () => {
+  it("reads from the markets collection", () => {
+    const state = stateWith([{ markets: { bitcoin: bitcoinMarket } }]);
+
+    expect(selectMarketByCurrency(state, "bitcoin")).toEqual(bitcoinMarket);
+  });
+
+  it("returns undefined when the currency has no market entry", () => {
+    const state = stateWith([{ markets: { bitcoin: bitcoinMarket } }]);
+
+    expect(selectMarketByCurrency(state, "ethereum")).toBeUndefined();
+  });
+
+  it("does not read from the interestRates collection", () => {
+    const state = stateWith([{ interestRates: { bitcoin: { rate: 4.2 } } }]);
+
+    expect(selectMarketByCurrency(state, "bitcoin")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty state", () => {
+    expect(selectMarketByCurrency({}, "bitcoin")).toBeUndefined();
+  });
+
+  it("returns partial market entries unchanged, without filling defaults", () => {
+    const state = stateWith([{ markets: { bitcoin: { price: 65000 } } }]);
+
+    expect(selectMarketByCurrency(state, "bitcoin")).toEqual({ price: 65000 });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/entities/__tests__/selectorUtils.test.ts
+++ b/libs/ledger-live-common/src/dada-client/entities/__tests__/selectorUtils.test.ts
@@ -1,0 +1,163 @@
+import { createCurrencyDataSelector, type ApiState } from "../selectorUtils";
+
+type Rate = { rate: number };
+
+function stateWithQueries(queries: Record<string, unknown>): ApiState {
+  return { assetsDataApi: { queries } } as ApiState;
+}
+
+function pagedQuery(...pages: Record<string, unknown>[]) {
+  return { data: { pages } };
+}
+
+describe("createCurrencyDataSelector", () => {
+  const selectRate = createCurrencyDataSelector<Rate>("interestRates");
+
+  it("finds the entry matching the currency id under the requested data key", () => {
+    const state = stateWithQueries({
+      'getAssetsData({"product":"lld"})': pagedQuery({
+        interestRates: { bitcoin: { rate: 4.2 } },
+      }),
+    });
+
+    expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+  });
+
+  it("returns undefined for a currency id that is absent", () => {
+    const state = stateWithQueries({
+      a: pagedQuery({ interestRates: { bitcoin: { rate: 4.2 } } }),
+    });
+
+    expect(selectRate(state, "ethereum")).toBeUndefined();
+  });
+
+  it("only reads the requested data key and ignores the others", () => {
+    const state = stateWithQueries({
+      a: pagedQuery({ markets: { bitcoin: { price: 100 } } }),
+    });
+
+    expect(selectRate(state, "bitcoin")).toBeUndefined();
+  });
+
+  describe("tolerates missing levels of the cache shape", () => {
+    it("returns undefined when the api slice is absent entirely", () => {
+      expect(selectRate({}, "bitcoin")).toBeUndefined();
+    });
+
+    it("returns undefined when the api slice has no queries", () => {
+      expect(selectRate({ assetsDataApi: {} }, "bitcoin")).toBeUndefined();
+    });
+
+    it("returns undefined when there are no cache entries", () => {
+      expect(selectRate(stateWithQueries({}), "bitcoin")).toBeUndefined();
+    });
+
+    it("skips a cache entry that has no data", () => {
+      const state = stateWithQueries({ pending: {} });
+
+      expect(selectRate(state, "bitcoin")).toBeUndefined();
+    });
+
+    it("skips a cache entry whose data has no pages and keeps scanning the rest", () => {
+      const state = stateWithQueries({
+        // shape produced by the non-infinite getAssetData endpoint
+        flat: { data: { interestRates: { bitcoin: { rate: 9.9 } } } },
+        paged: pagedQuery({ interestRates: { bitcoin: { rate: 4.2 } } }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+    });
+
+    it("skips a page that lacks the data key", () => {
+      const state = stateWithQueries({
+        a: pagedQuery({}, { interestRates: { bitcoin: { rate: 4.2 } } }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+    });
+  });
+
+  describe("scans every cache entry regardless of query args", () => {
+    /*
+     * Characterizes existing behavior, not a recommendation: the selector has no
+     * access to the query args of the entries it walks, so a value cached by one
+     * query is served to callers of any other. Preserve on migration.
+     */
+    it("returns a value cached by an unrelated query", () => {
+      const state = stateWithQueries({
+        'getAssetsData({"search":"something-else"})': pagedQuery({
+          interestRates: { solana: { rate: 7.1 } },
+        }),
+      });
+
+      expect(selectRate(state, "solana")).toEqual({ rate: 7.1 });
+    });
+
+    it("returns the first match in cache-entry order when several entries hold the same id", () => {
+      const state = stateWithQueries({
+        first: pagedQuery({ interestRates: { bitcoin: { rate: 1 } } }),
+        second: pagedQuery({ interestRates: { bitcoin: { rate: 2 } } }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 1 });
+    });
+
+    it("returns the first match in page order within one entry", () => {
+      const state = stateWithQueries({
+        a: pagedQuery(
+          { interestRates: { bitcoin: { rate: 1 } } },
+          { interestRates: { bitcoin: { rate: 2 } } },
+        ),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 1 });
+    });
+
+    it("finds a match on a later page of a later entry", () => {
+      const state = stateWithQueries({
+        a: pagedQuery({ interestRates: {} }),
+        b: pagedQuery({ interestRates: {} }, { interestRates: { cardano: { rate: 3.3 } } }),
+      });
+
+      expect(selectRate(state, "cardano")).toEqual({ rate: 3.3 });
+    });
+  });
+
+  describe("falsy stored values", () => {
+    it("treats a falsy stored value as absent", () => {
+      const state = stateWithQueries({
+        a: pagedQuery({ interestRates: { bitcoin: 0 } }),
+        b: pagedQuery({ interestRates: { bitcoin: { rate: 4.2 } } }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+    });
+  });
+
+  describe("independent instances", () => {
+    it("keeps separate data keys isolated from each other", () => {
+      const selectMarket = createCurrencyDataSelector<{ price: number }>("markets");
+      const state = stateWithQueries({
+        a: pagedQuery({
+          interestRates: { bitcoin: { rate: 4.2 } },
+          markets: { bitcoin: { price: 100 } },
+        }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+      expect(selectMarket(state, "bitcoin")).toEqual({ price: 100 });
+    });
+
+    it("returns correct values when called with alternating currency ids", () => {
+      const state = stateWithQueries({
+        a: pagedQuery({
+          interestRates: { bitcoin: { rate: 4.2 }, ethereum: { rate: 3.1 } },
+        }),
+      });
+
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+      expect(selectRate(state, "ethereum")).toEqual({ rate: 3.1 });
+      expect(selectRate(state, "bitcoin")).toEqual({ rate: 4.2 });
+    });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetData.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useAssetData.test.ts
@@ -1,0 +1,131 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useAssetData } from "../useAssetData";
+import { useGetAssetDataQuery } from "../../state-manager/api";
+
+jest.mock("../../state-manager/api", () => ({
+  useGetAssetDataQuery: jest.fn(),
+}));
+
+const mockUseGetAssetDataQuery = jest.mocked(useGetAssetDataQuery);
+
+const defaultQueryResult = {
+  data: undefined,
+  isLoading: false,
+  error: undefined,
+  isSuccess: false,
+  isError: false,
+  isFetching: false,
+  refetch: jest.fn(),
+};
+
+const baseParams = { product: "lld" as const, version: "1.0.0" };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockResult = (overrides: Record<string, unknown> = {}) =>
+  mockUseGetAssetDataQuery.mockReturnValue({ ...defaultQueryResult, ...overrides } as any);
+
+describe("useAssetData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("query arguments", () => {
+    it("forwards only currencyIds, product, version and isStaging", () => {
+      mockResult();
+
+      renderHook(() => useAssetData({ ...baseParams, currencyIds: ["bitcoin"], isStaging: true }));
+
+      expect(mockUseGetAssetDataQuery).toHaveBeenCalledWith({
+        currencyIds: ["bitcoin"],
+        product: "lld",
+        version: "1.0.0",
+        isStaging: true,
+      });
+    });
+
+    it("drops params the underlying query does not accept", () => {
+      mockResult();
+
+      renderHook(() =>
+        useAssetData({ ...baseParams, search: "btc", useCase: "send", includeTestNetworks: true }),
+      );
+
+      expect(mockUseGetAssetDataQuery).toHaveBeenCalledWith({
+        currencyIds: undefined,
+        product: "lld",
+        version: "1.0.0",
+        isStaging: undefined,
+      });
+    });
+
+    it("passes no options object, so the query is never skipped", () => {
+      mockResult();
+
+      renderHook(() => useAssetData(baseParams));
+
+      expect(mockUseGetAssetDataQuery).toHaveBeenCalledTimes(1);
+      expect(mockUseGetAssetDataQuery.mock.calls[0]).toHaveLength(1);
+    });
+  });
+
+  describe("loading state collapses isLoading and isFetching", () => {
+    it.each([
+      [{ isLoading: true, isFetching: false }, true],
+      [{ isLoading: false, isFetching: true }, true],
+      [{ isLoading: true, isFetching: true }, true],
+      [{ isLoading: false, isFetching: false }, false],
+    ])("reports %p as isLoading %p", (flags, expected) => {
+      mockResult(flags);
+
+      const { result } = renderHook(() => useAssetData(baseParams));
+
+      expect(result.current.isLoading).toBe(expected);
+    });
+
+    it("still reports loading while refetching with data already present", () => {
+      mockResult({ data: { cryptoAssets: {} }, isFetching: true, isSuccess: true });
+
+      const { result } = renderHook(() => useAssetData(baseParams));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toEqual({ cryptoAssets: {} });
+    });
+  });
+
+  describe("passthrough", () => {
+    it("passes data, success and refetch straight through", () => {
+      const refetch = jest.fn();
+      const data = { cryptoAssets: { bitcoin: {} } };
+      mockResult({ data, isSuccess: true, refetch });
+
+      const { result } = renderHook(() => useAssetData(baseParams));
+
+      expect(result.current.data).toBe(data);
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.refetch).toBe(refetch);
+    });
+
+    it("passes the raw error through without parsing it", () => {
+      const error = { status: 500, data: "boom" };
+      mockResult({ error, isError: true });
+
+      const { result } = renderHook(() => useAssetData(baseParams));
+
+      expect(result.current.error).toBe(error);
+      expect(result.current.isError).toBe(true);
+    });
+
+    it("does not expose errorInfo or isFetching", () => {
+      mockResult({ isFetching: true, error: { status: 500 } });
+
+      const { result } = renderHook(() => useAssetData(baseParams));
+
+      expect(result.current).not.toHaveProperty("errorInfo");
+      expect(result.current).not.toHaveProperty("isFetching");
+    });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useChunkedAssetsData.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useChunkedAssetsData.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useChunkedAssetsData } from "../useChunkedAssetsData";
+import { useGetChunkedAssetsDataQuery } from "../../state-manager/api";
+
+jest.mock("../../state-manager/api", () => ({
+  useGetChunkedAssetsDataQuery: jest.fn(),
+}));
+
+const mockUseGetChunkedAssetsDataQuery = jest.mocked(useGetChunkedAssetsDataQuery);
+
+const defaultQueryResult = {
+  data: undefined,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  error: undefined,
+  isFetching: false,
+  refetch: jest.fn(),
+};
+
+const baseParams = { product: "lld" as const, version: "1.0.0" };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockResult = (overrides: Record<string, unknown> = {}) =>
+  mockUseGetChunkedAssetsDataQuery.mockReturnValue({
+    ...defaultQueryResult,
+    ...overrides,
+  } as any);
+
+describe("useChunkedAssetsData", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("query arguments", () => {
+    it("separates skip from the query args", () => {
+      mockResult();
+
+      renderHook(() =>
+        useChunkedAssetsData({ ...baseParams, currencyIds: ["bitcoin"], skip: true }),
+      );
+
+      expect(mockUseGetChunkedAssetsDataQuery).toHaveBeenCalledWith(
+        { product: "lld", version: "1.0.0", currencyIds: ["bitcoin"] },
+        { skip: true },
+      );
+    });
+
+    it("forwards every other param unchanged", () => {
+      mockResult();
+
+      renderHook(() =>
+        useChunkedAssetsData({
+          ...baseParams,
+          currencyIds: ["bitcoin", "ethereum"],
+          useCase: "send",
+          isStaging: true,
+          includeTestNetworks: true,
+        }),
+      );
+
+      expect(mockUseGetChunkedAssetsDataQuery).toHaveBeenCalledWith(
+        {
+          product: "lld",
+          version: "1.0.0",
+          currencyIds: ["bitcoin", "ethereum"],
+          useCase: "send",
+          isStaging: true,
+          includeTestNetworks: true,
+        },
+        { skip: undefined },
+      );
+    });
+
+    it("passes skip as undefined when it is not provided", () => {
+      mockResult();
+
+      renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(mockUseGetChunkedAssetsDataQuery).toHaveBeenCalledWith(baseParams, {
+        skip: undefined,
+      });
+    });
+  });
+
+  describe("loading state suppresses refetch flicker", () => {
+    it("reports loading on the initial fetch", () => {
+      mockResult({ isLoading: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("reports loading while fetching with no data yet", () => {
+      mockResult({ isFetching: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("does NOT report loading while refetching when data is already present", () => {
+      mockResult({ isFetching: true, data: { cryptoAssets: {} }, isSuccess: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.data).toEqual({ cryptoAssets: {} });
+    });
+
+    it("is not loading when idle", () => {
+      mockResult({ isSuccess: true, data: { cryptoAssets: {} } });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("error reporting", () => {
+    it("exposes both the raw error and a parsed errorInfo", () => {
+      const error = { status: 500, data: "boom" };
+      mockResult({ error, isError: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.error).toBe(error);
+      expect(result.current.errorInfo).toEqual({
+        hasError: true,
+        isNetworkError: false,
+        isApiError: true,
+        apiStatus: 500,
+      });
+    });
+
+    it("classifies a fetch failure as a network error with no status", () => {
+      mockResult({ error: { status: "FETCH_ERROR", error: "offline" }, isError: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.errorInfo).toEqual({
+        hasError: true,
+        isNetworkError: true,
+        isApiError: false,
+        apiStatus: undefined,
+      });
+    });
+
+    it("still produces an errorInfo when there is no error", () => {
+      mockResult({ isSuccess: true });
+
+      const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+      expect(result.current.errorInfo).toEqual({
+        hasError: false,
+        isNetworkError: false,
+        isApiError: false,
+        apiStatus: undefined,
+      });
+    });
+  });
+
+  it("passes refetch straight through", () => {
+    const refetch = jest.fn();
+    mockResult({ refetch });
+
+    const { result } = renderHook(() => useChunkedAssetsData(baseParams));
+
+    expect(result.current.refetch).toBe(refetch);
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useDrawerConfiguration.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useDrawerConfiguration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useFeature } from "@features/platform-feature-flags";
+import { useDrawerConfiguration } from "../useDrawerConfiguration";
+
+jest.mock("@features/platform-feature-flags", () => ({ useFeature: jest.fn() }));
+
+const mockUseFeature = jest.mocked(useFeature);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const flag = (value: unknown) => mockUseFeature.mockReturnValue(value as any);
+
+function renderCreate() {
+  const { result } = renderHook(() => useDrawerConfiguration());
+  return result.current.createDrawerConfiguration;
+}
+
+describe("useDrawerConfiguration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    flag(null);
+  });
+
+  it("reads the ptxEarnDrawerConfiguration flag", () => {
+    renderHook(() => useDrawerConfiguration());
+
+    expect(mockUseFeature).toHaveBeenCalledWith("ptxEarnDrawerConfiguration");
+  });
+
+  it("always returns both assets and networks, even with no input", () => {
+    expect(renderCreate()(undefined, undefined)).toEqual({ assets: {}, networks: {} });
+  });
+
+  describe("earn use case comes from the feature flag", () => {
+    it("uses the flag params when the flag is enabled", () => {
+      flag({ enabled: true, params: { assets: { a: 1 }, networks: { n: 1 } } });
+
+      expect(renderCreate()(undefined, "earn")).toEqual({
+        assets: { a: 1 },
+        networks: { n: 1 },
+      });
+    });
+
+    it("ignores the params when the flag is disabled", () => {
+      flag({ enabled: false, params: { assets: { a: 1 } } });
+
+      expect(renderCreate()(undefined, "earn")).toEqual({ assets: {}, networks: {} });
+    });
+
+    it("tolerates an enabled flag with no params", () => {
+      flag({ enabled: true });
+
+      expect(renderCreate()(undefined, "earn")).toEqual({ assets: {}, networks: {} });
+    });
+
+    it("tolerates a missing flag", () => {
+      flag(undefined);
+
+      expect(renderCreate()(undefined, "earn")).toEqual({ assets: {}, networks: {} });
+    });
+
+    it("does not apply the earn config to another use case", () => {
+      flag({ enabled: true, params: { assets: { a: 1 } } });
+
+      expect(renderCreate()(undefined, "send")).toEqual({ assets: {}, networks: {} });
+    });
+
+    it("does not apply the earn config when no use case is given", () => {
+      flag({ enabled: true, params: { assets: { a: 1 } } });
+
+      expect(renderCreate()(undefined, undefined)).toEqual({ assets: {}, networks: {} });
+    });
+  });
+
+  describe("precedence", () => {
+    it("lets the explicit configuration win over the use-case config", () => {
+      flag({ enabled: true, params: { assets: { shared: "from-flag", only: "flag" } } });
+
+      expect(renderCreate()({ assets: { shared: "explicit" } }, "earn")).toEqual({
+        assets: { shared: "explicit", only: "flag" },
+        networks: {},
+      });
+    });
+
+    it("lets a custom use-case config override the default earn config", () => {
+      flag({ enabled: true, params: { assets: { a: "from-flag" } } });
+
+      expect(renderCreate()(undefined, "earn", { earn: { assets: { a: "from-custom" } } })).toEqual(
+        { assets: { a: "from-custom" }, networks: {} },
+      );
+    });
+
+    it("supports custom use cases beyond earn", () => {
+      expect(renderCreate()(undefined, "stake", { stake: { networks: { n: 1 } } })).toEqual({
+        assets: {},
+        networks: { n: 1 },
+      });
+    });
+
+    it("merges assets and networks independently", () => {
+      expect(
+        renderCreate()({ networks: { n: "explicit" } }, "stake", {
+          stake: { assets: { a: "use-case" } },
+        }),
+      ).toEqual({ assets: { a: "use-case" }, networks: { n: "explicit" } });
+    });
+  });
+
+  it("returns a stable callback while the flag is unchanged", () => {
+    const flagValue = { enabled: true, params: {} };
+    flag(flagValue);
+
+    const { result, rerender } = renderHook(() => useDrawerConfiguration());
+    const first = result.current.createDrawerConfiguration;
+    rerender();
+
+    expect(result.current.createDrawerConfiguration).toBe(first);
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useInterestRatesByCurrencies.test.tsx
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useInterestRatesByCurrencies.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { renderHook } from "@testing-library/react";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useInterestRatesByCurrencies } from "../useInterestRatesByCurrencies";
+import type { ApiState } from "../../entities/selectorUtils";
+
+const currency = (id: string) => ({ id }) as CryptoOrTokenCurrency;
+
+const rate = (currencyId: string, value: number, type: string) => ({
+  currencyId,
+  rate: value,
+  type,
+  fetchAt: "2026-07-31T00:00:00.000Z",
+});
+
+function renderWithRates(
+  interestRates: Record<string, unknown>,
+  currencies: CryptoOrTokenCurrency[],
+) {
+  const state = {
+    assetsDataApi: { queries: { a: { data: { pages: [{ interestRates }] } } } },
+  } as ApiState;
+  const store = configureStore({ reducer: () => state });
+
+  return renderHook(() => useInterestRatesByCurrencies(currencies), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+}
+
+describe("useInterestRatesByCurrencies", () => {
+  it("maps each currency id to its rate value and type", () => {
+    const { result } = renderWithRates(
+      { bitcoin: rate("bitcoin", 4.2, "APY"), ethereum: rate("ethereum", 3.1, "APR") },
+      [currency("bitcoin"), currency("ethereum")],
+    );
+
+    expect(result.current).toEqual({
+      bitcoin: { value: 4.2, type: "APY" },
+      ethereum: { value: 3.1, type: "APR" },
+    });
+  });
+
+  it("returns an empty map for an empty currency list", () => {
+    const { result } = renderWithRates({ bitcoin: rate("bitcoin", 4.2, "APY") }, []);
+
+    expect(result.current).toEqual({});
+  });
+
+  it("omits a currency that has no cached rate", () => {
+    const { result } = renderWithRates({ bitcoin: rate("bitcoin", 4.2, "APY") }, [
+      currency("bitcoin"),
+      currency("solana"),
+    ]);
+
+    expect(result.current).toEqual({ bitcoin: { value: 4.2, type: "APY" } });
+    expect(result.current).not.toHaveProperty("solana");
+  });
+
+  describe("apy type validation", () => {
+    it.each(["NRR", "APY", "APR"])("accepts the %s type", type => {
+      const { result } = renderWithRates({ bitcoin: rate("bitcoin", 4.2, type) }, [
+        currency("bitcoin"),
+      ]);
+
+      expect(result.current.bitcoin).toEqual({ value: 4.2, type });
+    });
+
+    it.each(["", "apy", "UNKNOWN", "STAKING"])("drops the unrecognised type %p", type => {
+      const { result } = renderWithRates({ bitcoin: rate("bitcoin", 4.2, type) }, [
+        currency("bitcoin"),
+      ]);
+
+      expect(result.current).toEqual({});
+    });
+
+    it("drops an entry with an unrecognised type but keeps its valid siblings", () => {
+      const { result } = renderWithRates(
+        { bitcoin: rate("bitcoin", 4.2, "NOPE"), ethereum: rate("ethereum", 3.1, "APY") },
+        [currency("bitcoin"), currency("ethereum")],
+      );
+
+      expect(result.current).toEqual({ ethereum: { value: 3.1, type: "APY" } });
+    });
+  });
+
+  it("passes a zero rate through rather than treating it as absent", () => {
+    const { result } = renderWithRates({ bitcoin: rate("bitcoin", 0, "APY") }, [
+      currency("bitcoin"),
+    ]);
+
+    expect(result.current.bitcoin).toEqual({ value: 0, type: "APY" });
+  });
+
+  it("keeps the same reference across re-renders when the content is unchanged", () => {
+    const currencies = [currency("bitcoin")];
+    const { result, rerender } = renderWithRates(
+      { bitcoin: rate("bitcoin", 4.2, "APY") },
+      currencies,
+    );
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useMarketByCurrencies.test.tsx
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useMarketByCurrencies.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { renderHook } from "@testing-library/react";
+import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
+import { useMarketByCurrencies } from "../useMarketByCurrencies";
+import type { ApiState } from "../../entities/selectorUtils";
+
+const currency = (id: string) => ({ id }) as CryptoOrTokenCurrency;
+
+function renderWithMarkets(markets: Record<string, unknown>, currencies: CryptoOrTokenCurrency[]) {
+  const state = {
+    assetsDataApi: { queries: { a: { data: { pages: [{ markets }] } } } },
+  } as ApiState;
+  const store = configureStore({ reducer: () => state });
+
+  return renderHook(() => useMarketByCurrencies(currencies), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+}
+
+describe("useMarketByCurrencies", () => {
+  it("maps each currency id to its price and 24h change", () => {
+    const { result } = renderWithMarkets(
+      {
+        bitcoin: { price: 65000, priceChangePercentage24h: 1.5 },
+        ethereum: { price: 3200, priceChangePercentage24h: -2.25 },
+      },
+      [currency("bitcoin"), currency("ethereum")],
+    );
+
+    expect(result.current).toEqual({
+      bitcoin: { price: 65000, priceChangePercentage24h: 1.5 },
+      ethereum: { price: 3200, priceChangePercentage24h: -2.25 },
+    });
+  });
+
+  it("returns an empty map for an empty currency list", () => {
+    const { result } = renderWithMarkets(
+      { bitcoin: { price: 1, priceChangePercentage24h: 1 } },
+      [],
+    );
+
+    expect(result.current).toEqual({});
+  });
+
+  it("omits a currency that has no cached market entry", () => {
+    const { result } = renderWithMarkets(
+      { bitcoin: { price: 65000, priceChangePercentage24h: 1 } },
+      [currency("bitcoin"), currency("solana")],
+    );
+
+    expect(result.current).toEqual({ bitcoin: { price: 65000, priceChangePercentage24h: 1 } });
+    expect(result.current).not.toHaveProperty("solana");
+  });
+
+  describe("requires both price and 24h change", () => {
+    it("omits an entry that has a price but no 24h change", () => {
+      const { result } = renderWithMarkets({ bitcoin: { price: 65000 } }, [currency("bitcoin")]);
+
+      expect(result.current).toEqual({});
+    });
+
+    it("omits an entry that has a 24h change but no price", () => {
+      const { result } = renderWithMarkets({ bitcoin: { priceChangePercentage24h: 1.5 } }, [
+        currency("bitcoin"),
+      ]);
+
+      expect(result.current).toEqual({});
+    });
+
+    it("keeps valid siblings when one entry is incomplete", () => {
+      const { result } = renderWithMarkets(
+        {
+          bitcoin: { price: 65000 },
+          ethereum: { price: 3200, priceChangePercentage24h: 1 },
+        },
+        [currency("bitcoin"), currency("ethereum")],
+      );
+
+      expect(result.current).toEqual({ ethereum: { price: 3200, priceChangePercentage24h: 1 } });
+    });
+  });
+
+  describe("zero is a value, not an absence", () => {
+    it("keeps an entry whose price is zero", () => {
+      const { result } = renderWithMarkets({ bitcoin: { price: 0, priceChangePercentage24h: 1 } }, [
+        currency("bitcoin"),
+      ]);
+
+      expect(result.current.bitcoin).toEqual({ price: 0, priceChangePercentage24h: 1 });
+    });
+
+    it("keeps an entry whose 24h change is zero", () => {
+      const { result } = renderWithMarkets(
+        { bitcoin: { price: 65000, priceChangePercentage24h: 0 } },
+        [currency("bitcoin")],
+      );
+
+      expect(result.current.bitcoin).toEqual({ price: 65000, priceChangePercentage24h: 0 });
+    });
+  });
+
+  describe("rounds the 24h change to two decimals", () => {
+    /*
+     * Values verified against the implementation. Rounding is `Math.round(x * 100) / 100`,
+     * so results follow binary float representation rather than decimal intuition:
+     * -2.345 * 100 is -234.50000000000003, which rounds away from zero, while
+     * -1.005 * 100 is -100.49999999999999, which rounds towards it.
+     */
+    it.each([
+      [1.23456, 1.23],
+      [1.235, 1.24],
+      [-2.345, -2.35],
+      [-1.005, -1],
+      [0.005, 0.01],
+      [99.999, 100],
+      [1.2, 1.2],
+    ])("rounds %p to %p", (input, expected) => {
+      const { result } = renderWithMarkets(
+        { bitcoin: { price: 1, priceChangePercentage24h: input } },
+        [currency("bitcoin")],
+      );
+
+      expect(result.current.bitcoin?.priceChangePercentage24h).toBe(expected);
+    });
+
+    it("rounds an exact .5 towards positive infinity, so sign changes the magnitude", () => {
+      const positive = renderWithMarkets(
+        { bitcoin: { price: 1, priceChangePercentage24h: 0.125 } },
+        [currency("bitcoin")],
+      );
+      const negative = renderWithMarkets(
+        { bitcoin: { price: 1, priceChangePercentage24h: -0.125 } },
+        [currency("bitcoin")],
+      );
+
+      expect(positive.result.current.bitcoin?.priceChangePercentage24h).toBe(0.13);
+      expect(negative.result.current.bitcoin?.priceChangePercentage24h).toBe(-0.12);
+    });
+
+    it("leaves the price unrounded", () => {
+      const { result } = renderWithMarkets(
+        { bitcoin: { price: 65000.123456, priceChangePercentage24h: 1 } },
+        [currency("bitcoin")],
+      );
+
+      expect(result.current.bitcoin?.price).toBe(65000.123456);
+    });
+  });
+
+  it("drops fields other than price and 24h change", () => {
+    const { result } = renderWithMarkets(
+      { bitcoin: { price: 65000, priceChangePercentage24h: 1, marketCap: 1_280_000_000_000 } },
+      [currency("bitcoin")],
+    );
+
+    expect(result.current.bitcoin).toEqual({ price: 65000, priceChangePercentage24h: 1 });
+  });
+
+  it("keeps the same reference across re-renders when the content is unchanged", () => {
+    const currencies = [currency("bitcoin")];
+    const { result, rerender } = renderWithMarkets(
+      { bitcoin: { price: 65000, priceChangePercentage24h: 1 } },
+      currencies,
+    );
+
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStockAssetIds.test.ts
+++ b/libs/ledger-live-common/src/dada-client/hooks/__tests__/useStockAssetIds.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+import { useStockAssetIds } from "../useStockAssetIds";
+import { useGetAssetCurrencyIdsByCategoryQuery } from "../../state-manager/api";
+import { AssetCategory } from "../../state-manager/types";
+
+jest.mock("../../state-manager/api", () => ({
+  useGetAssetCurrencyIdsByCategoryQuery: jest.fn(),
+}));
+
+const mockQuery = jest.mocked(useGetAssetCurrencyIdsByCategoryQuery);
+
+const defaultQueryResult = { data: undefined, isLoading: false, isError: false };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockResult = (overrides: Record<string, unknown> = {}) =>
+  mockQuery.mockReturnValue({ ...defaultQueryResult, ...overrides } as any);
+
+describe("useStockAssetIds", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("query arguments", () => {
+    it("always requests the stocks category", () => {
+      mockResult();
+
+      renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        { category: AssetCategory.Stocks, product: "lld", version: "1.0.0" },
+        { skip: undefined },
+      );
+    });
+
+    it("forwards the skip flag", () => {
+      mockResult();
+
+      renderHook(() => useStockAssetIds("llm", "2.0.0", true));
+
+      expect(mockQuery).toHaveBeenCalledWith(
+        { category: AssetCategory.Stocks, product: "llm", version: "2.0.0" },
+        { skip: true },
+      );
+    });
+
+    it("does not forward an isStaging flag", () => {
+      mockResult();
+
+      renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(mockQuery.mock.calls[0][0]).not.toHaveProperty("isStaging");
+    });
+  });
+
+  describe("ids", () => {
+    it("wraps the returned ids in a Set", () => {
+      mockResult({ data: ["applex", "teslax"] });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.ids).toBeInstanceOf(Set);
+      expect([...result.current.ids]).toEqual(["applex", "teslax"]);
+    });
+
+    it("does not upper-case the ids, unlike the stablecoin ticker hook", () => {
+      mockResult({ data: ["applex"] });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.ids.has("applex")).toBe(true);
+      expect(result.current.ids.has("APPLEX")).toBe(false);
+    });
+
+    it("deduplicates repeated ids", () => {
+      mockResult({ data: ["applex", "applex", "teslax"] });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.ids.size).toBe(2);
+    });
+
+    it("returns an empty set when there is no data", () => {
+      mockResult({ data: undefined });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.ids.size).toBe(0);
+    });
+
+    it("returns an empty set for an empty array", () => {
+      mockResult({ data: [] });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.ids.size).toBe(0);
+    });
+
+    it("shares one stable empty-set reference across hook instances without data", () => {
+      mockResult({ data: undefined });
+
+      const first = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+      const second = renderHook(() => useStockAssetIds("llm", "2.0.0"));
+
+      expect(first.result.current.ids).toBe(second.result.current.ids);
+    });
+
+    it("keeps the same set reference across re-renders with unchanged data", () => {
+      const data = ["applex"];
+      mockResult({ data });
+
+      const { result, rerender } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+      const firstSet = result.current.ids;
+      rerender();
+
+      expect(result.current.ids).toBe(firstSet);
+    });
+  });
+
+  describe("status passthrough", () => {
+    it("reports loading", () => {
+      mockResult({ isLoading: true });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("reports errors and still returns an empty set", () => {
+      mockResult({ isError: true });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(result.current.isError).toBe(true);
+      expect(result.current.ids.size).toBe(0);
+    });
+
+    it("exposes only ids, isLoading and isError", () => {
+      mockResult({ data: ["applex"] });
+
+      const { result } = renderHook(() => useStockAssetIds("lld", "1.0.0"));
+
+      expect(Object.keys(result.current).sort()).toEqual(["ids", "isError", "isLoading"]);
+    });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/apiTransforms.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/apiTransforms.test.ts
@@ -340,6 +340,26 @@ describe("getChunkedAssetsData", () => {
       expect(requestedUrl(fetchSpy.mock.calls[0])).toContain("currencyIds=bitcoin%2Cethereum");
     });
 
+    it("forwards networkIds unchunked alongside each chunk of currencyIds", async () => {
+      fetchSpy.mockResolvedValueOnce(okResponse(raw()));
+      fetchSpy.mockResolvedValueOnce(okResponse(raw()));
+      const store = makeStore();
+
+      await store.dispatch(
+        assetsDataApi.endpoints.getChunkedAssetsData.initiate({
+          ...queryArgs,
+          currencyIds: ids(26),
+          networkIds: ["ethereum", "polygon"],
+        }),
+      );
+
+      // currencyIds are split across chunks; networkIds are repeated in full on every request
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      for (const call of fetchSpy.mock.calls) {
+        expect(requestedUrl(call)).toContain("networkIds=ethereum%2Cpolygon");
+      }
+    });
+
     it("does not send a cursor, because it collects one page per chunk", async () => {
       await getChunked(["bitcoin"], [okResponse(raw(), "cursor-2")]);
 

--- a/libs/ledger-live-common/src/dada-client/state-manager/__tests__/apiTransforms.test.ts
+++ b/libs/ledger-live-common/src/dada-client/state-manager/__tests__/apiTransforms.test.ts
@@ -1,0 +1,463 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { assetsDataApi } from "../api";
+import type { RawApiResponse } from "../../entities";
+
+jest.mock("@shared/env", () => ({
+  getEnv: jest.fn().mockReturnValue("https://dada.api.ledger.com/v1"),
+}));
+
+/*
+ * `convertApiAssets`, `transformAssetsResponse` and `getChunkedAssetsData`'s queryFn are
+ * module-private, so they are characterized through the public endpoints. That also pins
+ * the observable contract rather than the internals, which is what the migration must
+ * preserve.
+ */
+
+function makeStore() {
+  return configureStore({
+    reducer: { [assetsDataApi.reducerPath]: assetsDataApi.reducer },
+    middleware: getDefault => getDefault().concat(assetsDataApi.middleware),
+  });
+}
+
+const emptyRaw: RawApiResponse = {
+  cryptoAssets: {},
+  networks: {},
+  cryptoOrTokenCurrencies: {},
+  interestRates: {},
+  markets: {},
+  currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: [] },
+};
+
+const raw = (overrides: Partial<RawApiResponse> = {}): RawApiResponse => ({
+  ...emptyRaw,
+  ...overrides,
+});
+
+function okResponse(body: RawApiResponse, nextCursor?: string): Response {
+  const headers = new Headers();
+  if (nextCursor) headers.set("x-ledger-next", nextCursor);
+  return new Response(JSON.stringify(body), { status: 200, headers });
+}
+
+const knownCrypto = {
+  type: "crypto_currency" as const,
+  id: "bitcoin",
+  name: "Bitcoin",
+  ticker: "BTC",
+  units: [{ name: "bitcoin", code: "BTC", magnitude: 8 }],
+};
+
+const unknownCrypto = {
+  type: "crypto_currency" as const,
+  id: "totallyunknownchain",
+  name: "Unknown Chain",
+  ticker: "UNK",
+  units: [{ name: "unknown", code: "UNK", magnitude: 6 }],
+  symbol: "U",
+  coinType: 42,
+  family: "unknownfamily",
+  hasSegwit: true,
+  disableCountervalue: true,
+};
+
+const knownToken = {
+  type: "token_currency" as const,
+  id: "ethereum/erc20/some_token",
+  contractAddress: "0xabc",
+  name: "Some Token",
+  ticker: "SOME",
+  units: [{ name: "Some Token", code: "SOME", magnitude: 18 }],
+  standard: "erc20",
+};
+
+const orphanToken = {
+  ...knownToken,
+  id: "notachain/erc20/orphan",
+  name: "Orphan Token",
+  ticker: "ORPH",
+};
+
+const queryArgs = { product: "lld" as const, version: "1.0.0" };
+
+/**
+ * `getAssetData` goes through `fetchBaseQuery`, which calls fetch with a `Request`, while the
+ * chunked endpoint calls it with a URL string. Normalise both to the requested URL.
+ */
+function requestedUrl(call: unknown[]): string {
+  const [input] = call;
+  return input instanceof Request ? input.url : String(input);
+}
+
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  fetchSpy = jest.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function getAssetData(body: RawApiResponse, nextCursor?: string) {
+  fetchSpy.mockResolvedValueOnce(okResponse(body, nextCursor));
+  const store = makeStore();
+  return store.dispatch(assetsDataApi.endpoints.getAssetData.initiate(queryArgs));
+}
+
+describe("transformAssetsResponse, via getAssetData", () => {
+  it("passes non-currency collections through untouched", async () => {
+    const body = raw({
+      cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
+      networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } },
+      interestRates: {
+        bitcoin: { currencyId: "bitcoin", rate: 4.2, type: "APY", fetchAt: "2026-07-31" },
+      },
+      markets: { bitcoin: { price: 65000 } },
+    });
+
+    const result = await getAssetData(body);
+
+    expect(result.data?.cryptoAssets).toEqual(body.cryptoAssets);
+    expect(result.data?.networks).toEqual(body.networks);
+    expect(result.data?.interestRates).toEqual(body.interestRates);
+    expect(result.data?.markets).toEqual(body.markets);
+    expect(result.data?.currenciesOrder).toEqual(body.currenciesOrder);
+  });
+
+  describe("pagination comes from the x-ledger-next header", () => {
+    it("exposes the header value as nextCursor", async () => {
+      const result = await getAssetData(raw(), "cursor-2");
+
+      expect(result.data?.pagination).toEqual({ nextCursor: "cursor-2" });
+    });
+
+    it("leaves nextCursor undefined when the header is absent", async () => {
+      const result = await getAssetData(raw());
+
+      expect(result.data?.pagination).toEqual({ nextCursor: undefined });
+    });
+  });
+
+  it("requests a single item", async () => {
+    await getAssetData(raw());
+
+    expect(requestedUrl(fetchSpy.mock.calls[0])).toContain("pageSize=1");
+  });
+
+  it("targets the /assets path on the resolved base url", async () => {
+    await getAssetData(raw());
+
+    expect(requestedUrl(fetchSpy.mock.calls[0])).toContain("https://dada.api.ledger.com/v1/assets");
+  });
+});
+
+describe("convertApiAssets, via getAssetData", () => {
+  it("resolves a known crypto from the local registry", async () => {
+    const result = await getAssetData(raw({ cryptoOrTokenCurrencies: { bitcoin: knownCrypto } }));
+
+    expect(result.data?.cryptoOrTokenCurrencies.bitcoin).toEqual(
+      expect.objectContaining({ type: "CryptoCurrency", id: "bitcoin" }),
+    );
+    // the registry entry wins over the wire payload
+    expect(result.data?.cryptoOrTokenCurrencies.bitcoin).not.toMatchObject({ color: "#999999" });
+  });
+
+  describe("synthesises a currency for a crypto missing from the registry", () => {
+    it("builds it from the wire payload with placeholder presentation fields", async () => {
+      const result = await getAssetData(raw({ cryptoOrTokenCurrencies: { unk: unknownCrypto } }));
+
+      expect(result.data?.cryptoOrTokenCurrencies.unk).toEqual({
+        type: "CryptoCurrency",
+        id: "totallyunknownchain",
+        name: "Unknown Chain",
+        ticker: "UNK",
+        units: unknownCrypto.units,
+        managerAppName: "Unknown Chain",
+        coinType: 42,
+        scheme: "totallyunknownchain",
+        color: "#999999",
+        family: "unknownfamily",
+        explorerViews: [],
+        symbol: "U",
+        disableCountervalue: true,
+        supportsSegwit: true,
+      });
+    });
+
+    it("falls back to the id for family and to 0 for coinType", async () => {
+      const bare = {
+        type: "crypto_currency" as const,
+        id: "barechain",
+        name: "Bare",
+        ticker: "BARE",
+        units: [{ name: "bare", code: "BARE", magnitude: 0 }],
+      };
+
+      const result = await getAssetData(raw({ cryptoOrTokenCurrencies: { bare } }));
+
+      expect(result.data?.cryptoOrTokenCurrencies.bare).toMatchObject({
+        family: "barechain",
+        coinType: 0,
+      });
+    });
+
+    it("lower-cases the id to build the scheme", async () => {
+      const upper = { ...unknownCrypto, id: "MixedCaseChain" };
+
+      const result = await getAssetData(raw({ cryptoOrTokenCurrencies: { upper } }));
+
+      expect(result.data?.cryptoOrTokenCurrencies.upper).toMatchObject({
+        id: "MixedCaseChain",
+        scheme: "mixedcasechain",
+      });
+    });
+
+    it("adds ethereumLikeInfo only when a chainId is present", async () => {
+      const withChain = { ...unknownCrypto, chainId: "137" };
+
+      const withResult = await getAssetData(raw({ cryptoOrTokenCurrencies: { withChain } }));
+      const withoutResult = await getAssetData(
+        raw({ cryptoOrTokenCurrencies: { unk: unknownCrypto } }),
+      );
+
+      expect(withResult.data?.cryptoOrTokenCurrencies.withChain).toMatchObject({
+        ethereumLikeInfo: { chainId: 137 },
+      });
+      expect(withoutResult.data?.cryptoOrTokenCurrencies.unk).not.toHaveProperty(
+        "ethereumLikeInfo",
+      );
+    });
+  });
+
+  describe("tokens", () => {
+    it("converts a token whose parent chain is known", async () => {
+      const result = await getAssetData(raw({ cryptoOrTokenCurrencies: { some: knownToken } }));
+
+      expect(result.data?.cryptoOrTokenCurrencies.some).toEqual(
+        expect.objectContaining({
+          type: "TokenCurrency",
+          id: "ethereum/erc20/some_token",
+          parentCurrencyId: "ethereum",
+        }),
+      );
+    });
+
+    it("silently drops a token whose parent chain is unknown", async () => {
+      const result = await getAssetData(
+        raw({ cryptoOrTokenCurrencies: { orphan: orphanToken, bitcoin: knownCrypto } }),
+      );
+
+      expect(result.data?.cryptoOrTokenCurrencies).not.toHaveProperty("orphan");
+      expect(result.data?.cryptoOrTokenCurrencies).toHaveProperty("bitcoin");
+    });
+  });
+
+  it("keys the output by the wire key, not by the asset id", async () => {
+    const result = await getAssetData(
+      raw({ cryptoOrTokenCurrencies: { "some-wire-key": knownCrypto } }),
+    );
+
+    expect(Object.keys(result.data!.cryptoOrTokenCurrencies)).toEqual(["some-wire-key"]);
+    expect(result.data?.cryptoOrTokenCurrencies["some-wire-key"]).toMatchObject({
+      id: "bitcoin",
+    });
+  });
+
+  it("returns an empty map when there are no currencies", async () => {
+    const result = await getAssetData(raw());
+
+    expect(result.data?.cryptoOrTokenCurrencies).toEqual({});
+  });
+
+  it("surfaces an error rather than dropping the asset when the id is empty", async () => {
+    const result = await getAssetData(
+      raw({ cryptoOrTokenCurrencies: { bad: { ...unknownCrypto, id: "" } } }),
+    );
+
+    // CryptoCurrencyIdSchema rejects "" and the throw propagates as a query error
+    expect(result.data).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe("getChunkedAssetsData", () => {
+  async function getChunked(currencyIds: string[], responses: Response[]) {
+    for (const response of responses) {
+      fetchSpy.mockResolvedValueOnce(response);
+    }
+    const store = makeStore();
+    return store.dispatch(
+      assetsDataApi.endpoints.getChunkedAssetsData.initiate({ ...queryArgs, currencyIds }),
+    );
+  }
+
+  const ids = (count: number, prefix = "id") =>
+    Array.from({ length: count }, (_, index) => `${prefix}-${index}`);
+
+  describe("no work to do", () => {
+    it("returns an empty shape for an empty id list without fetching", async () => {
+      const result = await getChunked([], []);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.data).toEqual({
+        cryptoAssets: {},
+        networks: {},
+        cryptoOrTokenCurrencies: {},
+        interestRates: {},
+        markets: {},
+        currenciesOrder: { metaCurrencyIds: [], key: "", order: "" },
+      });
+    });
+
+    it("returns an empty shape when currencyIds is omitted", async () => {
+      const store = makeStore();
+      const result = await store.dispatch(
+        assetsDataApi.endpoints.getChunkedAssetsData.initiate(queryArgs),
+      );
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.data?.cryptoOrTokenCurrencies).toEqual({});
+    });
+  });
+
+  describe("chunking", () => {
+    it("issues a single request for 25 ids or fewer", async () => {
+      await getChunked(ids(25), [okResponse(raw())]);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("splits 26 ids into two requests", async () => {
+      await getChunked(ids(26), [okResponse(raw()), okResponse(raw())]);
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("sends each chunk's ids as a comma-separated currencyIds param", async () => {
+      await getChunked(["bitcoin", "ethereum"], [okResponse(raw())]);
+
+      expect(requestedUrl(fetchSpy.mock.calls[0])).toContain("currencyIds=bitcoin%2Cethereum");
+    });
+
+    it("does not send a cursor, because it collects one page per chunk", async () => {
+      await getChunked(["bitcoin"], [okResponse(raw(), "cursor-2")]);
+
+      expect(requestedUrl(fetchSpy.mock.calls[0])).not.toContain("cursor=");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("merging chunk responses", () => {
+    it("combines collections from every chunk", async () => {
+      const first = raw({
+        networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } },
+        markets: { bitcoin: { price: 65000 } },
+        currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: ["btc"] },
+      });
+      const second = raw({
+        networks: { ethereum: { id: "ethereum", name: "Ethereum" } },
+        markets: { ethereum: { price: 3200 } },
+        currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: ["eth"] },
+      });
+
+      const result = await getChunked(ids(26), [okResponse(first), okResponse(second)]);
+
+      expect(Object.keys(result.data!.networks).sort()).toEqual(["bitcoin", "ethereum"]);
+      expect(Object.keys(result.data!.markets).sort()).toEqual(["bitcoin", "ethereum"]);
+      expect(result.data?.currenciesOrder.metaCurrencyIds).toEqual(["btc", "eth"]);
+    });
+
+    it("deep-merges assetsIds for a meta-currency split across chunks", async () => {
+      const first = raw({
+        cryptoAssets: {
+          eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: { ethereum: "ethereum" } },
+        },
+      });
+      const second = raw({
+        cryptoAssets: {
+          eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: { arbitrum: "arbitrum" } },
+        },
+      });
+
+      const result = await getChunked(ids(26), [okResponse(first), okResponse(second)]);
+
+      expect(result.data?.cryptoAssets.eth.assetsIds).toEqual({
+        ethereum: "ethereum",
+        arbitrum: "arbitrum",
+      });
+    });
+
+    it("leaves the merged result without a pagination field", async () => {
+      const result = await getChunked(["bitcoin"], [okResponse(raw(), "cursor-2")]);
+
+      expect(result.data).not.toHaveProperty("pagination");
+    });
+  });
+
+  describe("partial failure is tolerated", () => {
+    it("returns the surviving chunk when another chunk fails", async () => {
+      const good = raw({ networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } } });
+
+      const result = await getChunked(ids(26), [
+        okResponse(good),
+        new Response(null, { status: 500, statusText: "Server Error" }),
+      ]);
+
+      expect(result.data?.networks).toEqual({ bitcoin: { id: "bitcoin", name: "Bitcoin" } });
+      expect(result.error).toBeUndefined();
+    });
+
+    it("returns the surviving chunk when another chunk rejects outright", async () => {
+      const good = raw({ networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } } });
+      fetchSpy.mockResolvedValueOnce(okResponse(good));
+      fetchSpy.mockRejectedValueOnce(new Error("socket hang up"));
+
+      const store = makeStore();
+      const result = await store.dispatch(
+        assetsDataApi.endpoints.getChunkedAssetsData.initiate({
+          ...queryArgs,
+          currencyIds: ids(26),
+        }),
+      );
+
+      expect(result.data?.networks).toEqual({ bitcoin: { id: "bitcoin", name: "Bitcoin" } });
+    });
+
+    it("errors only when every chunk fails", async () => {
+      const result = await getChunked(ids(26), [
+        new Response(null, { status: 500, statusText: "Server Error" }),
+        new Response(null, { status: 503, statusText: "Unavailable" }),
+      ]);
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toMatchObject({ status: "FETCH_ERROR" });
+    });
+
+    it("reports the first failure's message when everything fails", async () => {
+      const result = await getChunked(
+        ["bitcoin"],
+        [new Response(null, { status: 500, statusText: "Server Error" })],
+      );
+
+      expect(result.error).toMatchObject({
+        status: "FETCH_ERROR",
+        error: expect.stringContaining("500"),
+      });
+    });
+  });
+
+  it("blocks a request to an untrusted host", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getEnv } = require("@shared/env");
+    getEnv.mockReturnValueOnce("https://evil.example.com/v1");
+
+    const result = await getChunked(["bitcoin"], []);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.error).toMatchObject({
+      status: "FETCH_ERROR",
+      error: expect.stringContaining("evil.example.com"),
+    });
+  });
+});

--- a/libs/ledger-live-common/src/dada-client/utils/__test__/mergeAssetsDataPages.test.ts
+++ b/libs/ledger-live-common/src/dada-client/utils/__test__/mergeAssetsDataPages.test.ts
@@ -1,0 +1,168 @@
+import { mergeAssetsDataPages } from "../mergeAssetsDataPages";
+import type { AssetsDataWithPagination } from "../../state-manager/types";
+
+const makePage = (overrides: Partial<AssetsDataWithPagination> = {}): AssetsDataWithPagination => ({
+  cryptoAssets: {},
+  networks: {},
+  cryptoOrTokenCurrencies: {},
+  interestRates: {},
+  markets: {},
+  currenciesOrder: { metaCurrencyIds: [], key: "", order: "" },
+  pagination: { nextCursor: "" },
+  ...overrides,
+});
+
+describe("mergeAssetsDataPages", () => {
+  it("returns undefined for undefined input", () => {
+    expect(mergeAssetsDataPages(undefined)).toBeUndefined();
+  });
+
+  it("returns an empty shape for an empty page list", () => {
+    expect(mergeAssetsDataPages([])).toEqual(makePage());
+  });
+
+  it("returns the single page's content unchanged", () => {
+    const page = makePage({
+      cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
+      currenciesOrder: { metaCurrencyIds: ["btc"], key: "marketCap", order: "desc" },
+      pagination: { nextCursor: "cursor-2" },
+    });
+
+    expect(mergeAssetsDataPages([page])).toEqual(page);
+  });
+
+  describe("collections are shallow-merged across pages", () => {
+    it("combines disjoint keys from every collection", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({
+          cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
+          networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } },
+          interestRates: {
+            btc: { currencyId: "btc", rate: 1, type: "APY", fetchAt: "2026-01-01" },
+          },
+          markets: { btc: { price: 1 } },
+        }),
+        makePage({
+          cryptoAssets: { eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: {} } },
+          networks: { ethereum: { id: "ethereum", name: "Ethereum" } },
+          interestRates: {
+            eth: { currencyId: "eth", rate: 2, type: "APR", fetchAt: "2026-01-01" },
+          },
+          markets: { eth: { price: 2 } },
+        }),
+      ]);
+
+      expect(Object.keys(merged!.cryptoAssets)).toEqual(["btc", "eth"]);
+      expect(Object.keys(merged!.networks)).toEqual(["bitcoin", "ethereum"]);
+      expect(Object.keys(merged!.interestRates)).toEqual(["btc", "eth"]);
+      expect(Object.keys(merged!.markets)).toEqual(["btc", "eth"]);
+    });
+
+    it("lets a later page overwrite an earlier key wholesale", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ markets: { btc: { price: 1, priceChangePercentage24h: 5 } } }),
+        makePage({ markets: { btc: { price: 2 } } }),
+      ]);
+
+      // Object.assign replaces the whole entry rather than deep-merging it
+      expect(merged!.markets.btc).toEqual({ price: 2 });
+    });
+
+    it("does not deep-merge nested assetsIds, unlike deepMergeCryptoAssets", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({
+          cryptoAssets: {
+            eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: { ethereum: "ethereum" } },
+          },
+        }),
+        makePage({
+          cryptoAssets: {
+            eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: { arbitrum: "arbitrum" } },
+          },
+        }),
+      ]);
+
+      expect(merged!.cryptoAssets.eth.assetsIds).toEqual({ arbitrum: "arbitrum" });
+    });
+  });
+
+  describe("currenciesOrder", () => {
+    it("concatenates metaCurrencyIds in page order", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ currenciesOrder: { metaCurrencyIds: ["btc", "eth"], key: "k", order: "desc" } }),
+        makePage({ currenciesOrder: { metaCurrencyIds: ["sol"], key: "k", order: "desc" } }),
+      ]);
+
+      expect(merged!.currenciesOrder.metaCurrencyIds).toEqual(["btc", "eth", "sol"]);
+    });
+
+    it("keeps duplicate ids rather than deduplicating them", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ currenciesOrder: { metaCurrencyIds: ["btc"], key: "k", order: "desc" } }),
+        makePage({ currenciesOrder: { metaCurrencyIds: ["btc"], key: "k", order: "desc" } }),
+      ]);
+
+      expect(merged!.currenciesOrder.metaCurrencyIds).toEqual(["btc", "btc"]);
+    });
+
+    it("takes key and order from the last page", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ currenciesOrder: { metaCurrencyIds: [], key: "marketCap", order: "desc" } }),
+        makePage({ currenciesOrder: { metaCurrencyIds: [], key: "name", order: "asc" } }),
+      ]);
+
+      expect(merged!.currenciesOrder.key).toBe("name");
+      expect(merged!.currenciesOrder.order).toBe("asc");
+    });
+  });
+
+  describe("pagination", () => {
+    it("takes nextCursor from the last page", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ pagination: { nextCursor: "cursor-2" } }),
+        makePage({ pagination: { nextCursor: "cursor-3" } }),
+      ]);
+
+      expect(merged!.pagination.nextCursor).toBe("cursor-3");
+    });
+
+    it("reports no next cursor once the last page has none", () => {
+      const merged = mergeAssetsDataPages([
+        makePage({ pagination: { nextCursor: "cursor-2" } }),
+        makePage({ pagination: { nextCursor: undefined } }),
+      ]);
+
+      expect(merged!.pagination.nextCursor).toBeUndefined();
+    });
+  });
+
+  it("does not mutate the input pages", () => {
+    const first = makePage({
+      cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
+      currenciesOrder: { metaCurrencyIds: ["btc"], key: "k", order: "desc" },
+    });
+    const second = makePage({
+      cryptoAssets: { eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: {} } },
+      currenciesOrder: { metaCurrencyIds: ["eth"], key: "k", order: "desc" },
+    });
+
+    mergeAssetsDataPages([first, second]);
+
+    expect(Object.keys(first.cryptoAssets)).toEqual(["btc"]);
+    expect(first.currenciesOrder.metaCurrencyIds).toEqual(["btc"]);
+    expect(Object.keys(second.cryptoAssets)).toEqual(["eth"]);
+  });
+
+  it("builds a fresh accumulator on every call", () => {
+    const page = makePage({
+      currenciesOrder: { metaCurrencyIds: ["btc"], key: "k", order: "desc" },
+    });
+
+    const first = mergeAssetsDataPages([page]);
+    const second = mergeAssetsDataPages([page]);
+
+    expect(first!.currenciesOrder.metaCurrencyIds).toEqual(["btc"]);
+    expect(second!.currenciesOrder.metaCurrencyIds).toEqual(["btc"]);
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _This PR is the tests._
- [x] **Impact of the changes:**
      - **No runtime impact — no production code was changed.** The diff is 11 new test files plus a changeset.
      - CI signal only: the `src/dada-client` suite goes from 10 suites / 96 tests to **21 suites / 245 tests**.
      - No QA pass needed. Nothing to test in the apps.

### 📝 Description

**Problem.** 14 source files under `libs/ledger-live-common/src/dada-client` had no colocated test, and the one existing api test covered only `buildAssetsQueryParams` and the two `fetchAll*ByCategory` helpers — not the RTK Query endpoints, `getChunkedAssetsData`, `convertApiAssets`, or `transformAssetsResponse`. The package is about to be relocated into DDD packages under LIVE-35223, and a green CI run would not have proven that relocation behaviour-neutral. The riskiest code in the package is also the least typed: `createCurrencyDataSelector` walks RTK Query's internal cache layout (`queries[*].data.pages[*][key][id]`) on `Record<string, unknown>`, so no refactor there can ever produce a type error.

**Solution.** 149 characterization tests pinning current behaviour, with no production change. These become the contract for the rest of the migration epic: they must keep passing **unmodified**, and a test that needs editing to accommodate a later change signals broken behaviour rather than a wrong test.

| File | Tests | Pins |
| --- | --- | --- |
| `state-manager/__tests__/apiTransforms.test.ts` | 30 | `convertApiAssets`, `transformAssetsResponse`, `getChunkedAssetsData` |
| `hooks/__tests__/useMarketByCurrencies.test.tsx` | 19 | both-fields-required, float rounding |
| `entities/__tests__/selectorUtils.test.ts` | 16 | cache-shape walk, cross-query bleed, first-match-wins, falsy-as-absent |
| `utils/__test__/mergeAssetsDataPages.test.ts` | 13 | shallow merge, last-page-wins, no input mutation |
| `hooks/__tests__/useInterestRatesByCurrencies.test.tsx` | 13 | APY-type allowlist, zero-is-a-value, `isEqual` stability |
| `hooks/__tests__/useStockAssetIds.test.ts` | 13 | Set wrapping, shared empty-set identity |
| `hooks/__tests__/useDrawerConfiguration.test.ts` | 13 | flag gating, config precedence |
| `hooks/__tests__/useAssetData.test.ts` | 11 | param narrowing, `isLoading ‖ isFetching` |
| `hooks/__tests__/useChunkedAssetsData.test.ts` | 11 | skip separation, full `ErrorInfo` shape |
| `entities/__tests__/interestRateSelectors.test.ts` | 5 | reads `interestRates` only |
| `entities/__tests__/marketSelectors.test.ts` | 5 | reads `markets` only |

**Four invariants that break silently are now pinned executably**, since none of them can produce a type error:

1. `assetsDataApi.reducerPath` is the literal string `"assetsDataApi"` — read by string in `selectorUtils.ts:25` and preloaded by three Storybook files.
2. The cache selectors scan **every** cache entry regardless of query args, so a value cached by one query is served to callers of another. Characterized, not endorsed.
3. `convertApiAssets` is deliberately lenient: it silently drops tokens whose parent chain is unknown, and *synthesises* a currency (`color: "#999999"`, `explorerViews: []`) for cryptos missing from the local registry rather than dropping them.
4. `getChunkedAssetsData` succeeds if **any** chunk resolves.

#### The contract already proved itself

This branch was rebased onto 59 new `develop` commits, two of which changed dada-client **production** code (`perf(modular-drawer): forward network filters to dada`, adding `networkIds` to `GetAssetsDataParams` and `buildAssetsQueryParams`). **Every characterization test passed unmodified** through that rebase.

That change did open one gap, closed by the second commit here: `networkIds` also flows through `getChunkedAssetsData`, where — unlike `currencyIds`, which is split across chunks — it must be repeated **in full on every request**. `buildAssetsQueryParams` is covered by that change's own tests, but the chunked path's forwarding was not. Exactly the kind of detail a relocation drops silently.

#### Notes for reviewers

- `convertApiAssets`, `transformAssetsResponse` and `emptyAssetsData` are module-private and this task must not touch production code, so they are driven through the `getAssetData` / `getChunkedAssetsData` endpoints with a real store and a stubbed `fetch`. That pins the observable contract rather than internals, which is what the migration has to preserve anyway.
- `getAssetData` goes through `fetchBaseQuery`, so `fetch` receives a **`Request`**; the chunked path calls `fetch` with a **string**. `requestedUrl()` normalises both.
- **Bug surfaced, not fixed here:** an asset with `id: ""` makes `CryptoCurrencyIdSchema.parse` throw and fails the *entire* query, not just that asset. Pinned as current behaviour in `apiTransforms.test.ts`; the follow-up validation ticket (LIVE-35233) must not make it worse.
- The `useMarketByCurrencies` rounding table was verified against the implementation rather than assumed. Rounding is `Math.round(x * 100) / 100`, so results follow float representation, not decimal intuition: `-2.345 → -2.35`, `-1.005 → -1`, and an exact `.5` rounds toward +∞ (`0.125 → 0.13` but `-0.125 → -0.12`).
- `useDrawerConfiguration` is tested here although it is not DADA code — it only reads a feature flag. It is misfiled in this directory and gets relocated later in the epic, so it needs the same protection.
- **Known, deliberately unfixed:** `apiTransforms.test.ts` leaves a worker to be force-exited (`A worker process has failed to exit gracefully`). Several endpoints set `keepUnusedDataFor: 86400`, which parks a 24-hour timer. Releasing the subscription via `unsubscribe()` was tried and was not sufficient; the real fix is fake timers or a `resetApiState` teardown. Left out of scope on purpose so this PR stays tests-only.
- Changeset is `patch` on `@ledgerhq/live-common` — internal-only change, no runtime behaviour affected.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35224](https://ledgerhq.atlassian.net/browse/LIVE-35224) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **Stack**: this is the bottom of a stack; [#20285](https://github.com/LedgerHQ/ledger-live/pull/20285) builds on it.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35224]: https://ledgerhq.atlassian.net/browse/LIVE-35224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ