### PR TITLE
[LWDM] fix(ci): reduce develop flakiness from jest worker oversubscription

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -70,7 +70,7 @@ jobs:
           touch libs/coverage/lcov.info
           touch libs/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:libs --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:libs --parallel=4 -- --maxWorkers=2
 
           for package_json in $(find ./libs -name "package.json"); do
             lib=$(dirname "$package_json")
@@ -95,7 +95,7 @@ jobs:
           touch features/coverage/lcov.info
           touch features/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:features --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:features --parallel=4 -- --maxWorkers=2
 
           for package_json in $(find ./features -name "package.json" -not -path "*/node_modules/*"); do
             pkg=$(dirname "$package_json")
@@ -118,7 +118,7 @@ jobs:
           touch shared/coverage/lcov.info
           touch shared/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --maxWorkers=2
 
           for package_json in $(find ./shared -name "package.json" -not -path "*/node_modules/*" -not -path "*/coverage/*"); do
             pkg=$(dirname "$package_json")
@@ -141,7 +141,7 @@ jobs:
           touch domain/coverage/lcov.info
           touch domain/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --maxWorkers=2
 
           for package_json in $(find ./domain -name "package.json" -not -path "*/node_modules/*" -not -path "*/coverage/*"); do
             pkg=$(dirname "$package_json")
@@ -164,7 +164,7 @@ jobs:
           touch devtools/coverage/lcov.info
           touch devtools/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:devtools --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:devtools --parallel=4 -- --maxWorkers=2
 
           for package_json in $(find ./devtools -name "package.json" -not -path "*/node_modules/*" -not -path "*/coverage/*"); do
             pkg=$(dirname "$package_json")

--- a/.github/workflows/test-devtools-reusable.yml
+++ b/.github/workflows/test-devtools-reusable.yml
@@ -76,7 +76,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:devtools --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:devtools --parallel=4 -- --maxWorkers=2
 
       - name: Process coverage files
         id: process-coverage

--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -79,7 +79,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --maxWorkers=2
 
       - name: Process coverage files
         id: process-coverage

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -76,7 +76,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:features --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:features --parallel=4 -- --maxWorkers=2
 
       - name: Process coverage files
         id: process-coverage

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -82,7 +82,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:libs-non-ui --parallel=6 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:libs-non-ui --parallel=6 -- --maxWorkers=2
 
       - name: Test libraries without coverage script & Process coverage files
         id: test-libs

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -312,11 +312,6 @@ jobs:
 
             ${statuses.tests.pass ? "All tests are fine" : "Some tests failed"}
               - ${statuses.tests.pass ? "✅" : "❌"} **Test Libs** ended with status \`${statuses.tests.status}\`
-
-            ### Common Tools
-
-            ${statuses.tool.pass ? "Common Tools are fine" : "Common Tools tests failed"}
-              - ${statuses.tool.pass ? "✅" : "❌"} **Common Tools* tests* ended with status \`${statuses.tool.status}\`
             `;
 
             const actions = [];

--- a/.github/workflows/test-shared-reusable.yml
+++ b/.github/workflows/test-shared-reusable.yml
@@ -76,7 +76,7 @@ jobs:
           touch ${{ github.workspace }}/coverage/lcov.info
           touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
 
-          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --runInBand=1
+          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --maxWorkers=2
 
       - name: Process coverage files
         id: process-coverage

--- a/apps/ledger-live-desktop/jest.config.js
+++ b/apps/ledger-live-desktop/jest.config.js
@@ -69,6 +69,12 @@ const commonConfig = {
   testEnvironment: "jsdom",
   clearMocks: true,
   restoreMocks: true,
+  /**
+   * jest's 5s default is not enough for the suites that mount a whole screen: on CI (one worker per
+   * core) `Default.test.tsx` has been measured at 9.9s and 11.0s and failed the run. This bounds how
+   * long a hung test can stall the job, so keep it well under the job's `timeout-minutes`.
+   */
+  testTimeout: 30_000,
   globals: {
     __DEV__: false,
     __APP_VERSION__: "2.0.0",

--- a/apps/ledger-live-desktop/tests/jestSetup.js
+++ b/apps/ledger-live-desktop/tests/jestSetup.js
@@ -32,8 +32,15 @@ setFrameworkCryptoAssetsStore({
 });
 import "@jest/globals";
 import "@testing-library/jest-dom";
+import { configure } from "@testing-library/react";
 import { server } from "./server";
 import { EventEmitter } from "events";
+
+// testing-library defaults `waitFor`/`findBy*` to 1s. Suites that mount large trees (Default,
+// OnboardModal) exceed that on CI, where jest runs one worker per core: the element does show up,
+// just later than 1s. Kept well below `testTimeout` so a genuine miss still reports the query error
+// rather than a bare jest timeout.
+configure({ asyncUtilTimeout: 5_000 });
 
 // Disable max listeners warning for MSW (known issue with multiple tests)
 EventEmitter.defaultMaxListeners = 0;

--- a/libs/disable-network-setup/src/index.ts
+++ b/libs/disable-network-setup/src/index.ts
@@ -6,4 +6,9 @@ beforeAll(() => {
 
 afterAll(() => {
   nock.enableNetConnect();
+  // Also drop nock's http/https overrides. Importing nock patches them process-wide, and jest reuses
+  // a worker process across test files, so without this a suite that mocks the network another way
+  // (MSW) inherits nock's interceptor from an earlier file in the same worker: nock answers first and
+  // MSW never sees the request. The next file that imports nock re-activates it on import.
+  nock.restore();
 });

--- a/libs/disable-network-setup/src/restore.test.ts
+++ b/libs/disable-network-setup/src/restore.test.ts
@@ -1,0 +1,23 @@
+import http from "http";
+import nock from "nock";
+
+// The `afterAll` in ./index relies on `nock.restore()` putting the native `http.ClientRequest` back,
+// so that a reused jest worker does not carry nock's interceptor into a later suite that mocks the
+// network with MSW. Guard the invariant: a nock upgrade that stopped restoring the override would
+// silently reintroduce that cross-suite leak.
+describe("nock.restore", () => {
+  it("puts the original http.ClientRequest back and deactivates nock", () => {
+    const patched = http.ClientRequest;
+
+    nock.restore();
+
+    const native = http.ClientRequest;
+    expect(nock.isActive()).toBe(false);
+    expect(native).not.toBe(patched);
+
+    // Leave nock as the rest of the run expects to find it.
+    nock.activate();
+    expect(nock.isActive()).toBe(true);
+    expect(http.ClientRequest).not.toBe(native);
+  });
+});

--- a/libs/ledger-live-common/jest.config.ts
+++ b/libs/ledger-live-common/jest.config.ts
@@ -12,7 +12,13 @@ const testPathIgnorePatterns = [
   "src/__tests__/(test-helpers/|handlers/|server\\.ts)",
 ];
 
-const esmDeps = ["ky", "@mysten", "@scure", "@noble"];
+// Dependencies shipped as ESM that jest has to transform. Matched against pnpm's store directory
+// name, where a scope separator becomes a `+` (`@scure+base@1.1.0`), hence the escaped `\+`.
+const esmDeps = ["ky@", "@mysten\\+", "@scure\\+", "@noble\\+", "@babel\\+runtime"];
+
+// Some of those deps ship a `sourceMappingURL` comment but no `.map` file (e.g. @scure/base), which
+// makes swc log `failed to read input source map` for every file it transforms.
+const swcOptions = { inputSourceMap: false, jsc: { target: "esnext" } };
 
 // Integration tests that depend on flaky third-party/external nodes and explorers.
 // Excluded from the per-PR and daily integration runs; executed weekly instead
@@ -91,24 +97,16 @@ const defaultConfig = {
   testRegex,
   coverageReporters: ["json", ["lcov", { projectRoot: "../../" }], "json-summary", "text"],
   transform: {
-    "^.+\\.(t|j)sx?$": [
-      "@swc/jest",
-      {
-        jsc: {
-          target: "esnext",
-        },
-      },
-    ],
+    "^.+\\.(t|j)sx?$": ["@swc/jest", swcOptions],
     [`node_modules[\\\\|/].pnpm[\\\\|/](${esmDeps.join("|")}).+\\.(js|jsx|mjs)$`]: [
       "@swc/jest",
-      {
-        jsc: {
-          target: "esnext",
-        },
-      },
+      swcOptions,
     ],
   },
-  transformIgnorePatterns: ["/node_modules/(?!|@babel/runtime/helpers/esm/)"],
+  // Only the ESM deps above are transformed. The previous pattern was
+  // `/node_modules/(?!|@babel/runtime/helpers/esm/)`, whose empty first alternative makes the
+  // negative lookahead always fail, so nothing was ignored and swc transformed all of node_modules.
+  transformIgnorePatterns: [`node_modules[\\\\|/]\\.pnpm[\\\\|/](?!(${esmDeps.join("|")}))`],
   moduleDirectories: ["node_modules", "cli/node_modules"],
   moduleNameMapper: {
     "^buffer$": "<rootDir>/jest.buffer-shim.js",


### PR DESCRIPTION
> [!NOTE]
> Incremental series of fixes for the ~30% failure rate currently seen on `develop`. One commit per topic.

### 📝 Description

`develop` is red on roughly 1 push in 3. Over the last 40 pushes, **12 runs failed**, spread across four jobs:

| Failing job | Failure | Runs | Addressed |
| --- | --- | --- | --- |
| Test Libraries | `coin-vechain` `broadcast.msw.test.ts` times out at 30s | 2 | ✅ commit 1 |
| Test Libraries | `live-common:coverage` dies mid-output with no failing test | 1 | ✅ commit 1 + 2 |
| Desktop Unit Tests | `Default › analytics consent › retains consent flags on mount` blows the 5s default | 2 | ✅ commit 3 |
| Desktop Unit Tests | `OnboardModal › should complete the full onboarding happy path` | 2 | ✅ commit 3 |
| Ubuntu Mock (E2E) | `delegate.evmNativeStaking.smoke.spec.ts` (sei_evm), `Ledger by Figment` never renders | 3 | ❌ see below |
| Ubuntu Mock (E2E) | one-offs (`settings.spec.ts`, `webview-dev-tools.spec.ts`) | 2 | ❌ |
| Android UI E2E Smoke | one-off | 1 | ❌ |

---

#### Commit 1 — `--runInBand=1` was a no-op, so CI ran ~42 jest workers on 8 cores

Every coverage step passed `-- --runInBand=1` to jest. jest's CLI parses that value as **`false`**:

```
--runInBand=1       runInBand=false maxWorkers=9
--runInBand=true    runInBand=true  maxWorkers=1
--runInBand         runInBand=true  maxWorkers=1
--maxWorkers=2      runInBand=false maxWorkers=2
```

(reproduce with `pnpm jest --runInBand=1 --showConfig` in any lib)

So each of the ~100 coverage tasks ran with jest's default pool of `cpus - 1` workers while `nx run-many` already ran 4–6 tasks in parallel — up to **42 jest worker processes on an 8-CPU runner**, each allowed a 7 GB heap by `NODE_OPTIONS`.

That is what makes these jobs flaky rather than broken:

- `coin-vechain`'s MSW suite gets starved past its 30s timeout. The tell-tale sign is that MSW reports the request **after** the test already failed — the URL is right, but `afterEach` has run `server.resetHandlers()` by then:
  ```
  ● broadcast via MSW › submits the signed raw transaction and returns the transaction id
    thrown: "Exceeded timeout of 30000 ms for a test."
  Attempted to log "[MSW] Error: intercepted a request without a matching request handler:
    • POST https://vechain-test.ledger.com/transactions"   <- logged after tests are done
  ```
  The suite's own config already suspected it: *"MSW suites make mocked network calls that are fast locally but can be starved past jest's 5s default under CI parallelism"*.
- `live-common:coverage` is killed with its output truncated mid-line and no failing test — consistent with the OOM killer under that memory pressure.

Capped at `--maxWorkers=2` per task across all 10 affected steps (`test-libs`, `test-features`, `test-shared`, `test-domain`, `test-devtools`, `sonar`), so peak concurrency stays close to the runner's core count.

> [!IMPORTANT]
> **This commit is not exercised by this PR's own CI.** `build-and-test-pr.yml` pins every reusable
> workflow to `@develop` (`uses: LedgerHQ/ledger-live/.github/workflows/test-libs-reusable.yml@develop`),
> so the Libraries Test job here still ran develop's `--runInBand=1` — its green tick validates
> commits 2 and 4, not this one. Exercised separately via `workflow_dispatch` on this branch.
>
> It also trades parallelism for stability, so the **Test Libraries** duration is worth a look before
> merging. Note that nx caching makes the number hard to read (one PR run reported 223/223 tasks
> restored from cache), so compare cache-hit ratios, not just wall clock. If the cost is too high the
> knob to turn is `nx --parallel`, not jest's worker count.

#### Commit 2 — live-common's jest was transforming *all* of node_modules

`transformIgnorePatterns` was `/node_modules/(?!|@babel/runtime/helpers/esm/)`. The lookahead's first alternative is empty, and an empty pattern matches everywhere, so the negative lookahead can never succeed: the entry matched nothing and swc transformed every file under node_modules.

That is the source of the error reported in the Libraries Test logs:

```
ERROR  failed to read input source map: failed to find input source map file "index.js.map"
in ".../node_modules/cross-sha256/index.js" ...
```

`cross-sha256` is a transitive dep of `c32check` that nothing asked jest to transform. It also made `live-common:coverage` far heavier than necessary — instrumenting the whole dependency tree on every run, on the exact task that was being killed.

Now node_modules is ignored except the ESM deps that genuinely need transforming (same shape as `ledger-live-desktop`'s config). `inputSourceMap: false` is set too, because `@scure/base` — which we *do* have to transform — ships a `sourceMappingURL` comment without the `.map` file and produced the same error.

Verified locally: full live-common run, 374 suites pass with no new transform or syntax failure, and no source-map error.

#### Commit 3 — desktop unit tests were failing on waiting, not on asserting

Neither desktop failure asserts anything wrong; both run out of time. The desktop unit job runs jest with `JEST_MAX_WORKERS=95%`, so per-test wall clock is dominated by contention.

- `testTimeout: 30_000` (jest's default is 5s; `Default.test.tsx` mounts the whole app shell, and CI reported `thrown: "Exceeded timeout of 5000 ms for a test."` with the suite at 9.9s and 11.0s — jest-circus's reported figure covers the hooks too, so it is the suite's total, not proof that the test body alone took that long).
- testing-library `asyncUtilTimeout: 5_000` (default is 1s, which is what makes `waitFor` report *"Unable to find an element with the text: /successfully connected to concordium id app/i"*).

`asyncUtilTimeout` is kept below `testTimeout` so a genuine miss still reports the query error rather than a bare jest timeout.

#### Commit 4 — nock was leaking its http override into MSW suites

Importing nock patches `http.ClientRequest` and `http.get/request` process-wide, and jest reuses a worker process across test files. `@ledgerhq/disable-network-setup` only called `enableNetConnect()` on teardown, so the override survived into the next file in that worker — including files from a jest project that deliberately does not use nock.

The consequence is that nock's interceptor answers first and MSW's `server.use(...)` handlers are never consulted. Reproduced by activating nock inside coin-vechain's MSW project:

```
● broadcast via MSW › submits the signed raw transaction and returns the transaction id
  NetConnectNotAllowedError: Nock: Disallowed net connect for "vechain-test.ledger.com:443/transactions"
```

11 packages already pair nock with MSW, so this is a live hazard rather than a hypothetical one. Teardown now calls `nock.restore()`; the next file that imports nock re-activates it on import, and a new test pins that invariant in case a nock upgrade changes `restore()`.

Verified: coin-solana, coin-near, coin-cosmos, coin-vechain, coin-evm, coin-ton, coin-tezos, coin-multiversx, coin-kaspa, coin-polkadot and coin-mina all pass.

---

### Found but not fixed here

<details>
<summary><b>Untested files are silently dropped from every coverage report (upstream jest 30.2 bug)</b></summary>

`@jest/reporters` `_addUntestedFiles` returns the `FileCoverage` instance from `CoverageWorker` through jest-worker with `serialization: 'json'`. `JSON.stringify` of a `FileCoverage` yields `{ data: … }`, so `coverageMap.addFileCoverage()` rejects it:

```
Failed to collect coverage from .../coin-concordium/src/bridge/transaction.ts
ERROR: Invalid file coverage object, missing keys, found:data
    at assertValidObject (istanbul-lib-coverage/lib/file-coverage.js:38:15)
```

It only happens when `maxWorkers > 1` (at `<= 1` jest requires the worker in-process). The impact goes beyond log noise: **every file with no test at all is dropped from the report**, so the coverage we publish to Sonar is inflated. Confirmed by running coin-concordium with `--maxWorkers=1`, where the errors disappear and `src/bridge/transaction.ts` correctly shows 0%.

Not worked around here — the only config-level lever is `maxWorkers <= 1`, which is too expensive. Worth an upstream issue.
</details>

<details>
<summary><b>Ubuntu Mock: <code>delegate.evmNativeStaking.smoke.spec.ts</code> (3 of the 12 failures)</b></summary>

```
Error: expect(locator).toBeVisible() failed
Locator: getByText('Ledger by Figment').first()
Timeout: 41000ms
Error: element(s) not found
```

`[data-e2e="title_Delegation"]` *is* visible, so the delegation itself (from the mocked Sei EVM precompile) arrives; only the validator **moniker** is missing, and that comes from the separate `rest.sei-apis.com` validators mock.

Suspected race: the `page` fixture launches the app, and `mockSeiValidatorsApi(page)` only registers its `page.route` afterwards in `beforeEach`. A validators request issued during boot escapes the mock. The handler also matches strictly on `pagination.limit === "200"`, so a change on the app side would fall through silently.

Left alone deliberately — this is Earn-owned and I could not run desktop Playwright here to confirm before changing it.
</details>

### 🔗 Context

- **JIRA / GitHub issue**: _to be filled_
- **ADR** (if any): n/a
- Failing run that started the investigation: https://github.com/LedgerHQ/ledger-live/actions/runs/30620850329/job/91124796352
