### PR TITLE
[LWDM] test(hedera): integ tests for mobile and desktop part 3 (LIVE-34469)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ClaimRewardsFlowModal/__integrations__/claimRewardsFlowModal.integ.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { act, render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import ClaimRewardsModal from "../index";
+import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
+import { subjectRefs } from "../../__mocks__/bridge.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+  clickContinueWhenEnabled,
+} from "../../__mocks__/flowHelpers";
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaValidators: jest.fn(() => []),
+  useHederaEnrichedDelegation: jest.fn(
+    () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
+  ),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+beforeEach(async () => {
+  await setupHederaModalTest();
+});
+
+afterEach(() => {
+  cleanupHederaModalTest();
+});
+
+function setupModal() {
+  createModalsContainer();
+
+  return render(<ClaimRewardsModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_HEDERA_CLAIM_REWARDS: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1 },
+        },
+      },
+    },
+  });
+}
+
+describe("Hedera ClaimRewardsFlowModal (integration)", () => {
+  it("completes the happy path: Rewards → ConnectDevice → Confirmation success", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(
+      () => expect(screen.getByText("You have successfully claimed your rewards")).toBeVisible(),
+      { timeout: 5000 },
+    );
+  });
+
+  it("shows the device error state and allows retry when signing fails", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.error(new Error("UserRefusedOnDevice"));
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/DelegationFlowModal/__integrations__/delegationFlowModal.integ.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { getEnv, setEnv } from "@shared/env";
+import DelegationModal from "../index";
+import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
+import { subjectRefs } from "../../__mocks__/bridge.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+  clickContinueWhenEnabled,
+} from "../../__mocks__/flowHelpers";
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaValidators: jest.fn(() => [
+    {
+      nodeId: 0,
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+  ]),
+  useHederaEnrichedDelegation: jest.fn(() => null),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+
+let prevLedgerNodeId: number;
+beforeEach(async () => {
+  prevLedgerNodeId = getEnv("HEDERA_STAKING_LEDGER_NODE_ID");
+  // nodeId 0 matches the first mocked validator so getDefaultValidator pre-selects it,
+  // enabling the Continue button on the Validator step without user interaction.
+  setEnv("HEDERA_STAKING_LEDGER_NODE_ID", 0);
+  await setupHederaModalTest();
+});
+
+afterEach(() => {
+  setEnv("HEDERA_STAKING_LEDGER_NODE_ID", prevLedgerNodeId);
+  cleanupHederaModalTest();
+});
+
+function setupModal() {
+  createModalsContainer();
+
+  return render(<DelegationModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_HEDERA_DELEGATION: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1 },
+        },
+      },
+    },
+  });
+}
+
+describe("Hedera DelegationFlowModal (integration)", () => {
+  it("completes the happy path: Validator → Amount → ConnectDevice → Confirmation success", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(
+      () => expect(screen.getByText("You have successfully delegated your assets")).toBeVisible(),
+      { timeout: 5000 },
+    );
+  }, 20_000);
+
+  it("shows the device error state and allows retry when signing fails", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.error(new Error("UserRefusedOnDevice"));
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/__integrations__/receiveWithAssociationModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/__integrations__/receiveWithAssociationModal.integ.test.tsx
@@ -1,0 +1,159 @@
+import React from "react";
+import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import ReceiveWithAssociationModal from "../index";
+import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { subjectRefs } from "../../__mocks__/bridge.mock";
+import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+} from "../../__mocks__/flowHelpers";
+
+const mockHtsToken = {
+  id: "hedera/hts/0.0.123456",
+  name: "Mock HTS Token",
+  ticker: "MHT",
+  contractAddress: "0.0.123456",
+  decimals: 8,
+  type: "TokenCurrency" as const,
+  tokenType: "hts" as const,
+  parentCurrency: { id: "hedera", family: "hedera" } as never,
+  units: [{ code: "MHT", name: "Mock HTS Token", magnitude: 8 }],
+  disableCountervalue: false,
+};
+
+jest.mock("@ledgerhq/live-common/families/hedera/utils", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/families/hedera/utils"),
+  isTokenAssociationRequired: jest.fn(() => true),
+}));
+
+// Mock StepAccount to auto-call onChangeToken so isMissingToken = false when receiveTokenMode = true
+jest.mock("~/renderer/modals/Receive/steps/StepAccount", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ onChangeToken }: { onChangeToken?: (t: unknown) => void }) => {
+      React.useEffect(() => {
+        if (onChangeToken) {
+          onChangeToken({
+            id: "hedera/hts/0.0.123456",
+            name: "Mock HTS Token",
+            ticker: "MHT",
+            contractAddress: "0.0.123456",
+            decimals: 8,
+            type: "TokenCurrency",
+          });
+        }
+      }, [onChangeToken]);
+      return <div data-testid="step-account">Select Account</div>;
+    },
+  };
+});
+
+// StepAssociationDevice uses hw/actions/transaction (not hw/actions/app), which isn't set up
+// in this harness. This mock preserves the real sign→broadcast→transition sequence while
+// driving it via subjectRefs.sign, the same pattern used by other Hedera modal integration tests.
+jest.mock("../steps/StepAssociationDevice", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({
+      transitionTo,
+      onOperationBroadcasted,
+      setSigned,
+    }: {
+      transitionTo: (id: string) => void;
+      onOperationBroadcasted: (op: unknown) => void;
+      setSigned: (v: boolean) => void;
+    }) => {
+      React.useEffect(() => {
+        const { subjectRefs, mockAccountBridge } = require("../../__mocks__/bridge.mock");
+        const sub = subjectRefs.sign.subscribe(
+          async (event: { type: string; signedOperation: unknown }) => {
+            if (event.type === "signed") {
+              setSigned(true);
+              const op = await mockAccountBridge.broadcast({
+                signedOperation: event.signedOperation,
+              });
+              onOperationBroadcasted(op);
+              transitionTo("associationConfirmation");
+            }
+          },
+        );
+        return () => sub.unsubscribe();
+      }, [setSigned, onOperationBroadcasted, transitionTo]);
+      return <div data-testid="step-association-device">Connecting device…</div>;
+    },
+  };
+});
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+beforeEach(async () => {
+  await setupHederaModalTest();
+});
+
+afterEach(() => {
+  cleanupHederaModalTest();
+});
+
+function setupModal(data: Record<string, unknown> = {}) {
+  createModalsContainer();
+
+  return render(<ReceiveWithAssociationModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      accounts: [HEDERA_ACCOUNT_1],
+      modals: {
+        MODAL_HEDERA_RECEIVE_WITH_ASSOCIATION: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1, ...data },
+        },
+      },
+    },
+  });
+}
+
+describe("Hedera ReceiveWithAssociationModal (integration)", () => {
+  it("renders the account step when opened with a pre-selected account", async () => {
+    setupModal();
+
+    await waitFor(() => expect(screen.getByTestId("step-account")).toBeVisible());
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled(),
+    );
+  });
+
+  it("association path: Account → AssociationDevice → Confirmation shows 'Transaction sent'", async () => {
+    setupModal({ receiveTokenMode: true, token: mockHtsToken });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled(),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(() => expect(screen.getByText("Transaction sent")).toBeVisible(), {
+      timeout: 5000,
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/RedelegationFlowModal/__integrations__/redelegationFlowModal.integ.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { HEDERA_DELEGATION_STATUS } from "@ledgerhq/live-common/families/hedera/constants";
+import RedelegationModal from "../index";
+import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
+import { subjectRefs } from "../../__mocks__/bridge.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+  clickContinueWhenEnabled,
+} from "../../__mocks__/flowHelpers";
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaValidators: jest.fn(() => [
+    {
+      nodeId: 0,
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+    {
+      nodeId: 5,
+      name: "Hedera Node 5",
+      address: "0.0.5",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+  ]),
+  useHederaEnrichedDelegation: jest.fn(() => ({
+    nodeId: 0,
+    delegated: new BigNumber(5_000_000_000),
+    pendingReward: new BigNumber(500_000),
+    status: HEDERA_DELEGATION_STATUS.Active,
+    validator: {
+      nodeId: 0,
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+  })),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+beforeEach(async () => {
+  await setupHederaModalTest();
+});
+
+afterEach(() => {
+  cleanupHederaModalTest();
+});
+
+function setupModal() {
+  createModalsContainer();
+
+  return render(<RedelegationModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_HEDERA_REDELEGATION: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1 },
+        },
+      },
+    },
+  });
+}
+
+describe("Hedera RedelegationFlowModal (integration)", () => {
+  it("completes the happy path: Validators → ConnectDevice → Confirmation success", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(
+      () => expect(screen.getByText("You have successfully redelegated your assets")).toBeVisible(),
+      { timeout: 5000 },
+    );
+  });
+
+  it("shows the device error state and allows retry when signing fails", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.error(new Error("UserRefusedOnDevice"));
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/UndelegationFlowModal/__integrations__/undelegationFlowModal.integ.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { act, render, screen, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import UndelegationModal from "../index";
+import { HEDERA_ACCOUNT_1 } from "../../__mocks__/account.mock";
+import { mockSignedOperation } from "../../__mocks__/signedOperation.mock";
+import { subjectRefs } from "../../__mocks__/bridge.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+  clickContinueWhenEnabled,
+} from "../../__mocks__/flowHelpers";
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaValidators: jest.fn(() => [
+    {
+      nodeId: 0,
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+  ]),
+  useHederaEnrichedDelegation: jest.fn(
+    () => require("../../__mocks__/delegation.mock").mockEnrichedDelegation,
+  ),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+beforeEach(async () => {
+  await setupHederaModalTest();
+});
+
+afterEach(() => {
+  cleanupHederaModalTest();
+});
+
+function setupModal() {
+  createModalsContainer();
+
+  return render(<UndelegationModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_HEDERA_UNDELEGATION: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1 },
+        },
+      },
+    },
+  });
+}
+
+describe("Hedera UndelegationFlowModal (integration)", () => {
+  it("completes the happy path: Summary → ConnectDevice → Confirmation success", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+    });
+
+    await waitFor(
+      () => expect(screen.getByText("You have successfully undelegated your assets")).toBeVisible(),
+      { timeout: 5000 },
+    );
+  });
+
+  it("shows the device error state and allows retry when signing fails", async () => {
+    setupModal();
+
+    await clickContinueWhenEnabled();
+
+    await act(async () => {
+      subjectRefs.sign.error(new Error("UserRefusedOnDevice"));
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__integrations__/sendFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__integrations__/sendFlow.integ.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { UserRefusedOnDevice } from "@ledgerhq/ledger-wallet-framework/errors";
 import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import SendModal from "~/renderer/modals/Send/index";

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__integrations__/sendFlow.integ.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__integrations__/sendFlow.integ.test.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { UserRefusedOnDevice } from "@ledgerhq/errors";
+import { act, render, screen, userEvent, waitFor } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import SendModal from "~/renderer/modals/Send/index";
+import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { HEDERA_RECIPIENT_ADDRESS } from "../__mocks__/transaction.mock";
+import { mockSignedOperation } from "../__mocks__/signedOperation.mock";
+import {
+  subjectRefs,
+  getTransactionStatusSpy,
+  prepareTransactionSpy,
+} from "../__mocks__/bridge.mock";
+import {
+  createModalsContainer,
+  setupHederaModalTest,
+  cleanupHederaModalTest,
+} from "../__mocks__/flowHelpers";
+
+jest.mock("@ledgerhq/live-common/account/recentAddresses", () => ({
+  getRecentAddressesStore: () => ({ addAddress: jest.fn() }),
+}));
+
+jest.mock("@ledgerhq/live-common/hw/actions/app", () => ({
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => {
+    const { mockAppState, mockDevice } = require("../__mocks__/bridge.mock");
+    return {
+      useHook: () => mockAppState,
+      mapResult: () => ({ device: mockDevice }),
+    };
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/bridge/impl", () => ({
+  __esModule: true,
+  getAccountBridge: () => require("../__mocks__/bridge.mock").resolvedAccountBridge,
+  getCurrencyBridge: () => require("../__mocks__/bridge.mock").resolvedCurrencyBridge,
+}));
+
+const defaultStatus = {
+  errors: {},
+  warnings: {},
+  estimatedFees: new BigNumber(100_000),
+  amount: new BigNumber(1_000_000),
+  totalSpent: new BigNumber(1_100_000),
+};
+beforeEach(async () => {
+  await setupHederaModalTest(defaultStatus);
+  prepareTransactionSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanupHederaModalTest();
+});
+
+function setupModal() {
+  createModalsContainer();
+
+  return render(<SendModal />, {
+    initialState: {
+      settings: AFTER_ONBOARDING_STATE,
+      modals: {
+        MODAL_SEND: {
+          isOpened: true,
+          data: { account: HEDERA_ACCOUNT_1, parentAccount: null },
+        },
+      },
+    },
+  });
+}
+
+function getContinueButton() {
+  return screen.getByRole("button", { name: "Continue" });
+}
+
+async function clickContinueWhenEnabled() {
+  await waitFor(() => expect(getContinueButton()).not.toBeDisabled());
+  await userEvent.click(getContinueButton());
+}
+
+async function fillRecipientAndContinue(recipient = HEDERA_RECIPIENT_ADDRESS) {
+  const input = await screen.findByTestId("send-recipient-input");
+  await userEvent.type(input, recipient);
+  await clickContinueWhenEnabled();
+}
+
+async function signSuccessfully() {
+  await act(async () => {
+    subjectRefs.sign.next({ type: "signed", signedOperation: mockSignedOperation as never });
+  });
+}
+
+describe("Hedera send flow — full modal", () => {
+  it("completes the full happy path: recipient → amount → summary → sign → success", async () => {
+    setupModal();
+
+    await fillRecipientAndContinue();
+    await clickContinueWhenEnabled(); // amount step
+    await clickContinueWhenEnabled(); // summary
+    await signSuccessfully();
+
+    await waitFor(() => expect(screen.getByText("Transaction sent")).toBeVisible(), {
+      timeout: 5000,
+    });
+  }, 20_000);
+
+  it("carries the typed memo through to the prepared transaction", async () => {
+    setupModal();
+
+    const recipientInput = await screen.findByTestId("send-recipient-input");
+    await userEvent.type(recipientInput, HEDERA_RECIPIENT_ADDRESS);
+
+    const memoInput = await screen.findByPlaceholderText(/Enter Tag \/ Memo/i);
+    await userEvent.type(memoInput, "ref-42");
+
+    await waitFor(() => {
+      const lastTx = prepareTransactionSpy.mock.calls.at(-1)?.[1];
+      expect(lastTx).toMatchObject({ memo: "ref-42" });
+    });
+  });
+
+  it("disables Continue in the recipient step when missingAssociation warning is present", async () => {
+    getTransactionStatusSpy.mockResolvedValue({
+      ...defaultStatus,
+      warnings: { missingAssociation: new Error("MissingAssociation") },
+    });
+
+    setupModal();
+
+    const recipientInput = await screen.findByTestId("send-recipient-input");
+    await userEvent.type(recipientInput, HEDERA_RECIPIENT_ADDRESS);
+
+    await waitFor(() => expect(getTransactionStatusSpy).toHaveBeenCalled());
+    expect(getContinueButton()).toBeDisabled();
+  });
+
+  it("disables Continue in the recipient step when unverifiedAssociation warning is present", async () => {
+    getTransactionStatusSpy.mockResolvedValue({
+      ...defaultStatus,
+      warnings: { unverifiedAssociation: new Error("UnverifiedAssociation") },
+    });
+
+    setupModal();
+
+    const recipientInput = await screen.findByTestId("send-recipient-input");
+    await userEvent.type(recipientInput, HEDERA_RECIPIENT_ADDRESS);
+
+    await waitFor(() => expect(getTransactionStatusSpy).toHaveBeenCalled());
+    expect(getContinueButton()).toBeDisabled();
+  });
+
+  it("shows the device error state and allows retry back to summary", async () => {
+    setupModal();
+
+    await fillRecipientAndContinue();
+    await clickContinueWhenEnabled(); // amount
+    await clickContinueWhenEnabled(); // summary
+
+    await act(async () => {
+      subjectRefs.sign.error(new UserRefusedOnDevice());
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /retry/i })).toBeVisible());
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).toBeVisible());
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/account.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/account.mock.ts
@@ -1,7 +1,30 @@
+import BigNumber from "bignumber.js";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import type { HederaAccount, HederaResources } from "@ledgerhq/live-common/families/hedera/types";
 import { hederaCurrency } from "./currency.mock";
 
 export const HEDERA_ACCOUNT_1 = {
   ...genAccount("hedera-1", { currency: hederaCurrency }),
   index: 0,
+  hederaResources: {
+    maxAutomaticTokenAssociations: 0,
+    isAutoTokenAssociationEnabled: false,
+    delegation: {
+      nodeId: 0,
+      delegated: new BigNumber(5_000_000_000),
+      pendingReward: new BigNumber(500_000),
+    },
+  },
 };
+
+export const baseResources: HederaResources = {
+  maxAutomaticTokenAssociations: 0,
+  isAutoTokenAssociationEnabled: false,
+  delegation: null,
+};
+
+export const makeHederaAccount = (resourceOverrides?: Partial<HederaResources>): HederaAccount =>
+  ({
+    ...HEDERA_ACCOUNT_1,
+    hederaResources: { ...baseResources, ...resourceOverrides },
+  }) as HederaAccount;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/bridge.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/bridge.mock.ts
@@ -1,0 +1,62 @@
+import BigNumber from "bignumber.js";
+import { ReplaySubject, Subject } from "rxjs";
+import type { Account, SignOperationEvent } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import { makeHederaTransaction } from "./transaction.mock";
+import { mockBroadcastedOperation } from "./signedOperation.mock";
+
+// Mutable refs — bridge methods close over these at call time so that
+// reinitialising subjects in beforeEach is transparently picked up.
+export const subjectRefs = {} as {
+  sync: Subject<(acc: Account) => Account>;
+  sign: ReplaySubject<SignOperationEvent>;
+};
+
+export function initSendSubjects(): void {
+  subjectRefs.sync = new Subject();
+  subjectRefs.sign = new ReplaySubject(1);
+}
+
+export const mockDevice = { modelId: "stax", deviceId: "test-device-id", wired: false } as const;
+export const mockAppState = { device: mockDevice, opened: true, isLocked: false };
+
+export const mockAccountBridge = {
+  createTransaction: (): Transaction => makeHederaTransaction(),
+  updateTransaction: (tx: Transaction, patch: Partial<Transaction>): Transaction =>
+    ({ ...tx, ...patch }) as Transaction,
+  prepareTransaction: jest.fn(async (_account: unknown, transaction: Transaction) => transaction),
+  getTransactionStatus: jest.fn(async () => ({
+    errors: {},
+    warnings: {},
+    estimatedFees: new BigNumber(100_000),
+    amount: new BigNumber(1_000_000),
+    totalSpent: new BigNumber(1_100_000),
+  })),
+  sync: () => subjectRefs.sync.asObservable(),
+  signOperation: () => subjectRefs.sign.asObservable(),
+  broadcast: async () => mockBroadcastedOperation,
+  estimateMaxSpendable: async () => new BigNumber(100_000_000),
+  // Hedera has no stuck-transaction (RBF) concept; mirror defaultBridgeExtensions behaviour.
+  getStuckAccountAndOperation: () => undefined,
+};
+
+// Convenience aliases for tests that want to assert on or override these.
+export const prepareTransactionSpy = mockAccountBridge.prepareTransaction;
+export const getTransactionStatusSpy = mockAccountBridge.getTransactionStatus;
+
+// React's use() fast-path reads .status/.value directly off an already-tracked thenable,
+// which is what Body.tsx's useAccountBridge() relies on (see bridge/useAccountBridge.ts).
+export const resolvedAccountBridge = Object.assign(Promise.resolve(mockAccountBridge), {
+  status: "fulfilled" as const,
+  value: mockAccountBridge,
+});
+
+const mockCurrencyBridge = {
+  preload: () => Promise.resolve(true),
+  hydrate: () => true,
+};
+
+export const resolvedCurrencyBridge = Object.assign(Promise.resolve(mockCurrencyBridge), {
+  status: "fulfilled" as const,
+  value: mockCurrencyBridge,
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/delegation.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/delegation.mock.ts
@@ -1,0 +1,27 @@
+import BigNumber from "bignumber.js";
+import { HEDERA_DELEGATION_STATUS } from "@ledgerhq/live-common/families/hedera/constants";
+import type { HederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/types";
+
+export const mockDelegation = {
+  nodeId: 3,
+  delegated: new BigNumber(50_000_000),
+  pendingReward: new BigNumber(10_000),
+};
+
+export const mockEnrichedDelegation: HederaEnrichedDelegation = {
+  nodeId: 3,
+  delegated: new BigNumber(50_000_000),
+  pendingReward: new BigNumber(10_000),
+  status: HEDERA_DELEGATION_STATUS.Active,
+  validator: {
+    nodeId: 3,
+    name: "Hedera Node 3",
+    address: "0.0.3",
+    addressChecksum: null,
+    minStake: new BigNumber(0),
+    maxStake: new BigNumber(0),
+    activeStake: new BigNumber(0),
+    activeStakePercentage: new BigNumber(0),
+    overstaked: false,
+  },
+};

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/flowHelpers.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/flowHelpers.ts
@@ -1,0 +1,37 @@
+import BigNumber from "bignumber.js";
+import { mockDomMeasurements } from "LLD/features/__tests__/shared";
+import { importLLDCoinFamily } from "~/renderer/families";
+import { screen, userEvent, waitFor } from "tests/testSetup";
+import { initSendSubjects, subjectRefs, getTransactionStatusSpy } from "./bridge.mock";
+
+export const DEFAULT_TX_STATUS = {
+  errors: {},
+  warnings: {},
+  estimatedFees: new BigNumber(100_000),
+  amount: new BigNumber(0),
+  totalSpent: new BigNumber(100_000),
+};
+
+export function createModalsContainer(): void {
+  const modalsDiv = document.createElement("div");
+  modalsDiv.id = "modals";
+  document.body.appendChild(modalsDiv);
+}
+
+export async function setupHederaModalTest(statusOverride = DEFAULT_TX_STATUS): Promise<void> {
+  mockDomMeasurements();
+  await importLLDCoinFamily("hedera");
+  initSendSubjects();
+  getTransactionStatusSpy.mockResolvedValue(statusOverride);
+}
+
+export function cleanupHederaModalTest(): void {
+  subjectRefs.sync.complete();
+  subjectRefs.sign.complete();
+  document.getElementById("modals")?.remove();
+}
+
+export async function clickContinueWhenEnabled(): Promise<void> {
+  await waitFor(() => expect(screen.getByRole("button", { name: "Continue" })).not.toBeDisabled());
+  await userEvent.click(screen.getByRole("button", { name: "Continue" }));
+}

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/signedOperation.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/signedOperation.mock.ts
@@ -1,0 +1,24 @@
+import BigNumber from "bignumber.js";
+import type { Operation } from "@ledgerhq/types-live";
+import { HEDERA_ACCOUNT_1 } from "./account.mock";
+
+export const mockSignedOperation = {
+  signature: "sig",
+  operation: {
+    id: "op-1",
+    hash: "0xabc123",
+    type: "OUT" as const,
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: [],
+    recipients: [],
+    blockHeight: null,
+    blockHash: null,
+    accountId: HEDERA_ACCOUNT_1.id,
+    date: new Date(),
+    extra: {},
+  },
+  expirationDate: null,
+};
+
+export const mockBroadcastedOperation = mockSignedOperation.operation as unknown as Operation;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/transaction.mock.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__mocks__/transaction.mock.ts
@@ -1,0 +1,15 @@
+import BigNumber from "bignumber.js";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
+
+export const HEDERA_RECIPIENT_ADDRESS = "0.0.9876543";
+
+export const makeHederaTransaction = (overrides?: Partial<Transaction>): Transaction =>
+  ({
+    family: "hedera",
+    mode: HEDERA_TRANSACTION_MODES.Send,
+    amount: new BigNumber(1_000_000),
+    recipient: HEDERA_RECIPIENT_ADDRESS,
+    useAllAmount: false,
+    ...overrides,
+  }) as Transaction;

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { useStake } from "LLD/hooks/useStake";
+import component from "../AccountBalanceSummaryFooter";
+import type { HederaAccount } from "@ledgerhq/live-common/families/hedera/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import { HEDERA_ACCOUNT_1, makeHederaAccount } from "../__mocks__/account.mock";
+
+jest.mock("LLD/hooks/useStake", () => ({ useStake: jest.fn() }));
+
+const AccountBalanceSummaryFooter = component as unknown as React.ComponentType<{
+  account: HederaAccount | TokenAccount;
+}>;
+const mockUseStake = jest.mocked(useStake);
+
+const defaultState = {
+  settings: AFTER_ONBOARDING_STATE,
+  accounts: [HEDERA_ACCOUNT_1],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseStake.mockReturnValue({
+    getCanStakeCurrency: jest.fn().mockReturnValue(true),
+  } as never);
+});
+
+describe("AccountBalanceSummaryFooter", () => {
+  describe("guard clauses — returns null", () => {
+    it("renders nothing when account has no hederaResources", () => {
+      const { container } = render(
+        <AccountBalanceSummaryFooter
+          account={{ ...HEDERA_ACCOUNT_1, hederaResources: undefined } as never}
+        />,
+        { initialState: defaultState },
+      );
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing when staking is disabled for the currency", () => {
+      mockUseStake.mockReturnValue({
+        getCanStakeCurrency: jest.fn().mockReturnValue(false),
+      } as never);
+
+      const { container } = render(<AccountBalanceSummaryFooter account={makeHederaAccount()} />, {
+        initialState: { ...defaultState, accounts: [makeHederaAccount()] },
+      });
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("without delegation", () => {
+    it("shows the available balance label", () => {
+      render(<AccountBalanceSummaryFooter account={makeHederaAccount()} />, {
+        initialState: { ...defaultState, accounts: [makeHederaAccount()] },
+      });
+
+      expect(screen.getByText(/available balance/i)).toBeVisible();
+    });
+
+    it("does not show delegated assets or claimable rewards sections", () => {
+      render(<AccountBalanceSummaryFooter account={makeHederaAccount()} />, {
+        initialState: { ...defaultState, accounts: [makeHederaAccount()] },
+      });
+
+      expect(screen.queryByText(/delegated/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/claimable/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with delegation", () => {
+    const delegatedAccount = makeHederaAccount({
+      delegation: {
+        nodeId: 3,
+        delegated: new BigNumber(50_000_000),
+        pendingReward: new BigNumber(10_000),
+      },
+    });
+
+    it("shows available balance, delegated assets and claimable rewards labels", () => {
+      render(<AccountBalanceSummaryFooter account={delegatedAccount} />, {
+        initialState: { ...defaultState, accounts: [delegatedAccount] },
+      });
+
+      expect(screen.getByText(/available balance/i)).toBeVisible();
+      expect(screen.getByText(/delegated/i)).toBeVisible();
+      expect(screen.getByText(/claimable/i)).toBeVisible();
+    });
+
+    it("shows three balance detail sections", () => {
+      render(<AccountBalanceSummaryFooter account={delegatedAccount} />, {
+        initialState: { ...defaultState, accounts: [delegatedAccount] },
+      });
+
+      // Available + delegated + claimable
+      expect(screen.getAllByText(/HBAR/i).length).toBeGreaterThanOrEqual(3);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/DelegatedPositions.test.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen, userEvent } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import { openModal } from "~/renderer/actions/modals";
+import { useStake } from "LLD/hooks/useStake";
+import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import DelegatedPositions from "../DelegatedPositions/index";
+import { HEDERA_ACCOUNT_1, makeHederaAccount } from "../__mocks__/account.mock";
+import { mockDelegation, mockEnrichedDelegation } from "../__mocks__/delegation.mock";
+
+jest.mock("LLD/hooks/useStake", () => ({ useStake: jest.fn() }));
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaEnrichedDelegation: jest.fn(),
+}));
+
+jest.mock("~/renderer/actions/modals", () => ({
+  openModal: jest.fn((name: string, data?: unknown) => ({
+    type: "MODAL_OPEN",
+    payload: { name, data },
+  })),
+}));
+
+jest.mock("~/renderer/families/hedera/DelegatedPositions/Row", () => ({
+  Row: ({ onManageAction }: { onManageAction: (key: string) => void }) => (
+    <div>
+      <button
+        data-testid="row-action-redelegation"
+        onClick={() => onManageAction("MODAL_HEDERA_REDELEGATION")}
+      >
+        Redelegate
+      </button>
+      <button
+        data-testid="row-action-undelegation"
+        onClick={() => onManageAction("MODAL_HEDERA_UNDELEGATION")}
+      >
+        Undelegate
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("~/renderer/families/hedera/DelegatedPositions/DelegationPlaceholder", () => ({
+  __esModule: true,
+  default: () => <div data-testid="delegation-placeholder">DelegationPlaceholder</div>,
+}));
+
+jest.mock("~/renderer/families/hedera/DelegatedPositions/Header", () => ({
+  Header: () => null,
+  TableLine: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockUseStake = jest.mocked(useStake);
+const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegation);
+const mockOpenModal = jest.mocked(openModal);
+
+const makeTokenAccount = (): TokenAccount =>
+  ({
+    ...HEDERA_ACCOUNT_1,
+    type: "TokenAccount",
+  }) as unknown as TokenAccount;
+
+const defaultState = { settings: AFTER_ONBOARDING_STATE };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseStake.mockReturnValue({
+    getCanStakeCurrency: jest.fn().mockReturnValue(true),
+  } as never);
+  mockUseHederaEnrichedDelegation.mockReturnValue(mockEnrichedDelegation);
+});
+
+describe("DelegatedPositions", () => {
+  describe("guard clauses — renders null", () => {
+    it("renders null for a token account", () => {
+      const { container } = render(<DelegatedPositions account={makeTokenAccount()} />, {
+        initialState: defaultState,
+      });
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders null when staking is disabled", () => {
+      mockUseStake.mockReturnValue({
+        getCanStakeCurrency: jest.fn().mockReturnValue(false),
+      } as never);
+
+      const { container } = render(<DelegatedPositions account={makeHederaAccount()} />, {
+        initialState: defaultState,
+      });
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("without delegation", () => {
+    it("renders DelegationPlaceholder when hederaResources is absent", () => {
+      render(
+        <DelegatedPositions
+          account={{ ...HEDERA_ACCOUNT_1, hederaResources: undefined } as never}
+        />,
+        { initialState: defaultState },
+      );
+      expect(screen.getByTestId("delegation-placeholder")).toBeVisible();
+    });
+
+    it("renders DelegationPlaceholder when delegation is null", () => {
+      render(<DelegatedPositions account={makeHederaAccount({ delegation: null })} />, {
+        initialState: defaultState,
+      });
+      expect(screen.getByTestId("delegation-placeholder")).toBeVisible();
+    });
+  });
+
+  describe("with delegation", () => {
+    const buildAccount = () => makeHederaAccount({ delegation: mockDelegation });
+
+    it("shows the Delegation section header", () => {
+      render(<DelegatedPositions account={buildAccount()} />, { initialState: defaultState });
+      expect(screen.getByText(/Delegation/i)).toBeVisible();
+    });
+
+    it("shows the Claim rewards button when pendingReward is positive", () => {
+      render(<DelegatedPositions account={buildAccount()} />, { initialState: defaultState });
+      expect(screen.getByRole("button", { name: /claim rewards/i })).toBeVisible();
+    });
+
+    it("hides the Claim rewards button when pendingReward is zero", () => {
+      mockUseHederaEnrichedDelegation.mockReturnValue({
+        ...mockEnrichedDelegation,
+        pendingReward: new BigNumber(0),
+      });
+
+      render(<DelegatedPositions account={buildAccount()} />, { initialState: defaultState });
+      expect(screen.queryByRole("button", { name: /claim rewards/i })).not.toBeInTheDocument();
+    });
+
+    it("dispatches MODAL_HEDERA_CLAIM_REWARDS when the Claim rewards button is clicked", async () => {
+      const account = buildAccount();
+      render(<DelegatedPositions account={account} />, { initialState: defaultState });
+
+      await userEvent.click(screen.getByRole("button", { name: /claim rewards/i }));
+
+      expect(mockOpenModal).toHaveBeenCalledWith("MODAL_HEDERA_CLAIM_REWARDS", { account });
+    });
+
+    it("dispatches MODAL_HEDERA_REDELEGATION when the row Redelegate action is triggered", async () => {
+      const account = buildAccount();
+      render(<DelegatedPositions account={account} />, { initialState: defaultState });
+
+      await userEvent.click(screen.getByTestId("row-action-redelegation"));
+
+      expect(mockOpenModal).toHaveBeenCalledWith("MODAL_HEDERA_REDELEGATION", { account });
+    });
+
+    it("dispatches MODAL_HEDERA_UNDELEGATION when the row Undelegate action is triggered", async () => {
+      const account = buildAccount();
+      render(<DelegatedPositions account={account} />, { initialState: defaultState });
+
+      await userEvent.click(screen.getByTestId("row-action-undelegation"));
+
+      expect(mockOpenModal).toHaveBeenCalledWith("MODAL_HEDERA_UNDELEGATION", { account });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/MemoField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/__tests__/MemoField.test.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { render, screen, fireEvent } from "tests/testSetup";
+import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
+import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/families/hedera/types";
+import MemoField from "../MemoField";
+import { HEDERA_ACCOUNT_1 } from "../__mocks__/account.mock";
+import { makeHederaTransaction } from "../__mocks__/transaction.mock";
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  useAccountBridge: () => ({
+    updateTransaction: (tx: Transaction, patch: Partial<Transaction>): Transaction =>
+      ({
+        ...tx,
+        ...patch,
+      }) as Transaction,
+  }),
+}));
+
+jest.mock("~/renderer/analytics/segment", () => ({ track: jest.fn() }));
+
+const makeStatus = (overrides: Partial<TransactionStatus> = {}): TransactionStatus => ({
+  errors: {},
+  warnings: {},
+  estimatedFees: new BigNumber(0),
+  amount: new BigNumber(0),
+  totalSpent: new BigNumber(0),
+  ...overrides,
+});
+
+const defaultState = {
+  settings: AFTER_ONBOARDING_STATE,
+  accounts: [HEDERA_ACCOUNT_1],
+};
+
+describe("MemoField", () => {
+  describe("without status", () => {
+    it("renders nothing", () => {
+      const { container } = render(
+        <MemoField
+          account={HEDERA_ACCOUNT_1}
+          transaction={makeHederaTransaction()}
+          onChange={jest.fn()}
+          status={undefined as never}
+        />,
+        { initialState: defaultState },
+      );
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("with status", () => {
+    it("renders the memo text input", () => {
+      render(
+        <MemoField
+          account={HEDERA_ACCOUNT_1}
+          transaction={makeHederaTransaction()}
+          onChange={jest.fn()}
+          status={makeStatus()}
+        />,
+        { initialState: defaultState },
+      );
+      expect(screen.getByRole("textbox")).toBeVisible();
+    });
+
+    it("displays the current memo value", () => {
+      render(
+        <MemoField
+          account={HEDERA_ACCOUNT_1}
+          transaction={makeHederaTransaction({ memo: "prefilled memo" })}
+          onChange={jest.fn()}
+          status={makeStatus()}
+        />,
+        { initialState: defaultState },
+      );
+      expect(screen.getByRole("textbox")).toHaveValue("prefilled memo");
+    });
+
+    it("calls onChange with the updated transaction when the user types", () => {
+      const handleChange = jest.fn();
+
+      render(
+        <MemoField
+          account={HEDERA_ACCOUNT_1}
+          transaction={makeHederaTransaction({ memo: "" })}
+          onChange={handleChange}
+          status={makeStatus()}
+        />,
+        { initialState: defaultState },
+      );
+
+      fireEvent.change(screen.getByRole("textbox"), { target: { value: "payment ref" } });
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith(expect.objectContaining({ memo: "payment ref" }));
+    });
+
+    it("shows an inline error when status.errors.transaction is set", () => {
+      render(
+        <MemoField
+          account={HEDERA_ACCOUNT_1}
+          transaction={makeHederaTransaction()}
+          onChange={jest.fn()}
+          status={makeStatus({ errors: { transaction: new Error("Memo too long") } })}
+        />,
+        { initialState: defaultState },
+      );
+      expect(screen.getByTestId("input-error")).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/__integrations__/associateTokenFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/AssociateTokenFlow/__integrations__/associateTokenFlow.integration.test.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { Observable } from "rxjs";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { component } from "../index";
+import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
+import { htsToken } from "../../__mocks__/currency.mock";
+import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+
+jest.mock(
+  "@ledgerhq/live-common/hw/actions/app",
+  () => require("../../__mocks__/deviceConnection.mock").hwActionsAppModule,
+);
+
+jest.mock(
+  "@ledgerhq/live-common/hw/index",
+  () => require("../../__mocks__/deviceConnection.mock").hwIndexModule,
+);
+
+jest.mock(
+  "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling",
+  () => require("../../__mocks__/deviceConnection.mock").deviceLockedPollingModule,
+);
+
+jest.mock("~/datadog", () => ({
+  isDatadogEnabled: false,
+  initializeDatadogProvider: jest.fn(),
+  customErrorEventMapper: jest.fn(),
+  customActionEventMapper: jest.fn(),
+  customLogEventMapper: jest.fn(),
+  viewNamePredicate: jest.fn(),
+  broadcastLogger: jest.fn(),
+}));
+
+const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.TokenAssociate);
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const {
+    makeResolvedAccountBridge,
+    resolvedCurrencyBridge,
+  } = require("../../__mocks__/bridge.mock");
+  return {
+    __esModule: true,
+    getAccountBridge: () => makeResolvedAccountBridge(mockAccountBridge),
+    getCurrencyBridge: () => resolvedCurrencyBridge,
+  };
+});
+
+const OuterStack = createNativeStackNavigator();
+
+function AssociateTokenFlowHarness() {
+  return (
+    <OuterStack.Navigator screenOptions={{ headerShown: false }}>
+      <OuterStack.Screen name={NavigatorName.HederaAssociateTokenFlow} component={component} />
+    </OuterStack.Navigator>
+  );
+}
+
+function renderFlow() {
+  return render(<AssociateTokenFlowHarness />, {
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.HederaAssociateTokenFlow,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: ScreenName.HederaAssociateTokenSummary,
+                params: { accountId: HEDERA_ACCOUNT_1.id, token: htsToken },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    overrideInitialState: overrideWithHederaAccount1,
+  });
+}
+describe("Hedera AssociateTokenFlow (integration)", () => {
+  beforeEach(() => {
+    mockAccountBridge.createTransaction.mockClear();
+    mockAccountBridge.updateTransaction.mockClear();
+    mockAccountBridge.signOperation.mockClear();
+  });
+
+  it("completes the happy path: Summary → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
+    const { user } = renderFlow();
+
+    // Button.tsx returns testID="proceed-button" for type="primary" when isFocused=true and not disabled.
+    await waitFor(() => expect(screen.getByTestId("proceed-button")).toBeVisible(), {
+      timeout: 10000,
+    });
+    await user.press(screen.getByTestId("proceed-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible(), {
+      timeout: 15000,
+    });
+  });
+
+  it("lands on ValidationError and shows Retry when signOperation fails", async () => {
+    mockAccountBridge.signOperation.mockImplementationOnce(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.error(new Error("UserRefusedOnDevice"));
+        }),
+    );
+
+    const { user } = renderFlow();
+
+    await waitFor(() => expect(screen.getByTestId("proceed-button")).toBeVisible(), {
+      timeout: 10000,
+    });
+    await user.press(screen.getByTestId("proceed-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
+    expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/ClaimRewardsFlow/__integrations__/claimRewardsFlow.integration.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Observable } from "rxjs";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { component } from "../index";
+import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
+import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+}));
+
+jest.mock(
+  "@ledgerhq/live-common/hw/actions/app",
+  () => require("../../__mocks__/deviceConnection.mock").hwActionsAppModule,
+);
+
+jest.mock(
+  "@ledgerhq/live-common/hw/index",
+  () => require("../../__mocks__/deviceConnection.mock").hwIndexModule,
+);
+
+jest.mock(
+  "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling",
+  () => require("../../__mocks__/deviceConnection.mock").deviceLockedPollingModule,
+);
+
+jest.mock("~/datadog", () => ({
+  isDatadogEnabled: false,
+  initializeDatadogProvider: jest.fn(),
+  customErrorEventMapper: jest.fn(),
+  customActionEventMapper: jest.fn(),
+  customLogEventMapper: jest.fn(),
+  viewNamePredicate: jest.fn(),
+  broadcastLogger: jest.fn(),
+}));
+
+const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.ClaimRewards);
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const {
+    makeResolvedAccountBridge,
+    resolvedCurrencyBridge,
+  } = require("../../__mocks__/bridge.mock");
+  return {
+    __esModule: true,
+    getAccountBridge: () => makeResolvedAccountBridge(mockAccountBridge),
+    getCurrencyBridge: () => resolvedCurrencyBridge,
+  };
+});
+
+const OuterStack = createNativeStackNavigator();
+
+function ClaimRewardsFlowHarness() {
+  return (
+    <OuterStack.Navigator screenOptions={{ headerShown: false }}>
+      <OuterStack.Screen name={NavigatorName.HederaClaimRewardsFlow} component={component} />
+    </OuterStack.Navigator>
+  );
+}
+
+function renderFlow() {
+  return render(<ClaimRewardsFlowHarness />, {
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.HederaClaimRewardsFlow,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: ScreenName.HederaClaimRewardsClaim,
+                params: {
+                  accountId: HEDERA_ACCOUNT_1.id,
+                  selectedDelegation: mockEnrichedDelegation,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    overrideInitialState: overrideWithHederaAccount1,
+  });
+}
+describe("Hedera ClaimRewardsFlow (integration)", () => {
+  beforeEach(() => {
+    mockAccountBridge.createTransaction.mockClear();
+    mockAccountBridge.signOperation.mockClear();
+  });
+
+  it("completes the happy path: Claim → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-claim-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-claim-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible(), {
+      timeout: 15000,
+    });
+  });
+
+  it("lands on ValidationError and shows Retry when signOperation fails", async () => {
+    mockAccountBridge.signOperation.mockImplementationOnce(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.error(new Error("UserRefusedOnDevice"));
+        }),
+    );
+
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-claim-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-claim-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
+    expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/DelegationFlow/__integrations__/delegationFlow.integration.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { Observable } from "rxjs";
+import BigNumber from "bignumber.js";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { component } from "../index";
+import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
+import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+}));
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaValidators: jest.fn(() => [
+    {
+      nodeId: 0,
+      name: "Hedera Node 0",
+      address: "0.0.3",
+      addressChecksum: null,
+      minStake: new BigNumber(0),
+      maxStake: new BigNumber(250_000_000_000_000_000),
+      activeStake: new BigNumber(0),
+      activeStakePercentage: new BigNumber(0),
+      overstaked: false,
+    },
+  ]),
+  useHederaEnrichedDelegation: jest.fn(() => null),
+}));
+
+jest.mock(
+  "@ledgerhq/live-common/hw/actions/app",
+  () => require("../../__mocks__/deviceConnection.mock").hwActionsAppModule,
+);
+
+jest.mock(
+  "@ledgerhq/live-common/hw/index",
+  () => require("../../__mocks__/deviceConnection.mock").hwIndexModule,
+);
+
+jest.mock(
+  "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling",
+  () => require("../../__mocks__/deviceConnection.mock").deviceLockedPollingModule,
+);
+
+jest.mock("~/datadog", () => ({
+  isDatadogEnabled: false,
+  initializeDatadogProvider: jest.fn(),
+  customErrorEventMapper: jest.fn(),
+  customActionEventMapper: jest.fn(),
+  customLogEventMapper: jest.fn(),
+  viewNamePredicate: jest.fn(),
+  broadcastLogger: jest.fn(),
+}));
+
+const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Delegate, {
+  stakingNodeId: 0,
+});
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const {
+    makeResolvedAccountBridge,
+    resolvedCurrencyBridge,
+  } = require("../../__mocks__/bridge.mock");
+  return {
+    __esModule: true,
+    getAccountBridge: () => makeResolvedAccountBridge(mockAccountBridge),
+    getCurrencyBridge: () => resolvedCurrencyBridge,
+  };
+});
+
+const OuterStack = createNativeStackNavigator();
+
+function DelegationFlowHarness() {
+  return (
+    <OuterStack.Navigator screenOptions={{ headerShown: false }}>
+      <OuterStack.Screen name={NavigatorName.HederaDelegationFlow} component={component} />
+    </OuterStack.Navigator>
+  );
+}
+
+function renderFlow() {
+  return render(<DelegationFlowHarness />, {
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.HederaDelegationFlow,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: ScreenName.HederaDelegationSummary,
+                params: { accountId: HEDERA_ACCOUNT_1.id },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    overrideInitialState: overrideWithHederaAccount1,
+  });
+}
+describe("Hedera DelegationFlow (integration)", () => {
+  beforeEach(() => {
+    mockAccountBridge.createTransaction.mockClear();
+    mockAccountBridge.signOperation.mockClear();
+  });
+
+  it("completes the happy path: Summary → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-summary-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-summary-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible(), {
+      timeout: 15000,
+    });
+  });
+
+  it("lands on ValidationError and shows Retry when signOperation fails", async () => {
+    mockAccountBridge.signOperation.mockImplementationOnce(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.error(new Error("UserRefusedOnDevice"));
+        }),
+    );
+
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-summary-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-summary-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
+    expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/Delegations/__tests__/index.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/Delegations/__tests__/index.test.tsx
@@ -1,0 +1,256 @@
+import React from "react";
+import BigNumber from "bignumber.js";
+import { fireEvent, render, screen } from "@tests/test-renderer";
+import { useStake } from "LLM/hooks/useStake/useStake";
+import { useHederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/react";
+import { NavigatorName, ScreenName } from "~/const";
+import HederaDelegations from "../index";
+import {
+  HEDERA_ACCOUNT_1,
+  HEDERA_ASSOCIATED_SUBACCOUNT,
+  makeHederaAccount,
+} from "../../__mocks__/account.mock";
+import { mockDelegation, mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
+
+const mockNavigate = jest.fn();
+
+jest.mock("LLM/hooks/useStake/useStake", () => ({ useStake: jest.fn() }));
+
+jest.mock("@ledgerhq/live-common/families/hedera/react", () => ({
+  useHederaEnrichedDelegation: jest.fn(),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+  useTheme: () => ({
+    colors: { fog: "#ccc", alert: "#f00", yellow: "#ff0", live: "#000", background: "#fff" },
+  }),
+}));
+
+jest.mock("~/components/DelegationDrawer", () => {
+  const { View, Text, TouchableOpacity } = require("react-native");
+  return ({
+    isOpen,
+    actions,
+  }: {
+    isOpen: boolean;
+    actions?: Array<{ label: string; disabled?: boolean; onPress: () => void }>;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <View testID="delegation-drawer">
+        {actions?.map((action, i) => (
+          <TouchableOpacity
+            key={i}
+            testID={`drawer-action-${i}`}
+            accessibilityState={{ disabled: !!action.disabled }}
+            onPress={action.disabled ? undefined : action.onPress}
+          >
+            <Text>{action.label}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    );
+  };
+});
+
+jest.mock("~/families/hedera/Delegations/DelegationRewards", () => () => null);
+
+jest.mock("~/families/hedera/shared/DelegationStatusModal", () => ({
+  DelegationStatusModal: () => null,
+}));
+
+jest.mock("~/families/hedera/shared/ValidatorIcon", () => () => null);
+
+const mockUseStake = jest.mocked(useStake);
+const mockUseHederaEnrichedDelegation = jest.mocked(useHederaEnrichedDelegation);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseStake.mockReturnValue({
+    getCanStakeCurrency: jest.fn().mockReturnValue(true),
+  } as never);
+  mockUseHederaEnrichedDelegation.mockReturnValue(mockEnrichedDelegation as never);
+});
+
+describe("HederaDelegations", () => {
+  describe("guard clauses — renders null", () => {
+    it("renders null for a token (sub)account", () => {
+      const { toJSON } = render(<HederaDelegations account={HEDERA_ASSOCIATED_SUBACCOUNT} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [HEDERA_ACCOUNT_1] },
+        }),
+      });
+      expect(toJSON()).toBeNull();
+    });
+
+    it("renders null when staking is disabled for the currency", () => {
+      mockUseStake.mockReturnValue({
+        getCanStakeCurrency: jest.fn().mockReturnValue(false),
+      } as never);
+
+      const account = makeHederaAccount();
+      const { toJSON } = render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+      expect(toJSON()).toBeNull();
+    });
+
+    it("renders null when hederaResources is absent", () => {
+      const { toJSON } = render(<HederaDelegations account={HEDERA_ACCOUNT_1} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [HEDERA_ACCOUNT_1] },
+        }),
+      });
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("without an active delegation", () => {
+    it("renders DelegationPlaceholder when delegation is null", () => {
+      const account = makeHederaAccount({ delegation: null });
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+      expect(screen.getByText("How delegation works")).toBeVisible();
+    });
+  });
+
+  describe("with an active delegation", () => {
+    const buildAccount = () => makeHederaAccount({ delegation: mockDelegation });
+
+    it("renders the delegation row", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+      expect(screen.getByText("Hedera Node 3")).toBeVisible();
+    });
+
+    it("opens the delegation drawer when the row is pressed", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      expect(screen.queryByTestId("delegation-drawer")).toBeNull();
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+      expect(screen.getByTestId("delegation-drawer")).toBeVisible();
+    });
+
+    it("shows Redelegate, Collect rewards, and Undelegate action labels in the drawer", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+
+      expect(screen.getByText("Redelegate")).toBeVisible();
+      expect(screen.getByText("Collect rewards")).toBeVisible();
+      expect(screen.getByText("Undelegate")).toBeVisible();
+    });
+
+    it("disables the Collect rewards action when pendingReward is zero", () => {
+      mockUseHederaEnrichedDelegation.mockReturnValue({
+        ...mockEnrichedDelegation,
+        pendingReward: new BigNumber(0),
+      } as never);
+
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+
+      expect(screen.getByTestId("drawer-action-1")).toHaveProp("accessibilityState", {
+        disabled: true,
+      });
+    });
+
+    it("navigates to HederaRedelegationFlow with correct params when Redelegate is pressed", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+      fireEvent.press(screen.getByTestId("drawer-action-0"));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        NavigatorName.HederaRedelegationFlow,
+        expect.objectContaining({
+          screen: ScreenName.HederaRedelegationSelectValidator,
+          params: expect.objectContaining({ accountId: account.id }),
+        }),
+      );
+    });
+
+    it("navigates to HederaClaimRewardsFlow with correct params when Collect rewards is pressed", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+      fireEvent.press(screen.getByTestId("drawer-action-1"));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        NavigatorName.HederaClaimRewardsFlow,
+        expect.objectContaining({
+          screen: ScreenName.HederaClaimRewardsSelectReward,
+          params: expect.objectContaining({ accountId: account.id }),
+        }),
+      );
+    });
+
+    it("navigates to HederaUndelegationFlow with correct params when Undelegate is pressed", () => {
+      const account = buildAccount();
+      render(<HederaDelegations account={account} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [account] },
+        }),
+      });
+
+      fireEvent.press(screen.getByText("Hedera Node 3"));
+      fireEvent.press(screen.getByTestId("drawer-action-2"));
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        NavigatorName.HederaUndelegationFlow,
+        expect.objectContaining({
+          screen: ScreenName.HederaUndelegationAmount,
+          params: expect.objectContaining({ accountId: account.id }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/__integrations__/redelegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/RedelegationFlow/__integrations__/redelegationFlow.integration.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { Observable } from "rxjs";
+import BigNumber from "bignumber.js";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { component } from "../index";
+import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
+import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+}));
+
+jest.mock(
+  "@ledgerhq/live-common/hw/actions/app",
+  () => require("../../__mocks__/deviceConnection.mock").hwActionsAppModule,
+);
+
+jest.mock(
+  "@ledgerhq/live-common/hw/index",
+  () => require("../../__mocks__/deviceConnection.mock").hwIndexModule,
+);
+
+jest.mock(
+  "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling",
+  () => require("../../__mocks__/deviceConnection.mock").deviceLockedPollingModule,
+);
+
+jest.mock("~/datadog", () => ({
+  isDatadogEnabled: false,
+  initializeDatadogProvider: jest.fn(),
+  customErrorEventMapper: jest.fn(),
+  customActionEventMapper: jest.fn(),
+  customLogEventMapper: jest.fn(),
+  viewNamePredicate: jest.fn(),
+  broadcastLogger: jest.fn(),
+}));
+
+const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Redelegate, {
+  stakingNodeId: 5,
+});
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const {
+    makeResolvedAccountBridge,
+    resolvedCurrencyBridge,
+  } = require("../../__mocks__/bridge.mock");
+  return {
+    __esModule: true,
+    getAccountBridge: () => makeResolvedAccountBridge(mockAccountBridge),
+    getCurrencyBridge: () => resolvedCurrencyBridge,
+  };
+});
+
+const mockSelectedValidator = {
+  nodeId: 5,
+  name: "Hedera Node 5",
+  address: "0.0.5",
+  addressChecksum: null,
+  minStake: new BigNumber(0),
+  maxStake: new BigNumber(250_000_000_000_000_000),
+  activeStake: new BigNumber(0),
+  activeStakePercentage: new BigNumber(0),
+  overstaked: false,
+};
+
+const OuterStack = createNativeStackNavigator();
+
+function RedelegationFlowHarness() {
+  return (
+    <OuterStack.Navigator screenOptions={{ headerShown: false }}>
+      <OuterStack.Screen name={NavigatorName.HederaRedelegationFlow} component={component} />
+    </OuterStack.Navigator>
+  );
+}
+
+function renderFlow() {
+  return render(<RedelegationFlowHarness />, {
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.HederaRedelegationFlow,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: ScreenName.HederaRedelegationAmount,
+                params: {
+                  accountId: HEDERA_ACCOUNT_1.id,
+                  enrichedDelegation: mockEnrichedDelegation,
+                  selectedValidator: mockSelectedValidator,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    overrideInitialState: overrideWithHederaAccount1,
+  });
+}
+describe("Hedera RedelegationFlow (integration)", () => {
+  beforeEach(() => {
+    mockAccountBridge.createTransaction.mockClear();
+    mockAccountBridge.signOperation.mockClear();
+  });
+
+  it("completes the happy path: Amount → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-amount-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-amount-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible(), {
+      timeout: 15000,
+    });
+  });
+
+  it("lands on ValidationError and shows Retry when signOperation fails", async () => {
+    mockAccountBridge.signOperation.mockImplementationOnce(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.error(new Error("UserRefusedOnDevice"));
+        }),
+    );
+
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-amount-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-amount-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
+    expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/UndelegationFlow/__integrations__/undelegationFlow.integration.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { Observable } from "rxjs";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { SignOperationEvent } from "@ledgerhq/types-live";
+import { HEDERA_TRANSACTION_MODES } from "@ledgerhq/live-common/families/hedera/constants";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import { NavigatorName, ScreenName } from "~/const";
+import { component } from "../index";
+import { HEDERA_ACCOUNT_1, overrideWithHederaAccount1 } from "../../__mocks__/account.mock";
+import { makeMockAccountBridge } from "../../__mocks__/bridge.mock";
+import { mockEnrichedDelegation } from "../../__mocks__/delegation.mock";
+
+jest.mock("LLM/features/NotificationsPrompt", () => ({
+  useNotificationsContext: () => ({ notifyFlowCompleted: jest.fn() }),
+}));
+
+jest.mock(
+  "@ledgerhq/live-common/hw/actions/app",
+  () => require("../../__mocks__/deviceConnection.mock").hwActionsAppModule,
+);
+
+jest.mock(
+  "@ledgerhq/live-common/hw/index",
+  () => require("../../__mocks__/deviceConnection.mock").hwIndexModule,
+);
+
+jest.mock(
+  "~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling",
+  () => require("../../__mocks__/deviceConnection.mock").deviceLockedPollingModule,
+);
+
+jest.mock("~/datadog", () => ({
+  isDatadogEnabled: false,
+  initializeDatadogProvider: jest.fn(),
+  customErrorEventMapper: jest.fn(),
+  customActionEventMapper: jest.fn(),
+  customLogEventMapper: jest.fn(),
+  viewNamePredicate: jest.fn(),
+  broadcastLogger: jest.fn(),
+}));
+
+const mockAccountBridge = makeMockAccountBridge(HEDERA_TRANSACTION_MODES.Undelegate);
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => {
+  const {
+    makeResolvedAccountBridge,
+    resolvedCurrencyBridge,
+  } = require("../../__mocks__/bridge.mock");
+  return {
+    __esModule: true,
+    getAccountBridge: () => makeResolvedAccountBridge(mockAccountBridge),
+    getCurrencyBridge: () => resolvedCurrencyBridge,
+  };
+});
+
+const OuterStack = createNativeStackNavigator();
+
+function UndelegationFlowHarness() {
+  return (
+    <OuterStack.Navigator screenOptions={{ headerShown: false }}>
+      <OuterStack.Screen name={NavigatorName.HederaUndelegationFlow} component={component} />
+    </OuterStack.Navigator>
+  );
+}
+
+function renderFlow() {
+  return render(<UndelegationFlowHarness />, {
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.HederaUndelegationFlow,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: ScreenName.HederaUndelegationAmount,
+                params: {
+                  accountId: HEDERA_ACCOUNT_1.id,
+                  enrichedDelegation: mockEnrichedDelegation,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    overrideInitialState: overrideWithHederaAccount1,
+  });
+}
+describe("Hedera UndelegationFlow (integration)", () => {
+  beforeEach(() => {
+    mockAccountBridge.createTransaction.mockClear();
+    mockAccountBridge.signOperation.mockClear();
+  });
+
+  it("completes the happy path: Amount → SelectDevice → ConnectDevice → ValidationSuccess", async () => {
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-amount-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-amount-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByTestId("validate-success-screen")).toBeVisible(), {
+      timeout: 15000,
+    });
+  });
+
+  it("lands on ValidationError and shows Retry when signOperation fails", async () => {
+    mockAccountBridge.signOperation.mockImplementationOnce(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.error(new Error("UserRefusedOnDevice"));
+        }),
+    );
+
+    const { user } = renderFlow();
+
+    await waitFor(
+      () => expect(screen.getByTestId("enabled-hedera-amount-continue-button")).toBeVisible(),
+      { timeout: 10000 },
+    );
+    await user.press(screen.getByTestId("enabled-hedera-amount-continue-button"));
+
+    const deviceItem = await screen.findByTestId("device-item-mock", {}, { timeout: 10000 });
+    await user.press(deviceItem);
+
+    await waitFor(() => expect(screen.getByText("Retry")).toBeVisible(), { timeout: 15000 });
+    expect(screen.queryByTestId("validate-success-screen")).toBeNull();
+  });
+});

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/account.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/account.mock.ts
@@ -2,6 +2,7 @@ import {
   createFixtureAccount,
   createFixtureTokenAccount,
 } from "@ledgerhq/live-common/mock/fixtures/cryptoCurrencies";
+import type { HederaAccount, HederaResources } from "@ledgerhq/live-common/families/hedera/types";
 import { hederaCurrency, htsToken } from "./currency.mock";
 
 export const HEDERA_ACCOUNT_1 = createFixtureAccount("01", hederaCurrency);
@@ -10,3 +11,22 @@ export const HEDERA_ASSOCIATED_SUBACCOUNT = {
   ...createFixtureTokenAccount("01", htsToken),
   parentId: HEDERA_ACCOUNT_1.id,
 };
+
+export const baseResources: HederaResources = {
+  maxAutomaticTokenAssociations: 0,
+  isAutoTokenAssociationEnabled: false,
+  delegation: null,
+};
+
+export const makeHederaAccount = (resourceOverrides?: Partial<HederaResources>): HederaAccount =>
+  ({
+    ...HEDERA_ACCOUNT_1,
+    hederaResources: { ...baseResources, ...resourceOverrides },
+  }) as HederaAccount;
+
+export const overrideWithHederaAccount1 = <S extends { accounts: { active: unknown[] } }>(
+  state: S,
+): S => ({
+  ...state,
+  accounts: { ...state.accounts, active: [HEDERA_ACCOUNT_1] },
+});

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/bridge.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/bridge.mock.ts
@@ -1,0 +1,76 @@
+import { Observable } from "rxjs";
+import BigNumber from "bignumber.js";
+import type { AccountLike, SignOperationEvent } from "@ledgerhq/types-live";
+import type { Transaction } from "@ledgerhq/live-common/families/hedera/types";
+import { HEDERA_ACCOUNT_1 } from "./account.mock";
+
+export const mockSignedOperation = {
+  signature: "sig",
+  operation: {
+    id: "op-1",
+    hash: "0xabc",
+    type: "OUT",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: [],
+    recipients: [],
+    blockHeight: null,
+    blockHash: null,
+    accountId: HEDERA_ACCOUNT_1.id,
+    date: new Date(),
+    extra: {},
+  },
+  expirationDate: undefined,
+};
+
+export function makeMockAccountBridge(
+  mode: Transaction["mode"],
+  properties?: Record<string, unknown>,
+) {
+  return {
+    createTransaction: jest.fn((_account: AccountLike) => ({
+      family: "hedera" as const,
+      mode,
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+      ...(properties !== undefined ? { properties } : {}),
+    })),
+    updateTransaction: jest.fn((tx: object, patch: object) => ({ ...tx, ...patch })),
+    prepareTransaction: async (_account: AccountLike, tx: unknown) => tx,
+    getTransactionStatus: async () => ({
+      errors: {},
+      warnings: {},
+      estimatedFees: new BigNumber(1000),
+      amount: new BigNumber(0),
+      totalSpent: new BigNumber(1000),
+    }),
+    estimateMaxSpendable: async () => new BigNumber(100_000_000),
+    getStuckAccountAndOperation: () => null,
+    signOperation: jest.fn(
+      () =>
+        new Observable<SignOperationEvent>(subscriber => {
+          subscriber.next({ type: "device-signature-requested" });
+          subscriber.next({ type: "device-signature-granted" });
+          subscriber.next({ type: "signed", signedOperation: mockSignedOperation as never });
+          subscriber.complete();
+        }),
+    ),
+    broadcast: async ({ signedOperation }: { signedOperation: typeof mockSignedOperation }) =>
+      signedOperation.operation,
+  };
+}
+
+const currencyBridge = { preload: () => Promise.resolve(true), hydrate: () => true };
+
+export const resolvedCurrencyBridge = Object.assign(Promise.resolve(currencyBridge), {
+  status: "fulfilled" as const,
+  value: currencyBridge,
+});
+
+export function makeResolvedAccountBridge(accountBridge: ReturnType<typeof makeMockAccountBridge>) {
+  return Object.assign(Promise.resolve(accountBridge), {
+    status: "fulfilled" as const,
+    value: accountBridge,
+  });
+}

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/delegation.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/delegation.mock.ts
@@ -1,0 +1,27 @@
+import BigNumber from "bignumber.js";
+import { HEDERA_DELEGATION_STATUS } from "@ledgerhq/live-common/families/hedera/constants";
+import type { HederaEnrichedDelegation } from "@ledgerhq/live-common/families/hedera/types";
+
+export const mockDelegation = {
+  nodeId: 3,
+  delegated: new BigNumber(50_000_000),
+  pendingReward: new BigNumber(10_000),
+};
+
+export const mockEnrichedDelegation: HederaEnrichedDelegation = {
+  nodeId: 3,
+  delegated: new BigNumber(50_000_000),
+  pendingReward: new BigNumber(10_000),
+  status: HEDERA_DELEGATION_STATUS.Active,
+  validator: {
+    nodeId: 3,
+    name: "Hedera Node 3",
+    address: "0.0.3",
+    addressChecksum: null,
+    minStake: new BigNumber(0),
+    maxStake: new BigNumber(0),
+    activeStake: new BigNumber(0),
+    activeStakePercentage: new BigNumber(0),
+    overstaked: false,
+  },
+};

--- a/apps/ledger-live-mobile/src/families/hedera/__mocks__/deviceConnection.mock.ts
+++ b/apps/ledger-live-mobile/src/families/hedera/__mocks__/deviceConnection.mock.ts
@@ -1,0 +1,41 @@
+import { of } from "rxjs";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+
+export const HEDERA_MOCK_DEVICE = { modelId: DeviceModelId.stax, deviceId: "mock" };
+const HEDERA_MOCK_APP_AND_VERSION = { name: "Hedera", version: "1.0.0" };
+
+export const hwIndexModule = {
+  ...jest.requireActual("@ledgerhq/live-common/hw/index"),
+  discoverDevices: jest.fn(() =>
+    of({
+      type: "add" as const,
+      id: HEDERA_MOCK_DEVICE.deviceId,
+      name: "Ledger Stax",
+      deviceModel: { id: HEDERA_MOCK_DEVICE.modelId },
+      wired: true,
+    }),
+  ),
+};
+
+export const hwActionsAppModule = {
+  ...jest.requireActual("@ledgerhq/live-common/hw/actions/app"),
+  createAction: () => ({
+    useHook: () => ({
+      device: HEDERA_MOCK_DEVICE,
+      appAndVersion: HEDERA_MOCK_APP_AND_VERSION,
+      isLocked: false,
+      opened: true,
+      inWrongDeviceForAccount: null,
+      error: null,
+    }),
+    mapResult: () => ({
+      device: HEDERA_MOCK_DEVICE,
+      appAndVersion: HEDERA_MOCK_APP_AND_VERSION,
+    }),
+  }),
+};
+
+export const deviceLockedPollingModule = {
+  ...jest.requireActual("~/hooks/useIsDeviceLockedPolling/useIsDeviceLockedPolling"),
+  useIsDeviceLockedPolling: () => ({ result: { type: "unlocked" }, retry: jest.fn() }),
+};

--- a/apps/ledger-live-mobile/src/families/hedera/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-mobile/src/families/hedera/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { render, screen } from "@tests/test-renderer";
+import { useStake } from "LLM/hooks/useStake/useStake";
+import AccountBalanceFooter from "../AccountBalanceSummaryFooter";
+import { HEDERA_ACCOUNT_1, makeHederaAccount } from "../__mocks__/account.mock";
+import { mockDelegation } from "../__mocks__/delegation.mock";
+
+jest.mock("LLM/hooks/useStake/useStake", () => ({ useStake: jest.fn() }));
+
+jest.mock("@ledgerhq/native-ui/pre-ldls", () => ({
+  CryptoIcon: () => null,
+}));
+
+jest.mock("~/modals/Info", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const mockUseStake = jest.mocked(useStake);
+
+const renderAccount = (account: ReturnType<typeof makeHederaAccount>) =>
+  render(<AccountBalanceFooter account={account} />, {
+    overrideInitialState: s => ({
+      ...s,
+      accounts: { ...s.accounts, active: [account] },
+    }),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseStake.mockReturnValue({
+    getCanStakeCurrency: jest.fn().mockReturnValue(true),
+  } as never);
+});
+
+describe("AccountBalanceFooter (Hedera)", () => {
+  describe("guard clause", () => {
+    it("renders null when hederaResources is absent", () => {
+      const { toJSON } = render(<AccountBalanceFooter account={HEDERA_ACCOUNT_1 as never} />, {
+        overrideInitialState: s => ({
+          ...s,
+          accounts: { ...s.accounts, active: [HEDERA_ACCOUNT_1] },
+        }),
+      });
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("without delegation", () => {
+    it("shows the Available balance section", () => {
+      renderAccount(makeHederaAccount());
+      expect(screen.getByText("Available balance")).toBeTruthy();
+    });
+
+    it("does not show Delegated assets or Claimable rewards sections", () => {
+      renderAccount(makeHederaAccount());
+      expect(screen.queryByText("Delegated assets")).toBeNull();
+      expect(screen.queryByText("Claimable rewards")).toBeNull();
+    });
+  });
+
+  describe("with delegation and staking enabled", () => {
+    it("shows Available balance, Delegated assets, and Claimable rewards sections", () => {
+      renderAccount(makeHederaAccount({ delegation: mockDelegation }));
+      expect(screen.getByText("Available balance")).toBeTruthy();
+      expect(screen.getByText("Delegated assets")).toBeTruthy();
+      expect(screen.getByText("Claimable rewards")).toBeTruthy();
+    });
+  });
+
+  describe("with delegation but staking disabled", () => {
+    it("shows Available balance but hides the delegation sections", () => {
+      mockUseStake.mockReturnValue({
+        getCanStakeCurrency: jest.fn().mockReturnValue(false),
+      } as never);
+
+      renderAccount(makeHederaAccount({ delegation: mockDelegation }));
+
+      expect(screen.getByText("Available balance")).toBeTruthy();
+      expect(screen.queryByText("Delegated assets")).toBeNull();
+      expect(screen.queryByText("Claimable rewards")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds integration and unit test coverage for all Hedera flows on both desktop and mobile, plus shared mock infrastructure to support them.

New integration tests
- Desktop (ClaimRewards, Delegation, Undelegation, Redelegation, ReceiveWithAssociation, Send modals)
- Mobile (ClaimRewards, Delegation, Undelegation, Redelegation, AssociateToken flows):

Unit test improvements
- DelegatedPositions, AccountBalanceSummaryFooter, MemoField — replaced toBeInTheDocument() with toBeVisible() on all positive assertions
- Fixed guard-clause tests that broke after HEDERA_ACCOUNT_1 gained hederaResources

Shared test infrastructure:

Desktop (__mocks__/):
- delegation.mock.ts — mockDelegation, mockEnrichedDelegation
- flowHelpers.ts — setupHederaModalTest, cleanupHederaModalTest, createModalsContainer, clickContinueWhenEnabled, DEFAULT_TX_STATUS
- account.mock.ts — added baseResources, makeHederaAccount

Mobile (__mocks__/):
- delegation.mock.ts — mockDelegation, mockEnrichedDelegation
- account.mock.ts — added baseResources, makeHederaAccount, overrideWithHederaAccount1
- bridge.mock.ts — added makeMockAccountBridge, resolvedCurrencyBridge, makeResolvedAccountBridge


### 🔗 Context

- **JIRA / GitHub issue**: [https://ledgerhq.atlassian.net/browse/LIVE-34469](https://ledgerhq.atlassian.net/browse/LIVE-34469)
