### PR TITLE
[LWDM] fix(coin-framework): improve nonce check to avoid error at broadcast

### DIFF
--- a/.changeset/quick-nonces-heal.md
+++ b/.changeset/quick-nonces-heal.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Prevent "nonce too low" errors on rapid consecutive sends by deriving the next sequence from both the network source and locally-tracked pending operations.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -3,7 +3,12 @@ import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import type { Account, DeviceId, SignOperationEvent, AccountBridge } from "@ledgerhq/types-live";
 import { getCoinModuleApi } from "./api";
 import { getBridgeApi } from "./bridge";
-import { bigNumberToBigIntDeep, buildOptimisticOperation, transactionToIntent } from "./utils";
+import {
+  bigNumberToBigIntDeep,
+  buildOptimisticOperation,
+  nextSequenceWithPending,
+  transactionToIntent,
+} from "./utils";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { type GetAddressResult } from "@ledgerhq/ledger-wallet-framework/derivation";
 import { log } from "@ledgerhq/logs";
@@ -58,9 +63,13 @@ export const genericSignOperation =
           transactionIntent.senderPublicKey = publicKey;
 
           if (typeof transactionIntent.sequence !== "bigint" || transactionIntent.sequence < 0n) {
-            // TODO: should compute it and pass it down to craftTransaction (duplicate call right now)
-            const sequenceNumber = await coinModuleApi.getNextSequence(transactionIntent.sender);
-            transactionIntent.sequence = sequenceNumber;
+            // The network sequence source lags behind a just-broadcast tx, so combine it with
+            // locally-tracked pending operations to avoid reusing a nonce on rapid consecutive sends.
+            const networkSequence = await coinModuleApi.getNextSequence(transactionIntent.sender);
+            transactionIntent.sequence = nextSequenceWithPending(
+              account.pendingOperations ?? [],
+              networkSequence,
+            );
           }
 
           /* Craft unsigned blob via coin-framework */

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -7,13 +7,14 @@ import {
   extractBalance,
   extractBalances,
   findCryptoCurrencyByNetwork,
+  nextSequenceWithPending,
   toGasOptionsFromUnknown,
   transactionToIntent,
 } from "./utils";
 import { addPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/index";
 import BigNumber from "bignumber.js";
 import type { Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
-import { Account } from "@ledgerhq/types-live";
+import { Account, Operation } from "@ledgerhq/types-live";
 import { GenericTransaction, GenericTransactionMode, OperationCommon } from "./types";
 import * as craftTransactionDataModule from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 
@@ -1340,6 +1341,44 @@ describe("coin-framework utils", () => {
         value: new BigNumber(25),
         fee: new BigNumber(25),
       });
+    });
+  });
+
+  describe("nextSequenceWithPending", () => {
+    const pendingOp = (seq: number | null): Operation =>
+      ({
+        transactionSequenceNumber: seq === null ? undefined : new BigNumber(seq),
+      }) as Operation;
+
+    it("uses the network sequence when there are no pending operations", () => {
+      expect(nextSequenceWithPending([], 22n)).toBe(22n);
+    });
+
+    it("bumps past a pending op the network source hasn't caught up to yet", () => {
+      // Just broadcast nonce 22 (still pending); network source still reports 22 -> next must be 23.
+      expect(nextSequenceWithPending([pendingOp(22)], 22n)).toBe(23n);
+    });
+
+    it("takes the highest pending sequence + 1 across several pending ops", () => {
+      expect(nextSequenceWithPending([pendingOp(22), pendingOp(24), pendingOp(23)], 22n)).toBe(25n);
+    });
+
+    it("prefers the network sequence once it has moved ahead of pending ops", () => {
+      // Network source caught up (26 > 24+1) -> it wins, self-correcting.
+      expect(nextSequenceWithPending([pendingOp(24)], 26n)).toBe(26n);
+    });
+
+    it("ignores pending ops without a sequence number", () => {
+      expect(nextSequenceWithPending([pendingOp(null), pendingOp(22)], 22n)).toBe(23n);
+    });
+
+    it("ignores non-integer pending sequence numbers", () => {
+      expect(nextSequenceWithPending([pendingOp(22.5), pendingOp(22)], 22n)).toBe(23n);
+    });
+
+    it("handles a large pending sequence without throwing (fixed-point, not exponential)", () => {
+      // BigNumber(1e21).toString() is "1e+21", which BigInt() cannot parse; .toFixed() must be used.
+      expect(nextSequenceWithPending([pendingOp(1e21)], 5n)).toBe(1000000000000000000001n);
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -142,6 +142,33 @@ export function getNativeSpendableAfterPending(account: Account): BigNumber {
   return BigNumber.max(0, account.spendableBalance.minus(pendingSpent));
 }
 
+/**
+ * Next transaction sequence (nonce) that accounts for locally-known pending operations.
+ *
+ * The network sequence source (indexer or a load-balanced RPC) can lag behind a
+ * just-broadcast transaction and briefly return an already-used nonce, causing a
+ * "nonce too low" on the next send. Taking the max with the highest pending
+ * sequence self-corrects once the network source catches up, without waiting for a sync.
+ */
+export function nextSequenceWithPending(
+  pendingOperations: Operation[],
+  networkSequence: bigint,
+): bigint {
+  let highestPending = -1n;
+  for (const op of pendingOperations) {
+    const rawSequence = op.transactionSequenceNumber;
+    // Skip missing or non-integer sequences; `.toFixed()` (not `.toString()`) avoids the
+    // exponential notation that BigInt() cannot parse.
+    if (rawSequence === undefined || rawSequence === null || !rawSequence.isInteger()) {
+      continue;
+    }
+    const seq = BigInt(rawSequence.toFixed());
+    if (seq > highestPending) highestPending = seq;
+  }
+  const pendingFloor = highestPending >= 0n ? highestPending + 1n : 0n;
+  return networkSequence > pendingFloor ? networkSequence : pendingFloor;
+}
+
 // Used for token sub-accounts: lock `op.value` for pending ops that should reduce token spendable.
 // This includes OUT-family and STAKE-family types (stake-family is fee-only on native; see getOperationAmountNumber).
 function isOutgoingOperation(op: Operation): boolean {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

When two transactions are sent in quick succession, the second one can be
rejected by the node with **"nonce too low"** (or trigger an unintended
replacement). This happens because the sequence/nonce source (indexer or a
load-balanced RPC) lags behind a just-broadcast transaction and briefly returns
a nonce that was already consumed by the first send.

Separately, when an intent carries an **explicit** nonce (dapp / WalletConnect /
speed-up flows), a stale value was only rejected *after* signing — the user went
through the whole device flow before hitting the error.

## What this PR does

1. **`nextSequenceWithPending` (generic-coin-framework)** — at sign time, derive
   the next sequence from **both** the network source and the locally-tracked
   pending operations: `max(networkSequence, highestPendingSequence + 1)`.
   Pending ops are tracked optimistically right after broadcast and carry their
   `transactionSequenceNumber`, so the next send no longer reuses a nonce. It is
   deterministic and self-corrects: once the network source catches up,
   `networkSequence` wins again.

2. **`validateNonce` (coin-evm `validateIntent`)** — when an intent carries an
   explicit sequence, validate it against the sender's on-chain nonce **before**
   signing and surface `"nonce is too low"` up front. Best-effort: a failed nonce
   fetch never blocks the user. When no explicit sequence is set, nothing is
   checked (crafting fetches a fresh nonce).

## Changes

- `generic-coin-framework/utils.ts` — add `nextSequenceWithPending()`
- `generic-coin-framework/signOperation.ts` — use it when the intent has no explicit sequence
- `coin-evm/logic/validateIntent.ts` — add the pre-sign `validateNonce()` guard


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35248](https://ledgerhq.atlassian.net/browse/LIVE-35248)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35248]: https://ledgerhq.atlassian.net/browse/LIVE-35248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ