### PR TITLE
[LWDM] fix(coin-hedera): support multi-transfers from single tx (LIVE-24949)

### DIFF
--- a/.changeset/shy-lobsters-crash.md
+++ b/.changeset/shy-lobsters-crash.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-hedera": minor
+---
+
+Fix Hedera transactions that pack several fund movements being reported as a single operation, and fix the sync cursor skipping or duplicating operations.

--- a/libs/coin-modules/coin-hedera/src/api/index.test.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.test.ts
@@ -392,6 +392,60 @@ describe("createApi", () => {
       expect(result.items[0].details).toMatchObject({ stakedAmount: 200n });
     });
 
+    it("should report the transaction fee on an op whose own fee is 0", async () => {
+      const splitOutOperation = getMockedOperation({
+        type: "OUT",
+        fee: new BigNumber(0),
+        extra: { chargedTxFee: "1176695" },
+      });
+
+      mockListOperationsV2.mockResolvedValue({
+        coinOperations: [splitOutOperation],
+        tokenOperations: [],
+        nextCursor: null,
+      });
+
+      const result = await api.listOperations(mockAddress, mockOptions);
+
+      expect(result.items[0].tx.fees).toBe(1176695n);
+    });
+
+    it("should report no fee on a REWARD op, whose fee belongs to the op that triggered it", async () => {
+      const rewardOperation = getMockedOperation({
+        type: "REWARD",
+        fee: new BigNumber(0),
+        extra: {},
+      });
+
+      mockListOperationsV2.mockResolvedValue({
+        coinOperations: [rewardOperation],
+        tokenOperations: [],
+        nextCursor: null,
+      });
+
+      const result = await api.listOperations(mockAddress, mockOptions);
+
+      expect(result.items[0].tx.fees).toBe(0n);
+    });
+
+    it("should fall back to the operation fee for ops stored before chargedTxFee existed", async () => {
+      const legacyOperation = getMockedOperation({
+        type: "OUT",
+        fee: new BigNumber(500000),
+        extra: { transactionId: "0.0.111-1234567890-1" },
+      });
+
+      mockListOperationsV2.mockResolvedValue({
+        coinOperations: [legacyOperation],
+        tokenOperations: [],
+        nextCursor: null,
+      });
+
+      const result = await api.listOperations(mockAddress, mockOptions);
+
+      expect(result.items[0].tx.fees).toBe(500000n);
+    });
+
     it("should omit feesPayer when transactionId is absent", async () => {
       const mockOperationWithoutTransactionId = getMockedOperation({
         extra: {},

--- a/libs/coin-modules/coin-hedera/src/api/index.ts
+++ b/libs/coin-modules/coin-hedera/src/api/index.ts
@@ -169,8 +169,8 @@ export function createApi(
           : { type: "native" };
 
         // Prefer inferred payer from operation extra, fallback to transaction_id parsing for legacy ops.
-        let feesPayer = liveOp.extra?.feesPayer;
-        if (!feesPayer && liveOp.extra?.transactionId)
+        let feesPayer = liveOp.extra.feesPayer;
+        if (!feesPayer && liveOp.extra.transactionId)
           feesPayer = extractInitiator(liveOp.extra.transactionId);
 
         // REWARD operations append a suffix to the tx.hash to ensure uniqueness
@@ -196,7 +196,8 @@ export function createApi(
           },
           tx: {
             hash,
-            fees: BigInt(liveOp.fee.toFixed(0)),
+            // it shouldn't come from liveOp.fee, which can be 0 on an op whose fee is reported separately
+            fees: BigInt(liveOp.extra.chargedTxFee ?? liveOp.fee.toFixed(0)),
             ...(feesPayer && { feesPayer }),
             date: liveOp.date,
             block: {

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.test.ts
@@ -114,6 +114,24 @@ describe("getAccountShape", () => {
     );
   });
 
+  it("passes the newest stored consensus timestamp as the cursor, at full precision", async () => {
+    // @ts-expect-error - no other fields are needed for this test
+    const initialAccount = {
+      syncHash: mockSyncHash,
+      operations: [
+        { date: new Date("2021-07-01T00:00:00Z"), extra: { pagingToken: "1625097600.111222333" } },
+        { date: new Date("2021-07-01T00:00:00Z"), extra: { pagingToken: "1625097600.999888777" } },
+      ],
+      pendingOperations: [],
+    } as Account;
+
+    await getAccountShape({ ...mockInfo, initialAccount }, { paginationConfig: {} });
+
+    expect(logic.listOperationsV2).toHaveBeenCalledWith(
+      expect.objectContaining({ cursor: "1625097600.999888777" }),
+    );
+  });
+
   it("should NOT pass cursor on fresh sync", async () => {
     await getAccountShape(mockInfo, { paginationConfig: {} });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/synchronisation.ts
@@ -13,7 +13,7 @@ import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
 import { HARDCODED_BLOCK_HEIGHT } from "../constants";
 import { listOperationsV2 } from "../logic";
-import { resolveConfig } from "../logic/utils";
+import { getSyncCursor, resolveConfig } from "../logic/utils";
 import { apiClient } from "../network/api";
 import { getERC20BalancesForAccountV2, toEVMAddress } from "../network/utils";
 import type { HederaAccount } from "../types";
@@ -61,15 +61,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
 
   const pendingOperations = shouldSyncFromScratch ? [] : (initialAccount?.pendingOperations ?? []);
   const oldOperations = shouldSyncFromScratch ? [] : (initialAccount?.operations ?? []);
-  const latestOperation = oldOperations[0];
-
-  // grab latest operation timestamps for incremental sync
-  let latestOperationTimestamp: string | null = null;
-
-  if (!shouldSyncFromScratch && latestOperation) {
-    const timestamp = Math.floor(latestOperation.date.getTime() / 1000);
-    latestOperationTimestamp = new BigNumber(timestamp).toFixed(9);
-  }
+  const syncCursor = getSyncCursor(shouldSyncFromScratch ? null : initialAccount);
 
   const calTokenByAddress = await buildCalTokenMap({
     erc20Tokens,
@@ -85,7 +77,7 @@ export const getAccountShape: GetAccountShape<HederaAccount> = async (
     tokenEvmAddresses: [...calTokenByAddress.values()]
       .filter(token => token.tokenType === "erc20")
       .map(token => token.contractAddress.toLowerCase()),
-    ...(latestOperationTimestamp && { cursor: latestOperationTimestamp }),
+    ...(syncCursor && { cursor: syncCursor }),
     fetchAllPages: true,
     skipFeesForTokenOperations: false,
     useEncodedHash: true,

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
@@ -64,6 +64,39 @@ describe("bridge utils", () => {
       expect(noneOp?.subOperations?.[0]).toEqual(mockedOrphanTokenOperation);
       expect(noneOp?.hash).toBe("unknown-hash");
     });
+
+    it("reuses one NONE coin operation for every orphan token op of the same hash", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const accountId = encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL);
+      // a multi-recipient token transfer produces one op per recipient, all under one hash
+      const orphans = [
+        getMockedOperation({ hash: "unknown-hash", accountId, recipients: ["0.0.67890"] }),
+        getMockedOperation({ hash: "unknown-hash", accountId, recipients: ["0.0.99999"] }),
+      ];
+
+      const result = await prepareOperations([], orphans);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subOperations).toEqual(orphans);
+    });
+
+    it("gives the NONE anchor the parent account id and the child's extra", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const extra: HederaOperationExtra = { pagingToken: "1625097600.999888777" };
+      const mockedOrphanTokenOperation = getMockedOperation({
+        hash: "unknown-hash",
+        accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
+        extra,
+      });
+
+      const result = await prepareOperations([], [mockedOrphanTokenOperation]);
+
+      // the anchor's pagingToken is what getSyncCursor reads, so it cannot be dropped
+      expect(result[0]).toMatchObject({
+        accountId: mockedTokenAccount.parentId,
+        extra,
+      });
+    });
   });
 
   describe("mergeSubAccounts", () => {
@@ -357,6 +390,94 @@ describe("bridge utils", () => {
       });
 
       expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+    });
+
+    it("keeps a FEES coin op that has no token op at all", () => {
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp],
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+    });
+
+    it("falls back to the value to tell apart colliding operations with no recipient", () => {
+      const coinOperations = [
+        getMockedOperation({ hash: "h1", type: "OUT", recipients: [], value: new BigNumber(1) }),
+        getMockedOperation({ hash: "h1", type: "OUT", recipients: [], value: new BigNumber(2) }),
+      ];
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations,
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      const ids = bridgeCoinOperations.map(op => op.id);
+      expect(new Set(ids).size).toBe(coinOperations.length);
+    });
+
+    it("assigns a distinct id to every operation of a multi-recipient transaction", () => {
+      const coinOperations = [
+        getMockedOperation({ hash: "h1", type: "OUT", recipients: ["0.0.67890"] }),
+        getMockedOperation({ hash: "h1", type: "OUT", recipients: ["0.0.99999"] }),
+      ];
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations,
+        tokenOperations: [],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      const ids = bridgeCoinOperations.map(op => op.id);
+      expect(new Set(ids).size).toBe(coinOperations.length);
+    });
+
+    it("keeps ids unique across coin and token operations of a multi-asset transaction", () => {
+      const htsToken = getMockedHTSTokenCurrency({ contractAddress: "0.0.1001" });
+      const erc20Token = getMockedERC20TokenCurrency({ contractAddress: "0xabc" });
+
+      const { bridgeCoinOperations, bridgeTokenOperations } = resolveBridgeOperations({
+        coinOperations: [
+          getMockedOperation({ hash: "h1", type: "OUT", recipients: ["0.0.67890"] }),
+          getMockedOperation({ hash: "h1", type: "OUT", recipients: ["0.0.99999"] }),
+        ],
+        tokenOperations: [
+          getMockedOperation({
+            hash: "h1",
+            type: "OUT",
+            recipients: ["0.0.67890"],
+            contract: htsToken.contractAddress,
+          }),
+          getMockedOperation({
+            hash: "h1",
+            type: "OUT",
+            recipients: ["0.0.99999"],
+            contract: htsToken.contractAddress,
+          }),
+          getMockedOperation({
+            hash: "h1",
+            type: "OUT",
+            recipients: ["0.0.67890"],
+            contract: erc20Token.contractAddress,
+          }),
+        ],
+        ledgerAccountId,
+        calTokenByAddress: new Map([
+          [htsToken.contractAddress, htsToken],
+          [erc20Token.contractAddress.toLowerCase(), erc20Token],
+        ]),
+      });
+
+      const ids = [...bridgeCoinOperations, ...bridgeTokenOperations].map(op => op.id);
+
+      expect(new Set(ids).size).toBe(ids.length);
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.test.ts
@@ -49,6 +49,42 @@ describe("bridge utils", () => {
       expect(result).toEqual([expect.objectContaining({ subOperations: [mockedTokenOperation] })]);
     });
 
+    it("nests a token movement under the FEES op only, not under every coin op of the tx", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const feesOperation = getMockedOperation({ id: "fees", hash: "shared", type: "FEES" });
+      const outOperation = getMockedOperation({ id: "out", hash: "shared", type: "OUT" });
+      const mockedTokenOperation = getMockedOperation({
+        hash: "shared",
+        accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
+      });
+
+      const result = await prepareOperations([feesOperation, outOperation], [mockedTokenOperation]);
+
+      expect(result.map(op => [op.id, op.subOperations])).toEqual([
+        ["fees", [mockedTokenOperation]],
+        ["out", []],
+      ]);
+    });
+
+    it("anchors on the lowest id, not the first in the array, when the tx has no FEES op", async () => {
+      const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
+      const coinOperations = [
+        getMockedOperation({ id: "b", hash: "shared", type: "OUT" }),
+        getMockedOperation({ id: "a", hash: "shared", type: "OUT" }),
+      ];
+      const mockedTokenOperation = getMockedOperation({
+        hash: "shared",
+        accountId: encodeTokenAccountId(mockedTokenAccount.parentId, tokenCurrencyFromCAL),
+      });
+
+      const result = await prepareOperations(coinOperations, [mockedTokenOperation]);
+
+      expect(result.map(op => [op.id, op.subOperations])).toEqual([
+        ["b", []],
+        ["a", [mockedTokenOperation]],
+      ]);
+    });
+
     it("creates NONE coin operation as parent if no coin op with matching hash exists", async () => {
       const mockedTokenAccount = getMockedTokenAccount(tokenCurrencyFromCAL);
       const mockedOrphanTokenOperation = getMockedOperation({
@@ -390,6 +426,21 @@ describe("bridge utils", () => {
       });
 
       expect(bridgeCoinOperations).toEqual([expect.objectContaining({ hash: "h1", type: "FEES" })]);
+    });
+
+    it("keeps the fee visible when its token op is hidden but another coin op of the hash remains", () => {
+      const tokenOp = getMockedOperation({ hash: "h1", type: "OUT", contract: "0x999" });
+      const feesOp = getMockedOperation({ hash: "h1", type: "FEES" });
+      const outOp = getMockedOperation({ hash: "h1", type: "OUT", recipients: ["0.0.67890"] });
+
+      const { bridgeCoinOperations } = resolveBridgeOperations({
+        coinOperations: [feesOp, outOp],
+        tokenOperations: [tokenOp],
+        ledgerAccountId,
+        calTokenByAddress: new Map(),
+      });
+
+      expect(bridgeCoinOperations.map(op => op.type)).toEqual(["FEES", "OUT"]);
     });
 
     it("keeps a FEES coin op that has no token op at all", () => {

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -152,6 +152,9 @@ export function resolveBridgeOperations({
 } {
   const keptTokenOperationHashes = new Set<string>();
   const allTokenOperationHashes = new Set(tokenOperations.map(op => op.hash));
+  const nonFeeCoinOperationHashes = new Set(
+    coinOperations.filter(op => op.type !== "FEES").map(op => op.hash),
+  );
 
   const resolvedTokenOperations = tokenOperations.flatMap(operation => {
     const tokenAddress = operation.contract?.toLowerCase();
@@ -163,13 +166,14 @@ export function resolveBridgeOperations({
     return [{ ...operation, accountId: tokenAccountId }];
   });
 
+  // dropped only when it would be the transaction's only visible row
+  const keepsFeesOperation = (hash: string) =>
+    !allTokenOperationHashes.has(hash) ||
+    keptTokenOperationHashes.has(hash) ||
+    nonFeeCoinOperationHashes.has(hash);
+
   const resolvedCoinOperations = coinOperations
-    .filter(
-      op =>
-        op.type !== "FEES" ||
-        keptTokenOperationHashes.has(op.hash) ||
-        !allTokenOperationHashes.has(op.hash),
-    )
+    .filter(op => op.type !== "FEES" || keepsFeesOperation(op.hash))
     .map(op => ({ ...op, accountId: ledgerAccountId }));
 
   return {
@@ -353,10 +357,12 @@ export const prepareOperations = async (
       coinOperationsByHash[tokenOperation.hash] = mainOperations;
     }
 
-    // ugly loop in loop but in theory, this can only be a 2 elements array maximum in the case of a self send
-    for (const mainOperation of mainOperations) {
-      mainOperation.subOperations.push(tokenOperation);
-    }
+    // mirror's transfer order is not stable, so fall back to the lowest id rather than the first op
+    const anchor =
+      mainOperations.find(op => op.type === "FEES") ??
+      mainOperations.reduce((lowest, op) => (op.id < lowest.id ? op : lowest), mainOperations[0]);
+
+    anchor.subOperations.push(tokenOperation);
   }
 
   return preparedCoinOperations;

--- a/libs/coin-modules/coin-hedera/src/bridge/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/bridge/utils.ts
@@ -116,6 +116,21 @@ export async function buildCalTokenMap({
   return tokenByAddress;
 }
 
+function assignBridgeOperationIds<O extends Operation<HederaOperationExtra>>(operations: O[]): O[] {
+  const baseIdCounts = new Map<string, number>();
+  for (const op of operations) {
+    const baseId = encodeOperationId(op.accountId, op.hash, op.type);
+    baseIdCounts.set(baseId, (baseIdCounts.get(baseId) ?? 0) + 1);
+  }
+
+  return operations.map(op => {
+    const baseId = encodeOperationId(op.accountId, op.hash, op.type);
+    const needsDiscriminator = (baseIdCounts.get(baseId) ?? 0) > 1;
+    const discriminator = op.recipients[0] ?? op.value.toString();
+    return { ...op, id: needsDiscriminator ? `${baseId}-${discriminator}` : baseId };
+  });
+}
+
 /**
  * Re-encodes id and accountId for both coin and token operations into the bridge's format.
  * Token operations: accountId becomes encodeTokenAccountId, filtered to CAL-listed tokens only.
@@ -136,33 +151,31 @@ export function resolveBridgeOperations({
   bridgeTokenOperations: Operation<HederaOperationExtra>[];
 } {
   const keptTokenOperationHashes = new Set<string>();
+  const allTokenOperationHashes = new Set(tokenOperations.map(op => op.hash));
 
-  const bridgeTokenOperations = tokenOperations.flatMap(operation => {
+  const resolvedTokenOperations = tokenOperations.flatMap(operation => {
     const tokenAddress = operation.contract?.toLowerCase();
     const token = tokenAddress ? calTokenByAddress.get(tokenAddress) : undefined;
     if (!token) return [];
 
     keptTokenOperationHashes.add(operation.hash);
     const tokenAccountId = encodeTokenAccountId(ledgerAccountId, token);
-    return [
-      {
-        ...operation,
-        accountId: tokenAccountId,
-        id: encodeOperationId(tokenAccountId, operation.hash, operation.type),
-      },
-    ];
+    return [{ ...operation, accountId: tokenAccountId }];
   });
 
-  // persist only FEES ops for token transfers that are in CAL
-  const bridgeCoinOperations = coinOperations
-    .filter(op => (op.type !== "FEES" ? true : keptTokenOperationHashes.has(op.hash)))
-    .map(op => ({
-      ...op,
-      id: encodeOperationId(ledgerAccountId, op.hash, op.type),
-      accountId: ledgerAccountId,
-    }));
+  const resolvedCoinOperations = coinOperations
+    .filter(
+      op =>
+        op.type !== "FEES" ||
+        keptTokenOperationHashes.has(op.hash) ||
+        !allTokenOperationHashes.has(op.hash),
+    )
+    .map(op => ({ ...op, accountId: ledgerAccountId }));
 
-  return { bridgeCoinOperations, bridgeTokenOperations };
+  return {
+    bridgeCoinOperations: assignBridgeOperationIds(resolvedCoinOperations),
+    bridgeTokenOperations: assignBridgeOperationIds(resolvedTokenOperations),
+  };
 }
 
 export const getSubAccounts = async ({
@@ -301,9 +314,9 @@ const makeCoinOperationForOrphanChildOperation = async (
     subOperations: [],
     nftOperations: [],
     internalOperations: [],
-    accountId: "",
+    accountId,
     date: childOperation.date,
-    extra: {},
+    extra: { ...childOperation.extra },
   };
 };
 
@@ -320,12 +333,10 @@ export const prepareOperations = async (
   // loop through coin operations to prepare a map of hash => operations
   const coinOperationsByHash: Record<string, CoinOperationForOrphanChildOperation[]> = {};
   preparedCoinOperations.forEach(op => {
-    if (!coinOperationsByHash[op.hash]) {
-      coinOperationsByHash[op.hash] = [];
-    }
-
     op.subOperations = [];
-    coinOperationsByHash[op.hash].push(op as CoinOperationForOrphanChildOperation);
+    coinOperationsByHash[op.hash] ??= [];
+    const operationsForHash = coinOperationsByHash[op.hash];
+    operationsForHash.push(op as CoinOperationForOrphanChildOperation);
   });
 
   // loop through token operations to potentially copy them as a child operation of a coin operation
@@ -339,6 +350,7 @@ export const prepareOperations = async (
       const noneOperation = await makeCoinOperationForOrphanChildOperation(tokenOperation);
       mainOperations = [noneOperation];
       preparedCoinOperations.push(noneOperation);
+      coinOperationsByHash[tokenOperation.hash] = mainOperations;
     }
 
     // ugly loop in loop but in theory, this can only be a 2 elements array maximum in the case of a self send

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -201,7 +201,11 @@ describe("listOperationsV2", () => {
         { token_id: mockTokenHTS.contractAddress, account: "0.0.67890", amount: 1000 },
       ],
       staking_reward_transfers: [],
-      transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
       name: "CRYPTOTRANSFER",
     });
 
@@ -269,6 +273,7 @@ describe("listOperationsV2", () => {
       staking_reward_transfers: [],
       token_transfers: [],
       transfers: [{ account: mockMirrorAccount.account, amount: -300000 }],
+      transaction_id: `${mockMirrorAccount.account}-${sharedTimestamp}`,
     });
     const mockERC20Transfer = getMockedERC20TokenTransfer({
       token_evm_address: mockTokenERC20.contractAddress,
@@ -349,6 +354,9 @@ describe("listOperationsV2", () => {
         type: "FEES",
         value: new BigNumber(300000),
         hash: sharedHash,
+        // a fee goes from the payer to the node, not between the token transfer's parties
+        senders: [mockMirrorAccount.account],
+        recipients: [mockMirrorTransaction.node],
       }),
     ]);
   });
@@ -595,7 +603,11 @@ describe("listOperationsV2", () => {
         { token_id: tokenId, account: "0.0.67890", amount: 1000 },
       ],
       staking_reward_transfers: [],
-      transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
       name: "CRYPTOTRANSFER",
     });
 
@@ -632,12 +644,12 @@ describe("listOperationsV2", () => {
     ]);
   });
 
-  it("should not emit FEES coin op for child HTS token transfer (nonce > 0)", async () => {
+  // child records such as TOKENWIPE land here; their `nonce` is never consulted
+  it("should not emit a coin op for a token transfer with no HBAR transfers and no fee", async () => {
     const tokenId = "0.0.7890";
     const mockTransaction = getMockedMirrorTransaction({
       consensus_timestamp: "1625097600.000000000",
       transaction_hash: "hash1",
-      nonce: 1,
       charged_tx_fee: 0,
       token_transfers: [
         { token_id: tokenId, account: mockMirrorAccount.account, amount: -1000 },
@@ -847,6 +859,50 @@ describe("listOperationsV2", () => {
     ]);
   });
 
+  it("should sum several staking reward rows for the same account", async () => {
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash1",
+      charged_tx_fee: 500000,
+      result: "SUCCESS",
+      memo_base64: "",
+      token_transfers: [],
+      // the mirror node can report an account's reward across several rows
+      staking_reward_transfers: [
+        { account: mockMirrorAccount.account, amount: 600000 },
+        { account: mockMirrorAccount.account, amount: 400000 },
+      ],
+      transfers: [{ account: mockMirrorAccount.account, amount: 500000 }],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+      name: "CRYPTOTRANSFER",
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [mockTransaction],
+      nextCursor: null,
+    });
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      currencyId: mockCurrency.id,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toMatchObject([
+      { type: "REWARD", value: new BigNumber(1000000) },
+      // the reward is netted out of the transfer row, leaving only the fee this account paid
+      { type: "FEES", value: new BigNumber(500000) },
+    ]);
+  });
+
   it("should create REWARD operation for ERC20 transfers with staking rewards", async () => {
     const mockTokenERC20 = getMockedERC20TokenCurrency();
     const mockRewardAmount = 10000000;
@@ -945,6 +1001,7 @@ describe("listOperationsV2", () => {
       token_transfers: [],
       staking_reward_transfers: [],
       transfers: [{ account: mockMirrorAccount.account, amount: -500000 }],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
       name: "CRYPTOUPDATEACCOUNT",
     });
 
@@ -1000,6 +1057,7 @@ describe("listOperationsV2", () => {
       token_transfers: [],
       staking_reward_transfers: [],
       transfers: [{ account: mockMirrorAccount.account, amount: -500000 }],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
       name: "CRYPTOUPDATEACCOUNT",
     });
 
@@ -1295,7 +1353,12 @@ describe("listOperationsV2", () => {
         { token_id: mockTokenHTS.contractAddress, account: "0.0.67890", amount: 1000 },
       ],
       staking_reward_transfers: [],
-      transfers: [],
+      // the account pays the fee in HBAR, so a FEES coin op is built and has to be dropped
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
       name: "CRYPTOTRANSFER",
     });
 
@@ -1327,6 +1390,74 @@ describe("listOperationsV2", () => {
     expect(result.coinOperations).toEqual([]);
     expect(result.tokenOperations).toHaveLength(1);
     expect(result.tokenOperations[0].type).toBe("OUT");
+  });
+
+  it("should keep a FEES operation whose hash has no token operation when skipping token fees", async () => {
+    const mockTokenHTS = getMockedHTSTokenCurrency();
+    const tokenTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash-token",
+      charged_tx_fee: 500000,
+      result: "SUCCESS",
+      token_transfers: [
+        {
+          token_id: mockTokenHTS.contractAddress,
+          account: mockMirrorAccount.account,
+          amount: -1000,
+        },
+        { token_id: mockTokenHTS.contractAddress, account: "0.0.67890", amount: 1000 },
+      ],
+      staking_reward_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+      name: "CRYPTOTRANSFER",
+    });
+    // no token transfer, so its fee is the only trace this transaction left on the account
+    const feeOnlyTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097601.000000000",
+      transaction_hash: "hash-fee-only",
+      charged_tx_fee: 500000,
+      result: "SUCCESS",
+      token_transfers: [],
+      staking_reward_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -500000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      transaction_id: `${mockMirrorAccount.account}-1625097601.000000000`,
+      name: "CRYPTOTRANSFER",
+    });
+
+    (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+      transactions: [tokenTransaction, feeOnlyTransaction],
+      nextCursor: null,
+    });
+
+    setCryptoAssetsStore({
+      findTokenById: async () => undefined,
+      findTokenByAddressInCurrency: jest.fn().mockResolvedValue(mockTokenHTS),
+      getTokensSyncHash: async () => "",
+    });
+
+    const result = await listOperations({
+      limit: mockLimit,
+      order: mockOrder,
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: true,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    });
+
+    expect(result.coinOperations).toMatchObject([{ hash: "hash-fee-only", type: "FEES" }]);
+    expect(result.tokenOperations).toMatchObject([{ hash: "hash-token", type: "OUT" }]);
   });
 
   it("should use encoded hash when useEncodedHash is true", async () => {
@@ -1750,5 +1881,746 @@ describe("listOperationsV2", () => {
     });
 
     expect(result.coinOperations).toEqual([]);
+  });
+
+  describe("multi-recipient transactions", () => {
+    const firstRecipient = "0.0.67890";
+    const secondRecipient = "0.0.99999";
+
+    const listArgs = {
+      limit: mockLimit,
+      order: mockOrder as "desc",
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    };
+
+    const mockTransaction = getMockedMirrorTransaction({
+      consensus_timestamp: "1625097600.000000000",
+      transaction_hash: "hash1",
+      charged_tx_fee: 500000,
+      result: "SUCCESS",
+      transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+      token_transfers: [],
+      staking_reward_transfers: [],
+      transfers: [
+        { account: mockMirrorAccount.account, amount: -2500000 },
+        { account: firstRecipient, amount: 1000000 },
+        { account: secondRecipient, amount: 1000000 },
+        { account: "0.0.3", amount: 500000 },
+      ],
+      name: "CRYPTOTRANSFER",
+    });
+
+    beforeEach(() => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [mockTransaction],
+        nextCursor: null,
+      });
+    });
+
+    it("emits one OUT per recipient, each addressed to that recipient alone", async () => {
+      const result = await listOperations(listArgs);
+
+      expect(
+        result.coinOperations
+          .map(op => ({ type: op.type, recipients: op.recipients }))
+          .sort((a, b) => a.recipients[0].localeCompare(b.recipients[0])),
+      ).toEqual([
+        { type: "OUT", recipients: [firstRecipient] },
+        { type: "OUT", recipients: [secondRecipient] },
+      ]);
+    });
+
+    it("splits the outflow so the operation values sum to what left the account", async () => {
+      const result = await listOperations(listArgs);
+
+      const total = result.coinOperations.reduce((sum, op) => sum.plus(op.value), new BigNumber(0));
+
+      expect(total).toEqual(new BigNumber(2500000));
+    });
+
+    it("charges the transaction fee to exactly one of the operations", async () => {
+      const result = await listOperations(listArgs);
+
+      const feesCharged = result.coinOperations.filter(op => op.fee.gt(0));
+
+      expect(feesCharged).toHaveLength(1);
+      expect(feesCharged[0].fee).toEqual(new BigNumber(500000));
+      expect(feesCharged[0].recipients).toEqual([firstRecipient]);
+    });
+
+    it("assigns a distinct id to every operation of a multi-recipient transaction", async () => {
+      const result = await listOperations(listArgs);
+
+      const ids = result.coinOperations.map(op => op.id);
+
+      expect(new Set(ids).size).toBe(ids.length);
+      expect(ids.sort()).toEqual([`hash1:OUT:${firstRecipient}`, `hash1:OUT:${secondRecipient}`]);
+    });
+
+    it("emits both the HBAR and the HTS movement of a multi-asset transaction", async () => {
+      const mockTokenHTS = getMockedHTSTokenCurrency();
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            staking_reward_transfers: [],
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -1500000 },
+              { account: firstRecipient, amount: 1000000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            token_transfers: [
+              {
+                token_id: mockTokenHTS.contractAddress,
+                account: mockMirrorAccount.account,
+                amount: -1000,
+              },
+              { token_id: mockTokenHTS.contractAddress, account: firstRecipient, amount: 1000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(result.coinOperations).toMatchObject([
+        {
+          type: "OUT",
+          value: new BigNumber(1500000),
+          fee: new BigNumber(500000),
+          recipients: [firstRecipient],
+        },
+      ]);
+      expect(result.tokenOperations.map(op => op.id)).toEqual([
+        `hash1:OUT:${mockTokenHTS.contractAddress}`,
+      ]);
+    });
+
+    it("emits one token operation per token id of a multi-asset transfer", async () => {
+      const soldToken = "0.0.1001";
+      const boughtToken = "0.0.1002";
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            staking_reward_transfers: [],
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -500000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            token_transfers: [
+              { token_id: soldToken, account: mockMirrorAccount.account, amount: -1000 },
+              { token_id: soldToken, account: firstRecipient, amount: 1000 },
+              { token_id: boughtToken, account: firstRecipient, amount: -500 },
+              { token_id: boughtToken, account: mockMirrorAccount.account, amount: 500 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(
+        result.tokenOperations.map(op => ({
+          id: op.id,
+          contract: op.contract,
+          type: op.type,
+          value: op.value,
+        })),
+      ).toEqual([
+        {
+          id: `hash1:OUT:${soldToken}`,
+          contract: soldToken,
+          type: "OUT",
+          value: new BigNumber(1000),
+        },
+        {
+          id: `hash1:IN:${boughtToken}`,
+          contract: boughtToken,
+          type: "IN",
+          value: new BigNumber(500),
+        },
+      ]);
+    });
+
+    it("emits no token operation for a token id the account's rows net out to zero", async () => {
+      const movedToken = "0.0.1001";
+      const passThroughToken = "0.0.1002";
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            staking_reward_transfers: [],
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -500000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            token_transfers: [
+              { token_id: movedToken, account: mockMirrorAccount.account, amount: -1000 },
+              { token_id: movedToken, account: firstRecipient, amount: 1000 },
+              // the account forwards everything it receives, so its holding does not change
+              { token_id: passThroughToken, account: firstRecipient, amount: -500 },
+              { token_id: passThroughToken, account: mockMirrorAccount.account, amount: 500 },
+              { token_id: passThroughToken, account: mockMirrorAccount.account, amount: -500 },
+              { token_id: passThroughToken, account: secondRecipient, amount: 500 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(
+        result.tokenOperations.map(op => ({ contract: op.contract, value: op.value })),
+      ).toEqual([{ contract: movedToken, value: new BigNumber(1000) }]);
+    });
+
+    it("emits one token operation per recipient of a multi-recipient token transfer", async () => {
+      const tokenId = "0.0.1001";
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            staking_reward_transfers: [],
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -500000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            token_transfers: [
+              { token_id: tokenId, account: mockMirrorAccount.account, amount: -1000 },
+              { token_id: tokenId, account: firstRecipient, amount: 600 },
+              { token_id: tokenId, account: secondRecipient, amount: 400 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(
+        result.tokenOperations
+          .map(op => ({ id: op.id, value: op.value, recipients: op.recipients }))
+          .sort((a, b) => a.recipients[0].localeCompare(b.recipients[0])),
+      ).toEqual([
+        {
+          id: `hash1:OUT:${tokenId}:${firstRecipient}`,
+          value: new BigNumber(600),
+          recipients: [firstRecipient],
+        },
+        {
+          id: `hash1:OUT:${tokenId}:${secondRecipient}`,
+          value: new BigNumber(400),
+          recipients: [secondRecipient],
+        },
+      ]);
+    });
+
+    it("splits the outflow when the fee is shared between the node and the reward accounts", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // how mainnet actually splits a fee: node, fee collector, and both reward accounts
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -2500000 },
+              { account: firstRecipient, amount: 1000000 },
+              { account: secondRecipient, amount: 1000000 },
+              { account: "0.0.3", amount: 250000 },
+              { account: "0.0.98", amount: 150000 },
+              { account: "0.0.800", amount: 50000 },
+              { account: "0.0.801", amount: 50000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(
+        result.coinOperations
+          .map(op => ({ recipients: op.recipients, value: op.value, fee: op.fee }))
+          .sort((a, b) => a.recipients[0].localeCompare(b.recipients[0])),
+      ).toEqual([
+        {
+          recipients: [firstRecipient],
+          value: new BigNumber(1500000),
+          fee: new BigNumber(500000),
+        },
+        { recipients: [secondRecipient], value: new BigNumber(1000000), fee: new BigNumber(0) },
+      ]);
+    });
+
+    it("keeps one netted OUT when a second account also sent HBAR", async () => {
+      const coSender = "0.0.55555";
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${coSender}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // the recipient amounts do add up to this account's outflow, but a second account also
+            // sent HBAR, so nothing proves it funded those recipients rather than the co-sender
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -1000000 },
+              { account: coSender, amount: -500000 },
+              { account: firstRecipient, amount: 600000 },
+              { account: secondRecipient, amount: 400000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(result.coinOperations).toMatchObject([
+        {
+          id: "hash1:OUT",
+          type: "OUT",
+          value: new BigNumber(1000000),
+          fee: new BigNumber(0),
+          recipients: [secondRecipient, firstRecipient],
+        },
+      ]);
+    });
+
+    it("keeps one netted OUT when the recipient amounts do not add up to what left the account", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // the fee rows account for 400000 of the 500000 charged, so the split cannot be trusted
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -2400000 },
+              { account: firstRecipient, amount: 1000000 },
+              { account: secondRecipient, amount: 1000000 },
+              { account: "0.0.3", amount: 400000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // the netted value still matches the mirror's own row, so the balance stays correct
+      expect(result.coinOperations).toMatchObject([
+        {
+          id: "hash1:OUT",
+          type: "OUT",
+          value: new BigNumber(2400000),
+          fee: new BigNumber(500000),
+        },
+      ]);
+    });
+  });
+
+  describe("transactions whose fee another account paid", () => {
+    const otherPayer = "0.0.55555";
+    const recipient = "0.0.67890";
+
+    const listArgs = {
+      limit: mockLimit,
+      order: mockOrder as "desc",
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    };
+
+    it("charges no fee to an OUT the account did not pay for", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${otherPayer}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            transfers: [
+              { account: otherPayer, amount: -500000 },
+              { account: mockMirrorAccount.account, amount: -1000000 },
+              { account: recipient, amount: 1000000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(result.coinOperations).toMatchObject([
+        { type: "OUT", value: new BigNumber(1000000), fee: new BigNumber(0) },
+      ]);
+    });
+
+    it("emits an IN and a FEES op when the account both received and paid", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // received 1000000 and paid the 500000 fee, so the mirror nets the row to +500000
+            transfers: [
+              { account: otherPayer, amount: -1000000 },
+              { account: mockMirrorAccount.account, amount: 500000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // the IN reports the gross amount received; the fee it paid is a row of its own
+      expect(result.coinOperations).toMatchObject([
+        {
+          type: "IN",
+          value: new BigNumber(1000000),
+          fee: new BigNumber(500000),
+          senders: [otherPayer],
+          recipients: [mockMirrorAccount.account],
+        },
+        {
+          type: "FEES",
+          value: new BigNumber(500000),
+          fee: new BigNumber(500000),
+          // a fee goes from the payer to the node, not between the transfer's parties
+          senders: [mockMirrorAccount.account],
+          recipients: ["0.0.3"],
+        },
+      ]);
+    });
+
+    it("emits a single IN with no companion FEES op when another account paid", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${otherPayer}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            transfers: [
+              { account: otherPayer, amount: -1500000 },
+              { account: mockMirrorAccount.account, amount: 1000000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // an IN op reports the charged fee whoever paid it, but only a payer gets a FEES op
+      expect(result.coinOperations).toMatchObject([
+        { type: "IN", value: new BigNumber(1000000), fee: new BigNumber(500000) },
+      ]);
+    });
+
+    it("emits nothing when the account's HBAR nets out and it paid no fee", async () => {
+      const sender = "0.0.44444";
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${otherPayer}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // the account forwards what it receives, so its HBAR balance is unchanged
+            transfers: [
+              { account: otherPayer, amount: -500000 },
+              { account: sender, amount: -1000000 },
+              { account: mockMirrorAccount.account, amount: 1000000 },
+              { account: mockMirrorAccount.account, amount: -1000000 },
+              { account: recipient, amount: 1000000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOTRANSFER",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // a FEES op here would debit a fee the account never paid
+      expect(result.coinOperations).toEqual([]);
+    });
+
+    it("charges no fee to a STAKE the account did not pay for", async () => {
+      const mockStakingAnalysis: StakingAnalysis = {
+        operationType: "STAKE",
+        previousStakingNodeId: null,
+        targetStakingNodeId: 3,
+        stakedAmount: BigInt(1000000000),
+      };
+      (networkUtils.analyzeStakingOperation as jest.Mock).mockResolvedValue(mockStakingAnalysis);
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${otherPayer}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // staking changes no balance, so only the payer and the node appear
+            transfers: [
+              { account: otherPayer, amount: -500000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+            name: "CRYPTOUPDATEACCOUNT",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // the STAKE family reads `fee` as its balance delta, so a foreign fee would debit the account
+      expect(result.coinOperations).toMatchObject([
+        { type: "STAKE", value: new BigNumber(0), fee: new BigNumber(0) },
+      ]);
+    });
+  });
+
+  describe("FEES operation recipients", () => {
+    const listArgs = {
+      limit: mockLimit,
+      order: mockOrder as "desc",
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+    };
+
+    it("falls back to the credited network account when the transaction has no node", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            consensus_timestamp: "1625097600.000000000",
+            transaction_hash: "hash1",
+            charged_tx_fee: 500000,
+            transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+            token_transfers: [],
+            staking_reward_transfers: [],
+            // mirror leaves `node` null on child records, which only move the fee
+            nonce: 1,
+            node: null,
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -500000 },
+              { account: "0.0.98", amount: 400000 },
+              { account: "0.0.800", amount: 50000 },
+              { account: "0.0.801", amount: 50000 },
+            ],
+            name: "CRYPTOCREATEACCOUNT",
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      // an empty recipients list would read as a fee paid to nobody
+      expect(result.coinOperations).toMatchObject([
+        {
+          type: "FEES",
+          value: new BigNumber(500000),
+          senders: [mockMirrorAccount.account],
+          recipients: ["0.0.98"],
+        },
+      ]);
+    });
+  });
+
+  describe("failed transactions", () => {
+    it("stays an OUT charged the transaction fee when the account paid it", async () => {
+      const mockTransaction = getMockedMirrorTransaction({
+        consensus_timestamp: "1625097600.000000000",
+        transaction_hash: "hash1",
+        charged_tx_fee: 500000,
+        result: "INSUFFICIENT_ACCOUNT_BALANCE",
+        transaction_id: `${mockMirrorAccount.account}-1625097600.000000000`,
+        token_transfers: [],
+        staking_reward_transfers: [],
+        // a failed transaction moves no value, only the fee
+        transfers: [
+          { account: mockMirrorAccount.account, amount: -500000 },
+          { account: "0.0.3", amount: 500000 },
+        ],
+        name: "CRYPTOTRANSFER",
+      });
+
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [mockTransaction],
+        nextCursor: null,
+      });
+
+      const result = await listOperations({
+        limit: mockLimit,
+        order: mockOrder,
+        currencyId: mockCurrency.id,
+        address: mockMirrorAccount.account,
+        evmAddress: mockMirrorAccount.evm_address,
+        mirrorTokens: [],
+        tokenEvmAddresses: [],
+        fetchAllPages: true,
+        skipFeesForTokenOperations: false,
+        useEncodedHash: false,
+        useSyntheticBlocks: false,
+      });
+
+      expect(result.coinOperations).toMatchObject([
+        {
+          id: "hash1:OUT",
+          type: "OUT",
+          hasFailed: true,
+          value: new BigNumber(500000),
+          fee: new BigNumber(500000),
+        },
+      ]);
+    });
+  });
+
+  describe("incremental sync", () => {
+    const listArgs = (cursor?: string) => ({
+      limit: mockLimit,
+      order: mockOrder as "desc",
+      currencyId: mockCurrency.id,
+      address: mockMirrorAccount.account,
+      evmAddress: mockMirrorAccount.evm_address,
+      mirrorTokens: [],
+      tokenEvmAddresses: [],
+      fetchAllPages: true,
+      skipFeesForTokenOperations: false,
+      useEncodedHash: false,
+      useSyntheticBlocks: false,
+      ...(cursor && { cursor }),
+    });
+
+    // two transactions inside one second: a cursor truncated to seconds re-fetches both
+    const chain = [
+      getMockedMirrorTransaction({
+        consensus_timestamp: "1625097600.111222333",
+        transaction_hash: "hash-early",
+        charged_tx_fee: 500000,
+        transaction_id: `${mockMirrorAccount.account}-1625097600.111222333`,
+        transfers: [
+          { account: mockMirrorAccount.account, amount: -1500000 },
+          { account: "0.0.67890", amount: 1000000 },
+        ],
+      }),
+      getMockedMirrorTransaction({
+        consensus_timestamp: "1625097600.999888777",
+        transaction_hash: "hash-late",
+        charged_tx_fee: 500000,
+        transaction_id: `${mockMirrorAccount.account}-1625097600.999888777`,
+        transfers: [
+          { account: mockMirrorAccount.account, amount: -2500000 },
+          { account: "0.0.67890", amount: 2000000 },
+        ],
+      }),
+    ];
+
+    beforeEach(() => {
+      // stands in for the mirror node's `timestamp=gt:` filter
+      (apiClient.getAccountTransactions as jest.Mock).mockImplementation(({ pagingToken }) => ({
+        transactions: pagingToken
+          ? chain.filter(tx => new BigNumber(tx.consensus_timestamp).gt(pagingToken))
+          : chain,
+        nextCursor: null,
+      }));
+    });
+
+    it("emits no operation twice when re-syncing with no new chain activity", async () => {
+      const first = await listOperations(listArgs());
+      expect(first.coinOperations).toHaveLength(2);
+
+      const cursor = utils.getSyncCursor({ operations: first.coinOperations });
+      const second = await listOperations(listArgs(cursor ?? undefined));
+
+      expect(second.coinOperations).toEqual([]);
+    });
+
+    it("still picks up a transaction landing in the same second as the stored one", async () => {
+      const stored = await listOperations(listArgs());
+      const earlyOperation = stored.coinOperations.filter(op => op.hash === "hash-early");
+      const cursor = utils.getSyncCursor({ operations: earlyOperation });
+
+      const next = await listOperations(listArgs(cursor ?? undefined));
+
+      expect(next.coinOperations.map(op => op.hash)).toEqual(["hash-late"]);
+    });
   });
 });

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.test.ts
@@ -843,6 +843,7 @@ describe("listOperationsV2", () => {
 
     expect(result.tokenOperations).toEqual([]);
     expect(rewardTimestamp).toBe(mainTimestamp + 1);
+    expect(result.coinOperations[0].extra).not.toHaveProperty("chargedTxFee");
     expect(result.coinOperations).toMatchObject([
       {
         type: "REWARD",
@@ -1933,6 +1934,7 @@ describe("listOperationsV2", () => {
           .map(op => ({ type: op.type, recipients: op.recipients }))
           .sort((a, b) => a.recipients[0].localeCompare(b.recipients[0])),
       ).toEqual([
+        { type: "FEES", recipients: ["0.0.3"] },
         { type: "OUT", recipients: [firstRecipient] },
         { type: "OUT", recipients: [secondRecipient] },
       ]);
@@ -1946,14 +1948,50 @@ describe("listOperationsV2", () => {
       expect(total).toEqual(new BigNumber(2500000));
     });
 
-    it("charges the transaction fee to exactly one of the operations", async () => {
+    it("keeps the fee out of the per-recipient operations and reports it as its own FEES op", async () => {
       const result = await listOperations(listArgs);
 
       const feesCharged = result.coinOperations.filter(op => op.fee.gt(0));
 
       expect(feesCharged).toHaveLength(1);
-      expect(feesCharged[0].fee).toEqual(new BigNumber(500000));
-      expect(feesCharged[0].recipients).toEqual([firstRecipient]);
+      expect(feesCharged[0]).toMatchObject({
+        type: "FEES",
+        value: new BigNumber(500000),
+        fee: new BigNumber(500000),
+        recipients: ["0.0.3"],
+      });
+      expect(result.coinOperations.filter(op => op.type === "OUT").map(op => op.value)).toEqual([
+        new BigNumber(1000000),
+        new BigNumber(1000000),
+      ]);
+    });
+
+    it("keeps the fee inside the OUT value and emits no FEES op when there is a single recipient", async () => {
+      (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+        transactions: [
+          getMockedMirrorTransaction({
+            ...mockTransaction,
+            transfers: [
+              { account: mockMirrorAccount.account, amount: -1500000 },
+              { account: firstRecipient, amount: 1000000 },
+              { account: "0.0.3", amount: 500000 },
+            ],
+          }),
+        ],
+        nextCursor: null,
+      });
+
+      const result = await listOperations(listArgs);
+
+      expect(result.coinOperations).toMatchObject([
+        {
+          id: "hash1:OUT",
+          type: "OUT",
+          value: new BigNumber(1500000),
+          fee: new BigNumber(500000),
+          recipients: [firstRecipient],
+        },
+      ]);
     });
 
     it("assigns a distinct id to every operation of a multi-recipient transaction", async () => {
@@ -1962,7 +2000,123 @@ describe("listOperationsV2", () => {
       const ids = result.coinOperations.map(op => op.id);
 
       expect(new Set(ids).size).toBe(ids.length);
-      expect(ids.sort()).toEqual([`hash1:OUT:${firstRecipient}`, `hash1:OUT:${secondRecipient}`]);
+      expect(ids.sort()).toEqual([
+        "hash1:FEES",
+        `hash1:OUT:${firstRecipient}`,
+        `hash1:OUT:${secondRecipient}`,
+      ]);
+    });
+
+    describe("mainnet 0.0.8835924-1760510873-321619819", () => {
+      const payer = "0.0.8835924";
+      const usdc = "0.0.456858";
+      const sauce = "0.0.5022567";
+      const chargedFee = 1176695;
+
+      const listArgsForPayer = { ...listArgs, address: payer };
+
+      beforeEach(() => {
+        (apiClient.getAccountTransactions as jest.Mock).mockResolvedValue({
+          transactions: [
+            getMockedMirrorTransaction({
+              consensus_timestamp: "1760510879.300860000",
+              transaction_hash: "hash1",
+              transaction_id: `${payer}-1760510873-321619819`,
+              charged_tx_fee: chargedFee,
+              node: "0.0.15",
+              staking_reward_transfers: [],
+              transfers: [
+                { account: "0.0.15", amount: 55631 },
+                { account: "0.0.801", amount: 1121064 },
+                { account: payer, amount: -3176695 },
+                { account: firstRecipient, amount: 1000000 },
+                { account: secondRecipient, amount: 1000000 },
+              ],
+              token_transfers: [
+                { token_id: usdc, account: payer, amount: -10000 },
+                { token_id: usdc, account: firstRecipient, amount: 10000 },
+                { token_id: sauce, account: payer, amount: -2 },
+                { token_id: sauce, account: firstRecipient, amount: 1 },
+                { token_id: sauce, account: secondRecipient, amount: 1 },
+              ],
+              name: "CRYPTOTRANSFER",
+            }),
+          ],
+          nextCursor: null,
+        });
+      });
+
+      it("emits a FEES operation for the fee and one fee-free OUT per HBAR recipient", async () => {
+        const result = await listOperations(listArgsForPayer);
+
+        expect(
+          result.coinOperations.map(op => ({
+            type: op.type,
+            value: op.value,
+            fee: op.fee,
+            senders: op.senders,
+            recipients: op.recipients,
+          })),
+        ).toEqual([
+          {
+            type: "FEES",
+            value: new BigNumber(chargedFee),
+            fee: new BigNumber(chargedFee),
+            senders: [payer],
+            recipients: ["0.0.15"],
+          },
+          {
+            type: "OUT",
+            value: new BigNumber(1000000),
+            fee: new BigNumber(0),
+            senders: [payer],
+            recipients: [secondRecipient],
+          },
+          {
+            type: "OUT",
+            value: new BigNumber(1000000),
+            fee: new BigNumber(0),
+            senders: [payer],
+            recipients: [firstRecipient],
+          },
+        ]);
+      });
+
+      it("emits one token operation per recipient of each token", async () => {
+        const result = await listOperations(listArgsForPayer);
+
+        expect(
+          result.tokenOperations.map(op => ({
+            contract: op.contract,
+            value: op.value,
+            recipients: op.recipients,
+          })),
+        ).toEqual([
+          { contract: usdc, value: new BigNumber(10000), recipients: [firstRecipient] },
+          { contract: sauce, value: new BigNumber(1), recipients: [secondRecipient] },
+          { contract: sauce, value: new BigNumber(1), recipients: [firstRecipient] },
+        ]);
+      });
+
+      it("adds the coin operation values back up to the total debited from the account", async () => {
+        const result = await listOperations(listArgsForPayer);
+
+        const debited = result.coinOperations.reduce(
+          (total, op) => total.plus(op.value),
+          new BigNumber(0),
+        );
+
+        expect(debited).toEqual(new BigNumber(3176695));
+      });
+
+      it("reports the charged transaction fee on every operation even where Operation.fee is 0", async () => {
+        const result = await listOperations(listArgsForPayer);
+        const operations = [...result.coinOperations, ...result.tokenOperations];
+
+        expect(operations.map(op => op.extra.chargedTxFee)).toEqual(
+          operations.map(() => String(chargedFee)),
+        );
+      });
     });
 
     it("emits both the HBAR and the HTS movement of a multi-asset transaction", async () => {
@@ -2176,11 +2330,8 @@ describe("listOperationsV2", () => {
           .map(op => ({ recipients: op.recipients, value: op.value, fee: op.fee }))
           .sort((a, b) => a.recipients[0].localeCompare(b.recipients[0])),
       ).toEqual([
-        {
-          recipients: [firstRecipient],
-          value: new BigNumber(1500000),
-          fee: new BigNumber(500000),
-        },
+        { recipients: ["0.0.3"], value: new BigNumber(500000), fee: new BigNumber(500000) },
+        { recipients: [firstRecipient], value: new BigNumber(1000000), fee: new BigNumber(0) },
         { recipients: [secondRecipient], value: new BigNumber(1000000), fee: new BigNumber(0) },
       ]);
     });

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -10,10 +10,16 @@ import {
 } from "../constants";
 import { apiClient } from "../network/api";
 import { hgraphClient } from "../network/hgraph";
-import { parseTransfers, enrichERC20Transfers, analyzeStakingOperation } from "../network/utils";
+import {
+  parseTransfers,
+  enrichERC20Transfers,
+  analyzeStakingOperation,
+  findFeeRecipient,
+} from "../network/utils";
 import type {
   EnrichedERC20Transfer,
   HederaMirrorToken,
+  HederaMirrorTokenTransfer,
   HederaMirrorTransaction,
   HederaOperationExtra,
   MergedTransaction,
@@ -62,11 +68,13 @@ function getCommonMirrorOperationData(
   };
 }
 
-function calculateStakingReward(rawTx: HederaMirrorTransaction, address: string): BigNumber {
-  return rawTx.staking_reward_transfers.reduce((acc, transfer) => {
-    const transferAmount = new BigNumber(transfer.amount);
-    return transfer.account === address ? acc.plus(transferAmount) : acc;
-  }, new BigNumber(0));
+function calculateStakingRewards(rawTx: HederaMirrorTransaction): Map<string, BigNumber> {
+  const rewards = new Map<string, BigNumber>();
+  for (const transfer of rawTx.staking_reward_transfers) {
+    const previous = rewards.get(transfer.account) ?? new BigNumber(0);
+    rewards.set(transfer.account, previous.plus(transfer.amount));
+  }
+  return rewards;
 }
 
 function createStakingRewardOperation({
@@ -186,6 +194,9 @@ async function processERC20TokenTransfer({
   // create FEES operation for outgoing ERC20 transfer
   const outgoingTransfer = tokenOperations.find(transfer => transfer.type === "OUT");
   if (outgoingTransfer) {
+    const { mirrorTransaction } = enrichedERC20Transfer;
+    const feeRecipient =
+      mirrorTransaction.node ?? findFeeRecipient(mirrorTransaction.transfers ?? []);
     coinOperation = {
       ...commonData,
       id: `${commonData.hash}:FEES`,
@@ -195,8 +206,8 @@ async function processERC20TokenTransfer({
       ...(outgoingTransfer.standard && { standard: outgoingTransfer.standard }),
       blockHeight: outgoingTransfer.blockHeight,
       blockHash: outgoingTransfer.blockHash,
-      senders: outgoingTransfer.senders,
-      recipients: outgoingTransfer.recipients,
+      senders: commonData.extra.feesPayer ? [commonData.extra.feesPayer] : [],
+      recipients: feeRecipient ? [feeRecipient] : [],
       fee: outgoingTransfer.fee,
       value: outgoingTransfer.fee,
       extra: outgoingTransfer.extra,
@@ -209,7 +220,56 @@ async function processERC20TokenTransfer({
   };
 }
 
-async function processHTSTokenTransfers({
+type RecipientAmount = { recipient: string; amount: BigNumber };
+
+/** null when the mirror transfers can't be attributed to individual recipients */
+function resolveAmountPerRecipient({
+  address,
+  senders,
+  recipients,
+  amountByRecipient,
+  expectedTotal,
+}: {
+  address: string;
+  senders: string[];
+  recipients: string[];
+  amountByRecipient: Map<string, BigNumber>;
+  expectedTotal: BigNumber;
+}): [RecipientAmount, ...RecipientAmount[]] | null {
+  const isSoleSender = senders.length === 1 && senders[0] === address;
+  if (!isSoleSender || recipients.length <= 1) return null;
+
+  const recipientSum = [...amountByRecipient.values()].reduce(
+    (acc, amount) => acc.plus(amount),
+    new BigNumber(0),
+  );
+  if (!recipientSum.eq(expectedTotal)) return null;
+
+  // the guard above keeps more than one recipient, so the list is never empty
+  const [firstRecipientAmount, ...otherRecipientAmounts] = recipients.map(recipient => ({
+    recipient,
+    amount: amountByRecipient.get(recipient) ?? new BigNumber(0),
+  }));
+
+  return [firstRecipientAmount, ...otherRecipientAmounts];
+}
+
+function groupTransfersByTokenId(
+  transfers: HederaMirrorTokenTransfer[],
+): Map<string, HederaMirrorTokenTransfer[]> {
+  const grouped = new Map<string, HederaMirrorTokenTransfer[]>();
+  for (const transfer of transfers) {
+    const group = grouped.get(transfer.token_id);
+    if (group) {
+      group.push(transfer);
+    } else {
+      grouped.set(transfer.token_id, [transfer]);
+    }
+  }
+  return grouped;
+}
+
+function processHTSTokenTransfers({
   rawTx,
   address,
   ledgerAccountId,
@@ -219,94 +279,142 @@ async function processHTSTokenTransfers({
   address: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
-}): Promise<{
-  coinOperation: Operation<HederaOperationExtra> | undefined;
-  tokenOperation: Operation<HederaOperationExtra>;
-} | null> {
+}): Operation<HederaOperationExtra>[] {
   const tokenTransfers = rawTx.token_transfers ?? [];
-  if (tokenTransfers.length === 0) return null;
+  if (tokenTransfers.length === 0) return [];
 
-  const tokenId = tokenTransfers[0].token_id;
-  const { type, value, senders, recipients } = parseTransfers(tokenTransfers, address);
   const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
-  const extra = { ...commonData.extra };
+  const transfersByTokenId = groupTransfersByTokenId(tokenTransfers);
+  const tokenOperations: Operation<HederaOperationExtra>[] = [];
 
-  let coinOperation: Operation<HederaOperationExtra> | undefined;
+  for (const [tokenId, group] of transfersByTokenId) {
+    const { senders, recipients, netAmount, amountByRecipient } = parseTransfers(group, address);
 
-  // Add main FEES coin operation for parent tx representing a token transfer (nonce > 0 means child transaction like TOKENWIPE)
-  if (type === "OUT" && rawTx.nonce === 0) {
-    coinOperation = {
-      id: `${hash}:FEES`,
+    if (!netAmount || netAmount.isZero()) continue;
+
+    const type: OperationType = netAmount.isNegative() ? "OUT" : "IN";
+    const value = netAmount.abs();
+
+    const commonFields = {
       accountId: ledgerAccountId,
-      type: "FEES",
-      value: fee,
-      recipients,
-      senders,
+      contract: tokenId,
+      standard: "hts",
+      type,
       hash,
       fee,
       date,
       blockHeight,
       blockHash,
       hasFailed,
-      extra,
-    } satisfies Operation<HederaOperationExtra>;
+      extra: { ...commonData.extra },
+    } satisfies Partial<Operation<HederaOperationExtra>>;
+
+    const pushTokenOperation = (idSuffix: string, amount: BigNumber, recipientList: string[]) => {
+      tokenOperations.push({
+        ...commonFields,
+        id: `${hash}:${type}:${tokenId}${idSuffix}`,
+        value: amount,
+        recipients: recipientList,
+        senders,
+      } satisfies Operation<HederaOperationExtra>);
+    };
+
+    const amountPerRecipient =
+      type === "OUT"
+        ? resolveAmountPerRecipient({
+            address,
+            senders,
+            recipients,
+            amountByRecipient,
+            expectedTotal: value,
+          })
+        : null;
+
+    if (amountPerRecipient) {
+      for (const { recipient, amount } of amountPerRecipient) {
+        pushTokenOperation(`:${recipient}`, amount, [recipient]);
+      }
+    } else {
+      pushTokenOperation("", value, recipients);
+    }
   }
 
-  const tokenOperation = {
-    id: `${hash}:${type}:${tokenId}`,
+  return tokenOperations;
+}
+
+// `recipient` marks one of several operations of the same type in a tx, so its id must say which
+type CoinOperationTarget = { recipients: string[] } | { recipient: string };
+
+function buildCoinOperation({
+  commonData,
+  ledgerAccountId,
+  type,
+  value,
+  fee,
+  senders,
+  extra,
+  ...target
+}: {
+  commonData: ReturnType<typeof getCommonMirrorOperationData>;
+  ledgerAccountId: string;
+  type: OperationType;
+  value: BigNumber;
+  fee?: BigNumber;
+  senders: string[];
+  extra: HederaOperationExtra;
+} & CoinOperationTarget): Operation<HederaOperationExtra> {
+  const { hash, fee: txFee, date, blockHeight, blockHash, hasFailed } = commonData;
+  const isPerRecipient = "recipient" in target;
+
+  return {
+    id: isPerRecipient ? `${hash}:${type}:${target.recipient}` : `${hash}:${type}`,
     accountId: ledgerAccountId,
-    contract: tokenId,
-    standard: "hts",
     type,
     value,
-    recipients,
+    recipients: isPerRecipient ? [target.recipient] : target.recipients,
     senders,
     hash,
-    fee,
+    fee: fee ?? txFee,
     date,
     blockHeight,
     blockHash,
     hasFailed,
     extra,
-  } satisfies Operation<HederaOperationExtra>;
-
-  return {
-    coinOperation,
-    tokenOperation,
   };
 }
 
-function processCoinTransfers({
+function toOperationTypeFromNetAmount(netAmount: BigNumber): OperationType {
+  if (netAmount.lt(0)) return "OUT";
+  if (netAmount.gt(0)) return "IN";
+  return "NONE";
+}
+
+function buildCustomOrStakingOperation({
   rawTx,
-  address,
   ledgerAccountId,
   commonData,
   mirrorTokens,
-  stakingReward,
   stakingAnalysis,
+  customType,
+  netAmount,
+  ownFee,
+  senders,
+  recipients,
 }: {
   rawTx: HederaMirrorTransaction;
-  address: string;
   ledgerAccountId: string;
   commonData: ReturnType<typeof getCommonMirrorOperationData>;
   mirrorTokens: HederaMirrorToken[];
-  stakingReward: BigNumber;
   stakingAnalysis: StakingAnalysis | null;
-}): Operation<HederaOperationExtra>[] {
-  const coinOperations: Operation<HederaOperationExtra>[] = [];
-  const transfers = rawTx.transfers ?? [];
-
-  if (transfers.length === 0) {
-    return [];
-  }
-
-  const { type, value, senders, recipients } = parseTransfers(transfers, address, stakingReward);
-
-  const { hash, fee, date, blockHeight, blockHash, hasFailed } = commonData;
+  customType: OperationType | undefined;
+  netAmount: BigNumber;
+  ownFee: BigNumber;
+  senders: string[];
+  recipients: string[];
+}): Operation<HederaOperationExtra> {
   const extra = { ...commonData.extra };
-  let operationType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name] ?? type;
+  let operationType: OperationType = customType ?? toOperationTypeFromNetAmount(netAmount);
 
-  // update operation type and extra fields if staking analysis is available
   if (stakingAnalysis) {
     operationType = stakingAnalysis.operationType;
     extra.previousStakingNodeId = stakingAnalysis.previousStakingNodeId;
@@ -314,15 +422,8 @@ function processCoinTransfers({
     extra.stakedAmount = new BigNumber(stakingAnalysis.stakedAmount.toString());
   }
 
-  // if recipients array is empty, add the node where the transaction was submitted as recipient
-  if (recipients.length === 0 && rawTx.node) {
-    recipients.push(rawTx.node);
-  }
-
-  // try to enrich ASSOCIATE_TOKEN operation with extra.associatedTokenId
-  // this value is used by custom OperationDetails components in Hedera family
-  // accounts or contracts must first associate with an HTS token before they can receive or send that token; without association, token transfers fail
   if (operationType === "ASSOCIATE_TOKEN") {
+    // read by the Hedera family's custom OperationDetails components
     const relatedMirrorToken = mirrorTokens.find(t => {
       return t.created_timestamp === rawTx.consensus_timestamp;
     });
@@ -332,23 +433,159 @@ function processCoinTransfers({
     }
   }
 
-  coinOperations.push({
-    id: `${hash}:${operationType}`,
-    accountId: ledgerAccountId,
+  return buildCoinOperation({
+    commonData,
+    ledgerAccountId,
     type: operationType,
-    value,
-    recipients,
+    value: netAmount.abs(),
+    fee: ownFee,
     senders,
-    hash,
-    fee,
-    date,
-    blockHeight,
-    blockHash,
-    hasFailed,
+    recipients: recipients.length === 0 && rawTx.node ? [rawTx.node] : recipients,
     extra,
   });
+}
 
-  return coinOperations;
+function processCoinTransfers({
+  rawTx,
+  address,
+  ledgerAccountId,
+  commonData,
+  mirrorTokens,
+  stakingRewards,
+  stakingAnalysis,
+}: {
+  rawTx: HederaMirrorTransaction;
+  address: string;
+  ledgerAccountId: string;
+  commonData: ReturnType<typeof getCommonMirrorOperationData>;
+  mirrorTokens: HederaMirrorToken[];
+  stakingRewards: Map<string, BigNumber>;
+  stakingAnalysis: StakingAnalysis | null;
+}): Operation<HederaOperationExtra>[] {
+  const transfers = rawTx.transfers ?? [];
+
+  if (transfers.length === 0) {
+    return [];
+  }
+
+  const parsed = parseTransfers(transfers, address, stakingRewards);
+  const { senders, recipients, amountByRecipient } = parsed;
+  const netAmount = parsed.netAmount ?? new BigNumber(0);
+  const fee = commonData.fee;
+  const isPayer = extractFeesPayer(rawTx) === address;
+  // an op's `fee` must match what is baked into its `value`, or getOperationValue subtracts it twice
+  const ownFee = isPayer ? fee : new BigNumber(0);
+
+  // the network collects the fee, so a FEES op is addressed to the node that submitted the tx;
+  // child records carry no node, so the transfers are the only trace of where the fee went
+  const feeRecipient = rawTx.node ?? findFeeRecipient(transfers);
+
+  const customType = MAP_TX_NAME_TO_CUSTOM_OPERATION_TYPE[rawTx.name];
+
+  if (customType || stakingAnalysis) {
+    return [
+      buildCustomOrStakingOperation({
+        rawTx,
+        ledgerAccountId,
+        commonData,
+        mirrorTokens,
+        stakingAnalysis,
+        customType,
+        netAmount,
+        ownFee,
+        senders,
+        recipients,
+      }),
+    ];
+  }
+
+  const buildFeesOperation = () =>
+    buildCoinOperation({
+      commonData,
+      ledgerAccountId,
+      type: "FEES",
+      value: fee,
+      senders: commonData.extra.feesPayer ? [commonData.extra.feesPayer] : [],
+      recipients: feeRecipient ? [feeRecipient] : [],
+      extra: { ...commonData.extra },
+    });
+
+  const buildNettedOperation = (type: OperationType, value: BigNumber) =>
+    buildCoinOperation({
+      commonData,
+      ledgerAccountId,
+      type,
+      value,
+      fee: ownFee,
+      senders,
+      recipients: recipients.length === 0 && rawTx.node ? [rawTx.node] : recipients,
+      extra: { ...commonData.extra },
+    });
+
+  const zeroValueOperations = (): Operation<HederaOperationExtra>[] => {
+    // a failed send only has fee transfers, but it stays an OUT so it still reads as a send
+    if (commonData.hasFailed && isPayer) {
+      return [buildNettedOperation("OUT", netAmount.abs())];
+    }
+
+    return isPayer && fee.gt(0) ? [buildFeesOperation()] : [];
+  };
+
+  const incomingOperations = (value: BigNumber): Operation<HederaOperationExtra>[] => {
+    // IN excludes the fee, so a fee paid by the user becomes a separate FEES op
+    const incoming = buildCoinOperation({
+      commonData,
+      ledgerAccountId,
+      type: "IN",
+      value,
+      senders,
+      recipients,
+      extra: { ...commonData.extra },
+    });
+
+    return isPayer && fee.gt(0) ? [incoming, buildFeesOperation()] : [incoming];
+  };
+
+  const outgoingOperations = (totalSent: BigNumber): Operation<HederaOperationExtra>[] => {
+    const amountPerRecipient = resolveAmountPerRecipient({
+      address,
+      senders,
+      recipients,
+      amountByRecipient,
+      expectedTotal: totalSent,
+    });
+
+    if (!amountPerRecipient) {
+      return [buildNettedOperation("OUT", netAmount.abs())];
+    }
+
+    // mirror's transfer order is not stable, so pick the lowest recipient id for determinism
+    const recipientCarryingFee = amountPerRecipient.reduce(
+      (lowest, transfer) => (transfer.recipient < lowest.recipient ? transfer : lowest),
+      amountPerRecipient[0],
+    ).recipient;
+
+    return amountPerRecipient.map(({ recipient, amount }) => {
+      const operationFee = recipient === recipientCarryingFee ? ownFee : new BigNumber(0);
+      return buildCoinOperation({
+        commonData,
+        ledgerAccountId,
+        type: "OUT",
+        value: amount.plus(operationFee),
+        fee: operationFee,
+        senders,
+        recipient,
+        extra: { ...commonData.extra },
+      });
+    });
+  };
+
+  // mirror nets the payer's row as value+fee, so add the fee back to recover the transfer amount
+  const valueDelta = netAmount.plus(ownFee);
+
+  if (valueDelta.isZero()) return zeroValueOperations();
+  if (valueDelta.isPositive()) return incomingOperations(valueDelta);
+  return outgoingOperations(valueDelta.abs());
 }
 
 async function processTransactionItem({
@@ -381,7 +618,8 @@ async function processTransactionItem({
   const mirrorTx = mergedTx.type === "mirror" ? mergedTx.data : mergedTx.data.mirrorTransaction;
   const commonData = getCommonMirrorOperationData(mirrorTx, useEncodedHash, useSyntheticBlocks);
 
-  const stakingReward = calculateStakingReward(mirrorTx, address);
+  const stakingRewards = calculateStakingRewards(mirrorTx);
+  const stakingReward = stakingRewards.get(address) ?? new BigNumber(0);
   const rewardOp = createStakingRewardOperation({
     stakingReward,
     address,
@@ -400,28 +638,25 @@ async function processTransactionItem({
       : null;
 
   if (mergedTx.type === "mirror") {
-    const htsTokenResult = await processHTSTokenTransfers({
+    // a single CryptoTransfer can move HBAR and HTS tokens at once, so run both paths
+    const tokenOps = processHTSTokenTransfers({
       rawTx: mirrorTx,
       address,
       ledgerAccountId,
       commonData,
     });
+    newTokenOperations.push(...tokenOps);
 
-    if (htsTokenResult?.tokenOperation) newTokenOperations.push(htsTokenResult.tokenOperation);
-    if (htsTokenResult?.coinOperation) newCoinOperations.push(htsTokenResult.coinOperation);
-
-    if (!htsTokenResult) {
-      const coinOps = processCoinTransfers({
-        rawTx: mirrorTx,
-        address,
-        ledgerAccountId,
-        commonData,
-        mirrorTokens,
-        stakingReward,
-        stakingAnalysis,
-      });
-      newCoinOperations.push(...coinOps);
-    }
+    const coinOps = processCoinTransfers({
+      rawTx: mirrorTx,
+      address,
+      ledgerAccountId,
+      commonData,
+      mirrorTokens,
+      stakingRewards,
+      stakingAnalysis,
+    });
+    newCoinOperations.push(...coinOps);
   } else {
     const erc20TokenResult = await processERC20TokenTransfer({
       enrichedERC20Transfer: mergedTx.data,
@@ -536,17 +771,17 @@ export async function listOperationsV2({
     tokenOperations.push(...result.newTokenOperations);
   }
 
-  // Drop `NONE` operations (account is neither sender nor recipient; value 0) to stay consistent with getBlock,
-  // which only emits real transfer participants. Fees are represented separately, so this never discards a fee.
-  // See BACK-11641.
-  const removeNone = (ops: Operation<HederaOperationExtra>[]) =>
-    ops.filter(op => op.type !== "NONE");
+  // a FEES op with no token op of the same tx is that tx's only trace, so it survives
+  const tokenOperationHashes = new Set(tokenOperations.map(op => op.hash));
 
+  // Drop NONE ops (account is neither sender nor recipient; value 0). See BACK-11641.
   return {
-    tokenOperations: removeNone(tokenOperations),
+    tokenOperations: tokenOperations.filter(op => op.type !== "NONE"),
     coinOperations: skipFeesForTokenOperations
-      ? removeNone(coinOperations).filter(op => op.type !== "FEES")
-      : removeNone(coinOperations),
+      ? coinOperations
+          .filter(op => op.type !== "NONE")
+          .filter(op => op.type !== "FEES" || !tokenOperationHashes.has(op.hash))
+      : coinOperations.filter(op => op.type !== "NONE"),
     nextCursor: mergeResult.nextCursor,
   };
 }

--- a/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/listOperations.v2.ts
@@ -54,6 +54,7 @@ function getCommonMirrorOperationData(
     consensusTimestamp: rawTx.consensus_timestamp,
     transactionId: rawTx.transaction_id,
     feesPayer,
+    chargedTxFee: fee.toFixed(0),
     ...(memo && { memo }),
   };
 
@@ -93,6 +94,8 @@ function createStakingRewardOperation({
   }
 
   const { hash, date, blockHeight, blockHash } = commonData;
+  // the reward itself is free; the fee belongs to the operation that triggered it
+  const { chargedTxFee: _, ...extra } = commonData.extra;
   const stakingRewardHash = createStakingRewardOperationHash(hash);
   const stakingRewardType: OperationType = "REWARD";
   // offset timestamp by +1ms so that, when operations are sorted newest-first, this reward appears just before the operation that triggered it
@@ -110,7 +113,7 @@ function createStakingRewardOperation({
     date: stakingRewardTimestamp,
     blockHeight,
     blockHash,
-    extra: commonData.extra,
+    extra,
   };
 }
 
@@ -472,7 +475,7 @@ function processCoinTransfers({
   const { senders, recipients, amountByRecipient } = parsed;
   const netAmount = parsed.netAmount ?? new BigNumber(0);
   const fee = commonData.fee;
-  const isPayer = extractFeesPayer(rawTx) === address;
+  const isPayer = commonData.extra.feesPayer === address;
   // an op's `fee` must match what is baked into its `value`, or getOperationValue subtracts it twice
   const ownFee = isPayer ? fee : new BigNumber(0);
 
@@ -559,25 +562,23 @@ function processCoinTransfers({
       return [buildNettedOperation("OUT", netAmount.abs())];
     }
 
-    // mirror's transfer order is not stable, so pick the lowest recipient id for determinism
-    const recipientCarryingFee = amountPerRecipient.reduce(
-      (lowest, transfer) => (transfer.recipient < lowest.recipient ? transfer : lowest),
-      amountPerRecipient[0],
-    ).recipient;
-
-    return amountPerRecipient.map(({ recipient, amount }) => {
-      const operationFee = recipient === recipientCarryingFee ? ownFee : new BigNumber(0);
-      return buildCoinOperation({
+    // no single OUT can carry the fee without overstating what that recipient received
+    const perRecipientOperations = amountPerRecipient.map(({ recipient, amount }) =>
+      buildCoinOperation({
         commonData,
         ledgerAccountId,
         type: "OUT",
-        value: amount.plus(operationFee),
-        fee: operationFee,
+        value: amount,
+        fee: new BigNumber(0),
         senders,
         recipient,
         extra: { ...commonData.extra },
-      });
-    });
+      }),
+    );
+
+    return isPayer && fee.gt(0)
+      ? [buildFeesOperation(), ...perRecipientOperations]
+      : perRecipientOperations;
   };
 
   // mirror nets the payer's row as value+fee, so add the fee back to recover the transfer amount

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -772,6 +772,15 @@ describe("logic utils", () => {
       expect(getSyncCursor(accountWith(operations))).toBe("1625097600.100000000");
     });
 
+    it("keeps nanosecond precision from a legacy consensusTimestamp when no pagingToken was stored", () => {
+      const operation = getMockedOperation({
+        date: new Date("2021-07-01T00:00:00.999Z"),
+        extra: { consensusTimestamp: "1625097600.999888777" },
+      });
+
+      expect(getSyncCursor(accountWith([operation]))).toBe("1625097600.999888777");
+    });
+
     it("takes token operations stored on subAccounts into account", () => {
       const cursor = getSyncCursor(
         accountWith(

--- a/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.test.ts
@@ -36,6 +36,7 @@ import { getMockedValidator } from "../test/fixtures/validator.fixture";
 import type {
   HederaAccount,
   HederaMemo,
+  HederaOperation,
   HederaPreloadData,
   HederaTxData,
   HederaValidator,
@@ -79,6 +80,7 @@ import {
   nanosToSeconds,
   secondsToNanos,
   toTimestamp,
+  getSyncCursor,
   createStakingRewardOperationHash,
   resolveConfig,
   base64ToUrlSafeBase64,
@@ -688,6 +690,97 @@ describe("logic utils", () => {
 
       expect(result.seconds.toString()).toBe("1758733200");
       expect(result.nanos.toString()).toBe("600000000");
+    });
+  });
+
+  describe("getSyncCursor", () => {
+    const operationAt = (pagingToken: string, date = new Date("2024-01-01T00:00:00Z")) =>
+      getMockedOperation({ date, extra: { pagingToken } });
+
+    const accountWith = (
+      operations: HederaOperation[],
+      subAccountOperations: HederaOperation[] = [],
+    ) =>
+      ({
+        operations,
+        ...(subAccountOperations.length > 0 && {
+          subAccounts: [{ operations: subAccountOperations }],
+        }),
+      }) as Pick<HederaAccount, "operations" | "subAccounts">;
+
+    it("returns null for an empty account", () => {
+      expect(getSyncCursor(accountWith([]))).toBeNull();
+    });
+
+    it("returns null when there is no account to resume from", () => {
+      expect(getSyncCursor(null)).toBeNull();
+    });
+
+    it("picks the highest pagingToken rather than the first operation's", () => {
+      const operations = [
+        operationAt("1625097600.111222333"),
+        operationAt("1625097600.999888777"),
+        operationAt("1625097600.444555666"),
+      ];
+
+      expect(getSyncCursor(accountWith(operations))).toBe("1625097600.999888777");
+    });
+
+    it("keeps nanosecond precision so a stored transaction cannot fall inside the next gt: window", () => {
+      expect(getSyncCursor(accountWith([operationAt("1625097600.000000001")]))).toBe(
+        "1625097600.000000001",
+      );
+    });
+
+    it("truncates a sub-nanosecond pagingToken instead of rounding it up", () => {
+      // rounding up would push the cursor past 1625097600.000000001 and skip it in the next gt: window
+      expect(getSyncCursor(accountWith([operationAt("1625097600.0000000009")]))).toBe(
+        "1625097600.000000000",
+      );
+    });
+
+    it("falls back to the operation date truncated to seconds when no pagingToken is stored", () => {
+      const operation = getMockedOperation({ date: new Date("2021-07-01T00:00:00.500Z") });
+
+      expect(getSyncCursor(accountWith([operation]))).toBe("1625097600.000000000");
+    });
+
+    it("prefers a pagingToken over a later-dated operation without one", () => {
+      const operations = [
+        getMockedOperation({ date: new Date("2021-07-01T00:00:00Z") }),
+        operationAt("1625097600.123456789"),
+      ];
+
+      expect(getSyncCursor(accountWith(operations))).toBe("1625097600.123456789");
+    });
+
+    it("falls back to the operation date when the stored pagingToken is not a number", () => {
+      const operation = operationAt("not-a-number", new Date("2021-07-01T00:00:00.500Z"));
+
+      // an unreadable pagingToken must not discard the operation, or the cursor moves past it
+      expect(getSyncCursor(accountWith([operation]))).toBe("1625097600.000000000");
+    });
+
+    it("never moves past an operation stored without a pagingToken", () => {
+      const operations = [
+        // migrated operation: no pagingToken, real consensus timestamp 1625097600.5
+        getMockedOperation({ date: new Date("2021-07-01T00:00:00.500Z"), extra: {} }),
+        operationAt("1625097600.100000000", new Date("2021-07-01T00:00:00.100Z")),
+      ];
+
+      // .1 is the newest timestamp we can prove was fetched, so 1625097600.5 is only re-fetched
+      expect(getSyncCursor(accountWith(operations))).toBe("1625097600.100000000");
+    });
+
+    it("takes token operations stored on subAccounts into account", () => {
+      const cursor = getSyncCursor(
+        accountWith(
+          [operationAt("1625097600.111222333")],
+          [operationAt("1625097600.999888777")], // token operation, newer than any coin operation
+        ),
+      );
+
+      expect(cursor).toBe("1625097600.999888777");
     });
   });
 

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -602,11 +602,12 @@ export function nanosToSeconds(nanos: number | BigNumber): BigNumber {
  *  anything coarser leaves stored transactions inside the next `gt:` window, where they get re-emitted. */
 function consensusTimestampLowerBound(operation: LiveOperation): BigNumber | null {
   const extra = isValidExtra(operation.extra) ? operation.extra : null;
-  const pagingToken = extra?.pagingToken ? new BigNumber(extra.pagingToken) : null;
+  const storedTimestamp = extra?.pagingToken ?? extra?.consensusTimestamp;
+  const timestamp = storedTimestamp ? new BigNumber(storedTimestamp) : null;
 
-  if (pagingToken && !pagingToken.isNaN()) return pagingToken;
+  if (timestamp && !timestamp.isNaN()) return timestamp;
 
-  // operations stored by older versions carry no pagingToken, so `date` is floored to the second:
+  // operations stored by even older versions carry neither, so `date` is floored to the second:
   // the next sync can only re-fetch this operation, never skip past it
   const flooredDate = millisToSeconds(operation.date.getTime()).integerValue(BigNumber.ROUND_FLOOR);
 

--- a/libs/coin-modules/coin-hedera/src/logic/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/logic/utils.ts
@@ -598,6 +598,45 @@ export function nanosToSeconds(nanos: number | BigNumber): BigNumber {
   return new BigNumber(nanos).dividedBy(10 ** 9);
 }
 
+/** Consensus timestamp this operation is known to be at or after, at nanosecond precision:
+ *  anything coarser leaves stored transactions inside the next `gt:` window, where they get re-emitted. */
+function consensusTimestampLowerBound(operation: LiveOperation): BigNumber | null {
+  const extra = isValidExtra(operation.extra) ? operation.extra : null;
+  const pagingToken = extra?.pagingToken ? new BigNumber(extra.pagingToken) : null;
+
+  if (pagingToken && !pagingToken.isNaN()) return pagingToken;
+
+  // operations stored by older versions carry no pagingToken, so `date` is floored to the second:
+  // the next sync can only re-fetch this operation, never skip past it
+  const flooredDate = millisToSeconds(operation.date.getTime()).integerValue(BigNumber.ROUND_FLOOR);
+
+  return flooredDate.isNaN() ? null : flooredDate;
+}
+
+/** Highest consensus timestamp already stored: everything at or below it was fetched by a previous
+ *  sync, so the next one can start there. */
+export function getSyncCursor(
+  account: Pick<HederaAccount, "operations" | "subAccounts"> | null | undefined,
+): string | null {
+  const operations = [
+    ...(account?.operations ?? []),
+    // token operations live on subAccounts; leaving them out drags the cursor behind, and a re-fetched
+    // operation whose id changed since it was stored ends up next to its stale copy instead of replacing it
+    ...(account?.subAccounts ?? []).flatMap(subAccount => subAccount.operations),
+  ];
+
+  let highest: BigNumber | null = null;
+
+  for (const operation of operations) {
+    const candidate = consensusTimestampLowerBound(operation);
+
+    if (!candidate) continue;
+    if (!highest || candidate.gt(highest)) highest = candidate;
+  }
+
+  return highest?.toFixed(9, BigNumber.ROUND_FLOOR) ?? null;
+}
+
 export function toTimestamp(consensusTimestamp: string): Timestamp {
   const [secondsPart, nanosPart] = consensusTimestamp.split(".");
 

--- a/libs/coin-modules/coin-hedera/src/network/utils.test.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.test.ts
@@ -119,8 +119,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("IN");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(100));
       expect(result.senders).toEqual(["0.0.5678"]);
       expect(result.recipients).toEqual([userAddress]);
     });
@@ -133,8 +132,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(-100));
       expect(result.senders).toEqual([userAddress]);
       expect(result.recipients).toEqual(["0.0.5678"]);
     });
@@ -148,10 +146,37 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(50));
+      expect(result.netAmount).toEqual(new BigNumber(-50));
       expect(result.senders).toEqual(["0.0.1234", "0.0.5678"]);
       expect(result.recipients).toEqual(["0.0.9999"]);
+    });
+
+    it("reports the amount received by each recipient", () => {
+      const transfers = [
+        createMirrorCoinTransfer(userAddress, -100),
+        createMirrorCoinTransfer("0.0.5678", 30),
+        createMirrorCoinTransfer("0.0.9999", 70),
+      ];
+
+      const result = parseTransfers(transfers, userAddress);
+
+      expect([...result.amountByRecipient]).toEqual([
+        ["0.0.5678", new BigNumber(30)],
+        ["0.0.9999", new BigNumber(70)],
+      ]);
+    });
+
+    it("sums several rows of the same account into one net amount", () => {
+      const transfers = [
+        createMirrorCoinTransfer(userAddress, -100),
+        createMirrorCoinTransfer(userAddress, 40),
+        createMirrorCoinTransfer("0.0.5678", 60),
+      ];
+
+      const result = parseTransfers(transfers, userAddress);
+
+      expect(result.netAmount).toEqual(new BigNumber(-60));
+      expect(result.senders).toEqual([userAddress]);
     });
 
     it("should correctly process token transfers", () => {
@@ -163,8 +188,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(10));
+      expect(result.netAmount).toEqual(new BigNumber(-10));
       expect(result.senders).toEqual([userAddress]);
       expect(result.recipients).toEqual(["0.0.5678"]);
     });
@@ -178,8 +202,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(-100));
       expect(result.senders).toEqual([userAddress]);
       expect(result.recipients).toEqual([]);
     });
@@ -193,10 +216,10 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(-100));
       expect(result.senders).toEqual([userAddress]);
       expect(result.recipients).toEqual([nodeAccount]);
+      expect(result.amountByRecipient.get(nodeAccount)).toEqual(new BigNumber(100));
     });
 
     it("should exclude node accounts if there are other recipients", () => {
@@ -210,13 +233,29 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("OUT");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(-100));
       expect(result.senders).toEqual([userAddress]);
       expect(result.recipients).toEqual([normalAccount]);
+      expect(result.amountByRecipient.has(nodeAccount)).toBe(false);
     });
 
-    it("should handle transactions where user is not involved", () => {
+    it("should exclude node accounts listed before the real recipient", () => {
+      const normalAccount = "0.0.5678";
+      const nodeAccount = "0.0.3";
+      // the mirror node lists the fee rows first as often as last
+      const transfers = [
+        createMirrorCoinTransfer(userAddress, -100),
+        createMirrorCoinTransfer(nodeAccount, 50),
+        createMirrorCoinTransfer(normalAccount, 50),
+      ];
+
+      const result = parseTransfers(transfers, userAddress);
+
+      expect(result.recipients).toEqual([normalAccount]);
+      expect(result.amountByRecipient.has(nodeAccount)).toBe(false);
+    });
+
+    it("returns a null netAmount when the account is absent from the transfers", () => {
       const transfers = [
         createMirrorCoinTransfer("0.0.5678", -100),
         createMirrorCoinTransfer("0.0.9999", 100),
@@ -224,8 +263,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("NONE");
-      expect(result.value).toEqual(new BigNumber(0));
+      expect(result.netAmount).toBeNull();
       expect(result.senders).toEqual(["0.0.5678"]);
       expect(result.recipients).toEqual(["0.0.9999"]);
     });
@@ -235,8 +273,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("NONE");
-      expect(result.value).toEqual(new BigNumber(0));
+      expect(result.netAmount).toBeNull();
       expect(result.senders).toEqual([]);
       expect(result.recipients).toEqual([]);
     });
@@ -250,8 +287,7 @@ describe("network utils", () => {
 
       const result = parseTransfers(transfers, userAddress);
 
-      expect(result.type).toBe("IN");
-      expect(result.value).toEqual(new BigNumber(100));
+      expect(result.netAmount).toEqual(new BigNumber(100));
       expect(result.senders).toEqual(["0.0.5678", "0.0.900"]);
       expect(result.recipients).toEqual([userAddress]);
     });
@@ -261,24 +297,61 @@ describe("network utils", () => {
       const stakingReward = new BigNumber(20);
       const transfers = [createMirrorCoinTransfer(userAddress, amount.toNumber())];
 
-      const expectedAmountWithoutReward = amount.minus(stakingReward);
-      const result = parseTransfers(transfers, userAddress, stakingReward);
+      const result = parseTransfers(
+        transfers,
+        userAddress,
+        new Map([[userAddress, stakingReward]]),
+      );
 
-      expect(result).toMatchObject({
-        type: "IN",
-        value: expectedAmountWithoutReward,
-      });
+      expect(result.netAmount).toEqual(amount.minus(stakingReward));
+    });
+
+    it("nets each recipient's reward out of the amount it received", () => {
+      const recipient = "0.0.5678";
+      const transfers = [
+        createMirrorCoinTransfer(userAddress, -100),
+        createMirrorCoinTransfer(recipient, 130),
+      ];
+
+      const result = parseTransfers(
+        transfers,
+        userAddress,
+        new Map([[recipient, new BigNumber(30)]]),
+      );
+
+      expect(result.amountByRecipient.get(recipient)).toEqual(new BigNumber(100));
     });
 
     it("excludes reward payer from senders when staking reward is present", () => {
-      const stakingReward = new BigNumber(30000000);
       const transfers = [
         createMirrorCoinTransfer(rewardPayer, -30000000),
         createMirrorCoinTransfer("0.0.801", 1000),
         createMirrorCoinTransfer(userAddress, 30000000),
       ];
 
-      const result = parseTransfers(transfers, userAddress, stakingReward);
+      const result = parseTransfers(
+        transfers,
+        userAddress,
+        new Map([[userAddress, new BigNumber(30000000)]]),
+      );
+
+      expect(result.senders).not.toContain(rewardPayer);
+    });
+
+    it("excludes reward payer from senders when another account received the reward", () => {
+      const otherAccount = "0.0.9999";
+      const transfers = [
+        createMirrorCoinTransfer(rewardPayer, -30000000),
+        createMirrorCoinTransfer(otherAccount, 30000000),
+        createMirrorCoinTransfer(userAddress, -100),
+        createMirrorCoinTransfer("0.0.5678", 100),
+      ];
+
+      const result = parseTransfers(
+        transfers,
+        userAddress,
+        new Map([[otherAccount, new BigNumber(30000000)]]),
+      );
 
       expect(result.senders).not.toContain(rewardPayer);
     });

--- a/libs/coin-modules/coin-hedera/src/network/utils.ts
+++ b/libs/coin-modules/coin-hedera/src/network/utils.ts
@@ -54,69 +54,153 @@ export async function createTransactionId(
   }
 }
 
-function isValidRecipient(accountId: AccountId, recipients: string[]): boolean {
-  if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
-    // account is a node, only add to list if we have none
-    if (accountId.num.lt(100)) {
-      return recipients.length === 0;
-    }
+type RecipientKind = "node" | "system" | "regular";
 
-    // account is a system account that is not a node, do NOT add
-    if (accountId.num.lt(1000)) {
-      return false;
+function classifyRecipient(accountId: AccountId): RecipientKind {
+  if (accountId.shard.eq(0) && accountId.realm.eq(0)) {
+    if (accountId.num.lt(100)) return "node";
+    if (accountId.num.lt(1000)) return "system";
+  }
+
+  return "regular";
+}
+
+// mirror can list one account on several rows of the same asset
+function sumNetByAccount(
+  mirrorTransfers: (HederaMirrorCoinTransfer | HederaMirrorTokenTransfer)[],
+): Map<string, BigNumber> {
+  const netByAccount = new Map<string, BigNumber>();
+
+  for (const transfer of mirrorTransfers) {
+    const previous = netByAccount.get(transfer.account) ?? new BigNumber(0);
+    netByAccount.set(transfer.account, previous.plus(transfer.amount));
+  }
+
+  return netByAccount;
+}
+
+/** First network account credited by these transfers: a consensus node, or the fee collection
+ *  account. Nodes take a fee share on every transaction, so a credited one is never a transfer's
+ *  real recipient — it only says where the fee went. */
+function findCreditedNetworkAccount(netByAccount: Map<string, BigNumber>): string | null {
+  for (const [account, net] of netByAccount) {
+    if (!net.isPositive()) continue;
+    if (classifyRecipient(AccountId.fromString(account)) === "node") return account;
+  }
+
+  return null;
+}
+
+/** The account that collected this transaction's fee. `rawTx.node` names it on top-level
+ *  transactions, but mirror reports `node: null` on child records, where the transfers are the
+ *  only trace of where the fee went. */
+export function findFeeRecipient(
+  mirrorTransfers: (HederaMirrorCoinTransfer | HederaMirrorTokenTransfer)[],
+): string | null {
+  return findCreditedNetworkAccount(sumNetByAccount(mirrorTransfers));
+}
+
+type TransferRole = "sender" | "recipient" | "ignored";
+
+function classifyTransferRole({
+  account,
+  net,
+  rewardPayerAddress,
+  hasStakingRewards,
+}: {
+  account: string;
+  net: BigNumber;
+  rewardPayerAddress: string;
+  hasStakingRewards: boolean;
+}): TransferRole {
+  if (net.isNegative()) {
+    // rewards are surfaced as separate REWARD operations, so their payer is not a sender
+    const shouldIgnoreAddress = account === rewardPayerAddress && hasStakingRewards;
+
+    return shouldIgnoreAddress ? "ignored" : "sender";
+  }
+
+  if (!net.isPositive()) return "ignored";
+
+  // the network's own cut (node fee share, system accounts) is not a transfer to a recipient
+  return classifyRecipient(AccountId.fromString(account)) === "regular" ? "recipient" : "ignored";
+}
+
+function splitTransferParties({
+  netByAccount,
+  stakingRewards,
+  rewardPayerAddress,
+  hasStakingRewards,
+}: {
+  netByAccount: Map<string, BigNumber>;
+  stakingRewards: Map<string, BigNumber>;
+  rewardPayerAddress: string;
+  hasStakingRewards: boolean;
+}): Pick<Operation, "senders" | "recipients"> & { amountByRecipient: Map<string, BigNumber> } {
+  const senders: string[] = [];
+  const recipients: string[] = [];
+  const amountByRecipient = new Map<string, BigNumber>();
+
+  for (const [account, rawNet] of netByAccount) {
+    // the mirror node folds each account's staking reward into its transfer row
+    const net = rawNet.minus(stakingRewards.get(account) ?? 0);
+
+    switch (classifyTransferRole({ account, net, rewardPayerAddress, hasStakingRewards })) {
+      case "sender":
+        senders.push(account);
+        break;
+      case "recipient":
+        recipients.push(account);
+        amountByRecipient.set(account, net);
+        break;
     }
   }
 
-  return true;
+  // nodes receive a fee share on every tx, so list one as recipient only if nobody else received
+  const nodeAccount = recipients.length === 0 ? findCreditedNetworkAccount(netByAccount) : null;
+
+  if (nodeAccount) {
+    recipients.push(nodeAccount);
+    amountByRecipient.set(nodeAccount, netByAccount.get(nodeAccount) ?? new BigNumber(0));
+  }
+
+  return { senders, recipients, amountByRecipient };
 }
 
 export function parseTransfers(
   mirrorTransfers: (HederaMirrorCoinTransfer | HederaMirrorTokenTransfer)[],
   address: string,
-  stakingReward = new BigNumber(0),
-): Pick<Operation, "type" | "value" | "senders" | "recipients"> {
-  let value = new BigNumber(0);
-  let type: OperationType = "NONE";
-
-  const senders: string[] = [];
-  const recipients: string[] = [];
+  stakingRewards: Map<string, BigNumber> = new Map(),
+): Pick<Operation, "senders" | "recipients"> & {
+  /** null when this account is absent from these transfers */
+  netAmount: BigNumber | null;
+  amountByRecipient: Map<string, BigNumber>;
+} {
   const rewardPayerAddress = getEnv("HEDERA_STAKING_REWARD_ACCOUNT_ID");
 
-  for (const transfer of mirrorTransfers) {
-    const amount = new BigNumber(transfer.amount);
-    const accountId = AccountId.fromString(transfer.account);
+  const netByAccount = sumNetByAccount(mirrorTransfers);
 
-    // staking reward is included in transfer, so it can be positive even if user sent less HBARs than the reward is
-    const amountWithoutReward = transfer.account === address ? amount.minus(stakingReward) : amount;
+  const userNet = netByAccount.get(address);
+  const netAmount = userNet === undefined ? null : userNet.minus(stakingRewards.get(address) ?? 0);
 
-    if (transfer.account === address) {
-      value = amountWithoutReward.abs();
-      type = amountWithoutReward.isNegative() ? "OUT" : "IN";
-    }
+  const hasStakingRewards = [...stakingRewards.values()].some(reward => reward.gt(0));
 
-    if (amountWithoutReward.isNegative()) {
-      // exclude reward payer from senders list, because rewards are shown as separate operations
-      const shouldIgnoreAddress = transfer.account === rewardPayerAddress && stakingReward.gt(0);
-
-      if (shouldIgnoreAddress) {
-        continue;
-      }
-
-      senders.push(transfer.account);
-    } else if (isValidRecipient(accountId, recipients)) {
-      recipients.push(transfer.account);
-    }
-  }
+  const { senders, recipients, amountByRecipient } = splitTransferParties({
+    netByAccount,
+    stakingRewards,
+    rewardPayerAddress,
+    hasStakingRewards,
+  });
 
   // NOTE: earlier addresses are the "fee" addresses
   senders.reverse();
   recipients.reverse();
 
   return {
-    type,
-    value,
     senders,
     recipients,
+    netAmount,
+    amountByRecipient,
   };
 }
 

--- a/libs/coin-modules/coin-hedera/src/types/bridge.ts
+++ b/libs/coin-modules/coin-hedera/src/types/bridge.ts
@@ -173,6 +173,8 @@ export type HederaOperationExtra = {
   targetStakingNodeId?: number | null;
   previousStakingNodeId?: number | null;
   stakedAmount?: BigNumber;
+  // unlike `op.fee`, this is identical on every operation of the same hash
+  chargedTxFee?: string;
 };
 
 export type HederaValidator = {

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -9,7 +9,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "freshAddressPath": "44/3030",
     "hederaResources": {
       "delegation": {
-        "delegated": "92300851514",
+        "delegated": "91736207521",
         "nodeId": 20,
       },
       "isAutoTokenAssociationEnabled": false,
@@ -17,7 +17,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     },
     "id": "js:2:hedera:0.0.1040977:hederaBip44",
     "index": 0,
-    "operationsCount": 94,
+    "operationsCount": 103,
     "pendingOperations": [],
     "seedIdentifier": "9e92a312233d5fd6b5a723875aeea2cea81a8e48ffc00341cff6dffcfd3ab7f2",
     "subAccounts": [],
@@ -52,13 +52,58 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     "type": "TokenAccountRaw",
   },
   {
+    "id": "js:2:hedera:0.0.1040977:hederaBip44+hedera%2Fhts%2Fsauce~!underscore!~0.0.731861",
+    "operationsCount": 0,
+    "parentId": "js:2:hedera:0.0.1040977:hederaBip44",
+    "pendingOperations": [],
+    "swapHistory": [],
+    "tokenId": "hedera/hts/sauce_0.0.731861",
+    "type": "TokenAccountRaw",
+  },
+  {
+    "id": "js:2:hedera:0.0.1040977:hederaBip44+hedera%2Fhts%2Fhbarsuite~!underscore!~0.0.786931",
+    "operationsCount": 0,
+    "parentId": "js:2:hedera:0.0.1040977:hederaBip44",
+    "pendingOperations": [],
+    "swapHistory": [],
+    "tokenId": "hedera/hts/hbarsuite_0.0.786931",
+    "type": "TokenAccountRaw",
+  },
+  {
+    "id": "js:2:hedera:0.0.1040977:hederaBip44+hedera%2Fhts%2Fpack~!underscore!~0.0.4794920",
+    "operationsCount": 0,
+    "parentId": "js:2:hedera:0.0.1040977:hederaBip44",
+    "pendingOperations": [],
+    "swapHistory": [],
+    "tokenId": "hedera/hts/pack_0.0.4794920",
+    "type": "TokenAccountRaw",
+  },
+  {
+    "id": "js:2:hedera:0.0.1040977:hederaBip44+hedera%2Fhts%2Fbitcoin~!underscore!~0.0.4873177",
+    "operationsCount": 0,
+    "parentId": "js:2:hedera:0.0.1040977:hederaBip44",
+    "pendingOperations": [],
+    "swapHistory": [],
+    "tokenId": "hedera/hts/bitcoin_0.0.4873177",
+    "type": "TokenAccountRaw",
+  },
+  {
+    "id": "js:2:hedera:0.0.1040977:hederaBip44+hedera%2Fhts%2Fxpack~!underscore!~0.0.7243470",
+    "operationsCount": 0,
+    "parentId": "js:2:hedera:0.0.1040977:hederaBip44",
+    "pendingOperations": [],
+    "swapHistory": [],
+    "tokenId": "hedera/hts/xpack_0.0.7243470",
+    "type": "TokenAccountRaw",
+  },
+  {
     "currencyId": "hedera",
     "derivationMode": "hederaBip44",
     "freshAddress": "0.0.7305122",
     "freshAddressPath": "44/3030",
     "hederaResources": {
       "delegation": {
-        "delegated": "45705731",
+        "delegated": "245705731",
         "nodeId": 0,
       },
       "isAutoTokenAssociationEnabled": false,
@@ -66,7 +111,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 1`] = `
     },
     "id": "js:2:hedera:0.0.7305122:hederaBip44",
     "index": 1,
-    "operationsCount": 36,
+    "operationsCount": 38,
     "pendingOperations": [],
     "seedIdentifier": "9e92a312233d5fd6b5a723875aeea2cea81a8e48ffc00341cff6dffcfd3ab7f2",
     "subAccounts": [],
@@ -266,6 +311,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "141844",
         "consensusTimestamp": "1783600346.045490061",
         "feesPayer": "0.0.10096335",
         "pagingToken": "1783600346.045490061",
@@ -289,6 +335,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "56687",
         "consensusTimestamp": "1760963950.231238974",
         "feesPayer": "0.0.9870888",
         "pagingToken": "1760963950.231238974",
@@ -312,6 +359,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225279",
         "consensusTimestamp": "1730811624.603795000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1730811624.603795000",
@@ -335,6 +383,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "157370",
         "consensusTimestamp": "1764939327.504699000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -385,6 +434,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163226",
         "consensusTimestamp": "1764676581.905435000",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -412,6 +462,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958515.919946557",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958515.919946557",
@@ -435,6 +486,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729155939.657319000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729155939.657319000",
@@ -458,6 +510,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225507",
         "consensusTimestamp": "1730813192.423784000",
         "feesPayer": "0.0.7305122",
         "memo": "send",
@@ -482,6 +535,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "81148",
         "consensusTimestamp": "1765219485.073358000",
         "feesPayer": "0.0.8217344",
         "memo": "(3/3) More info (including a dApp safety video) ➡️ visit @tozmdotio on YouTube or X 🔥",
@@ -537,6 +591,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "102687",
         "consensusTimestamp": "1773660464.530836000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1773660464.530836000",
@@ -560,6 +615,32 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "associatedTokenId": "0.0.731861",
+        "chargedTxFee": "70771741",
+        "consensusTimestamp": "1785853412.824159073",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785853412.824159073",
+        "transactionId": "0.0.1040977-1785853405-078152794",
+      },
+      "fee": "70771741",
+      "hasFailed": false,
+      "hash": "8mLnkJPf2bVo4V_i2C7xV4gFM3CgG9s-PP745VZeFneZydEM5c1gCtmLy1bMwvIe",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-8mLnkJPf2bVo4V_i2C7xV4gFM3CgG9s-PP745VZeFneZydEM5c1gCtmLy1bMwvIe-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.28",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "70771741",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "141844",
         "consensusTimestamp": "1783600355.641401441",
         "feesPayer": "0.0.10231006",
         "pagingToken": "1783600355.641401441",
@@ -583,6 +664,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "111602",
         "consensusTimestamp": "1777449214.469848000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1777449214.469848000",
@@ -606,6 +688,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "226772",
         "consensusTimestamp": "1730811403.115680000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1730811403.115680000",
@@ -629,6 +712,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "203103",
         "consensusTimestamp": "1726477122.251592000",
         "feesPayer": "0.0.7107424",
         "memo": "small send QA samy",
@@ -653,6 +737,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "180755",
         "consensusTimestamp": "1767959010.046823770",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -680,6 +765,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163226",
         "consensusTimestamp": "1764676088.728437000",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -707,6 +793,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "81129",
         "consensusTimestamp": "1765219489.841439143",
         "feesPayer": "0.0.8217344",
         "memo": "(2/3) Mint TOZM Gift 🎁 NFTs for Free (each costs only about $0.03 in network fees). 🚀",
@@ -739,6 +826,31 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "140945",
+        "consensusTimestamp": "1785851362.024349104",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785851362.024349104",
+        "transactionId": "0.0.1040977-1785851348-669358104",
+      },
+      "fee": "140945",
+      "hasFailed": false,
+      "hash": "c4x3vfE7eHH8ngDNp8MmeTI_lg_mEvF2esNgMBVQEO6mdowNmQP8V3AoCmHn8l_b",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-c4x3vfE7eHH8ngDNp8MmeTI_lg_mEvF2esNgMBVQEO6mdowNmQP8V3AoCmHn8l_b-OUT",
+      "recipients": [
+        "0.0.7305122",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "OUT",
+      "value": "100140945",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729155815.270550000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729155815.270550000",
@@ -762,6 +874,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "70763",
         "consensusTimestamp": "1765303698.040541000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1765303698.040541000",
@@ -785,6 +898,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "203410",
         "consensusTimestamp": "1726477062.311057502",
         "feesPayer": "0.0.7107424",
         "memo": "test QA samy normal send",
@@ -809,6 +923,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "56687",
         "consensusTimestamp": "1760963943.673922000",
         "feesPayer": "0.0.50571",
         "pagingToken": "1760963943.673922000",
@@ -832,6 +947,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "198012",
         "consensusTimestamp": "1766051926.733060576",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -859,6 +975,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "226772",
         "consensusTimestamp": "1730811531.050920029",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1730811531.050920029",
@@ -882,6 +999,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "198870",
         "consensusTimestamp": "1726235313.566576000",
         "feesPayer": "0.0.7107424",
         "memo": "give back to poor obelix - samy",
@@ -906,6 +1024,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "199068",
         "consensusTimestamp": "1729858464.980892000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729858464.980892000",
@@ -929,6 +1048,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "77864",
         "consensusTimestamp": "1765448860.100970000",
         "feesPayer": "0.0.9870888",
         "pagingToken": "1765448860.100970000",
@@ -952,6 +1072,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "167824",
         "consensusTimestamp": "1765556566.904748000",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -979,6 +1100,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "97410",
         "consensusTimestamp": "1769698035.720449444",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1769698035.720449444",
@@ -1002,6 +1124,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "349789",
         "consensusTimestamp": "1753699233.640576809",
         "feesPayer": "0.0.8313635",
         "pagingToken": "1753699233.640576809",
@@ -1022,6 +1145,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.127877",
+        "chargedTxFee": "17755051",
         "consensusTimestamp": "1753711721.783899000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1753711721.783899000",
@@ -1045,6 +1169,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "73908",
         "consensusTimestamp": "1765363209.429188000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1765363209.429188000",
@@ -1090,6 +1215,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "191792",
         "consensusTimestamp": "1729147655.662122737",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729147655.662122737",
@@ -1113,6 +1239,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "196236",
         "consensusTimestamp": "1729687467.306035525",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729687467.306035525",
@@ -1136,6 +1263,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "193637",
         "consensusTimestamp": "1729150225.131300000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729150225.131300000",
@@ -1159,6 +1287,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "82857",
         "consensusTimestamp": "1732192441.542423000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1732192441.542423000",
@@ -1182,6 +1311,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "103989",
         "consensusTimestamp": "1704213295.949352003",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1704213295.949352003",
@@ -1205,6 +1335,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "83709",
         "consensusTimestamp": "1732205762.558954000",
         "feesPayer": "0.0.7579210",
         "pagingToken": "1732205762.558954000",
@@ -1228,6 +1359,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163309",
         "consensusTimestamp": "1764676556.594347000",
         "feesPayer": "0.0.1040977",
         "memo": "Unstake",
@@ -1255,6 +1387,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "210184",
         "consensusTimestamp": "1697645669.026204003",
         "feesPayer": "0.0.1040977",
         "memo": "test send max",
@@ -1279,6 +1412,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225507",
         "consensusTimestamp": "1730813149.715064983",
         "feesPayer": "0.0.1040977",
         "memo": "send",
@@ -1303,6 +1437,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "961780",
         "consensusTimestamp": "1769699423.568370037",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1769699423.568370037",
@@ -1326,6 +1461,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163081",
         "consensusTimestamp": "1657021403.368076000",
         "feesPayer": "0.0.880760",
         "pagingToken": "1657021403.368076000",
@@ -1349,6 +1485,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163226",
         "consensusTimestamp": "1764676452.498442000",
         "feesPayer": "0.0.1040977",
         "memo": "Stake",
@@ -1376,6 +1513,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "1113116",
         "consensusTimestamp": "1777451057.014254000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777451057.014254000",
@@ -1395,6 +1533,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "198113",
         "consensusTimestamp": "1766051886.378264000",
         "feesPayer": "0.0.1040977",
         "memo": "Unstake",
@@ -1422,6 +1561,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163309",
         "consensusTimestamp": "1764676635.614168000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -1449,6 +1589,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958685.802702000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958685.802702000",
@@ -1472,6 +1613,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "77864",
         "consensusTimestamp": "1765448850.572930000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1765448850.572930000",
@@ -1517,6 +1659,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "424851",
         "consensusTimestamp": "1755785525.693277000",
         "feesPayer": "0.0.8313485",
         "memo": "toto",
@@ -1560,6 +1703,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "167909",
         "consensusTimestamp": "1765556530.722814000",
         "feesPayer": "0.0.1040977",
         "memo": "Unstake",
@@ -1587,6 +1731,32 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "associatedTokenId": "0.0.786931",
+        "chargedTxFee": "70771741",
+        "consensusTimestamp": "1785853786.636560104",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785853786.636560104",
+        "transactionId": "0.0.1040977-1785853778-203471104",
+      },
+      "fee": "70771741",
+      "hasFailed": false,
+      "hash": "LmmKM_V-vW27Z6EStXsg91VnHAIvbupM-u-nBChwgvM2ifGXCspcTV_Y8MIWIPIt",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-LmmKM_V-vW27Z6EStXsg91VnHAIvbupM-u-nBChwgvM2ifGXCspcTV_Y8MIWIPIt-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.25",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "70771741",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "70763",
         "consensusTimestamp": "1765303272.465501000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1765303272.465501000",
@@ -1632,6 +1802,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "347389",
         "consensusTimestamp": "1753690711.015332718",
         "feesPayer": "0.0.8313635",
         "pagingToken": "1753690711.015332718",
@@ -1651,6 +1822,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "197305",
         "consensusTimestamp": "1729177404.980663000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729177404.980663000",
@@ -1674,6 +1846,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "81054",
         "consensusTimestamp": "1765219496.001325817",
         "feesPayer": "0.0.8217344",
         "memo": "(1/3) 📢 This December is a great month to start playing TOZM - Token of Z Month! ✅",
@@ -1706,6 +1879,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729156701.804949000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729156701.804949000",
@@ -1729,6 +1903,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "189619",
         "consensusTimestamp": "1729585926.624752000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729585926.624752000",
@@ -1752,6 +1927,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "148589",
         "consensusTimestamp": "1721982048.841299095",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1721982048.841299095",
@@ -1775,6 +1951,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "55505",
         "consensusTimestamp": "1748539198.038322000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1748539198.038322000",
@@ -1798,6 +1975,56 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "associatedTokenId": "0.0.7243470",
+        "chargedTxFee": "70771741",
+        "consensusTimestamp": "1785853972.192706773",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785853972.192706773",
+        "transactionId": "0.0.1040977-1785853964-314443822",
+      },
+      "fee": "70771741",
+      "hasFailed": false,
+      "hash": "n6ztvkHkh6038d1fntnV-ayRG-i109_9VSDUivKXVxkkcBdlsWQYMx-o8mjcMqB8",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-n6ztvkHkh6038d1fntnV-ayRG-i109_9VSDUivKXVxkkcBdlsWQYMx-o8mjcMqB8-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.15",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "70771741",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "70771741",
+        "consensusTimestamp": "1785853814.939814104",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785853814.939814104",
+        "transactionId": "0.0.1040977-1785853806-107250104",
+      },
+      "fee": "70771741",
+      "hasFailed": true,
+      "hash": "nK84Gqewq5RPADfTI_uu3t1vrwITHePSKU14z107JtWwL1Hq97vSJJNAIPmxkx8I",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-nK84Gqewq5RPADfTI_uu3t1vrwITHePSKU14z107JtWwL1Hq97vSJJNAIPmxkx8I-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.18",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "70771741",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "167909",
         "consensusTimestamp": "1765556611.828482000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -1825,6 +2052,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "82707",
         "consensusTimestamp": "1732202577.896639115",
         "feesPayer": "0.0.1040977",
         "memo": "test nano x",
@@ -1849,6 +2077,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "54816",
         "consensusTimestamp": "1740739322.044670000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1740739322.044670000",
@@ -1872,6 +2101,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163309",
         "consensusTimestamp": "1764676405.364046000",
         "feesPayer": "0.0.1040977",
         "memo": "Unstake",
@@ -1899,6 +2129,57 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "associatedTokenId": "0.0.4873177",
+        "chargedTxFee": "71863515",
+        "consensusTimestamp": "1785856250.078725104",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785856250.078725104",
+        "transactionId": "0.0.1040977-1785856241-595576378",
+      },
+      "fee": "71863515",
+      "hasFailed": false,
+      "hash": "o24aRxkxpcVeEi-QQMudCHXEu2Pzfwkhlu0MuX9Rh5B82F26UXT_RU5h_BFmQ2HO",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-o24aRxkxpcVeEi-QQMudCHXEu2Pzfwkhlu0MuX9Rh5B82F26UXT_RU5h_BFmQ2HO-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.29",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "71863515",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "associatedTokenId": "0.0.4794920",
+        "chargedTxFee": "70771741",
+        "consensusTimestamp": "1785853683.024800294",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785853683.024800294",
+        "transactionId": "0.0.1040977-1785853669-656818104",
+      },
+      "fee": "70771741",
+      "hasFailed": false,
+      "hash": "Of3SrmwQzdoC6MvRA7uPt4b8SLJZNBp2zT6FlNUDdAZ1qf1DRbpHQUXXFVoIJ7Ap",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-Of3SrmwQzdoC6MvRA7uPt4b8SLJZNBp2zT6FlNUDdAZ1qf1DRbpHQUXXFVoIJ7Ap-ASSOCIATE_TOKEN",
+      "recipients": [
+        "0.0.20",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "ASSOCIATE_TOKEN",
+      "value": "70771741",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "163309",
         "consensusTimestamp": "1764676526.955756000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -1926,6 +2207,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "452531",
         "consensusTimestamp": "1756718310.549818000",
         "feesPayer": "0.0.1040977",
         "memo": "TOTO",
@@ -1950,6 +2232,53 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "140945",
+        "consensusTimestamp": "1785851042.317921405",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785851042.317921405",
+        "transactionId": "0.0.1040977-1785851025-177268208",
+      },
+      "fee": "140945",
+      "hasFailed": false,
+      "hash": "qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_-OUT",
+      "recipients": [
+        "0.0.7305122",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "OUT",
+      "value": "100140945",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "consensusTimestamp": "1785851042.317921405",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785851042.317921405",
+        "transactionId": "0.0.1040977-1785851025-177268208",
+      },
+      "fee": "0",
+      "hash": "qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_-staking-reward",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_-staking-reward-REWARD",
+      "recipients": [
+        "0.0.1040977",
+      ],
+      "senders": [
+        "0.0.800",
+      ],
+      "type": "REWARD",
+      "value": "61360117",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "197924",
         "consensusTimestamp": "1726235092.011928000",
         "feesPayer": "0.0.1040977",
         "memo": "test qa samy",
@@ -1974,6 +2303,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "163309",
         "consensusTimestamp": "1764676500.998306000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -2001,6 +2331,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "199161",
         "consensusTimestamp": "1669565599.465640003",
         "feesPayer": "0.0.1040977",
         "memo": "test",
@@ -2025,6 +2356,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "1108226",
         "consensusTimestamp": "1777448312.792707000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448312.792707000",
@@ -2044,6 +2376,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "196821",
         "consensusTimestamp": "1729237802.452111000",
         "feesPayer": "0.0.1040977",
         "memo": "send",
@@ -2068,6 +2401,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "198124",
         "consensusTimestamp": "1726233233.981368000",
         "feesPayer": "0.0.1040977",
         "memo": "send max develop",
@@ -2092,6 +2426,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "187371",
         "consensusTimestamp": "1729100859.761766000",
         "feesPayer": "0.0.1040977",
         "memo": "testsamy",
@@ -2116,6 +2451,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "187710",
         "consensusTimestamp": "1729103620.094329000",
         "feesPayer": "0.0.7107424",
         "memo": "cadeauQPM",
@@ -2141,6 +2477,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.456858",
+        "chargedTxFee": "17475021",
         "consensusTimestamp": "1753699142.805347000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1753699142.805347000",
@@ -2164,6 +2501,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "841395",
         "consensusTimestamp": "1767958839.769743751",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1767958839.769743751",
@@ -2187,6 +2525,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958580.114519000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958580.114519000",
@@ -2210,6 +2549,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "111602",
         "consensusTimestamp": "1777448280.668682000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448280.668682000",
@@ -2234,6 +2574,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.7893707",
+        "chargedTxFee": "17355085",
         "consensusTimestamp": "1753690589.721137000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1753690589.721137000",
@@ -2257,6 +2598,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "195597",
         "consensusTimestamp": "1729159845.725723000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729159845.725723000",
@@ -2280,6 +2622,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "180847",
         "consensusTimestamp": "1767958970.807605000",
         "feesPayer": "0.0.1040977",
         "memo": "Unstake",
@@ -2307,6 +2650,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "180847",
         "consensusTimestamp": "1767959337.240412000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -2334,6 +2678,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "67757",
         "consensusTimestamp": "1764748857.858276000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1764748857.858276000",
@@ -2357,6 +2702,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "70763",
         "consensusTimestamp": "1765303351.645838829",
         "feesPayer": "0.0.507737",
         "pagingToken": "1765303351.645838829",
@@ -2380,6 +2726,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "197824",
         "consensusTimestamp": "1726233110.321533000",
         "feesPayer": "0.0.7107424",
         "memo": "samy test!",
@@ -2404,6 +2751,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "158288",
         "consensusTimestamp": "1764943329.044339000",
         "feesPayer": "0.0.1040977",
         "memo": "Restake",
@@ -2431,6 +2779,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "199068",
         "consensusTimestamp": "1729858548.245891000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729858548.245891000",
@@ -2454,6 +2803,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "73908",
         "consensusTimestamp": "1765363275.830291000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1765363275.830291000",
@@ -2477,6 +2827,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "193637",
         "consensusTimestamp": "1729150309.511412000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729150309.511412000",
@@ -2500,6 +2851,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "148487",
         "consensusTimestamp": "1701941251.224927003",
         "feesPayer": "0.0.1040977",
         "memo": "test",
@@ -2527,6 +2879,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "1113116",
         "consensusTimestamp": "1777451057.014254000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777451057.014254000",
@@ -2552,6 +2905,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "424851",
         "consensusTimestamp": "1755785525.693277000",
         "feesPayer": "0.0.8313485",
         "memo": "toto",
@@ -2578,6 +2932,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "452531",
         "consensusTimestamp": "1756718310.549818000",
         "feesPayer": "0.0.1040977",
         "memo": "TOTO",
@@ -2604,6 +2959,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "1108226",
         "consensusTimestamp": "1777448312.792707000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448312.792707000",
@@ -2629,6 +2985,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "841395",
         "consensusTimestamp": "1767958839.769743751",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1767958839.769743751",
@@ -2656,6 +3013,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.456858",
       "extra": {
+        "chargedTxFee": "349789",
         "consensusTimestamp": "1753699233.640576809",
         "feesPayer": "0.0.8313635",
         "pagingToken": "1753699233.640576809",
@@ -2683,6 +3041,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.7893707",
       "extra": {
+        "chargedTxFee": "347389",
         "consensusTimestamp": "1753690711.015332718",
         "feesPayer": "0.0.8313635",
         "pagingToken": "1753690711.015332718",
@@ -2703,12 +3062,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "20000000",
     },
   ],
+  [],
+  [],
+  [],
+  [],
+  [],
   [
     {
       "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225279",
         "consensusTimestamp": "1730811624.603795000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1730811624.603795000",
@@ -2732,6 +3097,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "108243",
         "consensusTimestamp": "1778850875.554977000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1778850875.554977000",
@@ -2755,6 +3121,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958515.919946557",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958515.919946557",
@@ -2800,6 +3167,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729155939.657319000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729155939.657319000",
@@ -2823,6 +3191,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225507",
         "consensusTimestamp": "1730813192.423784000",
         "feesPayer": "0.0.7305122",
         "memo": "send",
@@ -2847,6 +3216,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "111602",
         "consensusTimestamp": "1777449214.469848000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1777449214.469848000",
@@ -2870,6 +3240,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "226772",
         "consensusTimestamp": "1730811403.115680000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1730811403.115680000",
@@ -2893,6 +3264,31 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "140945",
+        "consensusTimestamp": "1785851362.024349104",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785851362.024349104",
+        "transactionId": "0.0.1040977-1785851348-669358104",
+      },
+      "fee": "140945",
+      "hasFailed": false,
+      "hash": "c4x3vfE7eHH8ngDNp8MmeTI_lg_mEvF2esNgMBVQEO6mdowNmQP8V3AoCmHn8l_b",
+      "id": "js:2:hedera:0.0.7305122:hederaBip44-c4x3vfE7eHH8ngDNp8MmeTI_lg_mEvF2esNgMBVQEO6mdowNmQP8V3AoCmHn8l_b-IN",
+      "recipients": [
+        "0.0.7305122",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "IN",
+      "value": "100000000",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729155755.397758000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729155755.397758000",
@@ -2916,6 +3312,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729155815.270550000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729155815.270550000",
@@ -2939,6 +3336,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "226772",
         "consensusTimestamp": "1730811531.050920029",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1730811531.050920029",
@@ -2962,6 +3360,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "199068",
         "consensusTimestamp": "1729858464.980892000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729858464.980892000",
@@ -2985,6 +3384,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "191792",
         "consensusTimestamp": "1729147655.662122737",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729147655.662122737",
@@ -3008,6 +3408,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "196236",
         "consensusTimestamp": "1729687467.306035525",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729687467.306035525",
@@ -3031,6 +3432,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "193637",
         "consensusTimestamp": "1729150225.131300000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729150225.131300000",
@@ -3054,6 +3456,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "225507",
         "consensusTimestamp": "1730813149.715064983",
         "feesPayer": "0.0.1040977",
         "memo": "send",
@@ -3078,6 +3481,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "1113116",
         "consensusTimestamp": "1777451057.014254000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777451057.014254000",
@@ -3101,6 +3505,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958685.802702000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958685.802702000",
@@ -3124,6 +3529,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992359.883350234",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 271278,
@@ -3147,6 +3553,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.127877",
+        "chargedTxFee": "42034938",
         "consensusTimestamp": "1767958775.232558000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958775.232558000",
@@ -3170,6 +3577,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "197305",
         "consensusTimestamp": "1729177404.980663000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729177404.980663000",
@@ -3193,6 +3601,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "194053",
         "consensusTimestamp": "1729156701.804949000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729156701.804949000",
@@ -3216,6 +3625,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "189619",
         "consensusTimestamp": "1729585926.624752000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729585926.624752000",
@@ -3239,6 +3649,31 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "140945",
+        "consensusTimestamp": "1785851042.317921405",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1785851042.317921405",
+        "transactionId": "0.0.1040977-1785851025-177268208",
+      },
+      "fee": "140945",
+      "hasFailed": false,
+      "hash": "qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_",
+      "id": "js:2:hedera:0.0.7305122:hederaBip44-qfershVunTxiMQTjPFnw3RhSs1IZJ69CyzDf1d_TY2gfW-qEPxzCaXTqglPGkek_-IN",
+      "recipients": [
+        "0.0.7305122",
+      ],
+      "senders": [
+        "0.0.1040977",
+      ],
+      "type": "IN",
+      "value": "100000000",
+    },
+    {
+      "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
+      "blockHash": null,
+      "blockHeight": 10,
+      "extra": {
+        "chargedTxFee": "1108226",
         "consensusTimestamp": "1777448312.792707000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448312.792707000",
@@ -3262,6 +3697,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "196821",
         "consensusTimestamp": "1729237802.452111000",
         "feesPayer": "0.0.1040977",
         "memo": "send",
@@ -3286,6 +3722,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "414180",
         "consensusTimestamp": "1729156015.784781613",
         "feesPayer": "0.0.7305122",
         "memo": "Unstake",
@@ -3313,6 +3750,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "841395",
         "consensusTimestamp": "1767958839.769743751",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1767958839.769743751",
@@ -3332,6 +3770,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "84731",
         "consensusTimestamp": "1767958580.114519000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1767958580.114519000",
@@ -3356,6 +3795,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992619.916268000",
         "feesPayer": "0.0.7305122",
         "gasConsumed": 271278,
@@ -3405,6 +3845,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "111602",
         "consensusTimestamp": "1777448280.668682000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448280.668682000",
@@ -3428,6 +3869,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "195597",
         "consensusTimestamp": "1729159845.725723000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729159845.725723000",
@@ -3451,6 +3893,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "67757",
         "consensusTimestamp": "1764748857.858276000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1764748857.858276000",
@@ -3474,6 +3917,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "199068",
         "consensusTimestamp": "1729858548.245891000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1729858548.245891000",
@@ -3497,6 +3941,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "415339",
         "consensusTimestamp": "1729156037.761102000",
         "feesPayer": "0.0.7305122",
         "memo": "Update staked node",
@@ -3524,6 +3969,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "193637",
         "consensusTimestamp": "1729150309.511412000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1729150309.511412000",
@@ -3550,6 +3996,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "1113116",
         "consensusTimestamp": "1777451057.014254000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777451057.014254000",
@@ -3575,6 +4022,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "1108226",
         "consensusTimestamp": "1777448312.792707000",
         "feesPayer": "0.0.7305122",
         "pagingToken": "1777448312.792707000",
@@ -3600,6 +4048,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "841395",
         "consensusTimestamp": "1767958839.769743751",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1767958839.769743751",
@@ -3627,6 +4076,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992359.883350234",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 271278,
@@ -3655,6 +4105,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992619.916268000",
         "feesPayer": "0.0.7305122",
         "gasConsumed": 271278,
@@ -3684,6 +4135,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "82857",
         "consensusTimestamp": "1732192441.542423000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1732192441.542423000",
@@ -3707,6 +4159,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "82857",
         "consensusTimestamp": "1732193188.290747000",
         "feesPayer": "0.0.7560245",
         "pagingToken": "1732193188.290747000",
@@ -3733,6 +4186,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.456858",
+        "chargedTxFee": "53385342",
         "consensusTimestamp": "1774014743.391473000",
         "feesPayer": "0.0.7578015",
         "pagingToken": "1774014743.391473000",
@@ -3756,6 +4210,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "197491",
         "consensusTimestamp": "1766052249.959659000",
         "feesPayer": "0.0.7578015",
         "memo": "Unstake",
@@ -3783,6 +4238,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "82857",
         "consensusTimestamp": "1732193188.290747000",
         "feesPayer": "0.0.7560245",
         "pagingToken": "1732193188.290747000",
@@ -3806,6 +4262,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "197390",
         "consensusTimestamp": "1766052314.378850000",
         "feesPayer": "0.0.7578015",
         "memo": "Stake",
@@ -3836,6 +4293,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "26836467",
         "consensusTimestamp": "1740741189.513410000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740741189.513410000",
@@ -3859,6 +4317,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "108243",
         "consensusTimestamp": "1778850875.554977000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1778850875.554977000",
@@ -3904,6 +4363,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "54816",
         "consensusTimestamp": "1740739889.583598491",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740739889.583598491",
@@ -3927,6 +4387,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "526632",
         "consensusTimestamp": "1740741060.702187741",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740741060.702187741",
@@ -3950,6 +4411,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "544516",
         "consensusTimestamp": "1740739638.887363715",
         "feesPayer": "0.0.507737",
         "memo": "fromLeVtoLeL",
@@ -3970,6 +4432,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "1160556",
         "consensusTimestamp": "1740741706.219984000",
         "feesPayer": "0.0.995584",
         "pagingToken": "1740741706.219984000",
@@ -3994,6 +4457,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "67995",
         "consensusTimestamp": "1743884119.632624000",
         "feesPayer": "0.0.8217344",
         "memo": "(1/3) 📢 It's not too late to start playing TOZM - Token of Z Month! Learn more at tozm dot io.",
@@ -4026,6 +4490,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "25696084",
         "consensusTimestamp": "1740739889.583598490",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740739889.583598490",
@@ -4049,6 +4514,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "421965",
         "consensusTimestamp": "1755857525.720819000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755857525.720819000",
@@ -4068,6 +4534,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "553055",
         "consensusTimestamp": "1760441684.201301000",
         "feesPayer": "0.0.10006055",
         "pagingToken": "1760441684.201301000",
@@ -4087,6 +4554,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "52397",
         "consensusTimestamp": "1743094572.925082000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743094572.925082000",
@@ -4110,6 +4578,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "913252",
         "consensusTimestamp": "1766063577.780237000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1766063577.780237000",
@@ -4133,6 +4602,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "184287",
         "consensusTimestamp": "1768211891.563502685",
         "feesPayer": "0.0.8313485",
         "memo": "Stake",
@@ -4161,6 +4631,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.127877",
+        "chargedTxFee": "27194555",
         "consensusTimestamp": "1740739493.554732000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740739493.554732000",
@@ -4184,6 +4655,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "184381",
         "consensusTimestamp": "1768211549.921217740",
         "feesPayer": "0.0.8313485",
         "memo": "Restake",
@@ -4234,6 +4706,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "64500",
         "consensusTimestamp": "1743371982.785505000",
         "feesPayer": "0.0.8217344",
         "memo": "(3/3) Want more free tokens? 🔥 Check out the March 2025 Instructions 👀 on tozm dot io! 🚀",
@@ -4266,6 +4739,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "482779",
         "consensusTimestamp": "1747132022.307489000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1747132022.307489000",
@@ -4285,6 +4759,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "86906",
         "consensusTimestamp": "1765989230.220415000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1765989230.220415000",
@@ -4308,6 +4783,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "67995",
         "consensusTimestamp": "1743884110.485189168",
         "feesPayer": "0.0.8217344",
         "memo": "(3/3) Want more free tokens? 🔥 Check out the April 2025 Instructions 👀 on tozm dot io! 🚀",
@@ -4340,6 +4816,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "64514",
         "consensusTimestamp": "1743371987.018009000",
         "feesPayer": "0.0.8217344",
         "memo": "(2/3) To get started, simply associate with 0.0.8372908 ✅ and 0.0.8379490 ✅ before March 31st.",
@@ -4372,6 +4849,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "426904",
         "consensusTimestamp": "1755865083.033236000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755865083.033236000",
@@ -4391,6 +4869,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "421543",
         "consensusTimestamp": "1757929653.557852000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1757929653.557852000",
@@ -4411,6 +4890,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "16069053",
         "consensusTimestamp": "1766063963.625248000",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 202934,
@@ -4439,6 +4919,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "424851",
         "consensusTimestamp": "1755785525.693277000",
         "feesPayer": "0.0.8313485",
         "memo": "toto",
@@ -4463,6 +4944,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "602274",
         "consensusTimestamp": "1743601916.977125409",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743601916.977125409",
@@ -4487,6 +4969,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992359.883350234",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 271278,
@@ -4514,6 +4997,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "57474",
         "consensusTimestamp": "1762974093.971287000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1762974093.971287000",
@@ -4537,6 +5021,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "54816",
         "consensusTimestamp": "1740739322.044670000",
         "feesPayer": "0.0.1040977",
         "pagingToken": "1740739322.044670000",
@@ -4560,6 +5045,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "60000000",
         "consensusTimestamp": "1765992000.873157685",
         "feesPayer": "0.0.6391739",
         "gasConsumed": 266997,
@@ -4582,6 +5068,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "68011",
         "consensusTimestamp": "1743884114.875352000",
         "feesPayer": "0.0.8217344",
         "memo": "(2/3) To get started, simply associate with 0.0.8808338 ✅ and 0.0.8808584 ✅ by April 30th👍.",
@@ -4614,6 +5101,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "421543",
         "consensusTimestamp": "1757929013.916417000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1757929013.916417000",
@@ -4633,6 +5121,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "64500",
         "consensusTimestamp": "1743371991.769212000",
         "feesPayer": "0.0.8217344",
         "memo": "(1/3) 📢 It's not too late to start playing TOZM - Token of Z Month! Learn more at tozm dot io.",
@@ -4665,6 +5154,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "397764",
         "consensusTimestamp": "1755008519.962485000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755008519.962485000",
@@ -4684,6 +5174,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "452531",
         "consensusTimestamp": "1756718310.549818000",
         "feesPayer": "0.0.1040977",
         "memo": "TOTO",
@@ -4704,6 +5195,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "1212697",
         "consensusTimestamp": "1740740327.007740000",
         "feesPayer": "0.0.995584",
         "pagingToken": "1740740327.007740000",
@@ -4728,6 +5220,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "26918289",
         "consensusTimestamp": "1743089390.497908000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743089390.497908000",
@@ -4751,6 +5244,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "557852",
         "consensusTimestamp": "1760435993.267662000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1760435993.267662000",
@@ -4774,6 +5268,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "24935910",
         "consensusTimestamp": "1743089390.497907999",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743089390.497907999",
@@ -4797,6 +5292,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "184381",
         "consensusTimestamp": "1768211678.094779000",
         "feesPayer": "0.0.8313485",
         "memo": "Unstake",
@@ -4824,6 +5320,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "54816",
         "consensusTimestamp": "1740740097.334683000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740740097.334683000",
@@ -4848,6 +5345,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.456858",
+        "chargedTxFee": "54912267",
         "consensusTimestamp": "1777299976.995635000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1777299976.995635000",
@@ -4893,6 +5391,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "54982",
         "consensusTimestamp": "1740738764.065021000",
         "feesPayer": "0.0.507737",
         "memo": "fromLeVtoLeL",
@@ -4917,6 +5416,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "18371815",
         "consensusTimestamp": "1766059747.925585000",
         "feesPayer": "0.0.10096785",
         "gasConsumed": 248195,
@@ -4939,6 +5439,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "196192",
         "consensusTimestamp": "1766064273.982580754",
         "feesPayer": "0.0.8313485",
         "memo": "Stake",
@@ -4969,6 +5470,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "16069053",
         "consensusTimestamp": "1766063963.625248000",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 202934,
@@ -4998,6 +5500,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992359.883350234",
         "feesPayer": "0.0.8313485",
         "gasConsumed": 271278,
@@ -5026,6 +5529,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "60000000",
         "consensusTimestamp": "1765992000.873157685",
         "feesPayer": "0.0.6391739",
         "gasConsumed": 266997,
@@ -5054,6 +5558,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "18371815",
         "consensusTimestamp": "1766059747.925585000",
         "feesPayer": "0.0.10096785",
         "gasConsumed": 248195,
@@ -5084,6 +5589,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "26836467",
         "consensusTimestamp": "1740741189.513410000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740741189.513410000",
@@ -5109,6 +5615,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "526632",
         "consensusTimestamp": "1740741060.702187741",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1740741060.702187741",
@@ -5134,6 +5641,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "544516",
         "consensusTimestamp": "1740739638.887363715",
         "feesPayer": "0.0.507737",
         "memo": "fromLeVtoLeL",
@@ -5160,6 +5668,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "421965",
         "consensusTimestamp": "1755857525.720819000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755857525.720819000",
@@ -5185,6 +5694,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "553055",
         "consensusTimestamp": "1760441684.201301000",
         "feesPayer": "0.0.10006055",
         "pagingToken": "1760441684.201301000",
@@ -5210,6 +5720,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "913252",
         "consensusTimestamp": "1766063577.780237000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1766063577.780237000",
@@ -5235,6 +5746,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "482779",
         "consensusTimestamp": "1747132022.307489000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1747132022.307489000",
@@ -5260,6 +5772,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "426904",
         "consensusTimestamp": "1755865083.033236000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755865083.033236000",
@@ -5285,6 +5798,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "421543",
         "consensusTimestamp": "1757929653.557852000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1757929653.557852000",
@@ -5310,6 +5824,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "424851",
         "consensusTimestamp": "1755785525.693277000",
         "feesPayer": "0.0.8313485",
         "memo": "toto",
@@ -5336,6 +5851,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "602274",
         "consensusTimestamp": "1743601916.977125409",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743601916.977125409",
@@ -5361,6 +5877,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "421543",
         "consensusTimestamp": "1757929013.916417000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1757929013.916417000",
@@ -5386,6 +5903,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "397764",
         "consensusTimestamp": "1755008519.962485000",
         "feesPayer": "0.0.507737",
         "pagingToken": "1755008519.962485000",
@@ -5411,6 +5929,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "452531",
         "consensusTimestamp": "1756718310.549818000",
         "feesPayer": "0.0.1040977",
         "memo": "TOTO",
@@ -5437,6 +5956,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "26918289",
         "consensusTimestamp": "1743089390.497908000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1743089390.497908000",
@@ -5462,6 +5982,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "557852",
         "consensusTimestamp": "1760435993.267662000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1760435993.267662000",
@@ -5489,6 +6010,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "913252",
         "consensusTimestamp": "1766063577.780237000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1766063577.780237000",
@@ -5509,6 +6031,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "extra": {
         "associatedTokenId": "0.0.127877",
+        "chargedTxFee": "45624877",
         "consensusTimestamp": "1766063457.188069000",
         "feesPayer": "0.0.10096785",
         "pagingToken": "1766063457.188069000",
@@ -5532,6 +6055,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "57474",
         "consensusTimestamp": "1762974093.971287000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1762974093.971287000",
@@ -5555,6 +6079,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHash": null,
       "blockHeight": 10,
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992619.916268000",
         "feesPayer": "0.0.7305122",
         "gasConsumed": 271278,
@@ -5578,6 +6103,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "18371815",
         "consensusTimestamp": "1766059747.925585000",
         "feesPayer": "0.0.10096785",
         "gasConsumed": 248195,
@@ -5630,6 +6156,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0.0.127877",
       "extra": {
+        "chargedTxFee": "913252",
         "consensusTimestamp": "1766063577.780237000",
         "feesPayer": "0.0.8313485",
         "pagingToken": "1766063577.780237000",
@@ -5657,6 +6184,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "19877100",
         "consensusTimestamp": "1765992619.916268000",
         "feesPayer": "0.0.7305122",
         "gasConsumed": 271278,
@@ -5685,6 +6213,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "blockHeight": 10,
       "contract": "0xb7687538c7f4cad022d5e97cc778d0b46457c5db",
       "extra": {
+        "chargedTxFee": "18371815",
         "consensusTimestamp": "1766059747.925585000",
         "feesPayer": "0.0.10096785",
         "gasConsumed": 248195,

--- a/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
+++ b/libs/ledger-live-common/src/families/hedera/__snapshots__/bridge.integration.test.ts.snap
@@ -300,7 +300,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-_TBmdAYq7HVSMkbCZcpTeexqiDmZBcCNvL5EAZ4sDrEjNMqsAugvJ2dzcxwEZ-YH-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.17",
       ],
       "senders": [
         "0.0.9870888",
@@ -324,7 +323,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-_ZF8iWgETD9Y8JjmKDMJ512kJk4ZtgohOwMu2WjBI2w1kQg464A7ESzIOtDKVL9_-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -425,11 +423,9 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-4es76zI2MRbU3vMdeSnJRhXGo64kVgcAmH2dsuYjAHU1aJJasg9n6Io7gID99gbH-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.29",
       ],
       "senders": [
         "0.0.7305122",
-        "0.0.800",
       ],
       "type": "IN",
       "value": "23000",
@@ -450,7 +446,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-4t_ibZXGYqpoF8sN5HktGwEA0xyX4hLmjCrO7Vi6YPq9GuTncpA8T3cL-uTmViMB-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -475,7 +470,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-597wNJbpRrx1_mW32q3kbS40yjooZ36XtsGIDNLj_BQLZfMUQkt5uc7wxI6OCBHp-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -508,7 +502,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.3003290",
         "0.0.1986018",
         "0.0.1040977",
-        "0.0.29",
       ],
       "senders": [
         "0.0.8217344",
@@ -624,7 +617,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-Ax5Kiufx1qxAv05cpFKxNhTqehmGK6KDzk6093twLQMpVfeTYtDEG6igZjn-lEI3-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -649,7 +641,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-AXp5GsfiBSbwdBDkVX3snncUERbpa-0csxv0QrX23zT1c_2PgGOcNUfYX9GEflw6-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7107424",
@@ -736,7 +727,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.3003290",
         "0.0.1986018",
         "0.0.1040977",
-        "0.0.22",
       ],
       "senders": [
         "0.0.8217344",
@@ -760,7 +750,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-cdqATvnISnqFael7PUD1yhAqWNNYyKfck4p5cS22wKvP9ymzIytaS6o_1rSXwdcv-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.4",
       ],
       "senders": [
         "0.0.7305122",
@@ -784,7 +773,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-D6YO2o5HeKAyzOQVV6VYvKxmqgMVfTiv7glhAPJBT7EmeWOE-pYw7OKSfSwyuxII-OUT",
       "recipients": [
         "0.0.507737",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -809,11 +797,9 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-dc9kimkNghpi2LdVjEm6jRpgRfhJRwzaP4S37rlVxxZ2IeyxCD32I7mIgZWmcPuG-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7107424",
-        "0.0.800",
       ],
       "type": "IN",
       "value": "100000000",
@@ -834,7 +820,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-DISdC5RpTFYdxET8K2ghfenLprqmmwLsP6TeGWWgJ9c46D0FaE9WmHt02ymBn2xW-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.6",
       ],
       "senders": [
         "0.0.50571",
@@ -885,7 +870,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-DNptnQi6ClOCnJ8n45OLas1CyCWbHx9SwU-5wvAx7LHAOdgXvic9IV3JwqG5G6yq-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -910,7 +894,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-DU8fiVT77ZHD4YM7TnCH9-sdboY8eI2chghDTGeWRPUy-LGwY6uR0pB_gA-5lvGW-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7107424",
@@ -934,7 +917,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-E5dQ7JL0SINzr2JUaZS2ciX3EciNc6bHlHPwk8dOrZzucTPQGZAjohql00StEkgZ-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -958,7 +940,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-EBWsFuXGhnNdHX-WbNXL31bdtLwK8YBb4SvRLZyb_PDC3A-yAJQZ7Z2JkufYEh0H-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.19",
       ],
       "senders": [
         "0.0.9870888",
@@ -1006,21 +987,26 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "97410",
       "hasFailed": false,
       "hash": "EXEFhjx1__M7cV5WIqiDjF8TrzEtmES7_96T9-BfT4u8MMjZaEd69eXn_bcAQcw-",
-      "id": "js:2:hedera:0.0.1040977:hederaBip44-EXEFhjx1__M7cV5WIqiDjF8TrzEtmES7_96T9-BfT4u8MMjZaEd69eXn_bcAQcw--OUT",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-EXEFhjx1__M7cV5WIqiDjF8TrzEtmES7_96T9-BfT4u8MMjZaEd69eXn_bcAQcw--FEES",
       "recipients": [
         "0.0.30",
       ],
       "senders": [
         "0.0.1040977",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "97410",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1753699233.640576809",
+        "feesPayer": "0.0.8313635",
+        "pagingToken": "1753699233.640576809",
+        "transactionId": "0.0.8313635-1753699229-023150185",
+      },
       "fee": "0",
       "hash": "f-VthZHgsuaIypYFqjMKud0_xf5AcbOzgvpVuNI965hsiuzf4aPOdr2Kq7Dl3gqQ",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-f-VthZHgsuaIypYFqjMKud0_xf5AcbOzgvpVuNI965hsiuzf4aPOdr2Kq7Dl3gqQ-NONE",
@@ -1070,7 +1056,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-Ff1gfGLWdB1UHYGHAdBRpGG2fwa0uOBrDClH9W9LsOiqod_wpd1s7-tuaANKsoDa-OUT",
       "recipients": [
         "0.0.507737",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1116,7 +1101,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-fFUnwevTOhFVcXuH62vECBPFN9sxq5BqhNSEyy2F73N8NPGqms0uAFlKgNeqHddH-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1140,7 +1124,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-flTssQb-PABB-mCEFUuIFBjrwZ8jz176hDMbqjiJQUDHtpMmCWHl7bVr5B89D0mQ-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1164,7 +1147,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-G5bOWCgmRJz9njNXY5wPZNETmvOcOCBKnEnZftbZDySTzwlSqU3LKB3cG0or6Cjm-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -1188,7 +1170,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-geODvLCG3S-R_gRHW6ZcrSMUE6lSiO3DQjpnYnWVc2H2du1-_x_M_VSNpD69zGT2-OUT",
       "recipients": [
         "0.0.7560245",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1209,14 +1190,14 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "103989",
       "hasFailed": false,
       "hash": "H_sVqT3WhqNwX5Iw-Y_TaIiMy-C_jLTPNCg2fLcyUQqh2prPzMhQsawCmwcN5E_p",
-      "id": "js:2:hedera:0.0.1040977:hederaBip44-H_sVqT3WhqNwX5Iw-Y_TaIiMy-C_jLTPNCg2fLcyUQqh2prPzMhQsawCmwcN5E_p-OUT",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-H_sVqT3WhqNwX5Iw-Y_TaIiMy-C_jLTPNCg2fLcyUQqh2prPzMhQsawCmwcN5E_p-FEES",
       "recipients": [
         "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "103989",
     },
     {
@@ -1235,7 +1216,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-HBUllSXgRrXReT7pFosXQ0cgB-Y8FfHSS6LGxqgW6A-rNuU5w7ge780YmZzu4k8X-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.20",
       ],
       "senders": [
         "0.0.7579210",
@@ -1284,14 +1264,14 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "210184",
       "hasFailed": false,
       "hash": "hW0dnb0rNVpglweGCKaPaHlHxr3RqXpoMC9Juz86wDJHZ9e1Hp5WfmfqdzxkWeQC",
-      "id": "js:2:hedera:0.0.1040977:hederaBip44-hW0dnb0rNVpglweGCKaPaHlHxr3RqXpoMC9Juz86wDJHZ9e1Hp5WfmfqdzxkWeQC-OUT",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-hW0dnb0rNVpglweGCKaPaHlHxr3RqXpoMC9Juz86wDJHZ9e1Hp5WfmfqdzxkWeQC-FEES",
       "recipients": [
         "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "210184",
     },
     {
@@ -1311,7 +1291,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-i_mUYjjGcauOIq-wIdXUzGa5nnD2tq0AAhfezF5AHvl_AlQJeEfYy1ZCQU4n8SPg-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1358,7 +1337,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-iQ_oLq-PEMlwmoSEZBXpeK_J9ENApLJnz-uGB3_1XVqtRnMU-0VvdKmJV3E8ig5J-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.880760",
@@ -1394,10 +1372,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "163226",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1777451057.014254000",
+        "feesPayer": "0.0.7305122",
+        "pagingToken": "1777451057.014254000",
+        "transactionId": "0.0.7305122-1777451043-399658986",
+      },
       "fee": "0",
       "hash": "IXbEME86hURCO-VkcSzchs73tnTxzULtkZjtCfq3u_yW_F_XOSQVTICrpYlh8P11",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-IXbEME86hURCO-VkcSzchs73tnTxzULtkZjtCfq3u_yW_F_XOSQVTICrpYlh8P11-NONE",
@@ -1477,7 +1460,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-jTE287DknkJwW8E7ddjoraXG3pv7F0ykdlc2V_IHS7ZoarAXYyfi-bayjqtXdvwc-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.34",
       ],
       "senders": [
         "0.0.7305122",
@@ -1501,7 +1483,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-K2OxL3PVCNmT157KHikoFvMrzPuZ5btclsih9Ukrkyw9gSa25RsjYvkqFSArIVu7-OUT",
       "recipients": [
         "0.0.507737",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1532,10 +1513,16 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "2136888",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1755785525.693277000",
+        "feesPayer": "0.0.8313485",
+        "memo": "toto",
+        "pagingToken": "1755785525.693277000",
+        "transactionId": "0.0.8313485-1755785490-483918521",
+      },
       "fee": "0",
       "hash": "kPQrVav4moSwtzRn6jm5LOs_PCxv03Ka8WOZ_sLPuIqpnHxJDX9OC4_Lo1v0ktTI",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-kPQrVav4moSwtzRn6jm5LOs_PCxv03Ka8WOZ_sLPuIqpnHxJDX9OC4_Lo1v0ktTI-NONE",
@@ -1611,7 +1598,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-mgr5aE3ZlisOX5En0v3jBSgy4fd-_BcNCw7SYsXJowAMzcvh0XOLEb5EIUfbA4M0-OUT",
       "recipients": [
         "0.0.507737",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1642,10 +1628,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "2150586",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1753690711.015332718",
+        "feesPayer": "0.0.8313635",
+        "pagingToken": "1753690711.015332718",
+        "transactionId": "0.0.8313635-1753690706-348075771",
+      },
       "fee": "0",
       "hash": "Mh1szXUTxW8ea886ty7LHOqqbR_mSWlynKHuCxvwnC6BF5ieHDhhujEfTI8il1uI",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-Mh1szXUTxW8ea886ty7LHOqqbR_mSWlynKHuCxvwnC6BF5ieHDhhujEfTI8il1uI-NONE",
@@ -1671,7 +1662,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-Mq0CNEbhugTVQ1n6I-f5aSaFXF7-cA-wYSvuow-okMRHDTozoAb_fE1-1o7bb2P4-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1704,7 +1694,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.3003290",
         "0.0.1986018",
         "0.0.1040977",
-        "0.0.15",
       ],
       "senders": [
         "0.0.8217344",
@@ -1728,7 +1717,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-ms8ReEo0dI2vEjojzorZAto2mrYSImX2UOyB_lNYjVlg4w6giRafivPeeQAEwYL3-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -1752,7 +1740,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-MXshLxa4L9lF9rduImR7w-qMvZRgQC-z_XBQRc5Yl3nv_qHKNSQASAGX3sDkXT-h-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1776,11 +1763,9 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-n0oMavzcRvdYLyQVq0u-yXBIiLftalIoEVknXlNJDG6alDab16np8mcWt9lDg-Hh-OUT",
       "recipients": [
         "0.0.2024333",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "1148589",
@@ -1801,7 +1786,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-N0uyXj-S_rGVIAMREJCiYpw25NjdXA3fgJzF9IQj1f4kES6fLuJOPjJGPzyN0Haw-OUT",
       "recipients": [
         "0.0.6391318",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1853,7 +1837,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-NqDeX4kBO4rt5ugHajGvhJWY6q5DZ7GKAqmw2ysZBp2HXArxsaYFzOUZYWFcLsTz-OUT",
       "recipients": [
         "0.0.7579210",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1877,7 +1860,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-ntVwGzpooIIYSwktldo-Isbz6igXCw0jKilaxS8_vzvFg-tmLguXPlmhk3zyY-lY-OUT",
       "recipients": [
         "0.0.8313485",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1955,7 +1937,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "QDUwQqgrOgB4aPkMprRe3yiux277A7_PJVfpbv-P4GBMT33ahyXp8NQXbblLDA0c",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-QDUwQqgrOgB4aPkMprRe3yiux277A7_PJVfpbv-P4GBMT33ahyXp8NQXbblLDA0c-FEES",
       "recipients": [
-        "0.0.8313485",
+        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -1980,7 +1962,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-qnLNbcduW-SlQvIxCMwOJW7Eu3yDScHFmgEvRlp05a1RBsB94Ein74GGlH63-kk8-OUT",
       "recipients": [
         "0.0.7107424",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2029,21 +2010,26 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "199161",
       "hasFailed": false,
       "hash": "sBvHuXD8K0xKtonpe7r5WhuM_-0aTZ5up4LEha6buC3jjM_T3v645lxF96XyAKDA",
-      "id": "js:2:hedera:0.0.1040977:hederaBip44-sBvHuXD8K0xKtonpe7r5WhuM_-0aTZ5up4LEha6buC3jjM_T3v645lxF96XyAKDA-OUT",
+      "id": "js:2:hedera:0.0.1040977:hederaBip44-sBvHuXD8K0xKtonpe7r5WhuM_-0aTZ5up4LEha6buC3jjM_T3v645lxF96XyAKDA-FEES",
       "recipients": [
         "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "199161",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.1040977:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1777448312.792707000",
+        "feesPayer": "0.0.7305122",
+        "pagingToken": "1777448312.792707000",
+        "transactionId": "0.0.7305122-1777448299-585433000",
+      },
       "fee": "0",
       "hash": "sbxg1oEk2p1BXPWwxcYcyvFm4B-PXb8wJMmNrbwipVyprTfJKMqvRGb0S0xVNsjv",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-sbxg1oEk2p1BXPWwxcYcyvFm4B-PXb8wJMmNrbwipVyprTfJKMqvRGb0S0xVNsjv-NONE",
@@ -2070,7 +2056,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-SdVskGKV5xZioeu-hERlmM7jNXnjcdqUKHFT6J-CiPQymfzPXzafUrkqcoFtd8au-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2119,11 +2104,9 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-tRewhc7YRpuB6FJdi-8gKHmvyLmEwo7FJt55xEEMAcM8RAwafrlMJyr__7WzHpVy-OUT",
       "recipients": [
         "0.0.7107424",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "10187371",
@@ -2145,7 +2128,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-TUYXGAGmXtXiTavjIA3LOn_F4WXPHp-2f79vRKsgcxWynlJUc7eq5b0H2koUzAK2-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7107424",
@@ -2192,7 +2174,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "UNKoVU_ieZQBn4jfoZ7TE61C7HsbLrcapJvlLC0fJjxsNSF-K27qWB30eK_wYF8R",
       "id": "js:2:hedera:0.0.1040977:hederaBip44-UNKoVU_ieZQBn4jfoZ7TE61C7HsbLrcapJvlLC0fJjxsNSF-K27qWB30eK_wYF8R-FEES",
       "recipients": [
-        "0.0.7305122",
+        "0.0.22",
       ],
       "senders": [
         "0.0.1040977",
@@ -2216,7 +2198,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-w-3DZZuWDoQ04a8AcEkpaZ90hEVcyZLL2Quq2rHOr6QumhBpjgenIlmqo5xKF0Fj-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.30",
       ],
       "senders": [
         "0.0.7305122",
@@ -2287,7 +2268,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-wt0c7-dDE69WuBkj53U5o11RDvkBxdU-Z3wuuSN3btSwyMGlKC9AxphcmvTfiPP6-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -2365,7 +2345,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-XkIZpbgw_xScxbeqg-GvVZhuWkvNU_bvWglFXQ2aXRf3irK8RSUHsBvUZ80OMa52-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2389,7 +2368,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-XWzfUSW9wZkjRZCHG8-B93fNT7imCDVBmHIojkUdpYtufu8cTB9G-kJ0KWMtfUl5-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.507737",
@@ -2414,7 +2392,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-y6mQt2VeMBbxeplMNEhENjHt6tKz4LidJwup4Pt2hwP1CIwgrCwF7tn3wgeAh3zu-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7107424",
@@ -2465,7 +2442,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-YSw6vQYOoNyr258eb1GGetRlYActrg6PAFKtCjJzfIfiDykrPuhn5WV3OIWbhLK4-IN",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -2489,7 +2465,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-zl6DYuU84EYkLSVnq3tjGBzHqN4TKADY7U8NLRE9nMzXWjVWKIR7XMPcmTwS-7rF-OUT",
       "recipients": [
         "0.0.507737",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2513,7 +2488,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-zphHlC8Ku5wGJB1fmRHFWk2Kh0HuknpXxh4VSi9xYNFk2uX_9QZ8ilDO1s8iFfxf-OUT",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2538,11 +2512,9 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.1040977:hederaBip44-Zvr0zFzL2meSIoGWe0JlEOhBVetvj3IXH3OJ5Jy7k7zS4xLEIjqV6txRuPYgw3gw-OUT",
       "recipients": [
         "0.0.2024333",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
-        "0.0.800",
       ],
       "type": "OUT",
       "value": "10148487",
@@ -2748,7 +2720,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-_ZF8iWgETD9Y8JjmKDMJ512kJk4ZtgohOwMu2WjBI2w1kQg464A7ESzIOtDKVL9_-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -2775,7 +2746,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       ],
       "senders": [
         "0.0.8313485",
-        "0.0.800",
       ],
       "type": "IN",
       "value": "10000000",
@@ -2796,7 +2766,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-4es76zI2MRbU3vMdeSnJRhXGo64kVgcAmH2dsuYjAHU1aJJasg9n6Io7gID99gbH-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.29",
       ],
       "senders": [
         "0.0.7305122",
@@ -2842,7 +2811,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-4t_ibZXGYqpoF8sN5HktGwEA0xyX4hLmjCrO7Vi6YPq9GuTncpA8T3cL-uTmViMB-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2867,7 +2835,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-597wNJbpRrx1_mW32q3kbS40yjooZ36XtsGIDNLj_BQLZfMUQkt5uc7wxI6OCBHp-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -2914,7 +2881,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-Ax5Kiufx1qxAv05cpFKxNhTqehmGK6KDzk6093twLQMpVfeTYtDEG6igZjn-lEI3-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -2961,7 +2927,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-cdqATvnISnqFael7PUD1yhAqWNNYyKfck4p5cS22wKvP9ymzIytaS6o_1rSXwdcv-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.4",
       ],
       "senders": [
         "0.0.7305122",
@@ -2985,7 +2950,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-DNptnQi6ClOCnJ8n45OLas1CyCWbHx9SwU-5wvAx7LHAOdgXvic9IV3JwqG5G6yq-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3009,7 +2973,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-E5dQ7JL0SINzr2JUaZS2ciX3EciNc6bHlHPwk8dOrZzucTPQGZAjohql00StEkgZ-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3033,7 +2996,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-fFUnwevTOhFVcXuH62vECBPFN9sxq5BqhNSEyy2F73N8NPGqms0uAFlKgNeqHddH-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3057,7 +3019,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-flTssQb-PABB-mCEFUuIFBjrwZ8jz176hDMbqjiJQUDHtpMmCWHl7bVr5B89D0mQ-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3081,7 +3042,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-G5bOWCgmRJz9njNXY5wPZNETmvOcOCBKnEnZftbZDySTzwlSqU3LKB3cG0or6Cjm-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -3106,7 +3066,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-i_mUYjjGcauOIq-wIdXUzGa5nnD2tq0AAhfezF5AHvl_AlQJeEfYy1ZCQU4n8SPg-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3129,7 +3088,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "IXbEME86hURCO-VkcSzchs73tnTxzULtkZjtCfq3u_yW_F_XOSQVTICrpYlh8P11",
       "id": "js:2:hedera:0.0.7305122:hederaBip44-IXbEME86hURCO-VkcSzchs73tnTxzULtkZjtCfq3u_yW_F_XOSQVTICrpYlh8P11-FEES",
       "recipients": [
-        "0.0.1040977",
+        "0.0.14",
       ],
       "senders": [
         "0.0.7305122",
@@ -3153,7 +3112,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-jTE287DknkJwW8E7ddjoraXG3pv7F0ykdlc2V_IHS7ZoarAXYyfi-bayjqtXdvwc-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.34",
       ],
       "senders": [
         "0.0.7305122",
@@ -3162,10 +3120,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "130731",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1765992359.883350234",
+        "feesPayer": "0.0.8313485",
+        "gasConsumed": 271278,
+        "gasLimit": 331284,
+        "gasUsed": 265028,
+        "pagingToken": "1765992359.883350234",
+        "transactionId": "0.0.8313485-1765992340-727575734",
+      },
       "fee": "0",
       "hash": "Lx8AKRwOQm6seQqFbwW8GpTb9-tKXHJkgszHVPL9Cyo-fG4tDabtCEoMEusWNaYN",
       "id": "js:2:hedera:0.0.7305122:hederaBip44-Lx8AKRwOQm6seQqFbwW8GpTb9-tKXHJkgszHVPL9Cyo-fG4tDabtCEoMEusWNaYN-NONE",
@@ -3215,7 +3181,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-Mq0CNEbhugTVQ1n6I-f5aSaFXF7-cA-wYSvuow-okMRHDTozoAb_fE1-1o7bb2P4-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3239,7 +3204,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-ms8ReEo0dI2vEjojzorZAto2mrYSImX2UOyB_lNYjVlg4w6giRafivPeeQAEwYL3-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -3263,7 +3227,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-MXshLxa4L9lF9rduImR7w-qMvZRgQC-z_XBQRc5Yl3nv_qHKNSQASAGX3sDkXT-h-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3286,7 +3249,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "sbxg1oEk2p1BXPWwxcYcyvFm4B-PXb8wJMmNrbwipVyprTfJKMqvRGb0S0xVNsjv",
       "id": "js:2:hedera:0.0.7305122:hederaBip44-sbxg1oEk2p1BXPWwxcYcyvFm4B-PXb8wJMmNrbwipVyprTfJKMqvRGb0S0xVNsjv-FEES",
       "recipients": [
-        "0.0.1040977",
+        "0.0.29",
       ],
       "senders": [
         "0.0.7305122",
@@ -3311,7 +3274,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-SdVskGKV5xZioeu-hERlmM7jNXnjcdqUKHFT6J-CiPQymfzPXzafUrkqcoFtd8au-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3347,10 +3309,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "414180",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.7305122:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1767958839.769743751",
+        "feesPayer": "0.0.1040977",
+        "pagingToken": "1767958839.769743751",
+        "transactionId": "0.0.1040977-1767958823-238761698",
+      },
       "fee": "0",
       "hash": "UNKoVU_ieZQBn4jfoZ7TE61C7HsbLrcapJvlLC0fJjxsNSF-K27qWB30eK_wYF8R",
       "id": "js:2:hedera:0.0.7305122:hederaBip44-UNKoVU_ieZQBn4jfoZ7TE61C7HsbLrcapJvlLC0fJjxsNSF-K27qWB30eK_wYF8R-NONE",
@@ -3376,7 +3343,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-w-3DZZuWDoQ04a8AcEkpaZ90hEVcyZLL2Quq2rHOr6QumhBpjgenIlmqo5xKF0Fj-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.30",
       ],
       "senders": [
         "0.0.7305122",
@@ -3403,7 +3369,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "WbzavPaT_P5qgef65DMzBWvrLKmTqtptIMv6UGHy3lJ_K8ftHiff_gSnfiZJmnvX",
       "id": "js:2:hedera:0.0.7305122:hederaBip44-WbzavPaT_P5qgef65DMzBWvrLKmTqtptIMv6UGHy3lJ_K8ftHiff_gSnfiZJmnvX-FEES",
       "recipients": [
-        "0.0.10096785",
+        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -3473,7 +3439,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-wt0c7-dDE69WuBkj53U5o11RDvkBxdU-Z3wuuSN3btSwyMGlKC9AxphcmvTfiPP6-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -3497,7 +3462,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-XkIZpbgw_xScxbeqg-GvVZhuWkvNU_bvWglFXQ2aXRf3irK8RSUHsBvUZ80OMa52-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3521,7 +3485,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-YSw6vQYOoNyr258eb1GGetRlYActrg6PAFKtCjJzfIfiDykrPuhn5WV3OIWbhLK4-OUT",
       "recipients": [
         "0.0.1040977",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7305122",
@@ -3572,7 +3535,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7305122:hederaBip44-zphHlC8Ku5wGJB1fmRHFWk2Kh0HuknpXxh4VSi9xYNFk2uX_9QZ8ilDO1s8iFfxf-IN",
       "recipients": [
         "0.0.7305122",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3733,7 +3695,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7560245:hederaBip44-geODvLCG3S-R_gRHW6ZcrSMUE6lSiO3DQjpnYnWVc2H2du1-_x_M_VSNpD69zGT2-IN",
       "recipients": [
         "0.0.7560245",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -3757,7 +3718,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7560245:hederaBip44-jjb5_0au4hyPjyQaM44Fkn-d4IrGcDhsoqhA7r8rje7V0-7Sa3J70gUrpgmpgMsP-OUT",
       "recipients": [
         "0.0.7578015",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7560245",
@@ -3834,7 +3794,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.7578015:hederaBip44-jjb5_0au4hyPjyQaM44Fkn-d4IrGcDhsoqhA7r8rje7V0-7Sa3J70gUrpgmpgMsP-IN",
       "recipients": [
         "0.0.7578015",
-        "0.0.3",
       ],
       "senders": [
         "0.0.7560245",
@@ -3887,7 +3846,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "_ewGHkI-6ZCZPXq2ltcB7XHFw9RtCj20Qtdevtzm9SytscIFUL44i-VoSyFgvF1r",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-_ewGHkI-6ZCZPXq2ltcB7XHFw9RtCj20Qtdevtzm9SytscIFUL44i-VoSyFgvF1r-FEES",
       "recipients": [
-        "0.0.8367704",
+        "0.0.6",
       ],
       "senders": [
         "0.0.8313485",
@@ -3956,7 +3915,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44--wR3CTecetXx9-0B6G_r4zz-l5j9kUEPvQ7KxfIy95gG-zbXPojdNdQgcL-9lVqm-OUT",
       "recipients": [
         "0.0.8367704",
-        "0.0.30",
       ],
       "senders": [
         "0.0.8313485",
@@ -3979,7 +3937,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "05C7rBKw99WX0z1p1xCgXJohDc2441_c-aLX3g6UAnspz1Lppu1M-duYfs_dVuJn",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-05C7rBKw99WX0z1p1xCgXJohDc2441_c-aLX3g6UAnspz1Lppu1M-duYfs_dVuJn-FEES",
       "recipients": [
-        "0.0.507737",
+        "0.0.12",
       ],
       "senders": [
         "0.0.8313485",
@@ -3988,10 +3946,16 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "526632",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1740739638.887363715",
+        "feesPayer": "0.0.507737",
+        "memo": "fromLeVtoLeL",
+        "pagingToken": "1740739638.887363715",
+        "transactionId": "0.0.507737-1740739585-266960243",
+      },
       "fee": "0",
       "hash": "1Q3HZHH__yXIyTrDJ1QQvAQtcVBYgC1A-1dRhcMtfSeOwDijXGwXsWAW9kWQREsZ",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-1Q3HZHH__yXIyTrDJ1QQvAQtcVBYgC1A-1dRhcMtfSeOwDijXGwXsWAW9kWQREsZ-NONE",
@@ -4017,7 +3981,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-3JgGBvKlAT7OMf12rD0zC5h1fQxSyloS1DOUrEUQ3E_4crK-BHkrUeLcED-HDG_0-IN",
       "recipients": [
         "0.0.8313485",
-        "0.0.4",
       ],
       "senders": [
         "0.0.8367704",
@@ -4051,7 +4014,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.4590927",
         "0.0.4552078",
         "0.0.664803",
-        "0.0.31",
       ],
       "senders": [
         "0.0.8217344",
@@ -4072,21 +4034,26 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "25696084",
       "hasFailed": false,
       "hash": "4iK1Z91U5OXF4UFOw2LLnzSsF5okORut20B9Y_iTFCXd3_jO69a8jPd58d_tC4cv",
-      "id": "js:2:hedera:0.0.8313485:hederaBip44-4iK1Z91U5OXF4UFOw2LLnzSsF5okORut20B9Y_iTFCXd3_jO69a8jPd58d_tC4cv-OUT",
+      "id": "js:2:hedera:0.0.8313485:hederaBip44-4iK1Z91U5OXF4UFOw2LLnzSsF5okORut20B9Y_iTFCXd3_jO69a8jPd58d_tC4cv-FEES",
       "recipients": [
         "0.0.98",
       ],
       "senders": [
         "0.0.8313485",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "25696084",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1755857525.720819000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1755857525.720819000",
+        "transactionId": "0.0.507737-1755857506-487122839",
+      },
       "fee": "0",
       "hash": "4wtpbHiq8VYjlgMBvaQjTM9ShybbfqhTW8dW2cvIg2S0-yVaK3cSSOT2mAdks9Yx",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-4wtpbHiq8VYjlgMBvaQjTM9ShybbfqhTW8dW2cvIg2S0-yVaK3cSSOT2mAdks9Yx-NONE",
@@ -4097,10 +4064,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "0",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1760441684.201301000",
+        "feesPayer": "0.0.10006055",
+        "pagingToken": "1760441684.201301000",
+        "transactionId": "0.0.10006055-1760441665-655036606",
+      },
       "fee": "0",
       "hash": "7at5ja0NCURajPyi5FAGRNqNcphLFI_RNQWBSDCIGnQ6tlrm93EyZUfrIQk69ceJ",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-7at5ja0NCURajPyi5FAGRNqNcphLFI_RNQWBSDCIGnQ6tlrm93EyZUfrIQk69ceJ-NONE",
@@ -4126,7 +4098,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-85lLz0RGSQniFYplo8LtsWOzFIPpJDQi8eXNIT_2D2r1eVS6U3WmrKgxni7mmm5g-OUT",
       "recipients": [
         "0.0.8758518",
-        "0.0.17",
       ],
       "senders": [
         "0.0.8313485",
@@ -4149,7 +4120,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "8QJlOw1l9ckcapmVvWXgvcQg4o0a6kxZazaa10g-j_iKwLj1Oqn9W1A3K10m3h64",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-8QJlOw1l9ckcapmVvWXgvcQg4o0a6kxZazaa10g-j_iKwLj1Oqn9W1A3K10m3h64-FEES",
       "recipients": [
-        "0.0.10096785",
+        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4283,7 +4254,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.7611306",
         "0.0.7611305",
         "0.0.7611280",
-        "0.0.4",
       ],
       "senders": [
         "0.0.8217344",
@@ -4292,10 +4262,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "10000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1747132022.307489000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1747132022.307489000",
+        "transactionId": "0.0.507737-1747131999-789289940",
+      },
       "fee": "0",
       "hash": "g2A7D2SNH4HunX7aIYzdlBCVt5z45LZX6dtOdUENh32a5e6cjPb8BF0QJWEs-W8Z",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-g2A7D2SNH4HunX7aIYzdlBCVt5z45LZX6dtOdUENh32a5e6cjPb8BF0QJWEs-W8Z-NONE",
@@ -4321,7 +4296,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-gmk1ZtEUbZH5jTyE0NSbsnkNsMgAuSLNnj0elIczwKEo-yqPqC946RIJVFG51ImP-OUT",
       "recipients": [
         "0.0.10186715",
-        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4354,7 +4328,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.4590927",
         "0.0.4552078",
         "0.0.664803",
-        "0.0.3",
       ],
       "senders": [
         "0.0.8217344",
@@ -4387,7 +4360,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.7611306",
         "0.0.7611305",
         "0.0.7611280",
-        "0.0.8",
       ],
       "senders": [
         "0.0.8217344",
@@ -4396,10 +4368,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "10000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1755865083.033236000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1755865083.033236000",
+        "transactionId": "0.0.507737-1755865061-762935115",
+      },
       "fee": "0",
       "hash": "juIscpG-Iij32H97o5zLZM4cWOMMmpRBRAAOi65ElK7H6OhVzL40ny67HxheMyWk",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-juIscpG-Iij32H97o5zLZM4cWOMMmpRBRAAOi65ElK7H6OhVzL40ny67HxheMyWk-NONE",
@@ -4410,10 +4387,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "0",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1757929653.557852000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1757929653.557852000",
+        "transactionId": "0.0.507737-1757929611-191822644",
+      },
       "fee": "0",
       "hash": "JUKWXT7-WsKIRRHyV2ODKGmRZ8M1ATfsVO6qQ6c_97oN_2cSSSZc_Om9rkRjesLM",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-JUKWXT7-WsKIRRHyV2ODKGmRZ8M1ATfsVO6qQ6c_97oN_2cSSSZc_Om9rkRjesLM-NONE",
@@ -4443,7 +4425,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "jvTHOpAfQXacV90aFwfmPDW76pCmWUc6p5NWmSqIDBSUHNr-6jZDO4kAP3F1hE9I",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-jvTHOpAfQXacV90aFwfmPDW76pCmWUc6p5NWmSqIDBSUHNr-6jZDO4kAP3F1hE9I-FEES",
       "recipients": [
-        "0.0.6391739",
+        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4468,7 +4450,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "kPQrVav4moSwtzRn6jm5LOs_PCxv03Ka8WOZ_sLPuIqpnHxJDX9OC4_Lo1v0ktTI",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-kPQrVav4moSwtzRn6jm5LOs_PCxv03Ka8WOZ_sLPuIqpnHxJDX9OC4_Lo1v0ktTI-FEES",
       "recipients": [
-        "0.0.1040977",
+        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4491,7 +4473,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "la4OImgYRurAR8W3FACQKeCUWXZw8_ew77p4vdKyNavWzNjRhYzWDIAzeEeqPTkG",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-la4OImgYRurAR8W3FACQKeCUWXZw8_ew77p4vdKyNavWzNjRhYzWDIAzeEeqPTkG-FEES",
       "recipients": [
-        "0.0.8758518",
+        "0.0.29",
       ],
       "senders": [
         "0.0.8313485",
@@ -4518,7 +4500,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "Lx8AKRwOQm6seQqFbwW8GpTb9-tKXHJkgszHVPL9Cyo-fG4tDabtCEoMEusWNaYN",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-Lx8AKRwOQm6seQqFbwW8GpTb9-tKXHJkgszHVPL9Cyo-fG4tDabtCEoMEusWNaYN-FEES",
       "recipients": [
-        "0.0.7305122",
+        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4543,7 +4525,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-mzeaXvQD-ZN1cVCCQZmq0Yads_INb_TMoAcHNbZ8CJPE5AvUdA7bW7ZXrh--1pYW-OUT",
       "recipients": [
         "0.0.10096785",
-        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4567,7 +4548,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-ntVwGzpooIIYSwktldo-Isbz6igXCw0jKilaxS8_vzvFg-tmLguXPlmhk3zyY-lY-IN",
       "recipients": [
         "0.0.8313485",
-        "0.0.3",
       ],
       "senders": [
         "0.0.1040977",
@@ -4576,10 +4556,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "1000000000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1765992000.873157685",
+        "feesPayer": "0.0.6391739",
+        "gasConsumed": 266997,
+        "gasLimit": 1000000,
+        "gasUsed": 800000,
+        "pagingToken": "1765992000.873157685",
+        "transactionId": "0.0.6391739-1765991992-317644666",
+      },
       "fee": "0",
       "hash": "NyD2FitLJugF1yfFTkEYLxquEqms0DupW1VHqSb91G1KQaISjUWyrv6maW96w1JR",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-NyD2FitLJugF1yfFTkEYLxquEqms0DupW1VHqSb91G1KQaISjUWyrv6maW96w1JR-NONE",
@@ -4614,7 +4602,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.4590927",
         "0.0.4552078",
         "0.0.664803",
-        "0.0.6",
       ],
       "senders": [
         "0.0.8217344",
@@ -4623,10 +4610,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "10000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1757929013.916417000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1757929013.916417000",
+        "transactionId": "0.0.507737-1757928988-064153304",
+      },
       "fee": "0",
       "hash": "pEG44ZyFCqOEHsJhomyu64gwuvF1q2ssgjbO0jG8kNjb-6TmNtcp_PY8TBzhWs-s",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-pEG44ZyFCqOEHsJhomyu64gwuvF1q2ssgjbO0jG8kNjb-6TmNtcp_PY8TBzhWs-s-NONE",
@@ -4661,7 +4653,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
         "0.0.7611306",
         "0.0.7611305",
         "0.0.7611280",
-        "0.0.17",
       ],
       "senders": [
         "0.0.8217344",
@@ -4670,10 +4661,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "10000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1755008519.962485000",
+        "feesPayer": "0.0.507737",
+        "pagingToken": "1755008519.962485000",
+        "transactionId": "0.0.507737-1755008487-226122597",
+      },
       "fee": "0",
       "hash": "Q-L4mmsKI8ssDoI1KlOsGFYuVMpVxJW5uZDOdU9Q9ClU5uxewOAoeFUevLcrcL0B",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-Q-L4mmsKI8ssDoI1KlOsGFYuVMpVxJW5uZDOdU9Q9ClU5uxewOAoeFUevLcrcL0B-NONE",
@@ -4684,10 +4680,16 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "0",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1756718310.549818000",
+        "feesPayer": "0.0.1040977",
+        "memo": "TOTO",
+        "pagingToken": "1756718310.549818000",
+        "transactionId": "0.0.1040977-1756718286-727919995",
+      },
       "fee": "0",
       "hash": "QDUwQqgrOgB4aPkMprRe3yiux277A7_PJVfpbv-P4GBMT33ahyXp8NQXbblLDA0c",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-QDUwQqgrOgB4aPkMprRe3yiux277A7_PJVfpbv-P4GBMT33ahyXp8NQXbblLDA0c-NONE",
@@ -4713,7 +4715,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-QgtcED3A7geKeAOQQYN1BfgKyJADPtAVLeT7ey8gFMdu8tAACWEHx77z4FR_0MSV-IN",
       "recipients": [
         "0.0.8313485",
-        "0.0.4",
       ],
       "senders": [
         "0.0.8367704",
@@ -4737,7 +4738,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "qWJVsguWV08ZhHLfnakvnsDcS-O2tVtE6r_QlBbtFkLj7r-PWHgwIVKNh1a70-S_",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-qWJVsguWV08ZhHLfnakvnsDcS-O2tVtE6r_QlBbtFkLj7r-PWHgwIVKNh1a70-S_-FEES",
       "recipients": [
-        "0.0.8758518",
+        "0.0.19",
       ],
       "senders": [
         "0.0.8313485",
@@ -4760,7 +4761,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "shGaR01gNESn4WAfLYVOycTQ-lJoWNlWYY15u8SADLZiXbv08ozatmW7DfZDceoM",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-shGaR01gNESn4WAfLYVOycTQ-lJoWNlWYY15u8SADLZiXbv08ozatmW7DfZDceoM-FEES",
       "recipients": [
-        "0.0.10006055",
+        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -4781,14 +4782,14 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "fee": "24935910",
       "hasFailed": false,
       "hash": "sJDAVx1fkaLPGjkFuj3iNnC3GgOamMkRBwAl57rkYRKrcOlj1Lu-kb0D01c3eF4y",
-      "id": "js:2:hedera:0.0.8313485:hederaBip44-sJDAVx1fkaLPGjkFuj3iNnC3GgOamMkRBwAl57rkYRKrcOlj1Lu-kb0D01c3eF4y-OUT",
+      "id": "js:2:hedera:0.0.8313485:hederaBip44-sJDAVx1fkaLPGjkFuj3iNnC3GgOamMkRBwAl57rkYRKrcOlj1Lu-kb0D01c3eF4y-FEES",
       "recipients": [
         "0.0.98",
       ],
       "senders": [
         "0.0.8313485",
       ],
-      "type": "OUT",
+      "type": "FEES",
       "value": "24935910",
     },
     {
@@ -4834,7 +4835,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-uj5J-L_fkKOiXYEamSopL0p7kEc1G8RBHuQjsQfafcsi1N-ATZ5YZXgqz3OZfebn-OUT",
       "recipients": [
         "0.0.8367704",
-        "0.0.9",
       ],
       "senders": [
         "0.0.8313485",
@@ -4905,7 +4905,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.8313485:hederaBip44-wIHVqsGrwL1dn0JTJZijUBgiQwwkyPtI73c6-W91BEvs8nlY5-05GD_QPeajRNvP-IN",
       "recipients": [
         "0.0.8313485",
-        "0.0.5",
       ],
       "senders": [
         "0.0.507737",
@@ -4914,10 +4913,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "10000000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.8313485:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1766059747.925585000",
+        "feesPayer": "0.0.10096785",
+        "gasConsumed": 248195,
+        "gasLimit": 253976,
+        "gasUsed": 238595,
+        "pagingToken": "1766059747.925585000",
+        "transactionId": "0.0.10096785-1766059648-924913103",
+      },
       "fee": "0",
       "hash": "x3clDRmu7XHYTLYWTW8mRaSwf7D5NgnJ8EpocgBMJJES-Q0eajRt3KMv9nBwe5lo",
       "id": "js:2:hedera:0.0.8313485:hederaBip44-x3clDRmu7XHYTLYWTW8mRaSwf7D5NgnJ8EpocgBMJJES-Q0eajRt3KMv9nBwe5lo-NONE",
@@ -5478,10 +5485,15 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
   [],
   [
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.10096785:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1766063577.780237000",
+        "feesPayer": "0.0.8313485",
+        "pagingToken": "1766063577.780237000",
+        "transactionId": "0.0.8313485-1766063534-415377401",
+      },
       "fee": "0",
       "hash": "8QJlOw1l9ckcapmVvWXgvcQg4o0a6kxZazaa10g-j_iKwLj1Oqn9W1A3K10m3h64",
       "id": "js:2:hedera:0.0.10096785:hederaBip44-8QJlOw1l9ckcapmVvWXgvcQg4o0a6kxZazaa10g-j_iKwLj1Oqn9W1A3K10m3h64-NONE",
@@ -5531,7 +5543,6 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "id": "js:2:hedera:0.0.10096785:hederaBip44-mzeaXvQD-ZN1cVCCQZmq0Yads_INb_TMoAcHNbZ8CJPE5AvUdA7bW7ZXrh--1pYW-IN",
       "recipients": [
         "0.0.10096785",
-        "0.0.3",
       ],
       "senders": [
         "0.0.8313485",
@@ -5540,10 +5551,18 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "value": "100000000",
     },
     {
-      "accountId": "",
+      "accountId": "js:2:hedera:0.0.10096785:hederaBip44",
       "blockHash": null,
       "blockHeight": 10,
-      "extra": {},
+      "extra": {
+        "consensusTimestamp": "1765992619.916268000",
+        "feesPayer": "0.0.7305122",
+        "gasConsumed": 271278,
+        "gasLimit": 331284,
+        "gasUsed": 265028,
+        "pagingToken": "1765992619.916268000",
+        "transactionId": "0.0.7305122-1765992603-332568297",
+      },
       "fee": "0",
       "hash": "WbzavPaT_P5qgef65DMzBWvrLKmTqtptIMv6UGHy3lJ_K8ftHiff_gSnfiZJmnvX",
       "id": "js:2:hedera:0.0.10096785:hederaBip44-WbzavPaT_P5qgef65DMzBWvrLKmTqtptIMv6UGHy3lJ_K8ftHiff_gSnfiZJmnvX-NONE",
@@ -5572,7 +5591,7 @@ exports[`hedera currency bridge scanAccounts hedera seed 1 2`] = `
       "hash": "x3clDRmu7XHYTLYWTW8mRaSwf7D5NgnJ8EpocgBMJJES-Q0eajRt3KMv9nBwe5lo",
       "id": "js:2:hedera:0.0.10096785:hederaBip44-x3clDRmu7XHYTLYWTW8mRaSwf7D5NgnJ8EpocgBMJJES-Q0eajRt3KMv9nBwe5lo-FEES",
       "recipients": [
-        "0.0.8313485",
+        "0.0.3",
       ],
       "senders": [
         "0.0.10096785",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR fixes Hedera transactions parsing to cover multi-transfers that can be done with SDK. It also adjusts the sync cursor to skip fetching data that we already have.

https://hashscan.io/mainnet/transaction/1760510879.300860000 was incomplete before:

| <img width="1800" height="1169" alt="hedera-before-1" src="https://github.com/user-attachments/assets/4fcd638f-4249-4d48-ac04-66b311e2015c" /> | <img width="1800" height="1169" alt="hedera-before-2" src="https://github.com/user-attachments/assets/16d1ef16-4754-4255-aa16-fe690bb213d5" /> |
|---|--|


After:

| <img width="1800" height="1169" alt="hedera-after-1" src="https://github.com/user-attachments/assets/3f3854c5-6eb1-4ec1-8a5d-eebf62f8201d" /> | <img width="1800" height="1169" alt="hedera-after-2" src="https://github.com/user-attachments/assets/3de49030-0772-4369-a18c-b9d101f9588a" /> | <img width="1800" height="1169" alt="hedera-after-3" src="https://github.com/user-attachments/assets/58e4b5df-2b28-4870-9036-bda94a5ca56e" /> | <img width="1800" height="1169" alt="hedera-after-4" src="https://github.com/user-attachments/assets/26c08141-7f51-4daa-8a34-75119482b851" /> |
|---|--|--|--|

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-24949