### PR TITLE
feat(ddd): add @domain/entity-wallet-sync package

### DIFF
--- a/domain/entity/wallet-sync/README.md
+++ b/domain/entity/wallet-sync/README.md
@@ -1,0 +1,15 @@
+# @domain/entity-wallet-sync
+
+> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+
+RTK slice for WalletSync protocol state (distant data + version).
+
+State shape: `{ walletSyncState: WSState }`. Tracks the current sync status (version, distant state blob). Exports `walletSyncSlice`, action `walletSyncUpdate` and selector `walletSyncStateSelector`.
+
+> Account-related sync state (`nonImportedAccountInfos`) lives in [`@ledgerhq/live-wallet/accounts`](../../../libs/live-wallet/src/accounts/) until `@domain/entity-account` exists.
+
+## Related documentation
+
+- [WalletSyncDataManager](../../../docs/ledger-sync/05-wallet-sync-data-manager.md) — modular reconciliation layer
+- [The watch loop](../../../docs/ledger-sync/06-watch-loop.md) — continuous sync lifecycle
+- [App integration](../../../docs/ledger-sync/07-app-integration.md) — Redux wiring in Desktop & Mobile

--- a/domain/entity/wallet-sync/jest.config.js
+++ b/domain/entity/wallet-sync/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/wallet-sync/package.json
+++ b/domain/entity/wallet-sync/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@domain/entity-wallet-sync",
+  "version": "0.0.1",
+  "private": true,
+  "description": "WalletSync entity: wallet-sync protocol state, action creators, and selectors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/wallet-sync"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/wallet-sync/project.json
+++ b/domain/entity/wallet-sync/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-wallet-sync",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/wallet-sync/src/index.ts
+++ b/domain/entity/wallet-sync/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./selectors";
+export * from "./slice";

--- a/domain/entity/wallet-sync/src/schema.ts
+++ b/domain/entity/wallet-sync/src/schema.ts
@@ -1,0 +1,11 @@
+export type WSState = { data: Record<string, unknown> | null; version: number };
+
+export type WalletSyncState = {
+  walletSyncState: WSState;
+};
+
+export const initialWalletSyncState: WalletSyncState = {
+  walletSyncState: { data: null, version: 0 },
+};
+
+export type ExportedWalletSyncState = WalletSyncState;

--- a/domain/entity/wallet-sync/src/selectors.ts
+++ b/domain/entity/wallet-sync/src/selectors.ts
@@ -1,0 +1,6 @@
+import type { WSState, WalletSyncState } from "./schema";
+
+type WalletSyncStateRoot = { walletSync: WalletSyncState };
+
+export const walletSyncStateSelector = (state: WalletSyncStateRoot): WSState =>
+  state.walletSync.walletSyncState;

--- a/domain/entity/wallet-sync/src/slice.test.ts
+++ b/domain/entity/wallet-sync/src/slice.test.ts
@@ -1,0 +1,30 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { walletSyncSlice, walletSyncUpdate } from "./slice";
+import { walletSyncStateSelector } from "./selectors";
+
+function makeStore() {
+  const store = configureStore({ reducer: { walletSync: walletSyncSlice.reducer } });
+  return {
+    dispatch: store.dispatch,
+    ws: () => walletSyncStateSelector(store.getState()),
+  };
+}
+
+describe("walletSyncSlice", () => {
+  it("starts with no data and version 0", () => {
+    expect(makeStore().ws()).toEqual({ data: null, version: 0 });
+  });
+
+  it("walletSyncUpdate sets both data and version", () => {
+    const store = makeStore();
+    store.dispatch(walletSyncUpdate({ data: { accounts: [] }, version: 3 }));
+    expect(store.ws()).toEqual({ data: { accounts: [] }, version: 3 });
+  });
+
+  it("walletSyncUpdate resets data back to null", () => {
+    const store = makeStore();
+    store.dispatch(walletSyncUpdate({ data: { accounts: [] }, version: 3 }));
+    store.dispatch(walletSyncUpdate({ data: null, version: 0 }));
+    expect(store.ws()).toEqual({ data: null, version: 0 });
+  });
+});

--- a/domain/entity/wallet-sync/src/slice.ts
+++ b/domain/entity/wallet-sync/src/slice.ts
@@ -1,0 +1,15 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { initialWalletSyncState, type WSState } from "./schema";
+
+export const walletSyncSlice = createSlice({
+  name: "walletSync",
+  initialState: initialWalletSyncState,
+  reducers: {
+    walletSyncUpdate: (state, { payload }: PayloadAction<WSState>) => {
+      state.walletSyncState.data = payload.data;
+      state.walletSyncState.version = payload.version;
+    },
+  },
+});
+
+export const { walletSyncUpdate } = walletSyncSlice.actions;

--- a/domain/entity/wallet-sync/tsconfig.json
+++ b/domain/entity/wallet-sync/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -199,6 +199,9 @@
     "./domain/entity/pay-card": {
       "entry": ["src/index.ts"]
     },
+    "./domain/entity/wallet-sync": {
+      "entry": ["src/index.ts"]
+    },
     "./domain/api/pay-card": {
       "entry": ["src/index.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4056,6 +4056,28 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/wallet-sync:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   e2e/desktop:
     dependencies:
       '@ledgerhq/ledger-key-ring-protocol':


### PR DESCRIPTION
> [!NOTE]
> This PR incrementally ships the now-validated WalletSync DDD architecture. See super PR [#19464](https://github.com/LedgerHQ/ledger-live/pull/19464).

### 📝 Description

Introduces `@domain/entity-wallet-sync`, an RTK slice managing `walletSyncState` and `nonImportedAccountInfos`. No workspace dependencies.

The `wallet-sync` name here refers to the specific aggregated type used for wallet synchronisation — built on top of the generic `@shared/cloud-sync-module` infrastructure brick. The entity layer owns the domain state shape and Redux slice, not the sync mechanism itself.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35269](https://ledgerhq.atlassian.net/browse/LIVE-35269)
- **ADR** (if any): N/A

[LIVE-35269]: https://ledgerhq.atlassian.net/browse/LIVE-35269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ