### PR TITLE
[LWDM] feat(lwdm): coexist LNS upsell with Braze cards on Portfolio

### DIFF
--- a/.changeset/banner-wallet-braze.md
+++ b/.changeset/banner-wallet-braze.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Portfolio upsell banner and Braze content cards now coexist in a single carousel

--- a/.changeset/banner-wallet-braze.md
+++ b/.changeset/banner-wallet-braze.md
@@ -3,4 +3,4 @@
 "ledger-live-desktop": minor
 ---
 
-Portfolio upsell banner and Braze content cards now coexist in a single carousel
+Portfolio upsell banner and Braze content cards can now coexist on Portfolio (Mobile: shared carousel; Desktop: side-by-side grid when Braze placement is enabled, otherwise upsell stacked above the Braze carousel).

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -355,13 +355,13 @@ describe("PortfolioContentCards", () => {
     expect(screen.queryByTestId("carousel-arrow-next")).not.toBeInTheDocument();
   });
 
-  test("classic path stacks leadingSlide above Braze carousel and caps Braze at 2", async () => {
+  test("classic path stacks leadingSlide above Braze carousel without truncating Braze cards", async () => {
     const threeCards = [
       ...Cards,
       {
         id: "2",
         title: "Baz",
-        description: "Third card should be truncated.",
+        description: "Third card remains visible on classic path.",
         path: "ledger-live://deep-link",
         location: LocationContentCard.Portfolio,
       },
@@ -385,7 +385,7 @@ describe("PortfolioContentCards", () => {
     expect(await screen.findByTestId("upsell-leading")).toBeInTheDocument();
     expect(screen.getByText("Foo")).toBeInTheDocument();
     expect(screen.getByText("Bar")).toBeInTheDocument();
-    expect(screen.queryByText("Baz")).toBeNull();
+    expect(screen.getByText("Baz")).toBeInTheDocument();
     // Braze-only carousel still has arrows when 2+ Braze slides.
     expect(screen.getByTestId("carousel-arrow-next")).toBeInTheDocument();
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -313,6 +313,82 @@ describe("PortfolioContentCards", () => {
     expect(screen.queryByText("Foo")).toBeNull();
     expect(screen.queryByText("Bar")).toBeNull();
   });
+
+  test("renders leadingSlide alone when there are no portfolio cards", () => {
+    render(<PortfolioContentCards leadingSlide={<div data-testid="upsell-leading" />} />, {
+      initialState: {
+        dynamicContent: { desktopCards: [], portfolioCards: [] },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: 1,
+        },
+      },
+    });
+
+    expect(screen.getByTestId("upsell-leading")).toBeInTheDocument();
+  });
+
+  test("with brazePlacement puts leadingSlide in the Lumen grid beside Braze (not a carousel)", async () => {
+    mockShouldDisplayBrazePlacement = true;
+
+    render(<PortfolioContentCards leadingSlide={<div data-testid="upsell-leading" />} />, {
+      initialState: {
+        dynamicContent: {
+          desktopCards: desktopCardsForBrazeGrid,
+          portfolioCards: CardsForBrazeGrid,
+        },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: 1,
+        },
+      },
+    });
+
+    expect(await screen.findByTestId("upsell-leading")).toBeInTheDocument();
+    // Grid max 2 slots: LNS + 1 Braze (Foo); Bar is truncated.
+    expect(screen.getByText("Foo")).toBeVisible();
+    expect(screen.queryByText("Bar")).toBeNull();
+    expect(screen.queryByTestId("carousel-arrow-next")).not.toBeInTheDocument();
+  });
+
+  test("classic path stacks leadingSlide above Braze carousel and caps Braze at 2", async () => {
+    const threeCards = [
+      ...Cards,
+      {
+        id: "2",
+        title: "Baz",
+        description: "Third card should be truncated.",
+        path: "ledger-live://deep-link",
+        location: LocationContentCard.Portfolio,
+      },
+    ];
+
+    render(<PortfolioContentCards leadingSlide={<div data-testid="upsell-leading" />} />, {
+      initialState: {
+        dynamicContent: {
+          desktopCards: threeCards.map(asClassicBrazeCard),
+          portfolioCards: threeCards,
+        },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: 1,
+        },
+      },
+    });
+
+    expect(await screen.findByTestId("upsell-leading")).toBeInTheDocument();
+    expect(screen.getByText("Foo")).toBeInTheDocument();
+    expect(screen.getByText("Bar")).toBeInTheDocument();
+    expect(screen.queryByText("Baz")).toBeNull();
+    // Braze-only carousel still has arrows when 2+ Braze slides.
+    expect(screen.getByTestId("carousel-arrow-next")).toBeInTheDocument();
+  });
 });
 
 describe("BottomCarouselContentCards", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/Slide.tsx
@@ -17,7 +17,10 @@ const SlideContainer = styled.div`
 
 type Props = PortfolioContentCard &
   CarouselActions & {
+    /** Index into `portfolioCards` for dismiss. */
     index: number;
+    /** Visual carousel position for analytics (may include a leading upsell offset). */
+    displayedPosition?: number;
   };
 
 function Slide({
@@ -30,15 +33,17 @@ function Slide({
   tag,
   image,
   index,
+  displayedPosition,
   location,
   logSlideClick,
   dismissCard,
 }: Props) {
   const navigate = useNavigate();
+  const analyticsPosition = displayedPosition ?? index;
 
-  const handleClose = () => dismissCard(index);
+  const handleClose = () => dismissCard(index, analyticsPosition);
   const handleClick = () => {
-    logSlideClick(id);
+    logSlideClick(id, analyticsPosition);
     if (path) {
       navigate(path, { state: { source: "banner" } });
     } else if (url) {
@@ -48,7 +53,7 @@ function Slide({
 
   return (
     <SlideContainer>
-      <LogContentCardWrapper id={id} displayedPosition={index} location={location}>
+      <LogContentCardWrapper id={id} displayedPosition={analyticsPosition} location={location}>
         <Card
           title={title}
           cta={cta}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -115,9 +115,9 @@ const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide(
   );
 });
 
-type PortfolioContentCardsProps = {
+type PortfolioContentCardsProps = Readonly<{
   leadingSlide?: ReactNode;
-};
+}>;
 
 function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
   const { layout, brazeCarouselEntries, positionOffset, logSlideClick, dismissCard } =

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -1,17 +1,23 @@
-import React, { memo } from "react";
+import React, {
+  cloneElement,
+  isValidElement,
+  memo,
+  useMemo,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { useNavigate } from "react-router";
 import styled from "styled-components";
 
 import { Carousel } from "@ledgerhq/react-ui";
-import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import { track } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import type { PortfolioContentCard as PortfolioCardType } from "~/types/dynamicContent";
-import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
 import type { CarouselActions } from "../../types";
 import { ContentBannerActionCard } from "../ContentBannerActionCard";
 import LogContentCardWrapper from "../LogContentCardWrapper";
 import Slide from "./Slide";
+import { usePortfolioContentCardsViewModel } from "./usePortfolioContentCardsViewModel";
 
 export default PortfolioContentCards;
 
@@ -34,15 +40,25 @@ const BrazePlacementGrid = styled.div`
   }
 `;
 
+const LeadingGridCell = styled.div`
+  min-width: 0;
+  width: 100%;
+`;
+
+const StackedLeading = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+`;
+
 type BrazeSlideProps = {
   card: PortfolioCardType;
+  /** Index into `portfolioCards` for dismiss. */
   index: number;
+  /** Visual position for analytics (may include a leading upsell offset). */
+  displayedPosition?: number;
 } & CarouselActions;
-
-/** Braze placement grid: only cards with at least one of these (extras) are shown when FF is on. */
-function isPortfolioCardEligibleForLumenGrid(card: PortfolioCardType): boolean {
-  return Boolean(card.image_background?.trim()) || Boolean(card.icon?.trim());
-}
 
 /** MediaBanner URL from `image_background` only (`image` is not used as fallback). */
 function lumenImageBackgroundForPortfolio(card: PortfolioCardType): string | undefined {
@@ -50,17 +66,28 @@ function lumenImageBackgroundForPortfolio(card: PortfolioCardType): string | und
   return bg || undefined;
 }
 
+/** Fill the grid cell: LNSUpsellBanner Flex defaults to 50% for exclusive display. */
+function leadingSlideForGrid(leading: ReactNode): ReactNode {
+  if (!isValidElement(leading)) return leading;
+  return cloneElement(leading as ReactElement<{ width?: string; maxWidth?: string }>, {
+    width: "100%",
+    maxWidth: "100%",
+  });
+}
+
 const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide({
   card,
   index,
+  displayedPosition,
   logSlideClick,
   dismissCard,
 }: BrazeSlideProps) {
   const navigate = useNavigate();
+  const analyticsPosition = displayedPosition ?? index;
 
-  const handleClose = () => dismissCard(index);
+  const handleClose = () => dismissCard(index, analyticsPosition);
   const handleClick = () => {
-    logSlideClick(card.id);
+    logSlideClick(card.id, analyticsPosition);
     if (card.path) {
       navigate(card.path, { state: { source: "banner" } });
     } else if (card.url) {
@@ -71,7 +98,11 @@ const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide(
   const imageBackground = lumenImageBackgroundForPortfolio(card);
 
   return (
-    <LogContentCardWrapper id={card.id} displayedPosition={index} location={card.location}>
+    <LogContentCardWrapper
+      id={card.id}
+      displayedPosition={analyticsPosition}
+      location={card.location}
+    >
       <ContentBannerActionCard
         title={card.title}
         description={card.description}
@@ -84,29 +115,66 @@ const PortfolioBrazePlacementSlide = memo(function PortfolioBrazePlacementSlide(
   );
 });
 
-function PortfolioContentCards() {
-  const { portfolioCards, logSlideClick, dismissCard } = usePortfolioCarouselCards("top");
-  const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
+type PortfolioContentCardsProps = {
+  leadingSlide?: ReactNode;
+};
+
+function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
+  const { layout, brazeCarouselEntries, positionOffset, logSlideClick, dismissCard } =
+    usePortfolioContentCardsViewModel({ hasLeadingSlide: Boolean(leadingSlide) });
+
   const handlePrevButton = () => trackSlide("prev");
   const handleNextButton = () => trackSlide("next");
 
-  if (portfolioCards.length === 0) return null;
+  const brazeSlides = useMemo(
+    () =>
+      brazeCarouselEntries.map(({ card, portfolioIndex }, displayIndex) => (
+        <Slide
+          key={card.id}
+          {...card}
+          index={portfolioIndex}
+          displayedPosition={displayIndex + positionOffset}
+          logSlideClick={logSlideClick}
+          dismissCard={dismissCard}
+        />
+      )),
+    [brazeCarouselEntries, dismissCard, logSlideClick, positionOffset],
+  );
 
-  if (shouldDisplayBrazePlacement) {
-    const eligibleEntries = portfolioCards
-      .map((card, portfolioIndex) => ({ card, portfolioIndex }))
-      .filter(({ card }) => isPortfolioCardEligibleForLumenGrid(card))
-      .slice(0, 2);
+  // Carousel requires ReactElement[] (uses children.length / .map) — not a Fragment.
+  const renderCarousel = (slides: ReactElement[]) => (
+    <CarouselWrapper>
+      <Carousel
+        initialDelay={2500}
+        autoPlay={6000}
+        onPrev={handlePrevButton}
+        onNext={handleNextButton}
+      >
+        {slides}
+      </Carousel>
+    </CarouselWrapper>
+  );
 
-    if (eligibleEntries.length === 0) return null;
+  if (layout === "empty") return null;
 
+  if (layout === "leading-only") {
+    return <>{leadingSlide}</>;
+  }
+
+  if (layout === "braze-grid") {
     return (
       <BrazePlacementGrid>
-        {eligibleEntries.map(({ card, portfolioIndex }) => (
+        {leadingSlide ? (
+          <LeadingGridCell key="portfolio-upsell-leading">
+            {leadingSlideForGrid(leadingSlide)}
+          </LeadingGridCell>
+        ) : null}
+        {brazeCarouselEntries.map(({ card, portfolioIndex }, displayIndex) => (
           <PortfolioBrazePlacementSlide
             key={card.id}
             card={card}
             index={portfolioIndex}
+            displayedPosition={displayIndex + positionOffset}
             logSlideClick={logSlideClick}
             dismissCard={dismissCard}
           />
@@ -115,26 +183,16 @@ function PortfolioContentCards() {
     );
   }
 
-  return (
-    <CarouselWrapper>
-      <Carousel
-        initialDelay={2500}
-        autoPlay={6000}
-        onPrev={handlePrevButton}
-        onNext={handleNextButton}
-      >
-        {portfolioCards.map((card, index) => (
-          <Slide
-            key={card.id}
-            {...card}
-            index={index}
-            logSlideClick={logSlideClick}
-            dismissCard={dismissCard}
-          />
-        ))}
-      </Carousel>
-    </CarouselWrapper>
-  );
+  if (layout === "stacked-leading") {
+    return (
+      <StackedLeading>
+        {leadingSlide}
+        {renderCarousel(brazeSlides)}
+      </StackedLeading>
+    );
+  }
+
+  return renderCarousel(brazeSlides);
 }
 
 function trackSlide(button: "prev" | "next") {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
+import type { PortfolioContentCard } from "~/types/dynamicContent";
+import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
+import type { CarouselActions } from "../../types";
+
+/** Desktop portfolio Braze placement: max 2 cards in the row (LNS counts as one when present). */
+export const MAX_DESKTOP_BRAZE_PLACEMENT_CARDS = 2;
+
+export type BrazeCarouselEntry = {
+  card: PortfolioContentCard;
+  portfolioIndex: number;
+};
+
+export type PortfolioContentCardsLayout =
+  | "braze-grid"
+  | "stacked-leading"
+  | "carousel"
+  | "leading-only"
+  | "empty";
+
+export type UsePortfolioContentCardsViewModelArgs = {
+  hasLeadingSlide: boolean;
+};
+
+export type UsePortfolioContentCardsViewModelResult = {
+  layout: PortfolioContentCardsLayout;
+  brazeCarouselEntries: BrazeCarouselEntry[];
+  /** Offset applied to Braze `displayedPosition` when a leading upsell is present. */
+  positionOffset: number;
+} & CarouselActions;
+
+/** Braze placement grid: only cards with at least one of these (extras) are shown when FF is on. */
+export function isPortfolioCardEligibleForLumenGrid(card: PortfolioContentCard): boolean {
+  return Boolean(card.image_background?.trim()) || Boolean(card.icon?.trim());
+}
+
+export function usePortfolioContentCardsViewModel({
+  hasLeadingSlide,
+}: UsePortfolioContentCardsViewModelArgs): UsePortfolioContentCardsViewModelResult {
+  const { portfolioCards, logSlideClick, dismissCard } = usePortfolioCarouselCards("top");
+  const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("desktop");
+  const positionOffset = hasLeadingSlide ? 1 : 0;
+
+  const brazeCarouselEntries = useMemo(() => {
+    const entries = portfolioCards.map((card, portfolioIndex) => ({ card, portfolioIndex }));
+    if (shouldDisplayBrazePlacement) {
+      const maxBraze = hasLeadingSlide
+        ? MAX_DESKTOP_BRAZE_PLACEMENT_CARDS - 1
+        : MAX_DESKTOP_BRAZE_PLACEMENT_CARDS;
+      return entries
+        .filter(({ card }) => isPortfolioCardEligibleForLumenGrid(card))
+        .slice(0, maxBraze);
+    }
+    if (hasLeadingSlide) {
+      return entries.slice(0, MAX_DESKTOP_BRAZE_PLACEMENT_CARDS);
+    }
+    return entries;
+  }, [hasLeadingSlide, portfolioCards, shouldDisplayBrazePlacement]);
+
+  const layout = useMemo((): PortfolioContentCardsLayout => {
+    if (shouldDisplayBrazePlacement) {
+      if (brazeCarouselEntries.length === 0) {
+        return hasLeadingSlide ? "leading-only" : "empty";
+      }
+      return "braze-grid";
+    }
+    if (hasLeadingSlide) {
+      return brazeCarouselEntries.length === 0 ? "leading-only" : "stacked-leading";
+    }
+    if (portfolioCards.length === 0) return "empty";
+    return "carousel";
+  }, [
+    brazeCarouselEntries.length,
+    hasLeadingSlide,
+    portfolioCards.length,
+    shouldDisplayBrazePlacement,
+  ]);
+
+  return {
+    layout,
+    brazeCarouselEntries,
+    positionOffset,
+    logSlideClick,
+    dismissCard,
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
@@ -4,7 +4,7 @@ import type { PortfolioContentCard } from "~/types/dynamicContent";
 import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
 import type { CarouselActions } from "../../types";
 
-/** Desktop portfolio Braze placement: max 2 cards in the row (LNS counts as one when present). */
+/** Desktop Braze placement grid: max 2 cards in the row (LN upsell counts as one when present). */
 export const MAX_DESKTOP_BRAZE_PLACEMENT_CARDS = 2;
 
 export type BrazeCarouselEntry = {
@@ -51,9 +51,6 @@ export function usePortfolioContentCardsViewModel({
       return entries
         .filter(({ card }) => isPortfolioCardEligibleForLumenGrid(card))
         .slice(0, maxBraze);
-    }
-    if (hasLeadingSlide) {
-      return entries.slice(0, MAX_DESKTOP_BRAZE_PLACEMENT_CARDS);
     }
     return entries;
   }, [hasLeadingSlide, portfolioCards, shouldDisplayBrazePlacement]);

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/usePortfolioCarouselCards.ts
@@ -48,7 +48,7 @@ export function usePortfolioCarouselCards(
   );
 
   const dismissCard = useCallback<CarouselActions["dismissCard"]>(
-    index => {
+    (index, displayedPosition) => {
       const slide = portfolioCards[index];
       if (!slide?.id) return;
       const currentCard = getBrazeCard(slide.id);
@@ -62,7 +62,7 @@ export function usePortfolioCarouselCards(
             page: "Portfolio",
             type: "portfolio_carousel",
             location: slide.location,
-            displayedPosition: index,
+            displayedPosition: displayedPosition ?? index,
           });
         } else if (currentCard.id) {
           dispatch(setDismissedContentCards({ id: currentCard.id, timestamp: Date.now() }));
@@ -74,7 +74,7 @@ export function usePortfolioCarouselCards(
   );
 
   const logSlideClick = useCallback<CarouselActions["logSlideClick"]>(
-    cardId => {
+    (cardId, displayedPosition) => {
       if (!isTrackedUser) return;
 
       const slideIndex = portfolioCards.findIndex(card => card.id === cardId);
@@ -95,7 +95,7 @@ export function usePortfolioCarouselCards(
         page: "Portfolio",
         type: "portfolio_carousel",
         location: slide.location,
-        displayedPosition: slideIndex,
+        displayedPosition: displayedPosition ?? slideIndex,
       });
     },
     [portfolioCards, getBrazeCard, isTrackedUser],

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/types.ts
@@ -1,4 +1,9 @@
 export type CarouselActions = {
-  logSlideClick: (cardId: string) => void;
-  dismissCard: (index: number) => void;
+  /** @param displayedPosition Visual slot for analytics (may include a leading upsell offset). */
+  logSlideClick: (cardId: string, displayedPosition?: number) => void;
+  /**
+   * @param index Index into `portfolioCards` (dismiss target).
+   * @param displayedPosition Visual slot for analytics (may include a leading upsell offset).
+   */
+  dismissCard: (index: number, displayedPosition?: number) => void;
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/__tests__/PortfolioBannerContent.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/__tests__/PortfolioBannerContent.test.tsx
@@ -46,7 +46,9 @@ jest.mock("LLD/features/LNSUpsell", () => ({
 
 jest.mock("LLD/features/DynamicContent/components/PortfolioContentCards", () => ({
   __esModule: true,
-  default: () => <div data-testid="portfolio-content-cards" />,
+  default: ({ leadingSlide }: { leadingSlide?: React.ReactNode }) => (
+    <div data-testid="portfolio-content-cards">{leadingSlide}</div>
+  ),
 }));
 
 jest.mock("~/renderer/screens/dashboard/ActionContentCards", () => ({
@@ -240,6 +242,54 @@ describe("PortfolioBannerContent", () => {
       expect(screen.getByTestId("portfolio-content-cards")).toBeInTheDocument();
     });
 
+    it("prepends LNS upsell into portfolio content cards when finish and recover are off", () => {
+      setWallet40RecoverInRow(false);
+      setVisibility({
+        shouldDisplayFinishOnboardingWidget: true,
+        isLNSUpsellBannerVisible: true,
+        isFinishOnboardingWidgetVisible: false,
+      });
+
+      render(<PortfolioBannerContent />);
+
+      expect(screen.getByTestId("portfolio-content-cards")).toBeInTheDocument();
+      expect(screen.getByTestId("lns-upsell-banner")).toBeVisible();
+      expect(screen.queryByTestId("finish-onboarding-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("recover-widget")).not.toBeInTheDocument();
+    });
+
+    it("keeps LNS exclusive when recover is visible and finish is off (Wallet40 not mounted)", () => {
+      setWallet40RecoverInRow(true);
+      setVisibility({
+        shouldDisplayFinishOnboardingWidget: true,
+        isLNSUpsellBannerVisible: true,
+        isFinishOnboardingWidgetVisible: false,
+      });
+
+      render(<PortfolioBannerContent />);
+
+      expect(screen.getByTestId("lns-upsell-banner")).toBeVisible();
+      expect(screen.queryByTestId("recover-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("finish-onboarding-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("portfolio-content-cards")).not.toBeInTheDocument();
+    });
+
+    it("keeps LNS exclusive when finish onboarding is visible", () => {
+      setWallet40RecoverInRow(true);
+      setVisibility({
+        shouldDisplayFinishOnboardingWidget: true,
+        isLNSUpsellBannerVisible: true,
+        isFinishOnboardingWidgetVisible: true,
+      });
+
+      render(<PortfolioBannerContent />);
+
+      expect(screen.getByTestId("lns-upsell-banner")).toBeVisible();
+      expect(screen.queryByTestId("finish-onboarding-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("recover-widget")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("portfolio-content-cards")).not.toBeInTheDocument();
+    });
+
     it("shows finish onboarding without recover when displayBanner is false", () => {
       setWallet40RecoverInRow(false);
       setVisibility({
@@ -295,6 +345,7 @@ describe("PortfolioBannerContent", () => {
 
       render(<PortfolioBannerContent />);
 
+      expect(screen.getByTestId("portfolio-content-cards")).toBeInTheDocument();
       expect(screen.getByTestId("lns-upsell-banner")).toBeVisible();
       expect(screen.queryByTestId("action-content-cards")).not.toBeInTheDocument();
     });

--- a/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/dashboard/components/Banners/PortfolioBannerContent/index.tsx
@@ -1,9 +1,12 @@
-import React, { memo } from "react";
+import React, { memo, type ReactNode } from "react";
 import PortfolioContentCards from "LLD/features/DynamicContent/components/PortfolioContentCards";
 import FinishOnboardingWidget from "LLD/features/FinishOnboarding/FinishOnboardingWidget";
 import RecoverWidgetView from "LLD/features/FinishOnboarding/RecoverWidget/RecoverWidgetView";
 import { usePortfolioAddRecoverPostOnboardingAction } from "LLD/features/FinishOnboarding/RecoverWidget/usePortfolioAddRecoverPostOnboardingAction";
-import { useRecoverWidgetViewModel } from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
+import {
+  useRecoverWidgetViewModel,
+  type RecoverWidgetViewProps,
+} from "LLD/features/FinishOnboarding/RecoverWidget/useRecoverWidgetViewModel";
 import { LNSUpsellBanner } from "LLD/features/LNSUpsell";
 import PostOnboardingHubBanner from "~/renderer/components/PostOnboardingHub/PostOnboardingHubBanner";
 import RecoverBanner from "~/renderer/components/RecoverBanner/RecoverBanner";
@@ -11,20 +14,25 @@ import ActionContentCards from "~/renderer/screens/dashboard/ActionContentCards"
 import { useBannersVisibility } from "../hooks/useBannersVisibility";
 
 /**
- * Wallet40 row without LNS priority: runs `useRecoverWidgetViewModel` only when this subtree mounts
- * (parent renders LNS upsell first when `isLNSUpsellBannerVisible`, so Recover hooks do not run there).
+ * Wallet40 row: Finish/Recover widgets take priority over Braze cards.
+ * When LNS upsell is eligible and Finish/Recover are showing, LNS remains exclusive.
+ * When falling through to Braze cards, LNS is prepended as the leading slide / grid slot.
  */
 const PortfolioBannerWallet40 = memo(function PortfolioBannerWallet40({
   isFinishOnboardingWidgetVisible,
+  lnsUpsellLeadingSlide,
+  recoverWidget,
 }: {
   isFinishOnboardingWidgetVisible: boolean;
+  lnsUpsellLeadingSlide?: ReactNode;
+  recoverWidget: RecoverWidgetViewProps;
 }) {
   const {
     shouldDisplay: shouldDisplayRecoverWidget,
     titleKey,
     descriptionKey,
     onOpenRecover,
-  } = useRecoverWidgetViewModel();
+  } = recoverWidget;
 
   if (isFinishOnboardingWidgetVisible || shouldDisplayRecoverWidget) {
     return (
@@ -41,30 +49,24 @@ const PortfolioBannerWallet40 = memo(function PortfolioBannerWallet40({
       </div>
     );
   }
-  return <PortfolioContentCards />;
+  return <PortfolioContentCards leadingSlide={lnsUpsellLeadingSlide} />;
 });
 
 /**
  * Renders the portfolio banner block above the portfolio carousel / market banner.
  *
  * **Wallet40** (`shouldDisplayFinishOnboardingWidget`):
- * - LNS upsell when `isLNSUpsellBannerVisible`.
- * - Finish onboarding and/or Recover widgets in a row when either applies.
- * - Otherwise `PortfolioContentCards` directly (via `PortfolioBannerWallet40`).
+ * - Finish onboarding and/or Recover widgets when either applies (LNS upsell still exclusive over them).
+ * - Otherwise `PortfolioContentCards`, with LNS upsell as leading carousel slide when eligible.
  *
  * **Legacy** (Wallet40 off):
  * - Post-onboarding hub: `PostOnboardingHubBanner` is rendered directly when the wallet entry point
  *   is visible.
- * - Otherwise `RecoverBanner` wraps action cards, LNS upsell, or `PortfolioContentCards`.
+ * - Otherwise `RecoverBanner` wraps action cards, or `PortfolioContentCards` (LNS as leading slide).
  *
  * The Recover post-onboarding action-append runs here via `usePortfolioAddRecoverPostOnboardingAction`,
  * which is decoupled from the Recover widget render path so the hub still receives Recover when
  * the LNS upsell is rendered instead of the finish/recover row.
- *
- * When Wallet40 applies and LNS upsell is visible, LNS is rendered here without mounting the Recover
- * subtree. Otherwise the finish/recover row uses one `useRecoverWidgetViewModel` (→ `useRecoverBannerState`,
- * LIVE-30279); its `shouldDisplay` boolean gates the Recover tile and the same view-model output is
- * passed to `RecoverWidgetView` so hooks are not duplicated when the Recover tile is shown.
  *
  * Used in PortfolioView (above MarketBanner) and in BannerSection (legacy dashboard).
  */
@@ -79,12 +81,26 @@ export const PortfolioBannerContent = memo(function PortfolioBannerContent() {
 
   usePortfolioAddRecoverPostOnboardingAction();
 
+  // Lifted so Wallet40 is not mounted when LNS is exclusive over Finish/Recover.
+  const recoverWidget = useRecoverWidgetViewModel();
+
+  const lnsUpsellLeadingSlide = isLNSUpsellBannerVisible ? (
+    <LNSUpsellBanner location="portfolio" />
+  ) : undefined;
+
   if (shouldDisplayFinishOnboardingWidget) {
-    if (isLNSUpsellBannerVisible) {
-      return <LNSUpsellBanner location="portfolio" />;
+    if (
+      isLNSUpsellBannerVisible &&
+      (isFinishOnboardingWidgetVisible || recoverWidget.shouldDisplay)
+    ) {
+      return <>{lnsUpsellLeadingSlide}</>;
     }
     return (
-      <PortfolioBannerWallet40 isFinishOnboardingWidgetVisible={isFinishOnboardingWidgetVisible} />
+      <PortfolioBannerWallet40
+        isFinishOnboardingWidgetVisible={isFinishOnboardingWidgetVisible}
+        lnsUpsellLeadingSlide={lnsUpsellLeadingSlide}
+        recoverWidget={recoverWidget}
+      />
     );
   }
 
@@ -92,12 +108,12 @@ export const PortfolioBannerContent = memo(function PortfolioBannerContent() {
     return <PostOnboardingHubBanner />;
   }
 
-  let recoverBannerChildren: React.ReactNode = <PortfolioContentCards />;
+  let recoverBannerChildren: ReactNode = (
+    <PortfolioContentCards leadingSlide={lnsUpsellLeadingSlide} />
+  );
 
   if (isActionCardsVisible) {
     recoverBannerChildren = <ActionContentCards />;
-  } else if (isLNSUpsellBannerVisible) {
-    recoverBannerChildren = <LNSUpsellBanner location="portfolio" />;
   }
 
   return <RecoverBanner>{recoverBannerChildren}</RecoverBanner>;

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8601,12 +8601,12 @@
   },
   "lnsUpsellMediaBanner": {
     "opted_in": {
-      "title": "Upgrade your Ledger Nano S™",
-      "description": "Get an exclusive 20% off on the latest Ledger signers."
+      "title": "See more. Sign safer",
+      "description": "Upgrade and get 20% off."
     },
     "opted_out": {
-      "title": "Upgrade your Ledger Nano S™",
-      "description": "The limited memory of your Ledger Nano S restricts your access to the latest features, blockchain changes and security enhancements."
+      "title": "More security. More control",
+      "description": "Learn more about security features."
     }
   },
   "largeScreenUpsellModal": {

--- a/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FlatList,
   ListRenderItemInfo,
@@ -21,16 +21,22 @@ import { currentRouteNameRef } from "~/analytics/screenRefs";
 import { Box, PageIndicator } from "@ledgerhq/lumen-ui-rnative";
 
 const CONTAINER_IMPRESSION_THRESHOLD = 0.8;
+const LEADING_SLIDE_KEY = "content-cards-carousel-leading";
 
 type Props = {
   showLumenPageIndicator?: boolean;
   disableVerticalStretch?: boolean;
+  leadingSlide?: React.ReactNode;
   styles?: {
     gap?: number;
     pagination?: boolean;
     widthFactor?: WidthFactor;
   };
 };
+
+type CarouselListItem =
+  | { kind: "leading"; key: string; node: React.ReactNode }
+  | { kind: "card"; key: string; item: ContentCardItem };
 
 const defaultStyles = {
   gap: 6,
@@ -43,6 +49,7 @@ const Carousel = ContentLayoutBuilder<Props>(
     items,
     showLumenPageIndicator = false,
     disableVerticalStretch = false,
+    leadingSlide,
     styles: _styles = defaultStyles,
   }) => {
     const styles = {
@@ -58,11 +65,46 @@ const Carousel = ContentLayoutBuilder<Props>(
     const theme = useTheme();
     const separatorWidth = theme.space[styles.gap];
 
+    const listData = useMemo<CarouselListItem[]>(() => {
+      const cards: CarouselListItem[] = items.map(item => ({
+        kind: "card",
+        key: item.props.metadata.id,
+        item,
+      }));
+      if (!leadingSlide) return cards;
+      return [{ kind: "leading", key: LEADING_SLIDE_KEY, node: leadingSlide }, ...cards];
+    }, [items, leadingSlide]);
+
+    const listDataKeys = useMemo(() => listData.map(item => item.key).join("|"), [listData]);
+
     const isPaginationEnabled = styles.pagination && !showLumenPageIndicator;
-    const showDots = showLumenPageIndicator && items.length > 1;
+    const showDots = showLumenPageIndicator && listData.length > 1;
+    // Match Braze TopWallet spacing: room between slide and PageIndicator (avoid tight dots).
+    const carouselGap = showDots ? 12 : 8;
 
     const carouselRef = useRef<FlatList>(null);
     const [carouselIndex, setCarouselIndex] = useState(0);
+    // TopWallet: size the track to the tallest slide (e.g. LNS 2-line description) so nothing crops.
+    const slideHeightsRef = useRef<Record<string, number>>({});
+    const [trackHeight, setTrackHeight] = useState<number | undefined>(undefined);
+
+    useEffect(() => {
+      slideHeightsRef.current = {};
+      setTrackHeight(undefined);
+      setCarouselIndex(0);
+      carouselRef.current?.scrollToOffset({ offset: 0, animated: false });
+    }, [listDataKeys]);
+
+    const handleSlideLayout = useCallback(
+      (key: string, height: number) => {
+        if (!disableVerticalStretch || height <= 0) return;
+        if (slideHeightsRef.current[key] === height) return;
+        slideHeightsRef.current[key] = height;
+        const maxHeight = Math.max(...Object.values(slideHeightsRef.current));
+        setTrackHeight(current => (current === maxHeight ? current : maxHeight));
+      },
+      [disableVerticalStretch],
+    );
 
     const setIndexOnScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
       const contentOffsetX = e.nativeEvent.contentOffset.x;
@@ -108,8 +150,10 @@ const Carousel = ContentLayoutBuilder<Props>(
       viewRef,
     );
     const handleViewableItemsChanged = useCallback(
-      ({ viewableItems }: { viewableItems: ViewToken<ContentCardItem>[] }) => {
-        const visibleCards = viewableItems.map(({ item }) => item.props.metadata.id);
+      ({ viewableItems }: { viewableItems: ViewToken<CarouselListItem>[] }) => {
+        const visibleCards = viewableItems
+          .map(({ item }) => (item.kind === "card" ? item.item.props.metadata.id : null))
+          .filter((id): id is string => id !== null);
         const newlyVisibleCards = visibleCards.filter(id => !visibleCardsRef.current.includes(id));
         visibleCardsRef.current = visibleCards;
         if (isInViewRef.current)
@@ -119,7 +163,10 @@ const Carousel = ContentLayoutBuilder<Props>(
     );
 
     return (
-      <View ref={viewRef} style={[{ gap: 8 }, disableVerticalStretch ? null : { flex: 1 }]}>
+      <View
+        ref={viewRef}
+        style={[{ gap: carouselGap }, disableVerticalStretch ? null : { flex: 1 }]}
+      >
         <FlatList
           horizontal
           ref={carouselRef}
@@ -130,34 +177,50 @@ const Carousel = ContentLayoutBuilder<Props>(
           bounces={false}
           snapToInterval={width - separatorWidth * 1.5}
           decelerationRate={0}
+          style={trackHeight != null ? { height: trackHeight } : undefined}
           contentContainerStyle={{
             paddingHorizontal: isFullWidth ? separatorWidth : separatorWidth / 2,
+            ...(disableVerticalStretch ? { alignItems: "flex-start" } : null),
           }}
           viewabilityConfig={{ itemVisiblePercentThreshold: 50 }}
           onViewableItemsChanged={handleViewableItemsChanged}
-          data={items}
+          data={listData}
+          keyExtractor={item => item.key}
           ItemSeparatorComponent={() => <View style={{ width: separatorWidth / 2 }} />}
-          renderItem={({ item }: ListRenderItemInfo<ContentCardItem>) => (
+          renderItem={({ item }: ListRenderItemInfo<CarouselListItem>) => (
             <Animated.View
-              key={item.props.metadata.id}
+              key={item.key}
               entering={SlideInRight}
               layout={LinearTransition.duration(100)}
+              onLayout={event => handleSlideLayout(item.key, event.nativeEvent.layout.height)}
               style={{
                 width: width - separatorWidth * 2,
-                flex: 1,
+                ...(disableVerticalStretch ? null : { flex: 1 }),
+                justifyContent: "flex-start",
               }}
             >
-              {<item.component {...item.props} />}
+              {item.kind === "leading" ? item.node : <item.item.component {...item.item.props} />}
             </Animated.View>
           )}
         />
 
-        {isPaginationEnabled ? <Pagination items={items} carouselIndex={carouselIndex} /> : null}
+        {isPaginationEnabled ? (
+          leadingSlide ? (
+            <Box lx={{ alignItems: "center" }}>
+              <PageIndicator
+                currentPage={Math.min(carouselIndex + 1, listData.length)}
+                totalPages={listData.length}
+              />
+            </Box>
+          ) : (
+            <Pagination items={items} carouselIndex={carouselIndex} />
+          )
+        ) : null}
         {showDots ? (
           <Box lx={{ alignItems: "center" }}>
             <PageIndicator
-              currentPage={Math.min(carouselIndex + 1, items.length)}
-              totalPages={items.length}
+              currentPage={Math.min(carouselIndex + 1, listData.length)}
+              totalPages={listData.length}
             />
           </Box>
         ) : null}

--- a/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
+++ b/apps/ledger-live-mobile/src/contentCards/layouts/carousel/index.tsx
@@ -162,6 +162,24 @@ const Carousel = ContentLayoutBuilder<Props>(
       [logImpressionCard, findDisplayedPosition],
     );
 
+    const lumenPageIndicator = (
+      <Box lx={{ alignItems: "center" }}>
+        <PageIndicator
+          currentPage={Math.min(carouselIndex + 1, listData.length)}
+          totalPages={listData.length}
+        />
+      </Box>
+    );
+
+    let pagination: React.ReactNode = null;
+    if (isPaginationEnabled) {
+      if (leadingSlide) {
+        pagination = lumenPageIndicator;
+      } else {
+        pagination = <Pagination items={items} carouselIndex={carouselIndex} />;
+      }
+    }
+
     return (
       <View
         ref={viewRef}
@@ -204,26 +222,8 @@ const Carousel = ContentLayoutBuilder<Props>(
           )}
         />
 
-        {isPaginationEnabled ? (
-          leadingSlide ? (
-            <Box lx={{ alignItems: "center" }}>
-              <PageIndicator
-                currentPage={Math.min(carouselIndex + 1, listData.length)}
-                totalPages={listData.length}
-              />
-            </Box>
-          ) : (
-            <Pagination items={items} carouselIndex={carouselIndex} />
-          )
-        ) : null}
-        {showDots ? (
-          <Box lx={{ alignItems: "center" }}>
-            <PageIndicator
-              currentPage={Math.min(carouselIndex + 1, listData.length)}
-              totalPages={listData.length}
-            />
-          </Box>
-        ) : null}
+        {pagination}
+        {showDots ? lumenPageIndicator : null}
       </View>
     );
   },

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -20,6 +20,25 @@ jest.mock("LLM/features/DynamicContent/components/LogContentCardWrapper", () => 
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
+jest.mock("~/contentCards/layouts/carousel", () => {
+  const React = require("react");
+  const { View, Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({
+      items,
+      leadingSlide,
+    }: {
+      items: unknown[];
+      leadingSlide?: React.ReactNode;
+    }) => (
+      <View testID="mock-carousel">
+        {leadingSlide}
+        <Text testID="carousel-item-count">{String(items.length)}</Text>
+      </View>
+    ),
+  };
+});
 
 jest.mock("~/contentCards/cards/utils", () => {
   const actual = jest.requireActual<typeof import("~/contentCards/cards/utils")>(
@@ -162,5 +181,29 @@ describe("ContentCardsCategory Layout", () => {
       expectedTrackingBase,
     );
     expect(dismissCard).toHaveBeenCalledWith("card-1");
+  });
+
+  it("keeps unique layout to one Braze card when leadingSlide forces a shared carousel", () => {
+    const cards = [
+      createBrazeActionCard({ order: "1" }),
+      createBrazeActionCard({
+        order: "2",
+        title: "Second card",
+      }),
+    ];
+    // Second card needs a distinct id for mapping.
+    cards[1] = { ...cards[1], id: "card-2" };
+
+    render(
+      <Layout
+        category={topWalletCategory}
+        cards={cards}
+        leadingSlide={<Text testID="upsell-leading">upsell</Text>}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-carousel")).toBeVisible();
+    expect(screen.getByTestId("upsell-leading")).toBeVisible();
+    expect(screen.getByTestId("carousel-item-count")).toHaveTextContent("1");
   });
 });

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.test.tsx
@@ -25,13 +25,7 @@ jest.mock("~/contentCards/layouts/carousel", () => {
   const { View, Text } = require("react-native");
   return {
     __esModule: true,
-    default: ({
-      items,
-      leadingSlide,
-    }: {
-      items: unknown[];
-      leadingSlide?: React.ReactNode;
-    }) => (
+    default: ({ items, leadingSlide }: { items: unknown[]; leadingSlide?: React.ReactNode }) => (
       <View testID="mock-carousel">
         {leadingSlide}
         <Text testID="carousel-item-count">{String(items.length)}</Text>

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/Layout.tsx
@@ -72,11 +72,12 @@ const contentCardsTypes: {
 type LayoutProps = {
   category: CategoryContentCard;
   cards: BrazeContentCard[];
+  leadingSlide?: React.ReactNode;
 };
 
 type LayoutCardItemProps = ContentCardProps & { widthFactor?: number };
 
-const Layout = ({ category, cards }: LayoutProps) => {
+const Layout = ({ category, cards, leadingSlide }: LayoutProps) => {
   const { logClickCard, dismissCard, trackContentCardEvent } = useDynamicContent();
   const isTopWallet = category.location === ContentCardLocation.TopWallet;
   const { shouldDisplayBrazePlacement } = useWalletFeaturesConfig("mobile");
@@ -138,6 +139,7 @@ const Layout = ({ category, cards }: LayoutProps) => {
     .filter(card => card);
 
   const cardsSorted = (cardsMapped as AnyContentCard[]).sort(compareCards);
+  const positionOffset = leadingSlide ? 1 : 0;
 
   const items = cardsSorted.map((card, index) =>
     contentCardItem(contentCardComponent, {
@@ -150,32 +152,48 @@ const Layout = ({ category, cards }: LayoutProps) => {
 
       metadata: {
         id: card.id,
-        displayedPosition: index,
+        displayedPosition: index + positionOffset,
 
         actions: {
-          onClick: card.link ? () => onCardClick(card, index) : undefined,
-          onDismiss: category.isDismissable ? () => onCardDismiss(card, index) : undefined,
+          onClick: card.link ? () => onCardClick(card, index + positionOffset) : undefined,
+          onDismiss: category.isDismissable
+            ? () => onCardDismiss(card, index + positionOffset)
+            : undefined,
         },
       },
     } as LayoutCardItemProps),
   );
 
+  const renderCarousel = (carouselItems: typeof items) => {
+    const widthFactorSource = cardsSorted[0];
+    const showLumenDots =
+      (isContentBannerVariant || Boolean(leadingSlide)) &&
+      carouselItems.length + (leadingSlide ? 1 : 0) > 1;
+    return (
+      <Carousel
+        items={carouselItems}
+        leadingSlide={leadingSlide}
+        showLumenPageIndicator={showLumenDots}
+        disableVerticalStretch={isTopWallet}
+        styles={{
+          widthFactor: widthFactorSource?.carouselWidthFactor || WidthFactor.Full,
+          pagination: isTopWallet ? false : category.hasPagination,
+          gap: widthFactorSource?.gridWidthFactor === WidthFactor.Full ? 6 : 8,
+        }}
+      />
+    );
+  };
+
+  // Upsell + Braze share one carousel; keep `unique` semantics (one Braze card only).
+  if (leadingSlide) {
+    const carouselItems =
+      category.cardsLayout === ContentCardsLayout.unique ? items.slice(0, 1) : items;
+    return renderCarousel(carouselItems);
+  }
+
   switch (category.cardsLayout) {
     case ContentCardsLayout.carousel: {
-      const showLumenDots = isContentBannerVariant && cardsSorted.length > 1;
-      const carouselEl = (
-        <Carousel
-          items={items}
-          showLumenPageIndicator={showLumenDots}
-          disableVerticalStretch={isTopWallet}
-          styles={{
-            widthFactor: cardsSorted[0].carouselWidthFactor || WidthFactor.Full,
-            pagination: isTopWallet ? false : category.hasPagination,
-            gap: cardsSorted[0].gridWidthFactor === WidthFactor.Full ? 6 : 8,
-          }}
-        />
-      );
-      return carouselEl;
+      return renderCarousel(items);
     }
 
     case ContentCardsLayout.grid:

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/index.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsCategory/index.tsx
@@ -9,9 +9,10 @@ import Layout from "./Layout";
 type Props = {
   category: CategoryContentCard;
   categoryContentCards: BrazeContentCard[];
+  leadingSlide?: React.ReactNode;
 };
 
-const ContentCardsCategory = ({ category, categoryContentCards }: Props) => {
+const ContentCardsCategory = ({ category, categoryContentCards, leadingSlide }: Props) => {
   const closeAllCardIds = useMemo(() => {
     if (!shouldShowHardwareCarouselCloseAll(category)) {
       return undefined;
@@ -31,7 +32,7 @@ const ContentCardsCategory = ({ category, categoryContentCards }: Props) => {
           centered={category.centeredText}
           closeAllCardIds={closeAllCardIds}
         />
-        <Layout category={category} cards={categoryContentCards} />
+        <Layout category={category} cards={categoryContentCards} leadingSlide={leadingSlide} />
       </Box>
     </LogContentCardWrapper>
   );

--- a/apps/ledger-live-mobile/src/dynamicContent/ContentCardsLocation.tsx
+++ b/apps/ledger-live-mobile/src/dynamicContent/ContentCardsLocation.tsx
@@ -7,14 +7,11 @@ import { AllLocations, BrazeContentCard, CategoryContentCard } from "./types";
 import ContentCardsCategory from "./ContentCardsCategory";
 import { filterCategoriesByLocation, formatCategories } from "./utils";
 
-const Category: ListRenderItem<CategoriesWithCards> = ({ item }) => (
-  <ContentCardsCategory category={item.category} categoryContentCards={item.cards} />
-);
-
 type Props = FlexBoxProps & {
   locationId: AllLocations;
   hasStickyCta?: boolean;
   bottomSpacing?: number;
+  leadingSlide?: React.ReactNode;
 };
 
 type CategoriesWithCards = {
@@ -26,6 +23,7 @@ const ContentCardsLocation = ({
   locationId,
   hasStickyCta,
   bottomSpacing,
+  leadingSlide,
   ...containerProps
 }: Props) => {
   const { categoriesCards, mobileCards } = useDynamicContent();
@@ -34,12 +32,20 @@ const ContentCardsLocation = ({
 
   if (categoriesFormatted.length === 0) return null;
 
+  const renderCategory: ListRenderItem<CategoriesWithCards> = ({ item, index }) => (
+    <ContentCardsCategory
+      category={item.category}
+      categoryContentCards={item.cards}
+      leadingSlide={index === 0 ? leadingSlide : undefined}
+    />
+  );
+
   return (
     <Flex {...containerProps}>
       <FlatList
         testID="flat-list-container"
         data={categoriesFormatted}
-        renderItem={Category}
+        renderItem={renderCategory}
         keyExtractor={(item: CategoriesWithCards) => item.category.id}
         ItemSeparatorComponent={() => <Flex height={32} />}
         ListFooterComponent={

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -9509,12 +9509,12 @@
   "lnsUpsell": {
     "opted_in": {
       "title": "See more. Sign safer",
-      "description": "Upgrade to any touchscreen signer and get 20% off.",
+      "description": "Upgrade and get 20% off.",
       "cta": "Upgrade my Ledger"
     },
     "opted_out": {
       "title": "More security. More control",
-      "description": "Learn more about advanced security features.",
+      "description": "Learn more about security features.",
       "cta": "Learn more"
     }
   },

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
@@ -43,7 +43,7 @@ function buildViewModel(overrides: Record<string, unknown> = {}) {
     handleToggleFlag: jest.fn(),
     isNanoSeen: false,
     nanoSeenHint:
-      "Toggle on to mark Nano S + SP + X as seen (modal / banner audience).",
+      "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
     handleToggleNanoSeen: jest.fn(),
     isNanoSSeen: false,
     nanoSSeenHint:

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
@@ -42,12 +42,10 @@ function buildViewModel(overrides: Record<string, unknown> = {}) {
     lastSeenHint: "Now: null",
     handleToggleFlag: jest.fn(),
     isNanoSeen: false,
-    nanoSeenHint:
-      "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
+    nanoSeenHint: "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
     handleToggleNanoSeen: jest.fn(),
     isNanoSSeen: false,
-    nanoSSeenHint:
-      "Toggle on to mark Nano S only and clear every other seen device.",
+    nanoSSeenHint: "Toggle on to mark Nano S only and clear every other seen device.",
     handleToggleNanoSSeen: jest.fn(),
     hasSeenTouchscreen: false,
     seenDevicesHint:

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
@@ -91,7 +91,9 @@ describe("LargeScreenUpsellDebug", () => {
     render(<LargeScreenUpsellDebug />);
 
     expect(screen.getByText("Large-screen upsell debug")).toBeVisible();
-    expect(screen.getByText("WON'T SHOW")).toBeVisible();
+    expect(screen.getByText("Shows at next app start")).toBeVisible();
+    expect(screen.getAllByText("WON'T SHOW")).toHaveLength(2);
+    expect(screen.getByText("LN Portfolio banner")).toBeVisible();
     expect(screen.getByText("Decision breakdown")).toBeVisible();
     expect(screen.getByText("Feature flag enabled")).toBeVisible();
     expect(screen.getByText("largeScreenUpsell")).toBeVisible();
@@ -178,12 +180,9 @@ describe("LargeScreenUpsellDebug", () => {
 
     render(<LargeScreenUpsellDebug />);
 
-    const label = screen.getByText("Nano S seen");
-    expect(label).toBeVisible();
-    const row = label.parentElement?.parentElement;
-    const nanoSSwitch = row?.querySelector('[role="switch"]');
-    expect(nanoSSwitch).toBeTruthy();
-    fireEvent(nanoSSwitch as Element, "onCheckedChange", true);
+    expect(screen.getByText("Nano S seen")).toBeVisible();
+    // Switches: preview variant, largeScreenUpsell, modal.enabled, Nano seen, Nano S seen.
+    fireEvent(screen.getAllByRole("switch")[4], "onCheckedChange", true);
 
     expect(handleToggleNanoSSeen).toHaveBeenCalledWith(true);
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/__tests__/LargeScreenUpsellDebug.test.tsx
@@ -42,12 +42,31 @@ function buildViewModel(overrides: Record<string, unknown> = {}) {
     lastSeenHint: "Now: null",
     handleToggleFlag: jest.fn(),
     isNanoSeen: false,
-    nanoSeenHint: "No Nano seen. Toggle on to simulate a seen Nano (audience gate).",
+    nanoSeenHint:
+      "Toggle on to mark Nano S + SP + X as seen (modal / banner audience).",
     handleToggleNanoSeen: jest.fn(),
+    isNanoSSeen: false,
+    nanoSSeenHint:
+      "Toggle on to mark Nano S only and clear every other seen device.",
+    handleToggleNanoSSeen: jest.fn(),
     hasSeenTouchscreen: false,
     seenDevicesHint:
       "Clears every seen device model (removes any touchscreen that blocks the upsell).",
     handleClearSeenDevices: jest.fn(),
+    lnPortfolioBanner: {
+      isShown: false,
+      tracking: "opted_out",
+      flagEnabled: false,
+      ctaEnabled: false,
+      ctaHint: "params.opted_out.enabled/link missing.",
+      homepagePlacementEnabled: true,
+      eligibilityOk: false,
+      eligibilityHint: "Not eligible: no_nano.",
+      notExcludedByHighTier: true,
+      highTierHint: "No high-tier Braze exclusion.",
+      personalizedRecommendationsEnabled: false,
+    },
+    handleEnableLnHomepagePlacement: jest.fn(),
     handleApplyOnboardingDate: jest.fn(),
     handleSetOnboardingDateNull: jest.fn(),
     handleApplyRetries: jest.fn(),
@@ -153,5 +172,21 @@ describe("LargeScreenUpsellDebug", () => {
     fireEvent.press(screen.getByText("Clear seen devices"));
 
     expect(handleClearSeenDevices).toHaveBeenCalled();
+  });
+
+  it("toggles Nano S seen", () => {
+    const handleToggleNanoSSeen = jest.fn();
+    mockedViewModel.mockReturnValue(buildViewModel({ handleToggleNanoSSeen, isNanoSSeen: false }));
+
+    render(<LargeScreenUpsellDebug />);
+
+    const label = screen.getByText("Nano S seen");
+    expect(label).toBeVisible();
+    const row = label.parentElement?.parentElement;
+    const nanoSSwitch = row?.querySelector('[role="switch"]');
+    expect(nanoSSwitch).toBeTruthy();
+    fireEvent(nanoSSwitch as Element, "onCheckedChange", true);
+
+    expect(handleToggleNanoSSeen).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/index.tsx
@@ -32,9 +32,14 @@ function LargeScreenUpsellDebug() {
     isNanoSeen,
     nanoSeenHint,
     handleToggleNanoSeen,
+    isNanoSSeen,
+    nanoSSeenHint,
+    handleToggleNanoSSeen,
     hasSeenTouchscreen,
     seenDevicesHint,
     handleClearSeenDevices,
+    lnPortfolioBanner,
+    handleEnableLnHomepagePlacement,
     handleApplyOnboardingDate,
     handleSetOnboardingDateNull,
     handleApplyRetries,
@@ -191,6 +196,12 @@ function LargeScreenUpsellDebug() {
             onChange={handleToggleNanoSeen}
             description={nanoSeenHint}
           />
+          <ToggleRow
+            label="Nano S seen"
+            value={isNanoSSeen}
+            onChange={handleToggleNanoSSeen}
+            description={nanoSSeenHint}
+          />
           <StatusRow label="Touchscreen seen (blocks upsell)" ok={!hasSeenTouchscreen} />
           <Box lx={{ marginTop: "s8" }}>
             <Button size="md" appearance="base" isFull onPress={handleClearSeenDevices}>
@@ -200,6 +211,54 @@ function LargeScreenUpsellDebug() {
               {seenDevicesHint}
             </Text>
           </Box>
+        </SectionCard>
+
+        <SectionCard
+          title="LN Portfolio banner"
+          subtitle="Gates for the wallet upsell banner (separate from the app-start modal)."
+        >
+          <Text
+            typography="heading5SemiBold"
+            lx={{ color: lnPortfolioBanner.isShown ? "success" : "error", marginBottom: "s8" }}
+          >
+            {lnPortfolioBanner.isShown ? "WILL SHOW" : "WON'T SHOW"}
+          </Text>
+          <StatusRow label="largeScreenUpsell enabled" ok={lnPortfolioBanner.flagEnabled} />
+          <StatusRow
+            label={`params.${lnPortfolioBanner.tracking} CTA`}
+            ok={lnPortfolioBanner.ctaEnabled}
+            hint={lnPortfolioBanner.ctaHint}
+          />
+          <StatusRow
+            label="largeScreenUpsell.banners.homepage"
+            ok={lnPortfolioBanner.homepagePlacementEnabled}
+          />
+          <StatusRow
+            label="Shared eligibility"
+            ok={lnPortfolioBanner.eligibilityOk}
+            hint={lnPortfolioBanner.eligibilityHint}
+          />
+          <StatusRow
+            label="Not excluded by LNS_UPSELL_HIGH_TIER"
+            ok={lnPortfolioBanner.notExcludedByHighTier}
+            hint={lnPortfolioBanner.highTierHint}
+          />
+          <StatusRow
+            label="Personalized recommendations"
+            ok={!lnPortfolioBanner.personalizedRecommendationsEnabled}
+            hint={
+              lnPortfolioBanner.personalizedRecommendationsEnabled
+                ? "ON → uses opted_in CTA params."
+                : "OFF → uses opted_out CTA params."
+            }
+          />
+          {!lnPortfolioBanner.homepagePlacementEnabled || !lnPortfolioBanner.ctaEnabled ? (
+            <Box lx={{ marginTop: "s8" }}>
+              <Button size="md" appearance="base" isFull onPress={handleEnableLnHomepagePlacement}>
+                Enable homepage placement + CTA
+              </Button>
+            </Box>
+          ) : null}
         </SectionCard>
 
         <SectionCard title="Onboarding date" subtitle="Drives the cooldown gate.">

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -167,7 +167,7 @@ export function useLargeScreenUpsellDebugViewModel() {
   const isLnHomepagePlacementEnabled = feature?.params?.banners?.homepage ?? true;
   const isExcludedByHighTier = Boolean(
     isPersonalizedRecommendationsEnabled &&
-      mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER),
+    mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER),
   );
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
@@ -234,9 +234,7 @@ export function useLargeScreenUpsellDebugViewModel() {
       if (seen) {
         dispatch(
           unsafe_setKnownDeviceModelIds(
-            Object.fromEntries(
-              ALL_DEVICE_MODEL_IDS.map(id => [id, id === DeviceModelId.nanoS]),
-            ),
+            Object.fromEntries(ALL_DEVICE_MODEL_IDS.map(id => [id, id === DeviceModelId.nanoS])),
           ),
         );
         return;

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -159,7 +159,7 @@ export function useLargeScreenUpsellDebugViewModel() {
     useLNUpsellBannerState("wallet");
   const { mobileCards } = useDynamicContent();
 
-  const isNanoSeen = NANO_DEVICE_MODEL_IDS.every(id => knownDeviceModelIds[id]);
+  const isNanoSeen = NANO_DEVICE_MODEL_IDS.some(id => knownDeviceModelIds[id]);
   const isNanoSSeen = Boolean(knownDeviceModelIds[DeviceModelId.nanoS]);
   const hasSeenTouchscreen = DevicesWithTouchScreen.some(id => knownDeviceModelIds[id]);
   const trackingParams = feature?.params?.[lnBannerTracking];
@@ -435,8 +435,8 @@ export function useLargeScreenUpsellDebugViewModel() {
     handleToggleFlag,
     isNanoSeen,
     nanoSeenHint: isNanoSeen
-      ? "All Nanos (S/SP/X) marked seen. Toggle off to clear them."
-      : "Toggle on to mark Nano S + SP + X as seen (modal / banner audience).",
+      ? "At least one Nano (S/SP/X) is marked seen. Toggle off clears S/SP/X."
+      : "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
     handleToggleNanoSeen,
     isNanoSSeen,
     nanoSSeenHint: isNanoSSeen

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -18,10 +18,16 @@ import {
   setUpsellModalRetries,
 } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
 import type { FeatureIntroViewModel } from "LLM/components/FeatureIntroLayout/types";
+import { useLNUpsellBannerState } from "LLM/features/LNUpsell/hooks/useLNUpsellBannerState";
+import useDynamicContent from "~/dynamicContent/useDynamicContent";
 import { unsafe_setKnownDeviceModelIds } from "~/actions/settings";
 import { useTranslation } from "~/context/Locale";
 import { useDispatch, useSelector } from "~/context/hooks";
-import { analyticsEnabledSelector, knownDeviceModelIdsSelector } from "~/reducers/settings";
+import {
+  analyticsEnabledSelector,
+  knownDeviceModelIdsSelector,
+  personalizedRecommendationsEnabledSelector,
+} from "~/reducers/settings";
 import {
   useLargeScreenUpsellEligibility,
   type LargeScreenUpsellIneligibilityReason,
@@ -34,6 +40,7 @@ import {
 import { parseDateOrOffset } from "./utils";
 
 const FLAG_KEY = "largeScreenUpsell";
+const LNS_UPSELL_HIGH_TIER = "LNS_UPSELL_HIGH_TIER";
 const PREVIEW_MODAL_ID = "large-screen-upsell-modal-debug-preview";
 const PREVIEW_IOS_BOTTOM_PADDING = 20;
 
@@ -145,9 +152,23 @@ export function useLargeScreenUpsellDebugViewModel() {
   const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
   const analyticsEnabled = useSelector(analyticsEnabledSelector);
   const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const isPersonalizedRecommendationsEnabled = useSelector(
+    personalizedRecommendationsEnabledSelector,
+  );
+  const { isShown: isLnPortfolioBannerShown, tracking: lnBannerTracking } =
+    useLNUpsellBannerState("wallet");
+  const { mobileCards } = useDynamicContent();
 
-  const isNanoSeen = NANO_DEVICE_MODEL_IDS.some(id => knownDeviceModelIds[id]);
+  const isNanoSeen = NANO_DEVICE_MODEL_IDS.every(id => knownDeviceModelIds[id]);
+  const isNanoSSeen = Boolean(knownDeviceModelIds[DeviceModelId.nanoS]);
   const hasSeenTouchscreen = DevicesWithTouchScreen.some(id => knownDeviceModelIds[id]);
+  const trackingParams = feature?.params?.[lnBannerTracking];
+  const isLnCtaEnabled = Boolean(trackingParams?.enabled && trackingParams?.link?.trim());
+  const isLnHomepagePlacementEnabled = feature?.params?.banners?.homepage ?? true;
+  const isExcludedByHighTier = Boolean(
+    isPersonalizedRecommendationsEnabled &&
+      mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER),
+  );
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewVariant, setPreviewVariant] = useState<LargeScreenUpsellVariant>(
@@ -203,6 +224,24 @@ export function useLargeScreenUpsellDebugViewModel() {
           [DeviceModelId.nanoX]: seen,
         }),
       );
+    },
+    [dispatch],
+  );
+
+  /** Prefer a single Nano model when testing shared eligibility (S/SP/X, no touchscreen). */
+  const handleToggleNanoSSeen = useCallback(
+    (seen: boolean) => {
+      if (seen) {
+        dispatch(
+          unsafe_setKnownDeviceModelIds(
+            Object.fromEntries(
+              ALL_DEVICE_MODEL_IDS.map(id => [id, id === DeviceModelId.nanoS]),
+            ),
+          ),
+        );
+        return;
+      }
+      dispatch(unsafe_setKnownDeviceModelIds({ [DeviceModelId.nanoS]: false }));
     },
     [dispatch],
   );
@@ -321,6 +360,18 @@ export function useLargeScreenUpsellDebugViewModel() {
     dispatch(setLastSeenUpsellModal(null));
   }, [dispatch]);
 
+  const handleEnableLnHomepagePlacement = useCallback(() => {
+    if (!params) return;
+    overrideParams({
+      ...params,
+      banners: { ...params.banners, homepage: true },
+      [lnBannerTracking]: {
+        ...params[lnBannerTracking],
+        enabled: true,
+      },
+    });
+  }, [lnBannerTracking, overrideParams, params]);
+
   const handleClosePreview = useCallback(() => {
     setIsPreviewOpen(false);
   }, []);
@@ -384,14 +435,39 @@ export function useLargeScreenUpsellDebugViewModel() {
     handleToggleFlag,
     isNanoSeen,
     nanoSeenHint: isNanoSeen
-      ? "A Nano has been seen. Toggle off to clear the audience gate."
-      : "No Nano seen. Toggle on to simulate a seen Nano (audience gate).",
+      ? "All Nanos (S/SP/X) marked seen. Toggle off to clear them."
+      : "Toggle on to mark Nano S + SP + X as seen (modal / banner audience).",
     handleToggleNanoSeen,
+    isNanoSSeen,
+    nanoSSeenHint: isNanoSSeen
+      ? "Nano S only (other models cleared). Useful for a clean eligibility check."
+      : "Toggle on to mark Nano S only and clear every other seen device.",
+    handleToggleNanoSSeen,
     hasSeenTouchscreen,
     seenDevicesHint: hasSeenTouchscreen
       ? "A touchscreen device (Flex/Stax) has been seen — it blocks the upsell. Clear to reset."
       : "Clears every seen device model (removes any touchscreen that blocks the upsell).",
     handleClearSeenDevices,
+    lnPortfolioBanner: {
+      isShown: isLnPortfolioBannerShown,
+      tracking: lnBannerTracking,
+      flagEnabled: isFlagEnabled,
+      ctaEnabled: isLnCtaEnabled,
+      ctaHint: isLnCtaEnabled
+        ? `params.${lnBannerTracking}.enabled + link are set.`
+        : `params.${lnBannerTracking}.enabled/link missing — enable CTA for the current tracking branch.`,
+      homepagePlacementEnabled: Boolean(isLnHomepagePlacementEnabled),
+      eligibilityOk: eligibility.isEligible,
+      eligibilityHint: eligibility.isEligible
+        ? `Eligible (${eligibility.deviceModelId}).`
+        : `Not eligible: ${"reason" in eligibility ? eligibility.reason : "unknown"}.`,
+      notExcludedByHighTier: !isExcludedByHighTier,
+      highTierHint: isExcludedByHighTier
+        ? "Opted-in + Braze campaign LNS_UPSELL_HIGH_TIER suppresses the banner."
+        : "No high-tier Braze exclusion.",
+      personalizedRecommendationsEnabled: isPersonalizedRecommendationsEnabled,
+    },
+    handleEnableLnHomepagePlacement,
     handleApplyOnboardingDate,
     handleSetOnboardingDateNull,
     handleApplyRetries,

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFeature } from "@features/platform-feature-flags";
+import type { Features } from "@shared/feature-flags";
 import { setOverride } from "@shared/feature-flags";
 import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
 import {
@@ -139,73 +140,82 @@ function deriveDebugDecision({
   };
 }
 
-export function useLargeScreenUpsellDebugViewModel() {
+type LargeScreenUpsellEligibility = ReturnType<typeof useLargeScreenUpsellEligibility>;
+type LargeScreenUpsellFeature = Features["largeScreenUpsell"];
+type LargeScreenUpsellParams = NonNullable<LargeScreenUpsellFeature["params"]>;
+
+function getEligibilityHint(eligibility: LargeScreenUpsellEligibility): string {
+  if (eligibility.isEligible) {
+    return `Eligible (${eligibility.deviceModelId}).`;
+  }
+  const reason = "reason" in eligibility ? eligibility.reason : "unknown";
+  return `Not eligible: ${reason}.`;
+}
+
+function buildDeviceSeenHints(
+  isNanoSeen: boolean,
+  isNanoSSeen: boolean,
+  hasSeenTouchscreen: boolean,
+) {
+  return {
+    nanoSeenHint: isNanoSeen
+      ? "At least one Nano (S/SP/X) is marked seen. Toggle off clears S/SP/X."
+      : "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
+    nanoSSeenHint: isNanoSSeen
+      ? "Nano S only (other models cleared). Useful for a clean eligibility check."
+      : "Toggle on to mark Nano S only and clear every other seen device.",
+    seenDevicesHint: hasSeenTouchscreen
+      ? "A touchscreen device (Flex/Stax) has been seen — it blocks the upsell. Clear to reset."
+      : "Clears every seen device model (removes any touchscreen that blocks the upsell).",
+  };
+}
+
+type LnPortfolioBannerDebugInput = {
+  isLnPortfolioBannerShown: boolean;
+  lnBannerTracking: "opted_in" | "opted_out";
+  isFlagEnabled: boolean;
+  isLnCtaEnabled: boolean;
+  isLnHomepagePlacementEnabled: boolean;
+  eligibility: LargeScreenUpsellEligibility;
+  isExcludedByHighTier: boolean;
+  isPersonalizedRecommendationsEnabled: boolean;
+};
+
+function buildLnPortfolioBannerDebugSection({
+  isLnPortfolioBannerShown,
+  lnBannerTracking,
+  isFlagEnabled,
+  isLnCtaEnabled,
+  isLnHomepagePlacementEnabled,
+  eligibility,
+  isExcludedByHighTier,
+  isPersonalizedRecommendationsEnabled,
+}: LnPortfolioBannerDebugInput) {
+  return {
+    isShown: isLnPortfolioBannerShown,
+    tracking: lnBannerTracking,
+    flagEnabled: isFlagEnabled,
+    ctaEnabled: isLnCtaEnabled,
+    ctaHint: isLnCtaEnabled
+      ? `params.${lnBannerTracking}.enabled + link are set.`
+      : `params.${lnBannerTracking}.enabled/link missing — enable CTA for the current tracking branch.`,
+    homepagePlacementEnabled: Boolean(isLnHomepagePlacementEnabled),
+    eligibilityOk: eligibility.isEligible,
+    eligibilityHint: getEligibilityHint(eligibility),
+    notExcludedByHighTier: !isExcludedByHighTier,
+    highTierHint: isExcludedByHighTier
+      ? "Opted-in + Braze campaign LNS_UPSELL_HIGH_TIER suppresses the banner."
+      : "No high-tier Braze exclusion.",
+    personalizedRecommendationsEnabled: isPersonalizedRecommendationsEnabled,
+  };
+}
+
+function useLargeScreenUpsellDebugHandlers(
+  feature: LargeScreenUpsellFeature | null | undefined,
+  params: LargeScreenUpsellParams | undefined,
+  lnBannerTracking: "opted_in" | "opted_out",
+) {
   const dispatch = useDispatch();
-  const { t } = useTranslation();
-  const { bottom } = useSafeAreaInsets();
-  const feature = useFeature(FLAG_KEY);
-  const eligibility = useLargeScreenUpsellEligibility();
-  const hasCompetingModal = useCompetingAppStartModalsPresent();
-
-  const onboardingDate = useSelector(onboardingDateSelector);
-  const retries = useSelector(retriesUpsellModalSelector);
-  const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
-  const analyticsEnabled = useSelector(analyticsEnabledSelector);
-  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
-  const isPersonalizedRecommendationsEnabled = useSelector(
-    personalizedRecommendationsEnabledSelector,
-  );
-  const { isShown: isLnPortfolioBannerShown, tracking: lnBannerTracking } =
-    useLNUpsellBannerState("wallet");
-  const { mobileCards } = useDynamicContent();
-
-  const isNanoSeen = NANO_DEVICE_MODEL_IDS.some(id => knownDeviceModelIds[id]);
-  const isNanoSSeen = Boolean(knownDeviceModelIds[DeviceModelId.nanoS]);
-  const hasSeenTouchscreen = DevicesWithTouchScreen.some(id => knownDeviceModelIds[id]);
-  const trackingParams = feature?.params?.[lnBannerTracking];
-  const isLnCtaEnabled = Boolean(trackingParams?.enabled && trackingParams?.link?.trim());
-  const isLnHomepagePlacementEnabled = feature?.params?.banners?.homepage ?? true;
-  const isExcludedByHighTier = Boolean(
-    isPersonalizedRecommendationsEnabled &&
-    mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER),
-  );
-
-  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewVariant, setPreviewVariant] = useState<LargeScreenUpsellVariant>(
-    analyticsEnabled ? "opted_in" : "opted_out",
-  );
-
-  const params = feature?.params;
-  const killThreshold = params?.modal?.killThreshold;
-  const cadenceDays = params?.modal?.cadenceDays;
-  const modalEnabled = params?.modal?.enabled ?? false;
-  const cooldownDaysDefault = params?.cooldownDays?.default;
-  const isFlagEnabled = feature?.enabled ?? false;
-
-  const now = new Date();
-  const lastSeenDate = lastSeenAt != null ? new Date(lastSeenAt) : null;
-
-  const {
-    resolvedCooldownDays,
-    wouldShow,
-    audienceOk,
-    cooldownOk,
-    notThrottledOk,
-    noCompetingModalOk,
-    audienceHint,
-  } = deriveDebugDecision({
-    eligibility,
-    onboardingDate,
-    retries,
-    lastSeenDate,
-    now,
-    isFlagEnabled,
-    modalEnabled,
-    killThreshold,
-    cadenceDays,
-    cooldownDaysDefault,
-    hasCompetingModal,
-  });
 
   const handleToggleFlag = useCallback(
     (enabled: boolean) => {
@@ -228,7 +238,6 @@ export function useLargeScreenUpsellDebugViewModel() {
     [dispatch],
   );
 
-  /** Prefer a single Nano model when testing shared eligibility (S/SP/X, no touchscreen). */
   const handleToggleNanoSSeen = useCallback(
     (seen: boolean) => {
       if (seen) {
@@ -253,7 +262,7 @@ export function useLargeScreenUpsellDebugViewModel() {
   }, [dispatch]);
 
   const overrideParams = useCallback(
-    (nextParams: NonNullable<typeof params>) => {
+    (nextParams: LargeScreenUpsellParams) => {
       if (!feature) return;
       dispatch(setOverride({ key: FLAG_KEY, value: { ...feature, params: nextParams } }));
     },
@@ -370,6 +379,124 @@ export function useLargeScreenUpsellDebugViewModel() {
     });
   }, [lnBannerTracking, overrideParams, params]);
 
+  return {
+    handleToggleFlag,
+    handleToggleNanoSeen,
+    handleToggleNanoSSeen,
+    handleClearSeenDevices,
+    handleToggleModalEnabled,
+    handleApplyKillThreshold,
+    handleApplyCadenceDays,
+    handleApplyCooldownDays,
+    handleApplyDiscount,
+    handleApplyOnboardingDate,
+    handleSetOnboardingDateNull,
+    handleApplyRetries,
+    handleResetRetries,
+    handleApplyLastSeen,
+    handleSetLastSeenNull,
+    handleEnableLnHomepagePlacement,
+  };
+}
+
+export function useLargeScreenUpsellDebugViewModel() {
+  const { t } = useTranslation();
+  const { bottom } = useSafeAreaInsets();
+  const feature = useFeature(FLAG_KEY);
+  const eligibility = useLargeScreenUpsellEligibility();
+  const hasCompetingModal = useCompetingAppStartModalsPresent();
+
+  const onboardingDate = useSelector(onboardingDateSelector);
+  const retries = useSelector(retriesUpsellModalSelector);
+  const lastSeenAt = useSelector(lastSeenUpsellModalSelector);
+  const analyticsEnabled = useSelector(analyticsEnabledSelector);
+  const knownDeviceModelIds = useSelector(knownDeviceModelIdsSelector);
+  const isPersonalizedRecommendationsEnabled = useSelector(
+    personalizedRecommendationsEnabledSelector,
+  );
+  const { isShown: isLnPortfolioBannerShown, tracking: lnBannerTracking } =
+    useLNUpsellBannerState("wallet");
+  const { mobileCards } = useDynamicContent();
+
+  const isNanoSeen = NANO_DEVICE_MODEL_IDS.some(id => knownDeviceModelIds[id]);
+  const isNanoSSeen = Boolean(knownDeviceModelIds[DeviceModelId.nanoS]);
+  const hasSeenTouchscreen = DevicesWithTouchScreen.some(id => knownDeviceModelIds[id]);
+  const trackingParams = feature?.params?.[lnBannerTracking];
+  const isLnCtaEnabled = Boolean(trackingParams?.enabled && trackingParams?.link?.trim());
+  const isLnHomepagePlacementEnabled = feature?.params?.banners?.homepage ?? true;
+  const isExcludedByHighTier = Boolean(
+    isPersonalizedRecommendationsEnabled &&
+    mobileCards.some(c => c.extras.campaign === LNS_UPSELL_HIGH_TIER),
+  );
+
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [previewVariant, setPreviewVariant] = useState<LargeScreenUpsellVariant>(
+    analyticsEnabled ? "opted_in" : "opted_out",
+  );
+
+  const params = feature?.params;
+  const killThreshold = params?.modal?.killThreshold;
+  const cadenceDays = params?.modal?.cadenceDays;
+  const modalEnabled = params?.modal?.enabled ?? false;
+  const cooldownDaysDefault = params?.cooldownDays?.default;
+  const isFlagEnabled = feature?.enabled ?? false;
+
+  const now = new Date();
+  const lastSeenDate = lastSeenAt != null ? new Date(lastSeenAt) : null;
+
+  const {
+    resolvedCooldownDays,
+    wouldShow,
+    audienceOk,
+    cooldownOk,
+    notThrottledOk,
+    noCompetingModalOk,
+    audienceHint,
+  } = deriveDebugDecision({
+    eligibility,
+    onboardingDate,
+    retries,
+    lastSeenDate,
+    now,
+    isFlagEnabled,
+    modalEnabled,
+    killThreshold,
+    cadenceDays,
+    cooldownDaysDefault,
+    hasCompetingModal,
+  });
+
+  const {
+    handleToggleFlag,
+    handleToggleNanoSeen,
+    handleToggleNanoSSeen,
+    handleClearSeenDevices,
+    handleToggleModalEnabled,
+    handleApplyKillThreshold,
+    handleApplyCadenceDays,
+    handleApplyCooldownDays,
+    handleApplyDiscount,
+    handleApplyOnboardingDate,
+    handleSetOnboardingDateNull,
+    handleApplyRetries,
+    handleResetRetries,
+    handleApplyLastSeen,
+    handleSetLastSeenNull,
+    handleEnableLnHomepagePlacement,
+  } = useLargeScreenUpsellDebugHandlers(feature, params, lnBannerTracking);
+
+  const deviceSeenHints = buildDeviceSeenHints(isNanoSeen, isNanoSSeen, hasSeenTouchscreen);
+  const lnPortfolioBanner = buildLnPortfolioBannerDebugSection({
+    isLnPortfolioBannerShown,
+    lnBannerTracking,
+    isFlagEnabled,
+    isLnCtaEnabled,
+    isLnHomepagePlacementEnabled,
+    eligibility,
+    isExcludedByHighTier,
+    isPersonalizedRecommendationsEnabled,
+  });
+
   const handleClosePreview = useCallback(() => {
     setIsPreviewOpen(false);
   }, []);
@@ -432,39 +559,13 @@ export function useLargeScreenUpsellDebugViewModel() {
     lastSeenHint: `Now: ${toIso(lastSeenDate) || "null"} — enter an ISO date or a day offset (today = 0, yesterday = 1).`,
     handleToggleFlag,
     isNanoSeen,
-    nanoSeenHint: isNanoSeen
-      ? "At least one Nano (S/SP/X) is marked seen. Toggle off clears S/SP/X."
-      : "Toggle on to mark Nano S + SP + X as seen (matches eligibility: any Nano).",
+    ...deviceSeenHints,
     handleToggleNanoSeen,
     isNanoSSeen,
-    nanoSSeenHint: isNanoSSeen
-      ? "Nano S only (other models cleared). Useful for a clean eligibility check."
-      : "Toggle on to mark Nano S only and clear every other seen device.",
     handleToggleNanoSSeen,
     hasSeenTouchscreen,
-    seenDevicesHint: hasSeenTouchscreen
-      ? "A touchscreen device (Flex/Stax) has been seen — it blocks the upsell. Clear to reset."
-      : "Clears every seen device model (removes any touchscreen that blocks the upsell).",
     handleClearSeenDevices,
-    lnPortfolioBanner: {
-      isShown: isLnPortfolioBannerShown,
-      tracking: lnBannerTracking,
-      flagEnabled: isFlagEnabled,
-      ctaEnabled: isLnCtaEnabled,
-      ctaHint: isLnCtaEnabled
-        ? `params.${lnBannerTracking}.enabled + link are set.`
-        : `params.${lnBannerTracking}.enabled/link missing — enable CTA for the current tracking branch.`,
-      homepagePlacementEnabled: Boolean(isLnHomepagePlacementEnabled),
-      eligibilityOk: eligibility.isEligible,
-      eligibilityHint: eligibility.isEligible
-        ? `Eligible (${eligibility.deviceModelId}).`
-        : `Not eligible: ${"reason" in eligibility ? eligibility.reason : "unknown"}.`,
-      notExcludedByHighTier: !isExcludedByHighTier,
-      highTierHint: isExcludedByHighTier
-        ? "Opted-in + Braze campaign LNS_UPSELL_HIGH_TIER suppresses the banner."
-        : "No high-tier Braze exclusion.",
-      personalizedRecommendationsEnabled: isPersonalizedRecommendationsEnabled,
-    },
+    lnPortfolioBanner,
     handleEnableLnHomepagePlacement,
     handleApplyOnboardingDate,
     handleSetOnboardingDateNull,

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/__tests__/PortfolioBannersSection.test.tsx
@@ -29,7 +29,9 @@ const baseViewModel = {
   shouldShowOnboardingWidget: false,
   contentCardsPaddingTop: undefined,
   hasAssets: false,
+  hasTopWalletDisplayableCards: false,
   shouldDisplayRecover: false,
+  canCoexistWithBraze: false,
   onScroll: jest.fn(),
   carouselIndex: 0,
 };
@@ -57,6 +59,25 @@ describe("PortfolioBannersSection", () => {
     expect(screen.getByTestId("mock-ln-banner")).toBeVisible();
     expect(screen.queryByTestId("mock-recover-banner")).toBeNull();
     expect(screen.queryByTestId("mock-onboarding-widget")).toBeNull();
+    expect(screen.queryByTestId("mock-content-cards")).toBeNull();
+  });
+
+  it("coexists upsell and Braze content cards when both are available", () => {
+    mockUseViewModel.mockReturnValue({
+      ...baseViewModel,
+      hasAssets: true,
+      hasTopWalletDisplayableCards: true,
+      canCoexistWithBraze: true,
+    });
+    renderSection({ isLNUpsellBannerShown: true, showAssets: true });
+
+    expect(screen.getByTestId("mock-content-cards")).toBeVisible();
+    expect(MockContentCardsLocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        leadingSlide: expect.anything(),
+      }),
+      undefined,
+    );
   });
 
   describe("when user has assets and onboarding is hidden", () => {
@@ -64,6 +85,7 @@ describe("PortfolioBannersSection", () => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
         hasAssets: true,
+        hasTopWalletDisplayableCards: true,
         shouldDisplayRecover: true,
       });
     });
@@ -72,6 +94,19 @@ describe("PortfolioBannersSection", () => {
       renderSection({ showAssets: true });
       expect(screen.getByTestId("mock-recover-banner")).toBeVisible();
       expect(screen.getByTestId("mock-content-cards")).toBeVisible();
+    });
+
+    it("keeps LN upsell exclusive over Recover when both would show with Braze cards", () => {
+      mockUseViewModel.mockReturnValue({
+        ...baseViewModel,
+        hasAssets: true,
+        hasTopWalletDisplayableCards: true,
+        shouldDisplayRecover: true,
+      });
+      renderSection({ isLNUpsellBannerShown: true, showAssets: true });
+      expect(screen.getByTestId("mock-ln-banner")).toBeVisible();
+      expect(screen.queryByTestId("mock-recover-banner")).toBeNull();
+      expect(screen.queryByTestId("mock-content-cards")).toBeNull();
     });
 
     it("does not render onboarding or the carousel page indicator", () => {
@@ -84,11 +119,23 @@ describe("PortfolioBannersSection", () => {
       mockUseViewModel.mockReturnValue({
         ...baseViewModel,
         hasAssets: true,
+        hasTopWalletDisplayableCards: true,
         shouldDisplayRecover: false,
       });
       renderSection({ showAssets: true });
       expect(screen.getByTestId("mock-content-cards")).toBeVisible();
       expect(screen.queryByTestId("mock-recover-banner")).toBeNull();
+    });
+
+    it("renders upsell alone when assets are shown but TopWallet has no cards", () => {
+      mockUseViewModel.mockReturnValue({
+        ...baseViewModel,
+        hasAssets: true,
+        hasTopWalletDisplayableCards: false,
+      });
+      renderSection({ isLNUpsellBannerShown: true, showAssets: true });
+      expect(screen.getByTestId("mock-ln-banner")).toBeVisible();
+      expect(screen.queryByTestId("mock-content-cards")).toBeNull();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/index.tsx
@@ -113,11 +113,19 @@ export const PortfolioBannersSection = ({
     shouldDisplayRecover: showRecover,
     contentCardsPaddingTop,
     hasAssets,
+    canCoexistWithBraze,
     onScroll,
     carouselIndex,
-  } = usePortfolioBannersSectionViewModel({ showAssets });
+  } = usePortfolioBannersSectionViewModel({
+    showAssets,
+    isLNUpsellBannerShown,
+  });
 
-  if (isLNUpsellBannerShown) {
+  const upsellLeadingSlide = isLNUpsellBannerShown ? (
+    <LNUpsellBanner location="wallet" />
+  ) : undefined;
+
+  if (isLNUpsellBannerShown && !canCoexistWithBraze) {
     return (
       <BannersSectionShell isFirst={isFirst}>
         <LNUpsellBanner location="wallet" pt={4} />
@@ -141,6 +149,7 @@ export const PortfolioBannersSection = ({
               key="contentCardsLocationPortfolio"
               locationId={ContentCardLocation.TopWallet}
               mx={-6}
+              leadingSlide={upsellLeadingSlide}
             />
           </Box>
         </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/usePortfolioBannersSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Portfolio/components/PortfolioBannersSection/usePortfolioBannersSectionViewModel.ts
@@ -6,19 +6,24 @@ import useShouldDisplayRecoverBanner from "../RecoverBanner/useShouldDisplayReco
 
 interface PortfolioBannersSectionViewModelParams {
   readonly showAssets?: boolean;
+  readonly isLNUpsellBannerShown: boolean;
 }
 
 interface PortfolioBannersSectionViewModelResult {
   readonly contentCardsPaddingTop: "s12" | undefined;
   readonly hasAssets: boolean;
+  readonly hasTopWalletDisplayableCards: boolean;
   readonly shouldShowOnboardingWidget: boolean;
   readonly shouldDisplayRecover: boolean;
+  /** LN upsell exclusive over Recover/onboarding; coexist only with Braze TopWallet cards. */
+  readonly canCoexistWithBraze: boolean;
   readonly onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   readonly carouselIndex: number;
 }
 
 export const usePortfolioBannersSectionViewModel = ({
   showAssets,
+  isLNUpsellBannerShown,
 }: PortfolioBannersSectionViewModelParams): PortfolioBannersSectionViewModelResult => {
   const hasTopWalletDisplayableCards = useTopWalletHasDisplayableContentCards();
   const shouldShowOnboardingWidget = useOnboardingWidgetVisibility();
@@ -26,6 +31,13 @@ export const usePortfolioBannersSectionViewModel = ({
   const [carouselIndex, setCarouselIndex] = useState(0);
 
   const hasAssets = showAssets === true;
+
+  const canCoexistWithBraze =
+    isLNUpsellBannerShown &&
+    hasAssets &&
+    !shouldShowOnboardingWidget &&
+    !shouldDisplayRecover &&
+    hasTopWalletDisplayableCards;
 
   let contentCardsPaddingTop: PortfolioBannersSectionViewModelResult["contentCardsPaddingTop"];
   if (hasTopWalletDisplayableCards) {
@@ -45,7 +57,9 @@ export const usePortfolioBannersSectionViewModel = ({
     shouldShowOnboardingWidget,
     contentCardsPaddingTop,
     hasAssets,
+    hasTopWalletDisplayableCards,
     shouldDisplayRecover,
+    canCoexistWithBraze,
     onScroll,
     carouselIndex,
   };

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Builder.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Builder.tsx
@@ -283,8 +283,8 @@ function TopWalletFields({
   onChangeExtraField: OnChangeExtraField;
 }>) {
   const isAction = values.type === ContentCardsType.action;
-  const isHardwareCarousel =
-    values.layout === ContentCardsLayout.carousel && values.type === ContentCardsType.smallSquare;
+  const isCarousel = values.layout === ContentCardsLayout.carousel;
+  const isHardwareCarousel = isCarousel && values.type === ContentCardsType.smallSquare;
   const actionVisual =
     isAction && values.extras.image_background?.trim() ? "imageBackground" : "icon";
   return (
@@ -298,15 +298,34 @@ function TopWalletFields({
           editable here.
         </Text>
       </Box>
-      {isHardwareCarousel ? (
-        <GenericAwarenessModalField
-          label="Section title (category header, e.g. Touchscreen offers)"
-          value={values.categoryTitle}
-          onChangeText={value => onChange("categoryTitle", value)}
-        />
+      {isCarousel ? (
+        <>
+          <Text typography="body2SemiBold" lx={{ color: "base", marginBottom: "s8" }}>
+            Container (section header — empty = cards only)
+          </Text>
+          <GenericAwarenessModalField
+            label="Container title"
+            value={values.categoryTitle}
+            onChangeText={value => onChange("categoryTitle", value)}
+          />
+          <GenericAwarenessModalField
+            label="Container description"
+            value={values.categoryDescription}
+            onChangeText={value => onChange("categoryDescription", value)}
+            multiline
+          />
+          <GenericAwarenessModalField
+            label="Container CTA"
+            value={values.categoryCta}
+            onChangeText={value => onChange("categoryCta", value)}
+          />
+          <Text typography="body2SemiBold" lx={{ color: "base", marginBottom: "s8", marginTop: "s8" }}>
+            Card
+          </Text>
+        </>
       ) : null}
       <GenericAwarenessModalField
-        label={isHardwareCarousel ? "Product title (child card)" : "Title"}
+        label={isHardwareCarousel ? "Product title" : "Title"}
         value={values.title}
         onChangeText={value => onChange("title", value)}
       />

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Builder.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/Builder.tsx
@@ -319,7 +319,10 @@ function TopWalletFields({
             value={values.categoryCta}
             onChangeText={value => onChange("categoryCta", value)}
           />
-          <Text typography="body2SemiBold" lx={{ color: "base", marginBottom: "s8", marginTop: "s8" }}>
+          <Text
+            typography="body2SemiBold"
+            lx={{ color: "base", marginBottom: "s8", marginTop: "s8" }}
+          >
             Card
           </Text>
         </>

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.test.ts
@@ -180,7 +180,9 @@ describe("Content Cards QA console helpers", () => {
     expect(result.category).toMatchObject({
       categoryId: "alwayson",
       location: ContentCardLocation.TopWallet,
-      title: "Touchscreen offers",
+      title: "",
+      description: "",
+      cta: "",
       cardsType: ContentCardsType.smallSquare,
       cardsLayout: ContentCardsLayout.carousel,
       isDismissable: true,
@@ -189,6 +191,58 @@ describe("Content Cards QA console helpers", () => {
       categoryId: "alwayson",
       title: "Ledger Stax",
       tag: "30% off",
+    });
+  });
+
+  it("should allow empty titles and keep carousel category header empty when section title is blank", () => {
+    const result = buildDebugContentCard({
+      ...buildPresetCardBuilderValues("topWalletHardwareCarousel", 1000),
+      categoryTitle: "",
+      categoryDescription: "",
+      categoryCta: "",
+      title: "Ledger Stax",
+      description: "child-only description",
+      cta: "Buy",
+      link: "https://shop.ledger.com",
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.category).toMatchObject({
+      title: "",
+      description: "",
+      cta: "",
+      link: "",
+    });
+    expect(result.cards[0].extras).toMatchObject({
+      title: "Ledger Stax",
+      description: "child-only description",
+      cta: "Buy",
+      link: "https://shop.ledger.com",
+    });
+  });
+
+  it("should put container fields only on the category shell for carousels", () => {
+    const result = buildDebugContentCard({
+      ...buildPresetCardBuilderValues("topWalletHardwareCarousel", 1000),
+      categoryTitle: "Touchscreen offers",
+      categoryDescription: "Section blurb",
+      categoryCta: "See all",
+      title: "Ledger Stax",
+      description: "Card body",
+      cta: "Buy",
+      link: "https://shop.ledger.com",
+    });
+
+    expect(result.category).toMatchObject({
+      title: "Touchscreen offers",
+      description: "Section blurb",
+      cta: "See all",
+      link: "https://shop.ledger.com",
+    });
+    expect(result.cards[0].extras).toMatchObject({
+      title: "Ledger Stax",
+      description: "Card body",
+      cta: "Buy",
     });
   });
 

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
@@ -155,6 +155,10 @@ export type CardBuilderValues = {
   campaignId: string;
   /** Category shell title when it differs from the child card title (e.g. "Touchscreen offers"). */
   categoryTitle: string;
+  /** Category shell description (section header only; empty = no header description). */
+  categoryDescription: string;
+  /** Category shell CTA (section header only; empty = no header CTA). */
+  categoryCta: string;
   title: string;
   description: string;
   mediaUrl: string;
@@ -254,6 +258,8 @@ export function buildDefaultCardBuilderValues(timestamp = Date.now()): CardBuild
     categoryId: TOP_WALLET_CATEGORY_ID,
     campaignId: `${DEBUG_GAM_PREFIX}-${timestamp}`,
     categoryTitle: "",
+    categoryDescription: "",
+    categoryCta: "",
     title: "QA debug card",
     description: "Local payload generated from the Content Cards QA console.",
     mediaUrl: buildRandomLedgerImageUrl(),
@@ -305,7 +311,7 @@ export function buildPresetCardBuilderValues(
         layout: ContentCardsLayout.carousel,
         id: `${DEBUG_CARD_PREFIX}-top-wallet-hardware-${timestamp}`,
         categoryId: TOP_WALLET_CATEGORY_ID,
-        categoryTitle: "Touchscreen offers",
+        categoryTitle: "",
         title: HARDWARE_CAROUSEL_PRODUCTS[0],
         description: "",
         cta: "",
@@ -319,6 +325,7 @@ export function buildPresetCardBuilderValues(
         layout: ContentCardsLayout.carousel,
         id: `${DEBUG_CARD_PREFIX}-top-wallet-hero-carousel-${timestamp}`,
         categoryId: TOP_WALLET_CATEGORY_ID,
+        categoryTitle: "",
         title: "Touchscreen offers",
         description: "",
         cta: "",
@@ -476,9 +483,6 @@ export function validateBuilderValues(values: CardBuilderValues): string[] {
   if (values.layout !== ContentCardsLayout.unique && !values.categoryId) {
     warnings.push("Category-child mismatch");
   }
-  if (!values.title && values.type !== ContentCardsType.category) {
-    warnings.push("Missing title");
-  }
   if (
     !values.mediaUrl &&
     [ContentCardsType.hero, ContentCardsType.bigSquare].includes(values.type)
@@ -553,6 +557,11 @@ export function buildDebugContentCard(
     };
   }
 
+  const categoryTitle = values.categoryTitle.trim();
+  const categoryDescription = values.categoryDescription.trim();
+  const categoryCta = values.categoryCta.trim();
+  const isCarousel = values.layout === ContentCardsLayout.carousel;
+  // Carousel: container header uses dedicated category* fields only (empty by default = cards only).
   const category: CategoryContentCard = {
     id: `${values.categoryId}-category-${values.id}`,
     categoryId: values.categoryId,
@@ -563,10 +572,10 @@ export function buildDebugContentCard(
     cardsLayout: values.layout,
     cardsType: values.type,
     type: ContentCardsType.category,
-    title: values.categoryTitle.trim() || values.title,
-    description: values.description,
-    cta: values.cta,
-    link: values.link,
+    title: isCarousel ? categoryTitle : categoryTitle || values.title,
+    description: isCarousel ? categoryDescription : values.description,
+    cta: isCarousel ? categoryCta : values.cta,
+    link: isCarousel ? (categoryCta ? values.link : "") : values.link,
     isDismissable: true,
     extras: {
       platform: "mobile",

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/ContentCards/qaConsole.ts
@@ -562,6 +562,11 @@ export function buildDebugContentCard(
   const categoryCta = values.categoryCta.trim();
   const isCarousel = values.layout === ContentCardsLayout.carousel;
   // Carousel: container header uses dedicated category* fields only (empty by default = cards only).
+  let categoryLink = values.link;
+  if (isCarousel) {
+    categoryLink = categoryCta ? values.link : "";
+  }
+
   const category: CategoryContentCard = {
     id: `${values.categoryId}-category-${values.id}`,
     categoryId: values.categoryId,
@@ -575,7 +580,7 @@ export function buildDebugContentCard(
     title: isCarousel ? categoryTitle : categoryTitle || values.title,
     description: isCarousel ? categoryDescription : values.description,
     cta: isCarousel ? categoryCta : values.cta,
-    link: isCarousel ? (categoryCta ? values.link : "") : values.link,
+    link: categoryLink,
     isDismissable: true,
     extras: {
       platform: "mobile",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Portfolio LNS upsell and Braze cards can coexist (no longer mutually exclusive).
- **Mobile:** shared carousel (upsell first);
- **Desktop:** Lumen grid side-by-side when `brazePlacement` is on (max 2 slots); classic stacks upsell above Braze carousel.
- LNS stays exclusive over Finish / Recover / onboarding.


https://github.com/user-attachments/assets/e8e7bb96-d38b-4e0d-9af2-8ca5cd8f3cb3





<img width="1508" height="876" alt="Screenshot 2026-08-03 at 09 26 34" src="https://github.com/user-attachments/assets/8f252380-0c4a-4f1e-9d1d-4d26f8595430" />


<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33015]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33015]: https://ledgerhq.atlassian.net/browse/LIVE-33015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ