### PR TITLE
[LWDM] chore(llc): add base URLs and network mapping for A4

### DIFF
--- a/.changeset/tender-plants-clap.md
+++ b/.changeset/tender-plants-clap.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": patch
+"@shared/env": patch
+---
+
+chore(llc): add base URLs and network mapping for A4

--- a/docs/services.md
+++ b/docs/services.md
@@ -44,6 +44,7 @@ Inside the Internal and Third-party tables, rows are grouped by **owning team** 
 | EVM explorer (Etherscan proxy) | `proxyetherscan.api.live.ledger.com` | [coin-config](/libs/ledger-live-common/src/families/evm/config.ts) | prod |
 | EVM explorer (Blockscout proxy) | `proxyblockscout.api.live.ledger.com` | [coin-config](/libs/ledger-live-common/src/families/evm/config.ts) | prod |
 | EVM dApp RPC | `eth-dapps.api.live.ledger.com` | [coin-config](/libs/ledger-live-common/src/families/evm/config.ts) | prod |
+| A4 indexer (L2 backend) | `explorers.api.vault.ledger.com`<br>_path: `/a4`; pre-prod: `explorers.api.live.ppr.ledger-test.com`; staging: `explorers.api.live.stg.ledger-test.com`_ | [env](/shared/env/src/definitions/team-coin-integration/index.ts) | prod / staging |
 | Aptos node | `apt.coin.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Aptos indexer | `apt.coin.ledger.com` | [env](/libs/env/src/env.ts) | prod |
 | Algorand explorer/indexer | `algorand.coin.ledger.com` | [env](/libs/env/src/env.ts) | prod |

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -390,6 +390,7 @@
     "src/bridge/descriptor/stake/features.ts",
     "src/bridge/descriptor/types.ts",
     "src/bridge/generic-coin-framework/a4/config.ts",
+    "src/bridge/generic-coin-framework/a4/client/utils.ts",
     "src/bridge/jsHelpers.ts",
     "src/bridge/mockHelpers.ts",
     "src/bridge/setup.ts",

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.test.ts
@@ -1,0 +1,31 @@
+import { getEnv } from "@shared/env";
+import { toA4Network, resolveA4BaseUrl } from "./utils";
+
+jest.mock("@shared/env");
+
+const mockGetEnv = jest.mocked(getEnv);
+
+describe("resolveA4BaseUrl", () => {
+  it.each([
+    ["stg", "A4_URL_STG", "https://explorers.api.live.stg.ledger-test.com/a4"],
+    ["ppr", "A4_URL_PPR", "https://explorers.api.live.ppr.ledger-test.com/a4"],
+    ["prd", "A4_URL_PRD", "https://explorers.api.vault.ledger.com/a4"],
+  ] as const)("returns env var for %s", (env, key, url) => {
+    mockGetEnv.mockImplementation(k => (k === key ? url : ""));
+    expect(resolveA4BaseUrl(env)).toEqual(url);
+  });
+});
+
+describe("toA4Network", () => {
+  it("maps xrp to ripple", () => {
+    expect(toA4Network("xrp")).toEqual("ripple");
+  });
+
+  it.each([["ethereum"], ["solana"], ["bitcoin"], ["polygon"]])("returns identity for %s", id => {
+    expect(toA4Network(id)).toEqual(id);
+  });
+
+  it("returns null for unknown currency id", () => {
+    expect(toA4Network("totally_unknown_chain")).toEqual(null);
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.ts
@@ -1,0 +1,30 @@
+import { getEnv } from "@shared/env";
+import { A4_SUPPORTED_NETWORKS } from "../config";
+import type { A4Environment } from "../config";
+
+const A4_SUPPORTED_NETWORK_SET: ReadonlySet<string> = new Set(A4_SUPPORTED_NETWORKS);
+
+function remapCurrencyId(currencyId: string): string {
+  switch (currencyId) {
+    case "xrp":
+      return "ripple";
+    default:
+      return currencyId;
+  }
+}
+
+export function toA4Network(currencyId: string): string | null {
+  const network = remapCurrencyId(currencyId);
+  return A4_SUPPORTED_NETWORK_SET.has(network) ? network : null;
+}
+
+export function resolveA4BaseUrl(environment: A4Environment): string {
+  switch (environment) {
+    case "stg":
+      return getEnv("A4_URL_STG");
+    case "ppr":
+      return getEnv("A4_URL_PPR");
+    case "prd":
+      return getEnv("A4_URL_PRD");
+  }
+}

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/config.ts
@@ -36,7 +36,7 @@ const A4ConfigSchema = z.object({
 });
 
 // https://explorers.api.vault.ledger.com/a4/networks
-const A4_SUPPORTED_NETWORKS: ReadonlyArray<string> = [
+export const A4_SUPPORTED_NETWORKS: ReadonlyArray<string> = [
   "adi",
   "arbitrum",
   "arc",

--- a/shared/env/src/definitions/team-coin-integration/index.ts
+++ b/shared/env/src/definitions/team-coin-integration/index.ts
@@ -7,6 +7,21 @@ import {
 } from "@ledgerhq/live-env";
 
 const teamCoinIntegration = {
+  A4_URL_STG: {
+    def: "https://explorers.api.live.stg.ledger-test.com/a4",
+    parser: stringParser,
+    desc: "A4 indexer base URL for staging. No trailing network segment.",
+  },
+  A4_URL_PPR: {
+    def: "https://explorers.api.live.ppr.ledger-test.com/a4",
+    parser: stringParser,
+    desc: "A4 indexer base URL for pre-prod. No trailing network segment.",
+  },
+  A4_URL_PRD: {
+    def: "https://explorers.api.vault.ledger.com/a4",
+    parser: stringParser,
+    desc: "A4 indexer base URL for production. No trailing network segment.",
+  },
   API_ALGORAND_BLOCKCHAIN_EXPLORER_API_ENDPOINT: {
     def: "https://algorand.coin.ledger.com",
     parser: stringParser,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add base URLs for A4 environments
```json
{
  "A4_URL_STG": "https://explorers.api.live.stg.ledger-test.com/a4",
  "A4_URL_PPR":  "https://explorers.api.live.ppr.ledger-test.com/a4",
  "A4_URL_PRD": "https://explorers.api.vault.ledger.com/a4"
}
```

Add a helper to turn Ledger Wallet currency identifier into supported A4 network, with a fallback to `null`.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34038
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
