### PR TITLE
test(e2e-desktop): ensure account is synced before delegating

### DIFF
--- a/e2e/desktop/tests/page/account.page.ts
+++ b/e2e/desktop/tests/page/account.page.ts
@@ -108,6 +108,8 @@ export class AccountPage extends AppPage {
 
   @step("Click Stake button")
   async startStakingFlowFromMainStakeButton() {
+    // Wait if a sync is in progress to avoid empty stake modal
+    await this.layout.waitForSyncButtonToBeEnabled();
     await this.stakeButton.click();
   }
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Some flows navigate to accounts page and click delegate before the account is syned.

Focussed regression [report](https://ledger-live.allure.green.ledgerlabs.net/allure/reports/df5a3621-f768-4708-8fd4-818fffb562e8/#).

Filtered pattern: (4 patterns)
- delegate.spec.ts
- delegateSEI.spec.ts
- earn.V2.spec.ts
- stake.spec.ts

Repeat each: 3

All pass - 1 unrelated rerun in the report.


### 🔗 Context

- **JIRA / GitHub issue**: https://github.com/LedgerHQ/qaa-flaky-tests/issues/98
