### PR TITLE
fix(devtools): guard invalid WebSocket URLs

### DIFF
--- a/.changeset/dusty-spider-leaps.md
+++ b/.changeset/dusty-spider-leaps.md
@@ -1,0 +1,6 @@
+---
+"@devtools/wire": minor
+"@devtools/transport-panel": minor
+---
+
+Guard invalid WebSocket URLs before attempting connection to prevent native crash on mobile

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,11 @@ libs/feature-flag-module/                                @ledgerhq/platform
 libs/ledger-auth/                                        @ledgerhq/platform
 libs/oxc-live-libs/                                      @ledgerhq/platform
 
+# Platform — devtools
+devtools/transport/                                      @ledgerhq/platform
+devtools/protocols/                                      @ledgerhq/platform
+devtools/wire/                                           @ledgerhq/platform
+
 # Wallet — libs
 libs/live-countervalues-react/                           @ledgerhq/wallet-xp
 libs/live-countervalues/                                 @ledgerhq/wallet-xp

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.tsx
@@ -22,12 +22,12 @@ export interface TransportPanelContentProps<M extends MessageMap> {
 export function TransportPanelContent<M extends MessageMap>({
   bottomSheetRef,
   transport,
-}: TransportPanelContentProps<M>) {
+}: Readonly<TransportPanelContentProps<M>>) {
   const debugBottomSheetRef = useBottomSheetRef();
 
   return (
     <Box>
-      <BottomSheet ref={bottomSheetRef} snapPoints="medium">
+      <BottomSheet ref={bottomSheetRef} snapPoints="full">
         <BottomSheetView>
           <BottomSheetHeader
             title="Transport State"

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.web.tsx
@@ -11,7 +11,7 @@ interface TransportPanelContentProps<M extends MessageMap> {
 
 export function TransportPanelContent<M extends MessageMap>({
   transportConfig,
-}: TransportPanelContentProps<M>) {
+}: Readonly<TransportPanelContentProps<M>>) {
   const { transport, target, setTarget, hubUrl, setHubUrl, role } = transportConfig;
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   return (

--- a/devtools/wire/src/wire.test.ts
+++ b/devtools/wire/src/wire.test.ts
@@ -1,4 +1,4 @@
-import { buildTargetUrl, buildTransport, isMatch } from "./wire";
+import { buildTargetUrl, buildTransport, isMatch, isValidWsUrl } from "./wire";
 import type { MessageMap, TransportProtocol, WebSocketLike } from "@devtools/transport";
 
 const protocol: TransportProtocol<MessageMap> = {
@@ -46,6 +46,62 @@ describe("isMatch", () => {
 
   it("should only check keys present in partial, ignoring extra keys in origin", () => {
     expect(isMatch({ a: 1, b: 2, c: 3 }, { b: 2 })).toBe(true);
+  });
+});
+
+describe("isValidWsUrl", () => {
+  it("should return true for a valid ws URL with hostname", () => {
+    expect(isValidWsUrl("ws://localhost:9090")).toBe(true);
+  });
+
+  it("should return true for a valid wss URL", () => {
+    expect(isValidWsUrl("wss://example.com:9090")).toBe(true);
+  });
+
+  it("should return true for a valid IPv4 address", () => {
+    expect(isValidWsUrl("ws://192.168.1.1:9090")).toBe(true);
+  });
+
+  it("should return false for a non-ws protocol", () => {
+    expect(isValidWsUrl("http://localhost:9090")).toBe(false);
+  });
+
+  it("should return false when host is empty", () => {
+    expect(isValidWsUrl("ws://:9090")).toBe(false);
+  });
+
+  it("should return false for a partial IP with a single number", () => {
+    expect(isValidWsUrl("ws://127:9090")).toBe(false);
+  });
+
+  it("should return false for an incomplete IPv4 with trailing dot", () => {
+    expect(isValidWsUrl("ws://192.168.1.:9090")).toBe(false);
+  });
+
+  it("should return false for an IPv4 with an octet out of range", () => {
+    expect(isValidWsUrl("ws://192.168.1.256:9090")).toBe(false);
+  });
+
+  it("should return false for a malformed URL", () => {
+    expect(isValidWsUrl("not-a-url")).toBe(false);
+  });
+
+  it("should return false when only the scheme is present", () => {
+    expect(isValidWsUrl("ws://")).toBe(false);
+  });
+
+  it("should not update transport URL when setHubUrl is called with an invalid URL", () => {
+    const socketFactory = makeSocketFactory();
+    const wire = buildTransport({ ...BASE_OPTIONS, socketFactory }, protocol);
+    const urlBefore = wire.transport.getState().url;
+    wire.setHubUrl("ws://192.168.1.256:9090");
+    expect(wire.transport.getState().url).toBe(urlBefore);
+  });
+
+  it("should not connect on init when the initial hubUrl is invalid", () => {
+    const socketFactory = makeSocketFactory();
+    buildTransport({ ...BASE_OPTIONS, hubUrl: "ws://192.168.1.256:9090", socketFactory }, protocol);
+    expect(socketFactory).not.toHaveBeenCalled();
   });
 });
 

--- a/devtools/wire/src/wire.ts
+++ b/devtools/wire/src/wire.ts
@@ -29,6 +29,22 @@ export type Wire<M extends MessageMap> = {
   setHubUrl(hubUrl: string): void;
 };
 
+export function isValidWsUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    if (protocol !== "ws:" && protocol !== "wss:") return false;
+    const rawHostname = /^wss?:\/\/([^/:?#]*)/.exec(url)?.[1] ?? "";
+    if (rawHostname.length === 0) return false;
+    if (/^[\d.]+$/.test(rawHostname)) {
+      const parts = rawHostname.split(".");
+      return parts.length === 4 && parts.every(p => p.length > 0 && Number(p) <= 255);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function buildTargetUrl(options: WireTransportOptions): string {
   return identityUrl(options.hubUrl, {
     role: options.role,
@@ -50,7 +66,9 @@ export function buildTransport<M extends MessageMap>(
     { url: buildTargetUrl(config), origin: config.id, socketFactory: config.socketFactory },
     protocol,
   );
-  transport.connect();
+  if (isValidWsUrl(config.hubUrl)) {
+    transport.connect();
+  }
 
   let state: WireState = { hubUrl: config.hubUrl, role: config.role, target: config.target };
   const listeners = new Set<() => void>();
@@ -60,7 +78,9 @@ export function buildTransport<M extends MessageMap>(
     Object.assign(config, patch);
     state = { ...state, ...patch };
     listeners.forEach(l => l());
-    transport.setUrl(buildTargetUrl(config));
+    if (isValidWsUrl(config.hubUrl)) {
+      transport.setUrl(buildTargetUrl(config));
+    }
   }
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65963,7 +65963,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3
+      metro: 0.83.3(metro-transform-worker@0.83.3)
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -66087,6 +66087,54 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.3(metro-transform-worker@0.83.3):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 1.3.8
+      chalk: 4.1.2
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.32.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.3)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.3
+      metro-cache: 0.83.3
+      metro-cache-key: 0.83.3
+      metro-config: 0.83.3(metro-transform-worker@0.83.3)
+      metro-core: 0.83.3
+      metro-file-map: 0.83.3(metro@0.83.3)
+      metro-resolver: 0.83.3
+      metro-runtime: 0.83.3
+      metro-source-map: 0.83.3
+      metro-symbolicate: 0.83.3
+      metro-transform-plugins: 0.83.3
+      metro-transform-worker: 0.83.3
+      mime-types: 2.1.35
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

  Adds URL validation in `@devtools/wire` before attempting a WebSocket connection,
  preventing a native crash on React Native when an invalid or incomplete URL is
  passed to the native `WebSocket` constructor.

  On web, invalid URLs are caught by a JS try/catch. On mobile, the native WebSocket
  module throws a native exception before JS can intercept it — so validation must
  happen before the URL reaches `new WebSocket()`.

  ### What changed

  - **`@devtools/wire`**: Added `isValidWsUrl()` — validates protocol (`ws:`/`wss:`),
    non-empty host, and proper IPv4 format via `is-ip` for numeric hostnames.
    The guard runs in `update()` so connection attempts are silently skipped while
    the user is still typing.
  - **`@devtools/transport-panel`**: Expanded bottom sheet snap point from `"medium"`
    to `"full"` on native.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
