### PR TITLE
feat(ddd): add @domain/entity-recent-addresses package

### DIFF
--- a/domain/entity/recent-addresses/README.md
+++ b/domain/entity/recent-addresses/README.md
@@ -1,0 +1,13 @@
+# @domain/entity-recent-addresses
+
+> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+
+RTK slice and WalletSync module for recently used receive addresses.
+
+State shape: `recentAddresses: RecentAddressesState`. Exports `recentAddressesSlice`, action `updateRecentAddresses` and `recentAddressesSyncModule` — a `CloudSyncDataManager` that syncs recent addresses across devices via `@shared/cloud-sync-module`.
+
+## Related documentation
+
+- [CloudSyncDataManager](../../../docs/ledger-sync/05-wallet-sync-data-manager.md) — module contract and reconciliation
+- [Cookbook: add a module](../../../docs/ledger-sync/cookbook.md) — hands-on guide for new sync modules
+- [App integration](../../../docs/ledger-sync/07-app-integration.md) — how recent addresses are wired in Redux

--- a/domain/entity/recent-addresses/jest.config.js
+++ b/domain/entity/recent-addresses/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/domain/entity/recent-addresses/package.json
+++ b/domain/entity/recent-addresses/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@domain/entity-recent-addresses",
+  "version": "0.0.1",
+  "private": true,
+  "description": "RecentAddresses entity: state types, action creators, and wallet-sync module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage",
+    "unimported": "pnpm knip --directory ../../.. -W domain/entity/recent-addresses"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "catalog:",
+    "@shared/cloud-sync-module": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/domain/entity/recent-addresses/project.json
+++ b/domain/entity/recent-addresses/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@domain/entity-recent-addresses",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/domain/entity/recent-addresses/src/__tests__/cloudSyncModule.test.ts
+++ b/domain/entity/recent-addresses/src/__tests__/cloudSyncModule.test.ts
@@ -1,0 +1,188 @@
+import { recentAddressesSyncModule, recentAddressesSchema } from "../cloudSyncModule";
+import type { RecentAddressesState } from "../schema";
+
+const addr = (address: string, lastUsed = 1000) => ({ address, lastUsed });
+
+describe("recentAddressesSchema", () => {
+  it("parses valid distant state", () => {
+    const input = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    expect(recentAddressesSchema.parse(input)).toEqual(input);
+  });
+
+  it("filters out invalid entries, keeps valid ones", () => {
+    const input = {
+      bitcoin: [{ address: "bc1q", index: 0 }, "invalid", null, { address: "bc1b", index: 1 }],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin).toHaveLength(2);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+    expect(parsed.bitcoin[1].address).toBe("bc1b");
+  });
+
+  it("handles corrupted nested address format", () => {
+    const input = {
+      bitcoin: [{ address: { address: "bc1q", lastUsed: 500 }, index: 0, lastUsed: 600 }],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+    expect(parsed.bitcoin[0].lastUsed).toBe(500);
+  });
+
+  it("handles corrupted nested address format with ensName", () => {
+    const input = {
+      bitcoin: [
+        {
+          address: { address: "bc1q", lastUsed: 500, ensName: "wallet.eth" },
+          index: 0,
+        },
+      ],
+    };
+    const parsed = recentAddressesSchema.parse(input);
+    expect(parsed.bitcoin[0].address).toBe("bc1q");
+  });
+});
+
+describe("recentAddressesSyncModule.diffLocalToDistant", () => {
+  it("returns hasChanges=false for empty local and null distant", () => {
+    const result = recentAddressesSyncModule.diffLocalToDistant({}, null);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toEqual({});
+  });
+
+  it("returns hasChanges=false when local matches distant exactly", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(false);
+    expect(result.nextState).toBe(distant);
+  });
+
+  it("returns hasChanges=true when local has extra address", () => {
+    const local: RecentAddressesState = {
+      bitcoin: [addr("bc1q"), addr("bc1b")],
+    };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState.bitcoin).toHaveLength(2);
+  });
+
+  it("returns hasChanges=true when local has different address", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1DIFFERENT")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local has new currency", () => {
+    const local: RecentAddressesState = {
+      bitcoin: [addr("bc1q")],
+      ethereum: [addr("0x1")],
+    };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when local removed a currency", () => {
+    const local: RecentAddressesState = {};
+    const distant = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("returns hasChanges=true when distant index is out of bounds", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 5 }] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, distant);
+    expect(result.hasChanges).toBe(true);
+  });
+
+  it("serializes lastUsed in nextState", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q", 9999)] };
+    const result = recentAddressesSyncModule.diffLocalToDistant(local, null);
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState.bitcoin[0].lastUsed).toBe(9999);
+  });
+});
+
+describe("recentAddressesSyncModule.resolveIncrementalUpdate", () => {
+  it("returns hasChanges=false when incomingState is null", async () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, null);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false when incoming matches local", async () => {
+    const local: RecentAddressesState = { bitcoin: [addr("bc1q")] };
+    const distant = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(
+      local,
+      distant,
+      distant,
+    );
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=false for identical latestState and incomingState references", async () => {
+    const local: RecentAddressesState = {};
+    const state = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, state, state);
+    expect(result.hasChanges).toBe(false);
+  });
+
+  it("returns hasChanges=true when incoming has new addresses", async () => {
+    const local: RecentAddressesState = {};
+    const incoming = { bitcoin: [{ address: "bc1q", index: 0, lastUsed: 1000 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin).toHaveLength(1);
+      expect(result.update.bitcoin[0].address).toBe("bc1q");
+    }
+  });
+
+  it("sorts addresses by index in update", async () => {
+    const local: RecentAddressesState = {};
+    const incoming = {
+      bitcoin: [
+        { address: "bc1b", index: 1, lastUsed: 2000 },
+        { address: "bc1a", index: 0, lastUsed: 1000 },
+      ],
+    };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin[0].address).toBe("bc1a");
+      expect(result.update.bitcoin[1].address).toBe("bc1b");
+    }
+  });
+
+  it("falls back to Date.now() when lastUsed is undefined", async () => {
+    const before = Date.now();
+    const local: RecentAddressesState = {};
+    const incoming = { bitcoin: [{ address: "bc1q", index: 0 }] };
+    const result = await recentAddressesSyncModule.resolveIncrementalUpdate(local, null, incoming);
+    const after = Date.now();
+    expect(result.hasChanges).toBe(true);
+    if (result.hasChanges) {
+      expect(result.update.bitcoin[0].lastUsed).toBeGreaterThanOrEqual(before);
+      expect(result.update.bitcoin[0].lastUsed).toBeLessThanOrEqual(after);
+    }
+  });
+});
+
+describe("recentAddressesSyncModule.applyUpdate", () => {
+  it("replaces local data with update entirely", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("old")] };
+    const update: RecentAddressesState = { ethereum: [addr("0x1")] };
+    const result = recentAddressesSyncModule.applyUpdate(local, update);
+    expect(result).toBe(update);
+  });
+
+  it("ignores local data", () => {
+    const local: RecentAddressesState = { bitcoin: [addr("should-be-ignored")] };
+    const update: RecentAddressesState = {};
+    expect(recentAddressesSyncModule.applyUpdate(local, update)).toEqual({});
+  });
+});

--- a/domain/entity/recent-addresses/src/__tests__/store.test.ts
+++ b/domain/entity/recent-addresses/src/__tests__/store.test.ts
@@ -1,0 +1,45 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { recentAddressesSlice, updateRecentAddresses } from "../slice";
+import type { RecentAddressesState } from "../schema";
+
+function makeStore() {
+  return configureStore({ reducer: { recentAddresses: recentAddressesSlice.reducer } });
+}
+
+describe("recentAddressesSlice", () => {
+  it("starts empty", () => {
+    const store = makeStore();
+    expect(store.getState().recentAddresses).toEqual({});
+  });
+
+  it("updateRecentAddresses replaces state", () => {
+    const store = makeStore();
+    const payload: RecentAddressesState = {
+      bitcoin: [{ address: "bc1q...", lastUsed: 1000 }],
+    };
+    store.dispatch(updateRecentAddresses(payload));
+    expect(store.getState().recentAddresses).toEqual(payload);
+  });
+
+  it("handles multiple currencies", () => {
+    const store = makeStore();
+    const payload: RecentAddressesState = {
+      ethereum: [{ address: "0x123", lastUsed: 2000 }],
+      bitcoin: [
+        { address: "bc1a...", lastUsed: 1000 },
+        { address: "bc1b...", lastUsed: 1500 },
+      ],
+    };
+    store.dispatch(updateRecentAddresses(payload));
+    expect(store.getState().recentAddresses).toEqual(payload);
+  });
+
+  it("replaces previous state (not merge)", () => {
+    const store = makeStore();
+    store.dispatch(updateRecentAddresses({ bitcoin: [{ address: "bc1q...", lastUsed: 1000 }] }));
+    store.dispatch(updateRecentAddresses({ ethereum: [{ address: "0x123", lastUsed: 2000 }] }));
+    expect(store.getState().recentAddresses).toEqual({
+      ethereum: [{ address: "0x123", lastUsed: 2000 }],
+    });
+  });
+});

--- a/domain/entity/recent-addresses/src/cloudSyncModule.ts
+++ b/domain/entity/recent-addresses/src/cloudSyncModule.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { CloudSyncDataManager } from "@shared/cloud-sync-module";
+import type { RecentAddressesState } from "./schema";
+
+export const CorrectDistantAddressSchema = z.object({
+  address: z.string(),
+  index: z.number(),
+  lastUsed: z.number().optional(),
+});
+
+export const CorruptedNestedDistantAddressSchema = z
+  .object({
+    address: z.object({
+      address: z.string(),
+      lastUsed: z.number().optional(),
+      ensName: z.string().optional(),
+    }),
+    index: z.number(),
+    lastUsed: z.number().optional(),
+  })
+  .transform(entry => ({
+    address: entry.address.address,
+    index: entry.index,
+    lastUsed: entry.address.lastUsed ?? entry.lastUsed,
+  }));
+
+export const RecentAddressSchema = z.union([
+  CorrectDistantAddressSchema,
+  CorruptedNestedDistantAddressSchema,
+]);
+
+export const recentAddressesSchema = z.record(
+  z.string(),
+  z.array(z.unknown()).transform(entries =>
+    entries
+      .map(entry => {
+        const result = RecentAddressSchema.safeParse(entry);
+        return result.success ? result.data : null;
+      })
+      .filter((entry): entry is z.infer<typeof CorrectDistantAddressSchema> => entry !== null),
+  ),
+);
+
+type DistantRecentAddressesState = z.infer<typeof recentAddressesSchema>;
+
+function toDistantState(addressesByCurrency: RecentAddressesState): DistantRecentAddressesState {
+  const state: DistantRecentAddressesState = {};
+  Object.keys(addressesByCurrency).forEach(key => {
+    state[key] = addressesByCurrency[key].map((entry, index) => ({
+      address: entry.address,
+      index,
+      lastUsed: entry.lastUsed,
+    }));
+  });
+  return state;
+}
+
+function toState(addressesByCurrency: DistantRecentAddressesState): RecentAddressesState {
+  const state: RecentAddressesState = {};
+  Object.keys(addressesByCurrency).forEach(key => {
+    state[key] = [...addressesByCurrency[key]]
+      .sort((current, other) => current.index - other.index)
+      .map(data => ({ address: data.address, lastUsed: data.lastUsed ?? Date.now() }));
+  });
+  return state;
+}
+
+function sameDistantState(
+  localData: RecentAddressesState,
+  distantState: DistantRecentAddressesState,
+) {
+  const localDataKeys = Object.keys(localData);
+  const distantStateKeys = Object.keys(distantState);
+  return (
+    localDataKeys.length === distantStateKeys.length &&
+    distantStateKeys.every(key => {
+      return (
+        localData[key] &&
+        localData[key].length === distantState[key].length &&
+        !distantState[key].some(data => {
+          if (data.index < 0 || data.index >= localData[key].length) return true;
+          return localData[key][data.index].address !== data.address;
+        })
+      );
+    })
+  );
+}
+
+export const recentAddressesSyncModule: CloudSyncDataManager<
+  RecentAddressesState,
+  RecentAddressesState,
+  typeof recentAddressesSchema
+> = {
+  schema: recentAddressesSchema,
+
+  diffLocalToDistant(
+    localData: RecentAddressesState,
+    latestState: DistantRecentAddressesState | null,
+  ) {
+    if (!sameDistantState(localData, latestState ?? {})) {
+      return { hasChanges: true as const, nextState: toDistantState(localData) };
+    }
+    return { hasChanges: false as const, nextState: latestState ?? {} };
+  },
+
+  async resolveIncrementalUpdate(
+    localData: RecentAddressesState,
+    latestState: DistantRecentAddressesState | null,
+    incomingState: DistantRecentAddressesState | null,
+  ) {
+    if (!incomingState) return { hasChanges: false as const };
+    if (latestState === incomingState || sameDistantState(localData, incomingState)) {
+      return { hasChanges: false as const };
+    }
+    return { hasChanges: true as const, update: toState(incomingState) };
+  },
+
+  applyUpdate(_localData: RecentAddressesState, update: RecentAddressesState) {
+    return update;
+  },
+};

--- a/domain/entity/recent-addresses/src/index.ts
+++ b/domain/entity/recent-addresses/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema";
+export * from "./slice";
+export * from "./cloudSyncModule";

--- a/domain/entity/recent-addresses/src/schema.ts
+++ b/domain/entity/recent-addresses/src/schema.ts
@@ -1,0 +1,4 @@
+export type RecentAddress = { address: string; lastUsed: number };
+export type RecentAddressesState = Record<string, RecentAddress[]>;
+
+export const initialRecentAddressesState: RecentAddressesState = {};

--- a/domain/entity/recent-addresses/src/slice.ts
+++ b/domain/entity/recent-addresses/src/slice.ts
@@ -1,0 +1,15 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { initialRecentAddressesState, type RecentAddressesState } from "./schema";
+
+export const recentAddressesSlice = createSlice({
+  name: "recentAddresses",
+  initialState: initialRecentAddressesState,
+  reducers: {
+    updateRecentAddresses: (
+      _state,
+      { payload }: PayloadAction<RecentAddressesState>,
+    ): RecentAddressesState => payload,
+  },
+});
+
+export const { updateRecentAddresses } = recentAddressesSlice.actions;

--- a/domain/entity/recent-addresses/tsconfig.json
+++ b/domain/entity/recent-addresses/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["jest"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/knip.json
+++ b/knip.json
@@ -214,6 +214,9 @@
     "./domain/entity/account-name": {
       "entry": ["src/index.ts"]
     },
+    "./domain/entity/recent-addresses": {
+      "entry": ["src/index.ts"]
+    },
     "./domain/api/pay-card": {
       "entry": ["src/index.ts"]
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4156,6 +4156,34 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  domain/entity/recent-addresses:
+    dependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
+      '@shared/cloud-sync-module':
+        specifier: workspace:^
+        version: link:../../../shared/cloud-sync-module
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   domain/entity/starred-account:
     dependencies:
       '@reduxjs/toolkit':


### PR DESCRIPTION
> [!NOTE]
> This PR incrementally ships the now-validated WalletSync DDD architecture, stacked on top of `@shared/cloud-sync-module` (PR #20308). See parent epic [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990).

### 📝 Description

Introduces `@domain/entity-recent-addresses` — an RTK slice for recently used receive addresses with a `CloudSyncDataManager` module (`recentAddressesSyncModule`) driving the recentAddresses sync slot. Handles schema evolution and corrupted nested-format recovery.

Part of the DDD WalletSync architecture — see epic LIVE-34990.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35276](https://ledgerhq.atlassian.net/browse/LIVE-35276)
- **ADR** (if any): N/A

[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35276]: https://ledgerhq.atlassian.net/browse/LIVE-35276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ