### PR TITLE
[LWDM] chore(llc): add `config_generic_a4` live config

### DIFF
--- a/.changeset/friendly-schools-deliver.md
+++ b/.changeset/friendly-schools-deliver.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+chore(llc): add `config_generic_a4` live config

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -389,6 +389,7 @@
     "src/bridge/descriptor/send/memo.ts",
     "src/bridge/descriptor/stake/features.ts",
     "src/bridge/descriptor/types.ts",
+    "src/bridge/generic-coin-framework/a4/config.ts",
     "src/bridge/jsHelpers.ts",
     "src/bridge/mockHelpers.ts",
     "src/bridge/setup.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.test.ts
@@ -1,0 +1,192 @@
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import { resolveA4ChainConfig, a4Config } from "./config";
+import type { A4ChainEntry } from "./config";
+
+jest.mock("@ledgerhq/live-config/LiveConfig", () => ({
+  LiveConfig: {
+    getValueByKey: jest.fn(),
+  },
+}));
+
+const mockGetValueByKey = jest.mocked(LiveConfig.getValueByKey);
+
+describe("resolveA4ChainConfig", () => {
+  beforeEach(() => {
+    mockGetValueByKey.mockReset();
+  });
+
+  describe("graceful degradation", () => {
+    it("returns off when LiveConfig throws", () => {
+      mockGetValueByKey.mockImplementation(() => {
+        throw new Error("Config not set");
+      });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: false,
+        environment: "prd",
+      });
+    });
+
+    it.each([[null], ["string"], [42], [[]]])("returns off for malformed payload %j", payload => {
+      mockGetValueByKey.mockReturnValue(payload);
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: false,
+        environment: "prd",
+      });
+    });
+  });
+
+  describe("chain lookup", () => {
+    it("returns off for a chain absent from the chains map", () => {
+      mockGetValueByKey.mockReturnValue({ environment: "prd", chains: {} });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: false,
+        environment: "prd",
+      });
+    });
+
+    it("returns off when chains field is missing", () => {
+      mockGetValueByKey.mockReturnValue({ environment: "prd" });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: false,
+        environment: "prd",
+      });
+    });
+  });
+
+  describe("switch semantics", () => {
+    it.each([
+      [false, false, {}],
+      [false, false, { enabled: false, registerOnly: false }],
+      [false, true, { registerOnly: true }],
+      [true, true, { enabled: true }],
+      [false, true, { enabled: false, registerOnly: true }],
+      [true, true, { enabled: true, registerOnly: true }],
+      [true, true, { enabled: true, registerOnly: false }],
+    ] satisfies [boolean, boolean, A4ChainEntry][])(
+      "returns read:%s register:%s for entry %j",
+      (read, register, entry) => {
+        mockGetValueByKey.mockReturnValue({ environment: "prd", chains: { ethereum: entry } });
+        expect(resolveA4ChainConfig("ethereum")).toEqual({ read, register, environment: "prd" });
+      },
+    );
+  });
+
+  describe("environment resolution", () => {
+    it.each([
+      ["stg", "stg"],
+      ["ppr", "ppr"],
+      ["prd", "prd"],
+      ["invalid", "prd"],
+    ])("resolves global environment %s to %s", (raw, resolved) => {
+      mockGetValueByKey.mockReturnValue({
+        environment: raw,
+        chains: { ethereum: { registerOnly: true } },
+      });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: true,
+        environment: resolved,
+      });
+    });
+
+    it("per-chain environment overrides global", () => {
+      mockGetValueByKey.mockReturnValue({
+        environment: "stg",
+        chains: { ethereum: { registerOnly: true, environment: "ppr" } },
+      });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: true,
+        environment: "ppr",
+      });
+    });
+
+    it("falls back to prd on invalid per-chain environment", () => {
+      mockGetValueByKey.mockReturnValue({
+        environment: "stg",
+        chains: { ethereum: { registerOnly: true, environment: "invalid" } },
+      });
+      expect(resolveA4ChainConfig("ethereum")).toEqual({
+        read: false,
+        register: true,
+        environment: "prd",
+      });
+    });
+  });
+});
+
+describe("a4Config", () => {
+  it("registers config_generic_a4 as an object type with correct defaults", () => {
+    expect(a4Config.config_generic_a4).toEqual({
+      type: "object",
+      default: {
+        environment: "prd",
+        chains: {
+          adi: { enabled: false, registerOnly: true },
+          arbitrum: { enabled: false, registerOnly: true },
+          arc: { enabled: false, registerOnly: true },
+          avalanche_c_chain: { enabled: false, registerOnly: true },
+          avalanche_c_chain_fuji: { enabled: false, registerOnly: true },
+          base: { enabled: false, registerOnly: true },
+          berachain: { enabled: false, registerOnly: true },
+          bitcoin: { enabled: false, registerOnly: true },
+          bitcoin_cash: { enabled: false, registerOnly: true },
+          bitcoin_gold: { enabled: false, registerOnly: true },
+          bitcoin_testnet: { enabled: false, registerOnly: true },
+          bitcoin_testnet4: { enabled: false, registerOnly: true },
+          bitlayer: { enabled: false, registerOnly: true },
+          bittorrent: { enabled: false, registerOnly: true },
+          bsc: { enabled: false, registerOnly: true },
+          canton_network: { enabled: false, registerOnly: true },
+          canton_network_devnet: { enabled: false, registerOnly: true },
+          canton_network_testnet: { enabled: false, registerOnly: true },
+          cardano: { enabled: false, registerOnly: true },
+          cardano_testnet: { enabled: false, registerOnly: true },
+          dash: { enabled: false, registerOnly: true },
+          digibyte: { enabled: false, registerOnly: true },
+          dogecoin: { enabled: false, registerOnly: true },
+          ethereum: { enabled: false, registerOnly: true },
+          ethereum_classic: { enabled: false, registerOnly: true },
+          ethereum_hoodi: { enabled: false, registerOnly: true },
+          ethereum_sepolia: { enabled: false, registerOnly: true },
+          fantom: { enabled: false, registerOnly: true },
+          hedera: { enabled: false, registerOnly: true },
+          hedera_testnet: { enabled: false, registerOnly: true },
+          hyperevm: { enabled: false, registerOnly: true },
+          linea: { enabled: false, registerOnly: true },
+          linea_sepolia: { enabled: false, registerOnly: true },
+          litecoin: { enabled: false, registerOnly: true },
+          mantle: { enabled: false, registerOnly: true },
+          mantle_sepolia: { enabled: false, registerOnly: true },
+          monad: { enabled: false, registerOnly: true },
+          monad_testnet: { enabled: false, registerOnly: true },
+          optimism: { enabled: false, registerOnly: true },
+          polygon: { enabled: false, registerOnly: true },
+          ripple: { enabled: false, registerOnly: true },
+          ripple_testnet: { enabled: false, registerOnly: true },
+          robinhood: { enabled: false, registerOnly: true },
+          rsk: { enabled: false, registerOnly: true },
+          shape: { enabled: false, registerOnly: true },
+          solana: { enabled: false, registerOnly: true },
+          solana_devnet: { enabled: false, registerOnly: true },
+          somnia: { enabled: false, registerOnly: true },
+          sonic: { enabled: false, registerOnly: true },
+          stellar: { enabled: false, registerOnly: true },
+          stellar_testnet: { enabled: false, registerOnly: true },
+          story: { enabled: false, registerOnly: true },
+          sui: { enabled: false, registerOnly: true },
+          tezos: { enabled: false, registerOnly: true },
+          tezos_testnet: { enabled: false, registerOnly: true },
+          tron: { enabled: false, registerOnly: true },
+          tron_testnet: { enabled: false, registerOnly: true },
+          zero_gravity: { enabled: false, registerOnly: true },
+          zksync: { enabled: false, registerOnly: true },
+        },
+      },
+    });
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+import { log } from "@ledgerhq/logs";
+import { LiveConfig } from "@ledgerhq/live-config/LiveConfig";
+import type { ConfigSchema } from "@ledgerhq/live-config/LiveConfig";
+
+export type A4Environment = "stg" | "ppr" | "prd";
+
+export type A4ChainEntry = {
+  enabled?: boolean;
+  registerOnly?: boolean;
+  environment?: A4Environment;
+};
+
+export type A4Config = {
+  environment: A4Environment;
+  chains: Record<string, A4ChainEntry>;
+};
+
+export type A4ChainResolution = {
+  read: boolean;
+  register: boolean;
+  environment: A4Environment;
+};
+
+const A4EnvironmentSchema = z.enum(["stg", "ppr", "prd"]).catch("prd");
+
+const A4ChainEntrySchema = z.object({
+  enabled: z.boolean().optional(),
+  registerOnly: z.boolean().optional(),
+  environment: A4EnvironmentSchema.optional(),
+});
+
+const A4ConfigSchema = z.object({
+  environment: A4EnvironmentSchema.default("prd"),
+  chains: z.record(z.string(), A4ChainEntrySchema).default({}),
+});
+
+// https://explorers.api.vault.ledger.com/a4/networks
+const A4_SUPPORTED_NETWORKS: ReadonlyArray<string> = [
+  "adi",
+  "arbitrum",
+  "arc",
+  "avalanche_c_chain",
+  "avalanche_c_chain_fuji",
+  "base",
+  "berachain",
+  "bitcoin",
+  "bitcoin_cash",
+  "bitcoin_gold",
+  "bitcoin_testnet",
+  "bitcoin_testnet4",
+  "bitlayer",
+  "bittorrent",
+  "bsc",
+  "canton_network",
+  "canton_network_devnet",
+  "canton_network_testnet",
+  "cardano",
+  "cardano_testnet",
+  "dash",
+  "digibyte",
+  "dogecoin",
+  "ethereum",
+  "ethereum_classic",
+  "ethereum_hoodi",
+  "ethereum_sepolia",
+  "fantom",
+  "hedera",
+  "hedera_testnet",
+  "hyperevm",
+  "linea",
+  "linea_sepolia",
+  "litecoin",
+  "mantle",
+  "mantle_sepolia",
+  "monad",
+  "monad_testnet",
+  "optimism",
+  "polygon",
+  "ripple",
+  "ripple_testnet",
+  "robinhood",
+  "rsk",
+  "shape",
+  "solana",
+  "solana_devnet",
+  "somnia",
+  "sonic",
+  "stellar",
+  "stellar_testnet",
+  "story",
+  "sui",
+  "tezos",
+  "tezos_testnet",
+  "tron",
+  "tron_testnet",
+  "zero_gravity",
+  "zksync",
+];
+
+const DEFAULT_A4_CONFIG: A4Config = {
+  environment: "prd",
+  chains: Object.fromEntries(
+    A4_SUPPORTED_NETWORKS.map(id => [
+      id,
+      { enabled: false, registerOnly: true } satisfies A4ChainEntry,
+    ]),
+  ),
+};
+
+export const a4Config: ConfigSchema = {
+  config_generic_a4: {
+    type: "object",
+    default: DEFAULT_A4_CONFIG,
+  },
+};
+
+const A4_OFF: A4ChainResolution = Object.freeze({
+  read: false,
+  register: false,
+  environment: "prd",
+});
+
+let warnedConfigMissing = false;
+
+export function resolveA4ChainConfig(network: string): A4ChainResolution {
+  try {
+    const raw = LiveConfig.getValueByKey("config_generic_a4");
+
+    const parsed = A4ConfigSchema.safeParse(raw);
+    if (!parsed.success) return A4_OFF;
+
+    const { environment: globalEnv, chains } = parsed.data;
+    const entry = chains[network];
+
+    if (!entry) return A4_OFF;
+
+    const environment = entry.environment ?? globalEnv;
+
+    if (entry.enabled) return { read: true, register: true, environment };
+    if (entry.registerOnly) return { read: false, register: true, environment };
+    return A4_OFF;
+  } catch {
+    if (warnedConfigMissing) return A4_OFF;
+    warnedConfigMissing = true;
+    log("a4", "config_generic_a4 not set in LiveConfig - A4 disabled");
+    return A4_OFF;
+  }
+}

--- a/libs/ledger-live-common/src/config/sharedConfig.ts
+++ b/libs/ledger-live-common/src/config/sharedConfig.ts
@@ -29,6 +29,7 @@ import { suiConfig } from "../families/sui/config";
 import { cantonConfig } from "../families/canton/config";
 import { aleoConfig } from "../families/aleo/config";
 import { concordiumConfig } from "../families/concordium/config";
+import { a4Config } from "../bridge/generic-coin-framework/a4/config";
 
 const countervaluesConfig: ConfigSchema = {
   config_countervalues_refreshRate: {
@@ -77,4 +78,5 @@ export const liveConfig: ConfigSchema = {
   ...cantonConfig,
   ...aleoConfig,
   ...concordiumConfig,
+  ...a4Config,
 };


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Introduce `config_generic_a4` a cross-family LiveConfig key driving A4 indexer integration.

- Zod-validated schema with per-chain `enabled`/`registerOnly` switches and `environment` (`stg`/`ppr`/`prd`).
- `resolveA4ChainConfig(currencyId)` returning `{ read, register, environment }` with log-once fallback
- Default config: all 60 A4-supported networks at `{ enabled: false, registerOnly: true }`
- Registered in `sharedConfig.ts`

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34037
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
