### PR TITLE
fix(contacts): restrict address labels to ascii (LIVE-33930)

### DIFF
--- a/.changeset/ascii-address-labels.md
+++ b/.changeset/ascii-address-labels.md
@@ -1,0 +1,6 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+---
+
+Restrict Contacts address labels to printable ASCII characters

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -83,16 +83,16 @@ describe("ContactAddressSchema", () => {
     expect(() => ContactAddressValueSchema.parse("   ")).toThrow();
   });
 
-  it("accepts international and MAD-compatible address labels", () => {
-    expect(ContactAddressLabelSchema.parse(" محفظة ")).toBe("محفظة");
-    expect(ContactAddressLabelSchema.parse("Кошелек")).toBe("Кошелек");
-    expect(ContactAddressLabelSchema.parse("Ethér")).toBe("Ethér");
+  it("accepts printable ASCII address labels", () => {
     expect(ContactAddressLabelSchema.parse("Aave v3 1INCH")).toBe("Aave v3 1INCH");
     expect(ContactAddressLabelSchema.parse("USDC.e")).toBe("USDC.e");
     expect(ContactAddressLabelSchema.parse("123")).toBe("123");
   });
 
-  it("rejects punctuation-only, emoji, and control-character address labels", () => {
+  it("rejects non-ASCII, punctuation-only, emoji, and control-character address labels", () => {
+    expect(() => ContactAddressLabelSchema.parse("Ethér")).toThrow();
+    expect(() => ContactAddressLabelSchema.parse(" محفظة ")).toThrow();
+    expect(() => ContactAddressLabelSchema.parse("Кошелек")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("---")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum 💎")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum 1\uFE0F\u20E3")).toThrow();

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -11,7 +11,7 @@ export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCur
 
 const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;
-const ContactAddressLabelPattern = /^(?=.*[\p{L}\p{N}])[\p{L}\p{Mn}\p{Mc}\p{N}\p{P}\p{Zs}]+$/u;
+const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
 export const ContactNameSchema = NonEmptyStringSchema.regex(
   ContactNamePattern,

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -60,11 +60,11 @@ describe("contact address label validation", () => {
     expect(isValidContactAddressLabel(longLabel)).toBe(true);
   });
 
-  it("reports invalid characters for a non-empty invalid draft label", () => {
-    expect(getContactAddressLabelValidationError("Ethereum 💎")).toBe(
+  it("reports invalid non-ASCII characters for a non-empty draft label", () => {
+    expect(getContactAddressLabelValidationError("Ethér")).toBe(
       INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
     );
-    expect(isValidContactAddressLabel("Ethereum 💎")).toBe(false);
+    expect(isValidContactAddressLabel("Ethér")).toBe(false);
   });
 
   it("reports a duplicate within the existing labels", () => {
@@ -76,19 +76,14 @@ describe("contact address label validation", () => {
     expect(isValidContactAddressLabel("ETHEREUM", existingLabels)).toBe(false);
   });
 
-  it("treats canonically equivalent Unicode labels as duplicates", () => {
-    const existingLabels = [ContactAddressLabelSchema.parse("Ethér")];
-
-    expect(getContactAddressLabelValidationError("Ethe\u0301r", existingLabels)).toBe(
-      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-    );
-    expect(normalizeContactAddressLabelForComparison(" Ethér ")).toBe(
-      normalizeContactAddressLabelForComparison("ETHE\u0301R"),
+  it("normalizes ASCII labels for comparison", () => {
+    expect(normalizeContactAddressLabelForComparison(" Ethereum ")).toBe(
+      normalizeContactAddressLabelForComparison("ETHEREUM"),
     );
   });
 
   it("parses and normalizes a valid address label", () => {
-    expect(parseContactAddressLabel("  Ethe\u0301r  ")).toBe("Ethér");
+    expect(parseContactAddressLabel("  Ethereum  ")).toBe("Ethereum");
   });
 
   it("throws the matching domain error for invalid and duplicate labels", () => {

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressName.native.test.tsx
@@ -67,7 +67,7 @@ describe("ContactsAddAddressName", () => {
       name: "invalid characters",
       addressLabel: {
         status: "invalid",
-        value: "Ethereum 💎",
+        value: "Ethér",
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.web.test.ts
@@ -335,13 +335,13 @@ describe("useAddAddressFlowViewModel", () => {
     act(() => result.current.completeCurrencySelection(contact.id, ETHEREUM_SELECTION));
     await act(() => result.current.updateAddress(RAW_ADDRESS, "manual"));
     act(() => result.current.confirmAddress());
-    act(() => result.current.updateAddressLabel("Ethereum 💎"));
+    act(() => result.current.updateAddressLabel("Ethér"));
 
     expect(result.current.state).toMatchObject({
       status: "namingAddress",
       addressLabel: {
         status: "invalid",
-        value: "Ethereum 💎",
+        value: "Ethér",
         label: null,
         validationError: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
       },


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Contacts address labels now accept printable ASCII only.
  - Non-ASCII input remains blocked before address review.

### 📝 Description

Contacts address-label validation now follows the printable ASCII policy already used by the Stacks coin module.

The existing shared error state and review guard are reused; `é` is rejected while normal asset labels remain valid.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-33930](https://ledgerhq.atlassian.net/browse/LIVE-33930)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-33930]: https://ledgerhq.atlassian.net/browse/LIVE-33930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ