### PR TITLE
[LWM] feat(analytics-consent): add stored-policy inspector helper

### DIFF
--- a/.changeset/calm-clouds-inspector.md
+++ b/.changeset/calm-clouds-inspector.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-analytics-consent": patch
+"live-mobile": patch
+---
+
+Add shared stored-policy inspector status helper and use it on mobile analytics consent QA

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/AnalyticsConsentQA/index.tsx
@@ -30,6 +30,7 @@ import {
   resolveBaselinePolicyVersion,
   resolveScenarioConsentDate,
   resolveScenarioVersions,
+  resolveStoredPolicyInspectorStatus,
   SCENARIO_GROUPS,
   SYNTHETIC_BASELINE,
   VERDICT_META,
@@ -138,14 +139,11 @@ function buildInspectorFields(
     storedPolicyValue = "Invalid";
   }
 
-  let storedPolicyStatus: InspectorField["status"];
-  if (consentInfo.privacyPolicyVersion === null) {
-    storedPolicyStatus = { label: "Missing", tone: "error" };
-  } else if (storedVersion) {
-    storedPolicyStatus = { label: "Valid", tone: "success" };
-  } else {
-    storedPolicyStatus = { label: "Invalid", tone: "error" };
-  }
+  const storedPolicyStatus = resolveStoredPolicyInspectorStatus(
+    consentInfo.privacyPolicyVersion,
+    storedVersion,
+    currentPolicyVersion,
+  );
 
   let consentDateValue: string;
   if (formattedConsentDate) {

--- a/features/flow/analytics-consent/src/debug/index.ts
+++ b/features/flow/analytics-consent/src/debug/index.ts
@@ -12,6 +12,11 @@ export {
   type StoredPolicyRef,
 } from "./scenarios";
 export {
+  resolveStoredPolicyInspectorStatus,
+  type InspectorFieldStatus,
+  type InspectorFieldTone,
+} from "./inspector";
+export {
   mapDecisionToQaExpectation,
   REASON_LABEL,
   SCENARIO_GROUPS,

--- a/features/flow/analytics-consent/src/debug/inspector.test.ts
+++ b/features/flow/analytics-consent/src/debug/inspector.test.ts
@@ -1,0 +1,41 @@
+import { resolveStoredPolicyInspectorStatus } from "./inspector";
+
+const v1 = { major: 1, minor: 0, normalized: "1.0" };
+const v2 = { major: 2, minor: 0, normalized: "2.0" };
+
+describe("resolveStoredPolicyInspectorStatus", () => {
+  it("returns Missing when nothing is saved", () => {
+    expect(resolveStoredPolicyInspectorStatus(null, null, v1)).toEqual({
+      label: "Missing",
+      tone: "error",
+    });
+  });
+
+  it("returns Invalid when the saved value does not parse", () => {
+    expect(resolveStoredPolicyInspectorStatus("not-a-version", null, v1)).toEqual({
+      label: "Invalid",
+      tone: "error",
+    });
+  });
+
+  it("returns Valid when stored matches remote", () => {
+    expect(resolveStoredPolicyInspectorStatus("1.0", v1, v1)).toEqual({
+      label: "Valid",
+      tone: "success",
+    });
+  });
+
+  it("returns Valid · outdated when stored is behind a valid remote", () => {
+    expect(resolveStoredPolicyInspectorStatus("1.0", v1, v2)).toEqual({
+      label: "Valid · outdated",
+      tone: "warning",
+    });
+  });
+
+  it("returns Valid when remote is invalid even if stored is older", () => {
+    expect(resolveStoredPolicyInspectorStatus("1.0", v1, null)).toEqual({
+      label: "Valid",
+      tone: "success",
+    });
+  });
+});

--- a/features/flow/analytics-consent/src/debug/inspector.ts
+++ b/features/flow/analytics-consent/src/debug/inspector.ts
@@ -1,0 +1,29 @@
+import {
+  comparePolicyVersions,
+  type AnalyticsConsentInfo,
+  type PolicyVersion,
+} from "@domain/entity-analytics-consent";
+
+export type InspectorFieldTone = "success" | "error" | "warning" | "gray";
+
+export type InspectorFieldStatus = {
+  label: string;
+  tone: InspectorFieldTone;
+};
+
+export function resolveStoredPolicyInspectorStatus(
+  privacyPolicyVersion: AnalyticsConsentInfo["privacyPolicyVersion"],
+  storedVersion: PolicyVersion | null,
+  currentPolicyVersion: PolicyVersion | null,
+): InspectorFieldStatus {
+  if (privacyPolicyVersion === null) {
+    return { label: "Missing", tone: "error" };
+  }
+  if (!storedVersion) {
+    return { label: "Invalid", tone: "error" };
+  }
+  if (currentPolicyVersion && comparePolicyVersions(storedVersion, currentPolicyVersion) < 0) {
+    return { label: "Valid · outdated", tone: "warning" };
+  }
+  return { label: "Valid", tone: "success" };
+}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Mobile Analytics Consent QA: stored-policy status labels (Missing / Invalid / Valid / Valid · outdated)
  - Shared `@features/flow-analytics-consent/debug` inspector helper used by consumers

### 📝 Description

Mobile Analytics Consent QA needed a clear stored-policy status (including “valid but outdated”) without duplicating version-compare logic in the app.

This PR adds `resolveStoredPolicyInspectorStatus` under `@features/flow-analytics-consent/debug` and wires the mobile QA screen to it so status labels stay consistent with the shared decision helpers.

Stack layer above `#20265` (prune); consumed by desktop QA `#20266`.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-29595](https://ledgerhq.atlassian.net/browse/LIVE-29595)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-29595]: https://ledgerhq.atlassian.net/browse/LIVE-29595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ