### PR TITLE
[LWDM] feat(zcash): add optimistic note reservation [LIVE-34949]

### DIFF
--- a/.changeset/wet-bags-fold.md
+++ b/.changeset/wet-bags-fold.md
@@ -2,4 +2,4 @@
 "@ledgerhq/coin-zcash": minor
 ---
 
-Add optimistic note reservation for Zcash Ironwood shielded sends, released when the operation spending the notes is confirmed or retired
+Add optimistic note reservation for Zcash Ironwood shielded sends, released when the operation spending the notes is confirmed or retired, and carried across a restart by the nullifiers recorded on the pending operation

--- a/.changeset/wet-bags-fold.md
+++ b/.changeset/wet-bags-fold.md
@@ -2,4 +2,4 @@
 "@ledgerhq/coin-zcash": minor
 ---
 
-Add optimistic note reservation for Zcash Ironwood shielded sends
+Add optimistic note reservation for Zcash Ironwood shielded sends, released when the operation spending the notes is confirmed or retired

--- a/.changeset/wet-bags-fold.md
+++ b/.changeset/wet-bags-fold.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": minor
+---
+
+Add optimistic note reservation for Zcash Ironwood shielded sends

--- a/libs/coin-modules/coin-zcash/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/broadcast.test.ts
@@ -7,6 +7,7 @@ import type { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { broadcast } from "./broadcast";
 import { getWalletAccount } from "./getWalletAccount";
 import { broadcast as broadcastLogic } from "../logic/transaction/broadcast";
+import { reserveNotes, getReservedNullifiers, _resetReservationsForTest } from "./note-reservation";
 import type { ZcashAccount, ZcashOperationExtra } from "../types/bridge";
 
 jest.mock("./getWalletAccount");
@@ -22,17 +23,18 @@ const TX_HEX = "05" + "00".repeat(63);
 const fetchUtxoTx = jest.fn();
 const account = { id: "js:2:zcash:xpub:", currency: { id: "zcash" } } as unknown as ZcashAccount;
 
-const submit = (extra: ZcashOperationExtra) =>
+const submit = (extra: ZcashOperationExtra, hash = "") =>
   broadcast({
     account,
     signedOperation: {
       signature: TX_HEX,
-      operation: { id: "op1", hash: "", extra } as unknown as Operation,
+      operation: { id: "op1", hash, extra } as unknown as Operation,
     } as SignedOperation,
   });
 
 beforeEach(() => {
   jest.clearAllMocks();
+  _resetReservationsForTest();
   mockBroadcastLogic.mockResolvedValue(TXID);
   mockGetWalletAccount.mockReturnValue({
     xpub: { explorer: { fetchUtxoTx } },
@@ -66,5 +68,28 @@ describe("broadcast", () => {
 
     expect(mockBroadcastLogic).toHaveBeenCalledWith(TX_HEX, undefined);
     expect(mockGetWalletAccount).not.toHaveBeenCalled();
+  });
+
+  // Signing reserves the notes it spends. A send that never reached the network
+  // cannot spend them, and the user is about to retry with those very notes.
+  describe("note reservations", () => {
+    const NULLIFIER = "11".repeat(32);
+
+    it("hands the reserved notes back when the send does not go out", async () => {
+      reserveNotes(account.id, TXID, [NULLIFIER]);
+      mockBroadcastLogic.mockRejectedValue(new Error("network down"));
+
+      await expect(submit({ zcashShielded: true }, TXID)).rejects.toThrow("network down");
+
+      expect(getReservedNullifiers(account.id).size).toBe(0);
+    });
+
+    it("keeps them reserved once the send is out", async () => {
+      reserveNotes(account.id, TXID, [NULLIFIER]);
+
+      await submit({ zcashShielded: true }, TXID);
+
+      expect(getReservedNullifiers(account.id).has(NULLIFIER)).toBe(true);
+    });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/broadcast.test.ts
@@ -7,7 +7,11 @@ import type { Operation, SignedOperation } from "@ledgerhq/types-live";
 import { broadcast } from "./broadcast";
 import { getWalletAccount } from "./getWalletAccount";
 import { broadcast as broadcastLogic } from "../logic/transaction/broadcast";
-import { reserveNotes, getReservedNullifiers, _resetReservationsForTest } from "./note-reservation";
+import {
+  reserveNotes,
+  getSessionReservedNullifiers,
+  _resetReservationsForTest,
+} from "./note-reservation";
 import type { ZcashAccount, ZcashOperationExtra } from "../types/bridge";
 
 jest.mock("./getWalletAccount");
@@ -81,7 +85,7 @@ describe("broadcast", () => {
 
       await expect(submit({ zcashShielded: true }, TXID)).rejects.toThrow("network down");
 
-      expect(getReservedNullifiers(account.id).size).toBe(0);
+      expect(getSessionReservedNullifiers(account.id).size).toBe(0);
     });
 
     it("keeps them reserved once the send is out", async () => {
@@ -89,7 +93,7 @@ describe("broadcast", () => {
 
       await submit({ zcashShielded: true }, TXID);
 
-      expect(getReservedNullifiers(account.id).has(NULLIFIER)).toBe(true);
+      expect(getSessionReservedNullifiers(account.id).has(NULLIFIER)).toBe(true);
     });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/broadcast.ts
@@ -3,6 +3,7 @@ import type { AccountBridge } from "@ledgerhq/types-live";
 import type { BtcOperationExtra, Transaction, ZcashAccount } from "../types/bridge";
 import { getWalletAccount } from "./getWalletAccount";
 import { broadcast as broadcastLogic } from "../logic/transaction/broadcast";
+import { releaseReservation } from "./note-reservation";
 
 /**
  * Every Zcash send (including t→t) is broadcast over the Zaino gRPC endpoint
@@ -13,6 +14,10 @@ import { broadcast as broadcastLogic } from "../logic/transaction/broadcast";
  * What the bridge adds is the context for the double-spend guard that
  * `logic/transaction/broadcast.ts` runs: the outpoints the signing recorded on
  * the operation, and the account's explorer to check them against.
+ *
+ * A send that does not reach the network cannot spend the notes signing reserved
+ * for it, and the user is expected to retry with those very notes, so a failure
+ * hands them back instead of waiting for the reservation to age out.
  */
 export const broadcast: AccountBridge<Transaction, ZcashAccount>["broadcast"] = async ({
   account,
@@ -20,15 +25,21 @@ export const broadcast: AccountBridge<Transaction, ZcashAccount>["broadcast"] = 
 }) => {
   const inputRefs = (operation.extra as BtcOperationExtra | undefined)?.inputRefs ?? [];
 
-  const txid = await broadcastLogic(
-    signature,
-    inputRefs.length > 0
-      ? {
-          inputRefs,
-          fetchUtxoTx: hash => getWalletAccount(account).xpub.explorer.fetchUtxoTx(hash),
-        }
-      : undefined,
-  );
+  let txid: string;
+  try {
+    txid = await broadcastLogic(
+      signature,
+      inputRefs.length > 0
+        ? {
+            inputRefs,
+            fetchUtxoTx: hash => getWalletAccount(account).xpub.explorer.fetchUtxoTx(hash),
+          }
+        : undefined,
+    );
+  } catch (error) {
+    releaseReservation(account.id, operation.hash);
+    throw error;
+  }
 
   return patchOperationWithHash(operation, txid);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
@@ -7,6 +7,7 @@ import {
   estimateMaxSpendableTransparent,
 } from "../logic/coin-selection";
 import { isTransparentInputTransfer, resolveTransparentUtxos } from "./statusHelpers";
+import { getReservedNullifiers } from "./note-reservation";
 
 export const estimateMaxSpendable: AccountBridge<
   Transaction,
@@ -28,6 +29,8 @@ export const estimateMaxSpendable: AccountBridge<
   }
 
   const transactions = mainAccount.privateInfo?.transactions ?? [];
-  const notes = collectIronwoodSpendableNotes(transactions);
+  const allNotes = collectIronwoodSpendableNotes(transactions);
+  const reserved = getReservedNullifiers(mainAccount.id);
+  const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
   return estimateMaxSpendableAmount(notes, transferType);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/estimateMaxSpendable.ts
@@ -30,7 +30,7 @@ export const estimateMaxSpendable: AccountBridge<
 
   const transactions = mainAccount.privateInfo?.transactions ?? [];
   const allNotes = collectIronwoodSpendableNotes(transactions);
-  const reserved = getReservedNullifiers(mainAccount.id);
+  const reserved = getReservedNullifiers(mainAccount);
   const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
   return estimateMaxSpendableAmount(notes, transferType);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
@@ -6,6 +6,7 @@ import {
   releaseRetiredReservations,
   releaseReservation,
   getReservedNullifiers,
+  getSessionReservedNullifiers,
   _resetReservationsForTest,
 } from "./note-reservation";
 import { selectNotes, estimateMaxSpendableAmount } from "../logic/coin-selection";
@@ -35,6 +36,11 @@ function makeNote(overrides: Partial<SpendableNote> & { amount: BigNumber }): Sp
   };
 }
 
+/** The optimistic operation a signed shielded send leaves on the account. */
+const pendingOperation = (shieldedNullifiers: string[]) => ({
+  extra: { zcashShielded: true, shieldedNullifiers },
+});
+
 beforeEach(() => {
   _resetReservationsForTest();
 });
@@ -42,7 +48,7 @@ beforeEach(() => {
 describe("reserveNotes", () => {
   it("adds nullifiers to the store for the given account", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(true);
     expect(reserved.has(NF2)).toBe(true);
   });
@@ -50,7 +56,7 @@ describe("reserveNotes", () => {
   it("unions with what the same operation already holds — does not overwrite", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_A, OP_1, [NF2]);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(true);
     expect(reserved.has(NF2)).toBe(true);
   });
@@ -58,21 +64,82 @@ describe("reserveNotes", () => {
   it("holds the reservations of two operations in flight at once", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_A, OP_2, [NF2]);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(true);
     expect(reserved.has(NF2)).toBe(true);
   });
 
   it("is a no-op for an empty nullifier array", () => {
     reserveNotes(ACCOUNT_A, OP_1, []);
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 });
 
-describe("getReservedNullifiers", () => {
+describe("getSessionReservedNullifiers", () => {
   it("returns an empty Set for an unknown account", () => {
-    const reserved = getReservedNullifiers("no-such-account");
+    const reserved = getSessionReservedNullifiers("no-such-account");
     expect(reserved.size).toBe(0);
+  });
+});
+
+// The persisted half of a reservation. A spend signed and broadcast in a session
+// that ended before it confirmed leaves nothing in the store, and its notes must
+// still not be selectable — the optimistic operation is what carries them over.
+describe("getReservedNullifiers", () => {
+  it("holds the notes of a pending operation with nothing reserved in this session", () => {
+    const account = { id: ACCOUNT_A, pendingOperations: [pendingOperation([NF1, NF2])] };
+    const reserved = getReservedNullifiers(account);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("unions the session's reservations with the pending operations'", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    const account = { id: ACCOUNT_A, pendingOperations: [pendingOperation([NF2])] };
+    const reserved = getReservedNullifiers(account);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("counts a nullifier held by both sources once", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    const account = { id: ACCOUNT_A, pendingOperations: [pendingOperation([NF1])] };
+    expect(getReservedNullifiers(account).size).toBe(1);
+  });
+
+  it("reads every pending operation, not just the first", () => {
+    const account = {
+      id: ACCOUNT_A,
+      pendingOperations: [pendingOperation([NF1]), pendingOperation([NF2, NF3])],
+    };
+    expect(getReservedNullifiers(account).size).toBe(3);
+  });
+
+  it("ignores an extra that carries no shielded nullifier list", () => {
+    const account = {
+      id: ACCOUNT_A,
+      pendingOperations: [
+        { extra: undefined },
+        { extra: null },
+        { extra: {} },
+        { extra: { inputs: ["some-hash-0"] } },
+        { extra: "not-an-object" },
+        { extra: { shieldedNullifiers: "not-an-array" } },
+        { extra: { shieldedNullifiers: [NF1, 42, null] } },
+      ],
+    };
+    expect([...getReservedNullifiers(account)]).toEqual([NF1]);
+  });
+
+  it("holds nothing for an account with no pending operations", () => {
+    expect(getReservedNullifiers({ id: ACCOUNT_A, pendingOperations: [] }).size).toBe(0);
+    expect(getReservedNullifiers({ id: ACCOUNT_A }).size).toBe(0);
+  });
+
+  it("does not read another account's pending operations", () => {
+    reserveNotes(ACCOUNT_B, OP_1, [NF3]);
+    const account = { id: ACCOUNT_A, pendingOperations: [pendingOperation([NF1])] };
+    expect(getReservedNullifiers(account).has(NF3)).toBe(false);
   });
 });
 
@@ -80,7 +147,7 @@ describe("releaseConfirmedNullifiers", () => {
   it("removes the nullifiers the scan reported spent", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2, NF3]);
     releaseConfirmedNullifiers(ACCOUNT_A, [NF1]);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(false);
     expect(reserved.has(NF2)).toBe(true);
     expect(reserved.has(NF3)).toBe(true);
@@ -90,13 +157,13 @@ describe("releaseConfirmedNullifiers", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_A, OP_2, [NF2]);
     releaseConfirmedNullifiers(ACCOUNT_A, [NF1, NF2]);
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 
   it("keeps everything when the scan reported nothing spent", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
     releaseConfirmedNullifiers(ACCOUNT_A, []);
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(2);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(2);
   });
 
   it("is a no-op on an unknown account (no throw)", () => {
@@ -107,8 +174,8 @@ describe("releaseConfirmedNullifiers", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_B, OP_1, [NF1]);
     releaseConfirmedNullifiers(ACCOUNT_A, [NF1]);
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
-    expect(getReservedNullifiers(ACCOUNT_B).has(NF1)).toBe(true);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_B).has(NF1)).toBe(true);
   });
 });
 
@@ -116,14 +183,14 @@ describe("releaseRetiredReservations", () => {
   it("releases the reservation of an operation that has confirmed", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 
   it("leaves the operations still in flight reserved", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_A, OP_2, [NF2]);
     releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(false);
     expect(reserved.has(NF2)).toBe(true);
   });
@@ -133,13 +200,13 @@ describe("releaseRetiredReservations", () => {
   it("holds a reservation no confirmed operation accounts for", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
     releaseRetiredReservations(ACCOUNT_A, new Set(["some-other-transaction"]));
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(2);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(2);
   });
 
   it("holds a reservation right up to the end of the optimistic window", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION - 1);
-    expect(getReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
   });
 
   // Past that window Ledger Wallet drops the optimistic operation itself, so a
@@ -147,7 +214,7 @@ describe("releaseRetiredReservations", () => {
   it("releases a reservation that outlived the optimistic window", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION + 1);
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 
   it("is a no-op on an unknown account (no throw)", () => {
@@ -158,8 +225,8 @@ describe("releaseRetiredReservations", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_B, OP_1, [NF2]);
     releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
-    expect(getReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(true);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(true);
   });
 });
 
@@ -168,7 +235,7 @@ describe("releaseReservation", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_A, OP_2, [NF2]);
     releaseReservation(ACCOUNT_A, OP_1);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(false);
     expect(reserved.has(NF2)).toBe(true);
   });
@@ -177,7 +244,7 @@ describe("releaseReservation", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     releaseReservation(ACCOUNT_A, "no-such-operation");
     releaseReservation("no-such-account", OP_1);
-    expect(getReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
   });
 });
 
@@ -186,8 +253,8 @@ describe("_resetReservationsForTest", () => {
     reserveNotes(ACCOUNT_A, OP_1, [NF1]);
     reserveNotes(ACCOUNT_B, OP_1, [NF2]);
     _resetReservationsForTest();
-    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
-    expect(getReservedNullifiers(ACCOUNT_B).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getSessionReservedNullifiers(ACCOUNT_B).size).toBe(0);
   });
 });
 
@@ -224,7 +291,7 @@ describe("reservation filtering", () => {
     reserveNotes(ACCOUNT_ID, OP_1, firstNullifiers);
 
     // Second send: filter reserved notes, then select
-    const reserved = getReservedNullifiers(ACCOUNT_ID);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_ID);
     const filtered = allNotes.filter(n => !reserved.has(n.nullifier));
     const second = selectNotes(filtered, new BigNumber(500_000), "shielded");
     expect(second).not.toBeUndefined();
@@ -245,7 +312,7 @@ describe("reservation filtering", () => {
 
     reserveNotes(ACCOUNT_ID, OP_1, [note.nullifier]);
 
-    const reserved = getReservedNullifiers(ACCOUNT_ID);
+    const reserved = getSessionReservedNullifiers(ACCOUNT_ID);
     const filtered = [note].filter(n => !reserved.has(n.nullifier));
 
     // Filtered set is empty — selectNotes returns undefined
@@ -265,7 +332,7 @@ describe("reservation filtering", () => {
     reserveNotes(ACCOUNT_ID, OP_1, [note.nullifier]);
 
     // Verify reserved before reset
-    expect(getReservedNullifiers(ACCOUNT_ID).has(note.nullifier)).toBe(true);
+    expect(getSessionReservedNullifiers(ACCOUNT_ID).has(note.nullifier)).toBe(true);
 
     _resetReservationsForTest();
 

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
@@ -1,7 +1,10 @@
 import BigNumber from "bignumber.js";
+import { getEnv } from "@ledgerhq/live-env";
 import {
   reserveNotes,
-  reconcileReservations,
+  releaseConfirmedNullifiers,
+  releaseRetiredReservations,
+  releaseReservation,
   getReservedNullifiers,
   _resetReservationsForTest,
 } from "./note-reservation";
@@ -10,9 +13,13 @@ import type { SpendableNote } from "../network/types";
 
 const ACCOUNT_A = "account-a";
 const ACCOUNT_B = "account-b";
+const OP_1 = "76ec3b38";
+const OP_2 = "91ba4c07";
 const NF1 = "nf1111";
 const NF2 = "nf2222";
 const NF3 = "nf3333";
+
+const RETENTION = getEnv("OPERATION_OPTIMISTIC_RETENTION");
 
 function makeNote(overrides: Partial<SpendableNote> & { amount: BigNumber }): SpendableNote {
   return {
@@ -34,22 +41,30 @@ beforeEach(() => {
 
 describe("reserveNotes", () => {
   it("adds nullifiers to the store for the given account", () => {
-    reserveNotes(ACCOUNT_A, [NF1, NF2]);
+    reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
     const reserved = getReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(true);
     expect(reserved.has(NF2)).toBe(true);
   });
 
-  it("unions with the existing set on a second call — does not overwrite", () => {
-    reserveNotes(ACCOUNT_A, [NF1]);
-    reserveNotes(ACCOUNT_A, [NF2]);
+  it("unions with what the same operation already holds — does not overwrite", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_A, OP_1, [NF2]);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("holds the reservations of two operations in flight at once", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_A, OP_2, [NF2]);
     const reserved = getReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(true);
     expect(reserved.has(NF2)).toBe(true);
   });
 
   it("is a no-op for an empty nullifier array", () => {
-    reserveNotes(ACCOUNT_A, []);
+    reserveNotes(ACCOUNT_A, OP_1, []);
     expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 });
@@ -61,59 +76,115 @@ describe("getReservedNullifiers", () => {
   });
 });
 
-describe("reconcileReservations", () => {
-  it("removes confirmed-spent nullifiers from the store", () => {
-    reserveNotes(ACCOUNT_A, [NF1, NF2, NF3]);
-    reconcileReservations(ACCOUNT_A, [NF1], false);
+describe("releaseConfirmedNullifiers", () => {
+  it("removes the nullifiers the scan reported spent", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2, NF3]);
+    releaseConfirmedNullifiers(ACCOUNT_A, [NF1]);
     const reserved = getReservedNullifiers(ACCOUNT_A);
     expect(reserved.has(NF1)).toBe(false);
     expect(reserved.has(NF2)).toBe(true);
     expect(reserved.has(NF3)).toBe(true);
   });
 
-  it("with syncComplete=false does NOT clear unconfirmed reservations", () => {
-    reserveNotes(ACCOUNT_A, [NF1, NF2]);
-    reconcileReservations(ACCOUNT_A, [], false);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
-    expect(reserved.has(NF1)).toBe(true);
-    expect(reserved.has(NF2)).toBe(true);
+  it("reaches the nullifiers of every operation in flight", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_A, OP_2, [NF2]);
+    releaseConfirmedNullifiers(ACCOUNT_A, [NF1, NF2]);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
   });
 
-  it("with syncComplete=true clears ALL remaining reservations for the account", () => {
-    reserveNotes(ACCOUNT_A, [NF1, NF2, NF3]);
-    // NF1 is confirmed-spent; NF2 and NF3 were never broadcast or rejected
-    reconcileReservations(ACCOUNT_A, [NF1], true);
-    const reserved = getReservedNullifiers(ACCOUNT_A);
-    expect(reserved.size).toBe(0);
+  it("keeps everything when the scan reported nothing spent", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
+    releaseConfirmedNullifiers(ACCOUNT_A, []);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(2);
   });
 
   it("is a no-op on an unknown account (no throw)", () => {
-    expect(() => reconcileReservations("no-such-account", [NF1], true)).not.toThrow();
+    expect(() => releaseConfirmedNullifiers("no-such-account", [NF1])).not.toThrow();
   });
 
-  it("isolates accounts — reconciling account A does not affect account B", () => {
-    reserveNotes(ACCOUNT_A, [NF1]);
-    reserveNotes(ACCOUNT_B, [NF2]);
-    reconcileReservations(ACCOUNT_A, [NF1], true);
+  it("isolates accounts", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_B, OP_1, [NF1]);
+    releaseConfirmedNullifiers(ACCOUNT_A, [NF1]);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getReservedNullifiers(ACCOUNT_B).has(NF1)).toBe(true);
+  });
+});
+
+describe("releaseRetiredReservations", () => {
+  it("releases the reservation of an operation that has confirmed", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+  });
+
+  it("leaves the operations still in flight reserved", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_A, OP_2, [NF2]);
+    releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(false);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  // The premature release this store exists to avoid: a send is signed, a sync
+  // runs and confirms nothing about it, and its notes must stay off the table.
+  it("holds a reservation no confirmed operation accounts for", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1, NF2]);
+    releaseRetiredReservations(ACCOUNT_A, new Set(["some-other-transaction"]));
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(2);
+  });
+
+  it("holds a reservation right up to the end of the optimistic window", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION - 1);
+    expect(getReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
+  });
+
+  // Past that window Ledger Wallet drops the optimistic operation itself, so a
+  // broadcast that never confirmed stops holding notes at the same moment.
+  it("releases a reservation that outlived the optimistic window", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    releaseRetiredReservations(ACCOUNT_A, new Set(), Date.now() + RETENTION + 1);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+  });
+
+  it("is a no-op on an unknown account (no throw)", () => {
+    expect(() => releaseRetiredReservations("no-such-account", new Set([OP_1]))).not.toThrow();
+  });
+
+  it("isolates accounts — retiring account A's operation leaves account B alone", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_B, OP_1, [NF2]);
+    releaseRetiredReservations(ACCOUNT_A, new Set([OP_1]));
     expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
     expect(getReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(true);
   });
 });
 
-describe("account isolation", () => {
-  it("reservations for account A do not appear in account B's set", () => {
-    reserveNotes(ACCOUNT_A, [NF1, NF2]);
-    reserveNotes(ACCOUNT_B, [NF3]);
-    expect(getReservedNullifiers(ACCOUNT_A).has(NF3)).toBe(false);
-    expect(getReservedNullifiers(ACCOUNT_B).has(NF1)).toBe(false);
-    expect(getReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(false);
+describe("releaseReservation", () => {
+  it("hands back the notes of the operation named, and only those", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_A, OP_2, [NF2]);
+    releaseReservation(ACCOUNT_A, OP_1);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(false);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("is a no-op for an operation or account it holds nothing for", () => {
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    releaseReservation(ACCOUNT_A, "no-such-operation");
+    releaseReservation("no-such-account", OP_1);
+    expect(getReservedNullifiers(ACCOUNT_A).has(NF1)).toBe(true);
   });
 });
 
 describe("_resetReservationsForTest", () => {
   it("empties all state — getReservedNullifiers returns empty after reset", () => {
-    reserveNotes(ACCOUNT_A, [NF1]);
-    reserveNotes(ACCOUNT_B, [NF2]);
+    reserveNotes(ACCOUNT_A, OP_1, [NF1]);
+    reserveNotes(ACCOUNT_B, OP_1, [NF2]);
     _resetReservationsForTest();
     expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
     expect(getReservedNullifiers(ACCOUNT_B).size).toBe(0);
@@ -150,7 +221,7 @@ describe("reservation filtering", () => {
     const firstNullifiers = first!.selectedNotes.map(n => n.nullifier);
 
     // Reserve the first selection
-    reserveNotes(ACCOUNT_ID, firstNullifiers);
+    reserveNotes(ACCOUNT_ID, OP_1, firstNullifiers);
 
     // Second send: filter reserved notes, then select
     const reserved = getReservedNullifiers(ACCOUNT_ID);
@@ -172,7 +243,7 @@ describe("reservation filtering", () => {
       amount: new BigNumber(600_000),
     });
 
-    reserveNotes(ACCOUNT_ID, [note.nullifier]);
+    reserveNotes(ACCOUNT_ID, OP_1, [note.nullifier]);
 
     const reserved = getReservedNullifiers(ACCOUNT_ID);
     const filtered = [note].filter(n => !reserved.has(n.nullifier));
@@ -191,7 +262,7 @@ describe("reservation filtering", () => {
       amount: new BigNumber(600_000),
     });
 
-    reserveNotes(ACCOUNT_ID, [note.nullifier]);
+    reserveNotes(ACCOUNT_ID, OP_1, [note.nullifier]);
 
     // Verify reserved before reset
     expect(getReservedNullifiers(ACCOUNT_ID).has(note.nullifier)).toBe(true);

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.test.ts
@@ -1,0 +1,206 @@
+import BigNumber from "bignumber.js";
+import {
+  reserveNotes,
+  reconcileReservations,
+  getReservedNullifiers,
+  _resetReservationsForTest,
+} from "./note-reservation";
+import { selectNotes, estimateMaxSpendableAmount } from "../logic/coin-selection";
+import type { SpendableNote } from "../network/types";
+
+const ACCOUNT_A = "account-a";
+const ACCOUNT_B = "account-b";
+const NF1 = "nf1111";
+const NF2 = "nf2222";
+const NF3 = "nf3333";
+
+function makeNote(overrides: Partial<SpendableNote> & { amount: BigNumber }): SpendableNote {
+  return {
+    txid: "tx1",
+    outputIndex: 0,
+    nullifier: "aa".repeat(32),
+    rho: "ee".repeat(32),
+    rseed: "bb".repeat(32),
+    cmx: "cc".repeat(32),
+    position: "0",
+    recipient: "dd".repeat(43),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  _resetReservationsForTest();
+});
+
+describe("reserveNotes", () => {
+  it("adds nullifiers to the store for the given account", () => {
+    reserveNotes(ACCOUNT_A, [NF1, NF2]);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("unions with the existing set on a second call — does not overwrite", () => {
+    reserveNotes(ACCOUNT_A, [NF1]);
+    reserveNotes(ACCOUNT_A, [NF2]);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("is a no-op for an empty nullifier array", () => {
+    reserveNotes(ACCOUNT_A, []);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+  });
+});
+
+describe("getReservedNullifiers", () => {
+  it("returns an empty Set for an unknown account", () => {
+    const reserved = getReservedNullifiers("no-such-account");
+    expect(reserved.size).toBe(0);
+  });
+});
+
+describe("reconcileReservations", () => {
+  it("removes confirmed-spent nullifiers from the store", () => {
+    reserveNotes(ACCOUNT_A, [NF1, NF2, NF3]);
+    reconcileReservations(ACCOUNT_A, [NF1], false);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(false);
+    expect(reserved.has(NF2)).toBe(true);
+    expect(reserved.has(NF3)).toBe(true);
+  });
+
+  it("with syncComplete=false does NOT clear unconfirmed reservations", () => {
+    reserveNotes(ACCOUNT_A, [NF1, NF2]);
+    reconcileReservations(ACCOUNT_A, [], false);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.has(NF1)).toBe(true);
+    expect(reserved.has(NF2)).toBe(true);
+  });
+
+  it("with syncComplete=true clears ALL remaining reservations for the account", () => {
+    reserveNotes(ACCOUNT_A, [NF1, NF2, NF3]);
+    // NF1 is confirmed-spent; NF2 and NF3 were never broadcast or rejected
+    reconcileReservations(ACCOUNT_A, [NF1], true);
+    const reserved = getReservedNullifiers(ACCOUNT_A);
+    expect(reserved.size).toBe(0);
+  });
+
+  it("is a no-op on an unknown account (no throw)", () => {
+    expect(() => reconcileReservations("no-such-account", [NF1], true)).not.toThrow();
+  });
+
+  it("isolates accounts — reconciling account A does not affect account B", () => {
+    reserveNotes(ACCOUNT_A, [NF1]);
+    reserveNotes(ACCOUNT_B, [NF2]);
+    reconcileReservations(ACCOUNT_A, [NF1], true);
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(true);
+  });
+});
+
+describe("account isolation", () => {
+  it("reservations for account A do not appear in account B's set", () => {
+    reserveNotes(ACCOUNT_A, [NF1, NF2]);
+    reserveNotes(ACCOUNT_B, [NF3]);
+    expect(getReservedNullifiers(ACCOUNT_A).has(NF3)).toBe(false);
+    expect(getReservedNullifiers(ACCOUNT_B).has(NF1)).toBe(false);
+    expect(getReservedNullifiers(ACCOUNT_B).has(NF2)).toBe(false);
+  });
+});
+
+describe("_resetReservationsForTest", () => {
+  it("empties all state — getReservedNullifiers returns empty after reset", () => {
+    reserveNotes(ACCOUNT_A, [NF1]);
+    reserveNotes(ACCOUNT_B, [NF2]);
+    _resetReservationsForTest();
+    expect(getReservedNullifiers(ACCOUNT_A).size).toBe(0);
+    expect(getReservedNullifiers(ACCOUNT_B).size).toBe(0);
+  });
+});
+
+// ── reservation filtering ──────────────────────────────────────────────
+//
+// The bridge (prepareTransaction / estimateMaxSpendable) filters the reserved
+// nullifiers out of the spendable-note set before selection. These tests
+// exercise that combination against the ZIP-317 selector.
+
+describe("reservation filtering", () => {
+  const ACCOUNT_ID = "account-filtering-test";
+
+  it("two back-to-back sends select disjoint note sets when notes >= 2 × amount", () => {
+    const note1 = makeNote({
+      txid: "tx1",
+      outputIndex: 0,
+      nullifier: "aa".repeat(32),
+      amount: new BigNumber(600_000),
+    });
+    const note2 = makeNote({
+      txid: "tx2",
+      outputIndex: 0,
+      nullifier: "bb".repeat(32),
+      amount: new BigNumber(600_000),
+    });
+    const allNotes = [note1, note2];
+
+    // First send: select notes for 500_000
+    const first = selectNotes(allNotes, new BigNumber(500_000), "shielded");
+    expect(first).not.toBeUndefined();
+    const firstNullifiers = first!.selectedNotes.map(n => n.nullifier);
+
+    // Reserve the first selection
+    reserveNotes(ACCOUNT_ID, firstNullifiers);
+
+    // Second send: filter reserved notes, then select
+    const reserved = getReservedNullifiers(ACCOUNT_ID);
+    const filtered = allNotes.filter(n => !reserved.has(n.nullifier));
+    const second = selectNotes(filtered, new BigNumber(500_000), "shielded");
+    expect(second).not.toBeUndefined();
+    const secondNullifiers = second!.selectedNotes.map(n => n.nullifier);
+
+    // No nullifier may appear in both selections
+    const overlap = firstNullifiers.filter(nf => secondNullifiers.includes(nf));
+    expect(overlap).toHaveLength(0);
+  });
+
+  it("returns undefined from selectNotes when all notes are reserved", () => {
+    const note = makeNote({
+      txid: "tx1",
+      outputIndex: 0,
+      nullifier: "cc".repeat(32),
+      amount: new BigNumber(600_000),
+    });
+
+    reserveNotes(ACCOUNT_ID, [note.nullifier]);
+
+    const reserved = getReservedNullifiers(ACCOUNT_ID);
+    const filtered = [note].filter(n => !reserved.has(n.nullifier));
+
+    // Filtered set is empty — selectNotes returns undefined
+    expect(selectNotes(filtered, new BigNumber(500_000), "shielded")).toBeUndefined();
+    // estimateMaxSpendableAmount on an empty set returns 0
+    expect(estimateMaxSpendableAmount(filtered, "shielded").toNumber()).toBe(0);
+  });
+
+  it("selectNotes succeeds again over the full set after _resetReservationsForTest", () => {
+    const note = makeNote({
+      txid: "tx1",
+      outputIndex: 0,
+      nullifier: "dd".repeat(32),
+      amount: new BigNumber(600_000),
+    });
+
+    reserveNotes(ACCOUNT_ID, [note.nullifier]);
+
+    // Verify reserved before reset
+    expect(getReservedNullifiers(ACCOUNT_ID).has(note.nullifier)).toBe(true);
+
+    _resetReservationsForTest();
+
+    // After reset the full note set is unfiltered — selection succeeds
+    const result = selectNotes([note], new BigNumber(500_000), "shielded");
+    expect(result).not.toBeUndefined();
+    expect(result!.selectedNotes).toHaveLength(1);
+  });
+});

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
@@ -1,10 +1,32 @@
+import { getEnv } from "@ledgerhq/live-env";
+
 /**
  * Session-scoped, in-memory reservation store for shielded note nullifiers.
  *
- * After a shielded send is built and signed, the selected notes are reserved
- * here so that a concurrent or immediately-following send cannot select the
- * same notes. The store is reconciled against on-chain reality on every
- * shielded sync pass via reconcileReservations.
+ * After a shielded send is built and signed, the notes it spends are reserved
+ * under the hash of the operation spending them, so that a concurrent or
+ * immediately-following send cannot select the same notes. Selection filters the
+ * account's reserved nullifiers out of the spendable pool (prepareTransaction,
+ * estimateMaxSpendable).
+ *
+ * A reservation is released only on evidence about its own operation:
+ *
+ * - the scan reports its notes spent on-chain — `releaseConfirmedNullifiers`,
+ *   from the shielded sync reducer;
+ * - its operation has a confirmed counterpart in `account.operations`, the same
+ *   signal `reconcileConfirmedPendingOperations` retires the optimistic
+ *   operation on — `releaseRetiredReservations`, from `postSync`;
+ * - it outlived OPERATION_OPTIMISTIC_RETENTION, measured from signing time just
+ *   as `shouldRetainPendingOperation` measures the optimistic operation's own
+ *   date: a broadcast that never confirmed stops holding notes at the moment
+ *   Ledger Wallet itself stops believing in the operation — same function;
+ * - broadcast failed, so nothing can confirm — `releaseReservation`, from the
+ *   bridge's `broadcast`.
+ *
+ * A sync reaching the chain tip is deliberately not one of them: catching up to
+ * the tip a run started from is the outcome of nearly every poll of an account
+ * that is not backlogged, and says nothing about a spend in flight, which needs
+ * a block (~75s) at the very least to confirm.
  *
  * Scope: single-user desktop/mobile session. The store is module-level and
  * therefore shared for the lifetime of the process. It is not persisted across
@@ -13,70 +35,120 @@
  *
  * The transparent analog is inputRefs written into operation.extra; the
  * reservation store provides the same intra-session dedup for shielded spends.
- *
- * Risk note: a complete sync (remainingBlocks === 0) triggered immediately after
- * signOperation but before broadcast confirmation clears the reservation
- * prematurely. The mempool TTL and node-side nullifier rejection provide a safety
- * net; this store is an intra-session dedup helper, not the sole double-spend guard.
  */
 
-const _reserved = new Map<string, Set<string>>();
+type Reservation = {
+  nullifiers: Set<string>;
+  /** Signing time — the date the optimistic operation carries too. */
+  reservedAt: number;
+};
 
-/**
- * Adds nullifiers to the reservation set for the given account.
- * A second call for the same account unions with the existing set (no overwrite).
- */
-export function reserveNotes(accountId: string, nullifiers: ReadonlyArray<string>): void {
-  if (nullifiers.length === 0) return;
-  let set = _reserved.get(accountId);
-  if (!set) {
-    set = new Set<string>();
-    _reserved.set(accountId, set);
-  }
-  for (const nf of nullifiers) {
-    set.add(nf);
-  }
+/** accountId → operation hash → the notes that operation spends. */
+const _reserved = new Map<string, Map<string, Reservation>>();
+
+function pruneAccount(accountId: string, byOperation: Map<string, Reservation>): void {
+  if (byOperation.size === 0) _reserved.delete(accountId);
 }
 
 /**
- * Reconciles the reservation store against on-chain reality.
- *
- * - Removes each confirmedSpentNullifier from the account's reservation set
- *   (these notes are already excluded by isSpent: true after sync; removing
- *   them avoids growing the set unboundedly).
- * - When syncComplete is true, clears ALL remaining reservations for the account.
- *   Any nullifier still reserved at chain tip was never confirmed on-chain — the
- *   spend either was not broadcast or was rejected. Clearing releases those notes
- *   for future selection (fail-closed principle).
- *
- * A no-op when the account has no reservations.
+ * Reserves the notes an operation spends, keyed by the operation's hash.
+ * A second call for the same operation unions with what it already holds.
  */
-export function reconcileReservations(
+export function reserveNotes(
   accountId: string,
-  confirmedSpentNullifiers: string[],
-  syncComplete: boolean,
+  operationHash: string,
+  nullifiers: ReadonlyArray<string>,
 ): void {
-  const set = _reserved.get(accountId);
-  if (!set) return;
-
-  for (const nf of confirmedSpentNullifiers) {
-    set.delete(nf);
+  if (nullifiers.length === 0) return;
+  let byOperation = _reserved.get(accountId);
+  if (!byOperation) {
+    byOperation = new Map<string, Reservation>();
+    _reserved.set(accountId, byOperation);
   }
-
-  if (syncComplete) {
-    set.clear();
-    _reserved.delete(accountId);
-  } else if (set.size === 0) {
-    _reserved.delete(accountId);
+  const existing = byOperation.get(operationHash);
+  if (existing) {
+    for (const nf of nullifiers) {
+      existing.nullifiers.add(nf);
+    }
+    return;
   }
+  byOperation.set(operationHash, { nullifiers: new Set(nullifiers), reservedAt: Date.now() });
 }
 
 /**
- * Returns the current reservation set for the given account (read-only).
- * Returns an empty set when nothing is reserved.
+ * Drops nullifiers the scan reported spent on-chain from every reservation of
+ * the account. Those notes are excluded by isSpent: true from here on, so
+ * holding them reserved would only grow the store.
+ */
+export function releaseConfirmedNullifiers(
+  accountId: string,
+  confirmedSpentNullifiers: ReadonlyArray<string>,
+): void {
+  if (confirmedSpentNullifiers.length === 0) return;
+  const byOperation = _reserved.get(accountId);
+  if (!byOperation) return;
+
+  for (const [operationHash, reservation] of byOperation) {
+    for (const nf of confirmedSpentNullifiers) {
+      reservation.nullifiers.delete(nf);
+    }
+    if (reservation.nullifiers.size === 0) byOperation.delete(operationHash);
+  }
+  pruneAccount(accountId, byOperation);
+}
+
+/**
+ * Releases the reservations whose operation the account has done with: it now
+ * has a confirmed counterpart, or it has aged past the window Ledger Wallet
+ * keeps an unconfirmed optimistic operation for.
+ *
+ * Absence from the pending list is not the test used here. An operation is
+ * pending only from broadcast onwards, while its notes are reserved from
+ * signing, and a scan of a fresh account carries no pending operation at all —
+ * either would read as "done with" a spend that has not even been sent yet.
+ */
+export function releaseRetiredReservations(
+  accountId: string,
+  confirmedOperationHashes: ReadonlySet<string>,
+  now: number = Date.now(),
+): void {
+  const byOperation = _reserved.get(accountId);
+  if (!byOperation) return;
+
+  const retention = getEnv("OPERATION_OPTIMISTIC_RETENTION");
+  for (const [operationHash, reservation] of byOperation) {
+    const confirmed = confirmedOperationHashes.has(operationHash);
+    const expired = now - reservation.reservedAt >= retention;
+    if (confirmed || expired) byOperation.delete(operationHash);
+  }
+  pruneAccount(accountId, byOperation);
+}
+
+/**
+ * Releases a single operation's reservation, for a spend that cannot reach the
+ * chain any more — a failed broadcast.
+ */
+export function releaseReservation(accountId: string, operationHash: string): void {
+  const byOperation = _reserved.get(accountId);
+  if (!byOperation) return;
+  byOperation.delete(operationHash);
+  pruneAccount(accountId, byOperation);
+}
+
+/**
+ * Returns the nullifiers reserved across the account's in-flight operations
+ * (read-only). Returns an empty set when nothing is reserved.
  */
 export function getReservedNullifiers(accountId: string): ReadonlySet<string> {
-  return _reserved.get(accountId) ?? new Set<string>();
+  const byOperation = _reserved.get(accountId);
+  if (!byOperation) return new Set<string>();
+  const reserved = new Set<string>();
+  for (const reservation of byOperation.values()) {
+    for (const nf of reservation.nullifiers) {
+      reserved.add(nf);
+    }
+  }
+  return reserved;
 }
 
 /**

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
@@ -1,0 +1,88 @@
+/**
+ * Session-scoped, in-memory reservation store for shielded note nullifiers.
+ *
+ * After a shielded send is built and signed, the selected notes are reserved
+ * here so that a concurrent or immediately-following send cannot select the
+ * same notes. The store is reconciled against on-chain reality on every
+ * shielded sync pass via reconcileReservations.
+ *
+ * Scope: single-user desktop/mobile session. The store is module-level and
+ * therefore shared for the lifetime of the process. It is not persisted across
+ * restarts — on the next startup, sync will re-establish isSpent: true for any
+ * confirmed notes, which is the durable exclusion mechanism.
+ *
+ * The transparent analog is inputRefs written into operation.extra; the
+ * reservation store provides the same intra-session dedup for shielded spends.
+ *
+ * Risk note: a complete sync (remainingBlocks === 0) triggered immediately after
+ * signOperation but before broadcast confirmation clears the reservation
+ * prematurely. The mempool TTL and node-side nullifier rejection provide a safety
+ * net; this store is an intra-session dedup helper, not the sole double-spend guard.
+ */
+
+const _reserved = new Map<string, Set<string>>();
+
+/**
+ * Adds nullifiers to the reservation set for the given account.
+ * A second call for the same account unions with the existing set (no overwrite).
+ */
+export function reserveNotes(accountId: string, nullifiers: ReadonlyArray<string>): void {
+  if (nullifiers.length === 0) return;
+  let set = _reserved.get(accountId);
+  if (!set) {
+    set = new Set<string>();
+    _reserved.set(accountId, set);
+  }
+  for (const nf of nullifiers) {
+    set.add(nf);
+  }
+}
+
+/**
+ * Reconciles the reservation store against on-chain reality.
+ *
+ * - Removes each confirmedSpentNullifier from the account's reservation set
+ *   (these notes are already excluded by isSpent: true after sync; removing
+ *   them avoids growing the set unboundedly).
+ * - When syncComplete is true, clears ALL remaining reservations for the account.
+ *   Any nullifier still reserved at chain tip was never confirmed on-chain — the
+ *   spend either was not broadcast or was rejected. Clearing releases those notes
+ *   for future selection (fail-closed principle).
+ *
+ * A no-op when the account has no reservations.
+ */
+export function reconcileReservations(
+  accountId: string,
+  confirmedSpentNullifiers: string[],
+  syncComplete: boolean,
+): void {
+  const set = _reserved.get(accountId);
+  if (!set) return;
+
+  for (const nf of confirmedSpentNullifiers) {
+    set.delete(nf);
+  }
+
+  if (syncComplete) {
+    set.clear();
+    _reserved.delete(accountId);
+  } else if (set.size === 0) {
+    _reserved.delete(accountId);
+  }
+}
+
+/**
+ * Returns the current reservation set for the given account (read-only).
+ * Returns an empty set when nothing is reserved.
+ */
+export function getReservedNullifiers(accountId: string): ReadonlySet<string> {
+  return _reserved.get(accountId) ?? new Set<string>();
+}
+
+/**
+ * Resets all reservation state. Intended for test isolation only.
+ * @internal
+ */
+export function _resetReservationsForTest(): void {
+  _reserved.clear();
+}

--- a/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/note-reservation.ts
@@ -1,7 +1,11 @@
 import { getEnv } from "@ledgerhq/live-env";
+import type { Operation } from "@ledgerhq/types-live";
+import type { ZcashOperationExtra } from "../types/bridge";
 
 /**
- * Session-scoped, in-memory reservation store for shielded note nullifiers.
+ * Reservation store for shielded note nullifiers: an in-memory part scoped to
+ * the session, and a persisted part read back off the account's pending
+ * operations.
  *
  * After a shielded send is built and signed, the notes it spends are reserved
  * under the hash of the operation spending them, so that a concurrent or
@@ -29,12 +33,17 @@ import { getEnv } from "@ledgerhq/live-env";
  * a block (~75s) at the very least to confirm.
  *
  * Scope: single-user desktop/mobile session. The store is module-level and
- * therefore shared for the lifetime of the process. It is not persisted across
- * restarts — on the next startup, sync will re-establish isSpent: true for any
- * confirmed notes, which is the durable exclusion mechanism.
+ * therefore shared for the lifetime of the process. It does not survive a
+ * restart, and does not need to: `signOperation` also records the nullifiers on
+ * the optimistic operation it produces, and that operation is persisted, so
+ * `getReservedNullifiers` reads a still-in-flight spend back from
+ * `account.pendingOperations` on the next startup. Notes of a spend that did
+ * confirm are excluded by isSpent: true from then on.
  *
- * The transparent analog is inputRefs written into operation.extra; the
- * reservation store provides the same intra-session dedup for shielded spends.
+ * The transparent analog is inputRefs written into operation.extra; shielded
+ * spends record shieldedNullifiers the same way. What this store adds is the
+ * precision the persisted list cannot have on its own: notes are committed from
+ * signing, while a pending operation exists only from broadcast onwards.
  */
 
 type Reservation = {
@@ -136,10 +145,14 @@ export function releaseReservation(accountId: string, operationHash: string): vo
 }
 
 /**
- * Returns the nullifiers reserved across the account's in-flight operations
- * (read-only). Returns an empty set when nothing is reserved.
+ * Returns the nullifiers this session holds for the account, across every
+ * operation reserved in it. Empty when nothing is reserved.
+ *
+ * Covers the running process only. Callers deciding what a new spend may select
+ * want `getReservedNullifiers`, which also accounts for a spend in flight from
+ * a previous session.
  */
-export function getReservedNullifiers(accountId: string): ReadonlySet<string> {
+export function getSessionReservedNullifiers(accountId: string): ReadonlySet<string> {
   const byOperation = _reserved.get(accountId);
   if (!byOperation) return new Set<string>();
   const reserved = new Set<string>();
@@ -147,6 +160,47 @@ export function getReservedNullifiers(accountId: string): ReadonlySet<string> {
     for (const nf of reservation.nullifiers) {
       reserved.add(nf);
     }
+  }
+  return reserved;
+}
+
+/** Only `extra` is read off a pending operation. */
+type ReservingAccount = {
+  id: string;
+  pendingOperations?: ReadonlyArray<Pick<Operation, "extra">>;
+};
+
+/**
+ * The nullifiers the account's pending operations still hold.
+ *
+ * `extra` is persisted verbatim and typed `unknown` on the way back in, hence
+ * the narrowing — the same shape coin-bitcoin's `isBtcOperationExtra` guards.
+ */
+function pendingReservedNullifiers(
+  pendingOperations: ReadonlyArray<Pick<Operation, "extra">>,
+): string[] {
+  return pendingOperations.flatMap(({ extra }) => {
+    if (extra === null || typeof extra !== "object") return [];
+    const nullifiers = (extra as ZcashOperationExtra).shieldedNullifiers;
+    if (!Array.isArray(nullifiers)) return [];
+    return nullifiers.filter(nf => typeof nf === "string");
+  });
+}
+
+/**
+ * The nullifiers unavailable to a new spend: what this session reserved, plus
+ * what the account's pending operations hold.
+ *
+ * Nothing releases the pending-operation half, because the operation carrying it
+ * is what expires. It leaves `pendingOperations` once a confirmed counterpart
+ * retires it — its notes read isSpent: true from then on — or once it ages past
+ * OPERATION_OPTIMISTIC_RETENTION, the window `releaseRetiredReservations`
+ * measures too. A broadcast that failed never became a pending operation.
+ */
+export function getReservedNullifiers(account: ReservingAccount): ReadonlySet<string> {
+  const reserved = new Set(pendingReservedNullifiers(account.pendingOperations ?? []));
+  for (const nf of getSessionReservedNullifiers(account.id)) {
+    reserved.add(nf);
   }
   return reserved;
 }

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
@@ -1,18 +1,28 @@
 import { BigNumber } from "bignumber.js";
 import { prepareTransaction } from "./prepareTransaction";
 import { estimateMaxSpendable } from "./estimateMaxSpendable";
+import { reserveNotes, _resetReservationsForTest } from "./note-reservation";
 import { ZIP317_MINIMUM_FEE } from "../logic/coin-selection";
 import type { BitcoinOutput, Transaction, ZcashAccount, ZcashTransferType } from "../types/bridge";
 
 const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
 const U_ADDRESS =
   "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
+const ACCOUNT_ID = "js:2:zcash:xpub6D:";
+// The account fixture offsets the Ironwood pool by this much so the two pools
+// never share a nullifier or a position.
+const IRONWOOD_INDEX_OFFSET = 100;
+
+const nullifierAt = (index: number) => index.toString(16).padStart(2, "0").repeat(32);
+
+/** Nullifier the account fixture gives the i-th Ironwood note. */
+const ironwoodNullifier = (i: number) => nullifierAt(i + IRONWOOD_INDEX_OFFSET);
 
 const note = (amount: number, index: number) => ({
   amount: new BigNumber(amount),
   transfer_type: "incoming",
   memo: "",
-  nullifier: index.toString(16).padStart(2, "0").repeat(32),
+  nullifier: nullifierAt(index),
   rho: "ee".repeat(32),
   rseed: "ff".repeat(32),
   cmx: "11".repeat(32),
@@ -38,7 +48,7 @@ function account({
 }: { utxos?: number[]; notes?: number[]; ironwoodNotes?: number[] } = {}): ZcashAccount {
   return {
     type: "Account",
-    id: "js:2:zcash:xpub6D:",
+    id: ACCOUNT_ID,
     currency: { id: "zcash", name: "Zcash" },
     bitcoinResources: { utxos: utxos.map((value, i) => utxo(value, i)) },
     privateInfo: {
@@ -53,8 +63,9 @@ function account({
           decryptedData: {
             orchard_outputs: notes.map(note),
             sapling_outputs: [],
-            // Offset so the two pools never share a nullifier or a position.
-            ironwood_outputs: ironwoodNotes.map((amount, i) => note(amount, i + 100)),
+            ironwood_outputs: ironwoodNotes.map((amount, i) =>
+              note(amount, i + IRONWOOD_INDEX_OFFSET),
+            ),
           },
         },
       ],
@@ -75,6 +86,9 @@ function transaction(overrides: Partial<Transaction> = {}): Transaction {
 
 const sum = (values: BigNumber[]): BigNumber =>
   values.reduce((total, v) => total.plus(v), new BigNumber(0));
+
+// The reservation store is module-level and outlives a single test.
+beforeEach(_resetReservationsForTest);
 
 describe("prepareTransaction, transparent-input flows", () => {
   // Fees are the ZIP-317 figure for the flow's action layout, spelled out here
@@ -302,5 +316,92 @@ describe("estimateMaxSpendable", () => {
     expect(await max(transaction({ selectedUtxos: [utxo(25_000, 1)] }), acc)).toEqual(
       new BigNumber(15_000),
     );
+  });
+});
+
+// signOperation reserves the notes a signed send spends, so a second send built
+// in the same session cannot select them again and double-spend them. Both
+// selection entry points filter the pool against that reservation, and the two
+// have to answer consistently.
+describe("reserved notes", () => {
+  // 40k + 30k, so which note the reservation removes is visible in the result:
+  // largest-first takes the 40k unless it is reserved.
+  const acc = () => account({ ironwoodNotes: [40_000, 30_000] });
+  const shielded = (overrides: Partial<Transaction> = {}) =>
+    transaction({ transferType: "shielded", recipient: U_ADDRESS, ...overrides });
+  const maxShielded = (a: ZcashAccount) =>
+    estimateMaxSpendable({ account: a, transaction: shielded() } as never);
+
+  it("passes over a reserved note and spends the next one down", async () => {
+    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+
+    const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
+
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([30_000]);
+    expect(prepared).toMatchObject({
+      zcashFee: new BigNumber(10_000),
+      changeAmount: new BigNumber(5_000),
+    });
+  });
+
+  it("spends the 40k note when nothing is reserved", async () => {
+    const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
+
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([40_000]);
+  });
+
+  it("clears the selection once every note is reserved", async () => {
+    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0), ironwoodNullifier(1)]);
+
+    const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
+
+    expect(prepared.selectedNotes).toEqual([]);
+    expect(prepared).not.toHaveProperty("zcashFee");
+  });
+
+  // Reservations are keyed by account: another account's in-flight send must not
+  // take notes out of this one's pool.
+  it("ignores a reservation held against another account", async () => {
+    reserveNotes("js:2:zcash:xpubOTHER:", [ironwoodNullifier(0), ironwoodNullifier(1)]);
+
+    const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
+
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([40_000]);
+  });
+
+  it("counts a note another account has reserved as spendable", async () => {
+    reserveNotes("js:2:zcash:xpubOTHER:", [ironwoodNullifier(0), ironwoodNullifier(1)]);
+
+    // The whole 70k pool, minus the 2-action fee for spending both notes.
+    expect(await maxShielded(acc())).toEqual(new BigNumber(60_000));
+  });
+
+  it("drops reserved notes from the max spendable", async () => {
+    // The free 30k note minus the 2-action fee, not the 60k the whole pool offers.
+    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+
+    expect(await maxShielded(acc())).toEqual(new BigNumber(20_000));
+  });
+
+  it("answers zero for the max spendable once every note is reserved", async () => {
+    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0), ironwoodNullifier(1)]);
+
+    expect(await maxShielded(acc())).toEqual(new BigNumber(0));
+  });
+
+  // Both call sites filter the pool themselves, so they can disagree: a max the
+  // send cannot then price is a "send max" the user cannot complete.
+  it("prices a max send over the notes the max spendable counted", async () => {
+    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+    const spendable = await maxShielded(acc());
+
+    const prepared = await prepareTransaction(acc(), shielded({ useAllAmount: true }));
+
+    expect(prepared.amount).toEqual(spendable);
+    expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([30_000]);
+    expect(prepared).toMatchObject({
+      zcashFee: new BigNumber(10_000),
+      changeAmount: new BigNumber(0),
+    });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
@@ -412,4 +412,44 @@ describe("reserved notes", () => {
       changeAmount: new BigNumber(0),
     });
   });
+
+  // A send broadcast in a session that ended before it confirmed: the store is
+  // empty, and the notes it spends are known only from the optimistic operation
+  // the account persisted. Selecting them again would double-spend.
+  describe("a send left in flight by a previous session", () => {
+    const withPendingSend = (nullifiers: string[]) =>
+      ({
+        ...acc(),
+        pendingOperations: [
+          {
+            hash: IN_FLIGHT_TX,
+            extra: { zcashShielded: true, shieldedNullifiers: nullifiers },
+          },
+        ],
+      }) as unknown as ZcashAccount;
+
+    it("passes over the notes its pending operation holds", async () => {
+      const prepared = await prepareTransaction(
+        withPendingSend([ironwoodNullifier(0)]),
+        shielded({ amount: new BigNumber(15_000) }),
+      );
+
+      expect(prepared.selectedNotes?.map(n => n.amount.toNumber())).toEqual([30_000]);
+    });
+
+    it("clears the selection when its pending operation holds every note", async () => {
+      const prepared = await prepareTransaction(
+        withPendingSend([ironwoodNullifier(0), ironwoodNullifier(1)]),
+        shielded({ amount: new BigNumber(15_000) }),
+      );
+
+      expect(prepared.selectedNotes).toEqual([]);
+    });
+
+    it("drops those notes from the max spendable too", async () => {
+      expect(await maxShielded(withPendingSend([ironwoodNullifier(0)]))).toEqual(
+        new BigNumber(20_000),
+      );
+    });
+  });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.test.ts
@@ -9,6 +9,8 @@ const T_ADDRESS = "t1b1Rbw2shhJkP6MCnCyxCPuyFedHrwKty8";
 const U_ADDRESS =
   "u1u2h4ce7e2cn3z4nzur95muq2dl4da9x8h8kdp2l80gm9nl9raj8zzpx79ycjnfvar4v5exea5pqr5y9qsnlp0cdunwf9yjjx5c4q7ar9";
 const ACCOUNT_ID = "js:2:zcash:xpub6D:";
+// Reservations are held under the hash of the send that spends the notes.
+const IN_FLIGHT_TX = "76ec3b38";
 // The account fixture offsets the Ironwood pool by this much so the two pools
 // never share a nullifier or a position.
 const IRONWOOD_INDEX_OFFSET = 100;
@@ -333,7 +335,7 @@ describe("reserved notes", () => {
     estimateMaxSpendable({ account: a, transaction: shielded() } as never);
 
   it("passes over a reserved note and spends the next one down", async () => {
-    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+    reserveNotes(ACCOUNT_ID, IN_FLIGHT_TX, [ironwoodNullifier(0)]);
 
     const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
 
@@ -351,7 +353,7 @@ describe("reserved notes", () => {
   });
 
   it("clears the selection once every note is reserved", async () => {
-    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0), ironwoodNullifier(1)]);
+    reserveNotes(ACCOUNT_ID, IN_FLIGHT_TX, [ironwoodNullifier(0), ironwoodNullifier(1)]);
 
     const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
 
@@ -362,7 +364,10 @@ describe("reserved notes", () => {
   // Reservations are keyed by account: another account's in-flight send must not
   // take notes out of this one's pool.
   it("ignores a reservation held against another account", async () => {
-    reserveNotes("js:2:zcash:xpubOTHER:", [ironwoodNullifier(0), ironwoodNullifier(1)]);
+    reserveNotes("js:2:zcash:xpubOTHER:", IN_FLIGHT_TX, [
+      ironwoodNullifier(0),
+      ironwoodNullifier(1),
+    ]);
 
     const prepared = await prepareTransaction(acc(), shielded({ amount: new BigNumber(15_000) }));
 
@@ -370,7 +375,10 @@ describe("reserved notes", () => {
   });
 
   it("counts a note another account has reserved as spendable", async () => {
-    reserveNotes("js:2:zcash:xpubOTHER:", [ironwoodNullifier(0), ironwoodNullifier(1)]);
+    reserveNotes("js:2:zcash:xpubOTHER:", IN_FLIGHT_TX, [
+      ironwoodNullifier(0),
+      ironwoodNullifier(1),
+    ]);
 
     // The whole 70k pool, minus the 2-action fee for spending both notes.
     expect(await maxShielded(acc())).toEqual(new BigNumber(60_000));
@@ -378,13 +386,13 @@ describe("reserved notes", () => {
 
   it("drops reserved notes from the max spendable", async () => {
     // The free 30k note minus the 2-action fee, not the 60k the whole pool offers.
-    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+    reserveNotes(ACCOUNT_ID, IN_FLIGHT_TX, [ironwoodNullifier(0)]);
 
     expect(await maxShielded(acc())).toEqual(new BigNumber(20_000));
   });
 
   it("answers zero for the max spendable once every note is reserved", async () => {
-    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0), ironwoodNullifier(1)]);
+    reserveNotes(ACCOUNT_ID, IN_FLIGHT_TX, [ironwoodNullifier(0), ironwoodNullifier(1)]);
 
     expect(await maxShielded(acc())).toEqual(new BigNumber(0));
   });
@@ -392,7 +400,7 @@ describe("reserved notes", () => {
   // Both call sites filter the pool themselves, so they can disagree: a max the
   // send cannot then price is a "send max" the user cannot complete.
   it("prices a max send over the notes the max spendable counted", async () => {
-    reserveNotes(ACCOUNT_ID, [ironwoodNullifier(0)]);
+    reserveNotes(ACCOUNT_ID, IN_FLIGHT_TX, [ironwoodNullifier(0)]);
     const spendable = await maxShielded(acc());
 
     const prepared = await prepareTransaction(acc(), shielded({ useAllAmount: true }));

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
@@ -10,6 +10,7 @@ import {
   selectTransparentInputs,
 } from "../logic/coin-selection";
 import { isTransparentInputTransfer, resolveTransparentUtxos } from "./statusHelpers";
+import { getReservedNullifiers } from "./note-reservation";
 
 // Strip any stale fee/change from a prior prepare and reset the amount so the UI
 // never shows a spendable amount without a matching fee.
@@ -79,5 +80,8 @@ export const prepareTransaction: AccountBridge<
   }
 
   const transactions = account.privateInfo?.transactions ?? [];
-  return prepareNoteTransaction(collectIronwoodSpendableNotes(transactions), tx);
+  const allNotes = collectIronwoodSpendableNotes(transactions);
+  const reserved = getReservedNullifiers(account.id);
+  const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
+  return prepareNoteTransaction(notes, tx);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/prepareTransaction.ts
@@ -81,7 +81,7 @@ export const prepareTransaction: AccountBridge<
 
   const transactions = account.privateInfo?.transactions ?? [];
   const allNotes = collectIronwoodSpendableNotes(transactions);
-  const reserved = getReservedNullifiers(account.id);
+  const reserved = getReservedNullifiers(account);
   const notes = reserved.size > 0 ? allNotes.filter(n => !reserved.has(n.nullifier)) : allNotes;
   return prepareNoteTransaction(notes, tx);
 };

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -14,7 +14,7 @@ import { combine } from "../logic/transaction/combine";
 import { assertCanSend } from "../logic/engineClient";
 import { getWalletAccount } from "./getWalletAccount";
 import {
-  getReservedNullifiers,
+  getSessionReservedNullifiers,
   releaseRetiredReservations,
   _resetReservationsForTest,
 } from "./note-reservation";
@@ -404,14 +404,14 @@ describe("bridge/signOperation", () => {
       } as never);
       const signedEvent = events.find(e => e.type === "signed");
 
-      expect(getReservedNullifiers(account.id).has(nullifier)).toBe(true);
+      expect(getSessionReservedNullifiers(account.id).has(nullifier)).toBe(true);
       if (signedEvent?.type === "signed") {
         releaseRetiredReservations(
           account.id,
           new Set([signedEvent.signedOperation.operation.hash]),
         );
       }
-      expect(getReservedNullifiers(account.id).size).toBe(0);
+      expect(getSessionReservedNullifiers(account.id).size).toBe(0);
     });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -13,6 +13,7 @@ import { craftIronwoodTransaction, craftTransaction } from "../logic/transaction
 import { combine } from "../logic/transaction/combine";
 import { assertCanSend } from "../logic/engineClient";
 import { getWalletAccount } from "./getWalletAccount";
+import { _resetReservationsForTest } from "./note-reservation";
 import type { SpendableNote } from "../network/types";
 import type { SignerContext } from "../types/signer";
 import type { Transaction, ZcashAccount } from "../types/bridge";
@@ -320,5 +321,64 @@ describe("bridge/signOperation", () => {
     await expect(
       lastValueFrom(signOp({ account, deviceId: "device-1", transaction: tx } as never)),
     ).rejects.toThrow(/signPcztTransaction/);
+  });
+
+  describe("shieldedNullifiers on operation.extra", () => {
+    beforeEach(() => {
+      _resetReservationsForTest();
+    });
+
+    it("emits shieldedNullifiers on operation.extra matching tx.selectedNotes nullifiers", async () => {
+      const nullifier1 = "11".repeat(32);
+      const nullifier2 = "22".repeat(32);
+      const notes = [
+        makeSpendableNote({ nullifier: nullifier1, outputIndex: 0 }),
+        makeSpendableNote({ nullifier: nullifier2, outputIndex: 1 }),
+      ];
+      const account = makeAccount();
+      const tx = makeTx("shielded", {
+        selectedNotes: notes,
+        zcashFee: new BigNumber(10_000),
+        amount: new BigNumber(290_000),
+      });
+      const signOp = buildSignOperation(makeSignerContext());
+
+      const events = await collectEvents(signOp, {
+        account,
+        deviceId: "device-1",
+        transaction: tx,
+      } as never);
+      const signedEvent = events.find(e => e.type === "signed");
+      expect(signedEvent?.type).toBe("signed");
+      if (signedEvent?.type === "signed") {
+        const extra = signedEvent.signedOperation.operation.extra as Record<string, unknown>;
+        expect(extra).toHaveProperty("shieldedNullifiers");
+        expect(extra.shieldedNullifiers).toEqual([nullifier1, nullifier2]);
+      }
+    });
+
+    it("omits shieldedNullifiers from operation.extra when selectedNotes is empty", async () => {
+      // transparent-to-shielded: shields into Ironwood with no note spends
+      const account = makeAccount();
+      const tx = makeTx("transparent-to-shielded", {
+        selectedNotes: [],
+        zcashFee: new BigNumber(10_000),
+      });
+      const signOp = buildSignOperation(
+        makeSignerContext({ orchard: [], transparentInputSigs: [] }),
+      );
+
+      const events = await collectEvents(signOp, {
+        account,
+        deviceId: "device-1",
+        transaction: tx,
+      } as never);
+      const signedEvent = events.find(e => e.type === "signed");
+      expect(signedEvent?.type).toBe("signed");
+      if (signedEvent?.type === "signed") {
+        const extra = signedEvent.signedOperation.operation.extra as Record<string, unknown>;
+        expect(extra).not.toHaveProperty("shieldedNullifiers");
+      }
+    });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.test.ts
@@ -13,7 +13,11 @@ import { craftIronwoodTransaction, craftTransaction } from "../logic/transaction
 import { combine } from "../logic/transaction/combine";
 import { assertCanSend } from "../logic/engineClient";
 import { getWalletAccount } from "./getWalletAccount";
-import { _resetReservationsForTest } from "./note-reservation";
+import {
+  getReservedNullifiers,
+  releaseRetiredReservations,
+  _resetReservationsForTest,
+} from "./note-reservation";
 import type { SpendableNote } from "../network/types";
 import type { SignerContext } from "../types/signer";
 import type { Transaction, ZcashAccount } from "../types/bridge";
@@ -379,6 +383,35 @@ describe("bridge/signOperation", () => {
         const extra = signedEvent.signedOperation.operation.extra as Record<string, unknown>;
         expect(extra).not.toHaveProperty("shieldedNullifiers");
       }
+    });
+
+    // The reservation is released on the lifecycle of the operation that holds
+    // it, which can only find it if signing filed it under that operation's own
+    // hash.
+    it("reserves the spent notes under the hash of the operation spending them", async () => {
+      const nullifier = "33".repeat(32);
+      const account = makeAccount();
+      const tx = makeTx("shielded", {
+        selectedNotes: [makeSpendableNote({ nullifier })],
+        zcashFee: new BigNumber(10_000),
+      });
+      const signOp = buildSignOperation(makeSignerContext());
+
+      const events = await collectEvents(signOp, {
+        account,
+        deviceId: "device-1",
+        transaction: tx,
+      } as never);
+      const signedEvent = events.find(e => e.type === "signed");
+
+      expect(getReservedNullifiers(account.id).has(nullifier)).toBe(true);
+      if (signedEvent?.type === "signed") {
+        releaseRetiredReservations(
+          account.id,
+          new Set([signedEvent.signedOperation.operation.hash]),
+        );
+      }
+      expect(getReservedNullifiers(account.id).size).toBe(0);
     });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -16,6 +16,7 @@ import { combine } from "../logic/transaction/combine";
 import { mapOutputs, mapSpends, mapTransparentInputs } from "./mapping";
 import { getWalletAccount } from "./getWalletAccount";
 import { resolveTransparentUtxos } from "./statusHelpers";
+import { reserveNotes } from "./note-reservation";
 
 // The V6 builder mirrors zcash-utils' own precondition: the transaction must carry
 // an Ironwood bundle, which an Ironwood spend or an Ironwood output creates. Those
@@ -123,6 +124,12 @@ export const buildSignOperation =
         );
 
         const fee = new BigNumber(buildResult.feeZat);
+
+        const ironwoodNullifiers = transaction.selectedNotes.map(n => n.nullifier);
+        if (ironwoodNullifiers.length > 0) {
+          reserveNotes(account.id, ironwoodNullifiers);
+        }
+
         const operation: Operation = {
           id: encodeOperationId(account.id, finalizeResult.txid, "OUT"),
           hash: finalizeResult.txid,
@@ -137,6 +144,7 @@ export const buildSignOperation =
           date: new Date(),
           extra: {
             zcashShielded: true,
+            ...(ironwoodNullifiers.length > 0 && { shieldedNullifiers: ironwoodNullifiers }),
             ...(inputRefs.length > 0 && {
               inputs: inputRefs.map(r => `${r.hash}-${r.outputIndex}`),
               inputRefs,

--- a/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/signOperation.ts
@@ -127,7 +127,7 @@ export const buildSignOperation =
 
         const ironwoodNullifiers = transaction.selectedNotes.map(n => n.nullifier);
         if (ironwoodNullifiers.length > 0) {
-          reserveNotes(account.id, ironwoodNullifiers);
+          reserveNotes(account.id, finalizeResult.txid, ironwoodNullifiers);
         }
 
         const operation: Operation = {

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -1,7 +1,11 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { reduceShieldedSyncResult, postSync } from "./sync";
-import { reserveNotes, getReservedNullifiers, _resetReservationsForTest } from "./note-reservation";
+import {
+  reserveNotes,
+  getSessionReservedNullifiers,
+  _resetReservationsForTest,
+} from "./note-reservation";
 import type { ZcashAccount } from "../types/bridge";
 import type { ShieldedSyncResult, ShieldedTransaction } from "../network/types";
 import type { BtcOperation } from "../types/bridge";
@@ -268,7 +272,7 @@ describe("reduceShieldedSyncResult", () => {
           "acc-1",
         );
 
-        const reserved = getReservedNullifiers("acc-1");
+        const reserved = getSessionReservedNullifiers("acc-1");
         expect(reserved.has(RESERVED_A)).toBe(false);
         expect(reserved.has(RESERVED_B)).toBe(true);
       });
@@ -286,7 +290,7 @@ describe("reduceShieldedSyncResult", () => {
           "acc-1",
         );
 
-        expect(getReservedNullifiers("acc-1").size).toBe(2);
+        expect(getSessionReservedNullifiers("acc-1").size).toBe(2);
       });
 
       it("keeps the reservations of the accounts it is not syncing", () => {
@@ -306,8 +310,8 @@ describe("reduceShieldedSyncResult", () => {
           "acc-1",
         );
 
-        expect(getReservedNullifiers("acc-1").size).toBe(0);
-        expect(getReservedNullifiers("acc-2").has(RESERVED_B)).toBe(true);
+        expect(getSessionReservedNullifiers("acc-1").size).toBe(0);
+        expect(getSessionReservedNullifiers("acc-2").has(RESERVED_B)).toBe(true);
       });
     });
   });
@@ -391,7 +395,7 @@ describe("postSync", () => {
 
       postSync(account([], []), account([confirmed], []));
 
-      expect(getReservedNullifiers("acc-1").size).toBe(0);
+      expect(getSessionReservedNullifiers("acc-1").size).toBe(0);
     });
 
     // The double-spend race the reservation store exists for: a sync lands
@@ -403,7 +407,7 @@ describe("postSync", () => {
 
       postSync(account([], []), account([unrelated], [optimistic]));
 
-      expect(getReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
+      expect(getSessionReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
     });
 
     // A scan of an account carries no pending operation at all, and a send is
@@ -414,7 +418,7 @@ describe("postSync", () => {
 
       postSync(account([], []), account([], []));
 
-      expect(getReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
+      expect(getSessionReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
     });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -235,11 +235,11 @@ describe("reduceShieldedSyncResult", () => {
     });
   });
 
-  // Reconciliation is what keeps the session reservation store from growing
-  // forever, and the reducer is its only caller — one per branch, the chunk that
-  // discovered transactions and the chunk that did not. Both are covered here
-  // against the real store, since a mis-threaded argument is the regression that
-  // silently defeats the cleanup.
+  // Dropping the nullifiers a scan reported spent is what keeps the session
+  // reservation store from growing forever, and the reducer is its only caller —
+  // one per branch, the chunk that discovered transactions and the chunk that did
+  // not. Both are covered here against the real store, since a mis-threaded
+  // argument is the regression that silently defeats the cleanup.
   describe("reservation reconciliation", () => {
     const RESERVED_A = "11".repeat(32);
     const RESERVED_B = "22".repeat(32);
@@ -252,27 +252,8 @@ describe("reduceShieldedSyncResult", () => {
       { branch: "without new transactions", transactions: [] as ShieldedTransaction[] },
       { branch: "carrying new transactions", transactions: [incomingTx(3_425_869, 1000)] },
     ])("on a chunk $branch", ({ transactions }) => {
-      it("releases every reservation once the scan reaches the chain tip", () => {
-        reserveNotes("acc-1", [RESERVED_A, RESERVED_B]);
-
-        reduceShieldedSyncResult(
-          { processedOperations: [], accountUpdate: {} },
-          {
-            ...emptyChunk,
-            transactions,
-            processedBlocks: 15,
-            remainingBlocks: 0,
-            spentKnownNullifiers: [RESERVED_A],
-          },
-          infoWith({}),
-          "acc-1",
-        );
-
-        expect(getReservedNullifiers("acc-1").size).toBe(0);
-      });
-
-      it("drops only the reported nullifiers while blocks remain to scan", () => {
-        reserveNotes("acc-1", [RESERVED_A, RESERVED_B]);
+      it("drops the nullifiers the scan reported spent", () => {
+        reserveNotes("acc-1", "tx-in-flight", [RESERVED_A, RESERVED_B]);
 
         reduceShieldedSyncResult(
           { processedOperations: [], accountUpdate: {} },
@@ -292,13 +273,35 @@ describe("reduceShieldedSyncResult", () => {
         expect(reserved.has(RESERVED_B)).toBe(true);
       });
 
-      it("keeps the reservations of the accounts it is not syncing", () => {
-        reserveNotes("acc-1", [RESERVED_A]);
-        reserveNotes("acc-2", [RESERVED_B]);
+      // Reaching the tip a run started from is the outcome of nearly every poll
+      // of an account that is not backlogged. It confirms nothing about a spend
+      // in flight, so it must not hand its notes back to the next send.
+      it("keeps a reservation the scan said nothing about, tip or no tip", () => {
+        reserveNotes("acc-1", "tx-in-flight", [RESERVED_A, RESERVED_B]);
 
         reduceShieldedSyncResult(
           { processedOperations: [], accountUpdate: {} },
           { ...emptyChunk, transactions, processedBlocks: 15, remainingBlocks: 0 },
+          infoWith({}),
+          "acc-1",
+        );
+
+        expect(getReservedNullifiers("acc-1").size).toBe(2);
+      });
+
+      it("keeps the reservations of the accounts it is not syncing", () => {
+        reserveNotes("acc-1", "tx-in-flight", [RESERVED_A]);
+        reserveNotes("acc-2", "tx-elsewhere", [RESERVED_B]);
+
+        reduceShieldedSyncResult(
+          { processedOperations: [], accountUpdate: {} },
+          {
+            ...emptyChunk,
+            transactions,
+            processedBlocks: 15,
+            remainingBlocks: 0,
+            spentKnownNullifiers: [RESERVED_A],
+          },
           infoWith({}),
           "acc-1",
         );
@@ -370,5 +373,48 @@ describe("postSync", () => {
     const synced = postSync(account([], []), account([], [optimistic]));
 
     expect(synced.pendingOperations).toEqual([optimistic]);
+  });
+
+  // The notes a shielded send spends are released on the same evidence that
+  // retires its optimistic operation, so that a second send can reuse them only
+  // once the first one is genuinely out of the way.
+  describe("note reservations", () => {
+    const RESERVED = "11".repeat(32);
+
+    beforeEach(() => {
+      _resetReservationsForTest();
+    });
+
+    it("releases the notes of a send that has confirmed", () => {
+      reserveNotes("acc-1", "76ec3b38", [RESERVED]);
+      const confirmed = operation({ hash: "76ec3b38", type: "SHIELDED_TX_ORCHARD_OUT" });
+
+      postSync(account([], []), account([confirmed], []));
+
+      expect(getReservedNullifiers("acc-1").size).toBe(0);
+    });
+
+    // The double-spend race the reservation store exists for: a sync lands
+    // between two sends, and the first one has not confirmed yet.
+    it("holds the notes of a send no confirmed operation accounts for", () => {
+      reserveNotes("acc-1", "76ec3b38", [RESERVED]);
+      const unrelated = operation({ hash: "0e1d2c3b", type: "SHIELDED_TX_ORCHARD_IN" });
+      const optimistic = operation({ id: "op-pending", hash: "76ec3b38" });
+
+      postSync(account([], []), account([unrelated], [optimistic]));
+
+      expect(getReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
+    });
+
+    // A scan of an account carries no pending operation at all, and a send is
+    // only pending from broadcast onwards while its notes are reserved from
+    // signing — an empty pending list is no evidence of anything.
+    it("holds the notes of a send that is not pending yet", () => {
+      reserveNotes("acc-1", "76ec3b38", [RESERVED]);
+
+      postSync(account([], []), account([], []));
+
+      expect(getReservedNullifiers("acc-1").has(RESERVED)).toBe(true);
+    });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.test.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
 import { getCryptoCurrencyById } from "@ledgerhq/ledger-wallet-framework/currencies";
 import { reduceShieldedSyncResult, postSync } from "./sync";
+import { reserveNotes, getReservedNullifiers, _resetReservationsForTest } from "./note-reservation";
 import type { ZcashAccount } from "../types/bridge";
 import type { ShieldedSyncResult, ShieldedTransaction } from "../network/types";
 import type { BtcOperation } from "../types/bridge";
@@ -231,6 +232,80 @@ describe("reduceShieldedSyncResult", () => {
         output.accountUpdate.privateInfo?.transactions?.[0].decryptedData?.ironwood_outputs;
       expect(notes).toHaveLength(1);
       expect(notes?.[0].nullifier).toBe(nullifier);
+    });
+  });
+
+  // Reconciliation is what keeps the session reservation store from growing
+  // forever, and the reducer is its only caller — one per branch, the chunk that
+  // discovered transactions and the chunk that did not. Both are covered here
+  // against the real store, since a mis-threaded argument is the regression that
+  // silently defeats the cleanup.
+  describe("reservation reconciliation", () => {
+    const RESERVED_A = "11".repeat(32);
+    const RESERVED_B = "22".repeat(32);
+
+    beforeEach(() => {
+      _resetReservationsForTest();
+    });
+
+    describe.each([
+      { branch: "without new transactions", transactions: [] as ShieldedTransaction[] },
+      { branch: "carrying new transactions", transactions: [incomingTx(3_425_869, 1000)] },
+    ])("on a chunk $branch", ({ transactions }) => {
+      it("releases every reservation once the scan reaches the chain tip", () => {
+        reserveNotes("acc-1", [RESERVED_A, RESERVED_B]);
+
+        reduceShieldedSyncResult(
+          { processedOperations: [], accountUpdate: {} },
+          {
+            ...emptyChunk,
+            transactions,
+            processedBlocks: 15,
+            remainingBlocks: 0,
+            spentKnownNullifiers: [RESERVED_A],
+          },
+          infoWith({}),
+          "acc-1",
+        );
+
+        expect(getReservedNullifiers("acc-1").size).toBe(0);
+      });
+
+      it("drops only the reported nullifiers while blocks remain to scan", () => {
+        reserveNotes("acc-1", [RESERVED_A, RESERVED_B]);
+
+        reduceShieldedSyncResult(
+          { processedOperations: [], accountUpdate: {} },
+          {
+            ...emptyChunk,
+            transactions,
+            processedBlocks: 10,
+            remainingBlocks: 5,
+            spentKnownNullifiers: [RESERVED_A],
+          },
+          infoWith({}),
+          "acc-1",
+        );
+
+        const reserved = getReservedNullifiers("acc-1");
+        expect(reserved.has(RESERVED_A)).toBe(false);
+        expect(reserved.has(RESERVED_B)).toBe(true);
+      });
+
+      it("keeps the reservations of the accounts it is not syncing", () => {
+        reserveNotes("acc-1", [RESERVED_A]);
+        reserveNotes("acc-2", [RESERVED_B]);
+
+        reduceShieldedSyncResult(
+          { processedOperations: [], accountUpdate: {} },
+          { ...emptyChunk, transactions, processedBlocks: 15, remainingBlocks: 0 },
+          infoWith({}),
+          "acc-1",
+        );
+
+        expect(getReservedNullifiers("acc-1").size).toBe(0);
+        expect(getReservedNullifiers("acc-2").has(RESERVED_B)).toBe(true);
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -427,7 +427,7 @@ export async function performTransparentSync(
   const getInputsKey = (op: BtcOperation): string | null => {
     const inputs = op.extra?.inputs;
     if (!Array.isArray(inputs) || inputs.length === 0) return null;
-    return [...inputs].sort().join("|");
+    return [...inputs].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)).join("|");
   };
 
   const isBetterCandidate = (candidate: BtcOperation, existing: BtcOperation): boolean => {

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -134,6 +134,150 @@ function withRecoveredRecipients(
   return { ...op, recipients: [...transparentRecipients, ...payees] };
 }
 
+type AccountInputs = {
+  /** Every address the transaction spends from, ours or not. */
+  senders: Set<string>;
+  accountInputs: WalletInput[];
+  /** What the account's own inputs put in, before its change comes back. */
+  spent: BigNumber;
+};
+
+function collectAccountInputs(tx: TX, accountAddresses: Set<string>): AccountInputs {
+  const senders = new Set<string>();
+  const accountInputs: WalletInput[] = [];
+  let spent = new BigNumber(0);
+
+  for (const input of tx.inputs) {
+    if (!input.address) continue;
+    senders.add(input.address);
+    if (input.value && accountAddresses.has(input.address)) {
+      spent = spent.plus(input.value);
+      accountInputs.push(input);
+    }
+  }
+
+  return { senders, accountInputs, spent };
+}
+
+/**
+ * Minimum nSequence among the account's own inputs -- the conservative
+ * RBF/locktime signal. An input that omits it counts as 0xfffffffe, the
+ * Bitcoin Core default; no own input at all reads as 0.
+ */
+function minAccountSequence(accountInputs: WalletInput[]): BigNumber {
+  if (accountInputs.length === 0) return new BigNumber(0);
+  return new BigNumber(Math.min(...accountInputs.map(input => input.sequence ?? 0xfffffffe)));
+}
+
+/** Where a sender's own change sits: the last output of the transaction. */
+function changeOutputIndexOf(tx: TX): number {
+  return tx.outputs.reduce((highest, output) => Math.max(highest, output.output_index), 0);
+}
+
+type OutputContext = {
+  fundedByAccount: boolean;
+  singleOutput: boolean;
+  changeOutputIndex: number;
+  spentNothing: boolean;
+};
+
+/** An output the explorer could not attribute carries a placeholder address. */
+function isAttributed(output: WalletOutput): boolean {
+  return !!output.address && !output.address.includes("unknown");
+}
+
+/**
+ * A foreign address is a payee only when the account funded the transaction,
+ * and only among the outputs preceding the change.
+ */
+function isForeignPayee(output: WalletOutput, context: OutputContext): boolean {
+  if (!context.fundedByAccount) return false;
+  return context.singleOutput || output.output_index < context.changeOutputIndex;
+}
+
+/**
+ * One of the account's own addresses is a payee unless it is change -- which
+ * still counts when nothing else was paid, or when the account spent nothing
+ * and is therefore being paid rather than paying.
+ */
+function isOwnPayee(
+  output: WalletOutput,
+  changeAddresses: Set<string>,
+  recipientsSoFar: number,
+  context: OutputContext,
+): boolean {
+  if (!changeAddresses.has(output.address)) return true;
+  return (
+    (recipientsSoFar === 0 && output.output_index >= context.changeOutputIndex) ||
+    context.spentNothing
+  );
+}
+
+type OutputRoles = {
+  recipients: string[];
+  accountOutputs: WalletOutput[];
+};
+
+function assignOutputRoles(
+  tx: TX,
+  accountAddresses: Set<string>,
+  changeAddresses: Set<string>,
+  context: OutputContext,
+): OutputRoles {
+  const recipients: string[] = [];
+  const accountOutputs: WalletOutput[] = [];
+
+  for (const output of tx.outputs) {
+    if (!isAttributed(output)) continue;
+
+    const isOwn = accountAddresses.has(output.address);
+    if (isOwn) accountOutputs.push(output);
+
+    const isPayee = isOwn
+      ? isOwnPayee(output, changeAddresses, recipients.length, context)
+      : isForeignPayee(output, context);
+    if (isPayee) recipients.push(output.address);
+  }
+
+  return { recipients, accountOutputs };
+}
+
+function sumValues(outputs: WalletOutput[]): BigNumber {
+  return outputs.reduce((total, output) => total.plus(output.value), new BigNumber(0));
+}
+
+type OperationDraft = {
+  tx: TX;
+  accountId: string;
+  senders: Set<string>;
+  recipients: string[];
+  transactionSequenceNumber: BigNumber;
+};
+
+function buildOperation(
+  draft: OperationDraft,
+  type: OperationType,
+  value: BigNumber,
+): BtcOperation {
+  const { tx, accountId, senders, recipients, transactionSequenceNumber } = draft;
+  return {
+    id: encodeOperationId(accountId, tx.id, type),
+    hash: tx.id,
+    type,
+    value,
+    fee: explorerFee(tx),
+    senders: Array.from(senders),
+    recipients,
+    blockHeight: tx.block?.height,
+    blockHash: tx.block?.hash,
+    accountId,
+    date: txDate(tx),
+    hasFailed: false,
+    transactionSequenceNumber,
+    extra: { inputs: Array.from(new Set(spentOutpoints(tx))) },
+  } as BtcOperation;
+}
+
 /**
  * Maps a wallet-btc TX to LL operations. Ported from coin-bitcoin's
  * `logic.ts` `mapTxToOperations`, dropping the multi-currency `perCoinLogic`
@@ -145,127 +289,38 @@ function mapTxToOperations(
   accountAddresses: Set<string>,
   changeAddresses: Set<string>,
 ): BtcOperation[] {
+  const { senders, accountInputs, spent } = collectAccountInputs(tx, accountAddresses);
+  const fundedByAccount = accountInputs.length > 0;
+
+  const { recipients, accountOutputs } = assignOutputRoles(tx, accountAddresses, changeAddresses, {
+    fundedByAccount,
+    singleOutput: tx.outputs.length === 1,
+    changeOutputIndex: changeOutputIndexOf(tx),
+    spentNothing: spent.eq(0),
+  });
+
+  const draft: OperationDraft = {
+    tx,
+    accountId,
+    senders,
+    recipients,
+    transactionSequenceNumber: minAccountSequence(accountInputs),
+  };
+
   const operations: BtcOperation[] = [];
-  const txId = tx.id;
-  const fee = explorerFee(tx);
-  const blockHeight = tx.block?.height;
-  const blockHash = tx.block?.hash;
-  const date = txDate(tx);
-  const senders = new Set<string>();
-  const recipients: string[] = [];
-  let type: OperationType = "OUT";
-  let value = new BigNumber(0);
-  const hasFailed = false;
-  const accountInputs: WalletInput[] = [];
-  const accountOutputs: WalletOutput[] = [];
-  const inputs = new Set(spentOutpoints(tx));
 
-  for (const input of tx.inputs) {
-    if (input.address) {
-      senders.add(input.address);
-      if (input.value && accountAddresses.has(input.address)) {
-        value = value.plus(input.value);
-        accountInputs.push(input);
-      }
-    }
+  if (fundedByAccount) {
+    const change = accountOutputs.filter(output => changeAddresses.has(output.address));
+    operations.push(buildOperation(draft, "OUT", spent.minus(sumValues(change))));
   }
 
-  // Minimum nSequence among the account's own inputs -- the conservative
-  // RBF/locktime signal. An input that omits it counts as 0xfffffffe, the
-  // Bitcoin Core default; no own input at all reads as 0.
-  const transactionSequenceNumber = new BigNumber(
-    accountInputs.length === 0
-      ? 0
-      : Math.min(...accountInputs.map(input => input.sequence ?? 0xfffffffe)),
-  );
-
-  const hasSpentNothing = value.eq(0);
-  const changeOutputIndex =
-    tx.outputs.length === 0
-      ? 0
-      : tx.outputs.map(o => o.output_index).reduce((p, c) => (p > c ? p : c));
-
-  for (const output of tx.outputs) {
-    if (output.address && !output.address.includes("unknown")) {
-      if (!accountAddresses.has(output.address)) {
-        if (
-          accountInputs.length > 0 &&
-          (tx.outputs.length === 1 || output.output_index < changeOutputIndex)
-        ) {
-          recipients.push(output.address);
-        }
-      } else {
-        accountOutputs.push(output);
-        if (!changeAddresses.has(output.address)) {
-          recipients.push(output.address);
-        } else if (
-          (recipients.length === 0 && output.output_index >= changeOutputIndex) ||
-          hasSpentNothing
-        ) {
-          recipients.push(output.address);
-        }
-      }
-    }
-  }
-
-  if (accountInputs.length > 0) {
-    for (const output of accountOutputs) {
-      if (changeAddresses.has(output.address)) {
-        value = value.minus(output.value);
-      }
-    }
-
-    type = "OUT";
-    operations.push({
-      id: encodeOperationId(accountId, txId, type),
-      hash: txId,
-      type,
-      value,
-      fee,
-      senders: Array.from(senders),
-      recipients,
-      blockHeight,
-      blockHash,
-      accountId,
-      date,
-      hasFailed,
-      transactionSequenceNumber,
-      extra: { inputs: Array.from(inputs) },
-    } as BtcOperation);
-  }
-
-  if (accountOutputs.length > 0) {
-    const filterChangeAddresses = !!accountInputs.length;
-    let accountOutputCount = 0;
-    let finalAmount = new BigNumber(0);
-
-    for (const output of accountOutputs) {
-      if (!filterChangeAddresses || !changeAddresses.has(output.address)) {
-        finalAmount = finalAmount.plus(output.value);
-        accountOutputCount += 1;
-      }
-    }
-
-    if (accountOutputCount > 0) {
-      value = finalAmount;
-      type = "IN";
-      operations.push({
-        id: encodeOperationId(accountId, txId, type),
-        hash: txId,
-        type,
-        value,
-        fee,
-        senders: Array.from(senders),
-        recipients,
-        blockHeight,
-        blockHash,
-        accountId,
-        date,
-        hasFailed,
-        transactionSequenceNumber,
-        extra: { inputs: Array.from(inputs) },
-      } as BtcOperation);
-    }
+  // Change coming back to the account is not income, so a send only credits
+  // what it pays to an address of ours that is not change.
+  const credited = fundedByAccount
+    ? accountOutputs.filter(output => !changeAddresses.has(output.address))
+    : accountOutputs;
+  if (credited.length > 0) {
+    operations.push(buildOperation(draft, "IN", sumValues(credited)));
   }
 
   return operations;

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -45,6 +45,7 @@ import { DEFAULT_ZCASH_PRIVATE_INFO, getZainoEndpoint, ZCASH_LOG_TYPE } from "..
 import { getZCashClient } from "../logic/engineClient";
 import { resolveTransactionDetails, type ResolvedTransactions } from "./transaction-details";
 import { composeXpub } from "../signer/xpub";
+import { reconcileReservations } from "./note-reservation";
 
 export { removeReplaced } from "@ledgerhq/wallet-btc/operations";
 
@@ -715,6 +716,8 @@ export function reduceShieldedSyncResult(
       ironwoodBalance,
     });
 
+    reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
+
     return {
       ...accumulated,
       accountUpdate: {
@@ -796,6 +799,8 @@ export function reduceShieldedSyncResult(
     0,
     (info.initialAccount?.operationsCount ?? 0) - (info.initialAccount?.operations?.length ?? 0),
   );
+
+  reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
 
   return {
     processedOperations: [...result.transactions],

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -399,8 +399,7 @@ export async function performTransparentSync(
   }
 
   const newOperations = (resolved?.transactions ?? transactions)
-    ?.map(tx => mapTxToOperations(tx, accountId, accountAddresses, changeAddresses))
-    .flat()
+    ?.flatMap(tx => mapTxToOperations(tx, accountId, accountAddresses, changeAddresses))
     .map(op => withRecoveredRecipients(op, resolved?.payeesByTxId, changeAddresses));
 
   const newUniqueOperations = deduplicateOperations(newOperations);

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -672,6 +672,78 @@ function markSpentNotes(tx: ShieldedTransaction, spentSet: Set<string>): Shielde
   };
 }
 
+/** How far the scan got, as persisted on the account. */
+function scanProgress(
+  result: ShieldedSyncResult,
+): Pick<ZcashPrivateInfo, "syncState" | "progress"> {
+  const totalBlocks = result.processedBlocks + result.remainingBlocks;
+  return {
+    syncState: result.remainingBlocks > 0 ? "running" : "complete",
+    progress: totalBlocks > 0 ? Math.round((result.processedBlocks / totalBlocks) * 100) : 100,
+  };
+}
+
+/**
+ * Fold a chunk that carries no transaction the account does not already hold.
+ *
+ * Only the scan cursor and the spent flags can move here: a note already known
+ * may have been spent elsewhere, which the chunk reports through its
+ * nullifiers. Operations are left untouched.
+ */
+function reduceUnchangedShieldedChunk(
+  accumulated: ShieldedScanAccumulated,
+  result: ShieldedSyncResult,
+  context: {
+    existingPrivateInfo: ZcashPrivateInfo;
+    transparentBalance: BigNumber;
+    lastProcessedBlock: number | null;
+    accountId: string;
+  },
+): ShieldedScanAccumulated {
+  const { existingPrivateInfo, transparentBalance, lastProcessedBlock, accountId } = context;
+  // The NAPI uses a unified spentKnownNullifiers list for all pools.
+  const spentNfs = result.spentKnownNullifiers ?? [];
+  const hasNewlySpentNotes = spentNfs.length > 0;
+  const spentSet = new Set(spentNfs);
+
+  const updatedTransactions = hasNewlySpentNotes
+    ? existingPrivateInfo.transactions.map(tx => markSpentNotes(tx, spentSet))
+    : existingPrivateInfo.transactions;
+  const orchardBalance = hasNewlySpentNotes
+    ? computeBalanceFromNotes(updatedTransactions)
+    : existingPrivateInfo.orchardBalance;
+  const ironwoodBalance = hasNewlySpentNotes
+    ? computeIronwoodBalanceFromNotes(updatedTransactions)
+    : existingPrivateInfo.ironwoodBalance;
+
+  const balance = computeZcashBalance(transparentBalance, {
+    orchardBalance,
+    saplingBalance: existingPrivateInfo.saplingBalance,
+    ironwoodBalance,
+  });
+
+  reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
+
+  return {
+    ...accumulated,
+    accountUpdate: {
+      ...accumulated.accountUpdate,
+      balance,
+      spendableBalance: balance,
+      blockHeight: lastProcessedBlock ?? accumulated.accountUpdate.blockHeight ?? 0,
+      privateInfo: {
+        ...existingPrivateInfo,
+        ...scanProgress(result),
+        lastProcessedBlock,
+        lastSyncTimestamp: Date.now(),
+        transactions: updatedTransactions,
+        orchardBalance,
+        ironwoodBalance,
+      },
+    },
+  };
+}
+
 export function reduceShieldedSyncResult(
   accumulated: ShieldedScanAccumulated,
   result: ShieldedSyncResult,
@@ -693,51 +765,12 @@ export function reduceShieldedSyncResult(
   );
 
   if (newTransactions.length === 0) {
-    const totalBlocks = result.processedBlocks + result.remainingBlocks;
-    // The NAPI uses a unified spentKnownNullifiers list for all pools.
-    const spentNfs = result.spentKnownNullifiers ?? [];
-    let updatedTransactions = existingPrivateInfo.transactions;
-    if (spentNfs.length > 0) {
-      const spentSet = new Set(spentNfs);
-      updatedTransactions = updatedTransactions.map(tx => markSpentNotes(tx, spentSet));
-    }
-    const orchardBalance =
-      spentNfs.length > 0
-        ? computeBalanceFromNotes(updatedTransactions)
-        : existingPrivateInfo.orchardBalance;
-    const ironwoodBalance =
-      spentNfs.length > 0
-        ? computeIronwoodBalanceFromNotes(updatedTransactions)
-        : existingPrivateInfo.ironwoodBalance;
-
-    const balance = computeZcashBalance(transparentBalance, {
-      orchardBalance,
-      saplingBalance: existingPrivateInfo.saplingBalance,
-      ironwoodBalance,
+    return reduceUnchangedShieldedChunk(accumulated, result, {
+      existingPrivateInfo,
+      transparentBalance,
+      lastProcessedBlock,
+      accountId,
     });
-
-    reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
-
-    return {
-      ...accumulated,
-      accountUpdate: {
-        ...accumulated.accountUpdate,
-        balance,
-        spendableBalance: balance,
-        blockHeight: lastProcessedBlock ?? accumulated.accountUpdate.blockHeight ?? 0,
-        privateInfo: {
-          ...existingPrivateInfo,
-          syncState: result.remainingBlocks > 0 ? ("running" as const) : ("complete" as const),
-          progress:
-            totalBlocks > 0 ? Math.round((result.processedBlocks / totalBlocks) * 100) : 100,
-          lastProcessedBlock,
-          lastSyncTimestamp: Date.now(),
-          transactions: updatedTransactions,
-          orchardBalance,
-          ironwoodBalance,
-        },
-      },
-    };
   }
 
   const newOperations = convertShieldedTransactionsToOperations(newTransactions, accountId);
@@ -765,13 +798,11 @@ export function reduceShieldedSyncResult(
   const ironwoodBalance = computeIronwoodBalanceFromNotes(allShieldedTx);
   const saplingBalance = accumulated.accountUpdate.privateInfo?.saplingBalance ?? new BigNumber(0);
 
-  const totalBlocks = result.processedBlocks + result.remainingBlocks;
   const privateInfo: ZcashPrivateInfo = {
     saplingBalance,
     orchardBalance,
     ironwoodBalance,
-    syncState: result.remainingBlocks > 0 ? ("running" as const) : ("complete" as const),
-    progress: totalBlocks > 0 ? Math.round((result.processedBlocks / totalBlocks) * 100) : 100,
+    ...scanProgress(result),
     estimatedTimeRemaining: existingPrivateInfo.estimatedTimeRemaining ?? { hours: 0, minutes: 0 },
     ufvk: existingPrivateInfo?.ufvk ?? null,
     birthday: existingPrivateInfo?.birthday ?? null,

--- a/libs/coin-modules/coin-zcash/src/bridge/sync.ts
+++ b/libs/coin-modules/coin-zcash/src/bridge/sync.ts
@@ -45,7 +45,7 @@ import { DEFAULT_ZCASH_PRIVATE_INFO, getZainoEndpoint, ZCASH_LOG_TYPE } from "..
 import { getZCashClient } from "../logic/engineClient";
 import { resolveTransactionDetails, type ResolvedTransactions } from "./transaction-details";
 import { composeXpub } from "../signer/xpub";
-import { reconcileReservations } from "./note-reservation";
+import { releaseConfirmedNullifiers, releaseRetiredReservations } from "./note-reservation";
 
 export { removeReplaced } from "@ledgerhq/wallet-btc/operations";
 
@@ -722,7 +722,7 @@ function reduceUnchangedShieldedChunk(
     ironwoodBalance,
   });
 
-  reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
+  releaseConfirmedNullifiers(accountId, spentNfs);
 
   return {
     ...accumulated,
@@ -831,7 +831,7 @@ export function reduceShieldedSyncResult(
     (info.initialAccount?.operationsCount ?? 0) - (info.initialAccount?.operations?.length ?? 0),
   );
 
-  reconcileReservations(accountId, spentNfs, result.remainingBlocks === 0);
+  releaseConfirmedNullifiers(accountId, spentNfs);
 
   return {
     processedOperations: [...result.transactions],
@@ -997,5 +997,13 @@ function reconcileConfirmedPendingOperations(account: ZcashAccount): ZcashAccoun
   return { ...account, operations, pendingOperations };
 }
 
-export const postSync = (_initial: ZcashAccount, synced: ZcashAccount): ZcashAccount =>
-  reconcileConfirmedPendingOperations(synced);
+/**
+ * Note reservations hang off the same lifecycle: the notes a shielded send spends
+ * stay reserved until the operation spending them is retired, matched on the very
+ * hashes `reconcileConfirmedPendingOperations` resolves the optimistic operation
+ * by.
+ */
+export const postSync = (_initial: ZcashAccount, synced: ZcashAccount): ZcashAccount => {
+  releaseRetiredReservations(synced.id, new Set(synced.operations.map(op => op.hash)));
+  return reconcileConfirmedPendingOperations(synced);
+};

--- a/libs/coin-modules/coin-zcash/src/types/bridge.ts
+++ b/libs/coin-modules/coin-zcash/src/types/bridge.ts
@@ -70,7 +70,14 @@ export type BtcOperationExtra = {
   inputRefs?: BtcInputRef[];
 };
 
-export type ZcashOperationExtra = BtcOperationExtra & { zcashShielded?: boolean };
+export type ZcashOperationExtra = BtcOperationExtra & {
+  zcashShielded?: boolean;
+  /**
+   * Hex nullifiers of the Ironwood notes spent by this operation.
+   * Mirrors the transparent inputs/inputRefs fields for shielded sends.
+   */
+  shieldedNullifiers?: string[];
+};
 
 export type BtcOperation = Operation<BtcOperationExtra>;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Selected Ironwood notes are now reserved in a session-scoped in-memory store immediately after buildSignedOperation, so back-to-back shielded sends before the first confirms will select disjoint note sets. The store is reconciled on every shielded sync pass via reduceShieldedSyncResult.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-34949
