### PR TITLE
feat(ddd): add @domain/entity-account-name package

### DIFF
--- a/domain/entity/account-name/README.md
+++ b/domain/entity/account-name/README.md
@@ -1,0 +1,13 @@
+# @domain/entity-account-name
+
+> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+
+RTK slice and WalletSync module for user-defined account names.
+
+State shape: `accountNames: Map<string, string>` (accountId → name). Exports `accountNamesSlice`, actions (`setAccountName`, `bulkSetAccountNames`, `setNamesForAccounts`, `initFromUserData`), selectors (`accountNameSelector`, `accountNameWithDefaultSelector`) and `accountNamesSyncModule` — a `CloudSyncDataManager` that syncs account names across devices via `@shared/cloud-sync-module`.
+
+## Related documentation
+
+- [CloudSyncDataManager](../../../docs/ledger-sync/05-wallet-sync-data-manager.md) — module contract and reconciliation
+- [Cookbook: add a module](../../../docs/ledger-sync/cookbook.md) — hands-on guide for new sync modules
+- [App integration](../../../docs/ledger-sync/07-app-integration.md) — how account names are wired in Redux

--- a/domain/entity/account-name/jest.config.js
+++ b/domain/entity/account-name/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/account-name/package.json
+++ b/domain/entity/account-name/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@domain/entity-account-name",
+  "version": "0.0.1",
+  "private": true,
+  "description": "AccountName entity: naming utilities, account-names store, and wallet-sync module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": ["./src/slice.ts"],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/account-name"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "@shared/cloud-sync-module": "workspace:^",
+    "immer": "^11.0.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/account-name/project.json
+++ b/domain/entity/account-name/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-account-name",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/account-name/src/__tests__/accountName.test.ts
+++ b/domain/entity/account-name/src/__tests__/accountName.test.ts
@@ -1,0 +1,88 @@
+import {
+  getDefaultAccountName,
+  getDefaultAccountNameForCurrencyIndex,
+  normalizeName,
+  validateNameEdition,
+  MAX_ACCOUNT_NAME_LENGTH,
+} from "../accountName";
+
+describe(getDefaultAccountNameForCurrencyIndex.name, () => {
+  it("returns currency name with 1-based index", () => {
+    expect(getDefaultAccountNameForCurrencyIndex({ currency: { name: "Bitcoin" }, index: 0 })).toBe(
+      "Bitcoin 1",
+    );
+  });
+});
+
+describe(getDefaultAccountName.name, () => {
+  describe("given an Account", () => {
+    it("should return the account name", () => {
+      expect(
+        getDefaultAccountName({
+          id: "a1",
+          type: "Account",
+          currency: { name: "Ethereum" },
+          index: 1,
+        }),
+      ).toEqual("Ethereum 2");
+    });
+  });
+
+  describe("given a TokenAccount", () => {
+    it("should return the token account name", () => {
+      expect(
+        getDefaultAccountName({
+          id: "t1",
+          type: "TokenAccount",
+          token: { name: "USD Coin" },
+        }),
+      ).toEqual("USD Coin");
+    });
+  });
+
+  it("falls back to account id when no currency or token name", () => {
+    expect(getDefaultAccountName({ id: "fallback-id", type: "Other" })).toBe("fallback-id");
+  });
+});
+
+describe(validateNameEdition.name, () => {
+  const account = {
+    id: "a1",
+    type: "Account",
+    currency: { name: "Bitcoin" },
+    index: 0,
+  };
+
+  it("normalizes a custom name", () => {
+    expect(validateNameEdition(account, "  My Wallet  ")).toBe("My Wallet");
+  });
+
+  it("uses the default account name when name is empty", () => {
+    expect(validateNameEdition(account, "")).toBe("Bitcoin 1");
+  });
+
+  it("uses the default account name when name is undefined", () => {
+    expect(validateNameEdition(account)).toBe("Bitcoin 1");
+  });
+});
+
+describe(normalizeName.name, () => {
+  it.each([
+    ["  hello  ", "hello"],
+    ["hello   world", "hello world"],
+    ["hello\t\tworld", "hello world"],
+    ["hello \t world", "hello world"],
+    ["   ", ""],
+    ["", ""],
+    ["Ethereum 1", "Ethereum 1"],
+  ])("normalizeName(%j) → %j", (input, expected) => {
+    expect(normalizeName(input)).toBe(expected);
+  });
+
+  it("should truncate to MAX_ACCOUNT_NAME_LENGTH characters", () => {
+    const longName = "  " + "a".repeat(MAX_ACCOUNT_NAME_LENGTH + 10) + "  ";
+    const result = normalizeName(longName);
+    expect(result).toHaveLength(MAX_ACCOUNT_NAME_LENGTH);
+    expect(result).not.toMatch(/^\s/);
+  });
+});

--- a/domain/entity/account-name/src/__tests__/cloudSyncModule.test.ts
+++ b/domain/entity/account-name/src/__tests__/cloudSyncModule.test.ts
@@ -1,0 +1,131 @@
+import { accountNamesSyncModule } from "../cloudSyncModule";
+
+const makeMap = (entries: Record<string, string>) => new Map(Object.entries(entries));
+
+describe("accountNamesSyncModule.diffLocalToDistant", () => {
+  it("returns hasChanges=false for empty local and null distant", () => {
+    const result = accountNamesSyncModule.diffLocalToDistant(new Map(), null);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toEqual({});
+  });
+
+  it("returns hasChanges=false when local matches distant", () => {
+    const local = makeMap({ acc1: "Savings" });
+    const distant = { acc1: "Savings" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when local has new entry", () => {
+    const local = makeMap({ acc1: "Savings", acc2: "Trading" });
+    const distant = { acc1: "Savings" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState).toEqual({ acc1: "Savings", acc2: "Trading" });
+  });
+
+  it("returns hasChanges=true when local has renamed entry", () => {
+    const local = makeMap({ acc1: "New Name" });
+    const distant = { acc1: "Old Name" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local has removed entry vs distant", () => {
+    const local = makeMap({ acc1: "Savings" });
+    const distant = { acc1: "Savings", acc2: "Removed" };
+    const result = accountNamesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("serializes map to plain object in nextState", () => {
+    const local = makeMap({ acc1: "A", acc2: "B" });
+    const result = accountNamesSyncModule.diffLocalToDistant(local, null);
+    expect(result.nextState).toEqual({ acc1: "A", acc2: "B" });
+  });
+});
+
+describe("accountNamesSyncModule.resolveIncrementalUpdate", () => {
+  it("returns hasChanges=false when incomingState is null", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, null);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when local matches incoming", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const incoming = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when latestState === incomingState (same reference)", async () => {
+    const local = makeMap({});
+    const state = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, state, state);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when incoming has new names", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const incoming = { acc1: "Savings", acc2: "Trading" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.replaceAllNames).toEqual(incoming);
+    }
+  });
+
+  it("returns hasChanges=true when incoming renames an account", async () => {
+    const local = makeMap({ acc1: "Old Name" });
+    const incoming = { acc1: "New Name" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.replaceAllNames.acc1).toBe("New Name");
+    }
+  });
+
+  it("returns hasChanges=false when incoming differs from latestState reference but same content as local", async () => {
+    const local = makeMap({ acc1: "Savings" });
+    const latest = { acc1: "Savings" };
+    const incoming = { acc1: "Savings" };
+    const result = await accountNamesSyncModule.resolveIncrementalUpdate(local, latest, incoming);
+    expect(result.hasChanges).toBe(false);
+  });
+});
+
+describe("accountNamesSyncModule.applyUpdate", () => {
+  it("returns a new Map with replaceAllNames entries", () => {
+    const local = makeMap({ acc1: "Old" });
+    const update = { replaceAllNames: { acc1: "New", acc2: "Added" } };
+    const result = accountNamesSyncModule.applyUpdate(local, update);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.get("acc1")).toBe("New");
+    expect(result.get("acc2")).toBe("Added");
+  });
+
+  it("replaces all local names with replaceAllNames", () => {
+    const local = makeMap({ acc1: "Keep", acc2: "Remove" });
+    const update = { replaceAllNames: { acc1: "Keep" } };
+    const result = accountNamesSyncModule.applyUpdate(local, update);
+    expect(result.has("acc2")).toBe(false);
+  });
+
+  it("handles empty replaceAllNames", () => {
+    const local = makeMap({ acc1: "Name" });
+    const result = accountNamesSyncModule.applyUpdate(local, { replaceAllNames: {} });
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("accountNamesSyncModule.schema", () => {
+  it("parses record of strings", () => {
+    const input = { acc1: "Savings", acc2: "Trading" };
+    expect(accountNamesSyncModule.schema.parse(input)).toEqual(input);
+  });
+
+  it("fails on non-string values", () => {
+    expect(() => accountNamesSyncModule.schema.parse({ acc1: 123 })).toThrow();
+  });
+});

--- a/domain/entity/account-name/src/__tests__/selectors.test.ts
+++ b/domain/entity/account-name/src/__tests__/selectors.test.ts
@@ -1,0 +1,29 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { accountNamesSlice, setAccountName } from "../slice";
+import { accountNameWithDefaultSelector } from "../selectors";
+
+function makeStore() {
+  return configureStore({ reducer: { accountNames: accountNamesSlice.reducer } });
+}
+
+describe("accountNameWithDefaultSelector", () => {
+  const account = {
+    id: "a1",
+    type: "Account",
+    currency: { name: "Bitcoin" },
+    index: 0,
+  };
+
+  it("returns the custom name when set", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "Savings" }));
+    expect(accountNameWithDefaultSelector(store.getState().accountNames, account)).toBe("Savings");
+  });
+
+  it("returns the default name when no custom name exists", () => {
+    const store = makeStore();
+    expect(accountNameWithDefaultSelector(store.getState().accountNames, account)).toBe(
+      "Bitcoin 1",
+    );
+  });
+});

--- a/domain/entity/account-name/src/__tests__/store.test.ts
+++ b/domain/entity/account-name/src/__tests__/store.test.ts
@@ -1,0 +1,117 @@
+import { configureStore } from "@reduxjs/toolkit";
+import {
+  accountNamesSlice,
+  bulkSetAccountNames,
+  initFromUserData,
+  setAccountName,
+  setNamesForAccounts,
+} from "../slice";
+import { accountNameSelector } from "../selectors";
+
+function makeStore() {
+  return configureStore({ reducer: { accountNames: accountNamesSlice.reducer } });
+}
+
+describe("accountNamesSlice", () => {
+  it("starts empty", () => {
+    const store = makeStore();
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "x" })).toBeUndefined();
+  });
+
+  it("setAccountName sets a name", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "My Wallet" }));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "My Wallet",
+    );
+  });
+
+  it("setAccountName with empty name removes entry", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "My Wallet" }));
+    store.dispatch(setAccountName({ accountId: "a1", name: "" }));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+
+  it("bulkSetAccountNames merges names", () => {
+    const store = makeStore();
+    store.dispatch(bulkSetAccountNames(new Map([["a1", "First"]])));
+    store.dispatch(bulkSetAccountNames(new Map([["a2", "Second"]])));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe("First");
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a2" })).toBe("Second");
+  });
+
+  it("initFromUserData replaces all names", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "old", name: "Old" }));
+    store.dispatch(initFromUserData([{ id: "new", name: "New" }]));
+    expect(
+      accountNameSelector(store.getState().accountNames, { accountId: "old" }),
+    ).toBeUndefined();
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "new" })).toBe("New");
+  });
+
+  it("initFromUserData skips entries with empty name", () => {
+    const store = makeStore();
+    store.dispatch(initFromUserData([{ id: "a1", name: "" }]));
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+
+  it("ADD_ACCOUNTS stores edited names that differ from the default", () => {
+    const store = makeStore();
+    store.dispatch({
+      type: "ADD_ACCOUNTS",
+      payload: {
+        allAccounts: [
+          { id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 },
+          { id: "a2", type: "Account", currency: { name: "Bitcoin" }, index: 1 },
+        ],
+        editedNames: new Map([
+          ["a1", "My Renamed BTC"],
+          ["a2", "Bitcoin 2"], // equals default, must be ignored
+        ]),
+      },
+    });
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "My Renamed BTC",
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a2" })).toBeUndefined();
+  });
+
+  it("ADD_ACCOUNTS keeps existing custom names when not re-edited", () => {
+    const store = makeStore();
+    store.dispatch(setAccountName({ accountId: "a1", name: "Kept Name" }));
+    store.dispatch({
+      type: "ADD_ACCOUNTS",
+      payload: {
+        allAccounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map(),
+      },
+    });
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe(
+      "Kept Name",
+    );
+  });
+
+  it("setNamesForAccounts stores edited names that differ from the default", () => {
+    const store = makeStore();
+    store.dispatch(
+      setNamesForAccounts({
+        accounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map([["a1", "Custom"]]),
+      }),
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBe("Custom");
+  });
+
+  it("setNamesForAccounts ignores names equal to the default", () => {
+    const store = makeStore();
+    store.dispatch(
+      setNamesForAccounts({
+        accounts: [{ id: "a1", type: "Account", currency: { name: "Bitcoin" }, index: 0 }],
+        editedNames: new Map([["a1", "Bitcoin 1"]]),
+      }),
+    );
+    expect(accountNameSelector(store.getState().accountNames, { accountId: "a1" })).toBeUndefined();
+  });
+});

--- a/domain/entity/account-name/src/accountName.ts
+++ b/domain/entity/account-name/src/accountName.ts
@@ -1,0 +1,36 @@
+export const MAX_ACCOUNT_NAME_LENGTH = 50;
+
+export type AccountForName = {
+  id: string;
+  type: string;
+  currency?: { name: string };
+  index?: number;
+  token?: { name: string };
+};
+
+export const normalizeName = (name: string): string =>
+  name.replace(/\s+/g, " ").trim().slice(0, MAX_ACCOUNT_NAME_LENGTH);
+
+export const getDefaultAccountNameForCurrencyIndex = ({
+  currency,
+  index,
+}: {
+  currency: { name: string };
+  index: number;
+}): string => `${currency.name} ${index + 1}`;
+
+export const getDefaultAccountName = (account: AccountForName): string => {
+  if (account.type === "Account" && account.currency && account.index !== undefined) {
+    return getDefaultAccountNameForCurrencyIndex({
+      currency: account.currency,
+      index: account.index,
+    });
+  }
+  return account.token?.name ?? account.id;
+};
+
+export const validateNameEdition = (
+  account: AccountForName,
+  name?: string | null | undefined,
+): string =>
+  normalizeName(name || getDefaultAccountName(account) || "").slice(0, MAX_ACCOUNT_NAME_LENGTH);

--- a/domain/entity/account-name/src/cloudSyncModule.ts
+++ b/domain/entity/account-name/src/cloudSyncModule.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import type { CloudSyncDataManager } from "@shared/cloud-sync-module";
+
+const schema = z.record(z.string(), z.string());
+
+function sameDistantState(a: Record<string, string>, b: Record<string, string>) {
+  const aEntries = Object.entries(a);
+  if (aEntries.length !== Object.keys(b).length) return false;
+  for (const [k, v] of aEntries) {
+    if (b[k] !== v) return false;
+  }
+  return true;
+}
+
+export const accountNamesSyncModule: CloudSyncDataManager<
+  Map<string, string>,
+  { replaceAllNames: Record<string, string> },
+  typeof schema
+> = {
+  schema,
+
+  diffLocalToDistant(localData: Map<string, string>, latestState: Record<string, string> | null) {
+    const nextState = Object.fromEntries(localData.entries());
+    const hasChanges = !sameDistantState(latestState ?? {}, nextState);
+    return { hasChanges, nextState };
+  },
+
+  async resolveIncrementalUpdate(
+    localData: Map<string, string>,
+    latestState: Record<string, string> | null,
+    incomingState: Record<string, string> | null,
+  ) {
+    if (!incomingState) return { hasChanges: false as const };
+    const hasChanges =
+      latestState !== incomingState &&
+      !sameDistantState(Object.fromEntries(localData.entries()), incomingState);
+    if (!hasChanges) return { hasChanges: false as const };
+    return { hasChanges: true as const, update: { replaceAllNames: incomingState } };
+  },
+
+  applyUpdate(
+    _localData: Map<string, string>,
+    update: { replaceAllNames: Record<string, string> },
+  ) {
+    return new Map(Object.entries(update.replaceAllNames));
+  },
+};

--- a/domain/entity/account-name/src/index.ts
+++ b/domain/entity/account-name/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./accountName";
+export * from "./selectors";
+export * from "./slice";
+export { bulkSetAccountNames as setAccountNames } from "./slice";
+export * from "./cloudSyncModule";

--- a/domain/entity/account-name/src/selectors.ts
+++ b/domain/entity/account-name/src/selectors.ts
@@ -1,0 +1,14 @@
+import { type AccountNamesState } from "./slice";
+import { getDefaultAccountName, type AccountForName } from "./accountName";
+
+export const initialAccountNamesState: AccountNamesState = new Map();
+
+export const accountNameSelector = (
+  state: AccountNamesState,
+  { accountId }: { accountId: string },
+): string | undefined => state.get(accountId);
+
+export const accountNameWithDefaultSelector = (
+  state: AccountNamesState,
+  account: AccountForName,
+): string => state.get(account.id) || getDefaultAccountName(account);

--- a/domain/entity/account-name/src/slice.ts
+++ b/domain/entity/account-name/src/slice.ts
@@ -1,0 +1,75 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { enableMapSet } from "immer";
+import { getDefaultAccountName, type AccountForName } from "./accountName";
+
+// RTK freezes state through Immer; this slice keeps its names in a Map.
+enableMapSet();
+
+export type AccountNamesState = Map<string, string>;
+
+export const accountNamesSlice = createSlice({
+  name: "accountNames",
+  initialState: new Map<string, string>() as AccountNamesState,
+  reducers: {
+    setAccountName: (
+      state,
+      { payload }: PayloadAction<{ accountId: string; name: string }>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      if (!payload.name) next.delete(payload.accountId);
+      else next.set(payload.accountId, payload.name);
+      return next;
+    },
+    bulkSetAccountNames: (
+      state,
+      { payload }: PayloadAction<Map<string, string>>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      for (const [id, name] of payload) next.set(id, name);
+      return next;
+    },
+    setNamesForAccounts: (
+      state,
+      { payload }: PayloadAction<{ accounts: AccountForName[]; editedNames: Map<string, string> }>,
+    ): AccountNamesState => {
+      const next = new Map(state);
+      for (const account of payload.accounts) {
+        const name = payload.editedNames.get(account.id) || state.get(account.id);
+        if (name && name !== getDefaultAccountName(account)) next.set(account.id, name);
+      }
+      return next;
+    },
+    initFromUserData: (
+      _state,
+      { payload }: PayloadAction<{ id: string; name: string }[]>,
+    ): AccountNamesState => {
+      const next = new Map<string, string>();
+      for (const { id, name } of payload) {
+        if (name) next.set(id, name);
+      }
+      return next;
+    },
+  },
+  extraReducers: builder => {
+    // The app's ADD_ACCOUNTS action carries the full account list; mirror the names it edited.
+    builder.addMatcher(
+      (
+        action,
+      ): action is {
+        type: string;
+        payload: { allAccounts: AccountForName[]; editedNames: Map<string, string> };
+      } => (action as { type: string }).type === "ADD_ACCOUNTS",
+      (state, { payload }): AccountNamesState => {
+        const next = new Map(state);
+        for (const account of payload.allAccounts) {
+          const name = payload.editedNames.get(account.id) || state.get(account.id);
+          if (name && name !== getDefaultAccountName(account)) next.set(account.id, name);
+        }
+        return next;
+      },
+    );
+  },
+});
+
+export const { setAccountName, bulkSetAccountNames, setNamesForAccounts, initFromUserData } =
+  accountNamesSlice.actions;

--- a/domain/entity/account-name/tsconfig.json
+++ b/domain/entity/account-name/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -211,6 +211,9 @@
     "./domain/entity/interest-rate": {
       "entry": ["src/index.ts"]
     },
+    "./domain/entity/account-name": {
+      "entry": ["src/index.ts"]
+    },
     "./domain/api/pay-card": {
       "entry": ["src/index.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3741,6 +3741,40 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/account-name:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      '@shared/cloud-sync-module':
+        specifier: workspace:^
+        version: link:../../../shared/cloud-sync-module
+      immer:
+        specifier: ^11.0.0
+        version: 11.1.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/aggregated-asset:
     devDependencies:
       '@jest/globals':
@@ -14496,7 +14530,7 @@ packages:
   '@apollo/server@4.12.2':
     resolution: {integrity: sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==}
     engines: {node: '>=14.16.0'}
-    deprecated: Apollo Server v4 is end-of-life since January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
+    deprecated: Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.
     peerDependencies:
       graphql: ^16.6.0
 
@@ -23081,7 +23115,7 @@ packages:
       metro-react-native-babel-preset: '*'
       react: 19.1.4
       react-dom: 19.1.4
-      webpack: ^5.89.0
+      webpack: '*'
     peerDependenciesMeta:
       '@react-native/babel-preset':
         optional: true
@@ -25425,7 +25459,7 @@ packages:
     resolution: {integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==}
     engines: {node: '>=6'}
     peerDependencies:
-      rxjs: ^5.5.10
+      rxjs: '*'
       zenObservable: '*'
     peerDependenciesMeta:
       rxjs:
@@ -29575,7 +29609,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -66229,7 +66263,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66353,54 +66387,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -69442,7 +69428,7 @@ snapshots:
   react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       prop-types: 15.8.1
-      qrcode: 1.5.3
+      qrcode: 1.5.4
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -69450,7 +69436,7 @@ snapshots:
   react-native-qrcode-svg@6.1.1(react-native-svg@15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
     dependencies:
       prop-types: 15.8.1
-      qrcode: 1.5.3
+      qrcode: 1.5.4
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)


### PR DESCRIPTION
> [!NOTE]
> This PR incrementally ships the now-validated WalletSync DDD architecture, stacked on top of `@shared/cloud-sync-module` (PR #20308). See parent epic [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990).

### 📝 Description

Introduces `@domain/entity-account-name` — an RTK slice managing account display names (`Map<string, string>`) together with a `CloudSyncDataManager` module (``accountNamesSyncModule`) — a `CloudSyncDataManager` — that drives the accountNames sync slot.

Part of the DDD WalletSync architecture — see epic LIVE-34990.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35275](https://ledgerhq.atlassian.net/browse/LIVE-35275)
- **ADR** (if any): N/A

[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35275]: https://ledgerhq.atlassian.net/browse/LIVE-35275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ