### PR TITLE
feat(ddd): add @domain/entity-starred-account package

### DIFF
--- a/domain/entity/starred-account/README.md
+++ b/domain/entity/starred-account/README.md
@@ -1,0 +1,13 @@
+# @domain/entity-starred-account
+
+> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+
+> **⚠️ DEPRECATED** — The Wallet V4 implementation no longer uses the concept of starred accounts. This package is introduced for backwards compatibility and will not be actively developed further. Do not build new features on top of it.
+
+RTK slice for starred (pinned) accounts.
+
+State shape: `Set<string>` (the slice state IS the Set directly). Local-only state (not synced). Exports `starredAccountsSlice`, actions (`setAccountStarred`, `initStarredFromIds`) and selector `isStarredAccountSelector`.
+
+## Related documentation
+
+- [App integration](../../../docs/ledger-sync/07-app-integration.md) — wallet Redux wiring in Desktop & Mobile

--- a/domain/entity/starred-account/jest.config.js
+++ b/domain/entity/starred-account/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/starred-account/package.json
+++ b/domain/entity/starred-account/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@domain/entity-starred-account",
+  "version": "0.0.1",
+  "private": true,
+  "description": "StarredAccount entity: starred account IDs state, action creators, and selectors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./src/slice.ts"],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/starred-account"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "immer": "^11.0.0"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/starred-account/project.json
+++ b/domain/entity/starred-account/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-starred-account",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/starred-account/src/index.ts
+++ b/domain/entity/starred-account/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./selectors";
+export * from "./slice";

--- a/domain/entity/starred-account/src/schema.ts
+++ b/domain/entity/starred-account/src/schema.ts
@@ -1,0 +1,3 @@
+import type { StarredAccountState } from "./slice";
+
+export const initialStarredAccountState: StarredAccountState = new Set();

--- a/domain/entity/starred-account/src/selectors.ts
+++ b/domain/entity/starred-account/src/selectors.ts
@@ -1,0 +1,6 @@
+import type { StarredAccountState } from "./slice";
+
+export const isStarredAccountSelector = (
+  state: StarredAccountState,
+  { accountId }: { accountId: string },
+): boolean => state.has(accountId);

--- a/domain/entity/starred-account/src/slice.test.ts
+++ b/domain/entity/starred-account/src/slice.test.ts
@@ -1,0 +1,76 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { initStarredFromIds, setAccountStarred, starredAccountsSlice } from "./slice";
+import { isStarredAccountSelector } from "./selectors";
+
+function makeStore() {
+  const store = configureStore({
+    reducer: { starred: starredAccountsSlice.reducer },
+    // mirrors the apps: this slice holds a Set, which RTK's serializable check rejects
+    middleware: getDefaultMiddleware => getDefaultMiddleware({ serializableCheck: false }),
+  });
+  return {
+    dispatch: store.dispatch,
+    starred: () => store.getState().starred,
+    isStarred: (accountId: string) =>
+      isStarredAccountSelector(store.getState().starred, { accountId }),
+  };
+}
+
+describe("starredAccountsSlice", () => {
+  it("starts empty", () => {
+    expect(makeStore().starred().size).toBe(0);
+  });
+
+  it.each([
+    ["stars an account", true, true],
+    ["unstars an unknown account without throwing", false, false],
+  ])("setAccountStarred %s", (_name, starred, expected) => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred }));
+    expect(store.isStarred("a1")).toBe(expected);
+  });
+
+  it("setAccountStarred toggles back to unstarred", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: false }));
+    expect(store.isStarred("a1")).toBe(false);
+  });
+
+  it("setAccountStarred is idempotent", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    expect(store.starred().size).toBe(1);
+  });
+
+  it("setAccountStarred leaves other accounts untouched", () => {
+    const store = makeStore();
+    store.dispatch(initStarredFromIds(["a1", "a2"]));
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: false }));
+    expect([...store.starred()]).toEqual(["a2"]);
+  });
+
+  it("setAccountStarred returns a new Set rather than mutating the frozen state", () => {
+    const store = makeStore();
+    const before = store.starred();
+    store.dispatch(setAccountStarred({ accountId: "a1", starred: true }));
+    expect(store.starred()).not.toBe(before);
+    expect(before.size).toBe(0);
+  });
+
+  it("initStarredFromIds replaces the whole set and dedupes", () => {
+    const store = makeStore();
+    store.dispatch(setAccountStarred({ accountId: "old", starred: true }));
+    store.dispatch(initStarredFromIds(["a1", "a1", "a2"]));
+    expect([...store.starred()]).toEqual(["a1", "a2"]);
+    expect(store.isStarred("old")).toBe(false);
+  });
+
+  it("initStarredFromIds with an empty list clears everything", () => {
+    const store = makeStore();
+    store.dispatch(initStarredFromIds(["a1"]));
+    store.dispatch(initStarredFromIds([]));
+    expect(store.starred().size).toBe(0);
+  });
+});

--- a/domain/entity/starred-account/src/slice.ts
+++ b/domain/entity/starred-account/src/slice.ts
@@ -1,0 +1,26 @@
+import { enableMapSet } from "immer";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+enableMapSet();
+
+export type StarredAccountState = Set<string>;
+
+export const starredAccountsSlice = createSlice({
+  name: "starredAccounts",
+  initialState: new Set<string>(),
+  reducers: {
+    setAccountStarred: (
+      state,
+      { payload }: PayloadAction<{ accountId: string; starred: boolean }>,
+    ): StarredAccountState => {
+      const next = new Set(state);
+      if (payload.starred) next.add(payload.accountId);
+      else next.delete(payload.accountId);
+      return next;
+    },
+    initStarredFromIds: (_state, { payload }: PayloadAction<string[]>): StarredAccountState =>
+      new Set(payload),
+  },
+});
+
+export const { setAccountStarred, initStarredFromIds } = starredAccountsSlice.actions;

--- a/domain/entity/starred-account/tsconfig.json
+++ b/domain/entity/starred-account/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -202,6 +202,9 @@
     "./domain/entity/wallet-sync": {
       "entry": ["src/index.ts"]
     },
+    "./domain/entity/starred-account": {
+      "entry": ["src/index.ts"]
+    },
     "./domain/api/pay-card": {
       "entry": ["src/index.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4078,6 +4078,31 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/starred-account:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      immer:
+        specifier: ^11.0.0
+        version: 11.1.3
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   e2e/desktop:
     dependencies:
       '@ledgerhq/ledger-key-ring-protocol':
@@ -66037,7 +66062,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66161,6 +66186,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
> [!NOTE]
> This PR incrementally ships the now-validated WalletSync DDD architecture. See super PR [#19464](https://github.com/LedgerHQ/ledger-live/pull/19464).

### 📝 Description

Introduces `@domain/entity-starred-account`, an RTK slice managing the `starredAccountIds` Set. No workspace dependencies.

> **⚠️ DEPRECATED** — The Wallet V4 implementation no longer uses the concept of starred accounts. This package is introduced for backwards compatibility and will not be actively developed further. Do not build new features on top of it.

> [!NOTE]
> The earlier Copilot suggestion to remove `enableMapSet()` was a false positive — RTK uses Immer internally and the MapSet plugin is required when the Redux initial state is a `Set`. Tests confirmed this: removing it causes a runtime error (`The plugin for 'MapSet' has not been loaded into Immer`). `enableMapSet()` and the `immer` dependency have been restored.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35268](https://ledgerhq.atlassian.net/browse/LIVE-35268)
- **ADR** (if any): N/A

[LIVE-35268]: https://ledgerhq.atlassian.net/browse/LIVE-35268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ