### PR TITLE
[LWDM] feat(contacts): block sanctioned addresses (LIVE-33927)

### DIFF
--- a/.changeset/bright-sanctions-block.md
+++ b/.changeset/bright-sanctions-block.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Block sanctioned addresses in the Contacts add-address flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/adapters/contactsAddressValidationDependencies.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/adapters/contactsAddressValidationDependencies.ts
@@ -2,6 +2,7 @@ import { getRegistriesForDomain } from "@ledgerhq/domain-service/registries/inde
 import { resolveDomain } from "@ledgerhq/domain-service/resolvers/index";
 import { validateDomain } from "@ledgerhq/domain-service/utils/index";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { createContactsAddressValidationDependencies } from "@features/flow-contacts";
@@ -11,6 +12,7 @@ export const contactsAddressValidationDependencies = createContactsAddressValida
   getAccountBridgeByFamily,
   supportsDomain: sendFeatures.supportsDomain,
   getRegistriesForDomain,
+  isAddressSanctioned,
   resolveDomain,
   validateDomain,
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -99,6 +99,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       validAddress: t("contacts.addAddressEntry.validAddress"),
       invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
       domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+      sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
       validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
       ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
     }),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9302,6 +9302,7 @@
       "validAddress": "Valid address",
       "invalidAddress": "Invalid address",
       "domainNotFound": "Domain not found",
+      "sanctionedAddress": "This address is sanctioned and cannot be used.",
       "validationUnavailable": "Address validation is temporarily unavailable.",
       "ensDisclaimer": "This ENS name resolves to the address shown above."
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10203,6 +10203,7 @@
       "validAddress": "Valid address",
       "invalidAddress": "Invalid address",
       "domainNotFound": "No address found for this domain",
+      "sanctionedAddress": "This address is sanctioned and cannot be used.",
       "validationUnavailable": "Address validation is temporarily unavailable",
       "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing."
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/adapters/contactsAddressValidationDependencies.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/adapters/contactsAddressValidationDependencies.ts
@@ -2,6 +2,7 @@ import { getRegistriesForDomain } from "@ledgerhq/domain-service/registries/inde
 import { resolveDomain } from "@ledgerhq/domain-service/resolvers/index";
 import { validateDomain } from "@ledgerhq/domain-service/utils/index";
 import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { getAccountBridgeByFamily } from "@ledgerhq/live-common/bridge/index";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { createContactsAddressValidationDependencies } from "@features/flow-contacts";
@@ -11,6 +12,7 @@ export const contactsAddressValidationDependencies = createContactsAddressValida
   getAccountBridgeByFamily,
   supportsDomain: sendFeatures.supportsDomain,
   getRegistriesForDomain,
+  isAddressSanctioned,
   resolveDomain,
   validateDomain,
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -67,6 +67,7 @@ export function useContactsAddAddressFlowDrawerViewModel({
               validAddress: t("contacts.addAddressEntry.validAddress"),
               invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
               domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+              sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
               validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
               ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
             },

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
@@ -12,6 +12,7 @@ const labels: AddAddressEntryLabels = {
   validAddress: "Valid address",
   invalidAddress: "Invalid address",
   domainNotFound: "No address found for this domain",
+  sanctionedAddress: "This address is sanctioned and cannot be used.",
   validationUnavailable: "Address validation is unavailable",
   ensDisclaimer: "ENS names resolve to wallet addresses.",
 };
@@ -159,6 +160,7 @@ describe("ContactsAddAddressEntry", () => {
   it.each([
     ["invalid_format", "Invalid address"],
     ["domain_not_found", "No address found for this domain"],
+    ["sanctioned", "This address is sanctioned and cannot be used."],
   ] as const)("should render the %s error", (error, expectedMessage) => {
     renderEntry({
       status: "invalid",

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/dependencies.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/dependencies.ts
@@ -14,6 +14,7 @@ export function createContactsAddressValidationDependencies(
       return registries.some(registry => registry.name === "ens");
     },
     validateDomain: gateway.validateDomain,
+    isAddressSanctioned: gateway.isAddressSanctioned,
     resolveEnsDomain: async address => {
       const [resolution] = await gateway.resolveDomain(address, "ens");
       return resolution?.address ?? null;

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/dependencies.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/dependencies.web.test.ts
@@ -14,6 +14,7 @@ function createGateway(overrides: Partial<ContactsAddressValidationGateway> = {}
     getRegistriesForDomain: jest.fn().mockResolvedValue([]),
     resolveDomain: jest.fn().mockResolvedValue([]),
     validateDomain: jest.fn().mockReturnValue(true),
+    isAddressSanctioned: jest.fn().mockResolvedValue(false),
     getAccountBridgeByFamily: jest.fn().mockResolvedValue({ validateAddress }),
     ...overrides,
   } satisfies ContactsAddressValidationGateway;
@@ -29,6 +30,7 @@ describe("createContactsAddressValidationDependencies", () => {
     expect(dependencies.findTokenById).toBe(gateway.findTokenById);
     expect(dependencies.supportsDomain).toBe(gateway.supportsDomain);
     expect(dependencies.validateDomain).toBe(gateway.validateDomain);
+    expect(dependencies.isAddressSanctioned).toBe(gateway.isAddressSanctioned);
   });
 
   it("should detect ENS from the injected domain registry", async () => {

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.ts
@@ -90,6 +90,12 @@ export function createContactsAddressValidationService(
           };
         }
 
+        if (
+          await dependencies.isAddressSanctioned(resolvedCurrency.network, resolvedAddress.address)
+        ) {
+          return { status: "sanctioned" };
+        }
+
         return {
           status: "valid",
           resolvedAddress: ContactAddressValueSchema.parse(resolvedAddress.address),

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.ts
@@ -93,7 +93,7 @@ export function createContactsAddressValidationService(
         if (
           await dependencies.isAddressSanctioned(resolvedCurrency.network, resolvedAddress.address)
         ) {
-          return { status: "sanctioned" };
+          return { status: "sanctioned", isDomain: resolvedAddress.isDomain };
         }
 
         return {

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.web.test.ts
@@ -61,7 +61,7 @@ describe("createContactsAddressValidationService", () => {
 
     await expect(
       service.validateAddress({ currencyId: ETHEREUM.id, address: RAW_ADDRESS }),
-    ).resolves.toEqual({ status: "sanctioned" });
+    ).resolves.toEqual({ status: "sanctioned", isDomain: false });
     expect(dependencies.isAddressSanctioned).toHaveBeenCalledWith(ETHEREUM, RAW_ADDRESS);
   });
 
@@ -161,7 +161,7 @@ describe("createContactsAddressValidationService", () => {
 
     await expect(
       service.validateAddress({ currencyId: ETHEREUM.id, address: "ledger.eth" }),
-    ).resolves.toEqual({ status: "sanctioned" });
+    ).resolves.toEqual({ status: "sanctioned", isDomain: true });
     expect(dependencies.isAddressSanctioned).toHaveBeenCalledWith(ETHEREUM, RESOLVED_ADDRESS);
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/service.web.test.ts
@@ -18,6 +18,7 @@ function createDependencies(overrides: Partial<ContactsAddressValidationDependen
     validateDomain: jest.fn().mockReturnValue(true),
     resolveEnsDomain: jest.fn().mockResolvedValue(null),
     validateNetworkAddress,
+    isAddressSanctioned: jest.fn().mockResolvedValue(false),
     ...overrides,
   } satisfies ContactsAddressValidationDependencies;
 
@@ -50,6 +51,18 @@ describe("createContactsAddressValidationService", () => {
     await expect(
       service.validateAddress({ currencyId: ETHEREUM.id, address: "invalid" }),
     ).resolves.toEqual({ status: "invalid_format", isDomain: false });
+  });
+
+  it("should expose sanctioned after a valid raw address validation", async () => {
+    const { dependencies } = createDependencies({
+      isAddressSanctioned: jest.fn().mockResolvedValue(true),
+    });
+    const service = createContactsAddressValidationService(dependencies);
+
+    await expect(
+      service.validateAddress({ currencyId: ETHEREUM.id, address: RAW_ADDRESS }),
+    ).resolves.toEqual({ status: "sanctioned" });
+    expect(dependencies.isAddressSanctioned).toHaveBeenCalledWith(ETHEREUM, RAW_ADDRESS);
   });
 
   it("should use a token parent network and check domain support on the token", async () => {
@@ -135,6 +148,21 @@ describe("createContactsAddressValidationService", () => {
       network: ETHEREUM,
       address: RESOLVED_ADDRESS,
     });
+  });
+
+  it("should check the resolved ENS address for sanctions", async () => {
+    const { dependencies } = createDependencies({
+      supportsDomain: jest.fn().mockReturnValue(true),
+      isEnsDomain: jest.fn().mockResolvedValue(true),
+      resolveEnsDomain: jest.fn().mockResolvedValue(RESOLVED_ADDRESS),
+      isAddressSanctioned: jest.fn().mockResolvedValue(true),
+    });
+    const service = createContactsAddressValidationService(dependencies);
+
+    await expect(
+      service.validateAddress({ currencyId: ETHEREUM.id, address: "ledger.eth" }),
+    ).resolves.toEqual({ status: "sanctioned" });
+    expect(dependencies.isAddressSanctioned).toHaveBeenCalledWith(ETHEREUM, RESOLVED_ADDRESS);
   });
 
   it("should expose domain_not_found when an ENS domain has no resolution", async () => {

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/types.ts
@@ -22,6 +22,7 @@ export type ContactsAddressValidationResult =
     }>
   | Readonly<{
       status: "sanctioned";
+      isDomain: boolean;
     }>;
 
 export type ContactsAddressValidationPort = Readonly<{

--- a/features/flow/contacts/src/steps/AddAddress/model/addressValidation/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressValidation/types.ts
@@ -19,6 +19,9 @@ export type ContactsAddressValidationResult =
     }>
   | Readonly<{
       status: "domain_not_found" | "unavailable";
+    }>
+  | Readonly<{
+      status: "sanctioned";
     }>;
 
 export type ContactsAddressValidationPort = Readonly<{
@@ -32,6 +35,7 @@ export type ContactsAddressValidationDependencies = Readonly<{
   validateDomain(address: string): boolean;
   resolveEnsDomain(address: string): Promise<string | null>;
   validateNetworkAddress(input: { network: CryptoCurrency; address: string }): Promise<boolean>;
+  isAddressSanctioned(network: CryptoCurrency, address: string): Promise<boolean>;
 }>;
 
 export type ContactsAddressValidationGateway = Readonly<{
@@ -40,6 +44,7 @@ export type ContactsAddressValidationGateway = Readonly<{
   getRegistriesForDomain(address: string): Promise<readonly { name: string }[]>;
   resolveDomain(address: string, registry: "ens"): Promise<readonly { address: string }[]>;
   validateDomain: ContactsAddressValidationDependencies["validateDomain"];
+  isAddressSanctioned: ContactsAddressValidationDependencies["isAddressSanctioned"];
   getAccountBridgeByFamily(family: string): Promise<
     Readonly<{
       validateAddress(address: string, options: Readonly<{ currencyId: string }>): Promise<boolean>;

--- a/features/flow/contacts/src/steps/AddAddress/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/types.ts
@@ -40,7 +40,7 @@ export type AddAddressEntryState =
       value: string;
       resolvedAddress: null;
       inputMethod: AddAddressInputMethod;
-      error: "invalid_format" | "domain_not_found";
+      error: "invalid_format" | "domain_not_found" | "sanctioned";
     }>
   | Readonly<{
       status: "unavailable";
@@ -123,6 +123,7 @@ export type AddAddressEntryLabels = Readonly<{
   validAddress: string;
   invalidAddress: string;
   domainNotFound: string;
+  sanctionedAddress: string;
   validationUnavailable: string;
   ensDisclaimer: string;
 }>;

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -100,7 +100,8 @@ function resolveAddressEntryState(
         resolvedAddress: null,
         inputMethod:
           result.status === "domain_not_found" ||
-          (result.status === "invalid_format" && result.isDomain)
+          ((result.status === "invalid_format" || result.status === "sanctioned") &&
+            result.isDomain)
             ? "ens"
             : inputMethod,
         error: result.status,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -93,6 +93,7 @@ function resolveAddressEntryState(
       };
     case "invalid_format":
     case "domain_not_found":
+    case "sanctioned":
       return {
         status: "invalid",
         value,

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -469,6 +469,7 @@ describe("useAddAddressFlowViewModel", () => {
   it.each([
     ["invalid_format", "manual"],
     ["domain_not_found", "ens"],
+    ["sanctioned", "manual"],
   ] as const)("should expose %s as an invalid address", async (error, inputMethod) => {
     const contactId = mockContact().id;
     const addressValidation = createValidationPort({ status: error });
@@ -487,6 +488,22 @@ describe("useAddAddressFlowViewModel", () => {
         inputMethod,
         error,
       },
+    });
+  });
+
+  it("should prevent confirmation for a sanctioned address", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort({ status: "sanctioned" });
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
+    act(() => result.current.confirmAddress());
+
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      addressEntry: { status: "invalid", error: "sanctioned" },
     });
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -469,7 +469,6 @@ describe("useAddAddressFlowViewModel", () => {
   it.each([
     ["invalid_format", "manual"],
     ["domain_not_found", "ens"],
-    ["sanctioned", "manual"],
   ] as const)("should expose %s as an invalid address", async (error, inputMethod) => {
     const contactId = mockContact().id;
     const addressValidation = createValidationPort({ status: error });
@@ -493,7 +492,7 @@ describe("useAddAddressFlowViewModel", () => {
 
   it("should prevent confirmation for a sanctioned address", async () => {
     const contactId = mockContact().id;
-    const addressValidation = createValidationPort({ status: "sanctioned" });
+    const addressValidation = createValidationPort({ status: "sanctioned", isDomain: false });
     const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
 
     act(() => result.current.start(contactWithoutAddresses(contactId)));
@@ -503,7 +502,7 @@ describe("useAddAddressFlowViewModel", () => {
 
     expect(result.current.state).toMatchObject({
       status: "enteringAddress",
-      addressEntry: { status: "invalid", error: "sanctioned" },
+      addressEntry: { status: "invalid", inputMethod: "manual", error: "sanctioned" },
     });
   });
 
@@ -527,6 +526,27 @@ describe("useAddAddressFlowViewModel", () => {
         resolvedAddress: null,
         inputMethod: "ens",
         error: "invalid_format",
+      },
+    });
+  });
+
+  it("should keep ENS provenance when a resolved domain is sanctioned", async () => {
+    const contactId = mockContact().id;
+    const addressValidation = createValidationPort({ status: "sanctioned", isDomain: true });
+    const { result } = renderHook(() => useAddAddressFlowViewModel({ addressValidation }));
+
+    act(() => result.current.start(contactWithoutAddresses(contactId)));
+    act(() => result.current.completeCurrencySelection(contactId, ETHEREUM_SELECTION));
+    await act(() => result.current.updateAddress("ledger.eth", "manual"));
+
+    expect(result.current.state).toMatchObject({
+      status: "enteringAddress",
+      addressEntry: {
+        status: "invalid",
+        value: "ledger.eth",
+        resolvedAddress: null,
+        inputMethod: "ens",
+        error: "sanctioned",
       },
     });
   });

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
@@ -63,7 +63,11 @@ function resolveAddressInputPresentation(
       return {
         status: "error",
         helperText:
-          addressEntry.error === "domain_not_found" ? labels.domainNotFound : labels.invalidAddress,
+          addressEntry.error === "domain_not_found"
+            ? labels.domainNotFound
+            : addressEntry.error === "sanctioned"
+              ? labels.sanctionedAddress
+              : labels.invalidAddress,
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: false,
       };

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
@@ -59,18 +59,21 @@ function resolveAddressInputPresentation(
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: true,
       };
-    case "invalid":
+    case "invalid": {
+      let helperText = labels.invalidAddress;
+      if (addressEntry.error === "domain_not_found") {
+        helperText = labels.domainNotFound;
+      } else if (addressEntry.error === "sanctioned") {
+        helperText = labels.sanctionedAddress;
+      }
+
       return {
         status: "error",
-        helperText:
-          addressEntry.error === "domain_not_found"
-            ? labels.domainNotFound
-            : addressEntry.error === "sanctioned"
-              ? labels.sanctionedAddress
-              : labels.invalidAddress,
+        helperText,
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: false,
       };
+    }
     case "unavailable":
       return {
         status: "error",

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -13,6 +13,7 @@ const labels: AddAddressEntryLabels = {
   validAddress: "Valid address",
   invalidAddress: "Invalid address",
   domainNotFound: "Domain not found",
+  sanctionedAddress: "This address is sanctioned and cannot be used.",
   validationUnavailable: "Address validation is temporarily unavailable.",
   ensDisclaimer: "ENS disclaimer",
 };
@@ -109,5 +110,23 @@ describe("useContactsAddAddressEntryViewModel", () => {
     });
 
     expect(result.current.isConfirmEnabled).toBe(false);
+  });
+
+  it("should expose a sanctioned address as a blocking error", () => {
+    const { result } = renderViewModel({
+      addressEntry: {
+        status: "invalid",
+        value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        resolvedAddress: null,
+        inputMethod: "manual",
+        error: "sanctioned",
+      },
+    });
+
+    expect(result.current).toMatchObject({
+      inputStatus: "error",
+      helperText: "This address is sanctioned and cannot be used.",
+      isConfirmEnabled: false,
+    });
   });
 });

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -40,7 +40,11 @@ function resolveAddressInputPresentation(
       return {
         inputStatus: "error",
         helperText:
-          addressEntry.error === "domain_not_found" ? labels.domainNotFound : labels.invalidAddress,
+          addressEntry.error === "domain_not_found"
+            ? labels.domainNotFound
+            : addressEntry.error === "sanctioned"
+              ? labels.sanctionedAddress
+              : labels.invalidAddress,
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: false,
       };

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -36,18 +36,21 @@ function resolveAddressInputPresentation(
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: true,
       };
-    case "invalid":
+    case "invalid": {
+      let helperText = labels.invalidAddress;
+      if (addressEntry.error === "domain_not_found") {
+        helperText = labels.domainNotFound;
+      } else if (addressEntry.error === "sanctioned") {
+        helperText = labels.sanctionedAddress;
+      }
+
       return {
         inputStatus: "error",
-        helperText:
-          addressEntry.error === "domain_not_found"
-            ? labels.domainNotFound
-            : addressEntry.error === "sanctioned"
-              ? labels.sanctionedAddress
-              : labels.invalidAddress,
+        helperText,
         showEnsDisclaimer: addressEntry.inputMethod === "ens",
         isConfirmEnabled: false,
       };
+    }
     case "unavailable":
       return {
         inputStatus: "error",


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Contacts address validation now blocks sanctioned recipient addresses on Desktop and Mobile.
  - ENS addresses are checked after resolution; token addresses use their parent network.

### 📝 Description

Contacts address validation now reuses the existing sanctions helper used by Coin Integrations after a bridge accepts the address.

The shared validation contract exposes a sanctioned result, which is rendered as a blocking invalid state in both platforms. The flow never advances from an invalid address.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33927](https://ledgerhq.atlassian.net/browse/LIVE-33927)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33927]: https://ledgerhq.atlassian.net/browse/LIVE-33927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ