### PR TITLE
[LIVE-35268] feat(ddd): add @domain/entity-account-name and @domain/entity-recent-addresses packages

### DIFF
--- a/domain/entity/account-name/README.md
+++ b/domain/entity/account-name/README.md
@@ -1,0 +1,11 @@
+# @domain/entity-account-name
+
+RTK slice and WalletSync module for user-defined account names.
+
+State shape: `accountNames: Map<string, string>` (accountId → name). Exports `accountNamesSlice`, actions (`setAccountName`, `bulkSetAccountNames`, `setNamesForAccounts`, `initFromUserData`), selectors (`accountNameSelector`, `accountNameWithDefaultSelector`) and `accountNamesSyncModule` — a `WalletSyncDataManager` that syncs account names across devices via `@shared/wallet-sync`.
+
+## Related documentation
+
+- [WalletSyncDataManager](./../../docs/ledger-sync/05-wallet-sync-data-manager.md) — module contract and reconciliation
+- [Cookbook: add a module](./../../docs/ledger-sync/cookbook.md) — hands-on guide for new sync modules
+- [App integration](./../../docs/ledger-sync/07-app-integration.md) — how account names are wired in Redux

--- a/domain/entity/account-name/jest.config.js
+++ b/domain/entity/account-name/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/account-name/package.json
+++ b/domain/entity/account-name/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@domain/entity-account-name",
+  "version": "0.0.1",
+  "private": true,
+  "description": "AccountName entity: naming utilities, account-names store, and wallet-sync module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./src/slice.ts"],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/account-name"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "@shared/wallet-sync": "workspace:^",
+    "immer": "^11.0.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/account-name/project.json
+++ b/domain/entity/account-name/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-account-name",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/account-name/src/__tests__/accountName.test.ts
+++ b/domain/entity/account-name/src/__tests__/accountName.test.ts
@@ -1,0 +1,88 @@
+import {
+  getDefaultAccountName,
+  getDefaultAccountNameForCurrencyIndex,
+  normalizeName,
+  validateNameEdition,
+  MAX_ACCOUNT_NAME_LENGTH,
+} from "../accountName";
+
+describe(getDefaultAccountNameForCurrencyIndex.name, () => {
+  it("returns currency name with 1-based index", () => {
+    expect(getDefaultAccountNameForCurrencyIndex({ currency: { name: "Bitcoin" }, index: 0 })).toBe(
+      "Bitcoin 1",
+    );
+  });
+});
+
+describe(getDefaultAccountName.name, () => {
+  describe("given an Account", () => {
+    it("should return the account name", () => {
+      expect(
+        getDefaultAccountName({
+          id: "a1",
+          type: "Account",
+          currency: { name: "Ethereum" },
+          index: 1,
+        }),
+      ).toEqual("Ethereum 2");
+    });
+  });
+
+  describe("given a TokenAccount", () => {
+    it("should return the token account name", () => {
+      expect(
+        getDefaultAccountName({
+          id: "t1",
+          type: "TokenAccount",
+          token: { name: "USD Coin" },
+        }),
+      ).toEqual("USD Coin");
+    });
+  });
+
+  it("falls back to account id when no currency or token name", () => {
+    expect(getDefaultAccountName({ id: "fallback-id", type: "Other" })).toBe("fallback-id");
+  });
+});
+
+describe(validateNameEdition.name, () => {
+  const account = {
+    id: "a1",
+    type: "Account",
+    currency: { name: "Bitcoin" },
+    index: 0,
+  };
+
+  it("normalizes a custom name", () => {
+    expect(validateNameEdition(account, "  My Wallet  ")).toBe("My Wallet");
+  });
+
+  it("uses the default account name when name is empty", () => {
+    expect(validateNameEdition(account, "")).toBe("Bitcoin 1");
+  });
+
+  it("uses the default account name when name is undefined", () => {
+    expect(validateNameEdition(account)).toBe("Bitcoin 1");
+  });
+});
+
+describe(normalizeName.name, () => {
+  it.each([
+    ["  hello  ", "hello"],
+    ["hello   world", "hello world"],
+    ["hello\t\tworld", "hello world"],
+    ["hello \t world", "hello world"],
+    ["   ", ""],
+    ["", ""],
+    ["Ethereum 1", "Ethereum 1"],
+  ])("normalizeName(%j) → %j", (input, expected) => {
+    expect(normalizeName(input)).toBe(expected);
+  });
+
+  it("should truncate to MAX_ACCOUNT_NAME_LENGTH characters", () => {
+    const longName = "  " + "a".repeat(MAX_ACCOUNT_NAME_LENGTH + 10) + "  ";
+    const result = normalizeName(longName);
+    expect(result).toHaveLength(MAX_ACCOUNT_NAME_LENGTH);
+    expect(result).not.toMatch(/^\s/);
+  });
+});

--- a/domain/entity/account-name/src/__tests__/selectors.test.ts
+++ b/domain/entity/account-name/src/__tests__/selectors.test.ts
@@ -1,0 +1,29 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { accountNamesSlice, setAccountName } from "../slice";
+import { accountNameWithDefaultSelector } from "../selectors";
+
+function makeStore() {
+  return configureStore({ reducer: { accountNames: accountNamesSlice.reducer } });
+}
+
+describe("accountNameWithDefaultSelector", () => {
+  const account = {
+    id: "a1",
+    type: "Account",
+    currency: { name: "Bitcoin" },
+    index: 0,
+  };
+
+  it("returns the custom name when set", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "Savings" }));
+    expect(accountNameWithDefaultSelector(store.getState().accountNames, account)).toBe("Savings");
+  });
+
+  it("returns the default name when no custom name exists", () => {
+    const store = makeStore();
+    expect(accountNameWithDefaultSelector(store.getState().accountNames, account)).toBe(
+      "Bitcoin 1",
+    );
+  });
+});

--- a/domain/entity/account-name/src/__tests__/store.test.ts
+++ b/domain/entity/account-name/src/__tests__/store.test.ts
@@ -1,0 +1,117 @@
+import { configureStore } from "@reduxjs/toolkit";
+import {
+  accountNamesSlice,
+  bulkSetAccountNames,
+  initFromUserData,
+  setAccountName,
+  setNamesForAccounts,
+} from "../slice";
+import { accountNameSelector } from "../selectors";
+
+function makeStore() {
+  return configureStore({ reducer: { accountNames: accountNamesSlice.reducer } });
+}
+
+describe("accountNamesSlice", () => {
+  it("starts empty", () => {
+    const store = makeStore();
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "x" })).toBeUndefined();
+  });
+
+  it("setAccountName sets a name", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "My Wallet" }));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "My Wallet",
+    );
+  });
+
+  it("setAccountName with empty name removes entry", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "My Wallet" }));
+    store.dispatch(setAccountName({ accountId: "a1", name: "" }));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+
+  it("bulkSetAccountNames merges names", () => {
+    const store = makeStore();
+    store.dispatch(bulkSetAccountNames(new Map([["a1", "First"]])));
+    store.dispatch(bulkSetAccountNames(new Map([["a2", "Second"]])));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe("First");
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a2" })).toBe("Second");
+  });
+
+  it("initFromUserData replaces all names", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "old", name: "Old" }));
+    store.dispatch(initFromUserData([{ id: "new", name: "New" }]));
+    expect(
+      accountNameSelector(store.getState().accountNames, { accountId: "old" }),
+    ).toBeUndefined();
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "new" })).toBe("New");
+  });
+
+  it("initFromUserData skips entries with empty name", () => {
+    const store = makeStore();
+    store.dispatch(initFromUserData([{ id: "a1", name: "" }]));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+
+  it("ADD_ACCOUNTS stores edited names that differ from the default", () => {
+    const store = makeStore();
+    store.dispatch({
+      type: "ADD_ACCOUNTS",
+      payload: {
+        allAccounts: [
+          { id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 },
+          { id: "a2", type: "Account", currency: { name: "Bitcoin" }, index: 1 },
+        ],
+        editedNames: new Map([
+          ["a1", "My Renamed BTC"],
+          ["a2", "Bitcoin 2"], // equals default, must be ignored
+        ]),
+      },
+    });
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "My Renamed BTC",
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a2" })).toBeUndefined();
+  });
+
+  it("ADD_ACCOUNTS keeps existing custom names when not re-edited", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "Kept Name" }));
+    store.dispatch({
+      type: "ADD_ACCOUNTS",
+      payload: {
+        allAccounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map(),
+      },
+    });
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "Kept Name",
+    );
+  });
+
+  it("setNamesForAccounts stores edited names that differ from the default", () => {
+    const store = makeStore();
+    store.dispatch(
+      setNamesForAccounts({
+        accounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map([["a1", "Custom"]]),
+      }),
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe("Custom");
+  });
+
+  it("setNamesForAccounts ignores names equal to the default", () => {
+    const store = makeStore();
+    store.dispatch(
+      setNamesForAccounts({
+        accounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map([["a1", "Bitcoin 1"]]),
+      }),
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+});

--- a/domain/entity/account-name/src/__tests__/walletSyncModule.test.ts
+++ b/domain/entity/account-name/src/__tests__/walletSyncModule.test.ts
@@ -1,0 +1,131 @@
+import { accountNamesSyncModule } from "../walletSyncModule";
+
+const makeMap = (entries: Record<string, string>) => new Map(Object.entries(entries));
+
+describe("accountNamesSyncModule.diffLocalToDistant", () => {
+  it("returns hasChanges=false for empty local and null distant", () => {
+    const result = accountNamesSyncModule.diffLocalToDistant(new Map(), null);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toEqual({});
+  });
+
+  it("returns hasChanges=false when local matches distant", () => {
+    const local = makeMap({ acc1: "Savings" });
+    const distant = { acc1: "Savings" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when local has new entry", () => {
+    const local = makeMap({ acc1: "Savings", acc2: "Trading" });
+    const distant = { acc1: "Savings" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState).toEqual({ acc1: "Savings", acc2: "Trading" });
+  });
+
+  it("returns hasChanges=true when local has renamed entry", () => {
+    const local = makeMap({ acc1: "New Name" });
+    const distant = { acc1: "Old Name" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local has removed entry vs distant", () => {
+    const local = makeMap({ acc1: "Savings" });
+    const distant = { acc1: "Savings", acc2: "Removed" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("serializes map to plain object in nextState", () => {
+    const local = makeMap({ acc1: "A", acc2: "B" });
+    const result = accountNamesSyncModule.diffLocalToDistant(local, null);
+    expect(result.nextState).toEqual({ acc1: "A", acc2: "B" });
+  });
+});
+
+describe("accountNamesSyncModule.resolveIncrementalUpdate", () => {
+  it("returns hasChanges=false when incomingState is null", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, null);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when local matches incoming", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const incoming = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when latestState === incomingState (same reference)", async () => {
+    const local = makeMap({});
+    const state = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, state, state);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when incoming has new names", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const incoming = { acc1: "Savings", acc2: "Trading" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.replaceAllNames).toEqual(incoming);
+    }
+  });
+
+  it("returns hasChanges=true when incoming renames an account", async () => {
+    const local = makeMap({ acc1: "Old Name" });
+    const incoming = { acc1: "New Name" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.replaceAllNames.acc1).toBe("New Name");
+    }
+  });
+
+  it("returns hasChanges=false when incoming differs from latestState reference but same content as local", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const latest = { acc1: "Savings" };
+    const incoming = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, latest, incoming);
+    expect(result.hasChanges).toBe(false);
+  });
+});
+
+describe("accountNamesSyncModule.applyUpdate", () => {
+  it("returns a new Map with replaceAllNames entries", () => {
+    const local = makeMap({ acc1: "Old" });
+    const update = { replaceAllNames: { acc1: "New", acc2: "Added" } };
+    const result = accountNamesSyncModule.applyUpdate(local, update);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.get("acc1")).toBe("New");
+    expect(result.get("acc2")).toBe("Added");
+  });
+
+  it("replaces all local names with replaceAllNames", () => {
+    const local = makeMap({ acc1: "Keep", acc2: "Remove" });
+    const update = { replaceAllNames: { acc1: "Keep" } };
+    const result = accountNamesSyncModule.applyUpdate(local, update);
+    expect(result.has("acc2")).toBe(false);
+  });
+
+  it("handles empty replaceAllNames", () => {
+    const local = makeMap({ acc1: "Name" });
+    const result = accountNamesSyncModule.applyUpdate(local, { replaceAllNames: {} });
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("accountNamesSyncModule.schema", () => {
+  it("parses record of strings", () => {
+    const input = { acc1: "Savings", acc2: "Trading" };
+    expect(accountNamesSyncModule.schema.parse(input)).toEqual(input);
+  });
+
+  it("fails on non-string values", () => {
+    expect(() => accountNamesSyncModule.schema.parse({ acc1: 123 })).toThrow();
+  });
+});

--- a/domain/entity/account-name/src/accountName.ts
+++ b/domain/entity/account-name/src/accountName.ts
@@ -1,0 +1,36 @@
+export const MAX_ACCOUNT_NAME_LENGTH = 50;
+
+export type AccountForName = {
+  id: string;
+  type: string;
+  currency?: { name: string };
+  index?: number;
+  token?: { name: string };
+};
+
+export const normalizeName = (name: string): string =>
+  name.replace(/\s+/g, " ").trim().slice(0, MAX_ACCOUNT_NAME_LENGTH);
+
+export const getDefaultAccountNameForCurrencyIndex = ({
+  currency,
+  index,
+}: {
+  currency: { name: string };
+  index: number;
+}): string => `${currency.name} ${index + 1}`;
+
+export const getDefaultAccountName = (account: AccountForName): string => {
+  if (account.type === "Account" && account.currency && account.index !== undefined) {
+    return getDefaultAccountNameForCurrencyIndex({
+      currency: account.currency,
+      index: account.index,
+    });
+  }
+  return account.token?.name ?? account.id;
+};
+
+export const validateNameEdition = (
+  account: AccountForName,
+  name?: string | null | undefined,
+): string =>
+  normalizeName(name || getDefaultAccountName(account) || "").slice(0, MAX_ACCOUNT_NAME_LENGTH);

--- a/domain/entity/account-name/src/index.ts
+++ b/domain/entity/account-name/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./accountName";
+export * from "./selectors";
+export * from "./slice";
+export { bulkSetAccountNames as setAccountNames } from "./slice";
+export * from "./walletSyncModule";

--- a/domain/entity/account-name/src/selectors.ts
+++ b/domain/entity/account-name/src/selectors.ts
@@ -1,0 +1,14 @@
+import { type AccountNamesState } from "./slice";
+import { getDefaultAccountName, type AccountForName } from "./accountName";
+
+export const initialAccountNamesState: AccountNamesState = new Map();
+
+export const accountNameSelector = (
+  state: AccountNamesState,
+  { accountId }: { accountId: string },
+): string | undefined => state.get(accountId);
+
+export const accountNameWithDefaultSelector = (
+  state: AccountNamesState,
+  account: AccountForName,
+): string => state.get(account.id) || getDefaultAccountName(account);

--- a/domain/entity/account-name/src/slice.ts
+++ b/domain/entity/account-name/src/slice.ts
@@ -1,0 +1,75 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { enableMapSet } from "immer";
+import { getDefaultAccountName, type AccountForName } from "./accountName";
+
+// RTK freezes state through Immer; this slice keeps its names in a Map.
+enableMapSet();
+
+export type AccountNamesState = Map<string, string>;
+
+export const accountNamesSlice = createSlice({
+  name: "accountNames",
+  initialState: new Map<string, string>() as AccountNamesState,
+  reducers: {
+    setAccountName: (
+      state,
+      { payload }: PayloadAction<{ accountId: string; name: string }>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      if (!payload.name) next.delete(payload.accountId);
+      else next.set(payload.accountId, payload.name);
+      return next;
+    },
+    bulkSetAccountNames: (
+      state,
+      { payload }: PayloadAction<Map<string, string>>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      for (const [id, name] of payload) next.set(id, name);
+      return next;
+    },
+    setNamesForAccounts: (
+      state,
+      { payload }: PayloadAction<{ accounts: AccountForName[]; editedNames: Map<string, string> }>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      for (const account of payload.accounts) {
+        const name = payload.editedNames.get(account.id) || state.get(account.id);
+        if (name && name !== getDefaultAccountName(account)) next.set(account.id, name);
+      }
+      return next;
+    },
+    initFromUserData: (
+      _state,
+      { payload }: PayloadAction<{ id: string; name: string }[]>,
+    ): AccountNamesState => {
+      const next = new Map<string, string>();
+      for (const { id, name } of payload) {
+        if (name) next.set(id, name);
+      }
+      return next;
+    },
+  },
+  extraReducers: builder => {
+    // The app's ADD_ACCOUNTS action carries the full account list; mirror the names it edited.
+    builder.addMatcher(
+      (
+        action,
+      ): action is {
+        type: string;
+        payload: { allAccounts: AccountForName[]; editedNames: Map<string, string> };
+      } => (action as { type: string }).type === "ADD_ACCOUNTS",
+      (state, { payload }): AccountNamesState => {
+        const next = new Map(state);
+        for (const account of payload.allAccounts) {
+          const name = payload.editedNames.get(account.id) || state.get(account.id);
+          if (name && name !== getDefaultAccountName(account)) next.set(account.id, name);
+        }
+        return next;
+      },
+    );
+  },
+});
+
+export const { setAccountName, bulkSetAccountNames, setNamesForAccounts, initFromUserData } =
+  accountNamesSlice.actions;

--- a/domain/entity/account-name/src/walletSyncModule.ts
+++ b/domain/entity/account-name/src/walletSyncModule.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { WalletSyncDataManager } from "@shared/wallet-sync";
+
+const schema = z.record(z.string(), z.string());
+
+function sameDistantState(a: Record<string, string>, b: Record<string, string>) {
+  const aEntries = Object.entries(a);
+  if (aEntries.length !== Object.keys(b).length) return false;
+  for (const [k, v] of aEntries) {
+    if (b[k] !== v) return false;
+  }
+  return true;
+}
+
+export const accountNamesSyncModule: WalletSyncDataManager<
+  Map<string, string>,
+  { replaceAllNames: Record<string, string> },
+  typeof schema
+> = {
+  schema,
+
+  diffLocalToDistant(localData: Map<string, string>, latestState: Record<string, string> | null) {
+    const nextState = Object.fromEntries(localData.entries());
+    const hasChanges = !sameDistantState(latestState ?? {}, nextState);
+    return { hasChanges, nextState };
+  },
+
+  async resolveIncrementalUpdate(
+    localData: Map<string, string>,
+    latestState: Record<string, string> | null,
+    incomingState: Record<string, string> | null,
+  ) {
+    if (!incomingState) return { hasChanges: false as const };
+    const hasChanges =
+      latestState !== incomingState &&
+      !sameDistantState(Object.fromEntries(localData.entries()), incomingState);
+    if (!hasChanges) return { hasChanges: false as const };
+    return { hasChanges: true as const, update: { replaceAllNames: incomingState } };
+  },
+
+  applyUpdate(
+    _localData: Map<string, string>,
+    update: { replaceAllNames: Record<string, string> },
+  ) {
+    return new Map(Object.entries(update.replaceAllNames));
+  },
+};

--- a/domain/entity/account-name/tsconfig.json
+++ b/domain/entity/account-name/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/domain/entity/recent-addresses/README.md
+++ b/domain/entity/recent-addresses/README.md
@@ -1,0 +1,11 @@
+# @domain/entity-recent-addresses
+
+RTK slice and WalletSync module for recently used receive addresses.
+
+State shape: `recentAddresses: RecentAddressesState`. Exports `recentAddressesSlice`, action `updateRecentAddresses` and `recentAddressesSyncModule` — a `WalletSyncDataManager` that syncs recent addresses across devices via `@shared/wallet-sync`.
+
+## Related documentation
+
+- [WalletSyncDataManager](./../../docs/ledger-sync/05-wallet-sync-data-manager.md) — module contract and reconciliation
+- [Cookbook: add a module](./../../docs/ledger-sync/cookbook.md) — hands-on guide for new sync modules
+- [App integration](./../../docs/ledger-sync/07-app-integration.md) — how recent addresses are wired in Redux

--- a/domain/entity/recent-addresses/jest.config.js
+++ b/domain/entity/recent-addresses/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/recent-addresses/package.json
+++ b/domain/entity/recent-addresses/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@domain/entity-recent-addresses",
+  "version": "0.0.1",
+  "private": true,
+  "description": "RecentAddresses entity: state types, action creators, and wallet-sync module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/recent-addresses"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "@shared/wallet-sync": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/recent-addresses/project.json
+++ b/domain/entity/recent-addresses/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-recent-addresses",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/recent-addresses/src/__tests__/store.test.ts
+++ b/domain/entity/recent-addresses/src/__tests__/store.test.ts
@@ -1,0 +1,45 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { recentAddressesSlice, updateRecentAddresses } from "../slice";
+import type { RecentAddressesState } from "../schema";
+
+function makeStore() {
+  return configureStore({ reducer: { recentAddresses: recentAddressesSlice.reducer } });
+}
+
+describe("recentAddressesSlice", () => {
+  it("starts empty", () => {
+    const store = makeStore();
+    expect(store.getState().recentAddresses).toEqual({});
+  });
+
+  it("updateRecentAddresses replaces state", () => {
+    const store = makeStore();
+    const payload: RecentAddressesState = {
+      bitcoin: [{ address: "bc1q...", lastUsed: 1000 }],
+    };
+    store.dispatch(updateRecentAddresses(payload));
+    expect(store.getState().recentAddresses).toEqual(payload);
+  });
+
+  it("handles multiple currencies", () => {
+    const store = makeStore();
+    const payload: RecentAddressesState = {
+      ethereum: [{ address: "0x123", lastUsed: 2000 }],
+      bitcoin: [
+        { address: "bc1a...", lastUsed: 1000 },
+        { address: "bc1b...", lastUsed: 1500 },
+      ],
+    };
+    store.dispatch(updateRecentAddresses(payload));
+    expect(store.getState().recentAddresses).toEqual(payload);
+  });
+
+  it("replaces previous state (not merge)", () => {
+    const store = makeStore();
+    store.dispatch(updateRecentAddresses({ bitcoin: [{ address: "bc1q...", lastUsed: 1000 }] }));
+    store.dispatch(updateRecentAddresses({ ethereum: [{ address: "0x123", lastUsed: 2000 }] }));
+    expect(store.getState().recentAddresses).toEqual({
+      ethereum: [{ address: "0x123", lastUsed: 2000 }],
+    });
+  });
+});

--- a/domain/entity/recent-addresses/src/__tests__/walletSyncModule.test.ts
+++ b/domain/entity/recent-addresses/src/__tests__/walletSyncModule.test.ts
@@ -1,0 +1,188 @@
+import { recentAddressesSyncModule, recentAddressesSchema } from "../walletSyncModule";
+import { RecentAddressesState } from "../schema";
+
+const addr = (address: string, lastUsed = 1000) => ({ address, lastUsed });
+
+describe("recentAddressesSchema", () => {
+  it("parses valid distant state", () => {
+    const input = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    expect(recentAddressesSchema.parse(input)).toEqual(input);
+  });
+
+  it("filters out invalid entries, keeps valid ones", () => {
+    const input = {
+      bitcoin: [{ address: "bc1q", index: 0 }, "invalid", null, { address: "bc1b", index: 1 }],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin).toHaveLength(2);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+    expect(parsed.bitcoin[1].address).toBe("bc1b");
+  });
+
+  it("handles corrupted nested address format", () => {
+    const input = {
+      bitcoin: [{ address: { address: "bc1q", lastUsed: 500 }, index: 0, lastUsed: 600 }],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+    expect(parsed.bitcoin[0].lastUsed).toBe(500);
+  });
+
+  it("handles corrupted nested address format with ensName", () => {
+    const input = {
+      bitcoin: [
+        {
+          address: { address: "bc1q", lastUsed: 500, ensName: "wallet.eth" },
+          index: 0,
+        },
+      ],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+  });
+});
+
+describe("recentAddressesSyncModule.diffLocalToDistant", () => {
+  it("returns hasChanges=false for empty local and null distant", () => {
+    const result = recentAddressesSyncModule.diffLocalToDistant({}, null);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toEqual({});
+  });
+
+  it("returns hasChanges=false when local matches distant exactly", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toBe(distant);
+  });
+
+  it("returns hasChanges=true when local has extra address", () => {
+    const local: RecentAddressesState = {
+      bitcoin: [addr("bc1q"), addr("bc1b")],
+    };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState.bitcoin).toHaveLength(2);
+  });
+
+  it("returns hasChanges=true when local has different address", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1DIFFERENT")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local has new currency", () => {
+    const local: RecentAddressesState = {
+      bitcoin: [addr("bc1q")],
+      ethereum: [addr("0x1")],
+    };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local removed a currency", () => {
+    const local: RecentAddressesState = {};
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when distant index is out of bounds", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 5 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("serializes lastUsed in nextState", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q", 9999)] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, null);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState.bitcoin[0].lastUsed).toBe(9999);
+  });
+});
+
+describe("recentAddressesSyncModule.resolveIncrementalUpdate", () => {
+  it("returns hasChanges=false when incomingState is null", async () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, null);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when incoming matches local", async () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(
+      local,
+      distant,
+      distant,
+    );
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false for identical latestState and incomingState references", async () => {
+    const local: RecentAddressesState = {};
+    const state = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, state, state);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when incoming has new addresses", async () => {
+    const local: RecentAddressesState = {};
+    const incoming = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin).toHaveLength(1);
+      expect(result.update.bitcoin[0].address).toBe("bc1q");
+    }
+  });
+
+  it("sorts addresses by index in update", async () => {
+    const local: RecentAddressesState = {};
+    const incoming = {
+      bitcoin: [
+        { address: "bc1b", index: 1, lastUsed: 2000 },
+        { address: "bc1a", index: 0, lastUsed: 1000 },
+      ],
+    };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin[0].address).toBe("bc1a");
+      expect(result.update.bitcoin[1].address).toBe("bc1b");
+    }
+  });
+
+  it("falls back to Date.now() when lastUsed is undefined", async () => {
+    const before = Date.now();
+    const local: RecentAddressesState = {};
+    const incoming = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    const after = Date.now();
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin[0].lastUsed).toBeGreaterThanOrEqual(before);
+      expect(result.update.bitcoin[0].lastUsed).toBeLessThanOrEqual(after);
+    }
+  });
+});
+
+describe("recentAddressesSyncModule.applyUpdate", () => {
+  it("replaces local data with update entirely", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("old")] };
+    const update: RecentAddressesState = { ethereum: [addr("0x1")] };
+    const result = recentAddressesSyncModule.applyUpdate(local, update);
+    expect(result).toBe(update);
+  });
+
+  it("ignores local data", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("should-be-ignored")] };
+    const update: RecentAddressesState = {};
+    expect(recentAddressesSyncModule.applyUpdate(local, update)).toEqual({});
+  });
+});

--- a/domain/entity/recent-addresses/src/index.ts
+++ b/domain/entity/recent-addresses/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./slice";
+export * from "./walletSyncModule";

--- a/domain/entity/recent-addresses/src/schema.ts
+++ b/domain/entity/recent-addresses/src/schema.ts
@@ -1,0 +1,4 @@
+export type RecentAddress = { address: string; lastUsed: number };
+export type RecentAddressesState = Record<string, RecentAddress[]>;
+
+export const initialRecentAddressesState: RecentAddressesState = {};

--- a/domain/entity/recent-addresses/src/slice.ts
+++ b/domain/entity/recent-addresses/src/slice.ts
@@ -1,0 +1,15 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { RecentAddressesState } from "./schema";
+
+export const recentAddressesSlice = createSlice({
+  name: "recentAddresses",
+  initialState: {} as RecentAddressesState,
+  reducers: {
+    updateRecentAddresses: (
+      _state,
+      { payload }: PayloadAction<RecentAddressesState>,
+    ): RecentAddressesState => payload,
+  },
+});
+
+export const { updateRecentAddresses } = recentAddressesSlice.actions;

--- a/domain/entity/recent-addresses/src/walletSyncModule.ts
+++ b/domain/entity/recent-addresses/src/walletSyncModule.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { WalletSyncDataManager } from "@shared/wallet-sync";
+import { RecentAddressesState } from "./schema";
+
+export const CorrectDistantAddressSchema = z.object({
+  address: z.string(),
+  index: z.number(),
+  lastUsed: z.number().optional(),
+});
+
+export const CorruptedNestedDistantAddressSchema = z
+  .object({
+    address: z.object({
+      address: z.string(),
+      lastUsed: z.number().optional(),
+      ensName: z.string().optional(),
+    }),
+    index: z.number(),
+    lastUsed: z.number().optional(),
+  })
+  .transform(entry => ({
+    address: entry.address.address,
+    index: entry.index,
+    lastUsed: entry.address.lastUsed ?? entry.lastUsed,
+  }));
+
+export const RecentAddressSchema = z.union([
+  CorrectDistantAddressSchema,
+  CorruptedNestedDistantAddressSchema,
+]);
+
+export const recentAddressesSchema = z.record(
+  z.string(),
+  z.array(z.unknown()).transform(entries =>
+    entries
+      .map(entry => {
+        const result = RecentAddressSchema.safeParse(entry);
+        return result.success ? result.data : null;
+      })
+      .filter((entry): entry is z.infer<typeof CorrectDistantAddressSchema> => entry !== null),
+  ),
+);
+
+type DistantRecentAddressesState = z.infer<typeof recentAddressesSchema>;
+
+function toDistantState(addressesByCurrency: RecentAddressesState): DistantRecentAddressesState {
+  const state: DistantRecentAddressesState = {};
+  Object.keys(addressesByCurrency).forEach(key => {
+    state[key] = addressesByCurrency[key].map((entry, index) => ({
+      address: entry.address,
+      index,
+      lastUsed: entry.lastUsed,
+    }));
+  });
+  return state;
+}
+
+function toState(addressesByCurrency: DistantRecentAddressesState): RecentAddressesState {
+  const state: RecentAddressesState = {};
+  Object.keys(addressesByCurrency).forEach(key => {
+    state[key] = [...addressesByCurrency[key]]
+      .sort((current, other) => current.index - other.index)
+      .map(data => ({ address: data.address, lastUsed: data.lastUsed ?? Date.now() }));
+  });
+  return state;
+}
+
+function sameDistantState(
+  localData: RecentAddressesState,
+  distantState: DistantRecentAddressesState,
+) {
+  const localDataKeys = Object.keys(localData);
+  const distantStateKeys = Object.keys(distantState);
+  return (
+    localDataKeys.length === distantStateKeys.length &&
+    distantStateKeys.every(key => {
+      return (
+        localData[key] &&
+        localData[key].length === distantState[key].length &&
+        !distantState[key].some(data => {
+          if (data.index < 0 || data.index >= localData[key].length) return true;
+          return localData[key][data.index].address !== data.address;
+        })
+      );
+    })
+  );
+}
+
+export const recentAddressesSyncModule: WalletSyncDataManager<
+  RecentAddressesState,
+  RecentAddressesState,
+  typeof recentAddressesSchema
+> = {
+  schema: recentAddressesSchema,
+
+  diffLocalToDistant(
+    localData: RecentAddressesState,
+    latestState: DistantRecentAddressesState | null,
+  ) {
+    if (!sameDistantState(localData, latestState ?? {})) {
+      return { hasChanges: true as const, nextState: toDistantState(localData) };
+    }
+    return { hasChanges: false as const, nextState: latestState ?? {} };
+  },
+
+  async resolveIncrementalUpdate(
+    localData: RecentAddressesState,
+    latestState: DistantRecentAddressesState | null,
+    incomingState: DistantRecentAddressesState | null,
+  ) {
+    if (!incomingState) return { hasChanges: false as const };
+    if (latestState === incomingState || sameDistantState(localData, incomingState)) {
+      return { hasChanges: false as const };
+    }
+    return { hasChanges: true as const, update: toState(incomingState) };
+  },
+
+  applyUpdate(_localData: RecentAddressesState, update: RecentAddressesState) {
+    return update;
+  },
+};

--- a/domain/entity/recent-addresses/tsconfig.json
+++ b/domain/entity/recent-addresses/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3717,6 +3717,40 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/account-name:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      '@shared/wallet-sync':
+        specifier: workspace:^
+        version: link:../../../shared/wallet-sync
+      immer:
+        specifier: ^11.0.0
+        version: 11.1.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/altcoins-sentiment:
     dependencies:
       zod:
@@ -4040,6 +4074,34 @@ importers:
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.2.0
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
+  domain/entity/recent-addresses:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      '@shared/wallet-sync':
+        specifier: workspace:^
+        version: link:../../../shared/wallet-sync
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11


### PR DESCRIPTION
> [!WARNING]
> This is an exploratory PR extracted from the DDD WalletSync PoC. It introduces new packages only — no existing code is modified.
> **Stacked on** `feat/ddd-shared-packages` (PR-A). Retarget to `develop` once PR-A merges.

### 📝 Description

Introduces two domain entity packages that depend on `@shared/wallet-sync`:

- `@domain/entity-account-name` — RTK slice (`accountNames` Map) + `accountNamesSyncModule` for WalletSync
- `@domain/entity-recent-addresses` — RTK slice + `recentAddressesSyncModule` for WalletSync

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35268](https://ledgerhq.atlassian.net/browse/LIVE-35268) (epic: [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990))
- **ADR** (if any): see LIVE-34990 description for full package table and layer rationale

[LIVE-35268]: https://ledgerhq.atlassian.net/browse/LIVE-35268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ