### PR TITLE
fix(zcash): restrict raw source-tx override to V5 (LIVE-35215)

### DIFF
--- a/.changeset/PROD-12599-zcash-v4-source-tx-override.md
+++ b/.changeset/PROD-12599-zcash-v4-source-tx-override.md
@@ -1,0 +1,13 @@
+---
+"@ledgerhq/live-signer-zcash": patch
+---
+
+Fix Zcash sends failing before the device prompt when the coin being spent came from a V4-format transaction (PROD-12599).
+
+Signing a transparent Zcash transaction whose input came from a V4 (Sapling-format) transaction failed immediately: no review screen appeared on the device, and Ledger Live showed "Something went wrong" with no detail. V4 is still valid on mainnet and still emitted by exchanges and older wallets, while Ledger Live itself emits V5 — so an account funded from within Ledger Live never hit this, which is why the failure looked intermittent. It is in fact deterministic, decided by which software created the funding transaction.
+
+`serializedPreviousTransactionOverride` carries the source transaction's raw on-chain bytes so the device can compute the correct ZIP-244 txid for a V5 transaction, whose Orchard bundle the signer kit's serialization would otherwise strip. It was being set for every version. The kit chunks a V4 transaction expecting Ledger's internal serialization, whose header carries a consensus branch id absent from the on-chain bytes; given those bytes it read the input count four bytes late and threw while chunking that input. The override is now restricted to the versions that need it, and a V4 source transaction goes back through the serialization path that has always handled it, its Sapling fields travelling in `extraData` as before.
+
+The decision is made per input, which is what a send spending several coins looks like from the outside: the V5 inputs are chunked and their trusted inputs obtained from the device first, then the transaction dies when the V4 input's turn comes. The device has already answered several times by then, yet no review screen is ever reached — so the failure looks like a device problem rather than a serialization one.
+
+Untagged device action errors are also no longer flattened into a message-less `Error`, so a failure inside a device action task names itself in the logs instead of surfacing only as "Something went wrong".

--- a/libs/live-signer-zcash/package.json
+++ b/libs/live-signer-zcash/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ledgerhq/device-management-kit": "catalog:",
-    "@ledgerhq/device-signer-kit-zcash": "0.4.3",
+    "@ledgerhq/device-signer-kit-zcash": "0.5.0",
     "rxjs": "catalog:"
   },
   "devDependencies": {

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -40,6 +40,26 @@ type ZcashGetFullViewingKeyResult = {
   fullViewingKey: string | Uint8Array;
 };
 
+/** Mask clearing ZIP-202's fOverwintered bit, leaving the transaction version. */
+const OVERWINTERED_FLAG_MASK = 0x7fffffff;
+
+/** First version whose shielded bundles live outside `extraData` (NU5 / V5). */
+const FIRST_BUNDLE_CARRYING_VERSION = 5;
+
+function transactionVersion(version: Uint8Array): number {
+  if (version.length < 4) return 0;
+  const view = new DataView(version.buffer, version.byteOffset, version.byteLength);
+  return view.getUint32(0, true) & OVERWINTERED_FLAG_MASK;
+}
+
+function safeDescribe(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export class DmkSignerZcash implements ZcashSigner {
   private readonly signer: SignerZcash;
 
@@ -48,10 +68,19 @@ export class DmkSignerZcash implements ZcashSigner {
   }
 
   private mapError<E extends { _tag: string }>(error: E): Error {
-    if ("errorCode" in error && (error as { errorCode?: unknown }).errorCode === "6985") {
+    // A task can also reject with an untagged value, down to a primitive, so
+    // nothing here may assume an object shape (LIVE-35215).
+    const details: { errorCode?: unknown; _tag?: unknown } =
+      typeof error === "object" && error !== null ? error : {};
+
+    if (details.errorCode === "6985") {
       return new UserRefusedOnDevice();
     }
-    return new Error(error._tag);
+    if (typeof details._tag === "string" && details._tag.length > 0) {
+      return new Error(details._tag);
+    }
+    if (error instanceof Error) return error;
+    return new Error(`Untagged device action error: ${safeDescribe(error)}`);
   }
 
   private mapResult<T, E extends { _tag: string }>(state: DeviceActionState<T, E, unknown>): T {
@@ -147,16 +176,17 @@ export class DmkSignerZcash implements ZcashSigner {
   }
 
   private toLegacyTransaction(tx: SignerTransactionLike): LegacyTransaction {
-    // When the source transaction carries a shielded bundle (e.g. an Orchard
-    // bundle in a V5 tx), serializeTransaction strips it and emits zeroed
-    // routing-count bytes instead. The device then computes the ZIP-244 txid of
-    // those truncated bytes — not the original txid — and the resulting trusted
-    // input references a txid that does not exist on-chain, causing "Missing
-    // inputs" on broadcast. Passing the full raw bytes via
-    // serializedPreviousTransactionOverride lets the device hash the original
-    // transaction and produce the correct txid.
+    // A V5+ source can carry a shielded bundle that serializeTransaction strips,
+    // leaving the device to hash truncated bytes and derive a txid absent from
+    // the chain; the raw bytes let it hash the original. The override must stay
+    // scoped to V5+ because the signer kit splits raw bytes on the V5 header
+    // layout: a V4 header is shorter, so the input count is read at the wrong
+    // offset. V4 keeps the serialized-fields path (LIVE-35215).
+    const carriesShieldedBundle = transactionVersion(tx.version) >= FIRST_BUNDLE_CARRYING_VERSION;
     const serializedPreviousTransactionOverride =
-      tx.rawTxHex !== undefined ? Buffer.from(tx.rawTxHex, "hex") : undefined;
+      carriesShieldedBundle && tx.rawTxHex !== undefined
+        ? Buffer.from(tx.rawTxHex, "hex")
+        : undefined;
     return {
       version: tx.version,
       inputs: tx.inputs.map(input => ({

--- a/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
+++ b/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@ledgerhq/device-management-kit";
 import { SignerZcashBuilder } from "@ledgerhq/device-signer-kit-zcash";
 import { DmkSignerZcash } from "../src/DmkSignerZcash";
-import type { PcztTransaction } from "../src/types";
+import type { PcztTransaction, SignerTransactionLike } from "../src/types";
 
 jest.mock("@ledgerhq/device-signer-kit-zcash", () => ({
   SignerZcashBuilder: jest.fn(),
@@ -131,7 +131,10 @@ describe("DmkSignerZcash", () => {
 
     it("rejects with UserRefusedOnDevice (drives the 'Action rejected' UI) on the 6985 status word", async () => {
       mockSignerZcash.getAddress.mockReturnValue({
-        observable: createErrorStatusObservable({ _tag: "ZcashAppCommandError", errorCode: "6985" }),
+        observable: createErrorStatusObservable({
+          _tag: "ZcashAppCommandError",
+          errorCode: "6985",
+        }),
       });
 
       await expect(signer.getAddress("44'/133'/0'/0/0")).rejects.toMatchObject({
@@ -446,6 +449,88 @@ describe("DmkSignerZcash", () => {
       const legacyPrev = legacyArg.inputs[0][0];
       expect(legacyPrev.serializedPreviousTransactionOverride).toBeUndefined();
     });
+
+    const overrideOf = async (tx: SignerTransactionLike) => {
+      mockSignerZcash.signTransaction.mockReturnValue({
+        observable: createCompletedObservable("00signed"),
+      });
+
+      await signer.createPaymentTransaction({
+        ...baseArg,
+        inputs: [[tx, 0, null, 0xfffffffd, 2_000_000]] as Parameters<
+          typeof signer.createPaymentTransaction
+        >[0]["inputs"],
+      });
+
+      const [legacyArg] = mockSignerZcash.signTransaction.mock.calls[0];
+      return legacyArg.inputs[0][0].serializedPreviousTransactionOverride;
+    };
+
+    it("omits the override for a V4 source transaction even when rawTxHex is available", async () => {
+      // LIVE-35215: the V5 header layout the kit assumes would misplace the
+      // input count of a V4 source and throw before any APDU is sent.
+      const v4Prev = {
+        ...prevTx,
+        version: Buffer.from([0x04, 0x00, 0x00, 0x80]),
+        rawTxHex: "0400008085202f89" + "ab".repeat(59),
+      };
+
+      await expect(overrideOf(v4Prev)).resolves.toBeUndefined();
+    });
+
+    it("keeps the override for a V5 source transaction", async () => {
+      const v5Prev = { ...prevTx, rawTxHex: "0500008001" + "ab".repeat(59) };
+
+      await expect(overrideOf(v5Prev)).resolves.toBeInstanceOf(Uint8Array);
+    });
+
+    it("decides the override per input, so a V4 source among V5 ones is the only one skipped", async () => {
+      // The mix reported in LIVE-35215: two V5-funded inputs, then a V4 one.
+      const firstV5 = { ...prevTx, rawTxHex: "0500008001" + "ab".repeat(59) };
+      const secondV5 = { ...prevTx, rawTxHex: "0500008001" + "cd".repeat(59) };
+      const v4 = {
+        ...prevTx,
+        version: Buffer.from([0x04, 0x00, 0x00, 0x80]),
+        nVersionGroupId: Buffer.from([0x85, 0x20, 0x2f, 0x89]),
+        rawTxHex: "0400008085202f89" + "ef".repeat(59),
+      };
+
+      mockSignerZcash.signTransaction.mockReturnValue({
+        observable: createCompletedObservable("00signed"),
+      });
+
+      await signer.createPaymentTransaction({
+        ...baseArg,
+        inputs: [
+          [firstV5, 0, null, 0xfffffffd, 2_000_000],
+          [secondV5, 1, null, 0xfffffffd, 2_000_001],
+          [v4, 0, null, 0xfffffffd, 2_000_002],
+        ] as Parameters<typeof signer.createPaymentTransaction>[0]["inputs"],
+        associatedKeysets: ["44'/133'/0'/0/0", "44'/133'/0'/0/1", "44'/133'/0'/0/2"],
+      });
+
+      const [legacyArg] = mockSignerZcash.signTransaction.mock.calls[0];
+      const overrides = legacyArg.inputs.map(
+        ([tx]: [{ serializedPreviousTransactionOverride?: Uint8Array }]) =>
+          tx.serializedPreviousTransactionOverride,
+      );
+
+      expect(overrides[0]).toBeInstanceOf(Uint8Array);
+      expect(overrides[1]).toBeInstanceOf(Uint8Array);
+      expect(overrides[2]).toBeUndefined();
+    });
+
+    it("omits the override when the version field is too short to be read", async () => {
+      // Defensive: a truncated version cannot be proven to be bundle-carrying,
+      // so fall back to the path that works for every version.
+      const shortVersion = {
+        ...prevTx,
+        version: Buffer.from([0x05, 0x00]),
+        rawTxHex: "0500008001" + "ab".repeat(59),
+      };
+
+      await expect(overrideOf(shortVersion)).resolves.toBeUndefined();
+    });
   });
 
   describe("signPcztTransaction", () => {
@@ -554,6 +639,52 @@ describe("DmkSignerZcash", () => {
         "Unexpected device action status: stopped",
       );
     });
+  });
+
+  describe("device action error mapping", () => {
+    // LIVE-35215: an untagged task failure used to become `new Error(undefined)`,
+    // reaching users and support logs as a message-less "Something went wrong".
+    const untaggedErrorObservable = (error: unknown) =>
+      of({ status: DeviceActionStatus.Error, error }) as ReturnType<
+        typeof createErrorStatusObservable
+      >;
+
+    it("preserves the message of an untagged Error thrown inside a task", async () => {
+      mockSignerZcash.getAddress.mockReturnValue({
+        observable: untaggedErrorObservable(
+          new RangeError("Offset is outside the bounds of the DataView"),
+        ),
+      });
+
+      await expect(signer.getAddress("44'/133'/0'/0/0")).rejects.toThrow(
+        "Offset is outside the bounds of the DataView",
+      );
+    });
+
+    it("describes an untagged non-Error rejection instead of yielding an empty message", async () => {
+      mockSignerZcash.getAddress.mockReturnValue({
+        observable: untaggedErrorObservable({ reason: "split failed" }),
+      });
+
+      await expect(signer.getAddress("44'/133'/0'/0/0")).rejects.toThrow(
+        'Untagged device action error: {"reason":"split failed"}',
+      );
+    });
+
+    it.each([
+      ["a string", "split failed", 'Untagged device action error: "split failed"'],
+      ["null", null, "Untagged device action error: null"],
+      ["undefined", undefined, "Untagged device action error: undefined"],
+    ])(
+      "describes %s rejection rather than throwing while inspecting it",
+      async (_label, rejection, expected) => {
+        mockSignerZcash.getAddress.mockReturnValue({
+          observable: untaggedErrorObservable(rejection),
+        });
+
+        await expect(signer.getAddress("44'/133'/0'/0/0")).rejects.toThrow(expected);
+      },
+    );
   });
 
   describe("not implemented methods", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12800,8 +12800,8 @@ importers:
         specifier: 'catalog:'
         version: 1.7.1(rxjs@7.8.2)
       '@ledgerhq/device-signer-kit-zcash':
-        specifier: 0.4.3
-        version: 0.4.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
+        specifier: 0.5.0
+        version: 0.5.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -18831,8 +18831,8 @@ packages:
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.1
 
-  '@ledgerhq/device-signer-kit-zcash@0.4.3':
-    resolution: {integrity: sha512-l7VMVCzvaMX+YRSb2F26ffyqOAr4yDKmZttRMmAtVybKEk+cI4pNIkkse6SodpRVmcrxkd7vAUtFjDNW2Cin7Q==}
+  '@ledgerhq/device-signer-kit-zcash@0.5.0':
+    resolution: {integrity: sha512-Vsdf9X6zYsSNJXiEvyXdamH30htuIVYpJv46RApU5Xj9WCTqn6UWPxyWMqAIQQQu8/qEItyDGklILC+trJ7lxg==}
     peerDependencies:
       '@ledgerhq/device-management-kit': ^1.7.1
 
@@ -47084,7 +47084,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@ledgerhq/device-signer-kit-zcash@0.4.3(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
+  '@ledgerhq/device-signer-kit-zcash@0.5.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))':
     dependencies:
       '@ledgerhq/device-management-kit': 1.7.1(rxjs@7.8.2)
       '@ledgerhq/signer-utils': 1.3.0(@ledgerhq/device-management-kit@1.7.1(rxjs@7.8.2))


### PR DESCRIPTION
### 📝 Description

Signing a Zcash transparent transaction failed with "Something went wrong", no prompt ever reaching the device, whenever one of the selected UTXOs came from a V4 transaction. Reported in production as PROD-12599 and reproduced on `develop`.

**Previous behaviour:** `DmkSignerZcash` hands the raw source-transaction bytes to the signer kit through `serializedPreviousTransactionOverride`. That override exists for V5 sources, whose Orchard bundle the kit's own serialization strips — which would make the device commit to a wrong ZIP-244 txid. It was applied to every version, but the kit chunks those bytes expecting Ledger's internal serialization, whose V4 header carries a consensus branch id that the on-chain bytes do not have. It therefore read the input count four bytes late and threw while chunking that input, so the transaction died mid-flight, after any earlier V5 inputs had already been streamed. `mapError` then flattened the untagged error into a message-less `Error`, which is why the UI could only report "Something went wrong".

**Fix:** the override is now restricted to the versions that can carry a shielded bundle, V5 and above. A V4 source transaction goes back through the serialization path that has always handled it, its Sapling fields travelling in `extraData`. Untagged device-action errors keep their context instead of being flattened, so a failure inside a task names itself in the logs.

**Regression cover:** unit tests assert that the override is applied for V5, omitted for V4, and omitted when the version field is too short to read; a multi-input case mirrors the reported logs, with two V5 sources and one V4 among them, the V4 being the only one skipping the override. The error-mapping fallbacks are covered as well.

Verified on device: the account that reproduced the failure now signs.

This is one half of the Zcash signing problem. The other half — the device computing a wrong txid for a V5 source carrying an Orchard bundle, which surfaced as a 504 on broadcast — is fixed device-side in LedgerHQ/device-sdk-ts#1702 and will reach this repo through a `@ledgerhq/device-signer-kit-zcash` bump.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35215](https://ledgerhq.atlassian.net/browse/LIVE-35215), reported in production as [PROD-12599](https://ledgerhq.atlassian.net/browse/PROD-12599)
- **Related**: LedgerHQ/device-sdk-ts#1702 — device-side txid fix ([LIVE-35258](https://ledgerhq.atlassian.net/browse/LIVE-35258))


[PROD-12599]: https://ledgerhq.atlassian.net/browse/PROD-12599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[LIVE-35215]: https://ledgerhq.atlassian.net/browse/LIVE-35215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ