### PR TITLE
[LWDM] fix(coin-solana): correct max spendable while a send is pending

### DIFF
--- a/.changeset/solana-max-spendable-pending-ops.md
+++ b/.changeset/solana-max-spendable-pending-ops.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-solana": patch
+---
+
+Fix incorrect Solana max spendable amount while a previous send is still pending.
+
+`estimateMaxSpendable` derived the spendable amount from the synced `account.spendableBalance`, which is computed purely from the on-chain balance. Right after a send, the outgoing transaction is still unconfirmed, so the on-chain balance (and thus `spendableBalance`) does not yet reflect it — and `addPendingOperation` only appends to `pendingOperations` without decrementing the balance. As a result, a "send max" started right after another send used an inflated balance and failed at broadcast (`SolanaTxSimulationFailedWhilePendingOp`).
+
+- `estimateMaxSpendable` now subtracts pending outgoing operations (amount + fees) from the spendable balance.
+- The `estimateMaxSpendable` LRU cache key now includes the account's pending operations, so a fresh outflow busts the cache instead of returning a stale pre-outflow value.

--- a/libs/coin-modules/coin-solana/src/bridge/bridge.ts
+++ b/libs/coin-modules/coin-solana/src/bridge/bridge.ts
@@ -7,12 +7,13 @@ import {
   makeScanAccounts,
   makeSync,
 } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
+import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { minutes, makeLRUCache } from "@ledgerhq/live-network/cache";
 import { log } from "@ledgerhq/logs";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
-import type { AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
+import type { Account, AccountBridge, AccountLike, CurrencyBridge } from "@ledgerhq/types-live";
 import { BlockhashWithExpiryBlockHeight } from "@solana/web3.js";
 import { SOLANA_DUMMY_ADDRESS } from "../constants";
 import { createTransaction } from "../createTransaction";
@@ -71,6 +72,28 @@ function makeSyncAndScan(getChainAPI: (config: Config) => ChainAPI, getAddress: 
   };
 }
 
+/**
+ * Cache key for estimateMaxSpendable.
+ *
+ * Include pending operations so new outgoing txs bust the cache and "send max" stays correct.
+ * See: https://ledgerhq.atlassian.net/browse/LIVE-35129
+ */
+export const estimateMaxSpendableCacheKey = ({
+  account,
+  parentAccount,
+  transaction,
+}: {
+  account: AccountLike;
+  parentAccount?: Account | null | undefined;
+  transaction?: Transaction | null | undefined;
+}): string => {
+  const mainAccount = getMainAccount(account, parentAccount);
+  const pendingOpsSig = (mainAccount.pendingOperations ?? []).map(op => op.hash).join(",");
+  return `${account.id}:${account.spendableBalance.toString()}:pending:${pendingOpsSig}:tx:${
+    transaction?.model.kind ?? "<no transaction>"
+  }`;
+};
+
 function makeEstimateMaxSpendable(getChainAPI: (config: Config) => ChainAPI) {
   const estimateMaxSpendable: AccountBridge<
     Transaction,
@@ -94,19 +117,7 @@ function makeEstimateMaxSpendable(getChainAPI: (config: Config) => ChainAPI) {
     return estimateMaxSpendableWithAPI(arg, api);
   };
 
-  const cacheKeyByAccSpendableBalance = ({
-    account,
-    transaction,
-  }: {
-    account: AccountLike;
-    transaction?: Transaction | null | undefined;
-  }) => {
-    return `${account.id}:${account.spendableBalance.toString()}:tx:${
-      transaction?.model.kind ?? "<no transaction>"
-    }`;
-  };
-
-  return makeLRUCache(estimateMaxSpendable, cacheKeyByAccSpendableBalance, minutes(5));
+  return makeLRUCache(estimateMaxSpendable, estimateMaxSpendableCacheKey, minutes(5));
 }
 
 function makeBroadcast(

--- a/libs/coin-modules/coin-solana/src/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-solana/src/estimateMaxSpendable.ts
@@ -1,4 +1,5 @@
 import { getMainAccount } from "@ledgerhq/ledger-wallet-framework/account/index";
+import { getOperationAmountNumber } from "@ledgerhq/ledger-wallet-framework/operation";
 import type { Account, AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { calculateToken2022TransferFees } from "./helpers/token";
@@ -19,7 +20,23 @@ export const estimateFeeAndSpendable = async (
   const txKind = transaction?.model.kind ?? "transfer";
   const txFee = await estimateTxFee(api, account.freshAddress, txKind);
 
-  const spendableBalance = BigNumber.max(account.spendableBalance.minus(txFee), 0);
+  // A synced spendableBalance does not reflect still-pending outgoing txs (pending ops never
+  // decrement it and the on-chain balance is not yet confirmed), so subtract pending SOL
+  // debits to keep max spendable correct while a previous send is pending. See LIVE-35129.
+  //
+  // FEES ops are handled separately: a pending token send produces a parent FEES op on the
+  // main account whose `value` is the token amount (see optimisticOpForTokenTransfer), so only
+  // its SOL `fee` leaves this account. For every other op type getOperationAmountNumber already
+  // returns the signed native delta.
+  const pendingDebits = (account.pendingOperations ?? []).reduce((sum, op) => {
+    const delta = op.type === "FEES" ? op.fee.negated() : getOperationAmountNumber(op);
+    return delta.isNegative() ? sum.plus(delta.negated()) : sum;
+  }, new BigNumber(0));
+
+  const spendableBalance = BigNumber.max(
+    account.spendableBalance.minus(txFee).minus(pendingDebits),
+    0,
+  );
 
   switch (txKind) {
     case "token.createATA": {

--- a/libs/coin-modules/coin-solana/src/estimateMaxSpendable.unit.test.ts
+++ b/libs/coin-modules/coin-solana/src/estimateMaxSpendable.unit.test.ts
@@ -1,0 +1,180 @@
+import type { Account, Operation } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import { estimateMaxSpendableCacheKey } from "./bridge/bridge";
+import { estimateMaxSpendableWithAPI } from "./estimateMaxSpendable";
+import type { ChainAPI } from "./network";
+import type { SolanaAccount, Transaction } from "./types";
+
+const TX_FEE = 5000;
+
+jest.mock("./logic/estimateFees", () => ({
+  estimateTxFee: jest.fn().mockResolvedValue(5000),
+}));
+
+const api = {} as ChainAPI;
+
+function makeOp(partial: Partial<Operation>): Operation {
+  return {
+    id: "op-id",
+    hash: "op-hash",
+    type: "OUT",
+    value: new BigNumber(0),
+    fee: new BigNumber(0),
+    senders: [],
+    recipients: [],
+    blockHeight: null,
+    blockHash: null,
+    accountId: "acc-id",
+    date: new Date(),
+    extra: {},
+    ...partial,
+  } as Operation;
+}
+
+function makeAccount(partial: Partial<SolanaAccount>): SolanaAccount {
+  return {
+    type: "Account",
+    id: "acc-id",
+    freshAddress: "HxCvgjSbF8HMt3fj8P3j49jmajNCMwKAqBu79HUDPtkM",
+    balance: new BigNumber(1_000_000),
+    spendableBalance: new BigNumber(1_000_000),
+    pendingOperations: [],
+    ...partial,
+  } as SolanaAccount;
+}
+
+describe("estimateMaxSpendableWithAPI - pending outflow subtraction", () => {
+  it("returns spendableBalance minus fee when there are no pending operations", async () => {
+    const account = makeAccount({ spendableBalance: new BigNumber(1_000_000) });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(1_000_000 - TX_FEE);
+  });
+
+  it("subtracts a pending OUT operation (value already includes fees)", async () => {
+    const account = makeAccount({
+      spendableBalance: new BigNumber(1_000_000),
+      pendingOperations: [makeOp({ type: "OUT", value: new BigNumber(300_000), hash: "out-1" })],
+    });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(1_000_000 - TX_FEE - 300_000);
+  });
+
+  it("ignores incoming pending operations", async () => {
+    const account = makeAccount({
+      spendableBalance: new BigNumber(1_000_000),
+      pendingOperations: [makeOp({ type: "IN", value: new BigNumber(500_000), hash: "in-1" })],
+    });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(1_000_000 - TX_FEE);
+  });
+
+  it("sums multiple pending outflows and ignores incoming ones", async () => {
+    const account = makeAccount({
+      spendableBalance: new BigNumber(1_000_000),
+      pendingOperations: [
+        makeOp({ type: "OUT", value: new BigNumber(200_000), hash: "out-1" }),
+        makeOp({ type: "OUT", value: new BigNumber(100_000), hash: "out-2" }),
+        makeOp({ type: "IN", value: new BigNumber(999_999), hash: "in-1" }),
+      ],
+    });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(1_000_000 - TX_FEE - 300_000);
+  });
+
+  it("only subtracts the SOL fee of a pending token send (FEES op value is the token amount)", async () => {
+    const account = makeAccount({
+      spendableBalance: new BigNumber(1_000_000),
+      // A pending token transfer sets the parent FEES op value to the token amount; only the
+      // SOL fee actually leaves the main account.
+      pendingOperations: [
+        makeOp({
+          type: "FEES",
+          value: new BigNumber(750_000),
+          fee: new BigNumber(TX_FEE),
+          hash: "fees-1",
+        }),
+      ],
+    });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(1_000_000 - TX_FEE - TX_FEE);
+  });
+
+  it("floors the result at 0 when pending outflows exceed the balance", async () => {
+    const account = makeAccount({
+      spendableBalance: new BigNumber(100_000),
+      pendingOperations: [makeOp({ type: "OUT", value: new BigNumber(1_000_000), hash: "out-1" })],
+    });
+
+    const max = await estimateMaxSpendableWithAPI({ account }, api);
+
+    expect(max.toNumber()).toBe(0);
+  });
+});
+
+describe("estimateMaxSpendableCacheKey", () => {
+  const transaction = { model: { kind: "transfer" } } as Transaction;
+
+  it("produces the same key for identical account state", () => {
+    const account = makeAccount({});
+
+    expect(estimateMaxSpendableCacheKey({ account, transaction })).toBe(
+      estimateMaxSpendableCacheKey({ account: makeAccount({}), transaction }),
+    );
+  });
+
+  it("busts the cache when a pending operation appears", () => {
+    const before = makeAccount({ pendingOperations: [] });
+    const after = makeAccount({
+      pendingOperations: [makeOp({ type: "OUT", value: new BigNumber(300_000), hash: "out-1" })],
+    });
+
+    expect(estimateMaxSpendableCacheKey({ account: before, transaction })).not.toBe(
+      estimateMaxSpendableCacheKey({ account: after, transaction }),
+    );
+  });
+
+  it("busts the cache when the pending operation set changes", () => {
+    const one = makeAccount({
+      pendingOperations: [makeOp({ hash: "out-1" })],
+    });
+    const two = makeAccount({
+      pendingOperations: [makeOp({ hash: "out-2" })],
+    });
+
+    expect(estimateMaxSpendableCacheKey({ account: one, transaction })).not.toBe(
+      estimateMaxSpendableCacheKey({ account: two, transaction }),
+    );
+  });
+
+  it("does not throw when pendingOperations is undefined", () => {
+    const account = makeAccount({ pendingOperations: undefined as unknown as Operation[] });
+
+    expect(() => estimateMaxSpendableCacheKey({ account, transaction })).not.toThrow();
+  });
+
+  it("resolves the main account's pending ops for a token account", () => {
+    const parentAccount = makeAccount({
+      pendingOperations: [makeOp({ type: "OUT", value: new BigNumber(300_000), hash: "out-1" })],
+    }) as Account;
+    const tokenAccount = {
+      type: "TokenAccount",
+      id: "token-acc-id",
+      spendableBalance: new BigNumber(42),
+    } as unknown as Parameters<typeof estimateMaxSpendableCacheKey>[0]["account"];
+
+    const key = estimateMaxSpendableCacheKey({ account: tokenAccount, parentAccount, transaction });
+
+    expect(key).toContain("out-1");
+    expect(key).toContain("token-acc-id");
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

- Pending subtraction (estimateMaxSpendableWithAPI, estimateTxFee mocked): no pending → balance − fee; one OUT op subtracted; incoming (IN) ignored; multiple outflows summed; floored at 0 when pending exceeds balance.
- Cache key (estimateMaxSpendableCacheKey): stable for identical state; busts when a pending op appears; busts when the pending set changes; guarded against undefined pendingOperations; resolves the main account's pending ops for a token account.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35129](https://ledgerhq.atlassian.net/browse/LIVE-35129)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35129]: https://ledgerhq.atlassian.net/browse/LIVE-35129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ