### PR TITLE
[LIVE-35266] feat(ddd): add @shared/wallet-sync and @shared/cloud-sync packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13745,6 +13745,58 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  shared/cloud-sync:
+    dependencies:
+      base64-js:
+        specifier: '1'
+        version: 1.5.1
+      isomorphic-ws:
+        specifier: 'catalog:'
+        version: 5.0.0(ws@8.18.3)
+      pako:
+        specifier: ^2.0.4
+        version: 2.1.0
+      rxjs:
+        specifier: 'catalog:'
+        version: 7.8.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.2.0
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      '@types/pako':
+        specifier: ^2.0.0
+        version: 2.0.3
+      '@types/ws':
+        specifier: ^8.5.3
+        version: 8.5.10
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      msw:
+        specifier: 'catalog:'
+        version: 2.7.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+      ws:
+        specifier: 'catalog:'
+        version: 8.18.3
+
   shared/env:
     dependencies:
       '@ledgerhq/live-env':
@@ -13867,6 +13919,31 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  shared/wallet-sync:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'

--- a/shared/cloud-sync/README.md
+++ b/shared/cloud-sync/README.md
@@ -1,0 +1,19 @@
+# @shared/cloud-sync
+
+Generic cloud sync networking layer for Ledger Live wallet synchronisation.
+
+Provides `CloudSyncSDK` — a protocol-agnostic client that fetches, uploads and deletes encrypted wallet state on the WalletSync atomic API, and listens for real-time push notifications via WebSocket. Encryption/decryption delegates to the caller's `TrustchainSDK` (compress → encrypt → base64 on write; reverse on read).
+
+Also exports `getCloudSyncApi` (low-level fetch wrapper) and `makeCipher` (standalone encrypt/decrypt helper) for callers that need finer control.
+
+Structural trustchain types (`Trustchain`, `MemberCredentials`, `TrustchainSDK`, …) are inlined here to keep `@ledgerhq/ledger-key-ring-protocol` out of this package's runtime deps.
+
+## Related documentation
+
+- [CloudSyncSDK](./../../docs/ledger-sync/04-cloud-sync-sdk.md) — cipher layers, atomic pull/push/delete, versioning
+- [TrustchainSDK](./../../docs/ledger-sync/02-trustchain-sdk.md) — auth, members, key rotation (encryption key source)
+- [The watch loop](./../../docs/ledger-sync/06-watch-loop.md) — how CloudSyncSDK drives push/pull cycles
+
+## Code location
+
+Moved from `libs/live-wallet/src/cloudsync/` to [`shared/cloud-sync/src/cloudsync/`](src/cloudsync/).

--- a/shared/cloud-sync/jest.config.js
+++ b/shared/cloud-sync/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/shared/cloud-sync/package.json
+++ b/shared/cloud-sync/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@shared/cloud-sync",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Generic WalletSync engine: CloudSyncSDK, WalletSyncDataManager port, aggregator, watch loop",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/cloud-sync"
+  },
+  "dependencies": {
+    "base64-js": "1",
+    "isomorphic-ws": "catalog:",
+    "pako": "^2.0.4",
+    "rxjs": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "@types/pako": "^2.0.0",
+    "@types/ws": "^8.5.3",
+    "jest": "catalog:",
+    "msw": "catalog:",
+    "typescript": "catalog:",
+    "ws": "catalog:"
+  }
+}

--- a/shared/cloud-sync/project.json
+++ b/shared/cloud-sync/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@shared/cloud-sync",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/cloud-sync/src/__tests__/trustchain-types.test.ts
+++ b/shared/cloud-sync/src/__tests__/trustchain-types.test.ts
@@ -1,0 +1,9 @@
+import { WalletSyncOutdated } from "../trustchain-types";
+
+describe(WalletSyncOutdated.name, () => {
+  it("has the expected name and message", () => {
+    const error = new WalletSyncOutdated();
+    expect(error.name).toBe("WalletSyncOutdated");
+    expect(error.message).toBe("Wallet sync data is outdated");
+  });
+});

--- a/shared/cloud-sync/src/cloudsync/__tests__/api.test.ts
+++ b/shared/cloud-sync/src/cloudsync/__tests__/api.test.ts
@@ -1,0 +1,186 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import WebSocket from "ws";
+import { firstValueFrom, toArray } from "rxjs";
+import getApi from "../api";
+import type { Trustchain } from "../../trustchain-types";
+
+describe("getApi", () => {
+  const port = 54035;
+  const base = `http://localhost:${port}`;
+  const trustchain: Trustchain = {
+    rootId: "root-id",
+    applicationPath: "0'/16'/0'",
+    walletSyncEncryptionKey: "key",
+  };
+  const jwt = { accessToken: "mock-jwt" };
+
+  const server = setupServer(
+    http.get(`${base}/atomic/v1/:slug`, ({ request }) => {
+      const params = new URL(request.url).searchParams;
+      if (params.get("id") !== trustchain.rootId) {
+        return HttpResponse.json({}, { status: 400 });
+      }
+      const version = params.get("version");
+      if (!version) {
+        return HttpResponse.json({
+          status: "out-of-sync",
+          version: 2,
+          payload: "payload",
+          date: new Date().toISOString(),
+        });
+      }
+      if (version === "1") {
+        return HttpResponse.json({ status: "up-to-date" });
+      }
+      return HttpResponse.json({ status: "no-data" });
+    }),
+    http.post(`${base}/atomic/v1/:slug`, async ({ request }) => {
+      const body = (await request.json()) as { payload: string };
+      return HttpResponse.json({ status: "updated", payload: body.payload });
+    }),
+    http.delete(`${base}/atomic/v1/:slug`, () => new HttpResponse(null, { status: 204 })),
+    http.get(`${base}/_info`, () => HttpResponse.json({ name: "cloud-sync", version: "1.0.0" })),
+  );
+
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+
+  const api = getApi(base);
+
+  it("fetchData without version returns distant payload", async () => {
+    const response = await api.fetchData(jwt, "live", undefined, trustchain);
+    expect(response.status).toBe("out-of-sync");
+    if (response.status === "out-of-sync") {
+      expect(response.payload).toBe("payload");
+    }
+  });
+
+  it("fetchData with version returns up-to-date", async () => {
+    const response = await api.fetchData(jwt, "live", 1, trustchain);
+    expect(response).toEqual({ status: "up-to-date" });
+  });
+
+  it("fetchData with stale version returns no-data", async () => {
+    const response = await api.fetchData(jwt, "live", 99, trustchain);
+    expect(response).toEqual({ status: "no-data" });
+  });
+
+  it("uploadData posts payload with trustchain params", async () => {
+    const response = await api.uploadData(jwt, "live", 3, "base64-payload", trustchain);
+    expect(response.status).toBe("updated");
+  });
+
+  it("deleteData succeeds", async () => {
+    await expect(api.deleteData(jwt, "live", trustchain)).resolves.toBeUndefined();
+  });
+
+  it("deleteData throws on HTTP error", async () => {
+    server.use(
+      http.delete(`${base}/atomic/v1/:slug`, () => HttpResponse.json({}, { status: 500 })),
+    );
+    await expect(api.deleteData(jwt, "live", trustchain)).rejects.toThrow("HTTP 500 on DELETE");
+  });
+
+  it("fetchStatus returns service info", async () => {
+    await expect(api.fetchStatus()).resolves.toEqual({ name: "cloud-sync", version: "1.0.0" });
+  });
+
+  it("fetchStatus throws when HTTP response is not ok", async () => {
+    server.use(http.get(`${base}/_info`, () => HttpResponse.json({}, { status: 500 })));
+    await expect(api.fetchStatus()).rejects.toThrow("HTTP 500");
+  });
+
+  it("listenNotifications handles ping, jwt refresh, and version notifications", async () => {
+    server.close();
+    const { server: wsServer, port: wsPort, close: closeWsServer } = createWsServer();
+    const wsApi = getApi(`http://localhost:${wsPort}`);
+    const receiveTunnel = makeTunnel<string>();
+    const clientTunnel = makeTunnel<WebSocket>();
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    wsServer.on("connection", ws => {
+      clientTunnel.write(ws);
+      ws.on("message", data => receiveTunnel.write(data.toString()));
+    });
+
+    try {
+      const clientPromise = clientTunnel.read();
+      const notificationsPromise = firstValueFrom(
+        wsApi.listenNotifications(async () => jwt, "live").pipe(toArray()),
+      );
+      const client = await clientPromise;
+
+      expect(await receiveTunnel.read()).toBe("mock-jwt");
+      client.send("ping");
+      expect(await receiveTunnel.read()).toBe("pong");
+      client.send("JWT expired");
+      expect(await receiveTunnel.read()).toBe("mock-jwt");
+      client.send("42");
+      client.send("unexpected-message");
+      client.close();
+
+      await expect(notificationsPromise).resolves.toEqual([42]);
+      expect(warnSpy).toHaveBeenCalledWith("cloudsync: unexpected message", "unexpected-message");
+    } finally {
+      warnSpy.mockRestore();
+      await closeWsServer();
+      server.listen();
+    }
+  });
+
+  it("listenNotifications propagates jwt refresh failures", async () => {
+    server.close();
+    const { server: wsServer, port: wsPort, close: closeWsServer } = createWsServer();
+    const wsApi = getApi(`http://localhost:${wsPort}`);
+
+    wsServer.on("connection", () => {});
+
+    try {
+      await expect(
+        firstValueFrom(
+          wsApi
+            .listenNotifications(async () => {
+              throw new Error("jwt failed");
+            }, "live")
+            .pipe(toArray()),
+        ),
+      ).rejects.toThrow("jwt failed");
+    } finally {
+      await closeWsServer();
+      server.listen();
+    }
+  });
+});
+
+function createWsServer() {
+  const server = new WebSocket.Server({ port: 0 });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind websocket server");
+  }
+  return {
+    server,
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function makeTunnel<V>() {
+  let resolve = (_v: V | Promise<V>) => {};
+  let nextPromise = new Promise<V>(success => {
+    resolve = success;
+  });
+  return {
+    write: (v: V) => {
+      resolve(v);
+      nextPromise = new Promise<V>(success => {
+        resolve = success;
+      });
+    },
+    read: (): Promise<V> => nextPromise,
+  };
+}

--- a/shared/cloud-sync/src/cloudsync/__tests__/cipher.test.ts
+++ b/shared/cloud-sync/src/cloudsync/__tests__/cipher.test.ts
@@ -1,0 +1,26 @@
+import { makeCipher } from "../cipher";
+import type { Trustchain, TrustchainSDK } from "../../trustchain-types";
+
+function makeMockTrustchainSdk(): TrustchainSDK {
+  return {
+    withAuth: jest.fn(async (_trustchain, _creds, fn) => fn({ accessToken: "mock-jwt" })),
+    encryptUserData: jest.fn(async (_trustchain, data) => data),
+    decryptUserData: jest.fn(async (_trustchain, data) => data),
+  };
+}
+
+describe(makeCipher.name, () => {
+  const trustchain: Trustchain = {
+    rootId: "root",
+    walletSyncEncryptionKey: "key",
+    applicationPath: "0'/16'/0'",
+  };
+  const data = { foo: [{ bar: "baz" }, 4], emojis: "🚀", number: 42 };
+
+  it("encrypt/decrypt round-trips data", async () => {
+    const cipher = makeCipher(makeMockTrustchainSdk());
+    const encrypted = await cipher.encrypt(trustchain, data);
+    const decrypted = await cipher.decrypt(trustchain, encrypted);
+    expect(decrypted).toEqual(data);
+  });
+});

--- a/shared/cloud-sync/src/cloudsync/__tests__/sdk.test.ts
+++ b/shared/cloud-sync/src/cloudsync/__tests__/sdk.test.ts
@@ -1,0 +1,245 @@
+import { z } from "zod";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import WebSocket from "ws";
+import { CloudSyncSDK, UpdateEvent } from "../sdk";
+import { WalletSyncOutdated } from "../../trustchain-types";
+import type { MemberCredentials, Trustchain, TrustchainSDK } from "../../trustchain-types";
+
+describe("CloudSyncSDK", () => {
+  const port = 54036;
+  const base = `http://localhost:${port}`;
+  const schema = z.object({ value: z.string() });
+  type Data = z.infer<typeof schema>;
+
+  let storedData: string | null = null;
+  let storedVersion = 0;
+  let postCounter = 0;
+
+  const trustchain: Trustchain = {
+    rootId: "root-id",
+    applicationPath: "0'/16'/0'",
+    walletSyncEncryptionKey: "key",
+  };
+  const creds: MemberCredentials = { pubkey: "pub", privatekey: "priv" };
+
+  const server = setupServer(
+    http.get(`${base}/atomic/v1/:slug`, ({ request }) => {
+      const version = parseInt(new URL(request.url).searchParams.get("version") || "0", 10);
+      if (!storedData) return HttpResponse.json({ status: "no-data" });
+      if (storedVersion <= version) return HttpResponse.json({ status: "up-to-date" });
+      return HttpResponse.json({
+        status: "out-of-sync",
+        version: storedVersion,
+        payload: storedData,
+        date: new Date().toISOString(),
+      });
+    }),
+    http.post(`${base}/atomic/v1/:slug`, async ({ request }) => {
+      postCounter += 1;
+      const version = parseInt(new URL(request.url).searchParams.get("version") || "0", 10);
+      const { payload } = (await request.json()) as { payload: string };
+      if (version !== storedVersion + 1) {
+        const extra =
+          postCounter % 3 === 0
+            ? {}
+            : postCounter % 3 === 1
+              ? { info: "lld/0.0.0" }
+              : { info: null };
+        return HttpResponse.json({
+          status: "out-of-sync",
+          version: storedVersion,
+          payload: storedData,
+          date: new Date().toISOString(),
+          ...extra,
+        });
+      }
+      storedVersion = version;
+      storedData = payload;
+      return HttpResponse.json({ status: "updated" });
+    }),
+    http.delete(`${base}/atomic/v1/:slug`, () => {
+      storedData = null;
+      storedVersion = 0;
+      return new HttpResponse(null, { status: 204 });
+    }),
+  );
+
+  let version = 0;
+  let data: Data | null = null;
+  let trustchainSdk: TrustchainSDK;
+  let sdk: CloudSyncSDK<typeof schema>;
+
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    postCounter = 0;
+    storedData = null;
+    storedVersion = 0;
+    version = 0;
+    data = null;
+    trustchainSdk = makeMockTrustchainSdk();
+    sdk = new CloudSyncSDK({
+      apiBaseUrl: base,
+      slug: "test",
+      schema,
+      trustchainSdk,
+      getCurrentVersion: () => version,
+      saveNewUpdate: (update: UpdateEvent<Data>) => {
+        switch (update.type) {
+          case "new-data":
+          case "pushed-data":
+            version = update.version;
+            data = update.data;
+            break;
+          case "deleted-data":
+            version = 0;
+            data = null;
+            break;
+        }
+        return Promise.resolve();
+      },
+    });
+  });
+
+  it("pull/push/destroy keeps local and remote state in sync", async () => {
+    await sdk.pull(trustchain, creds);
+    expect(data).toBeNull();
+    expect(version).toBe(0);
+
+    await sdk.push(trustchain, creds, { value: "hello" });
+    expect(data).toEqual({ value: "hello" });
+    expect(version).toBe(1);
+
+    await sdk.push(trustchain, creds, { value: "bar" });
+    expect(data).toEqual({ value: "bar" });
+    expect(version).toBe(2);
+
+    await sdk.pull(trustchain, creds);
+    expect(version).toBe(2);
+
+    await sdk.destroy(trustchain, creds);
+    expect(data).toBeNull();
+    expect(version).toBe(0);
+    expect(storedData).toBeNull();
+  });
+
+  it("rejects invalid payloads on push", async () => {
+    await expect(sdk.push(trustchain, creds, { invalid: 42 } as unknown as Data)).rejects.toThrow();
+  });
+
+  it("throws WalletSyncOutdated when local version exists but remote has no data", async () => {
+    version = 1;
+    data = { value: "old" };
+    await expect(sdk.pull(trustchain, creds)).rejects.toThrow(WalletSyncOutdated);
+    expect(data).toBeNull();
+    expect(version).toBe(0);
+  });
+
+  it("prevents concurrent push/pull/destroy calls", async () => {
+    await expect(
+      Promise.all([sdk.pull(trustchain, creds), sdk.pull(trustchain, creds)]),
+    ).rejects.toThrow("CloudSyncSDK locked");
+  });
+
+  it("ignores push conflicts without updating local state", async () => {
+    await sdk.push(trustchain, creds, { value: "hello" });
+    version = 4;
+    data = { value: "hello" };
+    storedVersion = 5;
+
+    await sdk.push(trustchain, creds, { value: "conflict" });
+    expect(data).toEqual({ value: "hello" });
+    expect(version).toBe(4);
+  });
+
+  it("pulls newer remote data when local version is behind", async () => {
+    await sdk.push(trustchain, creds, { value: "remote" });
+    version = 0;
+    data = null;
+
+    await sdk.pull(trustchain, creds);
+    expect(data).toEqual({ value: "remote" });
+    expect(version).toBe(1);
+  });
+
+  it("propagates decrypt failures on pull", async () => {
+    await sdk.push(trustchain, creds, { value: "remote" });
+    trustchainSdk.decryptUserData = () => Promise.reject(new Error("decryption failed"));
+    version = 0;
+    await expect(sdk.pull(trustchain, creds)).rejects.toThrow("decryption failed");
+  });
+
+  it("listenNotifications requests a refreshed jwt for the websocket handshake", async () => {
+    const { server: wsServer, port: wsPort, close: closeWsServer } = createWsServer();
+    const sdkWithWs = new CloudSyncSDK({
+      apiBaseUrl: `http://localhost:${wsPort}`,
+      slug: "test",
+      schema,
+      trustchainSdk,
+      getCurrentVersion: () => version,
+      saveNewUpdate: async () => {},
+    });
+    const receiveTunnel = makeTunnel<string>();
+
+    wsServer.on("connection", ws => {
+      ws.on("message", data => receiveTunnel.write(data.toString()));
+    });
+
+    try {
+      const receivePromise = receiveTunnel.read();
+      const sub = sdkWithWs.listenNotifications(trustchain, creds).subscribe();
+      await expect(receivePromise).resolves.toBe("mock-live-jwt");
+      expect(trustchainSdk.withAuth).toHaveBeenCalledWith(
+        trustchain,
+        creds,
+        expect.any(Function),
+        "refresh",
+      );
+      sub.unsubscribe();
+    } finally {
+      await closeWsServer();
+    }
+  });
+});
+
+function makeTunnel<V>() {
+  let resolve = (_v: V | Promise<V>) => {};
+  let nextPromise = new Promise<V>(success => {
+    resolve = success;
+  });
+  return {
+    write: (v: V) => {
+      resolve(v);
+      nextPromise = new Promise<V>(success => {
+        resolve = success;
+      });
+    },
+    read: (): Promise<V> => nextPromise,
+  };
+}
+
+function createWsServer() {
+  const server = new WebSocket.Server({ port: 0 });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind websocket server");
+  }
+  return {
+    server,
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+function makeMockTrustchainSdk(): TrustchainSDK {
+  return {
+    withAuth: jest.fn(async (_trustchain, _creds, fn) => fn({ accessToken: "mock-live-jwt" })),
+    encryptUserData: jest.fn(async (_trustchain, payload) => payload),
+    decryptUserData: jest.fn(async (_trustchain, payload) => payload),
+  };
+}

--- a/shared/cloud-sync/src/cloudsync/api.ts
+++ b/shared/cloud-sync/src/cloudsync/api.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import WS from "isomorphic-ws";
+import type { WebSocket } from "ws";
+import { Observable } from "rxjs";
+import { JWT, Trustchain } from "../trustchain-types";
+
+const schemaAtomicGetNoData = z.object({ status: z.literal("no-data") });
+const schemaAtomicGetUpToDate = z.object({ status: z.literal("up-to-date") });
+const schemaAtomicGetOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  version: z.number(),
+  payload: z.string(),
+  date: z.string(),
+  info: z.string().nullable().optional(),
+});
+const schemaAtomicGetResponse = z.discriminatedUnion("status", [
+  schemaAtomicGetNoData,
+  schemaAtomicGetUpToDate,
+  schemaAtomicGetOutOfSync,
+]);
+export type APISyncResponse = z.infer<typeof schemaAtomicGetResponse>;
+export type StatusAPIResponse = { name: string; version: string };
+
+const schemaAtomicPostUpdated = z.object({ status: z.literal("updated") });
+const schemaAtomicPostOutOfSync = z.object({
+  status: z.literal("out-of-sync"),
+  version: z.number(),
+  payload: z.string(),
+  date: z.string(),
+  info: z.string().nullable().optional(),
+});
+const schemaAtomicPostResponse = z.discriminatedUnion("status", [
+  schemaAtomicPostUpdated,
+  schemaAtomicPostOutOfSync,
+]);
+export type APISyncUpdateResponse = z.infer<typeof schemaAtomicPostResponse>;
+
+async function apiFetch<T>(url: string, init: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText} on ${init.method} ${url}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function getApi(apiBaseURL: string) {
+  async function fetchData(
+    jwt: JWT,
+    datatype: string,
+    version: number | undefined,
+    trustchain: Trustchain,
+  ): Promise<APISyncResponse> {
+    const params = new URLSearchParams({
+      path: trustchain.applicationPath,
+      id: trustchain.rootId,
+    });
+    if (version !== undefined) params.set("version", String(version));
+    const data = await apiFetch<unknown>(
+      `${apiBaseURL}/atomic/v1/${datatype}?${params.toString()}`,
+      { method: "GET", headers: { Authorization: `Bearer ${jwt.accessToken}` } },
+    );
+    return schemaAtomicGetResponse.parse(data);
+  }
+
+  async function uploadData(
+    jwt: JWT,
+    datatype: string,
+    version: number,
+    payload: string,
+    trustchain: Trustchain,
+  ): Promise<APISyncUpdateResponse> {
+    const params = new URLSearchParams({
+      version: String(version),
+      path: trustchain.applicationPath,
+      id: trustchain.rootId,
+    });
+    const data = await apiFetch<unknown>(
+      `${apiBaseURL}/atomic/v1/${datatype}?${params.toString()}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${jwt.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ payload }),
+      },
+    );
+    return schemaAtomicPostResponse.parse(data);
+  }
+
+  async function deleteData(jwt: JWT, datatype: string, trustchain: Trustchain): Promise<void> {
+    const params = new URLSearchParams({
+      path: trustchain.applicationPath,
+      id: trustchain.rootId,
+    });
+    const res = await fetch(`${apiBaseURL}/atomic/v1/${datatype}?${params.toString()}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${jwt.accessToken}` },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} on DELETE`);
+  }
+
+  function listenNotifications(
+    getFreshJwt: () => Promise<JWT>,
+    datatype: string,
+  ): Observable<number> {
+    const url = `${apiBaseURL.replace(/^http/, "ws")}/atomic/v1/${datatype}/notifications`;
+    const ws: WebSocket = new WS(url);
+    return new Observable(observer => {
+      function sendJwt() {
+        getFreshJwt()
+          .then(jwt => ws.send(jwt.accessToken))
+          .catch(error => {
+            observer.error(error);
+            ws.close();
+          });
+      }
+      ws.addEventListener("message", e => {
+        const data = e.data.toString();
+        if (data === "ping") ws.send("pong");
+        else if (data === "JWT expired") sendJwt();
+        else {
+          const possiblyNumber = parseInt(data, 10);
+          if (!Number.isNaN(possiblyNumber)) observer.next(possiblyNumber);
+          else console.warn("cloudsync: unexpected message", data);
+        }
+      });
+      ws.addEventListener("close", () => observer.complete());
+      ws.addEventListener("error", error => observer.error(error));
+      ws.addEventListener("open", () => {
+        sendJwt();
+      });
+      return () => ws.close();
+    });
+  }
+
+  async function fetchStatus(): Promise<StatusAPIResponse> {
+    const data = await apiFetch<StatusAPIResponse>(`${apiBaseURL}/_info`, { method: "GET" });
+    return data;
+  }
+
+  return { fetchData, uploadData, deleteData, listenNotifications, fetchStatus };
+}
+
+export default getApi;

--- a/shared/cloud-sync/src/cloudsync/cipher.ts
+++ b/shared/cloud-sync/src/cloudsync/cipher.ts
@@ -1,0 +1,30 @@
+import Base64 from "base64-js";
+import pako from "pako";
+import { TrustchainSDK, Trustchain } from "../trustchain-types";
+
+export type Cipher<Data> = {
+  decrypt: (trustchain: Trustchain, base64payload: string) => Promise<Data>;
+  encrypt: (trustchain: Trustchain, data: Data) => Promise<string>;
+};
+
+export function makeCipher<Data>(trustchainSdk: TrustchainSDK): Cipher<Data> {
+  return {
+    decrypt: async (trustchain: Trustchain, base64payload: string): Promise<Data> => {
+      const decrypted = await trustchainSdk.decryptUserData(
+        trustchain,
+        Base64.toByteArray(base64payload),
+      );
+      const decompressed = pako.inflate(decrypted);
+      const json = JSON.parse(new TextDecoder().decode(decompressed));
+      return json;
+    },
+    encrypt: async (trustchain: Trustchain, data: Data): Promise<string> => {
+      const json = JSON.stringify(data);
+      const bytes = new TextEncoder().encode(json);
+      const compressed = pako.deflate(bytes);
+      const encrypted = await trustchainSdk.encryptUserData(trustchain, compressed);
+      const base64 = Base64.fromByteArray(encrypted);
+      return base64;
+    },
+  };
+}

--- a/shared/cloud-sync/src/cloudsync/sdk.ts
+++ b/shared/cloud-sync/src/cloudsync/sdk.ts
@@ -1,0 +1,151 @@
+import {
+  MemberCredentials,
+  Trustchain,
+  TrustchainSDK,
+  WalletSyncOutdated,
+  JWT,
+} from "../trustchain-types";
+import getApi from "./api";
+import { Observable } from "rxjs";
+import { z, ZodType } from "zod";
+import { Cipher, makeCipher } from "./cipher";
+
+export type UpdateEvent<Data> =
+  | { type: "new-data"; data: Data; version: number }
+  | { type: "pushed-data"; data: Data; version: number }
+  | { type: "deleted-data" };
+
+export interface CloudSyncSDKInterface<Data> {
+  push(trustchain: Trustchain, memberCredentials: MemberCredentials, data: Data): Promise<void>;
+  pull(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void>;
+  destroy(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void>;
+  listenNotifications(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Observable<number>;
+}
+
+export class CloudSyncSDK<
+  Schema extends ZodType,
+  Data = z.infer<Schema>,
+> implements CloudSyncSDKInterface<Data> {
+  private readonly slug: string;
+  private readonly schema: Schema;
+  private readonly trustchainSdk: TrustchainSDK;
+  private readonly getCurrentVersion: () => number | undefined;
+  private readonly saveNewUpdate: (updateEvent: UpdateEvent<Data>) => Promise<void>;
+  private readonly cipher: Cipher<Data>;
+  private readonly api: ReturnType<typeof getApi>;
+
+  constructor({
+    apiBaseUrl,
+    slug,
+    schema,
+    trustchainSdk,
+    getCurrentVersion,
+    saveNewUpdate,
+  }: {
+    apiBaseUrl: string;
+    slug: string;
+    schema: Schema;
+    trustchainSdk: TrustchainSDK;
+    getCurrentVersion: () => number | undefined;
+    saveNewUpdate: (event: UpdateEvent<Data>) => Promise<void>;
+  }) {
+    this.slug = slug;
+    this.schema = schema;
+    this.trustchainSdk = trustchainSdk;
+    this.getCurrentVersion = getCurrentVersion;
+    this.saveNewUpdate = saveNewUpdate;
+    this.cipher = makeCipher(trustchainSdk);
+    this.push = this.decorateMethod("push", this.push);
+    this.pull = this.decorateMethod("pull", this.pull);
+    this.destroy = this.decorateMethod("destroy", this.destroy);
+    this.api = getApi(apiBaseUrl);
+  }
+
+  async push(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+    data: Data,
+  ): Promise<void> {
+    this.schema.parse(data);
+    const validated = data;
+    const base64 = await this.cipher.encrypt(trustchain, validated);
+    const version = (this.getCurrentVersion() || 0) + 1;
+    const response = await this.trustchainSdk.withAuth(trustchain, memberCredentials, jwt =>
+      this.api.uploadData(jwt, this.slug, version, base64, trustchain),
+    );
+    switch (response.status) {
+      case "updated":
+        await this.saveNewUpdate({ type: "pushed-data", version, data });
+        break;
+      case "out-of-sync":
+        break;
+    }
+  }
+
+  async pull(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void> {
+    const response = await this.trustchainSdk.withAuth(trustchain, memberCredentials, jwt =>
+      this.api.fetchData(jwt, this.slug, this.getCurrentVersion(), trustchain),
+    );
+    switch (response.status) {
+      case "no-data": {
+        const version = this.getCurrentVersion();
+        if (version) {
+          await this.saveNewUpdate({ type: "deleted-data" });
+          throw new WalletSyncOutdated();
+        }
+        break;
+      }
+      case "up-to-date":
+        break;
+      case "out-of-sync": {
+        const json = await this.cipher.decrypt(trustchain, response.payload);
+        this.schema.parse(json);
+        const validated = json;
+        const version = response.version;
+        await this.saveNewUpdate({ type: "new-data", data: validated, version });
+        break;
+      }
+    }
+  }
+
+  async destroy(trustchain: Trustchain, memberCredentials: MemberCredentials): Promise<void> {
+    await this.trustchainSdk.withAuth(trustchain, memberCredentials, jwt =>
+      this.api.deleteData(jwt, this.slug, trustchain),
+    );
+    await this.saveNewUpdate({ type: "deleted-data" });
+  }
+
+  listenNotifications(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ): Observable<number> {
+    const getFreshJwt = (): Promise<JWT> =>
+      this.trustchainSdk.withAuth(
+        trustchain,
+        memberCredentials,
+        jwt => Promise.resolve(jwt),
+        "refresh",
+      );
+    return this.api.listenNotifications(getFreshJwt, this.slug);
+  }
+
+  private lock: string | null = null;
+  private decorateMethod<R, A extends unknown[]>(
+    methodName: string,
+    f: (...args: A) => Promise<R>,
+  ): (...args: A) => Promise<R> {
+    return async (...args) => {
+      const { lock } = this;
+      if (lock) throw new Error("CloudSyncSDK locked (" + this.lock + ")");
+      try {
+        this.lock = methodName;
+        return await f.apply(this, args);
+      } finally {
+        this.lock = null;
+      }
+    };
+  }
+}

--- a/shared/cloud-sync/src/index.ts
+++ b/shared/cloud-sync/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./trustchain-types";
+export * from "./cloudsync/api";
+export * from "./cloudsync/cipher";
+export * from "./cloudsync/sdk";
+export { default as getCloudSyncApi } from "./cloudsync/api";

--- a/shared/cloud-sync/src/trustchain-types.ts
+++ b/shared/cloud-sync/src/trustchain-types.ts
@@ -1,0 +1,47 @@
+// Local structural interfaces mirroring @ledgerhq/ledger-key-ring-protocol types.
+// Keeping lkrp out of this package's runtime deps avoids pulling in its native
+// addon chain (tiny-secp256k1 etc.) into domain build targets.
+
+export type JWT = {
+  accessToken: string;
+};
+
+export type Trustchain = {
+  rootId: string;
+  walletSyncEncryptionKey: string;
+  applicationPath: string;
+};
+
+export type MemberCredentials = {
+  pubkey: string;
+  privatekey: string;
+};
+
+export type AuthCachePolicy = "no-cache" | "refresh" | "cache";
+
+export interface TrustchainSDK {
+  withAuth<T>(
+    trustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+    fn: (jwt: JWT) => Promise<T>,
+    cachePolicy?: AuthCachePolicy,
+  ): Promise<T>;
+  encryptUserData(trustchain: Trustchain, data: Uint8Array): Promise<Uint8Array>;
+  decryptUserData(trustchain: Trustchain, data: Uint8Array): Promise<Uint8Array>;
+}
+
+export type TrustchainLifecycle = {
+  onTrustchainRotation: (
+    trustchainSdk: TrustchainSDK,
+    oldTrustchain: Trustchain,
+    memberCredentials: MemberCredentials,
+  ) => Promise<(newTrustchain: Trustchain) => Promise<void>>;
+};
+
+/** Thrown by CloudSyncSDK.pull() when local data is out of sync with the cloud. */
+export class WalletSyncOutdated extends Error {
+  constructor() {
+    super("Wallet sync data is outdated");
+    this.name = "WalletSyncOutdated";
+  }
+}

--- a/shared/cloud-sync/tsconfig.json
+++ b/shared/cloud-sync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/shared/wallet-sync/README.md
+++ b/shared/wallet-sync/README.md
@@ -1,0 +1,21 @@
+# @shared/wallet-sync
+
+Context-free aggregation core for Ledger Live wallet synchronisation.
+
+Exports `createAggregator()` which composes a list of `WalletSyncDataManager` modules (accounts, accountNames, recentAddresses, …) into a single aggregated schema, diff, incremental-update resolver and apply function. Has no knowledge of Redux, React or networking — it is a pure data-transformation layer.
+
+The `WalletSyncDataManager<LocalState, Update, Schema>` interface describes the contract each sync module must implement.
+
+## Related documentation
+
+- [WalletSyncDataManager](./../../docs/ledger-sync/05-wallet-sync-data-manager.md) — concepts, module contract, accounts reconciliation
+- [The watch loop](./../../docs/ledger-sync/06-watch-loop.md) — how aggregation feeds the continuous sync loop
+- [Cookbook: add a module](./../../docs/ledger-sync/cookbook.md) — hands-on module authoring guide
+
+## Implementation locations
+
+| Module | Package |
+|---|---|
+| accounts | [`@ledgerhq/live-wallet/accounts`](../../libs/live-wallet/src/accounts/) (interim) |
+| accountNames | [`@domain/entity-account-name`](../../domain/entity/account-name) |
+| recentAddresses | [`@domain/entity-recent-addresses`](../../domain/entity/recent-addresses) |

--- a/shared/wallet-sync/jest.config.js
+++ b/shared/wallet-sync/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/shared/wallet-sync/package.json
+++ b/shared/wallet-sync/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shared/wallet-sync",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared WalletSync module interface types (ctx-free)",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/wallet-sync"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/shared/wallet-sync/project.json
+++ b/shared/wallet-sync/project.json
@@ -1,0 +1,8 @@
+{
+  "tags": ["scope:shared"],
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/wallet-sync/src/__tests__/createAggregator.test.ts
+++ b/shared/wallet-sync/src/__tests__/createAggregator.test.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { createAggregator, mapValues } from "../index";
+
+describe(mapValues.name, () => {
+  it("maps object values while preserving keys", () => {
+    expect(mapValues({ a: 1, b: 2 }, value => value * 2)).toEqual({ a: 2, b: 4 });
+  });
+});
+
+describe(createAggregator.name, () => {
+  const alphaModule = {
+    schema: z.array(z.string()),
+    diffLocalToDistant: (local: string[], latest: string[] | null) => ({
+      hasChanges: local.join() !== (latest ?? []).join(),
+      nextState: local,
+    }),
+    resolveIncrementalUpdate: async (
+      local: string[],
+      latest: string[] | null,
+      incoming: string[] | null,
+    ) => {
+      if (!incoming || incoming.join() === (latest ?? []).join()) {
+        return { hasChanges: false as const };
+      }
+      if (incoming.join() === local.join()) {
+        return { hasChanges: false as const };
+      }
+      return { hasChanges: true as const, update: incoming };
+    },
+    applyUpdate: (_local: string[], update: string[]) => update,
+  };
+
+  const betaModule = {
+    schema: z.number(),
+    diffLocalToDistant: (local: number, latest: number | null) => ({
+      hasChanges: local !== (latest ?? 0),
+      nextState: local,
+    }),
+    resolveIncrementalUpdate: async (
+      local: number,
+      latest: number | null,
+      incoming: number | null,
+    ) => {
+      if (incoming == null || incoming === latest || incoming === local) {
+        return { hasChanges: false as const };
+      }
+      return { hasChanges: true as const, update: incoming };
+    },
+    applyUpdate: (_local: number, update: number) => update,
+  };
+
+  const aggregator = createAggregator({ alpha: alphaModule, beta: betaModule });
+
+  it("aggregates diffLocalToDistant across modules and preserves unknown distant keys", () => {
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 2 }, {
+      alpha: ["a"],
+      beta: 1,
+      legacy: true,
+    } as never);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState).toEqual({ alpha: ["a"], beta: 2, legacy: true });
+  });
+
+  it("returns hasChanges=false when all modules are unchanged", () => {
+    const distant = { alpha: ["a"], beta: 1 };
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 1 }, distant);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState.alpha).toEqual(["a"]);
+    expect(result.nextState.beta).toBe(1);
+  });
+
+  it("returns hasChanges=false when resolveIncrementalUpdate finds no changes", async () => {
+    const distant = { alpha: ["a"], beta: 1 };
+    const result = await aggregator.resolveIncrementalUpdate(
+      { alpha: ["a"], beta: 1 },
+      distant,
+      distant,
+    );
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns combined update when at least one module changes", async () => {
+    const result = await aggregator.resolveIncrementalUpdate(
+      { alpha: ["a"], beta: 1 },
+      { alpha: ["a"], beta: 1 },
+      { alpha: ["b"], beta: 1 },
+    );
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.alpha).toEqual({ hasChanges: true, update: ["b"] });
+      expect(result.update.beta).toEqual({ hasChanges: false });
+    }
+  });
+
+  it("applyUpdate only applies modules that reported changes", () => {
+    const local = { alpha: ["a"], beta: 1 };
+    const result = aggregator.applyUpdate(local, {
+      alpha: { hasChanges: true, update: ["z"] },
+      beta: { hasChanges: false },
+    } as Parameters<typeof aggregator.applyUpdate>[1]);
+    expect(result).toEqual({ alpha: ["z"], beta: 1 });
+  });
+
+  it("handles null distant states during diff and resolve", async () => {
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 1 }, null);
+    expect(result.hasChanges).toBe(true);
+
+    const resolved = await aggregator.resolveIncrementalUpdate({ alpha: [], beta: 0 }, null, {
+      alpha: ["a"],
+      beta: 1,
+    });
+    expect(resolved.hasChanges).toBe(true);
+  });
+});

--- a/shared/wallet-sync/src/index.ts
+++ b/shared/wallet-sync/src/index.ts
@@ -1,0 +1,95 @@
+import { ZodType, z } from "zod";
+
+export interface WalletSyncDataManager<
+  LocalState,
+  Update,
+  Schema extends ZodType,
+  DistantState = z.infer<Schema>,
+> {
+  schema: Schema;
+  diffLocalToDistant: (
+    localData: LocalState,
+    latestState: DistantState | null,
+  ) => DistantDiff<DistantState>;
+  resolveIncrementalUpdate: (
+    localData: LocalState,
+    latestState: DistantState | null,
+    incomingState: DistantState | null,
+  ) => Promise<UpdateDiff<Update>>;
+  applyUpdate: (localData: LocalState, update: Update) => LocalState;
+}
+
+export type UpdateDiff<Update> = { hasChanges: false } | { hasChanges: true; update: Update };
+
+export type DistantDiff<DistantState> = { hasChanges: boolean; nextState: DistantState };
+
+export type ExtractLocalState<T> = T extends WalletSyncDataManager<infer L, any, any> ? L : never;
+export type ExtractUpdateEvent<T> = T extends WalletSyncDataManager<any, infer U, any> ? U : never;
+export type ExtractSchema<T> = T extends WalletSyncDataManager<any, any, infer S> ? S : never;
+export type ExtractDistantState<T> =
+  T extends WalletSyncDataManager<any, any, any, infer D> ? D : never;
+
+export function createAggregator<Mods extends Record<string, WalletSyncDataManager<any, any, any>>>(
+  modules: Mods,
+) {
+  const schema = z.object(mapValues(modules, m => z.optional(m.schema)));
+
+  type Schema = typeof schema;
+  type DistantState = { [K in keyof Mods]?: z.infer<Mods[K]["schema"]> };
+  type LocalState = { [K in keyof Mods]: ExtractLocalState<Mods[K]> };
+  type UpdateEvent = { [K in keyof Mods]: UpdateDiff<ExtractUpdateEvent<Mods[K]>> };
+
+  const root: WalletSyncDataManager<LocalState, UpdateEvent, Schema, DistantState> = {
+    schema,
+
+    diffLocalToDistant(localData, latestState) {
+      let hasChanges = false;
+      const unknownRest: Record<string, unknown> = { ...latestState };
+      const nextState = mapValues(modules, (m, k) => {
+        const diff = m.diffLocalToDistant(
+          localData[k],
+          latestState != null ? (latestState[k] ?? null) : null,
+        );
+        delete unknownRest[k as string];
+        if (diff.hasChanges) hasChanges = true;
+        return diff.nextState;
+      });
+      return { hasChanges, nextState: { ...nextState, ...unknownRest } };
+    },
+
+    async resolveIncrementalUpdate(localData, latestState, incomingState) {
+      const resolved = mapValues(modules, (m, k) =>
+        m.resolveIncrementalUpdate(
+          localData[k],
+          latestState != null ? (latestState[k] ?? null) : null,
+          incomingState != null ? (incomingState[k] ?? null) : null,
+        ),
+      );
+      const results = await Promise.all(Object.values(resolved));
+      const hasChanges = results.some(r => r.hasChanges);
+      let index = 0;
+      const update = mapValues(modules, () => results[index++]) as UpdateEvent;
+      return !hasChanges ? { hasChanges: false } : { hasChanges: true, update };
+    },
+
+    applyUpdate(localData, update) {
+      const result = mapValues(modules, (m, k) => {
+        const up = update[k];
+        return up.hasChanges ? m.applyUpdate(localData[k], up.update) : localData[k];
+      });
+      return result;
+    },
+  };
+  return root;
+}
+
+export function mapValues<T extends object, U>(
+  obj: T,
+  fn: (value: T[keyof T], key: keyof T) => U,
+): { [K in keyof T]: U } {
+  const result = {} as { [K in keyof T]: U };
+  for (const key in obj) {
+    result[key] = fn(obj[key], key);
+  }
+  return result;
+}

--- a/shared/wallet-sync/tsconfig.json
+++ b/shared/wallet-sync/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
> [!WARNING]
> This is an exploratory PR extracted from the DDD WalletSync PoC. It introduces new packages only — no existing code is modified.

### 📝 Description

Introduces the two shared-layer packages with no workspace dependencies:

- `@shared/wallet-sync` — `createAggregator()`, context-free WalletSyncDataManager
- `@shared/cloud-sync` — CloudSyncSDK (native fetch/WebSocket, replaces live-network for sync)

These are the foundation packages that PR-C (`@domain/entity-account-name`, `@domain/entity-recent-addresses`) and PR-D (`@features/platform-wallet-sync`) stack on.

**Merge order:** PR-A and PR-B can be merged in parallel. PR-C and PR-D require PR-A first.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35266](https://ledgerhq.atlassian.net/browse/LIVE-35266) (epic: [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990))
- **ADR** (if any): see LIVE-34990 description for full package table and layer rationale

[LIVE-35266]: https://ledgerhq.atlassian.net/browse/LIVE-35266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ