### PR TITLE
chore(errors): ban @ledgerhq/errors as a dependency (LIVE-32915)

### DIFF
--- a/.agents/skills/coin-modules/SKILL.md
+++ b/.agents/skills/coin-modules/SKILL.md
@@ -29,7 +29,7 @@ Tests: `*.unit.test.ts` (co-located), `*.test.ts` (integration, no network), `*.
 Prefer native dependencies from the blockchain foundation and well-established open-source libraries.  
 **Avoid** proprietary third-party SDKs or closed-source vendor packages.
 
-In `api/`, `logic/`, and `network/`, the only permitted `@ledgerhq/*` imports are `@ledgerhq/errors`, `@ledgerhq/logs`, `@ledgerhq/live-network`, and `@ledgerhq/coin-module-framework` (enforced by `eslint/no-restricted-imports` in `libs/coin-modules/.oxlintrc.json`). Other directories (`bridge/`, `signer/`, `types/`) have no such restriction.
+In `api/`, `logic/`, and `network/`, the only permitted `@ledgerhq/*` imports are `@ledgerhq/logs`, `@ledgerhq/live-network`, `@ledgerhq/coin-module-framework`, and `@ledgerhq/ledger-wallet-framework` (enforced by `eslint/no-restricted-imports` in `libs/coin-modules/.oxlintrc.json`). Other directories (`bridge/`, `signer/`, `types/`) have no such restriction.
 
 ## Integration Paths
 

--- a/.agents/skills/errors/SKILL.md
+++ b/.agents/skills/errors/SKILL.md
@@ -2,16 +2,16 @@
 name: errors
 description: |
   How to define and check error classes in Ledger Live. Read when adding a new
-  error, creating an errors.ts file, or checking an error's type. Replaces the
-  deprecated @ledgerhq/errors lib (createCustomErrorClass + serialize/deserialize).
+  error, creating an errors.ts file, or checking an error's type.
 globs: ["**/errors.ts", "**/errors/**/*.ts"]
 ---
 
 # Errors
 
 Each package owns its errors in its own `src/errors.ts`, as plain native classes.
-Do **not** add new errors to `@ledgerhq/errors` (`libs/ledgerjs/packages/errors`) —
-that lib is deprecated and frozen (see its `DEPRECATED.md`).
+There is no shared errors lib: no workspace package may depend on `@ledgerhq/errors`,
+and the `enforce-boundaries` CI check fails on any manifest that does. It only still
+lives here to keep being published for external consumers (see its `DEPRECATED.md`).
 
 ## Define errors
 
@@ -102,5 +102,5 @@ Use `instanceof` only when you are certain the error has not crossed a boundary
 - Logic in one package → that package's `src/errors.ts`.
 - Used only by an app → the app's `src/errors.ts` (`apps/ledger-live-desktop`,
   `apps/ledger-live-mobile`).
-- Shared by several coin modules → for now stay in `@ledgerhq/errors` (no editable
-  shared package sits below the coin layer); do not add new ones there.
+- Shared by several coin modules → `libs/ledger-wallet-framework/src/errors.ts`
+  (`@ledgerhq/ledger-wallet-framework/errors`), the shared home below the coin layer.

--- a/.changeset/LIVE-32915-stop-depending-on-errors.md
+++ b/.changeset/LIVE-32915-stop-depending-on-errors.md
@@ -1,0 +1,41 @@
+---
+"@ledgerhq/coin-aleo": patch
+"@ledgerhq/coin-algorand": patch
+"@ledgerhq/coin-aptos": patch
+"@ledgerhq/coin-bitcoin": patch
+"@ledgerhq/coin-canton": patch
+"@ledgerhq/coin-cardano": patch
+"@ledgerhq/coin-casper": patch
+"@ledgerhq/coin-celo": patch
+"@ledgerhq/coin-concordium": patch
+"@ledgerhq/coin-cosmos": patch
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/coin-filecoin": patch
+"@ledgerhq/coin-hedera": patch
+"@ledgerhq/coin-icon": patch
+"@ledgerhq/coin-internet_computer": patch
+"@ledgerhq/coin-kaspa": patch
+"@ledgerhq/coin-mina": patch
+"@ledgerhq/coin-module-boilerplate": patch
+"@ledgerhq/coin-multiversx": patch
+"@ledgerhq/coin-near": patch
+"@ledgerhq/coin-polkadot": patch
+"@ledgerhq/coin-solana": patch
+"@ledgerhq/coin-stacks": patch
+"@ledgerhq/coin-sui": patch
+"@ledgerhq/coin-tester-stellar": patch
+"@ledgerhq/coin-tester-xrp": patch
+"@ledgerhq/coin-tezos": patch
+"@ledgerhq/coin-ton": patch
+"@ledgerhq/coin-tron": patch
+"@ledgerhq/coin-vechain": patch
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Stop depending on `@ledgerhq/errors` (LIVE-32915).
+
+No workspace package declares it anymore, and none may again: `enforce-boundaries` now fails CI on any manifest that does. The classes it held live in the package that owns them, with `@ledgerhq/ledger-wallet-framework/errors` as the shared home below the coin layer.
+
+The package itself stays in the repo so it keeps being published for external consumers, and is bridged to the external coin packages that still peer-depend on it via `pnpm.packageExtensions` using `workspace:*` (which reuses the single in-repo copy, so the dependency graph keeps exactly the physical copies it had before). [LedgerHQ/coin-modules#752](https://github.com/LedgerHQ/coin-modules/pull/752) removes that peerDependency upstream; once it is released the bridge can be dropped, but the package still needs publishing.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -107,7 +107,6 @@
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/device-intent": "workspace:^",
     "@ledgerhq/domain-service": "workspace:^",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/ethereum-provider": "workspace:^",
     "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -132,7 +132,6 @@
     "@ledgerhq/device-transport-kit-react-native-hid": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/domain-service": "workspace:^",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/ethereum-provider": "workspace:^",
     "@ledgerhq/hw-ledger-key-ring-protocol": "workspace:^",
     "@ledgerhq/hw-transport": "workspace:*",

--- a/apps/wallet-cli/src/device/classify-device-error.ts
+++ b/apps/wallet-cli/src/device/classify-device-error.ts
@@ -1,5 +1,5 @@
 /**
- * Single classifier that maps any thrown value from the device stack (DMK, @ledgerhq/errors,
+ * Single classifier that maps any thrown value from the device stack (DMK,
  * @ledgerhq/hw-transport, rxjs) to a canonical `DeviceState`.
  *
  * Kept deliberately free of rendering / I/O — callers use `renderDeviceState` or wrap the
@@ -96,7 +96,7 @@ export function classifyDeviceError(error: unknown, ctx: ClassifyContext = {}): 
   if (error == null) return { code: "unknown", cause: error };
 
   // Device-not-detected: rxjs EmptyError is thrown when lastValueFrom sees no emission,
-  // @ledgerhq/errors Disconnected* covers USB unplug / transport close.
+  // Disconnected* covers USB unplug / transport close.
   if (isDisconnectedError(error)) {
     return { code: "disconnected" };
   }

--- a/docs/new-library.md
+++ b/docs/new-library.md
@@ -25,7 +25,7 @@ The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it i
 - [ ] `tsconfig.json` — use the template below
 - [ ] `jest.config.js` — `@swc/jest` transformer, `testEnvironment: "node"` (or `"jsdom"` for React), sonar reporter; copy from a neighbouring package
 - [ ] `project.json` — minimum `{ "targets": { "build": { "executor": "nx:noop" } } }` for source-only packages; required for Nx task graph
-- [ ] `src/errors.ts` — if the package throws custom errors, define them here as plain `class extends Error` (not via `@ledgerhq/errors`)
+- [ ] `src/errors.ts` — if the package throws custom errors, define them here as plain `class extends Error`
 
 ## TypeScript configuration
 

--- a/features/platform/currencies/README.md
+++ b/features/platform/currencies/README.md
@@ -30,4 +30,4 @@ the `@domain/entity-currency-*` packages** (no slices here).
   not maintain its own list: `useSupportedCurrencies` takes the registry-backed list as
   input and applies feature-flag gating via `@features/platform-feature-flags`.
 - **Errors** — the store maps RTK-Query errors to a local error taxonomy (`src/errors.ts`)
-  with the same stable `name`s as the legacy `@ledgerhq/errors` classes.
+  of native classes with stable `name`s.

--- a/features/platform/currencies/src/errors.ts
+++ b/features/platform/currencies/src/errors.ts
@@ -2,10 +2,9 @@
  * Network / API error taxonomy thrown by the crypto-assets store builder when an
  * RTK-Query request fails.
  *
- * Native classes with stable `name`s mirroring the legacy `@ledgerhq/errors`
- * classes. `@ledgerhq/errors` is a frozen legacy lib the feature boundary forbids,
- * so the `name` string is the contract — prefer `error.name === "…"` over
- * `instanceof` (which breaks across process/serialization boundaries).
+ * Native classes with stable `name`s: the `name` string is the contract — prefer
+ * `error.name === "…"` over `instanceof` (which breaks across
+ * process/serialization boundaries).
  */
 
 export class NetworkDown extends Error {

--- a/libs/coin-modules/.oxlintrc.json
+++ b/libs/coin-modules/.oxlintrc.json
@@ -66,8 +66,6 @@
               {
                 "group": [
                   "@ledgerhq/**",
-                  "!@ledgerhq/errors",
-                  "!@ledgerhq/errors/**",
                   "!@ledgerhq/logs",
                   "!@ledgerhq/logs/**",
                   "!@ledgerhq/live-network",

--- a/libs/coin-modules/README.md
+++ b/libs/coin-modules/README.md
@@ -6,7 +6,7 @@ Coin framework compatibility
 
 The coin framework ships as the published `@ledgerhq/coin-module-framework` package (pinned in the `pnpm-workspace.yaml` catalog), not as an in-repo lib. Coin modules depend on it for their API/logic types (e.g. `CoinModuleApi` from `@ledgerhq/coin-module-framework/api/index`).
 
-In `api`, `logic`, and `network`, the only permitted `@ledgerhq/*` imports are `@ledgerhq/errors`, `@ledgerhq/logs`, `@ledgerhq/live-network`, and `@ledgerhq/coin-module-framework` (enforced by `eslint/no-restricted-imports` in [`.oxlintrc.json`](./.oxlintrc.json)).
+In `api`, `logic`, and `network`, the only permitted `@ledgerhq/*` imports are `@ledgerhq/logs`, `@ledgerhq/live-network`, `@ledgerhq/coin-module-framework`, and `@ledgerhq/ledger-wallet-framework` (enforced by `eslint/no-restricted-imports` in [`.oxlintrc.json`](./.oxlintrc.json)).
 
 ### Architectural Decision
 The following concepts are mandatory for a CoinModule to be *Coin framework compliant*.

--- a/libs/coin-modules/coin-aleo/.unimportedrc.json
+++ b/libs/coin-modules/coin-aleo/.unimportedrc.json
@@ -27,7 +27,6 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",
-    "@ledgerhq/live-env",
-    "@ledgerhq/errors"
+    "@ledgerhq/live-env"
   ]
 }

--- a/libs/coin-modules/coin-aleo/package.json
+++ b/libs/coin-modules/coin-aleo/package.json
@@ -114,8 +114,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.2",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@features/platform-currencies": "workspace:^",

--- a/libs/coin-modules/coin-algorand/.unimportedrc.json
+++ b/libs/coin-modules/coin-algorand/.unimportedrc.json
@@ -35,7 +35,6 @@
     "src/test/bridge.dataset.ts"
   ],
   "ignoreUnused": [
-    "@ledgerhq/live-env",
-    "@ledgerhq/errors"
+    "@ledgerhq/live-env"
   ]
 }

--- a/libs/coin-modules/coin-algorand/package.json
+++ b/libs/coin-modules/coin-algorand/package.json
@@ -94,8 +94,7 @@
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "prando": "^6.0.1",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-aptos/.unimportedrc.json
+++ b/libs/coin-modules/coin-aptos/.unimportedrc.json
@@ -14,8 +14,7 @@
   "ignoreUnused": [
     "@ledgerhq/devices",
     "invariant",
-    "got",
-    "@ledgerhq/errors"
+    "got"
   ],
   "ignoreUnimported": [
     "src/bridge/bridge.fixture.ts",

--- a/libs/coin-modules/coin-aptos/package.json
+++ b/libs/coin-modules/coin-aptos/package.json
@@ -114,8 +114,7 @@
     "graphql": "^16.10.0",
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-bitcoin/.unimportedrc.json
+++ b/libs/coin-modules/coin-bitcoin/.unimportedrc.json
@@ -55,7 +55,6 @@
     "jest-util"
   ],
   "ignoreUnused": [
-    "@ledgerhq/zcash-utils",
-    "@ledgerhq/errors"
+    "@ledgerhq/zcash-utils"
   ]
 }

--- a/libs/coin-modules/coin-bitcoin/package.json
+++ b/libs/coin-modules/coin-bitcoin/package.json
@@ -71,8 +71,7 @@
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "rxjs": "catalog:",
-    "utility-types": "^3.10.0",
-    "@ledgerhq/errors": "workspace:^"
+    "utility-types": "^3.10.0"
   },
   "devDependencies": {
     "@bitcoinerlab/secp256k1": "1.2.0",

--- a/libs/coin-modules/coin-canton/package.json
+++ b/libs/coin-modules/coin-canton/package.json
@@ -124,8 +124,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.4",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-cardano/.unimportedrc.json
+++ b/libs/coin-modules/coin-cardano/.unimportedrc.json
@@ -35,7 +35,5 @@
     "@jest/get-type",
     "jest-util"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-cardano/package.json
+++ b/libs/coin-modules/coin-cardano/package.json
@@ -66,8 +66,7 @@
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:^",

--- a/libs/coin-modules/coin-casper/.unimportedrc.json
+++ b/libs/coin-modules/coin-casper/.unimportedrc.json
@@ -22,9 +22,7 @@
     "jest-matcher-utils",
     "jest-message-util"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ],
+  "ignoreUnused": [],
   "ignoreUnimported": [
     "src/hw-signMessage.ts",
     "src/supportedFeatures.ts"

--- a/libs/coin-modules/coin-casper/package.json
+++ b/libs/coin-modules/coin-casper/package.json
@@ -112,8 +112,7 @@
     "casper-js-sdk": "5.0.5",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-celo/.unimportedrc.json
+++ b/libs/coin-modules/coin-celo/.unimportedrc.json
@@ -34,7 +34,6 @@
   "ignoreUnused": [
     "@ledgerhq/coin-evm",
     "@ledgerhq/devices",
-    "@ledgerhq/errors",
     "@ledgerhq/hw-app-eth",
     "@ledgerhq/live-config",
     "@ledgerhq/logs",

--- a/libs/coin-modules/coin-celo/package.json
+++ b/libs/coin-modules/coin-celo/package.json
@@ -127,8 +127,7 @@
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
     "rxjs": "catalog:",
-    "viem": "^2.27.0",
-    "@ledgerhq/errors": "workspace:^"
+    "viem": "^2.27.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",

--- a/libs/coin-modules/coin-concordium/package.json
+++ b/libs/coin-modules/coin-concordium/package.json
@@ -192,8 +192,7 @@
     "@walletconnect/types": "2.23.0",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.4",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-cosmos/.unimportedrc.json
+++ b/libs/coin-modules/coin-cosmos/.unimportedrc.json
@@ -40,7 +40,6 @@
     "src/supportedFeatures.ts"
   ],
   "ignoreUnused": [
-    "rxjs",
-    "@ledgerhq/errors"
+    "rxjs"
   ]
 }

--- a/libs/coin-modules/coin-cosmos/package.json
+++ b/libs/coin-modules/coin-cosmos/package.json
@@ -63,8 +63,7 @@
     "invariant": "^2.2.2",
     "prando": "^6.0.1",
     "rxjs": "catalog:",
-    "semver": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "semver": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-evm/.unimportedrc.json
+++ b/libs/coin-modules/coin-evm/.unimportedrc.json
@@ -38,7 +38,5 @@
     "lru-cache",
     "@ledgerhq/types-live"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-evm/package.json
+++ b/libs/coin-modules/coin-evm/package.json
@@ -76,8 +76,7 @@
     "eip55": "^2.1.1",
     "ethers": "catalog:",
     "invariant": "^2.2.2",
-    "react-native-get-random-values": "^1.8.0",
-    "@ledgerhq/errors": "workspace:^"
+    "react-native-get-random-values": "^1.8.0"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-filecoin/.unimportedrc.json
+++ b/libs/coin-modules/coin-filecoin/.unimportedrc.json
@@ -8,8 +8,7 @@
     "proxy-from-env"
   ],
   "ignoreUnused": [
-    "@ledgerhq/devices",
-    "@ledgerhq/errors"
+    "@ledgerhq/devices"
   ],
   "ignoreUnimported": [
     "src/bridge/deviceTransactionConfig.ts",

--- a/libs/coin-modules/coin-filecoin/package.json
+++ b/libs/coin-modules/coin-filecoin/package.json
@@ -117,8 +117,7 @@
     "invariant": "^2.2.2",
     "iso-filecoin": "^7.4.7",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-hedera/.unimportedrc.json
+++ b/libs/coin-modules/coin-hedera/.unimportedrc.json
@@ -29,7 +29,6 @@
   "ignoreUnused": [
     "@ledgerhq/devices",
     "lodash",
-    "rxjs",
-    "@ledgerhq/errors"
+    "rxjs"
   ]
 }

--- a/libs/coin-modules/coin-hedera/package.json
+++ b/libs/coin-modules/coin-hedera/package.json
@@ -102,8 +102,7 @@
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "rxjs": "catalog:",
-    "viem": "^2.27.0",
-    "@ledgerhq/errors": "workspace:^"
+    "viem": "^2.27.0"
   },
   "devDependencies": {
     "@domain/entity-currency-crypto": "workspace:^",

--- a/libs/coin-modules/coin-icon/.unimportedrc.json
+++ b/libs/coin-modules/coin-icon/.unimportedrc.json
@@ -43,7 +43,6 @@
     "@ledgerhq/live-promise",
     "@ledgerhq/logs",
     "prando",
-    "rxjs",
-    "@ledgerhq/errors"
+    "rxjs"
   ]
 }

--- a/libs/coin-modules/coin-icon/package.json
+++ b/libs/coin-modules/coin-icon/package.json
@@ -55,8 +55,7 @@
     "bignumber.js": "^9.1.2",
     "icon-sdk-js": "1.5.2",
     "prando": "^6.0.1",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-internet_computer/.unimportedrc.json
+++ b/libs/coin-modules/coin-internet_computer/.unimportedrc.json
@@ -52,7 +52,5 @@
   "ignoreUnimported": [
     "src/supportedFeatures.ts"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-internet_computer/package.json
+++ b/libs/coin-modules/coin-internet_computer/package.json
@@ -107,8 +107,7 @@
     "cbor": "10.0.11",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/coin-modules/coin-kaspa/.unimportedrc.json
+++ b/libs/coin-modules/coin-kaspa/.unimportedrc.json
@@ -90,7 +90,6 @@
     "lodash",
     "lru-cache",
     "prando",
-    "rxjs",
-    "@ledgerhq/errors"
+    "rxjs"
   ]
 }

--- a/libs/coin-modules/coin-kaspa/package.json
+++ b/libs/coin-modules/coin-kaspa/package.json
@@ -109,8 +109,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^7.14.1",
     "prando": "^6.0.1",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-mina/package.json
+++ b/libs/coin-modules/coin-mina/package.json
@@ -125,8 +125,7 @@
     "bs58check": "catalog:",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-module-boilerplate/.unimportedrc.json
+++ b/libs/coin-modules/coin-module-boilerplate/.unimportedrc.json
@@ -28,7 +28,6 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",
-    "invariant",
-    "@ledgerhq/errors"
+    "invariant"
   ]
 }

--- a/libs/coin-modules/coin-module-boilerplate/package.json
+++ b/libs/coin-modules/coin-module-boilerplate/package.json
@@ -113,8 +113,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.4",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-multiversx/.unimportedrc.json
+++ b/libs/coin-modules/coin-multiversx/.unimportedrc.json
@@ -24,8 +24,7 @@
     "axios",
     "expect",
     "invariant",
-    "lodash",
-    "@ledgerhq/errors"
+    "lodash"
   ],
   "ignoreUnresolved": [
     "@jest/expect-utils",

--- a/libs/coin-modules/coin-multiversx/package.json
+++ b/libs/coin-modules/coin-multiversx/package.json
@@ -65,8 +65,7 @@
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "protobufjs": "^7.2.6",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-near/.unimportedrc.json
+++ b/libs/coin-modules/coin-near/.unimportedrc.json
@@ -22,7 +22,5 @@
     "src/test/bridge.dataset.ts",
     "src/supportedFeatures.ts"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-near/package.json
+++ b/libs/coin-modules/coin-near/package.json
@@ -52,8 +52,7 @@
     "@ledgerhq/types-live": "workspace:^",
     "bignumber.js": "^9.1.2",
     "near-api-js": "^3.0.2",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-polkadot/.unimportedrc.json
+++ b/libs/coin-modules/coin-polkadot/.unimportedrc.json
@@ -32,7 +32,6 @@
   "ignoreUnused": [
     "@polkadot/api",
     "@polkadot/api-augment",
-    "@polkadot/api-derive",
-    "@ledgerhq/errors"
+    "@polkadot/api-derive"
   ]
 }

--- a/libs/coin-modules/coin-polkadot/package.json
+++ b/libs/coin-modules/coin-polkadot/package.json
@@ -152,8 +152,7 @@
     "@polkadot/util-crypto": "catalog:",
     "bignumber.js": "^9.1.2",
     "invariant": "^2.2.2",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-solana/.unimportedrc.json
+++ b/libs/coin-modules/coin-solana/.unimportedrc.json
@@ -30,7 +30,5 @@
     "src/test/bridge.dataset.ts",
     "src/tests/preload.fixtures.ts"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-solana/package.json
+++ b/libs/coin-modules/coin-solana/package.json
@@ -77,8 +77,7 @@
     "rxjs": "catalog:",
     "semver": "catalog:",
     "superstruct": "0.16.7",
-    "uuid": "11.1.0",
-    "@ledgerhq/errors": "workspace:^"
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-stacks/package.json
+++ b/libs/coin-modules/coin-stacks/package.json
@@ -110,8 +110,7 @@
     "invariant": "^2.2.4",
     "ripple-address-codec": "^5.0.0",
     "ripple-binary-codec": "^1.3.0",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-sui/.unimportedrc.json
+++ b/libs/coin-modules/coin-sui/.unimportedrc.json
@@ -31,7 +31,6 @@
     "src/test/testUtils.ts"
   ],
   "ignoreUnused": [
-    "@ledgerhq/live-env",
-    "@ledgerhq/errors"
+    "@ledgerhq/live-env"
   ]
 }

--- a/libs/coin-modules/coin-sui/package.json
+++ b/libs/coin-modules/coin-sui/package.json
@@ -168,8 +168,7 @@
     "bignumber.js": "^9.1.2",
     "gql.tada": "^1.9.2",
     "lodash": "4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@gql.tada/internal": "1.0.9",

--- a/libs/coin-modules/coin-tezos/.unimportedrc.json
+++ b/libs/coin-modules/coin-tezos/.unimportedrc.json
@@ -23,7 +23,5 @@
     "src/supportedFeatures.ts"
   ],
   "ignore": [],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-modules/coin-tezos/package.json
+++ b/libs/coin-modules/coin-tezos/package.json
@@ -59,8 +59,7 @@
     "@taquito/ledger-signer": "^23.0.0-RC.0",
     "@taquito/rpc": "^23.0.0-RC.0",
     "@taquito/taquito": "^23.0.0-RC.0",
-    "@taquito/utils": "^23.0.0-RC.0",
-    "@ledgerhq/errors": "workspace:^"
+    "@taquito/utils": "^23.0.0-RC.0"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-ton/.unimportedrc.json
+++ b/libs/coin-modules/coin-ton/.unimportedrc.json
@@ -20,7 +20,6 @@
   ],
   "ignoreUnused": [
     "msw",
-    "@ledgerhq/live-env",
-    "@ledgerhq/errors"
+    "@ledgerhq/live-env"
   ]
 }

--- a/libs/coin-modules/coin-ton/package.json
+++ b/libs/coin-modules/coin-ton/package.json
@@ -57,8 +57,7 @@
     "bignumber.js": "^9.1.2",
     "lodash": "^4.17.21",
     "msw": "catalog:",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-tron/.unimportedrc.json
+++ b/libs/coin-modules/coin-tron/.unimportedrc.json
@@ -27,7 +27,6 @@
   ],
   "ignoreUnused": [
     "@ledgerhq/devices",
-    "invariant",
-    "@ledgerhq/errors"
+    "invariant"
   ]
 }

--- a/libs/coin-modules/coin-tron/package.json
+++ b/libs/coin-modules/coin-tron/package.json
@@ -113,8 +113,7 @@
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
     "rxjs": "catalog:",
-    "tronweb": "6.2.0",
-    "@ledgerhq/errors": "workspace:^"
+    "tronweb": "6.2.0"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-modules/coin-vechain/.unimportedrc.json
+++ b/libs/coin-modules/coin-vechain/.unimportedrc.json
@@ -60,7 +60,6 @@
     "eip55",
     "invariant",
     "lodash",
-    "rxjs",
-    "@ledgerhq/errors"
+    "rxjs"
   ]
 }

--- a/libs/coin-modules/coin-vechain/package.json
+++ b/libs/coin-modules/coin-vechain/package.json
@@ -114,8 +114,7 @@
     "eip55": "^2.1.1",
     "invariant": "^2.2.2",
     "lodash": "^4.17.21",
-    "rxjs": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "rxjs": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/disable-network-setup": "workspace:^",

--- a/libs/coin-tester-modules/coin-tester-cosmos/.unimportedrc.json
+++ b/libs/coin-tester-modules/coin-tester-cosmos/.unimportedrc.json
@@ -1,5 +1,3 @@
 {
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-tester-modules/coin-tester-polkadot/.unimportedrc.json
+++ b/libs/coin-tester-modules/coin-tester-polkadot/.unimportedrc.json
@@ -5,8 +5,7 @@
     "jest-util"
   ],
   "ignoreUnused": [
-    "expect",
-    "@ledgerhq/errors"
+    "expect"
   ],
   "ignoreUnimported": []
 }

--- a/libs/coin-tester-modules/coin-tester-stellar/.unimportedrc.json
+++ b/libs/coin-tester-modules/coin-tester-stellar/.unimportedrc.json
@@ -1,5 +1,3 @@
 {
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-tester-modules/coin-tester-stellar/package.json
+++ b/libs/coin-tester-modules/coin-tester-stellar/package.json
@@ -71,8 +71,7 @@
     "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
     "docker-compose": "^1.1.0",
-    "msw": "catalog:",
-    "@ledgerhq/errors": "workspace:^"
+    "msw": "catalog:"
   },
   "devDependencies": {
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/coin-tester-modules/coin-tester-xrp/.unimportedrc.json
+++ b/libs/coin-tester-modules/coin-tester-xrp/.unimportedrc.json
@@ -4,7 +4,5 @@
     "**/lib/**",
     "**/lib-es/**"
   ],
-  "ignoreUnused": [
-    "@ledgerhq/errors"
-  ]
+  "ignoreUnused": []
 }

--- a/libs/coin-tester-modules/coin-tester-xrp/package.json
+++ b/libs/coin-tester-modules/coin-tester-xrp/package.json
@@ -71,8 +71,7 @@
     "docker-compose": "^1.1.0",
     "msw": "catalog:",
     "ripple-binary-codec": "^1.3.0",
-    "ripple-keypairs": "^2.0.0",
-    "@ledgerhq/errors": "workspace:^"
+    "ripple-keypairs": "^2.0.0"
   },
   "devDependencies": {
     "@ledgerhq/wallet-framework-test-setup": "workspace:^",

--- a/libs/ledger-live-common/dependencies.md
+++ b/libs/ledger-live-common/dependencies.md
@@ -22,7 +22,6 @@ yarn upgrade-interactive -i --latest
 | @ethereumjs/common                          | Ethereum coin integration                                         | monthly                                                              |
 | @ethereumjs/tx                              | Ethereum coin integration                                         | monthly                                                              |
 | @ledgerhq/devices                           | devices data                                                      | weekly                                                               |
-| @ledgerhq/errors                            | errors defintion                                                  | weekly                                                               |
 | @ledgerhq/hw-app-btc                        | Bitcoin coin integration                                          | weekly                                                               |
 | @ledgerhq/hw-app-cosmos                     | Cosmos coin integration                                           | weekly                                                               |
 | @ledgerhq/hw-app-eth                        | Ethereum coin integration                                         | weekly                                                               |

--- a/libs/ledger-live-common/package.json
+++ b/libs/ledger-live-common/package.json
@@ -312,7 +312,6 @@
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",
     "@ledgerhq/devices": "workspace:*",
     "@ledgerhq/domain-service": "workspace:^",
-    "@ledgerhq/errors": "workspace:^",
     "@ledgerhq/evm-tools": "workspace:^",
     "@ledgerhq/hw-app-algorand": "workspace:^",
     "@ledgerhq/hw-app-aptos": "workspace:^",

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -67,7 +67,7 @@ export function enrichSwapDeserializationError(
   error: unknown,
 ): CompleteExchangeError | undefined {
   // Duck-type on `name` + `statusCode` rather than `instanceof TransportStatusError`, matching
-  // the rest of this file and the repo-wide migration off `@ledgerhq/errors` class checks (#19849,
+  // the rest of this file and the repo-wide migration off shared error class checks (#19849,
   // which dropped the `TransportStatusError` import from here).
   const transportErr = error as { name?: string; statusCode?: number } | null | undefined;
   if (

--- a/libs/ledgerjs/packages/errors/DEPRECATED.md
+++ b/libs/ledgerjs/packages/errors/DEPRECATED.md
@@ -1,11 +1,15 @@
 # @ledgerhq/errors is deprecated
 
-This package is **frozen** and being sunset. It stays published for backward
-compatibility (it is consumed externally, including by `@ledgerhq/coin-module-framework`),
-but it must not grow.
+This package is **frozen**. Nothing in this monorepo depends on it anymore, and nothing
+may start to: the `enforce-boundaries` CI check fails on any workspace manifest that
+declares `@ledgerhq/errors` in any dependency field (see
+`tools/nx-plugins/enforce-boundaries/constraints.js`).
+
+It only still lives here so it keeps being published for external consumers.
 
 ## Do not
 
+- ❌ Add it back as a dependency of any workspace package.
 - ❌ Add new error classes here (whether via `createCustomErrorClass` or hand-written).
 - ❌ Use `createCustomErrorClass` in any package.
 - ❌ Use the serialization stack — `serializeError`, `deserializeError`,
@@ -18,12 +22,74 @@ Define errors as plain native classes in your own package's `src/errors.ts`, and
 check their type with `error.name === "X"` rather than `instanceof` (the name
 survives serialization across IPC / workers / external frameworks).
 
-In the ledger-live repo, the `errors` skill documents the full how-to, and
-`libs/ledger-auth/src/errors.ts` is a reference implementation.
+In the ledger-live repo, the `errors` skill documents the full how-to,
+`libs/ledger-auth/src/errors.ts` is a reference implementation, and
+`libs/ledger-wallet-framework/src/errors.ts` is the shared home for errors used by
+several coin modules.
 
-## Why it can't just be deleted
+## Why it is still here
 
-- The public API is consumed by external packages and apps; removal is future work.
-- ~22 errors are shared by several sibling coin modules and have no editable home
-  package below the coin layer yet. They stay here for now; future owner is the
-  `coin-module-framework` repo.
+Two independent reasons, and only the first one has an end in sight.
+
+**1. It is still published.** External consumers resolve `@ledgerhq/errors` from npm, so the
+package keeps living here to be released. Removing it from the workspace means no more
+publishes — a product decision, not a mechanical follow-up.
+
+**2. An external peerDependency.** `@ledgerhq/coin-module-framework`,
+`@ledgerhq/coin-stellar`, `@ledgerhq/coin-xrp` and `@ledgerhq/coin-hypercore` declare
+`@ledgerhq/errors` as a `peerDependency` and `require()` it at runtime. With
+`auto-install-peers=false` that peer has to be provided by us, so the root `package.json`
+bridges it through `pnpm.packageExtensions` pointing at this workspace copy.
+
+`workspace:*` is deliberate there: it reuses this single copy, so the dependency graph keeps
+exactly the physical copies it had before. Pinning an npm version instead adds a duplicate
+and Desktop Bundle Checks reports a renderer duplication regression.
+
+The bridge has **three parts**, and all are needed:
+
+1. **Resolution** — `pnpm.packageExtensions` in the root `package.json` turns the peer into a
+   real dependency for those four, so they can find `@ledgerhq/errors` at all. An override
+   alone does not do this: with `auto-install-peers=false` an undeclared peer is never
+   installed, it just gets its *range* rewritten (`missing peer @ledgerhq/errors@workspace:*`).
+2. **Deduplication** — `pnpm.overrides` carries `"@ledgerhq/errors": "workspace:*"`, the same
+   idiom already used for `@ledgerhq/devices` and `@ledgerhq/hw-transport`. Four *other*
+   external packages depend on published versions — `@ledgerhq/wallet-api-core` and
+   `@ledgerhq/live-network` (the npm one) on `6.36.0`, `iso-filecoin` and
+   `@mysten/ledgerjs-hw-app-sui` on `6.32.0` — and the override collapses all of them onto
+   this single copy.
+3. **Build order** — `targetDefaults.build.dependsOn` in `nx.workspace.json` carries
+   `{ "projects": ["@ledgerhq/errors"], "target": "build" }`, so this package is compiled
+   before anything that bundles those external packages.
+
+Part 2 is what keeps Desktop Bundle Checks quiet. `extractDuplicatesFromRspack` flags a
+package when the renderer contains **two or more distinct versions** under
+`node_modules/.pnpm/@ledgerhq+errors@<version>/`; a workspace link does not match that path
+at all, so it is invisible to the detector. Before this, `develop` stayed clean only by
+accident: `apps/ledger-live-desktop` declared the package, and rspack's
+`resolve.modules: [lldRoot/node_modules, …]` search path made every nested request resolve
+to that one copy. Removing the declaration exposed the registry copies underneath it.
+
+Part 3 is easy to miss. `lib/` and `lib-es/` are gitignored, so they only exist once
+`nx run @ledgerhq/errors:build` has run — and nx derives build order from the *package.json*
+project graph, which it cannot see `packageExtensions` in. Without that edge, a clean
+checkout resolves the symlink to a source directory with no `lib/index.js` and every bundler
+and Jest run fails with `Cannot find module '@ledgerhq/errors'`. A global edge is used rather
+than per-project `implicitDependencies` so no consumer can be missed, and so the bridge stays
+a few lines to delete instead of dozens.
+
+## Retiring the bridge
+
+Two upstream releases remove the need for these parts, independently:
+
+- [LedgerHQ/coin-modules#752](https://github.com/LedgerHQ/coin-modules/pull/752) drops the
+  `peerDependency` from those four coin packages. Once released, parts **1 and 3** can go.
+- [LedgerHQ/wallet-api@916d7a3](https://github.com/LedgerHQ/wallet-api/commit/916d7a398ef0dc656e7c5af06524639b20f73b32)
+  removes `@ledgerhq/errors` from `wallet-api-core` (local `serialization.ts` replaces
+  `serializeError` / `deserializeError`). It is merged but **unreleased** — npm latest is still
+  `wallet-api-core@1.35.0` requiring `^6.35.0`. Once released and picked up (our pin is
+  `^1.35.0`, so a lockfile refresh suffices), the `6.36.0` copy disappears and the only
+  remaining consumers, `iso-filecoin` and `@mysten/ledgerjs-hw-app-sui`, **both pin `6.32.0`**
+  — a single version, which the detector ignores. Part **2** can then go too.
+
+After both, nothing in this repo needs the package and it can be deleted — subject to reason 1
+above, which is a separate decision.

--- a/libs/ledgerjs/packages/hw-app-celo/.unimportedrc.json
+++ b/libs/ledgerjs/packages/hw-app-celo/.unimportedrc.json
@@ -8,7 +8,6 @@
     "jest-util"
   ],
   "ignoreUnused": [
-    "@ledgerhq/errors",
     "@ledgerhq/hw-app-eth",
     "@ledgerhq/hw-transport",
     "bip32-path",

--- a/nx.workspace.json
+++ b/nx.workspace.json
@@ -332,7 +332,13 @@
   "targetDefaults": {
     "build": {
       "dependsOn": [
-        "^build"
+        "^build",
+        {
+          "projects": [
+            "@ledgerhq/errors"
+          ],
+          "target": "build"
+        }
       ],
       "outputs": [
         "{projectRoot}/dist/**",

--- a/package.json
+++ b/package.json
@@ -277,6 +277,7 @@
       "remove-flow-types-loader>flow-remove-types": "^2",
       "remove-flow-types-loader>loader-utils": "*",
       "@ledgerhq/devices": "workspace:*",
+      "@ledgerhq/errors": "workspace:*",
       "@ledgerhq/hw-transport": "workspace:*",
       "@ledgerhq/context-module": "catalog:",
       "tslib": "2.6.2",
@@ -330,6 +331,26 @@
       "detox": {
         "dependencies": {
           "expect": "*"
+        }
+      },
+      "@ledgerhq/coin-module-framework": {
+        "dependencies": {
+          "@ledgerhq/errors": "workspace:*"
+        }
+      },
+      "@ledgerhq/coin-stellar": {
+        "dependencies": {
+          "@ledgerhq/errors": "workspace:*"
+        }
+      },
+      "@ledgerhq/coin-xrp": {
+        "dependencies": {
+          "@ledgerhq/errors": "workspace:*"
+        }
+      },
+      "@ledgerhq/coin-hypercore": {
+        "dependencies": {
+          "@ledgerhq/errors": "workspace:*"
         }
       }
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,6 +511,7 @@ overrides:
   remove-flow-types-loader>flow-remove-types: ^2
   remove-flow-types-loader>loader-utils: '*'
   '@ledgerhq/devices': workspace:*
+  '@ledgerhq/errors': workspace:*
   '@ledgerhq/hw-transport': workspace:*
   '@ledgerhq/context-module': 2.3.1
   tslib: 2.6.2
@@ -525,7 +526,7 @@ overrides:
   '@ledgerhq/device-signer-kit-aleo>@ledgerhq/signer-utils': 1.1.3
   '@ton/ton>zod': 4.3.6
 
-packageExtensionsChecksum: sha256-ncotzmACiC2rOyyMil4Rrs2djdIDzC2+p16TbkRXDRA=
+packageExtensionsChecksum: sha256-TOUMIYD04Sso33eHAaHi3luSO5Tbf6bgBpAG7b/7AcY=
 
 pnpmfileChecksum: sha256-xLqSS12ZnNWPulG7lBzO/RFXZkVYpafIseIHU3FfiO4=
 
@@ -930,7 +931,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/coin-zcash':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-zcash
@@ -946,9 +947,6 @@ importers:
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../../libs/domain-service
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/errors
       '@ledgerhq/ethereum-provider':
         specifier: workspace:^
         version: link:../../libs/ethereum-provider
@@ -1661,7 +1659,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-multiversx
@@ -1692,9 +1690,6 @@ importers:
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../../libs/domain-service
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../libs/ledgerjs/packages/errors
       '@ledgerhq/ethereum-provider':
         specifier: workspace:^
         version: link:../../libs/ethereum-provider
@@ -2208,7 +2203,7 @@ importers:
         version: 18.0.1
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6
+        version: 0.81.6(@babel/core@7.28.5)
       '@react-native/codegen':
         specifier: 'catalog:'
         version: 0.81.6(@babel/core@7.28.5)
@@ -5125,13 +5120,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5201,10 +5193,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5283,13 +5272,10 @@ importers:
         version: 3.1.3(got@11.8.5)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5374,10 +5360,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5525,13 +5508,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/hw-app-canton':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/hw-app-canton
@@ -5607,10 +5587,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5692,10 +5669,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5774,13 +5748,10 @@ importers:
         version: link:../coin-evm
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/hw-app-eth':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/hw-app-eth
@@ -5880,13 +5851,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/concordium-core':
         specifier: workspace:^
         version: link:../../concordium-core
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5980,10 +5948,7 @@ importers:
         version: 0.12.306
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6074,10 +6039,7 @@ importers:
         version: 5.7.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/evm-tools':
         specifier: workspace:^
         version: link:../../evm-tools
@@ -6165,13 +6127,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6256,13 +6215,10 @@ importers:
         version: 2.78.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6344,10 +6300,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6432,10 +6385,7 @@ importers:
         version: 2.14.0(@dfinity/agent@2.4.1(@dfinity/candid@2.4.1(@dfinity/principal@2.4.1))(@dfinity/principal@2.4.1))(@dfinity/candid@2.4.1(@dfinity/principal@2.4.1))(@dfinity/principal@2.4.1)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6508,13 +6458,10 @@ importers:
         version: 1.2.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6617,10 +6564,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6696,13 +6640,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6769,13 +6710,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6863,10 +6801,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6927,10 +6862,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7033,13 +6965,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7139,10 +7068,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7236,10 +7162,7 @@ importers:
         version: 1.0.11(graphql@16.13.2)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/hw-app-sui':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/hw-app-sui
@@ -7327,10 +7250,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7400,10 +7320,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 4.0.2
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7479,13 +7396,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7567,13 +7481,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -8306,13 +8217,10 @@ importers:
     dependencies:
       '@ledgerhq/coin-stellar':
         specifier: 'catalog:'
-        version: 6.26.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 6.26.4(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/coin-tester':
         specifier: workspace:^
         version: link:../../coin-tester
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -8552,10 +8460,7 @@ importers:
         version: link:../../coin-tester
       '@ledgerhq/coin-xrp':
         specifier: 'catalog:'
-        version: 7.25.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../../ledgerjs/packages/errors
+        version: 7.25.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -9331,7 +9236,7 @@ importers:
         version: link:../coin-modules/coin-hedera
       '@ledgerhq/coin-hypercore':
         specifier: 'catalog:'
-        version: 0.4.3(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 0.4.3(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/coin-icon':
         specifier: workspace:^
         version: link:../coin-modules/coin-icon
@@ -9346,7 +9251,7 @@ importers:
         version: link:../coin-modules/coin-mina
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+        version: 4.0.2
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../coin-modules/coin-multiversx
@@ -9364,7 +9269,7 @@ importers:
         version: link:../coin-modules/coin-stacks
       '@ledgerhq/coin-stellar':
         specifier: 'catalog:'
-        version: 6.26.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 6.26.4(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/coin-sui':
         specifier: workspace:^
         version: link:../coin-modules/coin-sui
@@ -9382,7 +9287,7 @@ importers:
         version: link:../coin-modules/coin-vechain
       '@ledgerhq/coin-xrp':
         specifier: 'catalog:'
-        version: 7.25.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
+        version: 7.25.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)
       '@ledgerhq/coin-zcash':
         specifier: workspace:^
         version: link:../coin-modules/coin-zcash
@@ -9407,9 +9312,6 @@ importers:
       '@ledgerhq/domain-service':
         specifier: workspace:^
         version: link:../domain-service
-      '@ledgerhq/errors':
-        specifier: workspace:^
-        version: link:../ledgerjs/packages/errors
       '@ledgerhq/evm-tools':
         specifier: workspace:^
         version: link:../evm-tools
@@ -13046,7 +12948,7 @@ importers:
         version: 0.81.6
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6
+        version: 0.81.6(@babel/core@7.28.5)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.0.9
@@ -13070,7 +12972,7 @@ importers:
         version: 10.4.4(@storybook/react@10.4.1(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/addon-react-native-web':
         specifier: 'catalog:'
-        version: 0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@storybook/jest':
         specifier: 'catalog:'
         version: 0.2.3
@@ -18526,26 +18428,21 @@ packages:
   '@ledgerhq/coin-hypercore@0.4.3':
     resolution: {integrity: sha512-da1KB1ul/hJS+joTxLrTVab9mn3Gs1ZFSyOaFqPEypBFUHsgyWrQqHs6CH4uzailNhNeLyNY/uIV5SifVErBvw==}
     peerDependencies:
-      '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
   '@ledgerhq/coin-module-framework@4.0.2':
     resolution: {integrity: sha512-uYbsVd6t5qzgSEyINEhfuruTO74wAEi+lpMvAPF67F9gWAsFC7109kxlG1AgRdIQmmW5cCMYaSMt69DrhN0BuQ==}
-    peerDependencies:
-      '@ledgerhq/errors': ^6.33.0
 
   '@ledgerhq/coin-stellar@6.26.4':
     resolution: {integrity: sha512-KZgJHQ2TcK20ZXK+2qM06lS45bi44uk2dXJ69iXK6ZUVBEtWuMrxbvqVjrlrfuFZzZ/EN8bZ468LyRT00yqxQQ==}
     peerDependencies:
-      '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
   '@ledgerhq/coin-xrp@7.25.2':
     resolution: {integrity: sha512-KYEB7D/VZwgiYc4EWMWErPiL5yQDNb2dQZKaMaKChy751gH5AIc6LH2wfLSse5zkn9s6X1r12kAE9GVvWCmZ+w==}
     peerDependencies:
-      '@ledgerhq/errors': ^6.33.0
       '@ledgerhq/live-network': ^2.4.0
       '@ledgerhq/logs': ^6.17.0
 
@@ -18644,15 +18541,6 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.0
       rxjs: 7.8.2
-
-  '@ledgerhq/errors@5.50.0':
-    resolution: {integrity: sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==}
-
-  '@ledgerhq/errors@6.32.0':
-    resolution: {integrity: sha512-BjjvhLM6UXYUbhllqAduo9PSneLt9FXZ3TBEUFQ3MMSZOCHt0gAgDySLwul99R8fdYWkXBza4DYQjUNckpN2lg==}
-
-  '@ledgerhq/errors@6.36.0':
-    resolution: {integrity: sha512-o2Q5hNvf2TzAzlH8ORAozppRbzixRPYDfmSQrP7FOcM997OEH7qDleXgp/uMpvRdxR/t3CJCG+n0i+bU/oYMKA==}
 
   '@ledgerhq/hw-bolos@6.35.1':
     resolution: {integrity: sha512-+osQFmZAKv1JOMZPiYU3G8wgW/JqxA0HCe/Y/O+b72TyH0SOyiXybdyIc1//We6AUyrJ2CiG8cev3vPYfjsjwQ==}
@@ -20727,6 +20615,8 @@ packages:
   '@react-native/babel-preset@0.81.6':
     resolution: {integrity: sha512-RtIr82ccPoyMLmIC3/vCG96MzRmIT+IzQkjCgTS5b93uAxiER9BS7+d1l7+zD00VanClt6CTBM4K4n6RCnAykg==}
     engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/codegen@0.77.3':
     resolution: {integrity: sha512-Q6ZJCE7h6Z3v3DiEZUnqzHbgwF3ZILN+ACTx6qu/x2X1cL96AatKwdX92e0+7J9RFg6gdoFYJgRrW8Q6VnWZsQ==}
@@ -22922,7 +22812,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25266,7 +25156,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -40562,6 +40452,16 @@ snapshots:
       regexpu-core: 6.2.0
       semver: 6.3.1
 
+  '@babel/helper-define-polyfill-provider@0.6.5':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -40636,6 +40536,14 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-remap-async-to-generator@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-wrap-function': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -40784,6 +40692,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-export-default-from@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -40870,9 +40782,17 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-dynamic-import@7.8.3':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-export-default-from@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.28.5)':
@@ -40883,6 +40803,10 @@ snapshots:
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-flow@7.27.1':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5)':
@@ -41027,6 +40951,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-async-generator-functions@7.28.0':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41042,6 +40974,14 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@7.27.1':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -41062,6 +41002,10 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-block-scoping@7.28.5':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
@@ -41133,6 +41077,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.28.6
 
+  '@babel/plugin-transform-computed-properties@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/template': 7.28.6
+
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41143,6 +41092,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-destructuring@7.28.5':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -41196,11 +41152,23 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-flow-strip-types@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-flow': 7.27.1
+
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
+
+  '@babel/plugin-transform-for-of@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -41213,6 +41181,14 @@ snapshots:
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-function-name@7.27.1':
+    dependencies:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.29.0
@@ -41238,9 +41214,17 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-literals@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-logical-assignment-operators@7.28.5':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
@@ -41294,6 +41278,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41314,6 +41303,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-numeric-separator@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41325,6 +41318,16 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
+
+  '@babel/plugin-transform-object-rest-spread@7.28.4':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5
+      '@babel/plugin-transform-parameters': 7.27.7
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
@@ -41344,6 +41347,10 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-optional-catch-binding@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -41370,10 +41377,21 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-parameters@7.27.7':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-private-methods@7.27.1':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -41388,6 +41406,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -41411,6 +41437,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-react-display-name@7.28.0':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41423,9 +41453,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.28.5)':
@@ -41440,6 +41478,16 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.27.1
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -41461,6 +41509,10 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-regenerator@7.28.4':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41476,6 +41528,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-runtime@7.25.9':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      babel-plugin-polyfill-corejs2: 0.4.14
+      babel-plugin-polyfill-corejs3: 0.10.6
+      babel-plugin-polyfill-regenerator: 0.6.5
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-runtime@7.25.9(@babel/core@7.28.5)':
     dependencies:
@@ -41506,6 +41569,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -41517,6 +41587,10 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-sticky-regex@7.27.1':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
@@ -46483,35 +46557,31 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@ledgerhq/coin-hypercore@0.4.3(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
+  '@ledgerhq/coin-hypercore@0.4.3(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+      '@ledgerhq/coin-module-framework': 4.0.2
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
 
   '@ledgerhq/coin-module-framework@4.0.2':
     dependencies:
-      bignumber.js: 9.1.2
-
-  '@ledgerhq/coin-module-framework@4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)':
-    dependencies:
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       bignumber.js: 9.1.2
 
-  '@ledgerhq/coin-stellar@6.26.4(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
+  '@ledgerhq/coin-stellar@6.26.4(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
       '@exodus/patch-broken-hermes-typed-arrays': 1.0.0-alpha.1(patch_hash=7deb6c5bd39ee007fca03da7609b2e0dee99dbb9962c3c8715edfd026da0a732)
-      '@ledgerhq/coin-module-framework': 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+      '@ledgerhq/coin-module-framework': 4.0.2
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
       '@stellar/stellar-sdk': 14.0.0
       bignumber.js: 9.1.2
 
-  '@ledgerhq/coin-xrp@7.25.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
+  '@ledgerhq/coin-xrp@7.25.2(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 4.0.2(@ledgerhq/errors@libs+ledgerjs+packages+errors)
+      '@ledgerhq/coin-module-framework': 4.0.2
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
@@ -46760,19 +46830,13 @@ snapshots:
       rxjs: 7.8.2
       uuid: 11.0.3
 
-  '@ledgerhq/errors@5.50.0': {}
-
-  '@ledgerhq/errors@6.32.0': {}
-
-  '@ledgerhq/errors@6.36.0': {}
-
   '@ledgerhq/hw-bolos@6.35.1':
     dependencies:
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
 
   '@ledgerhq/hw-transport-u2f@5.36.0-deprecated':
     dependencies:
-      '@ledgerhq/errors': 5.50.0
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       '@ledgerhq/logs': 5.50.0
       u2f-api: 0.2.7
@@ -46802,7 +46866,7 @@ snapshots:
 
   '@ledgerhq/live-network@2.4.3':
     dependencies:
-      '@ledgerhq/errors': 6.36.0
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-env': 2.31.0
       '@ledgerhq/live-promise': 0.2.2
       '@ledgerhq/logs': 6.16.0
@@ -47092,7 +47156,7 @@ snapshots:
 
   '@ledgerhq/wallet-api-core@1.35.0(@ton/crypto@3.3.0)':
     dependencies:
-      '@ledgerhq/errors': 6.36.0
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@stacks/transactions': 6.17.0
       '@ton/core': 0.62.0(patch_hash=9329da4fb3122df62d833d0c4d847d33a35a9457ee48997870bc044fc80b7324)(@ton/crypto@3.3.0)
       bignumber.js: 9.1.2
@@ -47281,7 +47345,7 @@ snapshots:
   '@mysten/ledgerjs-hw-app-sui@0.8.0':
     dependencies:
       '@ledgerhq/devices': link:libs/ledgerjs/packages/devices
-      '@ledgerhq/errors': 6.32.0
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/hw-bolos': 6.35.1
       '@ledgerhq/hw-transport': link:libs/ledgerjs/packages/hw-transport
       '@ledgerhq/ledger-cal-service': 1.15.1
@@ -49664,6 +49728,55 @@ snapshots:
       - supports-color
 
   '@react-native/babel-preset@0.81.6':
+    dependencies:
+      '@babel/plugin-proposal-export-default-from': 7.25.9
+      '@babel/plugin-syntax-dynamic-import': 7.8.3
+      '@babel/plugin-syntax-export-default-from': 7.25.9
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3
+      '@babel/plugin-transform-arrow-functions': 7.27.1
+      '@babel/plugin-transform-async-generator-functions': 7.28.0
+      '@babel/plugin-transform-async-to-generator': 7.27.1
+      '@babel/plugin-transform-block-scoping': 7.28.5
+      '@babel/plugin-transform-class-properties': 7.27.1
+      '@babel/plugin-transform-classes': 7.28.4
+      '@babel/plugin-transform-computed-properties': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5
+      '@babel/plugin-transform-flow-strip-types': 7.27.1
+      '@babel/plugin-transform-for-of': 7.27.1
+      '@babel/plugin-transform-function-name': 7.27.1
+      '@babel/plugin-transform-literals': 7.27.1
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5
+      '@babel/plugin-transform-modules-commonjs': 7.27.1
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1
+      '@babel/plugin-transform-numeric-separator': 7.27.1
+      '@babel/plugin-transform-object-rest-spread': 7.28.4
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.5
+      '@babel/plugin-transform-parameters': 7.27.7
+      '@babel/plugin-transform-private-methods': 7.27.1
+      '@babel/plugin-transform-private-property-in-object': 7.27.1
+      '@babel/plugin-transform-react-display-name': 7.28.0
+      '@babel/plugin-transform-react-jsx': 7.27.1
+      '@babel/plugin-transform-react-jsx-self': 7.25.9
+      '@babel/plugin-transform-react-jsx-source': 7.25.9
+      '@babel/plugin-transform-regenerator': 7.28.4
+      '@babel/plugin-transform-runtime': 7.25.9
+      '@babel/plugin-transform-shorthand-properties': 7.27.1
+      '@babel/plugin-transform-spread': 7.27.1
+      '@babel/plugin-transform-sticky-regex': 7.27.1
+      '@babel/plugin-transform-typescript': 7.28.5
+      '@babel/plugin-transform-unicode-regex': 7.27.1
+      '@babel/template': 7.28.6
+      '@react-native/babel-plugin-codegen': 0.81.6
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/babel-preset@0.81.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.28.5)
@@ -53146,11 +53259,11 @@ snapshots:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
 
-  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       babel-plugin-react-native-web: 0.19.10
     optionalDependencies:
-      '@react-native/babel-preset': 0.81.6
+      '@react-native/babel-preset': 0.81.6(@babel/core@7.28.5)
       metro-react-native-babel-preset: 0.77.0(@babel/core@7.28.5)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -56751,12 +56864,27 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.8
 
+  babel-plugin-polyfill-corejs2@0.4.14:
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/helper-define-polyfill-provider': 0.6.5
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.10.6:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.5
+      core-js-compat: 3.43.0
     transitivePeerDependencies:
       - supports-color
 
@@ -56773,6 +56901,12 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       core-js-compat: 3.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.5:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.5
     transitivePeerDependencies:
       - supports-color
 
@@ -56821,6 +56955,12 @@ snapshots:
       hermes-parser: 0.29.1
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
+  babel-plugin-transform-flow-enums@0.0.2:
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.27.1
+    transitivePeerDependencies:
+      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.28.5):
     dependencies:
@@ -62765,7 +62905,7 @@ snapshots:
   iso-filecoin@7.4.7(@typescript/typescript6@6.0.2):
     dependencies:
       '@ipld/dag-cbor': 9.2.7
-      '@ledgerhq/errors': 6.32.0
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@noble/curves': 1.9.7
       '@noble/hashes': 2.0.1
       '@scure/bip32': 1.7.0
@@ -65840,7 +65980,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7(metro-transform-worker@0.83.7)
+      metro: 0.83.7
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -65990,53 +66130,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.7(metro-transform-worker@0.83.7):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 2.0.0
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.35.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.7)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.7
-      metro-cache: 0.83.7
-      metro-cache-key: 0.83.7
-      metro-config: 0.83.7(metro-transform-worker@0.83.7)
-      metro-core: 0.83.7
-      metro-file-map: 0.83.7(metro@0.83.7)
-      metro-resolver: 0.83.7
-      metro-runtime: 0.83.7
-      metro-source-map: 0.83.7
-      metro-symbolicate: 0.83.7
-      metro-transform-plugins: 0.83.7
-      metro-transform-worker: 0.83.7
-      mime-types: 3.0.1
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/tools/nx-plugins/enforce-boundaries/constraints.js
+++ b/tools/nx-plugins/enforce-boundaries/constraints.js
@@ -45,4 +45,26 @@ const BOUNDARY_EXCEPTIONS = [
   { sourceRoot: "shared/env", targetRoot: "libs/env", allowedImport: "@ledgerhq/live-env" },
 ];
 
-module.exports = { DEP_CONSTRAINTS, BOUNDARY_EXCEPTIONS };
+/**
+ * Packages no workspace manifest may declare, whatever the dependency field.
+ *
+ * `hoist=false` means a package can only resolve what it declares, so banning the
+ * declaration is enough to ban the import too — an undeclared import fails to resolve.
+ *
+ * `@ledgerhq/errors` is frozen and being sunset (LIVE-32915): its classes now live in the
+ * package that owns them, with `@ledgerhq/ledger-wallet-framework/errors` as the shared
+ * home below the coin layer. It stays in the repo to keep being published for external
+ * consumers, and is bridged to the external coin packages that still peer-depend on it via
+ * `pnpm.packageExtensions` in the root package.json — see its DEPRECATED.md.
+ */
+const BANNED_DEPENDENCIES = [
+  {
+    name: "@ledgerhq/errors",
+    reason:
+      "frozen and being sunset (LIVE-32915). Define errors as native classes in your own " +
+      "src/errors.ts and branch on `error.name`; shared coin-layer errors live in " +
+      "@ledgerhq/ledger-wallet-framework/errors. See .agents/skills/errors/SKILL.md.",
+  },
+];
+
+module.exports = { DEP_CONSTRAINTS, BOUNDARY_EXCEPTIONS, BANNED_DEPENDENCIES };

--- a/tools/nx-plugins/enforce-boundaries/validate.js
+++ b/tools/nx-plugins/enforce-boundaries/validate.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { createProjectGraphAsync } = require("@nx/devkit");
-const { DEP_CONSTRAINTS, BOUNDARY_EXCEPTIONS } = require("./constraints");
+const { DEP_CONSTRAINTS, BOUNDARY_EXCEPTIONS, BANNED_DEPENDENCIES } = require("./constraints");
 const fs = require("node:fs");
 const path = require("node:path");
 
@@ -11,7 +11,15 @@ const path = require("node:path");
  * @typedef {{ nodes: Record<string, GraphNode>, dependencies: Record<string, GraphEdge[]> }} ProjectGraphLike
  * @typedef {{ sourceName: string, sourceTags: string[], target: string, targetTags: string[] }} Violation
  * @typedef {{ file: string, specifier: string }} SourceViolation
+ * @typedef {{ manifest: string, dependency: string, field: string, reason: string }} BannedDepViolation
  */
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+];
 
 const SKIP_DIRS = new Set(["node_modules", "dist", "lib", "build", ".turbo", ".cache"]);
 const SOURCE_EXTS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]);
@@ -124,6 +132,47 @@ function findSourceImportViolations(workspaceRoot, legacyPackages, exceptions = 
 }
 
 /**
+ * Check every workspace manifest for a dependency on a banned package.
+ *
+ * A banned package's own manifest is skipped: the package may still live in the repo (to
+ * keep being published) while nothing in the workspace is allowed to depend on it.
+ *
+ * @param {ProjectGraphLike} graph
+ * @param {string} workspaceRoot
+ * @param {Array<{name: string, reason: string}>} bannedDependencies
+ * @returns {BannedDepViolation[]}
+ */
+function findBannedDependencyViolations(graph, workspaceRoot, bannedDependencies = []) {
+  if (bannedDependencies.length === 0) return [];
+  const banned = new Map(bannedDependencies.map(b => [b.name, b.reason]));
+  const violations = [];
+
+  for (const node of Object.values(graph.nodes)) {
+    const root = node.data?.root;
+    if (!root) continue;
+    const manifest = path.join(root, "package.json");
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(path.join(workspaceRoot, manifest), "utf8"));
+    } catch {
+      continue;
+    }
+    if (banned.has(pkg.name)) continue; // the banned package itself
+
+    for (const field of DEPENDENCY_FIELDS) {
+      for (const dependency of Object.keys(pkg[field] ?? {})) {
+        const reason = banned.get(dependency);
+        if (reason !== undefined) {
+          violations.push({ manifest, dependency, field, reason });
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+/**
  * Walk the Nx project graph and collect every edge that violates the
  * DEP_CONSTRAINTS rules. A given edge can match multiple constraints
  * (e.g. a `type:domain-api` source also has `scope:domain`); the
@@ -212,11 +261,37 @@ async function main() {
     );
   }
 
+  const bannedDepViolations = findBannedDependencyViolations(
+    graph,
+    workspaceRoot,
+    BANNED_DEPENDENCIES,
+  );
+
+  if (bannedDepViolations.length > 0) {
+    hasError = true;
+    console.error(`\n✗ ${bannedDepViolations.length} banned-dependency violation(s):\n`);
+    for (const v of bannedDepViolations) {
+      console.error(`  ${v.manifest}  →  ${v.dependency}  (${v.field})`);
+    }
+    const reasons = new Map(bannedDepViolations.map(v => [v.dependency, v.reason]));
+    for (const [dependency, reason] of reasons) {
+      console.error(`\n${dependency} is banned: ${reason}`);
+    }
+    console.error(
+      "\nBanned packages are listed in tools/nx-plugins/enforce-boundaries/constraints.js\n",
+    );
+  }
+
   if (hasError) process.exit(1);
   console.log("✓ module boundaries ok");
 }
 
-module.exports = { findViolations, findSourceImportViolations, collectLegacyPackageNames };
+module.exports = {
+  findViolations,
+  findSourceImportViolations,
+  collectLegacyPackageNames,
+  findBannedDependencyViolations,
+};
 
 if (require.main === module) {
   main().catch(err => {

--- a/tools/nx-plugins/enforce-boundaries/validate.test.js
+++ b/tools/nx-plugins/enforce-boundaries/validate.test.js
@@ -9,6 +9,7 @@ const {
   findViolations,
   findSourceImportViolations,
   collectLegacyPackageNames,
+  findBannedDependencyViolations,
 } = require("./validate");
 
 /**
@@ -507,4 +508,85 @@ test("no violations in a clean workspace", t => {
   const legacy = new Set(["@ledgerhq/errors"]); // lumen not in set
   const violations = findSourceImportViolations(root, legacy);
   assert.equal(violations.length, 0);
+});
+
+const BANNED = [{ name: "@ledgerhq/banned", reason: "frozen" }];
+
+/** @param {Record<string, object>} manifests keyed by project root */
+function bannedDepGraph(manifests) {
+  return {
+    nodes: Object.fromEntries(Object.keys(manifests).map(root => [root, { data: { root } }])),
+    dependencies: {},
+  };
+}
+
+test("findBannedDependencyViolations flags a banned dependency", t => {
+  const manifests = {
+    "libs/a": { name: "@ledgerhq/a", dependencies: { "@ledgerhq/banned": "workspace:^" } },
+  };
+  const root = makeTmpWorkspace({
+    "libs/a/package.json": JSON.stringify(manifests["libs/a"]),
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const violations = findBannedDependencyViolations(bannedDepGraph(manifests), root, BANNED);
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].manifest, path.join("libs/a", "package.json"));
+  assert.equal(violations[0].dependency, "@ledgerhq/banned");
+  assert.equal(violations[0].field, "dependencies");
+});
+
+test("findBannedDependencyViolations covers every dependency field", t => {
+  const manifests = {
+    "libs/a": { name: "@ledgerhq/a", devDependencies: { "@ledgerhq/banned": "workspace:^" } },
+    "libs/b": { name: "@ledgerhq/b", peerDependencies: { "@ledgerhq/banned": "^6.0.0" } },
+    // optionalDependencies is a real escape hatch: 10 manifests in this repo use it
+    "libs/c": { name: "@ledgerhq/c", optionalDependencies: { "@ledgerhq/banned": "workspace:^" } },
+  };
+  const root = makeTmpWorkspace({
+    "libs/a/package.json": JSON.stringify(manifests["libs/a"]),
+    "libs/b/package.json": JSON.stringify(manifests["libs/b"]),
+    "libs/c/package.json": JSON.stringify(manifests["libs/c"]),
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const violations = findBannedDependencyViolations(bannedDepGraph(manifests), root, BANNED);
+  assert.equal(violations.length, 3);
+  assert.deepEqual(violations.map(v => v.field).sort(), [
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ]);
+});
+
+test("findBannedDependencyViolations skips the banned package's own manifest", t => {
+  const manifests = {
+    "libs/banned": { name: "@ledgerhq/banned", dependencies: { "@ledgerhq/banned": "1.0.0" } },
+  };
+  const root = makeTmpWorkspace({
+    "libs/banned/package.json": JSON.stringify(manifests["libs/banned"]),
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  assert.deepEqual(findBannedDependencyViolations(bannedDepGraph(manifests), root, BANNED), []);
+});
+
+test("findBannedDependencyViolations is a no-op with no banned packages", t => {
+  const manifests = {
+    "libs/a": { name: "@ledgerhq/a", dependencies: { "@ledgerhq/banned": "workspace:^" } },
+  };
+  const root = makeTmpWorkspace({
+    "libs/a/package.json": JSON.stringify(manifests["libs/a"]),
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  assert.deepEqual(findBannedDependencyViolations(bannedDepGraph(manifests), root, []), []);
+});
+
+test("findBannedDependencyViolations ignores unrelated dependencies and missing manifests", t => {
+  const manifests = {
+    "libs/a": { name: "@ledgerhq/a", dependencies: { "@ledgerhq/logs": "workspace:^" } },
+    "libs/gone": { name: "@ledgerhq/gone" },
+  };
+  const root = makeTmpWorkspace({
+    "libs/a/package.json": JSON.stringify(manifests["libs/a"]),
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  assert.deepEqual(findBannedDependencyViolations(bannedDepGraph(manifests), root, BANNED), []);
 });


### PR DESCRIPTION
### 📝 Description

The monorepo stops depending on `@ledgerhq/errors`, and is prevented from depending on it again. The package itself stays in the repo, frozen, so it keeps being published for external consumers.

No workspace source imported it anymore — the classes it held already live in the package that owns them, with `@ledgerhq/ledger-wallet-framework/errors` as the shared home below the coin layer. What is removed here is the 33 manifest declarations, 29 `.unimportedrc.json` allowlist entries, the `libs/coin-modules/.oxlintrc.json` import allowlist entry, and the stale docs/skills wording.

Define errors as native classes and branch on `name`, which survives serialization:

```diff
-import { createCustomErrorClass } from "@ledgerhq/errors";
-export const FooNotFound = createCustomErrorClass("FooNotFound");
+export class FooNotFound extends Error {
+  override name = "FooNotFound";
+}

-if (e instanceof FooNotFound) { … }
+if (e instanceof Error && e.name === "FooNotFound") { … }
```

#### Blocking new dependents

`enforce-boundaries` now fails on any workspace manifest declaring a banned package, in any dependency field:

```
✗ 1 banned-dependency violation(s):
  libs/coin-modules/coin-tezos/package.json  →  @ledgerhq/errors  (dependencies)

@ledgerhq/errors is banned: frozen and being sunset (LIVE-32915). Define errors as native
classes in your own src/errors.ts and branch on `error.name`; shared coin-layer errors live
in @ledgerhq/ledger-wallet-framework/errors. See .agents/skills/errors/SKILL.md.
```

One check is enough for both regression vectors: `hoist=false` means a package can only resolve what it declares, so an import without a declaration already fails to build. The ban list is one array in `tools/nx-plugins/enforce-boundaries/constraints.js`, and it rides the existing blocking `enforce-boundaries` job rather than adding CI wiring.

#### Why the package can't be deleted yet

The external `@ledgerhq/coin-module-framework`, `coin-stellar`, `coin-xrp` and `coin-hypercore` declare `@ledgerhq/errors` as a `peerDependency` and `require()` it at runtime (`coin-module-framework/config` → `./errors` → `createCustomErrorClass`). With `auto-install-peers=false`, that peer has to come from us — those 33 manifest entries looked like dead weight but were what satisfied it. So the root `package.json` bridges it:

```json
"@ledgerhq/coin-module-framework": { "dependencies": { "@ledgerhq/errors": "workspace:*" } }
```

`workspace:*` matters: it points the external packages at the single in-repo copy, so the dependency graph keeps exactly the physical copies develop already has — verified identical in `pnpm-lock.yaml` (same third-party `5.50.0` / `6.32.0` / `6.36.0`, same 4 workspace links). Pinning an npm version instead adds a duplicate and trips Desktop Bundle Checks.

The bridge needs a **second half**, which is easy to miss: `nx.workspace.json` adds

```json
"build": { "dependsOn": ["^build", { "projects": ["@ledgerhq/errors"], "target": "build" }] }
```

`lib/` and `lib-es/` are gitignored, so they exist only after `nx run @ledgerhq/errors:build` — and nx derives build order from the *package.json* project graph, which cannot see `packageExtensions`. Without that edge a clean checkout resolves the symlink to an uncompiled source directory and every bundler and Jest run fails with `Cannot find module '@ledgerhq/errors'`. A global edge is used rather than per-project `implicitDependencies` so no consumer can be missed, and so the whole bridge is two lines to remove instead of dozens. `test` / `coverage` / `typecheck` inherit it via their existing `build` / `^build` dependency.

[LedgerHQ/coin-modules#752](https://github.com/LedgerHQ/coin-modules/pull/752) removes that peerDependency upstream. Once it lands and those four are released, **both halves of the bridge can be dropped** — but the package itself still needs to exist here to be published for external consumers, so deleting it is a separate decision rather than a mechanical follow-up.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32915](https://ledgerhq.atlassian.net/browse/LIVE-32915)
- **ADR** (if any): n/a


[LIVE-32915]: https://ledgerhq.atlassian.net/browse/LIVE-32915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ