### PR TITLE
feat(coin-tron): add Tronify energy-rent provider client (LIVE-32773)

### DIFF
--- a/.changeset/quiet-hounds-gather.md
+++ b/.changeset/quiet-hounds-gather.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Add the Tronify energy-rent provider client (ADR-050): a `network/tronify` REST client, a `logic/energyRent` provider switch exposing quote/craft/broadcast/status, plus `energyRent` coin-config settings and the `TronifyApiError` / `EnergyRentProviderNotConfigured` error types. Additive and opt-in — the config field is optional and no existing behaviour changes.

--- a/libs/coin-modules/coin-tron/src/config.ts
+++ b/libs/coin-modules/coin-tron/src/config.ts
@@ -7,7 +7,10 @@ import buildCoinConfig, {
 export type TronifyProviderConfig = {
   /** Base URL of the Tronify REST API (e.g. https://open.tronify.io). */
   url: string;
-  /** Channel name agreed with Tronify, sent as `sourceFlag` on every request. */
+  /**
+   * Channel name agreed with Tronify, sent as `sourceFlag` on every request that takes it
+   * (all except `uploadHash`, which is keyed by the order id alone).
+   */
   sourceFlag: string;
   /**
    * Optional API key, sent as an auth header when present; omit when requests are
@@ -17,11 +20,18 @@ export type TronifyProviderConfig = {
   apiKey?: string;
 };
 
-/** Energy-rent provider selection and per-provider settings (ADR-050). */
+/**
+ * Energy-rent provider selection and its settings (ADR-050). The chosen provider's settings are
+ * required alongside its id, so a provider cannot be selected without being configured. Adding a
+ * provider turns this into a union of such pairs.
+ *
+ * This is a compile-time contract only — the value reaches us as unvalidated remote coin-config
+ * JSON, so the client still guards at runtime.
+ */
 export type EnergyRentConfig = {
   /** Active provider; the logic-layer switch dispatches on this. */
   provider: "tronify";
-  tronify?: TronifyProviderConfig;
+  tronify: TronifyProviderConfig;
 };
 
 export type TronConfig = {

--- a/libs/coin-modules/coin-tron/src/config.ts
+++ b/libs/coin-modules/coin-tron/src/config.ts
@@ -3,10 +3,32 @@ import buildCoinConfig, {
   type CurrencyConfig,
 } from "@ledgerhq/coin-module-framework/config";
 
+/** Settings for the Tronify energy-rent provider. */
+export type TronifyProviderConfig = {
+  /** Base URL of the Tronify REST API (e.g. https://open.tronify.io). */
+  url: string;
+  /** Channel name agreed with Tronify, sent as `sourceFlag` on every request. */
+  sourceFlag: string;
+  /**
+   * Optional API key, sent as an auth header when present; omit when requests are
+   * proxied through a Ledger backend that injects credentials.
+   * [assumption] exact header name/scheme to be confirmed with Tronify.
+   */
+  apiKey?: string;
+};
+
+/** Energy-rent provider selection and per-provider settings (ADR-050). */
+export type EnergyRentConfig = {
+  /** Active provider; the logic-layer switch dispatches on this. */
+  provider: "tronify";
+  tronify?: TronifyProviderConfig;
+};
+
 export type TronConfig = {
   explorer: {
     url: string;
   };
+  energyRent?: EnergyRentConfig;
 };
 
 export type TronCoinConfig = CurrencyConfig & TronConfig;

--- a/libs/coin-modules/coin-tron/src/config.ts
+++ b/libs/coin-modules/coin-tron/src/config.ts
@@ -12,12 +12,6 @@ export type TronifyProviderConfig = {
    * (all except `uploadHash`, which is keyed by the order id alone).
    */
   sourceFlag: string;
-  /**
-   * Optional API key, sent as an auth header when present; omit when requests are
-   * proxied through a Ledger backend that injects credentials.
-   * [assumption] exact header name/scheme to be confirmed with Tronify.
-   */
-  apiKey?: string;
 };
 
 /**

--- a/libs/coin-modules/coin-tron/src/logic/energyRent/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyRent/index.test.ts
@@ -1,0 +1,239 @@
+import coinConfig from "../../config";
+import {
+  addTronRentRecord,
+  myPayOrder,
+  queryPreorderInfo,
+  uploadHash,
+} from "../../network/tronify";
+import { EnergyRentProviderNotConfigured } from "../../types/errors";
+import {
+  broadcastEnergyRentTransaction,
+  craftEnergyRentTransaction,
+  getEnergyProvider,
+  getEnergyRentQuote,
+  getEnergyRentStatus,
+} from "./index";
+
+jest.mock("../../network/tronify", () => ({
+  queryPreorderInfo: jest.fn(),
+  addTronRentRecord: jest.fn(),
+  uploadHash: jest.fn(),
+  myPayOrder: jest.fn(),
+}));
+
+const mockedQueryPreorderInfo = queryPreorderInfo as jest.MockedFunction<typeof queryPreorderInfo>;
+const mockedAddTronRentRecord = addTronRentRecord as jest.MockedFunction<typeof addTronRentRecord>;
+const mockedUploadHash = uploadHash as jest.MockedFunction<typeof uploadHash>;
+const mockedMyPayOrder = myPayOrder as jest.MockedFunction<typeof myPayOrder>;
+
+const purchaseOrder = (overrides: Record<string, unknown>) => ({
+  orderId: "order-1",
+  fromAddress: request.payerAddress,
+  pledgeAddress: request.receiverAddress,
+  pledgeNum: 32000,
+  salePledgeNum: 0,
+  freezePledgeNum: 0,
+  leftPledgeNum: 32000,
+  orderPrice: "110",
+  orderType: "ENERGY",
+  pledgeDay: "0",
+  orderStatus: "wait_sale",
+  createTime: "2026-07-30 10:00:00",
+  ...overrides,
+});
+
+const enableTronify = () =>
+  coinConfig.setCoinConfig(() => ({
+    status: { type: "active" },
+    explorer: { url: "https://tron.coin.ledger.com" },
+    energyRent: {
+      provider: "tronify",
+      tronify: { url: "https://open.tronify.io", sourceFlag: "ll" },
+    },
+  }));
+
+const request = {
+  payerAddress: "TKghVbeEzvrV8GLK3YE1gRrjVHSf8rGB6k",
+  receiverAddress: "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1",
+  energy: 32000n,
+  durationSeconds: 600,
+};
+
+describe("energyRent provider switch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    enableTronify();
+  });
+
+  describe("getEnergyProvider", () => {
+    it("returns the tronify provider when selected", () => {
+      expect(getEnergyProvider().id).toBe("tronify");
+    });
+
+    it("throws when no provider is configured", () => {
+      coinConfig.setCoinConfig(() => ({
+        status: { type: "active" },
+        explorer: { url: "https://tron.coin.ledger.com" },
+      }));
+      expect(() => getEnergyProvider()).toThrow(EnergyRentProviderNotConfigured);
+    });
+  });
+
+  describe("getEnergyRentQuote", () => {
+    it("maps the Tronify quote to a provider-agnostic quote", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({
+        pledgeNum: 32000,
+        payCoinCode: "USDT",
+        payCoinAmt: "3.124527",
+        purchaseEnergyFee: "2.727422",
+        purchaseTRXFee: "0.397105",
+        purchaseBandwidthFee: "0",
+        activeAccountFee: "0",
+      } as never);
+
+      const quote = await getEnergyRentQuote(request);
+
+      expect(quote).toEqual({
+        energy: 32000n,
+        durationSeconds: 600,
+        payCoinCode: "USDT",
+        payCoinAmt: "3.124527",
+        fees: { energy: "2.727422", trx: "0.397105", bandwidth: "0", activateAccount: "0" },
+      });
+    });
+
+    it("rounds a duration up to the next window Tronify sells and reports it back", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 32000 } as never);
+
+      // 2h is not a window Tronify sells — it must be quoted (and priced) as the 3h one.
+      const quote = await getEnergyRentQuote({ ...request, durationSeconds: 2 * 3600 });
+
+      expect(quote.durationSeconds).toBe(3 * 3600);
+      expect(mockedQueryPreorderInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ pledgeDay: "0", pledgeHour: "3", pledgeMinute: "0" }),
+      );
+    });
+
+    it("maps a 10-minute duration to the fastTrade window and defaults extraTrxNum to 0", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 32000 } as never);
+
+      await getEnergyRentQuote(request);
+
+      expect(mockedQueryPreorderInfo).toHaveBeenCalledWith({
+        fromAddress: request.payerAddress,
+        pledgeAddress: request.receiverAddress,
+        pledgeNum: 32000,
+        extraTrxNum: "0",
+        pledgeDay: "0",
+        pledgeHour: "0",
+        pledgeMinute: "10",
+      });
+    });
+
+    it("forwards extraTrx as a string", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 1 } as never);
+
+      await getEnergyRentQuote({ ...request, extraTrx: 0.8 });
+
+      expect(mockedQueryPreorderInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ extraTrxNum: "0.8" }),
+      );
+    });
+  });
+
+  describe("craftEnergyRentTransaction", () => {
+    it("returns the order id, unsigned transaction and payment amount", async () => {
+      const transaction = { visible: false, txID: "abc", raw_data: {}, raw_data_hex: "0x" };
+      mockedAddTronRentRecord.mockResolvedValueOnce({
+        orderId: "order-1",
+        transaction,
+        payCoinCode: "USDT",
+        payCoinAmt: "3.12",
+        purchaseEnergyFee: "3",
+        purchaseTRXFee: "0",
+        purchaseBandwidthFee: "0",
+        activeAccountFee: "0",
+      });
+
+      const order = await craftEnergyRentTransaction(request);
+
+      expect(order).toEqual({
+        orderId: "order-1",
+        transaction,
+        payCoinCode: "USDT",
+        payCoinAmt: "3.12",
+      });
+    });
+  });
+
+  describe("broadcastEnergyRentTransaction", () => {
+    it("submits the signed payment via uploadHash using its txID as fromHash", async () => {
+      mockedUploadHash.mockResolvedValueOnce({});
+      const signedTransaction = {
+        visible: false,
+        txID: "abc",
+        raw_data: {},
+        raw_data_hex: "0x",
+        signature: ["sig"],
+      };
+
+      await broadcastEnergyRentTransaction({ orderId: "order-1", signedTransaction });
+
+      expect(mockedUploadHash).toHaveBeenCalledWith({
+        orderId: "order-1",
+        fromHash: "abc",
+        signedData: signedTransaction,
+      });
+    });
+  });
+
+  describe("getEnergyRentStatus", () => {
+    const respondWith = (orders: unknown[]) =>
+      mockedMyPayOrder.mockResolvedValueOnce({
+        data: orders,
+        pagination: { page: 1, pageSize: 50, total: orders.length },
+      } as never);
+
+    const statusOf = (orderStatus: string) => {
+      respondWith([purchaseOrder({ orderStatus })]);
+      return getEnergyRentStatus({ orderId: "order-1", payerAddress: request.payerAddress });
+    };
+
+    it("looks the order up by the payer address, requesting every order", async () => {
+      respondWith([]);
+
+      await getEnergyRentStatus({ orderId: "order-1", payerAddress: request.payerAddress });
+
+      expect(mockedMyPayOrder).toHaveBeenCalledWith({
+        fromAddress: request.payerAddress,
+        orderType: "2",
+        page: 1,
+        pageSize: 50,
+      });
+    });
+
+    it.each([
+      ["wait_deposit_send", "pending"],
+      ["wait_sale", "paid"],
+      ["complete", "delivered"],
+      ["timeout", "failed"],
+    ])("maps Tronify orderStatus %s to %s", async (orderStatus, expected) => {
+      expect(await statusOf(orderStatus)).toBe(expected);
+    });
+
+    it("returns 'unknown' when the order is not in the payer's records", async () => {
+      respondWith([purchaseOrder({ orderId: "another-order" })]);
+
+      const status = await getEnergyRentStatus({
+        orderId: "order-1",
+        payerAddress: request.payerAddress,
+      });
+
+      expect(status).toBe("unknown");
+    });
+
+    it("returns 'unknown' for an unrecognised orderStatus", async () => {
+      expect(await statusOf("some_new_status")).toBe("unknown");
+    });
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/energyRent/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyRent/index.test.ts
@@ -130,6 +130,28 @@ describe("energyRent provider switch", () => {
       });
     });
 
+    it("rounds a duration past the hour windows up to whole days, capped at Tronify's 30", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 32000 } as never);
+
+      const quote = await getEnergyRentQuote({ ...request, durationSeconds: 40 * 86_400 });
+
+      expect(quote.durationSeconds).toBe(30 * 86_400);
+      expect(mockedQueryPreorderInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ pledgeDay: "30", pledgeHour: "0", pledgeMinute: "0" }),
+      );
+    });
+
+    it("rounds a sub-day duration past 3h up to a single day", async () => {
+      mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 32000 } as never);
+
+      const quote = await getEnergyRentQuote({ ...request, durationSeconds: 4 * 3600 });
+
+      expect(quote.durationSeconds).toBe(86_400);
+      expect(mockedQueryPreorderInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ pledgeDay: "1", pledgeHour: "0", pledgeMinute: "0" }),
+      );
+    });
+
     it("forwards extraTrx as a string", async () => {
       mockedQueryPreorderInfo.mockResolvedValueOnce({ pledgeNum: 1 } as never);
 

--- a/libs/coin-modules/coin-tron/src/logic/energyRent/index.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyRent/index.ts
@@ -1,0 +1,50 @@
+import coinConfig from "../../config";
+import { EnergyRentProviderNotConfigured } from "../../types/errors";
+import { tronifyProvider } from "./tronify";
+import type {
+  EnergyProvider,
+  EnergyRentOrder,
+  EnergyRentOrderRef,
+  EnergyRentQuote,
+  EnergyRentRequest,
+  EnergyRentSignedTransaction,
+  EnergyRentStatus,
+} from "./types";
+
+export * from "./types";
+
+/** Resolve the energy-rent provider selected in coin-config (the single-file switch). */
+export function getEnergyProvider(): EnergyProvider {
+  const energyRent = coinConfig.getCoinConfig().energyRent;
+  if (!energyRent) {
+    throw new EnergyRentProviderNotConfigured("No energy-rent provider configured");
+  }
+  switch (energyRent.provider) {
+    case "tronify":
+      return tronifyProvider;
+    default:
+      // `provider` comes from remote coin-config, so guard against an unknown value at runtime.
+      throw new EnergyRentProviderNotConfigured(
+        `Unsupported energy-rent provider: ${energyRent.provider}`,
+      );
+  }
+}
+
+export function getEnergyRentQuote(request: EnergyRentRequest): Promise<EnergyRentQuote> {
+  return getEnergyProvider().getQuote(request);
+}
+
+export function craftEnergyRentTransaction(request: EnergyRentRequest): Promise<EnergyRentOrder> {
+  return getEnergyProvider().createOrder(request);
+}
+
+export function broadcastEnergyRentTransaction(payment: {
+  orderId: string;
+  signedTransaction: EnergyRentSignedTransaction;
+}): Promise<void> {
+  return getEnergyProvider().submitPayment(payment);
+}
+
+export function getEnergyRentStatus(order: EnergyRentOrderRef): Promise<EnergyRentStatus> {
+  return getEnergyProvider().getOrderStatus(order);
+}

--- a/libs/coin-modules/coin-tron/src/logic/energyRent/tronify.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyRent/tronify.ts
@@ -1,0 +1,101 @@
+import {
+  addTronRentRecord,
+  myPayOrder,
+  queryPreorderInfo,
+  uploadHash,
+} from "../../network/tronify";
+import type { TronifyEnergyOrderParams, TronifyOrderStatus } from "../../network/tronify/types";
+import type { EnergyProvider, EnergyRentRequest, EnergyRentStatus } from "./types";
+
+type TronifyDuration = Pick<TronifyEnergyOrderParams, "pledgeDay" | "pledgeHour" | "pledgeMinute">;
+
+/** Round a desired duration up to the nearest fastTrade window Tronify sells. */
+function toTronifyDuration(seconds: number): TronifyDuration {
+  if (seconds <= 10 * 60) return { pledgeDay: "0", pledgeHour: "0", pledgeMinute: "10" };
+  if (seconds <= 60 * 60) return { pledgeDay: "0", pledgeHour: "1", pledgeMinute: "0" };
+  if (seconds <= 3 * 60 * 60) return { pledgeDay: "0", pledgeHour: "3", pledgeMinute: "0" };
+  const days = Math.min(30, Math.max(1, Math.ceil(seconds / 86_400)));
+  return { pledgeDay: String(days), pledgeHour: "0", pledgeMinute: "0" };
+}
+
+function durationToSeconds({ pledgeDay, pledgeHour, pledgeMinute }: TronifyDuration): number {
+  return Number(pledgeDay) * 86_400 + Number(pledgeHour) * 3_600 + Number(pledgeMinute) * 60;
+}
+
+// [assumption] Mapping of Tronify's purchase-order lifecycle onto our status; to be confirmed
+// with Tronify (reconciliation Q7). `wait_sale` means the payment landed and the order is
+// waiting to be filled by a seller, i.e. energy not yet delegated.
+const ORDER_STATUS: Record<TronifyOrderStatus, EnergyRentStatus> = {
+  wait_deposit_send: "pending",
+  wait_sale: "paid",
+  complete: "delivered",
+  timeout: "failed",
+};
+
+/** Any value other than "0" (completed) or "1" (active) makes Tronify return every order. */
+const ALL_ORDERS = "2";
+
+// A just-created order is among the most recent, so a single page suffices in practice.
+const ORDER_LOOKUP_PAGE_SIZE = 50;
+
+function toOrderParams(request: EnergyRentRequest): TronifyEnergyOrderParams {
+  return {
+    fromAddress: request.payerAddress,
+    pledgeAddress: request.receiverAddress,
+    pledgeNum: Number(request.energy),
+    extraTrxNum: request.extraTrx ? String(request.extraTrx) : "0",
+    ...toTronifyDuration(request.durationSeconds),
+  };
+}
+
+export const tronifyProvider: EnergyProvider = {
+  id: "tronify",
+
+  async getQuote(request) {
+    const params = toOrderParams(request);
+    const data = await queryPreorderInfo(params);
+    return {
+      energy: BigInt(data.pledgeNum),
+      durationSeconds: durationToSeconds(params),
+      payCoinCode: data.payCoinCode,
+      payCoinAmt: data.payCoinAmt,
+      fees: {
+        energy: data.purchaseEnergyFee,
+        trx: data.purchaseTRXFee,
+        bandwidth: data.purchaseBandwidthFee,
+        activateAccount: data.activeAccountFee,
+      },
+    };
+  },
+
+  async createOrder(request) {
+    const data = await addTronRentRecord(toOrderParams(request));
+    return {
+      orderId: data.orderId,
+      transaction: data.transaction,
+      payCoinCode: data.payCoinCode,
+      payCoinAmt: data.payCoinAmt,
+    };
+  },
+
+  async submitPayment({ orderId, signedTransaction }) {
+    await uploadHash({
+      orderId,
+      fromHash: signedTransaction.txID,
+      signedData: signedTransaction,
+    });
+  },
+
+  async getOrderStatus({ orderId, payerAddress }) {
+    // `mypayorder` has no orderId filter, so we page through the payer's orders and match.
+    const { data } = await myPayOrder({
+      fromAddress: payerAddress,
+      orderType: ALL_ORDERS,
+      page: 1,
+      pageSize: ORDER_LOOKUP_PAGE_SIZE,
+    });
+
+    const order = data.find(entry => entry.orderId === orderId);
+    return order ? (ORDER_STATUS[order.orderStatus] ?? "unknown") : "unknown";
+  },
+};

--- a/libs/coin-modules/coin-tron/src/logic/energyRent/types.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyRent/types.ts
@@ -1,0 +1,78 @@
+import type {
+  TronifyUnsignedTransaction,
+  TronifySignedTransaction,
+} from "../../network/tronify/types";
+
+/** Energy-rent providers integrated in coin-tron. Only Tronify for now. */
+export type EnergyProviderId = "tronify";
+
+/** Lifecycle status of an energy-rent order. */
+export type EnergyRentStatus = "pending" | "paid" | "delivered" | "failed" | "unknown";
+
+/** Inputs to request a quote / create an order, provider-agnostic. */
+export type EnergyRentRequest = {
+  /** Address paying for the rent (buyer). */
+  payerAddress: string;
+  /** Address that receives the delegated energy. */
+  receiverAddress: string;
+  /** Energy units to rent. */
+  energy: bigint;
+  /** Desired rental duration in seconds; adapted to the provider's supported windows. */
+  durationSeconds: number;
+  /** Extra TRX to bundle for bandwidth, in TRX (e.g. 0.8). Defaults to 0. */
+  extraTrx?: number;
+};
+
+/** Provider-agnostic price quote. Amounts kept as provider-native decimal strings. */
+export type EnergyRentQuote = {
+  energy: bigint;
+  /**
+   * Rental window actually quoted. Providers only sell fixed windows, so this is rounded up
+   * from the requested duration and may exceed it (the price reflects this window, not the request).
+   */
+  durationSeconds: number;
+  /** Currency the buyer pays in, e.g. "USDT" or "TRX". */
+  payCoinCode: string;
+  /** Total amount to pay, decimal string in `payCoinCode` units. */
+  payCoinAmt: string;
+  fees: {
+    energy: string;
+    trx: string;
+    bandwidth: string;
+    activateAccount: string;
+  };
+};
+
+/** A created order plus the unsigned payment the wallet must sign. */
+export type EnergyRentOrder = {
+  orderId: string;
+  /** Unsigned payment transaction to sign (do not broadcast) and pass to `broadcastEnergyRentTransaction`. */
+  transaction: EnergyRentUnsignedTransaction;
+  payCoinCode: string;
+  payCoinAmt: string;
+};
+
+// Tron-shaped payment tx; aliased at the logic layer so callers don't import from network/.
+export type EnergyRentUnsignedTransaction = TronifyUnsignedTransaction;
+export type EnergyRentSignedTransaction = TronifySignedTransaction;
+
+/**
+ * An energy-rent marketplace client. `getEnergyRentQuote` / `craftEnergyRentTransaction` /
+ * `broadcastEnergyRentTransaction` / `getEnergyRentStatus` in the switch delegate to this.
+ */
+export interface EnergyProvider {
+  id: EnergyProviderId;
+  getQuote(request: EnergyRentRequest): Promise<EnergyRentQuote>;
+  createOrder(request: EnergyRentRequest): Promise<EnergyRentOrder>;
+  submitPayment(payment: {
+    orderId: string;
+    signedTransaction: EnergyRentSignedTransaction;
+  }): Promise<void>;
+  getOrderStatus(order: EnergyRentOrderRef): Promise<EnergyRentStatus>;
+}
+
+/** Identifies an order to look up. The payer address is required to scope the provider query. */
+export type EnergyRentOrderRef = {
+  orderId: string;
+  payerAddress: string;
+};

--- a/libs/coin-modules/coin-tron/src/logic/index.ts
+++ b/libs/coin-modules/coin-tron/src/logic/index.ts
@@ -1,6 +1,7 @@
 export * from "./broadcast";
 export * from "./combine";
 export * from "./craftTransaction";
+export * from "./energyRent";
 export * from "./estimateFees";
 export * from "./getBalance";
 export * from "./getBlock";

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.integ.test.ts
@@ -1,0 +1,44 @@
+import coinConfig from "../../config";
+import { queryPreorderInfo } from "./index";
+
+// Credentials/channel are not committed. Provide them via the integ env to run this suite:
+//   TRONIFY_URL, TRONIFY_SOURCE_FLAG, (optional) TRONIFY_API_KEY
+// Only queryPreorderInfo is exercised — it is a read-only quote. addTronRentRecord/uploadHash
+// create real, paid orders and must run against a Tronify sandbox (reconciliation Q10).
+const { TRONIFY_URL, TRONIFY_SOURCE_FLAG, TRONIFY_API_KEY } = process.env;
+const run = TRONIFY_URL && TRONIFY_SOURCE_FLAG ? describe : describe.skip;
+
+const RECEIVER = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
+
+run("tronify queryPreorderInfo [integ]", () => {
+  beforeAll(() => {
+    coinConfig.setCoinConfig(() => ({
+      status: { type: "active" },
+      explorer: { url: "https://tron.coin.ledger.com" },
+      energyRent: {
+        provider: "tronify",
+        tronify: {
+          url: TRONIFY_URL as string,
+          sourceFlag: TRONIFY_SOURCE_FLAG as string,
+          apiKey: TRONIFY_API_KEY,
+        },
+      },
+    }));
+  });
+
+  it("returns a priced quote for a 10-minute, 32000-energy rental", async () => {
+    const quote = await queryPreorderInfo({
+      fromAddress: RECEIVER,
+      pledgeAddress: RECEIVER,
+      pledgeNum: 32000,
+      pledgeDay: "0",
+      pledgeHour: "0",
+      pledgeMinute: "10",
+      extraTrxNum: "0",
+    });
+
+    expect(quote.pledgeNum).toBe(32000);
+    expect(Number(quote.payCoinAmt)).toBeGreaterThan(0);
+    expect(quote.payCoinCode.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.integ.test.ts
@@ -1,11 +1,11 @@
 import coinConfig from "../../config";
 import { queryPreorderInfo } from "./index";
 
-// Credentials/channel are not committed. Provide them via the integ env to run this suite:
-//   TRONIFY_URL, TRONIFY_SOURCE_FLAG, (optional) TRONIFY_API_KEY
+// The channel name is not committed. Provide it via the integ env to run this suite:
+//   TRONIFY_URL, TRONIFY_SOURCE_FLAG
 // Only queryPreorderInfo is exercised — it is a read-only quote. addTronRentRecord/uploadHash
 // create real, paid orders and must run against a Tronify sandbox (reconciliation Q10).
-const { TRONIFY_URL, TRONIFY_SOURCE_FLAG, TRONIFY_API_KEY } = process.env;
+const { TRONIFY_URL, TRONIFY_SOURCE_FLAG } = process.env;
 const run = TRONIFY_URL && TRONIFY_SOURCE_FLAG ? describe : describe.skip;
 
 const RECEIVER = "TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1";
@@ -20,7 +20,6 @@ run("tronify queryPreorderInfo [integ]", () => {
         tronify: {
           url: TRONIFY_URL as string,
           sourceFlag: TRONIFY_SOURCE_FLAG as string,
-          apiKey: TRONIFY_API_KEY,
         },
       },
     }));

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
@@ -1,0 +1,170 @@
+import network from "@ledgerhq/live-network";
+import coinConfig from "../../config";
+import { EnergyRentProviderNotConfigured } from "../../types/errors";
+import { addTronRentRecord, myPayOrder, queryPreorderInfo, queryTrades, uploadHash } from "./index";
+import type { TronifyEnergyOrderParams } from "./types";
+
+jest.mock("@ledgerhq/live-network", () => ({ __esModule: true, default: jest.fn() }));
+
+const mockedNetwork = network as jest.MockedFunction<typeof network>;
+
+const TRONIFY_URL = "https://open.tronify.io";
+const SOURCE_FLAG = "ledgerLive";
+
+const setConfig = (tronify?: { url: string; sourceFlag: string; apiKey?: string }) =>
+  coinConfig.setCoinConfig(() => ({
+    status: { type: "active" },
+    explorer: { url: "https://tron.coin.ledger.com" },
+    energyRent: tronify ? { provider: "tronify", tronify } : undefined,
+  }));
+
+const envelope = <T>(data: T, resCode = 100, resMsg = "Success") => ({
+  data: { resCode, resMsg, data },
+});
+
+const orderParams: TronifyEnergyOrderParams = {
+  fromAddress: "TKghVbeEzvrV8GLK3YE1gRrjVHSf8rGB6k",
+  pledgeAddress: "TKghVbeEzvrV8GLK3YE1gRrjVHSf8rGB6k",
+  pledgeNum: 32000,
+  pledgeDay: "0",
+  pledgeHour: "0",
+  pledgeMinute: "10",
+  extraTrxNum: "0",
+};
+
+describe("tronify network client", () => {
+  beforeEach(() => {
+    mockedNetwork.mockReset();
+    setConfig({ url: TRONIFY_URL, sourceFlag: SOURCE_FLAG });
+  });
+
+  it("throws EnergyRentProviderNotConfigured when tronify is not configured", async () => {
+    setConfig(undefined);
+    await expect(queryPreorderInfo(orderParams)).rejects.toBeInstanceOf(
+      EnergyRentProviderNotConfigured,
+    );
+  });
+
+  describe("queryPreorderInfo", () => {
+    it("POSTs to the endpoint with injected orderType/tradeType/sourceFlag and returns data", async () => {
+      const data = { payCoinCode: "USDT", payCoinAmt: "3.12" };
+      mockedNetwork.mockResolvedValueOnce(envelope(data) as never);
+
+      const result = await queryPreorderInfo(orderParams);
+
+      expect(result).toEqual(data);
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          url: `${TRONIFY_URL}/api/tronRent/queryPreorderInfo`,
+          data: expect.objectContaining({
+            ...orderParams,
+            orderType: "ENERGY",
+            tradeType: "fastTrade",
+            sourceFlag: SOURCE_FLAG,
+          }),
+        }),
+      );
+    });
+
+    it("throws TronifyApiError carrying resCode on a non-100 response", async () => {
+      mockedNetwork.mockResolvedValueOnce(
+        envelope({}, 132, "pledgeNum cannot be less than 15000") as never,
+      );
+
+      await expect(queryPreorderInfo(orderParams)).rejects.toMatchObject({
+        name: "TronifyApiError",
+        resCode: 132,
+      });
+    });
+  });
+
+  describe("auth header", () => {
+    it("sends the api-key header only when apiKey is configured", async () => {
+      setConfig({ url: TRONIFY_URL, sourceFlag: SOURCE_FLAG, apiKey: "secret" });
+      mockedNetwork.mockResolvedValueOnce(envelope({}) as never);
+
+      await queryPreorderInfo(orderParams);
+
+      expect(mockedNetwork.mock.calls[0][0]).toMatchObject({ headers: { apikey: "secret" } });
+    });
+
+    it("omits headers when no apiKey is configured", async () => {
+      mockedNetwork.mockResolvedValueOnce(envelope({}) as never);
+
+      await queryPreorderInfo(orderParams);
+
+      expect(mockedNetwork.mock.calls[0][0]).not.toHaveProperty("headers");
+    });
+  });
+
+  describe("addTronRentRecord", () => {
+    it("returns the created order and unsigned transaction", async () => {
+      const data = {
+        orderId: "order-1",
+        transaction: { visible: false, txID: "abc", raw_data: {}, raw_data_hex: "0x" },
+        payCoinCode: "USDT",
+        payCoinAmt: "3.12",
+      };
+      mockedNetwork.mockResolvedValueOnce(envelope(data) as never);
+
+      const result = await addTronRentRecord(orderParams);
+
+      expect(result).toEqual(data);
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({ url: `${TRONIFY_URL}/api/tronRent/addTronRentRecord` }),
+      );
+    });
+  });
+
+  describe("uploadHash", () => {
+    it("POSTs the signed payment without a sourceFlag", async () => {
+      mockedNetwork.mockResolvedValueOnce(envelope({}) as never);
+      const signedData = {
+        visible: false,
+        txID: "abc",
+        raw_data: {},
+        raw_data_hex: "0x",
+        signature: ["sig"],
+      };
+
+      await uploadHash({ orderId: "order-1", fromHash: "abc", signedData });
+
+      const body = mockedNetwork.mock.calls[0][0].data as Record<string, unknown>;
+      expect(body).toEqual({ orderId: "order-1", fromHash: "abc", signedData });
+      expect(body).not.toHaveProperty("sourceFlag");
+    });
+  });
+
+  describe("queryTrades", () => {
+    it("injects the sourceFlag into the request body", async () => {
+      mockedNetwork.mockResolvedValueOnce(envelope({ data: [], pagination: {} }) as never);
+
+      await queryTrades({ sort: "0", page: 1, pageSize: 10 });
+
+      expect(mockedNetwork.mock.calls[0][0].data).toMatchObject({ sourceFlag: SOURCE_FLAG });
+    });
+  });
+
+  describe("myPayOrder", () => {
+    it("POSTs to mypayorder with the payer address and the sourceFlag", async () => {
+      mockedNetwork.mockResolvedValueOnce(envelope({ data: [], pagination: {} }) as never);
+
+      await myPayOrder({ fromAddress: "TKgh", orderType: "2", page: 1, pageSize: 50 });
+
+      expect(mockedNetwork).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "POST",
+          url: `${TRONIFY_URL}/api/tronRent/mypayorder`,
+          data: {
+            fromAddress: "TKgh",
+            orderType: "2",
+            page: 1,
+            pageSize: 50,
+            sourceFlag: SOURCE_FLAG,
+          },
+        }),
+      );
+    });
+  });
+});

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
@@ -38,8 +38,25 @@ describe("tronify network client", () => {
     setConfig({ url: TRONIFY_URL, sourceFlag: SOURCE_FLAG });
   });
 
-  it("throws EnergyRentProviderNotConfigured when tronify is not configured", async () => {
+  it("rejects with EnergyRentProviderNotConfigured when energyRent is absent", async () => {
     setConfig(undefined);
+    await expect(queryPreorderInfo(orderParams)).rejects.toBeInstanceOf(
+      EnergyRentProviderNotConfigured,
+    );
+  });
+
+  // The config type requires `tronify` alongside the provider id, but coin-config reaches us as
+  // unvalidated remote JSON — hence the runtime guard this covers.
+  it("rejects with EnergyRentProviderNotConfigured when remote config omits the tronify settings", async () => {
+    coinConfig.setCoinConfig(
+      () =>
+        ({
+          status: { type: "active" },
+          explorer: { url: "https://tron.coin.ledger.com" },
+          energyRent: { provider: "tronify" },
+        }) as never,
+    );
+
     await expect(queryPreorderInfo(orderParams)).rejects.toBeInstanceOf(
       EnergyRentProviderNotConfigured,
     );

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.test.ts
@@ -1,7 +1,7 @@
 import network from "@ledgerhq/live-network";
 import coinConfig from "../../config";
 import { EnergyRentProviderNotConfigured } from "../../types/errors";
-import { addTronRentRecord, myPayOrder, queryPreorderInfo, queryTrades, uploadHash } from "./index";
+import { addTronRentRecord, myPayOrder, queryPreorderInfo, uploadHash } from "./index";
 import type { TronifyEnergyOrderParams } from "./types";
 
 jest.mock("@ledgerhq/live-network", () => ({ __esModule: true, default: jest.fn() }));
@@ -11,7 +11,7 @@ const mockedNetwork = network as jest.MockedFunction<typeof network>;
 const TRONIFY_URL = "https://open.tronify.io";
 const SOURCE_FLAG = "ledgerLive";
 
-const setConfig = (tronify?: { url: string; sourceFlag: string; apiKey?: string }) =>
+const setConfig = (tronify?: { url: string; sourceFlag: string }) =>
   coinConfig.setCoinConfig(() => ({
     status: { type: "active" },
     explorer: { url: "https://tron.coin.ledger.com" },
@@ -96,25 +96,6 @@ describe("tronify network client", () => {
     });
   });
 
-  describe("auth header", () => {
-    it("sends the api-key header only when apiKey is configured", async () => {
-      setConfig({ url: TRONIFY_URL, sourceFlag: SOURCE_FLAG, apiKey: "secret" });
-      mockedNetwork.mockResolvedValueOnce(envelope({}) as never);
-
-      await queryPreorderInfo(orderParams);
-
-      expect(mockedNetwork.mock.calls[0][0]).toMatchObject({ headers: { apikey: "secret" } });
-    });
-
-    it("omits headers when no apiKey is configured", async () => {
-      mockedNetwork.mockResolvedValueOnce(envelope({}) as never);
-
-      await queryPreorderInfo(orderParams);
-
-      expect(mockedNetwork.mock.calls[0][0]).not.toHaveProperty("headers");
-    });
-  });
-
   describe("addTronRentRecord", () => {
     it("returns the created order and unsigned transaction", async () => {
       const data = {
@@ -150,16 +131,6 @@ describe("tronify network client", () => {
       const body = mockedNetwork.mock.calls[0][0].data as Record<string, unknown>;
       expect(body).toEqual({ orderId: "order-1", fromHash: "abc", signedData });
       expect(body).not.toHaveProperty("sourceFlag");
-    });
-  });
-
-  describe("queryTrades", () => {
-    it("injects the sourceFlag into the request body", async () => {
-      mockedNetwork.mockResolvedValueOnce(envelope({ data: [], pagination: {} }) as never);
-
-      await queryTrades({ sort: "0", page: 1, pageSize: 10 });
-
-      expect(mockedNetwork.mock.calls[0][0].data).toMatchObject({ sourceFlag: SOURCE_FLAG });
     });
   });
 

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.ts
@@ -1,0 +1,88 @@
+import network from "@ledgerhq/live-network";
+import { log } from "@ledgerhq/logs";
+import coinConfig, { type TronifyProviderConfig } from "../../config";
+import { EnergyRentProviderNotConfigured, TronifyApiError } from "../../types/errors";
+import type {
+  AddTronRentRecordData,
+  MyPayOrderData,
+  MyPayOrderRequest,
+  QueryPreorderInfoData,
+  TradesData,
+  TradesRequest,
+  TronifyEnergyOrderParams,
+  TronifyResponse,
+  UploadHashData,
+  UploadHashRequest,
+} from "./types";
+
+const TRONIFY_SUCCESS = 100;
+
+// [assumption] Tronify authenticates API calls with a key header; the exact header name is
+// not documented and must be confirmed. Only sent when `apiKey` is set in coin-config.
+const TRONIFY_API_KEY_HEADER = "apikey";
+
+const ENERGY_ORDER_DEFAULTS = {
+  orderType: "ENERGY",
+  tradeType: "fastTrade",
+} as const;
+
+function getTronifyConfig(): TronifyProviderConfig {
+  const tronify = coinConfig.getCoinConfig().energyRent?.tronify;
+  if (!tronify) {
+    throw new EnergyRentProviderNotConfigured("Tronify provider is not configured in coin-config");
+  }
+  return tronify;
+}
+
+async function post<Body extends object, Data>(endpoint: string, body: Body): Promise<Data> {
+  const { url, apiKey } = getTronifyConfig();
+  const { data } = await network<TronifyResponse<Data>, Body>({
+    method: "POST",
+    url: `${url}/api/tronRent/${endpoint}`,
+    data: body,
+    ...(apiKey ? { headers: { [TRONIFY_API_KEY_HEADER]: apiKey } } : {}),
+  });
+
+  if (data.resCode !== TRONIFY_SUCCESS) {
+    log("tronify-error", data.resMsg, { endpoint, resCode: data.resCode });
+    throw new TronifyApiError(data.resMsg, { resCode: data.resCode });
+  }
+
+  return data.data;
+}
+
+/** Query a price quote for an energy rental. No order is created. */
+export async function queryPreorderInfo(
+  params: TronifyEnergyOrderParams,
+): Promise<QueryPreorderInfoData> {
+  const { sourceFlag } = getTronifyConfig();
+  return post("queryPreorderInfo", { ...ENERGY_ORDER_DEFAULTS, ...params, sourceFlag });
+}
+
+/** Create an energy-rent order; returns the order id and an unsigned payment transaction. */
+export async function addTronRentRecord(
+  params: TronifyEnergyOrderParams,
+): Promise<AddTronRentRecordData> {
+  const { sourceFlag } = getTronifyConfig();
+  return post("addTronRentRecord", { ...ENERGY_ORDER_DEFAULTS, ...params, sourceFlag });
+}
+
+/** Submit the signed (not broadcast) payment; Tronify broadcasts it and delegates energy. */
+export async function uploadHash(request: UploadHashRequest): Promise<UploadHashData> {
+  return post("uploadHash", request);
+}
+
+/**
+ * List the market's recent orders for the configured channel (paginated). Channel-wide and
+ * carries no per-order status — use {@link myPayOrder} to follow a specific order.
+ */
+export async function queryTrades(request: TradesRequest): Promise<TradesData> {
+  const { sourceFlag } = getTronifyConfig();
+  return post("trades", { ...request, sourceFlag });
+}
+
+/** List a buyer's own purchase orders, including each order's `orderStatus`. */
+export async function myPayOrder(request: MyPayOrderRequest): Promise<MyPayOrderData> {
+  const { sourceFlag } = getTronifyConfig();
+  return post("mypayorder", { ...request, sourceFlag });
+}

--- a/libs/coin-modules/coin-tron/src/network/tronify/index.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/index.ts
@@ -7,8 +7,6 @@ import type {
   MyPayOrderData,
   MyPayOrderRequest,
   QueryPreorderInfoData,
-  TradesData,
-  TradesRequest,
   TronifyEnergyOrderParams,
   TronifyResponse,
   UploadHashData,
@@ -16,10 +14,6 @@ import type {
 } from "./types";
 
 const TRONIFY_SUCCESS = 100;
-
-// [assumption] Tronify authenticates API calls with a key header; the exact header name is
-// not documented and must be confirmed. Only sent when `apiKey` is set in coin-config.
-const TRONIFY_API_KEY_HEADER = "apikey";
 
 const ENERGY_ORDER_DEFAULTS = {
   orderType: "ENERGY",
@@ -35,12 +29,11 @@ function getTronifyConfig(): TronifyProviderConfig {
 }
 
 async function post<Body extends object, Data>(endpoint: string, body: Body): Promise<Data> {
-  const { url, apiKey } = getTronifyConfig();
+  const { url } = getTronifyConfig();
   const { data } = await network<TronifyResponse<Data>, Body>({
     method: "POST",
     url: `${url}/api/tronRent/${endpoint}`,
     data: body,
-    ...(apiKey ? { headers: { [TRONIFY_API_KEY_HEADER]: apiKey } } : {}),
   });
 
   if (data.resCode !== TRONIFY_SUCCESS) {
@@ -70,15 +63,6 @@ export async function addTronRentRecord(
 /** Submit the signed (not broadcast) payment; Tronify broadcasts it and delegates energy. */
 export async function uploadHash(request: UploadHashRequest): Promise<UploadHashData> {
   return post("uploadHash", request);
-}
-
-/**
- * List the market's recent orders for the configured channel (paginated). Channel-wide and
- * carries no per-order status — use {@link myPayOrder} to follow a specific order.
- */
-export async function queryTrades(request: TradesRequest): Promise<TradesData> {
-  const { sourceFlag } = getTronifyConfig();
-  return post("trades", { ...request, sourceFlag });
 }
 
 /** List a buyer's own purchase orders, including each order's `orderStatus`. */

--- a/libs/coin-modules/coin-tron/src/network/tronify/types.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/types.ts
@@ -1,0 +1,162 @@
+// Wire types for the Tronify energy-rental REST API.
+// Endpoints live under `${baseUrl}/api/tronRent/` and all return the envelope below.
+// Docs: https://docs-tron.en.tronify.io
+
+/** Standard Tronify response envelope. `resCode` 100 means success. */
+export type TronifyResponse<T> = {
+  resCode: number;
+  resMsg: string;
+  data: T;
+};
+
+/**
+ * Common energy-order parameters shared by `queryPreorderInfo` (quote) and
+ * `addTronRentRecord` (create order). `orderType`, `tradeType` and `sourceFlag`
+ * are injected by the client and so are omitted here.
+ */
+export type TronifyEnergyOrderParams = {
+  /** Buyer wallet address (base58). */
+  fromAddress: string;
+  /** Address that receives the delegated energy (base58). */
+  pledgeAddress: string;
+  /** Energy units to rent; Tronify minimum is 15000. */
+  pledgeNum: number;
+  /** Rental duration — days (0-30). */
+  pledgeDay: string;
+  /** Rental duration — hours (0, 1, 3 for fastTrade). */
+  pledgeHour: string;
+  /** Rental duration — minutes (0, 10 for fastTrade). */
+  pledgeMinute: string;
+  /** Extra TRX to bundle for bandwidth: "0" (none) or a value in [0.8, 500]. */
+  extraTrxNum: string;
+  /** Extra bandwidth to rent; "0" or omitted means none. */
+  pledgeBandwidthNum?: string;
+};
+
+export type QueryPreorderInfoData = {
+  fromAddress: string;
+  pledgeAddress: string;
+  pledgeDay: string;
+  pledgeHour: string;
+  pledgeMinute: string;
+  source: string;
+  orderType: string;
+  orderPrice: number;
+  pledgeNum: number;
+  pledgeTrxNum: string;
+  /** Whether paying the rent in USDT (Flow 2) is currently available. */
+  usdtModeAvailable: boolean;
+  /** Currency the buyer pays in, e.g. "USDT" or "TRX". */
+  payCoinCode: string;
+  /** Total amount to pay, decimal string in `payCoinCode` units. */
+  payCoinAmt: string;
+  extraTrxNum: string;
+  pledgeBandwidthNum: string;
+  activeAccountFee: string;
+  purchaseTRXFee: string;
+  purchaseBandwidthFee: string;
+  purchaseEnergyFee: string;
+};
+
+/**
+ * Unsigned Tron transaction handed back by `addTronRentRecord`. It is the payment
+ * the buyer must sign (but NOT broadcast) and return via `uploadHash`; Tronify
+ * broadcasts it and delegates the energy.
+ */
+export type TronifyUnsignedTransaction = {
+  visible: boolean;
+  txID: string;
+  raw_data: Record<string, unknown>;
+  raw_data_hex: string;
+};
+
+export type TronifySignedTransaction = TronifyUnsignedTransaction & {
+  signature: string[];
+};
+
+export type AddTronRentRecordData = {
+  orderId: string;
+  transaction: TronifyUnsignedTransaction;
+  payCoinCode: string;
+  payCoinAmt: string;
+  purchaseEnergyFee: string;
+  purchaseTRXFee: string;
+  purchaseBandwidthFee: string;
+  activeAccountFee: string;
+};
+
+export type UploadHashRequest = {
+  /** Order id returned by `addTronRentRecord`. */
+  orderId: string;
+  /** `txID` of the payment transaction returned by `addTronRentRecord`. */
+  fromHash: string;
+  /** The signed (not broadcast) payment transaction. */
+  signedData: TronifySignedTransaction;
+};
+
+/** `uploadHash` returns an empty object on success. */
+export type UploadHashData = Record<string, never>;
+
+export type TradesRequest = {
+  /** 0: by time desc, 1: by energy+bandwidth desc, 2: by amount desc, 3: by energy desc. */
+  sort: "0" | "1" | "2" | "3";
+  page: number;
+  pageSize: number;
+};
+
+export type TronifyTradeOrder = {
+  orderId: string;
+  fromAddress: string;
+  pledgeAddress: string;
+  pledgeNum: number;
+  orderPrice: string;
+  orderType: string;
+  pledgeDay: string;
+  createTime: string;
+};
+
+export type TradesData = {
+  data: TronifyTradeOrder[];
+  pagination: TronifyPagination;
+};
+
+export type TronifyPagination = {
+  page: number;
+  pageSize: number;
+  total: number;
+};
+
+/** Lifecycle of a purchase order as reported by `mypayorder`. */
+export type TronifyOrderStatus = "wait_deposit_send" | "wait_sale" | "complete" | "timeout";
+
+export type MyPayOrderRequest = {
+  /** Buyer wallet address whose orders are returned. */
+  fromAddress: string;
+  /**
+   * Order filter — NOT the "ENERGY" order type used elsewhere:
+   * "1" active (wait_deposit_send, wait_sale), "0" completed, any other value returns all.
+   */
+  orderType: string;
+  page: number;
+  pageSize: number;
+};
+
+export type TronifyPurchaseOrder = {
+  orderId: string;
+  fromAddress: string;
+  pledgeAddress: string;
+  pledgeNum: number;
+  salePledgeNum: number;
+  freezePledgeNum: number;
+  leftPledgeNum: number;
+  orderPrice: string;
+  orderType: string;
+  pledgeDay: string;
+  orderStatus: TronifyOrderStatus;
+  createTime: string;
+};
+
+export type MyPayOrderData = {
+  data: TronifyPurchaseOrder[];
+  pagination: TronifyPagination;
+};

--- a/libs/coin-modules/coin-tron/src/network/tronify/types.ts
+++ b/libs/coin-modules/coin-tron/src/network/tronify/types.ts
@@ -21,11 +21,11 @@ export type TronifyEnergyOrderParams = {
   pledgeAddress: string;
   /** Energy units to rent; Tronify minimum is 15000. */
   pledgeNum: number;
-  /** Rental duration — days (0-30). */
+  /** Rental duration — days "0"-"30"; valid under fastTrade alongside the hour/minute windows. */
   pledgeDay: string;
-  /** Rental duration — hours (0, 1, 3 for fastTrade). */
+  /** Rental duration — hours "0" | "1" | "3". */
   pledgeHour: string;
-  /** Rental duration — minutes (0, 10 for fastTrade). */
+  /** Rental duration — minutes "0" | "10". Day, hour and minute may not all be "0". */
   pledgeMinute: string;
   /** Extra TRX to bundle for bandwidth: "0" (none) or a value in [0.8, 500]. */
   extraTrxNum: string;
@@ -96,29 +96,6 @@ export type UploadHashRequest = {
 
 /** `uploadHash` returns an empty object on success. */
 export type UploadHashData = Record<string, never>;
-
-export type TradesRequest = {
-  /** 0: by time desc, 1: by energy+bandwidth desc, 2: by amount desc, 3: by energy desc. */
-  sort: "0" | "1" | "2" | "3";
-  page: number;
-  pageSize: number;
-};
-
-export type TronifyTradeOrder = {
-  orderId: string;
-  fromAddress: string;
-  pledgeAddress: string;
-  pledgeNum: number;
-  orderPrice: string;
-  orderType: string;
-  pledgeDay: string;
-  createTime: string;
-};
-
-export type TradesData = {
-  data: TronifyTradeOrder[];
-  pagination: TronifyPagination;
-};
 
 export type TronifyPagination = {
   page: number;

--- a/libs/coin-modules/coin-tron/src/types/errors.ts
+++ b/libs/coin-modules/coin-tron/src/types/errors.ts
@@ -157,3 +157,22 @@ export class NotEnoughGas extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/** A Tronify REST call returned a non-success `resCode`. Carries the raw code. */
+export class TronifyApiError extends Error {
+  override name = "TronifyApiError";
+  resCode?: number;
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "TronifyApiError");
+    if (fields) Object.assign(this, fields);
+  }
+}
+
+/** An energy-rent operation was requested but no provider is configured in coin-config. */
+export class EnergyRentProviderNotConfigured extends Error {
+  override name = "EnergyRentProviderNotConfigured";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "EnergyRentProviderNotConfigured");
+    if (fields) Object.assign(this, fields);
+  }
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the Tronify energy-rent provider client to `coin-tron` — the first energy provider for TRON gas sponsoring.

- `network/tronify/` — REST client for the Tronify marketplace (`queryPreorderInfo`, `addTronRentRecord`, `uploadHash`, `mypayorder`), `{resCode,resMsg,data}` envelope, non-`100` codes raise `TronifyApiError`.
- `logic/energyRent/` — provider-agnostic `EnergyProvider` interface, the Tronify adapter, and a single-file switch dispatching on the provider named in coin-config.
- `config.ts` — optional `energyRent` settings (`provider`, `url`, `sourceFlag`, `apiKey?`).

Additive and opt-in: the config field is optional and no existing behaviour changes. Fee-option wiring (`listFeeOptions` / `estimateFees`) is out of scope — it follows in LIVE-34996 / LIVE-34999 once [coin-modules#766](https://github.com/LedgerHQ/coin-modules/pull/766) lands.

**Usage**

```ts
import {
  getEnergyRentQuote,
  craftEnergyRentTransaction,
  broadcastEnergyRentTransaction,
  getEnergyRentStatus,
} from "@ledgerhq/coin-tron/logic/index";

const quote = await getEnergyRentQuote({
  payerAddress,
  receiverAddress,
  energy: 32_000n,
  durationSeconds: 600,
});

const order = await craftEnergyRentTransaction({ payerAddress, receiverAddress, energy: 32_000n, durationSeconds: 600 });
// sign order.transaction — do NOT broadcast it; Tronify does
await broadcastEnergyRentTransaction({ orderId: order.orderId, signedTransaction });
await getEnergyRentStatus({ orderId: order.orderId, payerAddress }); // pending | paid | delivered | failed | unknown
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32773](https://ledgerhq.atlassian.net/browse/LIVE-32773?atlOrigin=eyJpIjoiYWRlYWZlMGIxZmE0NDNiNDllNzI4ZTQ4Y2M3M2RjNGQiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-32773]: https://ledgerhq.atlassian.net/browse/LIVE-32773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ