### PR TITLE
[LIVE-35267] feat(ddd): add @domain/entity-starred-account and @domain/entity-wallet-sync packages

### DIFF
--- a/domain/entity/starred-account/README.md
+++ b/domain/entity/starred-account/README.md
@@ -1,0 +1,9 @@
+# @domain/entity-starred-account
+
+RTK slice for starred (pinned) accounts.
+
+State shape: `starredAccountIds: Set<string>`. Local-only state (not synced). Exports `starredAccountsSlice`, actions (`setAccountStarred`, `initStarredFromIds`) and selector `isStarredAccountSelector`.
+
+## Related documentation
+
+- [App integration](./../../docs/ledger-sync/07-app-integration.md) — wallet Redux wiring in Desktop & Mobile

--- a/domain/entity/starred-account/jest.config.js
+++ b/domain/entity/starred-account/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/starred-account/package.json
+++ b/domain/entity/starred-account/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@domain/entity-starred-account",
+  "version": "0.0.1",
+  "private": true,
+  "description": "StarredAccount entity: starred account IDs state, action creators, and selectors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./src/slice.ts"],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/starred-account"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "immer": "^11.0.0"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/starred-account/project.json
+++ b/domain/entity/starred-account/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-starred-account",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/starred-account/src/__tests__/store.test.ts
+++ b/domain/entity/starred-account/src/__tests__/store.test.ts
@@ -1,0 +1,76 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { initStarredFromIds, setAccountStarred, starredAccountsSlice } from "../slice";
+import { isStarredAccountSelector } from "../selectors";
+
+function makeStore() {
+  const store = configureStore({
+    reducer: { starred: starredAccountsSlice.reducer },
+    // mirrors the apps: this slice holds a Set, which RTK's serializable check rejects
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+  });
+  return {
+    dispatch: store.dispatch,
+    starred: () => store.getState().starred,
+    isStarred: (accountId: string) =>
+      isStarredAccountSelector(store.getState().starred, { accountId }),
+  };
+}
+
+describe("starredAccountsSlice", () => {
+  it("starts empty", () => {
+    expect(makeStore().starred().size).toBe(0);
+  });
+
+  it.each([
+    ["stars an account", true, true],
+    ["unstars an unknown account without throwing", false, false],
+  ])("setAccountStarred %s", (_name, starred, expected) => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred }));
+    expect(store.isStarred("a1")).toBe(expected);
+  });
+
+  it("setAccountStarred toggles back to unstarred", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: false }));
+    expect(store.isStarred("a1")).toBe(false);
+  });
+
+  it("setAccountStarred is idempotent", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    expect(store.starred().size).toBe(1);
+  });
+
+  it("setAccountStarred leaves other accounts untouched", () => {
+    const store = makeStore();
+    store.dispatch(initStarredFromIds(["a1", "a2"]));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: false }));
+    expect([...store.starred()]).toEqual(["a2"]);
+  });
+
+  it("setAccountStarred returns a new Set rather than mutating the frozen state", () => {
+    const store = makeStore();
+    const before = store.starred();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    expect(store.starred()).not.toBe(before);
+    expect(before.size).toBe(0);
+  });
+
+  it("initStarredFromIds replaces the whole set and dedupes", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "old", starred: true }));
+    store.dispatch(initStarredFromIds(["a1", "a1", "a2"]));
+    expect([...store.starred()]).toEqual(["a1", "a2"]);
+    expect(store.isStarred("old")).toBe(false);
+  });
+
+  it("initStarredFromIds with an empty list clears everything", () => {
+    const store = makeStore();
+    store.dispatch(initStarredFromIds(["a1"]));
+    store.dispatch(initStarredFromIds([]));
+    expect(store.starred().size).toBe(0);
+  });
+});

--- a/domain/entity/starred-account/src/index.ts
+++ b/domain/entity/starred-account/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./selectors";
+export * from "./slice";

--- a/domain/entity/starred-account/src/schema.ts
+++ b/domain/entity/starred-account/src/schema.ts
@@ -1,0 +1,3 @@
+import type { StarredAccountState } from "./slice";
+
+export const initialStarredAccountState: StarredAccountState = new Set();

--- a/domain/entity/starred-account/src/selectors.ts
+++ b/domain/entity/starred-account/src/selectors.ts
@@ -1,0 +1,6 @@
+import type { StarredAccountState } from "./slice";
+
+export const isStarredAccountSelector = (
+  state: StarredAccountState,
+  { accountId }: { accountId: string },
+): boolean => state.has(accountId);

--- a/domain/entity/starred-account/src/slice.ts
+++ b/domain/entity/starred-account/src/slice.ts
@@ -1,0 +1,27 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { enableMapSet } from "immer";
+
+// RTK freezes state through Immer; this slice keeps its starred ids in a Set.
+enableMapSet();
+
+export type StarredAccountState = Set<string>;
+
+export const starredAccountsSlice = createSlice({
+  name: "starredAccounts",
+  initialState: new Set<string>() as StarredAccountState,
+  reducers: {
+    setAccountStarred: (
+      state,
+      { payload }: PayloadAction<{ accountId: string; starred: boolean }>,
+    ): StarredAccountState => {
+      const next = new Set(state);
+      if (payload.starred) next.add(payload.accountId);
+      else next.delete(payload.accountId);
+      return next;
+    },
+    initStarredFromIds: (_state, { payload }: PayloadAction<string[]>): StarredAccountState =>
+      new Set(payload),
+  },
+});
+
+export const { setAccountStarred, initStarredFromIds } = starredAccountsSlice.actions;

--- a/domain/entity/starred-account/tsconfig.json
+++ b/domain/entity/starred-account/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/domain/entity/wallet-sync/README.md
+++ b/domain/entity/wallet-sync/README.md
@@ -1,0 +1,13 @@
+# @domain/entity-wallet-sync
+
+RTK slice for WalletSync protocol state (distant data + version).
+
+State shape: `{ walletSyncState: WSState }`. Tracks the current sync status (version, distant state blob). Exports `walletSyncSlice`, action `walletSyncUpdate` and selector `walletSyncStateSelector`.
+
+> Account-related sync state (`nonImportedAccountInfos`) lives in [`@ledgerhq/live-wallet/accounts`](../../../libs/live-wallet/src/accounts/) until `@domain/entity-account` exists.
+
+## Related documentation
+
+- [WalletSyncDataManager](./../../docs/ledger-sync/05-wallet-sync-data-manager.md) — modular reconciliation layer
+- [The watch loop](./../../docs/ledger-sync/06-watch-loop.md) — continuous sync lifecycle
+- [App integration](./../../docs/ledger-sync/07-app-integration.md) — Redux wiring in Desktop & Mobile

--- a/domain/entity/wallet-sync/jest.config.js
+++ b/domain/entity/wallet-sync/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/wallet-sync/package.json
+++ b/domain/entity/wallet-sync/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@domain/entity-wallet-sync",
+  "version": "0.0.1",
+  "private": true,
+  "description": "WalletSync entity: wallet-sync state, non-imported accounts, action creators, and selectors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/wallet-sync"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/wallet-sync/project.json
+++ b/domain/entity/wallet-sync/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-wallet-sync",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/wallet-sync/src/__tests__/store.test.ts
+++ b/domain/entity/wallet-sync/src/__tests__/store.test.ts
@@ -1,0 +1,30 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { walletSyncSlice, walletSyncUpdate } from "../slice";
+import { walletSyncStateSelector } from "../selectors";
+
+function makeStore() {
+  const store = configureStore({ reducer: { walletSync: walletSyncSlice.reducer } });
+  return {
+    dispatch: store.dispatch,
+    ws: () => walletSyncStateSelector(store.getState().walletSync),
+  };
+}
+
+describe("walletSyncSlice", () => {
+  it("starts with no data and version 0", () => {
+    expect(makeStore().ws()).toEqual({ data: null, version: 0 });
+  });
+
+  it("walletSyncUpdate sets both data and version", () => {
+    const store = makeStore();
+    store.dispatch(walletSyncUpdate({ data: { accounts: [] }, version: 3 }));
+    expect(store.ws()).toEqual({ data: { accounts: [] }, version: 3 });
+  });
+
+  it("walletSyncUpdate resets data back to null", () => {
+    const store = makeStore();
+    store.dispatch(walletSyncUpdate({ data: { accounts: [] }, version: 3 }));
+    store.dispatch(walletSyncUpdate({ data: null, version: 0 }));
+    expect(store.ws()).toEqual({ data: null, version: 0 });
+  });
+});

--- a/domain/entity/wallet-sync/src/index.ts
+++ b/domain/entity/wallet-sync/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./selectors";
+export * from "./slice";

--- a/domain/entity/wallet-sync/src/schema.ts
+++ b/domain/entity/wallet-sync/src/schema.ts
@@ -1,0 +1,13 @@
+export type WSState = { data: Record<string, unknown> | null; version: number };
+
+export type WalletSyncState = {
+  walletSyncState: WSState;
+};
+
+export const initialWalletSyncState: WalletSyncState = {
+  walletSyncState: { data: null, version: 0 },
+};
+
+export type ExportedWalletSyncState = {
+  walletSyncState: WSState;
+};

--- a/domain/entity/wallet-sync/src/selectors.ts
+++ b/domain/entity/wallet-sync/src/selectors.ts
@@ -1,0 +1,5 @@
+import type { WalletSyncState } from "./schema";
+
+export const walletSyncStateSelector = (
+  state: WalletSyncState,
+): WalletSyncState["walletSyncState"] => state.walletSyncState;

--- a/domain/entity/wallet-sync/src/slice.ts
+++ b/domain/entity/wallet-sync/src/slice.ts
@@ -1,0 +1,20 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { WalletSyncState } from "./schema";
+
+export const walletSyncSlice = createSlice({
+  name: "walletSync",
+  initialState: {
+    walletSyncState: { data: null, version: 0 },
+  } as WalletSyncState,
+  reducers: {
+    walletSyncUpdate: (
+      state,
+      { payload }: PayloadAction<{ data: Record<string, unknown> | null; version: number }>,
+    ) => {
+      state.walletSyncState.data = payload.data;
+      state.walletSyncState.version = payload.version;
+    },
+  },
+});
+
+export const { walletSyncUpdate } = walletSyncSlice.actions;

--- a/domain/entity/wallet-sync/tsconfig.json
+++ b/domain/entity/wallet-sync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4056,6 +4056,53 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/starred-account:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      immer:
+        specifier: ^11.0.0
+        version: 11.1.3
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  domain/entity/wallet-sync:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   e2e/desktop:
     dependencies:
       '@ledgerhq/ledger-key-ring-protocol':


### PR DESCRIPTION
> [!WARNING]
> This is an exploratory PR extracted from the DDD WalletSync PoC. It introduces new packages only — no existing code is modified.

### 📝 Description

Introduces two domain entity packages with no workspace dependencies:

- `@domain/entity-starred-account` — RTK slice for `starredAccountIds` Set
- `@domain/entity-wallet-sync` — RTK slice for `walletSyncState` + `nonImportedAccountInfos`

**Merge order:** Can be merged in parallel with PR-A (`feat/ddd-shared-packages`). No dependency on it.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35267](https://ledgerhq.atlassian.net/browse/LIVE-35267) (epic: [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990))
- **ADR** (if any): see LIVE-34990 description for full package table and layer rationale

[LIVE-35267]: https://ledgerhq.atlassian.net/browse/LIVE-35267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ