### PR TITLE
[LWDM] feat(coin-tester): add the NEAR coin-tester

### DIFF
--- a/.changeset/near-coin-tester.md
+++ b/.changeset/near-coin-tester.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-tester-near": minor
+"@ledgerhq/live-common": minor
+---
+
+Add the NEAR coin-tester

--- a/.github/workflows/test-coin-tester.yml
+++ b/.github/workflows/test-coin-tester.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 env:
-  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano vechain"
+  COIN_TESTER_CURRENCIES: "evm polkadot solana bitcoin tezos tron xrp stellar multiversx cosmos cardano vechain near"
 
 jobs:
   is-affected:

--- a/libs/coin-modules/coin-near/src/logic/fees.ts
+++ b/libs/coin-modules/coin-near/src/logic/fees.ts
@@ -32,16 +32,18 @@ export const computeFees = ({
   let sendFee = costs.transferCostSend.plus(costs.receiptCreationSend);
   let executionFee = costs.transferCostExecution.plus(costs.receiptCreationExecution);
 
+  // nearcore floors the execution gas price only for the CreateAccount+AddKey receipt a new
+  // implicit account triggers, not a plain transfer (confirmed via near-sandbox: flooring it
+  // there overestimated the fee ~5.5x).
+  let executionGasPrice = gasPrice;
+
   if (isImplicitAccount(recipient)) {
     sendFee = sendFee.plus(costs.createAccountCostSend).plus(costs.addKeyCostSend);
     executionFee = executionFee
       .plus(costs.createAccountCostExecution)
       .plus(costs.addKeyCostExecution);
+    executionGasPrice = BigNumber.max(gasPrice, costs.minGasPurchasePrice);
   }
-
-  // nearcore floors the gas price on the execution half only (runtime/runtime/src/config.rs) —
-  // the send half is always priced at the raw gas price.
-  const executionGasPrice = BigNumber.max(gasPrice, costs.minGasPurchasePrice);
 
   return sendFee.multipliedBy(gasPrice).plus(executionFee.multipliedBy(executionGasPrice));
 };

--- a/libs/coin-modules/coin-near/src/logic/tests/fees.test.ts
+++ b/libs/coin-modules/coin-near/src/logic/tests/fees.test.ts
@@ -29,7 +29,6 @@ describe("computeFees", () => {
       costs,
     });
 
-    // (100 + 10 + 200 + 20) * gasPrice
     expect(fees.toFixed()).toBe(new BigNumber(330).multipliedBy(GAS_PRICE).toFixed());
   });
 
@@ -41,7 +40,6 @@ describe("computeFees", () => {
       costs,
     });
 
-    // 330 + createAccount (1000 + 2000) + addKey (500 + 700)
     expect(fees.toFixed()).toBe(new BigNumber(4530).multipliedBy(GAS_PRICE).toFixed());
   });
 
@@ -53,8 +51,6 @@ describe("computeFees", () => {
       costs,
     });
 
-    // (5 * base + base buffer) * gasPrice — the full prepaid gas, not a fraction of it: the
-    // runtime locks the whole amount at conversion time and refunds the unburnt part on-chain.
     const expected = new BigNumber(STAKING_GAS_BASE).multipliedBy(6).multipliedBy(GAS_PRICE);
     expect(fees.toFixed()).toBe(expected.toFixed());
   });
@@ -68,12 +64,28 @@ describe("computeFees", () => {
       costs,
     });
 
-    // (7 * base + base buffer) * gasPrice
     const expected = new BigNumber(STAKING_GAS_BASE).multipliedBy(8).multipliedBy(GAS_PRICE);
     expect(fees.toFixed()).toBe(expected.toFixed());
   });
 
-  it("floors the execution-half gas price at minGasPurchasePrice", () => {
+  it("floors the execution-half gas price at minGasPurchasePrice for a new implicit account", () => {
+    const floorPrice = GAS_PRICE.multipliedBy(5);
+    const highFloor: NearFeeCosts = { ...costs, minGasPurchasePrice: floorPrice };
+
+    const fees = computeFees({
+      mode: "send",
+      recipient: IMPLICIT_RECIPIENT,
+      gasPrice: GAS_PRICE,
+      costs: highFloor,
+    });
+
+    const expected = new BigNumber(1610)
+      .multipliedBy(GAS_PRICE)
+      .plus(new BigNumber(2920).multipliedBy(floorPrice));
+    expect(fees.toFixed()).toBe(expected.toFixed());
+  });
+
+  it("does not floor a transfer to an already-existing named account", () => {
     const floorPrice = GAS_PRICE.multipliedBy(5);
     const highFloor: NearFeeCosts = { ...costs, minGasPurchasePrice: floorPrice };
 
@@ -84,11 +96,7 @@ describe("computeFees", () => {
       costs: highFloor,
     });
 
-    // send half (110) at the raw gasPrice, execution half (220) at the floored price
-    const expected = new BigNumber(110)
-      .multipliedBy(GAS_PRICE)
-      .plus(new BigNumber(220).multipliedBy(floorPrice));
-    expect(fees.toFixed()).toBe(expected.toFixed());
+    expect(fees.toFixed()).toBe(new BigNumber(330).multipliedBy(GAS_PRICE).toFixed());
   });
 
   it("does not treat a staking recipient as an implicit account", () => {

--- a/libs/coin-tester-modules/coin-tester-near/.gitignore
+++ b/libs/coin-tester-modules/coin-tester-near/.gitignore
@@ -1,0 +1,2 @@
+# staking-pool wasm, downloaded on first run
+.cache/

--- a/libs/coin-tester-modules/coin-tester-near/CHANGELOG.md
+++ b/libs/coin-tester-modules/coin-tester-near/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @ledgerhq/coin-tester-near

--- a/libs/coin-tester-modules/coin-tester-near/README.md
+++ b/libs/coin-tester-modules/coin-tester-near/README.md
@@ -1,0 +1,53 @@
+# @ledgerhq/coin-tester-near
+
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
+Deterministic integration tester for the NEAR family. Starts a local `near-sandbox` node and runs
+one scenario through both the legacy account bridge and the generic coin-framework bridge
+(Alpaca/`CoinModuleApi`), so the two are compared against each other on every run.
+
+## Run
+
+```sh
+pnpm coin:tester:near start
+```
+
+No Docker required: `near-sandbox` downloads a native binary for the host platform on first run
+(Darwin arm64 and Linux x86_64 are both published). The coin module must be built first
+(`pnpm --filter @ledgerhq/coin-near build`).
+
+## Coverage
+
+- transfers to an existing named account and to a fresh implicit account
+- staking: delegate, undelegate, and withdraw after the unlock period
+- the account's balance breakdown and operation history after each transaction
+
+## How it works
+
+**Node.** `near-sandbox` is a build of `neard` carrying the `sandbox` feature, which adds the
+`sandbox_fast_forward` RPC. Genesis is left untouched — shrinking `epoch_length` to speed up the
+staking unlock stops the node from ever becoming ready, so block height is advanced explicitly
+instead.
+
+The node sometimes keeps a socket open and never completes its shutdown, which holds the event loop
+open long after the assertions are done. Teardown is therefore bounded by a timeout, and the run uses
+`--forceExit`, as the polkadot and stellar testers do for the same reason. `near-sandbox` exposes no
+handle on the process, so there is nothing to kill directly; the RPC port is picked per run, so a
+leftover node never collides with the next one.
+
+**Staking pool.** NEAR staking runs through a contract rather than the protocol, so the scenario
+deploys `staking_pool.wasm` from `near/core-contracts` and delegates to it. The download is pinned to
+a commit and checked against its sha256, so neither upstream nor a stale cache can swap the contract
+out from under the run. The pool logs a
+`minimum_stake` failure once per epoch because it also tries to become a protocol validator with far
+less than the seat price; that is expected and does not affect delegation.
+
+**Indexer.** The coin module reads its history, gas price, staking deposits and validator list from
+an indexer that no local node provides, so those four endpoints are served by an `msw` stub built
+from the sandbox's own state. `/v3/stats` is stubbed too, despite `getGasPrice` having a node-RPC
+fallback: that fallback only covers a response without a `gas_price`, not a request that throws, and
+an unstubbed host fails DNS resolution long before it is reached.
+
+**Signing.** The local signer signs `sha256` of the Borsh-serialized transaction, which is what the
+device app does. Signing the raw payload produces a signature the network rejects at broadcast.

--- a/libs/coin-tester-modules/coin-tester-near/jest.config.ts
+++ b/libs/coin-tester-modules/coin-tester-near/jest.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from "jest";
+
+const esmDeps = ["ky"];
+
+const config: Config = {
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["@ledgerhq/wallet-framework-test-setup"],
+  transform: {
+    "^.+\\.(t|j)sx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+    [`node_modules[\\\\|/].pnpm[\\\\|/](${esmDeps.join("|")}).+\\.(js|jsx|mjs)$`]: [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "esnext",
+        },
+      },
+    ],
+  },
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  transformIgnorePatterns: [`node_modules/.pnpm/(?!(${esmDeps.join("|")}))`],
+  reporters: ["default", ...(process.env.CI ? ["github-actions"] : [])],
+};
+
+export default config;

--- a/libs/coin-tester-modules/coin-tester-near/package.json
+++ b/libs/coin-tester-modules/coin-tester-near/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@ledgerhq/coin-tester-near",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Ledger NEAR Coin Tester",
+  "main": "src/scenarii.test.ts",
+  "keywords": [
+    "Ledger",
+    "LedgerWallet",
+    "NEAR",
+    "Testing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LedgerHQ/ledger-live.git"
+  },
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/ledger-live/issues"
+  },
+  "homepage": "https://github.com/LedgerHQ/ledger-live/tree/develop/libs/coin-tester-modules/coin-tester-near",
+  "typesVersions": {
+    "*": {
+      "lib/*": [
+        "lib/*"
+      ],
+      "lib-es/*": [
+        "lib-es/*"
+      ],
+      "*": [
+        "lib/*"
+      ]
+    }
+  },
+  "exports": {
+    "./scenarii/near": {
+      "@ledgerhq/source": "./src/scenarii/near.ts",
+      "require": "./lib/scenarii/near.js",
+      "default": "./lib-es/scenarii/near.js"
+    },
+    "./lib/*": "./lib/*.js",
+    "./lib-es/*": "./lib-es/*.js",
+    "./package.json": "./package.json"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "clean": "rimraf lib lib-es",
+    "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "prewatch": "pnpm build",
+    "watch": "tsc --watch --project tsconfig.build.json",
+    "watch:es": "tsc --watch --project tsconfig.build.json -m esnext --moduleResolution bundler --outDir lib-es",
+    "lint": "oxlint src",
+    "lint:fix": "oxfmt src && oxlint src --fix --quiet",
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
+    "typecheck": "tsc --noEmit --customConditions node",
+    "start": "pnpm jest --runTestsByPath src/*.test.ts --runInBand --forceExit",
+    "unimported": "pnpm knip --directory ../../.. -W libs/coin-tester-modules/coin-tester-near"
+  },
+  "dependencies": {
+    "@ledgerhq/coin-near": "workspace:^",
+    "@ledgerhq/coin-tester": "workspace:^",
+    "@ledgerhq/ledger-wallet-framework": "workspace:^",
+    "@ledgerhq/live-common": "workspace:^",
+    "@ledgerhq/live-config": "workspace:^",
+    "@ledgerhq/types-live": "workspace:^",
+    "bignumber.js": "^9",
+    "msw": "catalog:",
+    "near-api-js": "^3.0.2",
+    "near-sandbox": "^0.3.2"
+  },
+  "devDependencies": {
+    "@ledgerhq/wallet-framework-test-setup": "workspace:^",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "rimraf": "^5",
+    "typescript": "catalog:"
+  }
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/fixtures.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/fixtures.ts
@@ -1,0 +1,88 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { decodeAccountId } from "@ledgerhq/ledger-wallet-framework/account";
+import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
+import {
+  getDerivationScheme,
+  runDerivationScheme,
+} from "@ledgerhq/ledger-wallet-framework/derivation";
+import { DEFAULT_ACCOUNT_ID } from "near-sandbox";
+
+export const NETWORK_ID = "sandbox";
+
+/** Every account the scenario touches is a subaccount of the genesis account. */
+export const SENDER_ID = `sender.${DEFAULT_ACCOUNT_ID}`;
+export const NAMED_RECIPIENT_ID = `recipient.${DEFAULT_ACCOUNT_ID}`;
+export const POOL_ID = `pool.${DEFAULT_ACCOUNT_ID}`;
+
+/**
+ * A 64-character hex address. NEAR creates such an account implicitly on first transfer, which is
+ * the branch that costs more than a transfer to an existing account.
+ */
+export const IMPLICIT_RECIPIENT_ID =
+  "4e7de0a21d8a20f970c86b6edf407906d7ba9e205979c3268270eef80a286e2d";
+
+export const NEAR = 10n ** 24n;
+
+export const SENDER_BALANCE = 200n * NEAR;
+export const RECIPIENT_BALANCE = 10n * NEAR;
+export const POOL_BALANCE = 50n * NEAR;
+
+/** Base URL the coin config points at; msw intercepts it, nothing listens on it. */
+export const INDEXER_URL = "http://indexer.coin-tester-near.local";
+
+/** Four epochs of 500 blocks, the pool's `NUM_EPOCHS_TO_UNLOCK`, plus a margin. */
+export const EPOCHS_TO_UNLOCK_BLOCKS = 2500;
+
+export const coinConfig = (rpcUrl: string) => () => ({
+  status: { type: "active" as const },
+  infra: {
+    API_NEAR_PRIVATE_NODE: rpcUrl,
+    API_NEAR_PUBLIC_NODE: rpcUrl,
+    API_NEAR_INDEXER: INDEXER_URL,
+    API_NEARBLOCKS_INDEXER: INDEXER_URL,
+  },
+});
+
+export const NEAR_CURRENCY = getCryptoCurrencyById("near");
+
+/** The account the scenario starts from, before the first sync fills it in. */
+export const makeAccount = (address: string): Account => {
+  const id = `js:2:${NEAR_CURRENCY.id}:${address}:`;
+  const { derivationMode, xpubOrAddress } = decodeAccountId(id);
+  const scheme = getDerivationScheme({ derivationMode, currency: NEAR_CURRENCY });
+  const index = 0;
+
+  return {
+    type: "Account",
+    id,
+    xpub: xpubOrAddress,
+    subAccounts: [],
+    seedIdentifier: xpubOrAddress,
+    used: true,
+    swapHistory: [],
+    derivationMode,
+    currency: NEAR_CURRENCY,
+    index,
+    nfts: [],
+    freshAddress: xpubOrAddress,
+    freshAddressPath: runDerivationScheme(scheme, NEAR_CURRENCY, {
+      account: index,
+      node: 0,
+      address: 0,
+    }),
+    creationDate: new Date(),
+    lastSyncDate: new Date(0),
+    blockHeight: 0,
+    balance: new BigNumber(0),
+    spendableBalance: new BigNumber(0),
+    operationsCount: 0,
+    operations: [],
+    pendingOperations: [],
+    balanceHistoryCache: {
+      HOUR: { latestDate: null, balances: [] },
+      DAY: { latestDate: null, balances: [] },
+      WEEK: { latestDate: null, balances: [] },
+    },
+  } as unknown as Account;
+};

--- a/libs/coin-tester-modules/coin-tester-near/src/helpers.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/helpers.ts
@@ -1,0 +1,145 @@
+import BigNumber from "bignumber.js";
+import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
+import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getAddressWrapper";
+import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
+import { createBridges } from "@ledgerhq/coin-near/bridge/js";
+import nearResolver from "@ledgerhq/coin-near/hw-getAddress";
+import type { NearSigner } from "@ledgerhq/coin-near/signer";
+import type { NearAccount, Transaction } from "@ledgerhq/coin-near/types";
+import { getCoinFrameworkAccountBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/accountBridge";
+import { getCoinFrameworkCurrencyBridge } from "@ledgerhq/live-common/bridge/generic-coin-framework/currencyBridge";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import { coinModuleLoaders } from "@ledgerhq/live-common/coin-modules/loaders";
+import { registerCoinModules } from "@ledgerhq/live-common/coin-modules/registry";
+import type { BridgeStrategy } from "@ledgerhq/coin-tester/types";
+import { coinConfig } from "./fixtures";
+import type { FrameworkNearSigner, Signers } from "./signer";
+
+registerCoinModules(coinModuleLoaders);
+
+function genericToTransaction(tx: GenericTransaction): Transaction {
+  return {
+    family: "near",
+    mode: tx.mode ?? "send",
+    amount: tx.amount ?? new BigNumber(0),
+    recipient: tx.recipient ?? "",
+    useAllAmount: tx.useAllAmount ?? false,
+  } as Transaction;
+}
+
+// Adapts the legacy bridge to `GenericTransaction`; the prepared legacy tx is kept aside (keyed by
+// the generic one) so status/sign/broadcast reuse the exact object prepareTransaction produced.
+function adaptLegacyBridge(
+  bridge: AccountBridge<Transaction, NearAccount>,
+): AccountBridge<GenericTransaction> {
+  const prepared = new WeakMap<GenericTransaction, Transaction>();
+
+  const requirePrepared = (tx: GenericTransaction): Transaction => {
+    const found = prepared.get(tx);
+    if (!found) {
+      throw new Error(
+        "coin-tester-near: no prepared legacy transaction for this generic transaction — " +
+          "the reference from prepareTransaction was lost before status/sign",
+      );
+    }
+    return found;
+  };
+
+  // Same runtime object, different declared type (NearAccount vs generic Account) — asserted, not restructured.
+  const adapted = {
+    sync: bridge.sync,
+    receive: bridge.receive,
+    broadcast: bridge.broadcast,
+    validateAddress: bridge.validateAddress,
+    signRawOperation: bridge.signRawOperation,
+    getSerializedAddressParameters: bridge.getSerializedAddressParameters,
+    createTransaction: (): GenericTransaction =>
+      ({
+        family: "near",
+        mode: "send",
+        amount: new BigNumber(0),
+        recipient: "",
+        useAllAmount: false,
+      }) as unknown as GenericTransaction,
+    updateTransaction: (tx: GenericTransaction, patch: Partial<GenericTransaction>) => ({
+      ...tx,
+      ...patch,
+    }),
+    prepareTransaction: async (account: Account, tx: GenericTransaction) => {
+      const legacy = await bridge.prepareTransaction(
+        account as unknown as NearAccount,
+        genericToTransaction(tx),
+      );
+      const result: GenericTransaction = {
+        ...tx,
+        amount: legacy.amount,
+        recipient: legacy.recipient,
+      };
+      prepared.set(result, legacy);
+      return result;
+    },
+    getTransactionStatus: (account: Account, tx: GenericTransaction) =>
+      bridge.getTransactionStatus(account as unknown as NearAccount, requirePrepared(tx)),
+    signOperation: ({
+      account,
+      transaction,
+      deviceId,
+    }: {
+      account: Account;
+      transaction: GenericTransaction;
+      deviceId: string;
+    }) =>
+      bridge.signOperation({
+        account: account as unknown as NearAccount,
+        transaction: requirePrepared(transaction),
+        deviceId,
+      }),
+    estimateMaxSpendable: ({
+      account,
+      parentAccount,
+      transaction,
+    }: {
+      account: Account;
+      parentAccount?: Account | null;
+      transaction?: GenericTransaction | null;
+    }) =>
+      bridge.estimateMaxSpendable({
+        account: account as never,
+        parentAccount: parentAccount as never,
+        transaction: transaction ? genericToTransaction(transaction) : undefined,
+      }),
+  };
+
+  return adapted as unknown as AccountBridge<GenericTransaction>;
+}
+
+export async function getBridges(
+  strategy: BridgeStrategy,
+  signers: Signers,
+  rpcUrl: string,
+): Promise<{
+  currencyBridge: CurrencyBridge;
+  accountBridge: AccountBridge<GenericTransaction>;
+  getAddress: GetAddressFn;
+}> {
+  if (strategy === "legacy") {
+    const context: SignerContext<NearSigner> = (_, fn) => fn(signers.bridge);
+    const { currencyBridge, accountBridge } = createBridges(context, coinConfig(rpcUrl));
+
+    return {
+      currencyBridge,
+      accountBridge: adaptLegacyBridge(accountBridge),
+      getAddress: nearResolver(context),
+    };
+  }
+
+  const context: SignerContext<FrameworkNearSigner> = (_, fn) => fn(signers.coinframework);
+  const getAddress: GetAddressFn = async (deviceId, { path, verify }) =>
+    context(deviceId, signer => signer.getAddress(path, { verify })) as ReturnType<GetAddressFn>;
+
+  return {
+    currencyBridge: await getCoinFrameworkCurrencyBridge("near", "local", { context, getAddress }),
+    accountBridge: await getCoinFrameworkAccountBridge("near", "local", { context, getAddress }),
+    getAddress,
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/indexer.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/indexer.ts
@@ -1,0 +1,205 @@
+import { http, HttpResponse } from "msw";
+import { setupServer, type SetupServerApi } from "msw/node";
+import type { NearTransaction } from "@ledgerhq/coin-near/network/sdk.types";
+import { INDEXER_URL, POOL_ID } from "./fixtures";
+
+// Stubs the indexer (history, staking deposits, validators) from the sandbox's own RPC state,
+// since no local node exposes one. Response envelopes match each endpoint's own parser.
+
+type RpcCall = <T>(method: string, params: unknown) => Promise<T>;
+
+type NearRpcAction = Record<string, unknown> & {
+  Transfer?: { deposit: string };
+  FunctionCall?: { method_name: string; deposit: string };
+};
+
+type NearRpcTxStatus = {
+  transaction: { signer_id: string; receiver_id: string; hash: string; actions: NearRpcAction[] };
+  transaction_outcome: { block_hash: string; outcome: { tokens_burnt: string } };
+  receipts_outcome: { outcome: { tokens_burnt: string } }[];
+  status: Record<string, unknown>;
+};
+
+type NearRpcBlock = {
+  header: { hash: string; height: number; timestamp_nanosec: string };
+};
+
+/** Hashes the scenario has broadcast, oldest first. Fed by the scenario's `mockIndexer` hook. */
+const broadcast: { hash: string; accountId: string }[] = [];
+const resolved = new Map<string, NearTransaction>();
+
+export function recordTransaction(hash: string, accountId: string): void {
+  if (!broadcast.some(entry => entry.hash === hash)) {
+    broadcast.push({ hash, accountId });
+  }
+}
+
+export function resetIndexer(): void {
+  broadcast.length = 0;
+  resolved.clear();
+}
+
+function describeActions(actions: NearRpcAction[]): NearTransaction["actions"] {
+  return actions.map(action => {
+    if (action.Transfer) {
+      return { action: "TRANSFER", method: null };
+    }
+    if (action.FunctionCall) {
+      return { action: "FUNCTION_CALL", method: action.FunctionCall.method_name };
+    }
+    return { action: Object.keys(action)[0]?.toUpperCase() ?? "UNKNOWN", method: null };
+  });
+}
+
+function totalDeposit(actions: NearRpcAction[]): string {
+  const sum = actions.reduce((acc, action) => {
+    if (action.Transfer) {
+      return acc + BigInt(action.Transfer.deposit);
+    }
+    if (action.FunctionCall) {
+      return acc + BigInt(action.FunctionCall.deposit);
+    }
+    return acc;
+  }, 0n);
+
+  return sum.toString();
+}
+
+/** Fee is what the whole transaction burnt, receipts included, matching the real indexer. */
+function totalFee(status: NearRpcTxStatus): string {
+  const receipts = status.receipts_outcome.reduce(
+    (acc, receipt) => acc + BigInt(receipt.outcome.tokens_burnt),
+    0n,
+  );
+
+  return (receipts + BigInt(status.transaction_outcome.outcome.tokens_burnt)).toString();
+}
+
+async function resolveTransaction(
+  rpc: RpcCall,
+  hash: string,
+  accountId: string,
+): Promise<NearTransaction> {
+  const cached = resolved.get(hash);
+  if (cached) {
+    return cached;
+  }
+
+  const status = await rpc<NearRpcTxStatus>("tx", [hash, accountId]);
+  const block = await rpc<NearRpcBlock>("block", {
+    block_id: status.transaction_outcome.block_hash,
+  });
+
+  const transaction: NearTransaction = {
+    signer_account_id: status.transaction.signer_id,
+    receiver_account_id: status.transaction.receiver_id,
+    transaction_hash: hash,
+    block_timestamp: block.header.timestamp_nanosec,
+    outcomes_agg: { transaction_fee: totalFee(status) },
+    outcomes: { status: "SuccessValue" in status.status || "SuccessReceiptId" in status.status },
+    block: {
+      block_hash: block.header.hash,
+      block_height: String(block.header.height),
+      block_timestamp: block.header.timestamp_nanosec,
+    },
+    actions_agg: { deposit: totalDeposit(status.transaction.actions) },
+    actions: describeActions(status.transaction.actions),
+  };
+
+  resolved.set(hash, transaction);
+  return transaction;
+}
+
+async function historyFor(rpc: RpcCall, address: string, limit: number) {
+  const transactions: NearTransaction[] = [];
+
+  // Newest first, matching the indexer's own ordering.
+  for (const entry of [...broadcast].reverse()) {
+    const transaction = await resolveTransaction(rpc, entry.hash, entry.accountId);
+    const involved =
+      transaction.signer_account_id === address || transaction.receiver_account_id === address;
+
+    if (involved) {
+      transactions.push(transaction);
+    }
+    if (transactions.length >= limit) {
+      break;
+    }
+  }
+
+  return transactions;
+}
+
+export function startIndexer(rpc: RpcCall): SetupServerApi {
+  const server = setupServer(
+    http.get(`${INDEXER_URL}/v3/accounts/:address/txns`, async ({ params, request }) => {
+      const limit = Number(new URL(request.url).searchParams.get("limit") ?? 25);
+      const data = await historyFor(rpc, String(params.address), limit);
+      return HttpResponse.json({ data });
+    }),
+
+    // Read as `response.data.gas_price`, so the payload is `{ data: { gas_price } }`.
+    http.get(`${INDEXER_URL}/v3/stats`, async () => {
+      const { gas_price: gasPrice } = await rpc<{ gas_price: string }>("gas_price", [null]);
+      return HttpResponse.json({ data: { gas_price: gasPrice } });
+    }),
+
+    http.get(`${INDEXER_URL}/v3/kitwallet/staking-deposits/:address`, async ({ params }) => {
+      const deposit = await rpc<{ result: number[] }>("query", {
+        request_type: "call_function",
+        finality: "final",
+        account_id: POOL_ID,
+        method_name: "get_account_total_balance",
+        args_base64: Buffer.from(JSON.stringify({ account_id: params.address })).toString("base64"),
+      }).catch(() => undefined);
+
+      if (!deposit) {
+        return HttpResponse.json([]);
+      }
+
+      const total = JSON.parse(Buffer.from(deposit.result).toString()) as string;
+      // `getStakingPositions` maps over the body itself, so this one is not wrapped in `data`.
+      return HttpResponse.json(
+        BigInt(total) > 0n ? [{ deposit: total, validator_id: POOL_ID }] : [],
+      );
+    }),
+
+    // The deployed pool never joins the protocol's validator set — it holds far less than the seat
+    // price — so it is reported here rather than read from the chain.
+    http.get(`${INDEXER_URL}/v3/validators`, async () => {
+      const staked = await rpc<{ result: number[] }>("query", {
+        request_type: "call_function",
+        finality: "final",
+        account_id: POOL_ID,
+        method_name: "get_total_staked_balance",
+        args_base64: Buffer.from("{}").toString("base64"),
+      }).catch(() => undefined);
+
+      const currentEpochStake = staked
+        ? (JSON.parse(Buffer.from(staked.result).toString()) as string)
+        : "0";
+
+      return HttpResponse.json({
+        data: [
+          {
+            account_id: POOL_ID,
+            current_epoch_stake: currentEpochStake,
+            fee_numerator: 10,
+            fee_denominator: 100,
+          },
+        ],
+      });
+    }),
+  );
+
+  server.listen({
+    onUnhandledRequest: request => {
+      const hostname = new URL(request.url).hostname;
+      // Allow requests to the local sandbox node to pass through to the real node.
+      if (["127.0.0.1", "localhost"].includes(hostname)) return;
+      throw new Error(`Unhandled request: ${request.method} ${request.url}`);
+    },
+  });
+
+  return server;
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/sandbox.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/sandbox.ts
@@ -1,0 +1,115 @@
+import { Sandbox, DEFAULT_ACCOUNT_ID, DEFAULT_PRIVATE_KEY } from "near-sandbox";
+import { connect, keyStores, utils, type Account, type Near } from "near-api-js";
+import type { KeyPair } from "near-api-js/lib/utils/key_pair";
+import { createServer } from "node:net";
+import { NETWORK_ID } from "./fixtures";
+
+export type SandboxHandle = {
+  rpcUrl: string;
+  near: Near;
+  keyStore: keyStores.KeyStore;
+  /** Genesis account holding the whole supply; every test account is funded from it. */
+  root: Account;
+  /** Pass a key pair when the signer has to hold the same key as the on-chain account. */
+  createFundedAccount(accountId: string, yocto: bigint, keyPair?: KeyPair): Promise<Account>;
+  /** Skip ahead in block height. The staking pool's unlock is counted in epochs, not wall clock. */
+  fastForward(deltaHeight: number): Promise<void>;
+  rpc<T = unknown>(method: string, params: unknown): Promise<T>;
+  tearDown(): Promise<void>;
+};
+
+// Picked per run so the two strategies don't collide with each other or a leftover node.
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address() as { port: number };
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+export async function startSandbox(): Promise<SandboxHandle> {
+  // Genesis is left alone on purpose: shrinking `epoch_length` to speed the unstake lock up stops
+  // the node from ever becoming ready. `fastForward` covers the same need without touching consensus.
+  const sandbox = await Sandbox.start({ config: { rpcPort: await freePort() } });
+  const { rpcUrl } = sandbox;
+
+  const rpc = async <T>(method: string, params: unknown): Promise<T> => {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: "coin-tester", method, params }),
+    });
+    const body = (await response.json()) as { result?: T; error?: unknown };
+
+    if (body.error) {
+      throw new Error(`near-sandbox ${method}: ${JSON.stringify(body.error)}`);
+    }
+
+    return body.result as T;
+  };
+
+  // A fresh account is visible optimistically before final, but the coin module queries with finality: "final".
+  const waitUntilFinal = async (accountId: string): Promise<void> => {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      try {
+        await rpc("query", {
+          request_type: "view_account",
+          finality: "final",
+          account_id: accountId,
+        });
+        return;
+      } catch {
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+    }
+    throw new Error(`coin-tester-near: ${accountId} never became final`);
+  };
+
+  const keyStore = new keyStores.InMemoryKeyStore();
+  await keyStore.setKey(
+    NETWORK_ID,
+    DEFAULT_ACCOUNT_ID,
+    utils.KeyPair.fromString(DEFAULT_PRIVATE_KEY),
+  );
+
+  const near = await connect({ networkId: NETWORK_ID, nodeUrl: rpcUrl, keyStore });
+  const root = await near.account(DEFAULT_ACCOUNT_ID);
+
+  return {
+    rpcUrl,
+    near,
+    keyStore,
+    root,
+    rpc,
+    async createFundedAccount(accountId, yocto, keyPair) {
+      const key = keyPair ?? utils.KeyPair.fromRandom("ed25519");
+      await keyStore.setKey(NETWORK_ID, accountId, key);
+      await root.createAccount(accountId, key.getPublicKey(), yocto);
+      await waitUntilFinal(accountId);
+      return near.account(accountId);
+    },
+    async fastForward(deltaHeight) {
+      await rpc("sandbox_fast_forward", { delta_height: deltaHeight });
+    },
+    async tearDown() {
+      // The node occasionally keeps a socket open and never resolves; the temp home is disposable,
+      // so a stuck shutdown must not hold the whole suite hostage.
+      let timer: NodeJS.Timeout | undefined;
+      await Promise.race([
+        sandbox.tearDown(),
+        new Promise<void>(resolve => {
+          timer = setTimeout(() => {
+            console.warn("coin-tester-near: sandbox teardown timed out, continuing");
+            resolve();
+          }, 15_000);
+        }),
+      ]);
+      if (timer) {
+        clearTimeout(timer);
+      }
+    },
+  };
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/scenarii.test.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/scenarii.test.ts
@@ -1,0 +1,21 @@
+import { executeScenario } from "@ledgerhq/coin-tester/main";
+import { killSandbox, scenarioNear } from "./scenarii/near";
+
+// Both strategies run the same 6-transaction scenario end to end (sandbox startup, staking pool
+// deploy, epoch fast-forward); the default 5s is nowhere near enough for either.
+jest.setTimeout(20 * 60 * 1000);
+
+["exit", "SIGINT", "SIGQUIT", "SIGTERM", "SIGUSR1", "SIGUSR2", "uncaughtException"].forEach(e =>
+  process.on(e, () => {
+    void killSandbox().catch(() => {});
+  }),
+);
+
+describe.each([["legacy"], ["generic-adapter"]] as const)(
+  "NEAR Deterministic Tester (%s strategy)",
+  strategy => {
+    it("scenario NEAR", async () => {
+      await executeScenario(scenarioNear, strategy);
+    });
+  },
+);

--- a/libs/coin-tester-modules/coin-tester-near/src/scenarii/near.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/scenarii/near.ts
@@ -1,0 +1,204 @@
+import BigNumber from "bignumber.js";
+import type { Account } from "@ledgerhq/types-live";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import type { Scenario, ScenarioTransaction } from "@ledgerhq/coin-tester/main";
+import type { GenericTransaction } from "@ledgerhq/live-common/bridge/generic-coin-framework/types";
+import type { SetupServerApi } from "msw/node";
+import {
+  EPOCHS_TO_UNLOCK_BLOCKS,
+  IMPLICIT_RECIPIENT_ID,
+  NAMED_RECIPIENT_ID,
+  NEAR,
+  POOL_ID,
+  RECIPIENT_BALANCE,
+  SENDER_BALANCE,
+  SENDER_ID,
+  coinConfig,
+  makeAccount,
+} from "../fixtures";
+import { getBridges } from "../helpers";
+import { recordTransaction, resetIndexer, startIndexer } from "../indexer";
+import { startSandbox, type SandboxHandle } from "../sandbox";
+import { buildSigners, randomKeyPair } from "../signer";
+import { deployStakingPool, pingPool } from "../stakingPool";
+
+let sandbox: SandboxHandle | undefined;
+let indexer: SetupServerApi | undefined;
+
+/** Index of the next transaction, so the unstake lock can be skipped before the withdrawal. */
+let step = 0;
+const WITHDRAW_STEP = 4;
+
+const has = (account: Account, type: string): boolean =>
+  account.operations.some(operation => operation.type === type);
+
+const countOf = (account: Account, type: string): number =>
+  account.operations.filter(operation => operation.type === type).length;
+
+const ONE_NEAR = new BigNumber((1n * NEAR).toString());
+const FIVE_NEAR = new BigNumber((5n * NEAR).toString());
+const TEN_NEAR = new BigNumber((10n * NEAR).toString());
+
+type NearScenarioTransaction = ScenarioTransaction<GenericTransaction, Account>;
+
+// Asserted against the balance, not the operation's `value`: the two bridges disagree on whether
+// the fee is inside `value`, but `balance = previous - amount - fee` holds for both.
+function makeTransactions(): NearScenarioTransaction[] {
+  return [
+    {
+      name: "transfer to a named account",
+      mode: "send",
+      recipient: NAMED_RECIPIENT_ID,
+      amount: ONE_NEAR,
+      expect: (previous, current) => {
+        const [latestOp] = current.operations;
+        expect(latestOp.type).toBe("OUT");
+        expect(latestOp.recipients).toContain(NAMED_RECIPIENT_ID);
+        expect(latestOp.fee.gt(0)).toBe(true);
+        expect(current.balance).toEqual(previous.balance.minus(ONE_NEAR).minus(latestOp.fee));
+        expect(countOf(current, "OUT")).toBe(1);
+      },
+    },
+    {
+      name: "transfer to an implicit account that does not exist yet",
+      mode: "send",
+      recipient: IMPLICIT_RECIPIENT_ID,
+      amount: ONE_NEAR,
+      expect: (previous, current) => {
+        const [implicitOp, namedOp] = current.operations;
+        expect(implicitOp.type).toBe("OUT");
+        expect(implicitOp.recipients).toContain(IMPLICIT_RECIPIENT_ID);
+        expect(current.balance).toEqual(previous.balance.minus(ONE_NEAR).minus(implicitOp.fee));
+        // Creating the account and its access key is charged on top of the transfer itself.
+        expect(implicitOp.fee.gt(namedOp.fee)).toBe(true);
+        expect(countOf(current, "OUT")).toBe(2);
+      },
+    },
+    {
+      name: "stake",
+      mode: "stake",
+      recipient: POOL_ID,
+      amount: TEN_NEAR,
+      expect: (previous, current) => {
+        const [latestOp] = current.operations;
+        expect(latestOp.type).toBe("STAKE");
+        expect(latestOp.fee.gt(0)).toBe(true);
+        // The stake leaves the spendable balance but stays in the total, which only pays the fee.
+        expect(current.balance).toStrictEqual(previous.balance.minus(latestOp.fee));
+        expect(current.spendableBalance).toStrictEqual(
+          previous.spendableBalance.minus(TEN_NEAR).minus(latestOp.fee),
+        );
+        expect(current.spendableBalance.lt(current.balance)).toBe(true);
+      },
+    },
+    {
+      name: "unstake",
+      mode: "unstake",
+      recipient: POOL_ID,
+      amount: FIVE_NEAR,
+      expect: (previous, current) => {
+        const [latestOp] = current.operations;
+        expect(latestOp.type).toBe("UNSTAKE");
+        expect(latestOp.fee.gt(0)).toBe(true);
+        // Unstaking moves the principal between pool buckets; only the fee leaves the account.
+        expect(previous.balance.minus(current.balance).lt(ONE_NEAR)).toBe(true);
+      },
+    },
+    {
+      name: "withdraw once the unstake lock has elapsed",
+      mode: "withdraw",
+      recipient: POOL_ID,
+      amount: FIVE_NEAR,
+      expect: (previous, current) => {
+        const [latestOp] = current.operations;
+        expect(latestOp.type).toBe("WITHDRAW_UNSTAKED");
+        expect(latestOp.fee.gt(0)).toBe(true);
+        expect(current.spendableBalance.gt(previous.spendableBalance)).toBe(true);
+      },
+    },
+    {
+      name: "send max to a named account",
+      mode: "send",
+      recipient: NAMED_RECIPIENT_ID,
+      amount: new BigNumber(0),
+      useAllAmount: true,
+      expect: (_previous, current) => {
+        const [latestOp] = current.operations;
+        expect(latestOp.type).toBe("OUT");
+        expect(latestOp.recipients).toContain(NAMED_RECIPIENT_ID);
+        // The remaining 5 NEAR staked principal is untouched; only the spendable side drains.
+        expect(current.spendableBalance.isZero()).toBe(true);
+        expect(countOf(current, "OUT")).toBe(3);
+      },
+    },
+  ];
+}
+
+export const scenarioNear: Scenario<GenericTransaction, Account> = {
+  name: "NEAR",
+
+  setup: async strategy => {
+    sandbox = await startSandbox();
+
+    // The generic bridge reads the endpoints from live-config, not from the coin module's own
+    // setter, so both have to point at the sandbox for the two strategies to be comparable.
+    LiveConfig.setConfig({
+      config_currency_near: { type: "object", default: coinConfig(sandbox.rpcUrl)() },
+    });
+
+    await deployStakingPool(sandbox);
+
+    const keyPair = randomKeyPair();
+    await sandbox.createFundedAccount(SENDER_ID, SENDER_BALANCE, keyPair);
+    await sandbox.createFundedAccount(NAMED_RECIPIENT_ID, RECIPIENT_BALANCE);
+
+    indexer = startIndexer(sandbox.rpc);
+    step = 0;
+
+    const signers = buildSigners(SENDER_ID, keyPair);
+    const { accountBridge, currencyBridge } = await getBridges(strategy, signers, sandbox.rpcUrl);
+
+    return { account: makeAccount(SENDER_ID), accountBridge, currencyBridge, retryLimit: 20 };
+  },
+
+  getTransactions: () => makeTransactions(),
+
+  beforeEach: async () => {
+    // The pool releases an unstaked balance a fixed number of epochs later. Advancing the height is
+    // the only way to reach it without waiting for real time to pass.
+    if (step === WITHDRAW_STEP && sandbox) {
+      await sandbox.fastForward(EPOCHS_TO_UNLOCK_BLOCKS);
+      await pingPool(await sandbox.near.account(SENDER_ID));
+    }
+    step += 1;
+  },
+
+  mockIndexer: async (_account, optimistic) => {
+    recordTransaction(optimistic.hash, SENDER_ID);
+  },
+
+  beforeAll: account => {
+    // toFixed, not toString: BigNumber prints 1e21 and above in exponential form.
+    expect(account.balance.toFixed()).toBe(SENDER_BALANCE.toString());
+    expect(account.operations.length).toBe(0);
+  },
+
+  afterAll: account => {
+    expect(countOf(account, "OUT")).toBe(3);
+    expect(has(account, "STAKE")).toBe(true);
+    expect(has(account, "UNSTAKE")).toBe(true);
+    expect(has(account, "WITHDRAW_UNSTAKED")).toBe(true);
+  },
+
+  teardown: killSandbox,
+};
+
+// Exported so `scenarii.test.ts` can tear the sandbox down on a process kill signal, not just on
+// the scenario's own (awaited) teardown hook.
+export async function killSandbox(): Promise<void> {
+  indexer?.close();
+  resetIndexer();
+  await sandbox?.tearDown();
+  sandbox = undefined;
+  indexer = undefined;
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/signer.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/signer.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import { utils } from "near-api-js";
+import type { KeyPair } from "near-api-js/lib/utils/key_pair";
+import type { NearSigner } from "@ledgerhq/coin-near/signer";
+
+// Same Borsh-serialized transaction, different shape per caller: base64 in / hex out for the framework, raw bytes / Buffer for the account bridge.
+export type FrameworkNearSigner = {
+  getAddress(
+    path: string,
+    options?: { verify?: boolean },
+  ): Promise<{ path: string; address: string; publicKey: string }>;
+  signTransaction(path: string, unsigned: string): Promise<string>;
+};
+
+export type Signers = {
+  bridge: NearSigner;
+  coinframework: FrameworkNearSigner;
+  keyPair: KeyPair;
+  publicKey: string;
+};
+
+// NEAR signs the sha256 of the serialized transaction, not the raw bytes (verified against near-api-js).
+function sign(keyPair: KeyPair, serialized: Uint8Array): Buffer {
+  const digest = createHash("sha256").update(serialized).digest();
+  return Buffer.from(keyPair.sign(digest).signature);
+}
+
+// accountId is fixed rather than derived: NEAR account ids are names, not hashes of a public key.
+export function buildSigners(accountId: string, keyPair: KeyPair): Signers {
+  const publicKey = keyPair.getPublicKey().toString();
+
+  const bridge: NearSigner = {
+    getAddress: async () => ({ address: accountId, publicKey }),
+    signTransaction: async (transaction: Uint8Array) => sign(keyPair, transaction),
+  };
+
+  const coinframework: FrameworkNearSigner = {
+    getAddress: async (path: string) => ({ path, address: accountId, publicKey }),
+    signTransaction: async (_path: string, unsigned: string) =>
+      sign(keyPair, Buffer.from(unsigned, "base64")).toString("hex"),
+  };
+
+  return { bridge, coinframework, keyPair, publicKey };
+}
+
+/** A fresh key per run; account ids stay fixed, so scenarios remain reproducible. */
+export function randomKeyPair(): KeyPair {
+  return utils.KeyPair.fromRandom("ed25519");
+}

--- a/libs/coin-tester-modules/coin-tester-near/src/stakingPool.ts
+++ b/libs/coin-tester-modules/coin-tester-near/src/stakingPool.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { utils, type Account } from "near-api-js";
+import { NETWORK_ID, POOL_BALANCE, POOL_ID } from "./fixtures";
+import type { SandboxHandle } from "./sandbox";
+
+// Pinned to a commit (not `master`) and checked against its digest, so it can't change under the scenario.
+const WASM_COMMIT = "1720c0cfee238974ebeae8ad43076abeb951504f";
+const WASM_URL = `https://raw.githubusercontent.com/near/core-contracts/${WASM_COMMIT}/staking-pool/res/staking_pool.wasm`;
+const WASM_SHA256 = "454cf4a54ff49a1b144e2591eb4ec833bf3ab5fa4792128beb6d9d0cc8d76e58";
+
+const CACHE_DIR = join(__dirname, "..", ".cache");
+const WASM_PATH = join(CACHE_DIR, "staking_pool.wasm");
+
+const TGAS = 1_000_000_000_000n;
+
+const digestOf = (wasm: Buffer): string => createHash("sha256").update(wasm).digest("hex");
+
+async function stakingPoolWasm(): Promise<Buffer> {
+  if (existsSync(WASM_PATH)) {
+    const cached = await readFile(WASM_PATH);
+    if (digestOf(cached) === WASM_SHA256) {
+      return cached;
+    }
+  }
+
+  const response = await fetch(WASM_URL);
+  if (!response.ok) {
+    throw new Error(`coin-tester-near: cannot download staking_pool.wasm (${response.status})`);
+  }
+
+  const wasm = Buffer.from(await response.arrayBuffer());
+  const digest = digestOf(wasm);
+  if (digest !== WASM_SHA256) {
+    throw new Error(
+      `coin-tester-near: staking_pool.wasm digest mismatch, expected ${WASM_SHA256}, got ${digest}`,
+    );
+  }
+
+  await mkdir(CACHE_DIR, { recursive: true });
+  await writeFile(WASM_PATH, wasm);
+  return wasm;
+}
+
+// Deploys a staking pool the scenario can delegate to. It logs a harmless `minimum_stake` failure
+// every epoch since it holds far less than the validator seat price; getValidators is stubbed anyway.
+export async function deployStakingPool(sandbox: SandboxHandle): Promise<Account> {
+  const keyPair = utils.KeyPair.fromRandom("ed25519");
+  await sandbox.keyStore.setKey(NETWORK_ID, POOL_ID, keyPair);
+  await sandbox.root.createAccount(POOL_ID, keyPair.getPublicKey(), POOL_BALANCE);
+
+  const pool = await sandbox.near.account(POOL_ID);
+  await pool.deployContract(await stakingPoolWasm());
+
+  await pool.functionCall({
+    contractId: POOL_ID,
+    methodName: "new",
+    args: {
+      owner_id: sandbox.root.accountId,
+      stake_public_key: keyPair.getPublicKey().toString(),
+      reward_fee_fraction: { numerator: 10, denominator: 100 },
+    },
+    gas: 300n * TGAS,
+  });
+
+  return pool;
+}
+
+/** Nudges the pool to settle rewards, which is what refreshes an account's unlock epoch. */
+export async function pingPool(account: Account): Promise<void> {
+  await account.functionCall({
+    contractId: POOL_ID,
+    methodName: "ping",
+    args: {},
+    gas: 125n * TGAS,
+  });
+}

--- a/libs/coin-tester-modules/coin-tester-near/tsconfig.build.json
+++ b/libs/coin-tester-modules/coin-tester-near/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "customConditions": [],
+    "types": ["node", "jest"]
+  },
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**/*",
+    "**/tests/**/*",
+    "**/__mocks__/**/*",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx"
+  ]
+}

--- a/libs/coin-tester-modules/coin-tester-near/tsconfig.json
+++ b/libs/coin-tester-modules/coin-tester-near/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "src/**/*.json"]
+}

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -786,6 +786,7 @@
     "src/families/multiversx/bridge/api.ts",
     "src/families/multiversx/coinModuleApi.ts",
     "src/families/multiversx/config.ts",
+    "src/families/near/bridge/api.ts",
     "src/families/near/coinModuleApi.ts",
     "src/families/near/config.ts",
     "src/families/polkadot/config.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
@@ -85,12 +85,14 @@ export function createTransaction(account: Account | TokenAccount): GenericTrans
         useAllAmount: false,
         mode: "send",
       };
+    case "near":
     case "vechain":
     case "cardano":
-      // Neither has an account sequence: Cardano is UTXO, VeChain's nonce is a random uniqueness
-      // field. getNextSequence throws in both modules, and utils.ts maps nonce → intent.sequence,
-      // which lets signOperation skip that call. The value is inert for crafting — both modules
-      // build their own — so the default tx is signable without callers having to set it.
+      // None has an account sequence: Cardano is UTXO, VeChain's nonce is a random uniqueness
+      // field, and a NEAR nonce belongs to an access key rather than the account. getNextSequence
+      // throws in all three modules, and utils.ts maps nonce → intent.sequence, which lets
+      // signOperation skip that call. The value is inert for crafting — each module builds its
+      // own — so the default tx is signable without callers having to set it.
       return {
         family: currency.family,
         amount: new BigNumber(0),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/createTransaction.ts
@@ -59,15 +59,8 @@ export function createTransaction(account: Account | TokenAccount): GenericTrans
       };
     }
     case "solana":
-      return {
-        family: currency.family,
-        amount: new BigNumber(0),
-        recipient: "",
-        fees: null,
-        mode: "send",
-      };
+    // hypercore has no send flow; this is a neutral tx used only for (de)serialization.
     case "hypercore":
-      // No send flow; return a neutral tx only for (de)serialization.
       return {
         family: currency.family,
         amount: new BigNumber(0),

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -440,6 +440,28 @@ describe("coin-framework utils", () => {
           : {}),
       });
     });
+
+    it("converts a fee at or above 1e21, where BigNumber switches to exponential notation", () => {
+      const fees = new BigNumber("1500000000000000000000");
+      const amount = new BigNumber("10000000000000000000000000");
+
+      expect(fees.toString()).toBe("1.5e+21");
+      expect(() => BigInt(fees.toString())).toThrow(SyntaxError);
+
+      const operation = buildOptimisticOperation(
+        { id: "parent-account-id", freshAddress: "account-address" } as Account,
+        {
+          mode: "send",
+          amount,
+          fees,
+          recipient: "recipient-address",
+        } as GenericTransaction,
+        3n,
+      );
+
+      expect(operation.fee).toEqual(fees);
+      expect(operation.value).toEqual(amount);
+    });
   });
 
   describe("cleanedOperation", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -159,7 +159,7 @@ export function nextSequenceWithPending(
     const rawSequence = op.transactionSequenceNumber;
     // Skip missing or non-integer sequences; `.toFixed()` (not `.toString()`) avoids the
     // exponential notation that BigInt() cannot parse.
-    if (rawSequence === undefined || rawSequence === null || !rawSequence.isInteger()) {
+    if (!rawSequence?.isInteger()) {
       continue;
     }
     const seq = BigInt(rawSequence.toFixed());

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -711,7 +711,8 @@ export const buildOptimisticOperation = (
       type = "OUT";
       break;
   }
-  const fees = BigInt(transaction.fees?.toString() || "0");
+  // toFixed, not toString: BigNumber goes exponential above 1e21, which BigInt can't parse.
+  const fees = transaction.fees ? BigInt(transaction.fees.toFixed()) : 0n;
   const { subAccountId } = transaction;
   const { subAccounts } = account;
   const parentType = subAccountId ? "FEES" : type;

--- a/libs/ledger-live-common/src/coin-modules/loaders.ts
+++ b/libs/ledger-live-common/src/coin-modules/loaders.ts
@@ -304,6 +304,7 @@ export const coinModuleLoaders: CoinModuleLoader[] = [
     supportedCoins: ["near"],
     loadSetup: () => import("../families/near/setup"),
     loadLocalApi: () => import("../families/near/coinModuleApi").then(m => m.createLocalNearApi),
+    loadBridgeApi: () => import("../families/near/bridge/api").then(m => m.default),
     loadTransaction: () => import("@ledgerhq/coin-near/transaction").then(m => m.default),
     loadDeviceTxConfig: () =>
       import("@ledgerhq/coin-near/deviceTransactionConfig").then(m => m.default),

--- a/libs/ledger-live-common/src/families/near/bridge/api.test.ts
+++ b/libs/ledger-live-common/src/families/near/bridge/api.test.ts
@@ -1,0 +1,51 @@
+import * as nearBridge from "./api";
+
+const { computeIntentType } = nearBridge;
+const bridgeApi = nearBridge.default;
+
+describe("generic-coin-framework NEAR bridge api", () => {
+  describe("computeIntentType", () => {
+    it.each(["send", "stake", "unstake"] as const)("returns '%s' unchanged", mode => {
+      expect(computeIntentType({ mode })).toBe(mode);
+    });
+
+    it("maps NEAR's 'withdraw' onto the framework's 'finalize_unstake'", () => {
+      expect(computeIntentType({ mode: "withdraw" })).toBe("finalize_unstake");
+    });
+
+    it.each([{}, { mode: undefined }, { mode: null }])(
+      "falls back to 'send' when mode is absent (%p)",
+      transaction => {
+        expect(computeIntentType(transaction)).toBe("send");
+      },
+    );
+
+    it("throws for an unsupported string mode", () => {
+      expect(() => computeIntentType({ mode: "changeTrust" })).toThrow(
+        "Unsupported transaction mode: changeTrust",
+      );
+    });
+
+    it("throws a TypeError when mode is a non-string value", () => {
+      expect(() => computeIntentType({ mode: 42 })).toThrow(TypeError);
+      expect(() => computeIntentType({ mode: 42 })).toThrow("Unsupported transaction mode: 42");
+    });
+
+    it("reports an object mode without collapsing it to [object Object]", () => {
+      expect(() => computeIntentType({ mode: { kind: "stake" } })).toThrow(
+        'Unsupported transaction mode: {"kind":"stake"}',
+      );
+    });
+  });
+
+  describe("default export", () => {
+    it("declares staking support", () => {
+      expect(bridgeApi.stakingSupported).toBe(true);
+    });
+
+    it("wires computeIntentType so the framework picks it up over its own whitelist", () => {
+      expect(bridgeApi.computeIntentType).toBe(computeIntentType);
+      expect(bridgeApi.computeIntentType?.({ mode: "withdraw" })).toBe("finalize_unstake");
+    });
+  });
+});

--- a/libs/ledger-live-common/src/families/near/bridge/api.ts
+++ b/libs/ledger-live-common/src/families/near/bridge/api.ts
@@ -1,0 +1,30 @@
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
+
+/**
+ * NEAR names its staking modes `stake` / `unstake` / `withdraw`, while the generic framework's
+ * default mapping only knows `stake` / `unstake` / `finalize_unstake` and throws on anything else.
+ */
+export function computeIntentType(transaction: Record<string, unknown>): string {
+  const { mode } = transaction;
+  if (mode == null) {
+    return "send";
+  }
+  if (typeof mode !== "string") {
+    throw new TypeError(`Unsupported transaction mode: ${JSON.stringify(mode)}`);
+  }
+  switch (mode) {
+    case "send":
+    case "stake":
+    case "unstake":
+      return mode;
+    case "withdraw":
+      return "finalize_unstake";
+    default:
+      throw new Error(`Unsupported transaction mode: ${mode}`);
+  }
+}
+
+export default {
+  stakingSupported: true,
+  computeIntentType,
+} satisfies BridgeApi;

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "coin:tester:stellar": "pnpm --filter coin-tester-stellar",
     "coin:tester:tezos": "pnpm --filter coin-tester-tezos",
     "coin:tester:multiversx": "pnpm --filter coin-tester-multiversx",
+    "coin:tester:near": "pnpm --filter coin-tester-near",
     "coin:tester:tron": "pnpm --filter coin-tester-tron",
     "coin:tester:vechain": "pnpm --filter coin-tester-vechain",
     "coin:tester:xrp": "pnpm --filter coin-tester-xrp",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8789,6 +8789,70 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  libs/coin-tester-modules/coin-tester-near:
+    dependencies:
+      '@ledgerhq/coin-near':
+        specifier: workspace:^
+        version: link:../../coin-modules/coin-near
+      '@ledgerhq/coin-tester':
+        specifier: workspace:^
+        version: link:../../coin-tester
+      '@ledgerhq/ledger-wallet-framework':
+        specifier: workspace:^
+        version: link:../../ledger-wallet-framework
+      '@ledgerhq/live-common':
+        specifier: workspace:^
+        version: link:../../ledger-live-common
+      '@ledgerhq/live-config':
+        specifier: workspace:^
+        version: link:../../live-config
+      '@ledgerhq/types-live':
+        specifier: workspace:^
+        version: link:../../ledgerjs/packages/types-live
+      bignumber.js:
+        specifier: 9.1.2
+        version: 9.1.2
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      near-api-js:
+        specifier: ^3.0.2
+        version: 3.0.2
+      near-sandbox:
+        specifier: ^0.3.2
+        version: 0.3.2
+    devDependencies:
+      '@ledgerhq/wallet-framework-test-setup':
+        specifier: workspace:^
+        version: link:../../wallet-framework-test-setup
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.51.0
+      rimraf:
+        specifier: ^5
+        version: 5.0.10
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   libs/coin-tester-modules/coin-tester-polkadot:
     dependencies:
       '@ledgerhq/coin-module-framework':
@@ -23828,7 +23892,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -26169,7 +26233,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -30471,6 +30535,10 @@ packages:
     resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
     engines: {node: '>=10.19.0'}
 
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+
   gql.tada@1.9.2:
     resolution: {integrity: sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==}
     hasBin: true
@@ -31994,6 +32062,9 @@ packages:
   json-cycle@1.5.0:
     resolution: {integrity: sha512-GOehvd5PO2FeZ5T4c+RxobeT5a1PiGpF4u9/3+UvrMU4bhnVqzJY7hm39wg8PDCqkU91fWGH8qjWR4bn+wgq9w==}
     engines: {node: '>= 4'}
+
+  json-merge-patch@1.0.2:
+    resolution: {integrity: sha512-M6Vp2GN9L7cfuMXiWOmHj9bEFbeC250iVtcKQbqVgEsDVYnIsrNsbU+h/Y/PkbBQCtEa4Bez+Ebv0zfbC8ObLg==}
 
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -33778,6 +33849,11 @@ packages:
   near-api-js@3.0.2:
     resolution: {integrity: sha512-o8rgHH5ZV+V9grZTu4GSILupq41JyU3Mt/G6rZ2pBybHA2ozkfp9oIXKRqC4mCkbUtYLy//YoXuLRGLsRDlB2w==}
 
+  near-sandbox@0.3.2:
+    resolution: {integrity: sha512-RuAlxXHU2wMSVIuUiZENipuuF0YQBdtJ1wq34NvLroSODajpEvmApbSyY8aHWYp9AoiremJ4GPb6Cp41ovAqew==}
+    engines: {node: '>=22.22.2'}
+    hasBin: true
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -35261,6 +35337,9 @@ packages:
 
   proper-lockfile@3.2.0:
     resolution: {integrity: sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   properties@1.2.1:
     resolution: {integrity: sha512-qYNxyMj1JeW54i/EWEFsM1cVwxJbtgPp8+0Wg9XjNaK6VE/c4oRi6PNu5p7w1mNXEIQIjV5Wwn8v8Gz82/QzdQ==}
@@ -37613,6 +37692,10 @@ packages:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
 
   tar@7.5.16:
     resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
@@ -62697,6 +62780,20 @@ snapshots:
       p-cancelable: 2.1.1
       responselike: 2.0.1
 
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   gql.tada@1.9.2(@typescript/typescript6@6.0.2)(graphql@16.13.2):
     dependencies:
       '@0no-co/graphql.web': 1.0.11(graphql@16.13.2)
@@ -65012,6 +65109,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-cycle@1.5.0: {}
+
+  json-merge-patch@1.0.2:
+    dependencies:
+      fast-deep-equal: 3.1.3
 
   json-parse-better-errors@1.0.2: {}
 
@@ -67586,6 +67687,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  near-sandbox@0.3.2:
+    dependencies:
+      got: 11.8.6
+      json-merge-patch: 1.0.2
+      proper-lockfile: 4.1.2
+      tar: 7.5.13
+      tmp-promise: 3.0.3
+
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
@@ -69260,6 +69369,12 @@ snapshots:
   propagate@2.0.1: {}
 
   proper-lockfile@3.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
       retry: 0.12.0
@@ -72636,6 +72751,14 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.0.2
       mkdirp: 3.0.1
+      yallist: 5.0.0
+
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
       yallist: 5.0.0
 
   tar@7.5.16:


### PR DESCRIPTION
### 📝 Description

Adds `@ledgerhq/coin-tester-near`, a deterministic integration tester for the NEAR family. It boots a local `near-sandbox` node and runs one scenario through both the legacy account bridge and the generic coin-framework bridge, so the two surfaces are compared against each other on every run.

The scenario covers a transfer to an existing named account, a transfer to a fresh implicit account, and the full staking cycle: delegate, undelegate, and withdraw after the unlock period.

No Docker. `near-sandbox` downloads a native `neard` build for the host platform, so it runs on the standard CI runner and on a laptop with no extra setup. `staking_pool.wasm` is pinned to a commit and verified against its sha256, so neither upstream nor a stale cache can change the contract the scenario delegates to.

**Three changes outside the tester package** are needed for the generic-adapter half of the run:

- `families/near/bridge/api.ts` (new): NEAR names its staking modes `stake` / `unstake` / `withdraw`, while the framework's default whitelist knows `stake` / `unstake` / `finalize_unstake` and throws on anything else. Without the mapping, `withdraw` cannot be built through the framework at all.
- `generic-coin-framework/createTransaction.ts`: NEAR joins the Cardano branch, since a NEAR nonce belongs to an access key rather than the account, so the default transaction must be signable without callers setting a sequence.
- `generic-coin-framework/utils.ts`: `buildOptimisticOperation` converted fees with `BigNumber.toString()`, which switches to exponential notation from 1e21 up and cannot be parsed by `BigInt`. At NEAR's 24 decimals a staking fee crosses that threshold at 0.0015, so every staked operation threw. Now uses `toFixed()`, with a regression test asserting the boundary directly.

The last one is a shared-framework fix affecting any family with a large-magnitude fee. It is bundled here rather than split out because the tester is red without it.

### What the first end-to-end run caught

Four contract mismatches that unit tests had missed, all wrong assumptions about the indexer contract rather than bugs in the coin module:

| Finding | Why unit tests missed it |
| --- | --- |
| `/v3/stats` must be stubbed | `getGasPrice`'s node-RPC fallback only covers a response without a `gas_price`, not a request that throws |
| `staking-deposits` returns a bare array | the module maps over the body itself, with no `{ data }` envelope |
| `loadBridgeApi` is required | the framework reads `computeIntentType` from the loader registry, not from the caller |
| a fresh account is not immediately final | the module queries with `finality: "final"` while a new account is first visible only optimistically |

### Notes for reviewers

- Most of the diff is test code and the generated lockfile entry. The shipped logic is `bridge/api.ts` (30 lines) plus two small framework edits.
- `families/near/bridge/api.ts` gets the `bridge/api.test.ts` that the other nine families already have.
- Runtime is about 52 s per strategy. The coin-tester job is `continue-on-error: true`, so it reports without gating the merge.
- **Based on #20296.** The base branch will retarget to `develop` automatically once that merges.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34293](https://ledgerhq.atlassian.net/browse/LIVE-34293)
- **ADR** (if any): n/a


[LIVE-34293]: https://ledgerhq.atlassian.net/browse/LIVE-34293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ