### PR TITLE
[LWM] feat(contacts): add address label flow (LIVE-33919)

### DIFF
--- a/.changeset/calm-ravens-smile.md
+++ b/.changeset/calm-ravens-smile.md
@@ -1,0 +1,6 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+---
+
+Add address label validation and flow

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10213,7 +10213,8 @@
       "namingDisclaimer": "We recommend giving this address a name to easily find it when needed. It will be only visible by you.",
       "continueToReview": "Continue to review",
       "invalidLabel": "Special characters are not allowed.",
-      "duplicateLabel": "This address name is already used for this contact."
+      "duplicateLabel": "This address name is already used for this contact.",
+      "labelTooLong": "This address name is too long."
     },
     "addAddressFlow": {
       "review": "Validation",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -1,5 +1,6 @@
 import { Platform } from "react-native";
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
@@ -92,6 +93,9 @@ export function useContactsAddAddressFlowDrawerViewModel({
                 ),
                 [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t(
                   "contacts.addAddressName.duplicateLabel",
+                ),
+                [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(
+                  "contacts.addAddressName.labelTooLong",
                 ),
               },
             },

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -19,9 +19,12 @@ export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME = "InvalidContactAddressLa
 
 export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME = "DuplicateContactAddressLabelError";
 
+export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME = "ContactAddressLabelTooLongError";
+
 export type ContactAddressLabelValidationErrorName =
   | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
+  | typeof CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 
 export class InvalidContactAddressLabelError extends ContactError {
   override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
@@ -29,4 +32,8 @@ export class InvalidContactAddressLabelError extends ContactError {
 
 export class DuplicateContactAddressLabelError extends ContactError {
   override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+}
+
+export class ContactAddressLabelTooLongError extends ContactError {
+  override name = CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -98,6 +98,10 @@ describe("ContactAddressSchema", () => {
     expect(() => ContactAddressLabelSchema.parse("Ethereum 1\uFE0F\u20E3")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum\nWallet")).toThrow();
   });
+
+  it("rejects address labels longer than 32 characters", () => {
+    expect(() => ContactAddressLabelSchema.parse("a".repeat(33))).toThrow();
+  });
 });
 
 describe("contact mock factories", () => {

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -13,12 +13,16 @@ const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;
 const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
+export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;
+
 export const ContactNameSchema = NonEmptyStringSchema.regex(
   ContactNamePattern,
   "Expected letters, spaces, apostrophes, or hyphens",
 );
 
-export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern);
+export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern).max(
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+);
 
 export const ContactAddressValueSchema = NonEmptyStringSchema;
 

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,4 +1,6 @@
 import {
+  ContactAddressLabelTooLongError,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DuplicateContactAddressLabelError,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   InvalidContactAddressLabelError,
@@ -53,11 +55,21 @@ describe("contact address label validation", () => {
     expect(isValidContactAddressLabel("")).toBe(false);
   });
 
-  it("accepts a valid draft label without imposing a length limit", () => {
+  it("rejects an address label longer than 32 characters", () => {
     const longLabel = "Ethereum ".repeat(50);
 
     expect(getContactAddressLabelValidationError("Ethereum")).toBeNull();
-    expect(isValidContactAddressLabel(longLabel)).toBe(true);
+    expect(getContactAddressLabelValidationError(longLabel)).toBe(
+      CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+    );
+    expect(isValidContactAddressLabel(longLabel)).toBe(false);
+  });
+
+  it("ignores surrounding whitespace when checking the address label length", () => {
+    const labelWithWhitespace = `  ${"a".repeat(32)}  `;
+
+    expect(getContactAddressLabelValidationError(labelWithWhitespace)).toBeNull();
+    expect(parseContactAddressLabel(labelWithWhitespace)).toBe("a".repeat(32));
   });
 
   it("reports invalid non-ASCII characters for a non-empty draft label", () => {
@@ -92,6 +104,9 @@ describe("contact address label validation", () => {
     expect(() => parseContactAddressLabel("Ethereum 💎")).toThrow(InvalidContactAddressLabelError);
     expect(() => parseContactAddressLabel("ethereum", existingLabels)).toThrow(
       DuplicateContactAddressLabelError,
+    );
+    expect(() => parseContactAddressLabel("Ethereum ".repeat(50))).toThrow(
+      ContactAddressLabelTooLongError,
     );
   });
 });

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,5 +1,7 @@
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
@@ -8,7 +10,11 @@ import {
   type ContactAddressLabelValidationErrorName,
   type ContactNameValidationErrorName,
 } from "./errors";
-import { ContactAddressLabelSchema, ContactNameSchema } from "./schema";
+import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  ContactAddressLabelSchema,
+  ContactNameSchema,
+} from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
 export function getContactNameValidationError(
@@ -47,10 +53,16 @@ export function getContactAddressLabelValidationError(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = [],
 ): ContactAddressLabelValidationErrorName | null {
-  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+  const trimmedDraftLabel = draftLabel.trim();
+
+  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
+    return CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
+  }
+
+  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
 
   if (!parsed.success) {
-    return draftLabel.trim().length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+    return trimmedDraftLabel.length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
   }
 
   const comparisonLabel = normalizeContactAddressLabelForComparison(parsed.data);
@@ -75,7 +87,13 @@ export function parseContactAddressLabel(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = [],
 ): ContactAddressLabel {
-  const parsed = ContactAddressLabelSchema.safeParse(draftLabel);
+  const trimmedDraftLabel = draftLabel.trim();
+
+  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
+    throw new ContactAddressLabelTooLongError();
+  }
+
+  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
 
   if (!parsed.success) {
     throw new InvalidContactAddressLabelError();

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   ContactAddressLabelSchema,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
-import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
+import type { AddAddressLabelState, AddAddressNameLabels } from "../types";
 import { ContactsAddAddressName } from "./ContactsAddAddressName.native";
 
 const labels: AddAddressNameLabels = {
@@ -18,6 +19,7 @@ const labels: AddAddressNameLabels = {
     [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
     [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
       "This address name is already used for this contact.",
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
   },
 };
 

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
@@ -86,6 +86,16 @@ describe("ContactsAddAddressName", () => {
       helperText: "This address name is already used for this contact.",
     },
     {
+      name: "too long label",
+      addressLabel: {
+        status: "invalid",
+        value: "E".repeat(CONTACT_ADDRESS_LABEL_MAX_LENGTH + 1),
+        label: null,
+        validationError: CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+      },
+      helperText: "This address name is too long.",
+    },
+    {
       name: "empty label",
       addressLabel: {
         status: "empty",

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.tsx
@@ -9,8 +9,8 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-rnative/symbols";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
-import type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import type { ContactsAddAddressNameNativeProps } from "./types";
 
 export function ContactsAddAddressName({
   addressLabel,
@@ -18,7 +18,7 @@ export function ContactsAddAddressName({
   bottomOffset = 0,
   onChangeText,
   onContinue,
-}: ContactsAddAddressNameProps): React.JSX.Element {
+}: ContactsAddAddressNameNativeProps): React.JSX.Element {
   const validationMessage = addressLabel.validationError
     ? labels.validationErrors[addressLabel.validationError]
     : undefined;

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  ContactAddressLabelSchema,
+  ContactAddressValueSchema,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+} from "@domain/entity-contact";
+import { ContactsAddAddressNameView } from "./ContactsAddAddressNameView.web";
+import type { ContactsAddAddressNameViewProps } from "./types";
+
+const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
+  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+);
+
+function createProps(
+  overrides: Partial<ContactsAddAddressNameViewProps> = {},
+): ContactsAddAddressNameViewProps {
+  return {
+    address: RESOLVED_ADDRESS,
+    addressLabel: {
+      status: "valid",
+      value: "Ethereum",
+      label: ContactAddressLabelSchema.parse("Ethereum"),
+      validationError: null,
+    },
+    labels: {
+      inputLabel: "Address name",
+      continueToReview: "Continue to review",
+      validAddress: "Valid address",
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
+          "This address name is already used for this contact.",
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "This address name is too long.",
+      },
+    },
+    isContinueEnabled: true,
+    onAddressLabelChange: jest.fn(),
+    onContinue: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactsAddAddressNameView", () => {
+  it("should render the address details and forward input actions", () => {
+    const onAddressLabelChange = jest.fn();
+    const onContinue = jest.fn();
+
+    render(<ContactsAddAddressNameView {...createProps({ onAddressLabelChange, onContinue })} />);
+
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
+      "value",
+      RESOLVED_ADDRESS,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+
+    fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
+      target: { value: "Exchange" },
+    });
+    fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
+
+    expect(onAddressLabelChange).toHaveBeenCalledTimes(1);
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("should display an invalid label and disable continuation", () => {
+    render(
+      <ContactsAddAddressNameView
+        {...createProps({
+          addressLabel: {
+            status: "invalid",
+            value: "Ethereum 💎",
+            label: null,
+            validationError: "InvalidContactAddressLabelError",
+          },
+          validationMessage: "Special characters are not allowed.",
+          isContinueEnabled: false,
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "helpertext",
+      "Special characters are not allowed.",
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { AddressInput, Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import type { ContactsAddAddressNameViewProps } from "./types";
+
+export function ContactsAddAddressNameView({
+  address,
+  addressLabel,
+  labels,
+  validationMessage,
+  isContinueEnabled,
+  onAddressLabelChange,
+  onContinue,
+}: ContactsAddAddressNameViewProps): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-24">
+      <AddressInput
+        autoComplete="off"
+        autoCorrect="off"
+        data-testid="contacts-add-address-confirmed-input"
+        helperText={labels.validAddress}
+        hideClearButton
+        prefix=""
+        readOnly
+        spellCheck={false}
+        status="success"
+        value={address}
+      />
+      <TextInput
+        autoComplete="off"
+        autoCorrect="off"
+        data-testid="contacts-add-address-name-input"
+        helperText={validationMessage}
+        label={labels.inputLabel}
+        maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+        maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+        onChange={onAddressLabelChange}
+        spellCheck={false}
+        status={addressLabel.status === "invalid" ? "error" : undefined}
+        value={addressLabel.value}
+      />
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid="contacts-add-address-name-continue"
+        disabled={!isContinueEnabled}
+        icon={LedgerLogo}
+        onClick={onContinue}
+        size="lg"
+      >
+        {labels.continueToReview}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressLabelSchema,
+  ContactAddressValueSchema,
+} from "@domain/entity-contact";
+import { ContactsAddAddressNameInput } from "./ContactsAddAddressNameInput.web";
+import type { ContactsAddAddressNameProps } from "../types";
+
+const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
+  "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+);
+
+function createProps(
+  overrides: Partial<ContactsAddAddressNameProps> = {},
+): ContactsAddAddressNameProps {
+  return {
+    addressEntry: {
+      status: "valid",
+      value: RESOLVED_ADDRESS,
+      resolvedAddress: RESOLVED_ADDRESS,
+      inputMethod: "manual",
+    },
+    addressLabel: {
+      status: "valid",
+      value: "Ethereum",
+      label: ContactAddressLabelSchema.parse("Ethereum"),
+      validationError: null,
+    },
+    labels: {
+      inputLabel: "Address name",
+      continueToReview: "Continue to review",
+      validAddress: "Valid address",
+      validationErrors: {
+        [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "Special characters are not allowed.",
+        [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]:
+          "This address name is already used for this contact.",
+        [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]:
+          "Address names must be 32 characters or fewer.",
+      },
+    },
+    onAddressLabelChange: jest.fn(),
+    onContinue: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ContactsAddAddressNameInput", () => {
+  it("should render the confirmed address and prefilled label with the 32-character limit", () => {
+    render(<ContactsAddAddressNameInput {...createProps()} />);
+
+    expect(screen.getByTestId("contacts-add-address-confirmed-input")).toHaveAttribute(
+      "value",
+      RESOLVED_ADDRESS,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveValue("Ethereum");
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "maxlength",
+      "32",
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeEnabled();
+  });
+
+  it("should forward address-label edits", () => {
+    const onAddressLabelChange = jest.fn();
+    render(<ContactsAddAddressNameInput {...createProps({ onAddressLabelChange })} />);
+
+    fireEvent.change(screen.getByTestId("contacts-add-address-name-input"), {
+      target: { value: "Exchange" },
+    });
+
+    expect(onAddressLabelChange).toHaveBeenCalledWith("Exchange");
+  });
+
+  it.each([
+    [INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME, "Special characters are not allowed."],
+    [
+      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      "This address name is already used for this contact.",
+    ],
+    [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME, "Address names must be 32 characters or fewer."],
+  ] as const)("should render the shared %s validation error", (validationError, message) => {
+    render(
+      <ContactsAddAddressNameInput
+        {...createProps({
+          addressLabel: {
+            status: "invalid",
+            value: "Ethereum",
+            label: null,
+            validationError,
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-input")).toHaveAttribute(
+      "helpertext",
+      message,
+    );
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+
+  it("should continue only with a valid address label", () => {
+    const onContinue = jest.fn();
+    const { rerender } = render(<ContactsAddAddressNameInput {...createProps({ onContinue })} />);
+
+    fireEvent.click(screen.getByTestId("contacts-add-address-name-continue"));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ContactsAddAddressNameInput
+        {...createProps({
+          onContinue,
+          addressLabel: { status: "empty", value: "", label: null, validationError: null },
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-continue")).toBeDisabled();
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import type { ContactsAddAddressNameProps } from "../types";
+import { ContactsAddAddressNameView } from "../ContactsAddAddressNameView.web";
+import { useContactsAddAddressNameViewModel } from "../useContactsAddAddressNameViewModel.web";
+
+export function ContactsAddAddressNameInput(props: ContactsAddAddressNameProps): React.JSX.Element {
+  return <ContactsAddAddressNameView {...useContactsAddAddressNameViewModel(props)} />;
+}

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
@@ -1,0 +1,40 @@
+import type { ChangeEvent } from "react";
+import type { ContactAddressLabelValidationErrorName } from "@domain/entity-contact";
+import type {
+  AddAddressLabelState,
+  AddAddressNameLabels,
+  ValidAddAddressEntryState,
+} from "../types";
+
+export type ContactsAddAddressNameLabels = Readonly<{
+  inputLabel: string;
+  continueToReview: string;
+  validAddress: string;
+  validationErrors: Record<ContactAddressLabelValidationErrorName, string>;
+}>;
+
+export type ContactsAddAddressNameProps = Readonly<{
+  addressEntry: ValidAddAddressEntryState;
+  addressLabel: AddAddressLabelState;
+  labels: ContactsAddAddressNameLabels;
+  onAddressLabelChange: (value: string) => void;
+  onContinue: () => void;
+}>;
+
+export type ContactsAddAddressNameViewProps = Readonly<{
+  address: string;
+  addressLabel: AddAddressLabelState;
+  labels: ContactsAddAddressNameLabels;
+  validationMessage?: string;
+  isContinueEnabled: boolean;
+  onAddressLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onContinue: () => void;
+}>;
+
+export type ContactsAddAddressNameNativeProps = Readonly<{
+  addressLabel: AddAddressLabelState;
+  labels: AddAddressNameLabels;
+  bottomOffset?: number;
+  onChangeText: (value: string) => void;
+  onContinue: () => void;
+}>;

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/useContactsAddAddressNameViewModel.web.ts
@@ -1,0 +1,32 @@
+import { useCallback, useMemo, type ChangeEvent } from "react";
+import type { ContactsAddAddressNameProps, ContactsAddAddressNameViewProps } from "./types";
+
+export function useContactsAddAddressNameViewModel({
+  addressEntry,
+  addressLabel,
+  labels,
+  onAddressLabelChange,
+  onContinue,
+}: ContactsAddAddressNameProps): ContactsAddAddressNameViewProps {
+  const validationMessage = useMemo(
+    () =>
+      addressLabel.validationError
+        ? labels.validationErrors[addressLabel.validationError]
+        : undefined,
+    [addressLabel.validationError, labels.validationErrors],
+  );
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onAddressLabelChange(event.target.value),
+    [onAddressLabelChange],
+  );
+
+  return {
+    address: addressEntry.value,
+    addressLabel,
+    labels,
+    validationMessage,
+    isContinueEnabled: addressLabel.status === "valid",
+    onAddressLabelChange: onChange,
+    onContinue,
+  };
+}

--- a/features/flow/contacts/src/steps/AddAddress/Completion/ContactsAddAddressCompletion.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Completion/ContactsAddAddressCompletion.web.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Button } from "@ledgerhq/lumen-ui-react";
+import type { AddAddressPlaceholderViewProps } from "../types";
+
+export function ContactsAddAddressCompletion({
+  title,
+  buttonLabel,
+  testID,
+  onContinue,
+}: AddAddressPlaceholderViewProps): React.JSX.Element {
+  return (
+    <div className="flex min-h-256 flex-col justify-between gap-24" data-testid={testID}>
+      <div className="flex flex-1 items-center justify-center">
+        <h2 className="heading-3-semi-bold text-base">{title}</h2>
+      </div>
+      <Button
+        appearance="base"
+        className="w-full"
+        data-testid={`${testID}-continue`}
+        onClick={onContinue}
+        size="lg"
+      >
+        {buttonLabel}
+      </Button>
+    </div>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
@@ -1,14 +1,50 @@
 import type { ChangeEvent, ClipboardEvent } from "react";
-import type { AddAddressEntryLabels, AddAddressEntryState, AddAddressInputSource } from "./types";
+import type { ContactsAddAddressNameLabels } from "./AddressName/types";
+import type {
+  AddAddressEntryLabels,
+  AddAddressEntryState,
+  AddAddressInputSource,
+  AddAddressLabelState,
+} from "./types";
 
-export type ContactsAddAddressEntryWebProps = Readonly<{
+type AddressLabelConfiguration = Readonly<{
+  addressLabel: AddAddressLabelState;
+  nameLabels: ContactsAddAddressNameLabels;
+  onAddressLabelChange: (value: string) => void;
+}>;
+
+type WithoutAddressLabelConfiguration = Readonly<{
+  addressLabel?: never;
+  nameLabels?: never;
+  onAddressLabelChange?: never;
+}>;
+
+type AddressLabelViewConfiguration = Readonly<{
+  addressLabel: AddAddressLabelState;
+  nameLabels: ContactsAddAddressNameLabels;
+  nameValidationMessage?: string;
+  onAddressLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}>;
+
+type WithoutAddressLabelViewConfiguration = Readonly<{
+  addressLabel?: never;
+  nameLabels?: never;
+  nameValidationMessage?: never;
+  onAddressLabelChange?: never;
+}>;
+
+type ContactsAddAddressEntryWebBaseProps = Readonly<{
   addressEntry: AddAddressEntryState;
   labels: AddAddressEntryLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onConfirm?: () => void;
 }>;
 
-export type ContactsAddAddressEntryWebViewProps = Readonly<{
+export type ContactsAddAddressEntryWebProps =
+  | (ContactsAddAddressEntryWebBaseProps & AddressLabelConfiguration)
+  | (ContactsAddAddressEntryWebBaseProps & WithoutAddressLabelConfiguration);
+
+type ContactsAddAddressEntryWebViewBaseProps = Readonly<{
   value: string;
   labels: AddAddressEntryLabels;
   inputStatus?: "error" | "success";
@@ -19,3 +55,7 @@ export type ContactsAddAddressEntryWebViewProps = Readonly<{
   onPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
   onConfirm?: () => void;
 }>;
+
+export type ContactsAddAddressEntryWebViewProps =
+  | (ContactsAddAddressEntryWebViewBaseProps & AddressLabelViewConfiguration)
+  | (ContactsAddAddressEntryWebViewBaseProps & WithoutAddressLabelViewConfiguration);

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
@@ -7,7 +7,7 @@ import type {
   AddAddressLabelState,
 } from "./types";
 
-type AddressLabelConfiguration = Readonly<{
+export type AddressLabelConfiguration = Readonly<{
   addressLabel: AddAddressLabelState;
   nameLabels: ContactsAddAddressNameLabels;
   onAddressLabelChange: (value: string) => void;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { AddressInput, Banner, Button } from "@ledgerhq/lumen-ui-react";
+import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
 
 export function ContactsAddAddressEntryView({
@@ -9,9 +10,13 @@ export function ContactsAddAddressEntryView({
   inputStatus,
   helperText,
   showEnsDisclaimer,
+  addressLabel,
+  nameLabels,
+  nameValidationMessage,
   isConfirmEnabled,
   onChange,
   onPaste,
+  onAddressLabelChange,
   onConfirm,
 }: ContactsAddAddressEntryWebViewProps): React.JSX.Element {
   return (
@@ -35,6 +40,21 @@ export function ContactsAddAddressEntryView({
           appearance="info"
           data-testid="contacts-add-address-ens-disclaimer"
           description={labels.ensDisclaimer}
+        />
+      ) : null}
+      {addressLabel && nameLabels && onAddressLabelChange ? (
+        <TextInput
+          autoComplete="off"
+          autoCorrect="off"
+          data-testid="contacts-add-address-name-input"
+          helperText={nameValidationMessage}
+          label={nameLabels.inputLabel}
+          maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+          maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+          onChange={onAddressLabelChange}
+          spellCheck={false}
+          status={addressLabel.status === "invalid" ? "error" : undefined}
+          value={addressLabel.value}
         />
       ) : null}
       <Button

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.types.ts
@@ -1,9 +1,0 @@
-import type { AddAddressLabelState, AddAddressNameLabels } from "./types";
-
-export type ContactsAddAddressNameProps = Readonly<{
-  addressLabel: AddAddressLabelState;
-  labels: AddAddressNameLabels;
-  bottomOffset?: number;
-  onChangeText: (value: string) => void;
-  onContinue: () => void;
-}>;

--- a/features/flow/contacts/src/steps/AddAddress/index.ts
+++ b/features/flow/contacts/src/steps/AddAddress/index.ts
@@ -3,7 +3,6 @@ export type {
   ContactsAddressValidationResult,
   ContactsCurrencySelectionPort,
 } from "./model/ports";
-export { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 export {
   createContactsAddressValidationDependencies,
   createContactsAddressValidationService,

--- a/features/flow/contacts/src/steps/AddAddress/model/constants.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/constants.ts
@@ -1,1 +1,0 @@
-export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;

--- a/features/flow/contacts/src/steps/AddAddress/native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/native.ts
@@ -1,5 +1,5 @@
 export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.native";
 export type { ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.types";
-export { ContactsAddAddressName } from "./ContactsAddAddressName.native";
-export type { ContactsAddAddressNameProps } from "./ContactsAddAddressName.types";
+export { ContactsAddAddressName } from "./AddressName/ContactsAddAddressName.native";
+export type { ContactsAddAddressNameNativeProps as ContactsAddAddressNameProps } from "./AddressName/types";
 export { ContactsAddAddressPlaceholderView } from "./ContactsAddAddressPlaceholderView.native";

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -99,7 +99,11 @@ export type AddAddressFlowState =
     }>
   | (AddAddressSession & Readonly<{ status: "enteringAddress" }>)
   | (ConfirmedAddAddressSession & Readonly<{ status: "namingAddress" }>)
-  | (NamedAddAddressSession & Readonly<{ status: "reviewingAddress" }>)
+  | (NamedAddAddressSession &
+      Readonly<{
+        status: "reviewingAddress";
+        origin: "addressDetails" | "addressName";
+      }>)
   | (NamedAddAddressSession & Readonly<{ status: "success" }>);
 
 export type AddAddressFlowViewModel = Readonly<{
@@ -109,6 +113,7 @@ export type AddAddressFlowViewModel = Readonly<{
   updateAddress: (address: string, inputMethod: AddAddressInputSource) => Promise<void>;
   updateAddressLabel: (label: string) => void;
   confirmAddress: () => void;
+  continueFromAddressDetails: () => void;
   continueFromName: () => void;
   continueFromReview: () => void;
   goBack: () => void;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
   getContactAddressLabelValidationError,
   parseContactAddressLabel,
   type ContactAddress,
   type ContactAddressLabel,
   type ContactId,
 } from "@domain/entity-contact";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import type {
   AddAddressContact,
@@ -258,7 +258,7 @@ export function useAddAddressFlowViewModel({
   );
   const updateAddressLabel = useCallback((value: string) => {
     setState(currentState => {
-      if (currentState.status !== "namingAddress") {
+      if (currentState.status !== "enteringAddress" && currentState.status !== "namingAddress") {
         return currentState;
       }
 
@@ -304,15 +304,41 @@ export function useAddAddressFlowViewModel({
         selectedCurrencyId: currentState.selectedCurrencyId,
         addressEntry: currentState.addressEntry,
         addressLabel: currentState.addressLabel,
+        origin: "addressName",
       };
     });
   }, []);
+  const continueFromAddressDetails = useCallback(() => {
+    cancelAddressValidation();
+    setState(currentState => {
+      if (
+        currentState.status !== "enteringAddress" ||
+        currentState.addressEntry.status !== "valid" ||
+        currentState.addressLabel.status !== "valid"
+      ) {
+        return currentState;
+      }
+
+      return {
+        status: "reviewingAddress",
+        selectedContactId: currentState.selectedContactId,
+        existingAddressLabels: currentState.existingAddressLabels,
+        selectedCurrencyId: currentState.selectedCurrencyId,
+        addressEntry: currentState.addressEntry,
+        addressLabel: currentState.addressLabel,
+        origin: "addressDetails",
+      };
+    });
+  }, [cancelAddressValidation]);
   const continueFromReview = useCallback(() => {
-    setState(currentState =>
-      currentState.status === "reviewingAddress"
-        ? { ...currentState, status: "success" }
-        : currentState,
-    );
+    setState(currentState => {
+      if (currentState.status !== "reviewingAddress") {
+        return currentState;
+      }
+
+      const { origin, ...session } = currentState;
+      return { ...session, status: "success" };
+    });
   }, []);
   const goBack = useCallback(() => {
     cancelAddressValidation();
@@ -330,8 +356,12 @@ export function useAddAddressFlowViewModel({
           };
         case "namingAddress":
           return { ...currentState, status: "enteringAddress" };
-        case "reviewingAddress":
-          return { ...currentState, status: "namingAddress" };
+        case "reviewingAddress": {
+          const { origin, ...session } = currentState;
+          return origin === "addressDetails"
+            ? { ...session, status: "enteringAddress" }
+            : { ...session, status: "namingAddress" };
+        }
         case "success":
           return currentState;
       }
@@ -350,6 +380,7 @@ export function useAddAddressFlowViewModel({
     updateAddress,
     updateAddressLabel,
     confirmAddress,
+    continueFromAddressDetails,
     continueFromName,
     continueFromReview,
     goBack,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -1,12 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import {
+  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
   ContactAddressValueSchema,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
 } from "@domain/entity-contact";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
-import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "./model/constants";
 import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
 import { useAddAddressFlowViewModel } from "./useAddAddressFlowViewModel";
 
@@ -324,6 +324,44 @@ describe("useAddAddressFlowViewModel", () => {
         value: longEditedLabel.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH),
       },
     });
+  });
+
+  it("should continue directly from address details to review when both inputs are valid", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    act(() => result.current.updateAddressLabel("Exchange"));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.continueFromAddressDetails());
+
+    expect(result.current.state).toMatchObject({
+      status: "reviewingAddress",
+      origin: "addressDetails",
+      addressLabel: { label: "Exchange", status: "valid" },
+    });
+
+    act(() => result.current.goBack());
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      addressLabel: { label: "Exchange", status: "valid" },
+    });
+  });
+
+  it("should prevent direct review when either address detail is invalid", async () => {
+    const contact = mockContact();
+    const addressValidation = createValidationPort();
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contact));
+    act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
+    act(() => result.current.updateAddressLabel("Ethereum 💎"));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.continueFromAddressDetails());
+
+    expect(result.current.state.status).toBe("enteringAddress");
   });
 
   it("should expose invalid characters and prevent review", async () => {

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -1,6 +1,10 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ClipboardEvent } from "react";
-import { ContactAddressValueSchema } from "@domain/entity-contact";
+import {
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  ContactAddressValueSchema,
+} from "@domain/entity-contact";
+import type { ContactsAddAddressNameLabels } from "./AddressName/types";
 import type { ContactsAddAddressEntryWebProps } from "./ContactsAddAddressEntry.web.types";
 import type { AddAddressEntryLabels } from "./types";
 import { useContactsAddAddressEntryViewModel } from "./useContactsAddAddressEntryViewModel.web";
@@ -20,15 +24,38 @@ const labels: AddAddressEntryLabels = {
 const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
   "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
 );
+const nameLabels: ContactsAddAddressNameLabels = {
+  inputLabel: "Address name",
+  continueToReview: "Continue to review",
+  validAddress: "Valid address",
+  validationErrors: {
+    InvalidContactAddressLabelError: "Special characters are not allowed.",
+    DuplicateContactAddressLabelError: "Duplicate address name.",
+    ContactAddressLabelTooLongError: "Address name is too long.",
+  },
+};
 
-function renderViewModel(overrides: Partial<ContactsAddAddressEntryWebProps> = {}) {
+type ContactsAddAddressEntryWebBaseOverrides = Partial<
+  Omit<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
+>;
+
+type ContactsAddAddressEntryWebWithLabelOverrides = ContactsAddAddressEntryWebBaseOverrides &
+  Required<
+    Pick<ContactsAddAddressEntryWebProps, "addressLabel" | "nameLabels" | "onAddressLabelChange">
+  >;
+
+function renderViewModel(
+  overrides:
+    | ContactsAddAddressEntryWebBaseOverrides
+    | ContactsAddAddressEntryWebWithLabelOverrides = {},
+) {
   const onAddressChange = jest.fn();
   const props: ContactsAddAddressEntryWebProps = {
     addressEntry: { status: "empty", value: "", resolvedAddress: null, inputMethod: null },
     labels,
     onAddressChange,
     ...overrides,
-  };
+  } as ContactsAddAddressEntryWebProps;
 
   return {
     onAddressChange,
@@ -128,5 +155,58 @@ describe("useContactsAddAddressEntryViewModel", () => {
       helperText: "This address is sanctioned and cannot be used.",
       isConfirmEnabled: false,
     });
+  });
+
+  it("should require a valid address label for the combined Desktop form", () => {
+    const onAddressLabelChange = jest.fn();
+    const { result } = renderViewModel({
+      addressEntry: {
+        status: "valid",
+        value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        resolvedAddress: RESOLVED_ADDRESS,
+        inputMethod: "manual",
+      },
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum 💎",
+        label: null,
+        validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      },
+      nameLabels,
+      onAddressLabelChange,
+      onConfirm: jest.fn(),
+    });
+
+    expect(result.current.isConfirmEnabled).toBe(false);
+    expect(result.current.nameValidationMessage).toBe("Special characters are not allowed.");
+
+    act(() => {
+      result.current.onAddressLabelChange?.({
+        target: { value: "Exchange" },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(onAddressLabelChange).toHaveBeenCalledWith("Exchange");
+  });
+
+  it("should ignore an incomplete address-label configuration at runtime", () => {
+    const { result } = renderViewModel({
+      addressEntry: {
+        status: "valid",
+        value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        resolvedAddress: RESOLVED_ADDRESS,
+        inputMethod: "manual",
+      },
+      addressLabel: {
+        status: "invalid",
+        value: "Ethereum 💎",
+        label: null,
+        validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      },
+      onConfirm: jest.fn(),
+    } as unknown as ContactsAddAddressEntryWebProps);
+
+    expect(result.current.addressLabel).toBeUndefined();
+    expect(result.current.isConfirmEnabled).toBe(true);
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -1,16 +1,9 @@
 import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
-import type { ContactsAddAddressNameLabels } from "./AddressName/types";
 import type {
+  AddressLabelConfiguration,
   ContactsAddAddressEntryWebProps,
   ContactsAddAddressEntryWebViewProps,
 } from "./ContactsAddAddressEntry.web.types";
-import type { AddAddressLabelState } from "./types";
-
-type AddressLabelConfiguration = Readonly<{
-  addressLabel: AddAddressLabelState;
-  nameLabels: ContactsAddAddressNameLabels;
-  onAddressLabelChange: (value: string) => void;
-}>;
 
 function getAddressLabelConfiguration({
   addressLabel,

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -1,8 +1,26 @@
 import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
+import type { ContactsAddAddressNameLabels } from "./AddressName/types";
 import type {
   ContactsAddAddressEntryWebProps,
   ContactsAddAddressEntryWebViewProps,
 } from "./ContactsAddAddressEntry.web.types";
+import type { AddAddressLabelState } from "./types";
+
+type AddressLabelConfiguration = Readonly<{
+  addressLabel: AddAddressLabelState;
+  nameLabels: ContactsAddAddressNameLabels;
+  onAddressLabelChange: (value: string) => void;
+}>;
+
+function getAddressLabelConfiguration({
+  addressLabel,
+  nameLabels,
+  onAddressLabelChange,
+}: Partial<AddressLabelConfiguration>): AddressLabelConfiguration | undefined {
+  return addressLabel && nameLabels && onAddressLabelChange
+    ? { addressLabel, nameLabels, onAddressLabelChange }
+    : undefined;
+}
 
 function getPastedValue(value: string, event: ClipboardEvent<HTMLInputElement>): string {
   const input = event.currentTarget;
@@ -66,7 +84,9 @@ export function useContactsAddAddressEntryViewModel({
   labels,
   onAddressChange,
   onConfirm,
+  ...addressLabelProps
 }: ContactsAddAddressEntryWebProps): ContactsAddAddressEntryWebViewProps {
+  const addressLabelConfiguration = getAddressLabelConfiguration(addressLabelProps);
   const presentation = useMemo(
     () => resolveAddressInputPresentation(addressEntry, labels),
     [addressEntry, labels],
@@ -82,12 +102,39 @@ export function useContactsAddAddressEntryViewModel({
     },
     [addressEntry.value, onAddressChange],
   );
+  const onNameChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) =>
+      addressLabelConfiguration?.onAddressLabelChange(event.target.value),
+    [addressLabelConfiguration],
+  );
+  const nameValidationMessage = useMemo(
+    () =>
+      addressLabelConfiguration?.addressLabel.validationError
+        ? addressLabelConfiguration.nameLabels.validationErrors[
+            addressLabelConfiguration.addressLabel.validationError
+          ]
+        : undefined,
+    [addressLabelConfiguration],
+  );
+  const isNameValid =
+    addressLabelConfiguration === undefined ||
+    addressLabelConfiguration.addressLabel.status === "valid";
+
+  const addressLabelViewProps = addressLabelConfiguration
+    ? {
+        addressLabel: addressLabelConfiguration.addressLabel,
+        nameLabels: addressLabelConfiguration.nameLabels,
+        nameValidationMessage,
+        onAddressLabelChange: onNameChange,
+      }
+    : {};
 
   return {
     value: addressEntry.value,
     labels,
     ...presentation,
-    isConfirmEnabled: presentation.isConfirmEnabled && onConfirm !== undefined,
+    ...addressLabelViewProps,
+    isConfirmEnabled: presentation.isConfirmEnabled && isNameValid && onConfirm !== undefined,
     onChange,
     onPaste,
     onConfirm,

--- a/features/flow/contacts/src/steps/AddAddress/web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/web.ts
@@ -1,3 +1,9 @@
 export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.web";
 export type { ContactsAddAddressEntryWebProps as ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.web.types";
 export type { AddAddressEntryLabels as ContactsAddAddressEntryLabels } from "./types";
+export { ContactsAddAddressNameInput as ContactsAddAddressName } from "./AddressName/Input/ContactsAddAddressNameInput.web";
+export { ContactsAddAddressCompletion } from "./Completion/ContactsAddAddressCompletion.web";
+export type {
+  ContactsAddAddressNameLabels,
+  ContactsAddAddressNameProps,
+} from "./AddressName/types";


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Address-label validation and the 32-character limit.
      - Direct continuation from address details when both inputs are valid.
      - Mobile validation-message compatibility.

### 📝 Description

This PR introduces the shared address-label flow required by LIVE-33919.

It adds the address-label validation contract, the reusable web flow components, the 32-character limit, and the Mobile validation-message mapping. Desktop rendering is intentionally delivered by the next stacked PR.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33919](https://ledgerhq.atlassian.net/browse/LIVE-33919)

---

https://github.com/user-attachments/assets/764f8a9d-3a4c-48ea-81eb-cfaa93f78c2c



### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33919]: https://ledgerhq.atlassian.net/browse/LIVE-33919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ