### PR TITLE
feat(ddd): add @shared/cloud-sync-module package

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -232,6 +232,9 @@
     "./shared/cloud-sync": {
       "entry": ["src/index.ts"]
     },
+    "./shared/cloud-sync-module": {
+      "entry": ["src/index.ts"]
+    },
     "./features/flow/market-banner": {
       "entry": ["src/index.ts", "src/components/MarketBanner/index.native.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13948,6 +13948,31 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  shared/cloud-sync-module:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   tests/dummy-live-app:
     dependencies:
       '@ledgerhq/live-app-sdk':

--- a/shared/cloud-sync-module/README.md
+++ b/shared/cloud-sync-module/README.md
@@ -1,0 +1,23 @@
+# @shared/cloud-sync-module
+
+> **Status: UNSTABLE** — This package is incrementally shipping the validated CloudSync DDD architecture; API may change.
+
+Context-free aggregation core for Ledger Live cloud synchronisation.
+
+Exports `createAggregator()` which composes a list of `CloudSyncDataManager` modules (accounts, accountNames, recentAddresses, …) into a single aggregated schema, diff, incremental-update resolver and apply function. Has no knowledge of Redux, React or networking — it is a pure data-transformation layer.
+
+The `CloudSyncDataManager<LocalState, Update, Schema>` interface describes the contract each sync module must implement.
+
+## Related documentation
+
+- [CloudSyncDataManager](./../../docs/ledger-sync/05-wallet-sync-data-manager.md) — concepts, module contract, accounts reconciliation
+- [The watch loop](./../../docs/ledger-sync/06-watch-loop.md) — how aggregation feeds the continuous sync loop
+- [Cookbook: add a module](./../../docs/ledger-sync/cookbook.md) — hands-on module authoring guide
+
+## Implementation locations
+
+| Module | Package |
+|---|---|
+| accounts | [`@ledgerhq/live-wallet/accounts`](../../libs/live-wallet/src/accounts/) (interim) |
+| accountNames | [`@domain/entity-account-name`](../../domain/entity/account-name) |
+| recentAddresses | [`@domain/entity-recent-addresses`](../../domain/entity/recent-addresses) |

--- a/shared/cloud-sync-module/jest.config.js
+++ b/shared/cloud-sync-module/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/shared/cloud-sync-module/package.json
+++ b/shared/cloud-sync-module/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@shared/cloud-sync-module",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared CloudSync module interface types (ctx-free)",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../.. -W shared/cloud-sync-module"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/shared/cloud-sync-module/project.json
+++ b/shared/cloud-sync-module/project.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/shared/cloud-sync-module/src/__tests__/createAggregator.test.ts
+++ b/shared/cloud-sync-module/src/__tests__/createAggregator.test.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { createAggregator, mapValues } from "../index";
+
+describe(mapValues.name, () => {
+  it("maps object values while preserving keys", () => {
+    expect(mapValues({ a: 1, b: 2 }, value => value * 2)).toEqual({ a: 2, b: 4 });
+  });
+});
+
+describe(createAggregator.name, () => {
+  const alphaModule = {
+    schema: z.array(z.string()),
+    diffLocalToDistant: (local: string[], latest: string[] | null) => ({
+      hasChanges: local.join() !== (latest ?? []).join(),
+      nextState: local,
+    }),
+    resolveIncrementalUpdate: async (
+      local: string[],
+      latest: string[] | null,
+      incoming: string[] | null,
+    ) => {
+      if (!incoming || incoming.join() === (latest ?? []).join()) {
+        return { hasChanges: false as const };
+      }
+      if (incoming.join() === local.join()) {
+        return { hasChanges: false as const };
+      }
+      return { hasChanges: true as const, update: incoming };
+    },
+    applyUpdate: (_local: string[], update: string[]) => update,
+  };
+
+  const betaModule = {
+    schema: z.number(),
+    diffLocalToDistant: (local: number, latest: number | null) => ({
+      hasChanges: local !== (latest ?? 0),
+      nextState: local,
+    }),
+    resolveIncrementalUpdate: async (
+      local: number,
+      latest: number | null,
+      incoming: number | null,
+    ) => {
+      if (incoming == null || incoming === latest || incoming === local) {
+        return { hasChanges: false as const };
+      }
+      return { hasChanges: true as const, update: incoming };
+    },
+    applyUpdate: (_local: number, update: number) => update,
+  };
+
+  const aggregator = createAggregator({ alpha: alphaModule, beta: betaModule });
+
+  it("aggregates diffLocalToDistant across modules and preserves unknown distant keys", () => {
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 2 }, {
+      alpha: ["a"],
+      beta: 1,
+      legacy: true,
+    } as never);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState).toEqual({ alpha: ["a"], beta: 2, legacy: true });
+  });
+
+  it("returns hasChanges=false when all modules are unchanged", () => {
+    const distant = { alpha: ["a"], beta: 1 };
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 1 }, distant);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState.alpha).toEqual(["a"]);
+    expect(result.nextState.beta).toBe(1);
+  });
+
+  it("returns hasChanges=false when resolveIncrementalUpdate finds no changes", async () => {
+    const distant = { alpha: ["a"], beta: 1 };
+    const result = await aggregator.resolveIncrementalUpdate(
+      { alpha: ["a"], beta: 1 },
+      distant,
+      distant,
+    );
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns combined update when at least one module changes", async () => {
+    const result = await aggregator.resolveIncrementalUpdate(
+      { alpha: ["a"], beta: 1 },
+      { alpha: ["a"], beta: 1 },
+      { alpha: ["b"], beta: 1 },
+    );
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.alpha).toEqual({ hasChanges: true, update: ["b"] });
+      expect(result.update.beta).toEqual({ hasChanges: false });
+    }
+  });
+
+  it("applyUpdate only applies modules that reported changes", () => {
+    const local = { alpha: ["a"], beta: 1 };
+    const result = aggregator.applyUpdate(local, {
+      alpha: { hasChanges: true, update: ["z"] },
+      beta: { hasChanges: false },
+    } as Parameters<typeof aggregator.applyUpdate>[1]);
+    expect(result).toEqual({ alpha: ["z"], beta: 1 });
+  });
+
+  it("handles null distant states during diff and resolve", async () => {
+    const result = aggregator.diffLocalToDistant({ alpha: ["a"], beta: 1 }, null);
+    expect(result.hasChanges).toBe(true);
+
+    const resolved = await aggregator.resolveIncrementalUpdate({ alpha: [], beta: 0 }, null, {
+      alpha: ["a"],
+      beta: 1,
+    });
+    expect(resolved.hasChanges).toBe(true);
+  });
+});

--- a/shared/cloud-sync-module/src/index.ts
+++ b/shared/cloud-sync-module/src/index.ts
@@ -1,0 +1,95 @@
+import { ZodType, z } from "zod";
+
+export interface CloudSyncDataManager<
+  LocalState,
+  Update,
+  Schema extends ZodType,
+  DistantState = z.infer<Schema>,
+> {
+  schema: Schema;
+  diffLocalToDistant: (
+    localData: LocalState,
+    latestState: DistantState | null,
+  ) => DistantDiff<DistantState>;
+  resolveIncrementalUpdate: (
+    localData: LocalState,
+    latestState: DistantState | null,
+    incomingState: DistantState | null,
+  ) => Promise<UpdateDiff<Update>>;
+  applyUpdate: (localData: LocalState, update: Update) => LocalState;
+}
+
+export type UpdateDiff<Update> = { hasChanges: false } | { hasChanges: true; update: Update };
+
+export type DistantDiff<DistantState> = { hasChanges: boolean; nextState: DistantState };
+
+export type ExtractLocalState<T> = T extends CloudSyncDataManager<infer L, any, any> ? L : never;
+export type ExtractUpdateEvent<T> = T extends CloudSyncDataManager<any, infer U, any> ? U : never;
+export type ExtractSchema<T> = T extends CloudSyncDataManager<any, any, infer S> ? S : never;
+export type ExtractDistantState<T> =
+  T extends CloudSyncDataManager<any, any, any, infer D> ? D : never;
+
+export function createAggregator<Mods extends Record<string, CloudSyncDataManager<any, any, any>>>(
+  modules: Mods,
+) {
+  const schema = z.object(mapValues(modules, m => z.optional(m.schema)));
+
+  type Schema = typeof schema;
+  type DistantState = { [K in keyof Mods]?: z.infer<Mods[K]["schema"]> };
+  type LocalState = { [K in keyof Mods]: ExtractLocalState<Mods[K]> };
+  type UpdateEvent = { [K in keyof Mods]: UpdateDiff<ExtractUpdateEvent<Mods[K]>> };
+
+  const root: CloudSyncDataManager<LocalState, UpdateEvent, Schema, DistantState> = {
+    schema,
+
+    diffLocalToDistant(localData, latestState) {
+      let hasChanges = false;
+      const unknownRest: Record<string, unknown> = { ...latestState };
+      const nextState = mapValues(modules, (m, k) => {
+        const diff = m.diffLocalToDistant(
+          localData[k],
+          latestState != null ? (latestState[k] ?? null) : null,
+        );
+        delete unknownRest[k as string];
+        if (diff.hasChanges) hasChanges = true;
+        return diff.nextState;
+      });
+      return { hasChanges, nextState: { ...nextState, ...unknownRest } };
+    },
+
+    async resolveIncrementalUpdate(localData, latestState, incomingState) {
+      const resolved = mapValues(modules, (m, k) =>
+        m.resolveIncrementalUpdate(
+          localData[k],
+          latestState != null ? (latestState[k] ?? null) : null,
+          incomingState != null ? (incomingState[k] ?? null) : null,
+        ),
+      );
+      const results = await Promise.all(Object.values(resolved));
+      const hasChanges = results.some(r => r.hasChanges);
+      let index = 0;
+      const update = mapValues(modules, () => results[index++]) as UpdateEvent;
+      return !hasChanges ? { hasChanges: false } : { hasChanges: true, update };
+    },
+
+    applyUpdate(localData, update) {
+      const result = mapValues(modules, (m, k) => {
+        const up = update[k];
+        return up.hasChanges ? m.applyUpdate(localData[k], up.update) : localData[k];
+      });
+      return result;
+    },
+  };
+  return root;
+}
+
+export function mapValues<T extends object, U>(
+  obj: T,
+  fn: (value: T[keyof T], key: keyof T) => U,
+): { [K in keyof T]: U } {
+  const result = {} as { [K in keyof T]: U };
+  for (const key in obj) {
+    result[key] = fn(obj[key], key);
+  }
+  return result;
+}

--- a/shared/cloud-sync-module/tsconfig.json
+++ b/shared/cloud-sync-module/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
> [!NOTE]
> This PR incrementally ships the now-validated WalletSync DDD architecture. See super PR [#19464](https://github.com/LedgerHQ/ledger-live/pull/19464).

### 📝 Description

Introduces `@shared/cloud-sync-module`, a pure, context-free package providing the `CloudSyncDataManager` (via `createAggregator()`). This layer is responsible for aggregating wallet sync data independently of any platform or infrastructure concern.

> **Rename note**: originally prototyped as `@shared/wallet-sync` / `WalletSyncDataManager`. Renamed to `@shared/cloud-sync-module` / `CloudSyncDataManager` because this shared module provides the generic brick to build a "wallet-sync" which the actual aggregated type we use for the wallet.

### 🧩 What this enables

Any domain entity that wants to participate in wallet sync can introduce a `cloudSyncModule.ts` file that implements `CloudSyncDataManager<LocalState, DistantState>`. This module describes how the entity:

- **serialises** its local state into a distant (cloud) representation
- **deserialises** and **reconciles** incoming distant state back into local state
- **detects diffs** to avoid unnecessary pushes

**Example** — [`domain/entity/account-name/src/cloudSyncModule.ts`](https://github.com/LedgerHQ/ledger-live/blob/feat/LIVE-35275-entity-account-name/domain/entity/account-name/src/cloudSyncModule.ts) (introduced in PR [#20325](https://github.com/LedgerHQ/ledger-live/pull/20325)) and [`domain/entity/recent-addresses/src/cloudSyncModule.ts`](https://github.com/LedgerHQ/ledger-live/blob/feat/LIVE-35276-entity-recent-addresses/domain/entity/recent-addresses/src/cloudSyncModule.ts) (introduced in PR [#20326](https://github.com/LedgerHQ/ledger-live/pull/20326)).

The modules are then passed to `createAggregator()` from this package to compose the full `CloudSyncDataManager` used at the feature/app level.

### 📖 Documentation

- [CloudSyncDataManager contract](https://github.com/LedgerHQ/ledger-live/blob/develop/docs/ledger-sync/05-wallet-sync-data-manager.md) — module interface and reconciliation semantics
- [Cookbook: add a sync module](https://github.com/LedgerHQ/ledger-live/blob/develop/docs/ledger-sync/cookbook.md) — step-by-step guide for new sync slots
- [App integration](https://github.com/LedgerHQ/ledger-live/blob/develop/docs/ledger-sync/07-app-integration.md) — how modules are wired into Redux at the app level

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35266](https://ledgerhq.atlassian.net/browse/LIVE-35266)
- **ADR** (if any): N/A

[LIVE-35266]: https://ledgerhq.atlassian.net/browse/LIVE-35266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ