### PR TITLE
[LWDM] feat(contacts): block duplicate contact names (LIVE-35066)

### DIFF
--- a/.changeset/unique-contact-names.md
+++ b/.changeset/unique-contact-names.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Block duplicate Contacts names before creation

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -281,6 +281,25 @@ describe("Contacts integration", () => {
     });
   });
 
+  it("should block a duplicate contact name and allow a unique replacement", async () => {
+    const me = mockMeContact();
+    const ada = mockContact({ id: "contact-ada", name: "Ada" });
+    const { user } = renderContactsScreen({ contacts: { contacts: [me, ada] } });
+
+    await user.click(screen.getByTestId("contacts-add-contact"));
+    const input = screen.getByTestId("contacts-add-contact-name-input");
+
+    fireEvent.change(input, { target: { value: " ada " } });
+
+    expect(screen.getByText("This contact name is already in use.")).toBeVisible();
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "Ben" } });
+
+    expect(screen.queryByText("This contact name is already in use.")).not.toBeInTheDocument();
+    expect(screen.getByTestId("contacts-add-contact-save")).toBeEnabled();
+  });
+
   it("should filter saved contacts when searching", async () => {
     const { user } = renderContactsScreen(populatedContactsPageState);
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useAddContactDialogAdapter.ts
@@ -1,4 +1,9 @@
-import { addContact, contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import {
+  addContact,
+  contact,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "@domain/entity-contact";
 import {
   type ContactCreationPort,
   type ContactsAddContactDialogLabels,
@@ -32,7 +37,10 @@ export function useAddContactDialogAdapter(
     }),
     [dispatch],
   );
-  const dialogViewModel = useAddContactDrawerViewModel({ contactCreation, onSaveSuccess });
+  const dialogViewModel = useAddContactDrawerViewModel({
+    contactCreation,
+    onSaveSuccess,
+  });
   const labels = useMemo<ContactsAddContactDialogLabels>(
     () => ({
       title: t("contacts.addContact"),
@@ -41,6 +49,7 @@ export function useAddContactDialogAdapter(
       confirmName: t("contacts.addContact"),
       nameValidationErrors: {
         [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
+        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
       },
     }),
     [t],

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
@@ -1,5 +1,6 @@
 import {
   ContactIdSchema,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
   type ContactId,
 } from "@domain/entity-contact";
@@ -48,6 +49,7 @@ export function useContactDetailEditDeleteAdapter(
     applyChanges: t("contacts.editContact.applyChanges"),
     nameValidationErrors: {
       [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.editContact.invalidNameError"),
+      [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
     },
   };
   const deleteLabels = {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9322,7 +9322,8 @@
     "addContactDrawer": {
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
-      "invalidNameError": "Special characters are not allowed."
+      "invalidNameError": "Special characters are not allowed.",
+      "duplicateNameError": "This contact name is already in use."
     },
     "searchPlaceholder": "Search contact",
     "searchNoResults": "No contact found",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10193,7 +10193,8 @@
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
       "confirmName": "Confirm name",
-      "invalidNameError": "Special characters are not allowed."
+      "invalidNameError": "Special characters are not allowed.",
+      "duplicateNameError": "This contact name is already in use."
     },
     "addAddressEntry": {
       "title": "Enter address",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/AddContactDrawer.integration.test.tsx
@@ -66,6 +66,35 @@ describe("Contacts add contact drawer integration", () => {
     });
   });
 
+  it("should block a duplicate contact name and allow a unique replacement", async () => {
+    const me = mockMeContact();
+    const ada = mockContact({ id: "contact-ada", name: "Ada" });
+    const { user } = render(<ContactsTestApp />, {
+      overrideInitialState: withFlagOverrides(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({
+          ...state,
+          contacts: { contacts: [me, ada] },
+        }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("contacts-add-contact-header"));
+    const input = screen.getByTestId("contacts-add-contact-name-input");
+
+    fireEvent.changeText(input, " ada ");
+
+    expect(screen.getByText("This contact name is already in use.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
+
+    fireEvent.changeText(input, "Ben");
+
+    await waitFor(() => {
+      expect(screen.queryByText("This contact name is already in use.")).toBeNull();
+      expect(screen.getByRole("button", { name: "Confirm name" })).toBeEnabled();
+    });
+  });
+
   it("should add a contact from the header and restore the unfiltered list", async () => {
     const me = mockMeContact();
     const ben = mockContact({ id: "contact-ben", name: "Ben" });

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -1,4 +1,8 @@
-import { INVALID_CONTACT_NAME_ERROR_NAME, type ContactId } from "@domain/entity-contact";
+import {
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+  type ContactId,
+} from "@domain/entity-contact";
 import {
   type ContactsDeleteContactDrawerProps,
   type ContactsEditSignerDrawerProps,
@@ -51,6 +55,7 @@ export function useContactDetailEditDeleteAdapter(
       applyChanges: t("contacts.editContact.applyChanges"),
       nameValidationErrors: {
         [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.editContact.invalidNameError"),
+        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
       },
     }),
     [t],

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -32,6 +32,7 @@ function createViewModel(
       confirmName: "Confirm name",
       nameValidationErrors: {
         InvalidContactNameError: "Special characters are not allowed.",
+        DuplicateContactNameError: "This contact name is already in use.",
       },
     },
     onOpen: jest.fn(),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsPageContent/ContactsPageContent.test.tsx
@@ -79,6 +79,7 @@ function createViewModel({
         confirmName: "Confirm name",
         nameValidationErrors: {
           InvalidContactNameError: "Special characters are not allowed.",
+          DuplicateContactNameError: "This contact name is already in use.",
         },
       },
       onOpen: jest.fn(),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 import { v4 as uuid } from "uuid";
-import { addContact, contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import {
+  addContact,
+  contact,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "@domain/entity-contact";
 import {
   type ContactCreationPort,
   type ContactsAddContactDrawerLabels,
@@ -44,6 +49,7 @@ export function useContactsAddContactDrawerAdapter(
       confirmName: t("contacts.addContactDrawer.confirmName"),
       nameValidationErrors: {
         [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.invalidNameError"),
+        [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),
       },
     }),
     [t],

--- a/domain/entity/contact/src/errors.test.ts
+++ b/domain/entity/contact/src/errors.test.ts
@@ -1,6 +1,7 @@
 import {
   ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
+  DuplicateContactNameError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
 } from "./errors";
@@ -8,6 +9,7 @@ import {
 describe("errors", () => {
   it.each([
     [new InvalidContactNameError(), "InvalidContactNameError"],
+    [new DuplicateContactNameError(), "DuplicateContactNameError"],
     [new InvalidContactAddressLabelError(), "InvalidContactAddressLabelError"],
     [
       new DuplicateContactAddressLabelError(),

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -10,6 +10,10 @@ export class InvalidContactNameError extends ContactError {
   }
 }
 
+export class DuplicateContactNameError extends ContactError {
+  override name = "DuplicateContactNameError" as const;
+}
+
 export class InvalidContactAddressLabelError extends ContactError {
   override name = "InvalidContactAddressLabelError" as const;
 }

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,26 +1,30 @@
 import {
   ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
+  DuplicateContactNameError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
 } from "./errors";
 import {
+  ContactAddressLabelInputSchema,
+  ContactAddressLabelSchema,
+  ContactNameSchema,
+} from "./schema";
+import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
   getContactAddressLabelValidationError,
   getContactNameValidationError,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
   isValidContactAddressLabel,
   isValidContactName,
   normalizeContactAddressLabelForComparison,
+  normalizeContactNameForComparison,
   parseContactAddressLabel,
   parseContactName,
 } from "./validation";
-import {
-  ContactAddressLabelInputSchema,
-  ContactAddressLabelSchema,
-} from "./schema";
 
 describe("contact name validation", () => {
   it("does not report an error for an empty draft name", () => {
@@ -38,6 +42,18 @@ describe("contact name validation", () => {
     );
   });
 
+  it("reports a duplicate name after trimming, normalizing, and folding case", () => {
+    const existingNames = [ContactNameSchema.parse("Élodie")];
+
+    expect(getContactNameValidationError(" e\u0301LODIE ", existingNames)).toBe(
+      DUPLICATE_CONTACT_NAME_ERROR_NAME
+    );
+    expect(isValidContactName(" e\u0301LODIE ", existingNames)).toBe(false);
+    expect(normalizeContactNameForComparison(" Élodie ")).toBe(
+      normalizeContactNameForComparison("e\u0301LODIE")
+    );
+  });
+
   it("validates trimmed names consistently", () => {
     expect(isValidContactName("  Ben  ")).toBe(true);
     expect(isValidContactName("Olive2")).toBe(false);
@@ -48,8 +64,20 @@ describe("contact name validation", () => {
     expect(() => parseContactName("Olive2")).toThrow(InvalidContactNameError);
   });
 
+  it("parseContactName throws DuplicateContactNameError for an existing name", () => {
+    const existingNames = [ContactNameSchema.parse("Ada")];
+
+    expect(() => parseContactName(" ada ", existingNames)).toThrow(
+      DuplicateContactNameError
+    );
+  });
+
   it("parseContactName returns a parsed name for a valid draft name", () => {
     expect(parseContactName("  Ben  ")).toBe("Ben");
+  });
+
+  it("parseContactName returns a NFC-normalized name", () => {
+    expect(parseContactName(" E\u0301lodie ")).toBe("Élodie");
   });
 });
 

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,6 +1,7 @@
 import {
   ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
+  DuplicateContactNameError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
 } from "./errors";
@@ -10,10 +11,15 @@ import {
 } from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
-export type ContactNameValidationErrorName = InvalidContactNameError["name"];
+export type ContactNameValidationErrorName =
+  | InvalidContactNameError["name"]
+  | DuplicateContactNameError["name"];
 
 export const INVALID_CONTACT_NAME_ERROR_NAME =
   "InvalidContactNameError" satisfies ContactNameValidationErrorName;
+
+export const DUPLICATE_CONTACT_NAME_ERROR_NAME =
+  "DuplicateContactNameError" satisfies ContactNameValidationErrorName;
 
 export type ContactAddressLabelValidationErrorName =
   | InvalidContactAddressLabelError["name"]
@@ -40,7 +46,8 @@ type ContactAddressLabelValidationResult = {
 };
 
 function validateContactNameInput(
-  draftName: string
+  draftName: string,
+  existingNames: readonly ContactName[]
 ): ContactNameValidationResult {
   const parsed = ContactNameInputSchema.safeParse(draftName);
 
@@ -48,28 +55,59 @@ function validateContactNameInput(
     return { validationError: INVALID_CONTACT_NAME_ERROR_NAME, value: null };
   }
 
-  return parsed.data === ""
-    ? { validationError: null, value: null }
-    : { validationError: null, value: parsed.data };
+  if (parsed.data === "") {
+    return { validationError: null, value: null };
+  }
+
+  const validationError = existingNames.some(
+    (name) =>
+      normalizeContactNameForComparison(name) ===
+      normalizeContactNameForComparison(parsed.data)
+  )
+    ? DUPLICATE_CONTACT_NAME_ERROR_NAME
+    : null;
+
+  return { validationError, value: parsed.data };
 }
 
 export function getContactNameValidationError(
-  draftName: string
+  draftName: string,
+  existingNames: readonly ContactName[] = []
 ): ContactNameValidationErrorName | null {
-  return validateContactNameInput(draftName).validationError;
+  return validateContactNameInput(draftName, existingNames).validationError;
 }
 
-export function isValidContactName(draftName: string): boolean {
-  const { validationError, value } = validateContactNameInput(draftName);
+export function isValidContactName(
+  draftName: string,
+  existingNames: readonly ContactName[] = []
+): boolean {
+  const { validationError, value } = validateContactNameInput(
+    draftName,
+    existingNames
+  );
 
   return validationError === null && value !== null;
 }
 
-export function parseContactName(draftName: string): ContactName {
-  const { validationError, value } = validateContactNameInput(draftName);
+export function normalizeContactNameForComparison(name: string): string {
+  return name.trim().normalize("NFC").toLocaleLowerCase("en-US");
+}
+
+export function parseContactName(
+  draftName: string,
+  existingNames: readonly ContactName[] = []
+): ContactName {
+  const { validationError, value } = validateContactNameInput(
+    draftName,
+    existingNames
+  );
 
   if (validationError === INVALID_CONTACT_NAME_ERROR_NAME || value === null) {
     throw new InvalidContactNameError();
+  }
+
+  if (validationError === DUPLICATE_CONTACT_NAME_ERROR_NAME) {
+    throw new DuplicateContactNameError();
   }
 
   return value;

--- a/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddContact/ContactsAddContactDialog.web.test.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import {
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "@domain/entity-contact";
 import { ContactsAddContactDialog } from "./ContactsAddContactDialog.web";
 import type { ContactsAddContactDialogProps } from "./types";
 
 function createViewModel(
-  overrides: Partial<ContactsAddContactDialogProps> = {},
+  overrides: Partial<ContactsAddContactDialogProps> = {}
 ): ContactsAddContactDialogProps {
   return {
     isOpen: true,
@@ -21,7 +24,10 @@ function createViewModel(
         "For privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S'.",
       confirmName: "Add contact",
       nameValidationErrors: {
-        [INVALID_CONTACT_NAME_ERROR_NAME]: "Special characters are not allowed.",
+        [INVALID_CONTACT_NAME_ERROR_NAME]:
+          "Special characters are not allowed.",
+        [DUPLICATE_CONTACT_NAME_ERROR_NAME]:
+          "This contact name is already in use.",
       },
     },
     onClose: jest.fn(),
@@ -40,10 +46,12 @@ describe("ContactsAddContactDialog", () => {
           draftName: "Cédric",
           invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
         })}
-      />,
+      />
     );
 
-    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveValue("Cédric");
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveValue(
+      "Cédric"
+    );
     expect(screen.getByTestId("contacts-add-contact-save")).toBeDisabled();
   });
 
@@ -57,7 +65,7 @@ describe("ContactsAddContactDialog", () => {
           isConfirmEnabled: true,
           onDraftNameChange,
         })}
-      />,
+      />
     );
 
     fireEvent.change(screen.getByTestId("contacts-add-contact-name-input"), {

--- a/features/flow/contacts/src/steps/AddContact/model/controller.ts
+++ b/features/flow/contacts/src/steps/AddContact/model/controller.ts
@@ -1,20 +1,31 @@
-import { parseContactName, type Contact } from "@domain/entity-contact";
+import {
+  parseContactName,
+  type Contact,
+  type ContactName,
+} from "@domain/entity-contact";
 import type { ContactCreationPort } from "./ports";
 import { createAddContactViewModel } from "./viewModel";
 import type { AddContactViewModel } from "./types";
 
 export type AddContactController = Readonly<{
-  getViewModel: (draftName: string) => AddContactViewModel;
-  save: (draftName: string) => Promise<Contact>;
+  getViewModel: (
+    draftName: string,
+    existingNames?: readonly ContactName[]
+  ) => AddContactViewModel;
+  save: (
+    draftName: string,
+    existingNames?: readonly ContactName[]
+  ) => Promise<Contact>;
 }>;
 
 export function createAddContactController(
-  contactCreation: ContactCreationPort,
+  contactCreation: ContactCreationPort
 ): AddContactController {
   return {
-    getViewModel: draftName => createAddContactViewModel(draftName),
-    save: async draftName => {
-      const name = parseContactName(draftName);
+    getViewModel: (draftName, existingNames = []) =>
+      createAddContactViewModel(draftName, existingNames),
+    save: async (draftName, existingNames = []) => {
+      const name = parseContactName(draftName, existingNames);
 
       return contactCreation.createContact({ name });
     },

--- a/features/flow/contacts/src/steps/AddContact/model/controller.web.test.ts
+++ b/features/flow/contacts/src/steps/AddContact/model/controller.web.test.ts
@@ -1,23 +1,31 @@
-import { contact } from "@domain/entity-contact";
+import {
+  contact,
+  ContactNameSchema,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+} from "@domain/entity-contact";
 import { createAddContactController } from "./controller";
 import type { ContactCreationPort } from "./ports";
 
 function createContactCreationPort(
-  implementation: ContactCreationPort["createContact"],
+  implementation: ContactCreationPort["createContact"]
 ): ContactCreationPort {
   return { createContact: implementation };
 }
 
 describe("createAddContactController", () => {
   it("keeps save disabled until the draft name is valid", () => {
-    const controller = createAddContactController(createContactCreationPort(jest.fn()));
+    const controller = createAddContactController(
+      createContactCreationPort(jest.fn())
+    );
 
     expect(controller.getViewModel("").isSaveEnabled).toBe(false);
     expect(controller.getViewModel("Ben").isSaveEnabled).toBe(true);
   });
 
   it("exposes the stable invalid name error while the draft name is invalid", () => {
-    const controller = createAddContactController(createContactCreationPort(jest.fn()));
+    const controller = createAddContactController(
+      createContactCreationPort(jest.fn())
+    );
 
     expect(controller.getViewModel("Olive2")).toMatchObject({
       invalidNameError: "InvalidContactNameError",
@@ -25,8 +33,25 @@ describe("createAddContactController", () => {
     });
   });
 
+  it("rejects a duplicate name before calling the creation port", async () => {
+    const createContact = jest.fn();
+    const controller = createAddContactController(
+      createContactCreationPort(createContact)
+    );
+    const existingNames = [ContactNameSchema.parse("Ada")];
+
+    expect(controller.getViewModel(" ada ", existingNames)).toMatchObject({
+      invalidNameError: DUPLICATE_CONTACT_NAME_ERROR_NAME,
+      isSaveEnabled: false,
+    });
+    await expect(controller.save(" ada ", existingNames)).rejects.toThrow();
+    expect(createContact).not.toHaveBeenCalled();
+  });
+
   it("rejects save when the draft name is empty", async () => {
-    const controller = createAddContactController(createContactCreationPort(jest.fn()));
+    const controller = createAddContactController(
+      createContactCreationPort(jest.fn())
+    );
 
     await expect(controller.save("")).rejects.toThrow();
   });
@@ -38,9 +63,11 @@ describe("createAddContactController", () => {
         isMe: false,
         name,
         addresses: [],
-      }),
+      })
     );
-    const controller = createAddContactController(createContactCreationPort(createContact));
+    const controller = createAddContactController(
+      createContactCreationPort(createContact)
+    );
 
     await expect(controller.save("Olivia")).resolves.toMatchObject({
       id: "contact-olivia",
@@ -49,5 +76,23 @@ describe("createAddContactController", () => {
       addresses: [],
     });
     expect(createContact).toHaveBeenCalledWith({ name: "Olivia" });
+  });
+
+  it("normalizes a contact name before calling the creation port", async () => {
+    const createContact = jest.fn(async ({ name }) =>
+      contact({
+        id: "contact-elodie",
+        isMe: false,
+        name,
+        addresses: [],
+      })
+    );
+    const controller = createAddContactController(
+      createContactCreationPort(createContact)
+    );
+
+    await controller.save(" E\u0301lodie ");
+
+    expect(createContact).toHaveBeenCalledWith({ name: "Élodie" });
   });
 });

--- a/features/flow/contacts/src/steps/AddContact/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/AddContact/model/viewModel.ts
@@ -1,10 +1,19 @@
-import { getContactNameValidationError } from "@domain/entity-contact";
+import {
+  getContactNameValidationError,
+  type ContactName,
+} from "@domain/entity-contact";
 import { getContactInitial } from "../../../utils";
 import type { AddContactViewModel } from "./types";
 
-export function createAddContactViewModel(draftName: string): AddContactViewModel {
+export function createAddContactViewModel(
+  draftName: string,
+  existingNames: readonly ContactName[] = []
+): AddContactViewModel {
   const trimmedDraftName = draftName.trim();
-  const invalidNameError = getContactNameValidationError(draftName);
+  const invalidNameError = getContactNameValidationError(
+    draftName,
+    existingNames
+  );
 
   return {
     draftName,

--- a/features/flow/contacts/src/steps/AddContact/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddContact/model/viewModel.web.test.ts
@@ -1,4 +1,8 @@
-import { INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import {
+  ContactNameSchema,
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "@domain/entity-contact";
 import { createAddContactViewModel } from "./viewModel";
 
 describe("createAddContactViewModel", () => {
@@ -25,6 +29,15 @@ describe("createAddContactViewModel", () => {
       draftName: "Olive2",
       avatarInitial: "O",
       invalidNameError: INVALID_CONTACT_NAME_ERROR_NAME,
+      isSaveEnabled: false,
+    });
+  });
+
+  it("disables save for a normalized duplicate name", () => {
+    expect(
+      createAddContactViewModel(" ada ", [ContactNameSchema.parse("Ada")])
+    ).toMatchObject({
+      invalidNameError: DUPLICATE_CONTACT_NAME_ERROR_NAME,
       isSaveEnabled: false,
     });
   });

--- a/features/flow/contacts/src/steps/AddContact/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddContact/useAddContactDrawerViewModel.web.test.ts
@@ -1,9 +1,18 @@
 import { act, renderHook } from "@testing-library/react";
 import { contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import { useContacts } from "../../hooks";
 import type { ContactCreationPort } from "./model/ports";
 import { useAddContactDrawerViewModel } from "./useAddContactDrawerViewModel";
 
+jest.mock("../../hooks", () => ({ useContacts: jest.fn() }));
+
+const mockedUseContacts = jest.mocked(useContacts);
+
 describe("useAddContactDrawerViewModel", () => {
+  beforeEach(() => {
+    mockedUseContacts.mockReturnValue([]);
+  });
+
   it("should save through the injected port, reset the draft, and close", async () => {
     const onSaveSuccess = jest.fn();
     const contactCreation: ContactCreationPort = {

--- a/features/flow/contacts/src/steps/AddContact/useAddContactViewModel.ts
+++ b/features/flow/contacts/src/steps/AddContact/useAddContactViewModel.ts
@@ -1,5 +1,6 @@
 import type { Contact } from "@domain/entity-contact";
 import { useCallback, useMemo, useState } from "react";
+import { useContacts } from "../../hooks";
 import { createAddContactController } from "./model/controller";
 import type { ContactCreationPort } from "./model/ports";
 import type { AddContactViewModel } from "./model/types";
@@ -15,12 +16,26 @@ export type UseAddContactViewModelResult = AddContactViewModel &
  * Pass a stable `ContactCreationPort`; a new reference each render recreates the controller.
  */
 export function useAddContactViewModel(
-  contactCreation: ContactCreationPort,
+  contactCreation: ContactCreationPort
 ): UseAddContactViewModelResult {
   const [draftName, setDraftName] = useState("");
-  const controller = useMemo(() => createAddContactController(contactCreation), [contactCreation]);
-  const viewModel = useMemo(() => controller.getViewModel(draftName), [controller, draftName]);
-  const save = useCallback(() => controller.save(draftName), [controller, draftName]);
+  const contacts = useContacts();
+  const existingContactNames = useMemo(
+    () => contacts.map((contact) => contact.name),
+    [contacts]
+  );
+  const controller = useMemo(
+    () => createAddContactController(contactCreation),
+    [contactCreation]
+  );
+  const viewModel = useMemo(
+    () => controller.getViewModel(draftName, existingContactNames),
+    [controller, draftName, existingContactNames]
+  );
+  const save = useCallback(
+    () => controller.save(draftName, existingContactNames),
+    [controller, draftName, existingContactNames]
+  );
 
   return {
     ...viewModel,

--- a/features/flow/contacts/src/steps/AddContact/useAddContactViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddContact/useAddContactViewModel.web.test.ts
@@ -1,15 +1,33 @@
 import { renderHook, act } from "@testing-library/react";
-import { INVALID_CONTACT_NAME_ERROR_NAME, contact } from "@domain/entity-contact";
+import {
+  DUPLICATE_CONTACT_NAME_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+  contact,
+} from "@domain/entity-contact";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { useContacts } from "../../hooks";
 import type { ContactCreationPort } from "./model/ports";
 import { useAddContactViewModel } from "./useAddContactViewModel";
 
+jest.mock("../../hooks", () => ({ useContacts: jest.fn() }));
+
+const mockedUseContacts = jest.mocked(useContacts);
+
 describe("useAddContactViewModel", () => {
+  beforeEach(() => {
+    mockedUseContacts.mockReturnValue([
+      mockMeContact(),
+      mockContact({ name: "Ada" }),
+    ]);
+  });
   it("updates derived state when the draft name changes", () => {
     const contactCreation: ContactCreationPort = {
       createContact: jest.fn(),
     };
 
-    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+    const { result } = renderHook(() =>
+      useAddContactViewModel(contactCreation)
+    );
 
     expect(result.current.isSaveEnabled).toBe(false);
 
@@ -29,14 +47,42 @@ describe("useAddContactViewModel", () => {
     const contactCreation: ContactCreationPort = {
       createContact: jest.fn(),
     };
-    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+    const { result } = renderHook(() =>
+      useAddContactViewModel(contactCreation)
+    );
 
     act(() => {
       result.current.setDraftName("Olive2");
     });
 
-    expect(result.current.invalidNameError).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(result.current.invalidNameError).toBe(
+      INVALID_CONTACT_NAME_ERROR_NAME
+    );
     expect(result.current.isSaveEnabled).toBe(false);
+  });
+
+  it("blocks saving a duplicate contact name from the current Contacts state", async () => {
+    const createContact = jest.fn();
+    const contactCreation: ContactCreationPort = { createContact };
+    const { result } = renderHook(() =>
+      useAddContactViewModel(contactCreation)
+    );
+
+    act(() => {
+      result.current.setDraftName(" ada ");
+    });
+
+    expect(result.current.invalidNameError).toBe(
+      DUPLICATE_CONTACT_NAME_ERROR_NAME
+    );
+    expect(result.current.isSaveEnabled).toBe(false);
+
+    await expect(
+      act(async () => {
+        await result.current.save();
+      })
+    ).rejects.toThrow();
+    expect(createContact).not.toHaveBeenCalled();
   });
 
   it("delegates save to the injected creation port", async () => {
@@ -46,10 +92,12 @@ describe("useAddContactViewModel", () => {
         isMe: false,
         name,
         addresses: [],
-      }),
+      })
     );
     const contactCreation: ContactCreationPort = { createContact };
-    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+    const { result } = renderHook(() =>
+      useAddContactViewModel(contactCreation)
+    );
 
     act(() => {
       result.current.setDraftName("Olivia");
@@ -65,7 +113,9 @@ describe("useAddContactViewModel", () => {
   it("rejects save when the draft name is invalid", async () => {
     const createContact = jest.fn();
     const contactCreation: ContactCreationPort = { createContact };
-    const { result } = renderHook(() => useAddContactViewModel(contactCreation));
+    const { result } = renderHook(() =>
+      useAddContactViewModel(contactCreation)
+    );
 
     act(() => {
       result.current.setDraftName("Olive2");
@@ -74,7 +124,7 @@ describe("useAddContactViewModel", () => {
     await expect(
       act(async () => {
         await result.current.save();
-      }),
+      })
     ).rejects.toThrow();
     expect(createContact).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** _Desktop and Mobile integration commands are blocked in this workspace before execution by generated dependencies unavailable locally._
- [x] **Impact of the changes:**
  - Contacts cannot be created with an existing normalized name.
  - Desktop and Mobile display the same validation message before any creation action.

### 📝 Description

The shared Contacts domain now recognizes duplicate names after trimming, NFC normalization, and case folding.

The Add Contact flow reads existing Contacts, disables confirmation for duplicates, and validates again before calling the creation port. Both platforms provide the English duplicate-name message.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35066](https://ledgerhq.atlassian.net/browse/LIVE-35066)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35066]: https://ledgerhq.atlassian.net/browse/LIVE-35066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ