### PR TITLE
feat(ddd): add @features/platform-wallet-sync package

### DIFF
--- a/.changeset/swift-wallet-sync-platform.md
+++ b/.changeset/swift-wallet-sync-platform.md
@@ -1,0 +1,5 @@
+---
+"@features/platform-wallet-sync": minor
+---
+
+feat(ddd): add @features/platform-wallet-sync package — platform-level orchestration for WalletSync: watch loop, incremental update handlers, trustchain lifecycle

--- a/features/platform/wallet-sync/README.md
+++ b/features/platform/wallet-sync/README.md
@@ -1,0 +1,20 @@
+# @features/platform-wallet-sync
+
+Platform-level orchestration for Ledger Live wallet synchronisation.
+
+Wires together `@shared/cloud-sync` (network), `@shared/cloud-sync-module` (aggregation) and the domain entity modules into a runnable watch loop. Exports:
+
+- `createWalletSyncWatchLoop` — drives push/pull cycles using a `CloudSyncSDKInterface`
+- `makeSaveNewUpdate` / `makeLocalIncrementalUpdate` — helpers for processing incoming sync events and dispatching Redux actions
+- `trustchainLifecycle` / `liveSlug` — lifecycle hooks called on trustchain rotation
+
+## Related documentation
+
+- [The watch loop](./../../docs/ledger-sync/06-watch-loop.md) — continuous sync lifecycle inside apps
+- [App integration](./../../docs/ledger-sync/07-app-integration.md) — Desktop & Mobile Redux/React wiring
+- [User-facing errors](./../../docs/ledger-sync/errors.md) — errors surfaced in sync hooks
+- [Test strategy](./../../docs/ledger-sync/test-strategy.md) — layered testing approach
+
+## Code location
+
+Moved from `libs/live-wallet/src/walletsync/` (watch loop, incremental updates, trustchain lifecycle).

--- a/features/platform/wallet-sync/jest.config.js
+++ b/features/platform/wallet-sync/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  testEnvironment: "node",
+  passWithNoTests: true,
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+  transform: {
+    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
+  },
+  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
+  reporters: [
+    "default",
+    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
+  ],
+};

--- a/features/platform/wallet-sync/package.json
+++ b/features/platform/wallet-sync/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@features/platform-wallet-sync",
+  "version": "0.0.1",
+  "private": true,
+  "description": "WalletSync orchestration for the Live platform: pull/push watch loop, incremental update handlers and trustchain lifecycle",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "unimported": "pnpm knip --directory ../../.. -W features/platform/wallet-sync",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
+  },
+  "dependencies": {
+    "@shared/cloud-sync": "workspace:^",
+    "@shared/cloud-sync-module": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/node": "catalog:",
+    "jest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/platform/wallet-sync/project.json
+++ b/features/platform/wallet-sync/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/platform-wallet-sync",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/platform/wallet-sync/src/__tests__/createWalletSyncWatchLoop.test.ts
+++ b/features/platform/wallet-sync/src/__tests__/createWalletSyncWatchLoop.test.ts
@@ -1,0 +1,525 @@
+import { z } from "zod";
+import { CloudSyncDataManager } from "@shared/cloud-sync-module";
+import { createWalletSyncWatchLoop } from "../createWalletSyncWatchLoop";
+import type {
+  CreateWalletSyncWatchLoopParams,
+  VisualConfig,
+  WatchConfig,
+} from "../createWalletSyncWatchLoop";
+
+type LocalState = { value: string };
+type Update = { newValue: string };
+const schema = z.object({ value: z.string() });
+type DistantState = z.infer<typeof schema>;
+
+const trustchain = { rootId: "root", walletSyncEncryptionKey: "key", applicationPath: "path" };
+const memberCredentials = { pubkey: "pub", privatekey: "priv" };
+
+function makeModule(
+  overrides: Partial<CloudSyncDataManager<LocalState, Update, typeof schema>> = {},
+): CloudSyncDataManager<LocalState, Update, typeof schema> {
+  return {
+    schema,
+    diffLocalToDistant: jest.fn(() => ({ hasChanges: false, nextState: { value: "distant" } })),
+    resolveIncrementalUpdate: jest.fn(async () => ({ hasChanges: false as const })),
+    applyUpdate: jest.fn((local: LocalState) => local),
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal stand-in for the notifications Observable, so this package keeps no rxjs dependency.
+ * The loop only ever calls `.subscribe()` and `.unsubscribe()`.
+ */
+function makeNotifications() {
+  const listeners = new Set<() => void>();
+  return {
+    subscribe(cb: () => void) {
+      listeners.add(cb);
+      return { unsubscribe: () => listeners.delete(cb) };
+    },
+    emit: () => listeners.forEach(l => l()),
+    get subscribed() {
+      return listeners.size > 0;
+    },
+  };
+}
+
+function makeSdk(overrides: Record<string, unknown> = {}) {
+  return {
+    pull: jest.fn(async () => {}),
+    push: jest.fn(async () => {}),
+    destroy: jest.fn(async () => {}),
+    listenNotifications: jest.fn(() => makeNotifications()),
+    ...overrides,
+  };
+}
+
+type Params = CreateWalletSyncWatchLoopParams<
+  { local: LocalState; distant: DistantState | null },
+  LocalState,
+  Update,
+  typeof schema
+>;
+
+type Overrides = Partial<{
+  walletsync: ReturnType<typeof makeModule>;
+  walletSyncSdk: ReturnType<typeof makeSdk>;
+  localIncrementUpdate: jest.Mock;
+  onTrustchainRefreshNeeded: jest.Mock;
+  onError: jest.Mock | undefined;
+  onStartPolling: jest.Mock | undefined;
+  setVisualPending: jest.Mock | undefined;
+  watchConfig: WatchConfig;
+  visualConfig: VisualConfig;
+}>;
+
+function setup(overrides: Overrides = {}) {
+  const state = { local: { value: "local" }, distant: { value: "distant" } as DistantState | null };
+  const params = {
+    walletsync: makeModule(),
+    walletSyncSdk: makeSdk(),
+    trustchain,
+    memberCredentials,
+    localIncrementUpdate: jest.fn(async () => {}),
+    onTrustchainRefreshNeeded: jest.fn(async () => {}),
+    onError: jest.fn(),
+    onStartPolling: jest.fn(),
+    setVisualPending: jest.fn(),
+    getState: () => state,
+    localStateSelector: (s: typeof state) => s.local,
+    latestDistantStateSelector: (s: typeof state) => s.distant,
+    isTrustchainRefreshError: (e: unknown) => e instanceof Error && e.name === "NeedsRefresh",
+    ...overrides,
+  };
+
+  const handle = createWalletSyncWatchLoop(params as unknown as Params);
+  return { handle, state, ...params };
+}
+
+/** Let the loop's pending promise chain settle without advancing timers. */
+const flush = () => new Promise<void>(resolve => setImmediate(resolve));
+
+describe("createWalletSyncWatchLoop", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] });
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe("scheduling", () => {
+    it("applies default timings when no watchConfig is provided", async () => {
+      const { walletSyncSdk, handle } = setup();
+
+      // defaults: initialTimeout 1000ms, pollingInterval 10000ms
+      jest.advanceTimersByTime(999);
+      await flush();
+      expect(walletSyncSdk.pull).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(10_000);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(2);
+      handle.unsubscribe();
+    });
+
+    it("does not run before the initial timeout elapses", async () => {
+      const { walletSyncSdk, handle } = setup();
+      await flush();
+      expect(walletSyncSdk.pull).not.toHaveBeenCalled();
+      handle.unsubscribe();
+    });
+
+    it("runs a first pass after the initial timeout", async () => {
+      const { walletSyncSdk, handle } = setup({ watchConfig: { initialTimeout: 50 } });
+      jest.advanceTimersByTime(50);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledWith(trustchain, memberCredentials);
+      handle.unsubscribe();
+    });
+
+    it("keeps polling on the configured interval", async () => {
+      const { walletSyncSdk, handle } = setup({
+        watchConfig: { initialTimeout: 10, pollingInterval: 100 },
+      });
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(100);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(2);
+
+      jest.advanceTimersByTime(100);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(3);
+      handle.unsubscribe();
+    });
+
+    it("abandons a pass unsubscribed while the pull is in flight", async () => {
+      let resolvePull: () => void = () => {};
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(() => new Promise<void>(resolve => (resolvePull = resolve))),
+      });
+      const { localIncrementUpdate, handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      handle.unsubscribe();
+      resolvePull();
+      await flush();
+
+      expect(localIncrementUpdate).not.toHaveBeenCalled();
+      expect(walletSyncSdk.push).not.toHaveBeenCalled();
+    });
+
+    it("abandons a pass unsubscribed while the local update is in flight", async () => {
+      let resolveLocal: () => void = () => {};
+      const localIncrementUpdate = jest.fn(
+        () => new Promise<void>(resolve => (resolveLocal = resolve)),
+      );
+      const walletsync = makeModule({
+        diffLocalToDistant: jest.fn(() => ({ hasChanges: true, nextState: { value: "next" } })),
+      });
+      const { walletSyncSdk, handle } = setup({
+        walletsync,
+        localIncrementUpdate,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(localIncrementUpdate).toHaveBeenCalled();
+
+      handle.unsubscribe();
+      resolveLocal();
+      await flush();
+
+      expect(walletsync.diffLocalToDistant).not.toHaveBeenCalled();
+      expect(walletSyncSdk.push).not.toHaveBeenCalled();
+    });
+
+    it("stops polling after unsubscribe", async () => {
+      const { walletSyncSdk, handle } = setup({
+        watchConfig: { initialTimeout: 10, pollingInterval: 100 },
+      });
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+
+      handle.unsubscribe();
+      jest.advanceTimersByTime(1000);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("onUserRefreshIntent", () => {
+    it("reschedules the next run to the debounce delay", async () => {
+      const { walletSyncSdk, handle } = setup({
+        watchConfig: { initialTimeout: 10_000, userIntentDebounce: 50 },
+      });
+
+      handle.onUserRefreshIntent();
+      jest.advanceTimersByTime(50);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+      handle.unsubscribe();
+    });
+
+    it("debounces bursts of intents into a single run", async () => {
+      const { walletSyncSdk, handle } = setup({
+        watchConfig: { initialTimeout: 10_000, userIntentDebounce: 50 },
+      });
+
+      handle.onUserRefreshIntent();
+      jest.advanceTimersByTime(30);
+      handle.onUserRefreshIntent();
+      jest.advanceTimersByTime(30);
+      handle.onUserRefreshIntent();
+      await flush();
+      expect(walletSyncSdk.pull).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(50);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+      handle.unsubscribe();
+    });
+
+    it("is a no-op once unsubscribed", async () => {
+      const { walletSyncSdk, handle } = setup({
+        watchConfig: { initialTimeout: 10_000, userIntentDebounce: 50 },
+      });
+
+      handle.unsubscribe();
+      handle.onUserRefreshIntent();
+      jest.advanceTimersByTime(1000);
+      await flush();
+      expect(walletSyncSdk.pull).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("push", () => {
+    it("pushes the next state when the local diff has changes", async () => {
+      const walletsync = makeModule({
+        diffLocalToDistant: jest.fn(() => ({
+          hasChanges: true,
+          nextState: { value: "next" },
+        })),
+      });
+      const { walletSyncSdk, handle } = setup({
+        walletsync,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.push).toHaveBeenCalledWith(trustchain, memberCredentials, {
+        value: "next",
+      });
+      handle.unsubscribe();
+    });
+
+    it("does not push when there is nothing to push", async () => {
+      const { walletSyncSdk, handle } = setup({ watchConfig: { initialTimeout: 10 } });
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.push).not.toHaveBeenCalled();
+      handle.unsubscribe();
+    });
+
+    it("applies the local incremental update before diffing to push", async () => {
+      const order: string[] = [];
+      const localIncrementUpdate = jest.fn(async () => {
+        order.push("localIncrementUpdate");
+      });
+      const walletsync = makeModule({
+        diffLocalToDistant: jest.fn(() => {
+          order.push("diffLocalToDistant");
+          return { hasChanges: false, nextState: { value: "distant" } };
+        }),
+      });
+      const { handle } = setup({
+        walletsync,
+        localIncrementUpdate,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(order).toEqual(["localIncrementUpdate", "diffLocalToDistant"]);
+      handle.unsubscribe();
+    });
+  });
+
+  describe("error handling", () => {
+    it("reports a pull failure through onError and keeps polling", async () => {
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(async () => {
+          throw new Error("network down");
+        }),
+      });
+      const { onError, handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10, pollingInterval: 100 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "network down" }));
+
+      jest.advanceTimersByTime(100);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(2);
+      handle.unsubscribe();
+    });
+
+    it("triggers a trustchain refresh instead of onError for refresh errors", async () => {
+      const refreshError = new Error("outdated");
+      refreshError.name = "NeedsRefresh";
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(async () => {
+          throw refreshError;
+        }),
+      });
+      const { onError, onTrustchainRefreshNeeded, handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(onTrustchainRefreshNeeded).toHaveBeenCalledWith(trustchain);
+      expect(onError).not.toHaveBeenCalled();
+      handle.unsubscribe();
+    });
+
+    it("does not report errors raised after unsubscribe", async () => {
+      let rejectPull: (e: Error) => void = () => {};
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(() => new Promise((_, reject) => (rejectPull = reject))),
+      });
+      const { onError, handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      handle.unsubscribe();
+      rejectPull(new Error("late failure"));
+      await flush();
+      expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("falls back to console.error when no onError handler is given", async () => {
+      const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(async () => {
+          throw new Error("unhandled");
+        }),
+      });
+      const { handle } = setup({
+        walletSyncSdk,
+        onError: undefined,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(consoleError).toHaveBeenCalledWith(expect.objectContaining({ message: "unhandled" }));
+      handle.unsubscribe();
+      consoleError.mockRestore();
+    });
+
+    it("runs without the optional setVisualPending and onStartPolling callbacks", async () => {
+      const { walletSyncSdk, handle } = setup({
+        setVisualPending: undefined,
+        onStartPolling: undefined,
+        watchConfig: { initialTimeout: 10 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+      handle.unsubscribe();
+    });
+
+    it("calls onStartPolling at the beginning of each pass", async () => {
+      const { onStartPolling, handle } = setup({
+        watchConfig: { initialTimeout: 10, pollingInterval: 100 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      jest.advanceTimersByTime(100);
+      await flush();
+      expect(onStartPolling).toHaveBeenCalledTimes(2);
+      handle.unsubscribe();
+    });
+  });
+
+  describe("visual pending", () => {
+    it("clears the visual pending flag once a pass completes", async () => {
+      const { setVisualPending, handle } = setup({ watchConfig: { initialTimeout: 10 } });
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(setVisualPending).toHaveBeenLastCalledWith(false);
+      handle.unsubscribe();
+    });
+
+    it("raises the visual pending flag when a pass outlives the timeout", async () => {
+      const walletSyncSdk = makeSdk({ pull: jest.fn(() => new Promise<void>(() => {})) });
+      const { setVisualPending, handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10 },
+        visualConfig: { visualPendingTimeout: 40 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(setVisualPending).not.toHaveBeenCalledWith(true);
+
+      jest.advanceTimersByTime(40);
+      await flush();
+      expect(setVisualPending).toHaveBeenCalledWith(true);
+      handle.unsubscribe();
+    });
+  });
+
+  describe("notifications", () => {
+    it("does not subscribe when notifications are disabled", () => {
+      const { walletSyncSdk, handle } = setup({ watchConfig: {} });
+      expect(walletSyncSdk.listenNotifications).not.toHaveBeenCalled();
+      handle.unsubscribe();
+    });
+
+    it("runs a pass on each notification when enabled", async () => {
+      const notifications = makeNotifications();
+      const walletSyncSdk = makeSdk({ listenNotifications: jest.fn(() => notifications) });
+      const { handle } = setup({
+        walletSyncSdk,
+        watchConfig: { notificationsEnabled: true, initialTimeout: 10_000 },
+      });
+
+      expect(walletSyncSdk.listenNotifications).toHaveBeenCalledWith(trustchain, memberCredentials);
+      notifications.emit();
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+      handle.unsubscribe();
+    });
+
+    it("unsubscribes from notifications on unsubscribe", async () => {
+      const notifications = makeNotifications();
+      const walletSyncSdk = makeSdk({ listenNotifications: jest.fn(() => notifications) });
+      const { handle } = setup({
+        walletSyncSdk,
+        watchConfig: { notificationsEnabled: true, initialTimeout: 10_000 },
+      });
+
+      expect(notifications.subscribed).toBe(true);
+      handle.unsubscribe();
+      expect(notifications.subscribed).toBe(false);
+      notifications.emit();
+      await flush();
+      expect(walletSyncSdk.pull).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("concurrency", () => {
+    it("skips a scheduled pass while the previous one is still running", async () => {
+      let resolvePull: () => void = () => {};
+      const walletSyncSdk = makeSdk({
+        pull: jest.fn(() => new Promise<void>(resolve => (resolvePull = resolve))),
+      });
+      const { handle } = setup({
+        walletSyncSdk,
+        watchConfig: { initialTimeout: 10, pollingInterval: 100 },
+      });
+
+      jest.advanceTimersByTime(10);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(300);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(1);
+
+      resolvePull();
+      await flush();
+      jest.advanceTimersByTime(100);
+      await flush();
+      expect(walletSyncSdk.pull).toHaveBeenCalledTimes(2);
+      handle.unsubscribe();
+    });
+  });
+});

--- a/features/platform/wallet-sync/src/__tests__/incrementalUpdates.test.ts
+++ b/features/platform/wallet-sync/src/__tests__/incrementalUpdates.test.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+import { makeSaveNewUpdate, makeLocalIncrementalUpdate } from "../incrementalUpdates";
+import { CloudSyncDataManager } from "@shared/cloud-sync-module";
+
+type SimpleState = { value: string };
+type SimpleUpdate = { newValue: string };
+const schema = z.object({ value: z.string() });
+
+function makeMockModule(
+  overrides: Partial<CloudSyncDataManager<SimpleState, SimpleUpdate, typeof schema>> = {},
+): CloudSyncDataManager<SimpleState, SimpleUpdate, typeof schema> {
+  return {
+    schema,
+    diffLocalToDistant: jest.fn(() => ({ hasChanges: false, nextState: { value: "s" } })),
+    resolveIncrementalUpdate: jest.fn(async () => ({ hasChanges: false as const })),
+    applyUpdate: jest.fn((local: SimpleState) => local),
+    ...overrides,
+  };
+}
+
+describe("makeSaveNewUpdate", () => {
+  const makeSetup = (
+    moduleOverrides: Partial<CloudSyncDataManager<SimpleState, SimpleUpdate, typeof schema>> = {},
+  ) => {
+    const module = makeMockModule(moduleOverrides);
+    const saveUpdate = jest.fn(async () => {});
+    const localState: SimpleState = { value: "local" };
+    const distantState = { value: "distant" };
+    const state = { local: localState, distant: distantState, version: 5 };
+    const handler = makeSaveNewUpdate({
+      walletsync: module,
+      getState: () => state,
+      latestDistantStateSelector: s => s.distant,
+      latestDistantVersionSelector: s => s.version,
+      localStateSelector: s => s.local,
+      saveUpdate,
+    });
+    return { module, saveUpdate, state, handler };
+  };
+
+  describe("new-data event", () => {
+    it("calls resolveIncrementalUpdate with current state", async () => {
+      const { module, handler, state } = makeSetup();
+      await handler({ type: "new-data", data: { value: "incoming" }, version: 6 });
+      expect(module.resolveIncrementalUpdate).toHaveBeenCalledWith(state.local, state.distant, {
+        value: "incoming",
+      });
+    });
+
+    it("calls saveUpdate with new local state when resolveIncrementalUpdate has changes", async () => {
+      const newLocal: SimpleState = { value: "updated" };
+      const { saveUpdate, handler } = makeSetup({
+        resolveIncrementalUpdate: jest.fn(async () => ({
+          hasChanges: true,
+          update: { newValue: "updated" },
+        })),
+        applyUpdate: jest.fn(() => newLocal),
+      });
+      await handler({ type: "new-data", data: { value: "incoming" }, version: 6 });
+      expect(saveUpdate).toHaveBeenCalledWith({ value: "incoming" }, 6, newLocal);
+    });
+
+    it("does not call saveUpdate with local state when no changes", async () => {
+      const { saveUpdate, handler } = makeSetup();
+      await handler({ type: "new-data", data: { value: "same" }, version: 5 });
+      // version matches latestDistantVersionSelector (5), no changes → saveUpdate NOT called
+      expect(saveUpdate).not.toHaveBeenCalled();
+    });
+
+    it("calls saveUpdate to bump version when event version differs from latest", async () => {
+      const { saveUpdate, handler } = makeSetup();
+      // version 7 != state.version 5, no content changes
+      await handler({ type: "new-data", data: { value: "same" }, version: 7 });
+      expect(saveUpdate).toHaveBeenCalledWith({ value: "same" }, 7, null);
+    });
+  });
+
+  describe("pushed-data event", () => {
+    it("saves pushed data without calling resolveIncrementalUpdate", async () => {
+      const { module, saveUpdate, handler } = makeSetup();
+      await handler({ type: "pushed-data", data: { value: "pushed" }, version: 3 });
+      expect(module.resolveIncrementalUpdate).not.toHaveBeenCalled();
+      expect(saveUpdate).toHaveBeenCalledWith({ value: "pushed" }, 3, null);
+    });
+  });
+
+  describe("deleted-data event", () => {
+    it("saves null data with version 0", async () => {
+      const { saveUpdate, handler } = makeSetup();
+      await handler({ type: "deleted-data" });
+      expect(saveUpdate).toHaveBeenCalledWith(null, 0, null);
+    });
+  });
+});
+
+describe("makeLocalIncrementalUpdate", () => {
+  const makeSetup = (
+    moduleOverrides: Partial<CloudSyncDataManager<SimpleState, SimpleUpdate, typeof schema>> = {},
+  ) => {
+    const module = makeMockModule(moduleOverrides);
+    const saveUpdate = jest.fn(async () => {});
+    const localState: SimpleState = { value: "local" };
+    const walletState = { data: { value: "distant" }, version: 3 };
+    const state = { local: localState, wallet: walletState };
+    const update = makeLocalIncrementalUpdate({
+      walletsync: module,
+      getState: () => state,
+      latestWalletStateSelector: s => s.wallet,
+      localStateSelector: s => s.local,
+      saveUpdate,
+    });
+    return { module, saveUpdate, state, update };
+  };
+
+  it("calls resolveIncrementalUpdate with local and distant (same for both)", async () => {
+    const { module, state, update } = makeSetup();
+    await update();
+    expect(module.resolveIncrementalUpdate).toHaveBeenCalledWith(
+      state.local,
+      state.wallet.data,
+      state.wallet.data,
+    );
+  });
+
+  it("calls saveUpdate with new local state when changes detected", async () => {
+    const newLocal: SimpleState = { value: "applied" };
+    const { saveUpdate, state, update } = makeSetup({
+      resolveIncrementalUpdate: jest.fn(async () => ({
+        hasChanges: true,
+        update: { newValue: "applied" },
+      })),
+      applyUpdate: jest.fn(() => newLocal),
+    });
+    await update();
+    expect(saveUpdate).toHaveBeenCalledWith(state.wallet.data, state.wallet.version, newLocal);
+  });
+
+  it("does not call saveUpdate when no changes", async () => {
+    const { saveUpdate, update } = makeSetup();
+    await update();
+    expect(saveUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/features/platform/wallet-sync/src/__tests__/trustchainLifecycle.test.ts
+++ b/features/platform/wallet-sync/src/__tests__/trustchainLifecycle.test.ts
@@ -1,0 +1,149 @@
+import { liveSlug, trustchainLifecycle } from "../trustchainLifecycle";
+
+const deleteData = jest.fn(async () => {});
+const uploadData = jest.fn(async () => {});
+const encrypt = jest.fn(async () => "encrypted-payload");
+
+jest.mock("@shared/cloud-sync", () => ({
+  getCloudSyncApi: jest.fn(() => ({ deleteData, uploadData })),
+  makeCipher: jest.fn(() => ({ encrypt })),
+}));
+
+// imported after the mock so the factory above is in place
+import { getCloudSyncApi, makeCipher } from "@shared/cloud-sync";
+
+const oldTrustchain = { rootId: "old-root", walletSyncEncryptionKey: "old-key" };
+const newTrustchain = { rootId: "new-root", walletSyncEncryptionKey: "new-key" };
+const memberCredentials = { pubkey: "pub", privatekey: "priv" };
+
+/** Mimics trustchainSdk.withAuth, which hands a JWT to the callback. */
+function makeTrustchainSdk() {
+  return {
+    withAuth: jest.fn(
+      async (trustchain: { rootId: string }, _creds: unknown, job: (jwt: string) => unknown) =>
+        job(`jwt-for-${trustchain.rootId}`),
+    ),
+  };
+}
+
+function setup(wsState: { data: unknown; version: number }) {
+  const trustchainSdk = makeTrustchainSdk();
+  const lifecycle = trustchainLifecycle({
+    cloudSyncApiBaseUrl: "https://cloudsync.test",
+    getCurrentWSState: () => wsState,
+  });
+  return { trustchainSdk, lifecycle };
+}
+
+async function rotate(wsState: { data: unknown; version: number }) {
+  const { trustchainSdk, lifecycle } = setup(wsState);
+  const finish = await lifecycle.onTrustchainRotation!(
+    trustchainSdk as never,
+    oldTrustchain as never,
+    memberCredentials as never,
+  );
+  await finish(newTrustchain as never);
+  return { trustchainSdk };
+}
+
+describe("liveSlug", () => {
+  it("is the wallet sync slug used by Live", () => {
+    expect(liveSlug).toBe("live");
+  });
+});
+
+describe("trustchainLifecycle.onTrustchainRotation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("authenticates against the old trustchain before rotating", async () => {
+    const { trustchainSdk } = await rotate({ data: { accounts: [] }, version: 7 });
+    expect(trustchainSdk.withAuth).toHaveBeenCalledWith(
+      oldTrustchain,
+      memberCredentials,
+      expect.any(Function),
+      "refresh",
+    );
+  });
+
+  it("deletes the old trustchain data with the old JWT", async () => {
+    await rotate({ data: { accounts: [] }, version: 7 });
+    expect(deleteData).toHaveBeenCalledWith("jwt-for-old-root", liveSlug, oldTrustchain);
+  });
+
+  it("re-uploads the current state encrypted for the new trustchain", async () => {
+    const data = { accounts: ["a"] };
+    await rotate({ data, version: 7 });
+
+    expect(encrypt).toHaveBeenCalledWith(newTrustchain, data);
+    expect(uploadData).toHaveBeenCalledWith(
+      "jwt-for-new-root",
+      liveSlug,
+      7,
+      "encrypted-payload",
+      newTrustchain,
+    );
+  });
+
+  it("deletes before uploading, so the old copy never outlives the rotation", async () => {
+    const order: string[] = [];
+    deleteData.mockImplementationOnce(async () => {
+      order.push("delete");
+    });
+    uploadData.mockImplementationOnce(async () => {
+      order.push("upload");
+    });
+
+    await rotate({ data: { accounts: [] }, version: 1 });
+    expect(order).toEqual(["delete", "upload"]);
+  });
+
+  it("skips the re-upload when there is no local state to migrate", async () => {
+    await rotate({ data: null, version: 0 });
+
+    expect(deleteData).toHaveBeenCalled();
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(uploadData).not.toHaveBeenCalled();
+  });
+
+  it("targets the configured cloudsync base url", async () => {
+    await rotate({ data: { accounts: [] }, version: 1 });
+    expect(getCloudSyncApi).toHaveBeenCalledWith("https://cloudsync.test");
+  });
+
+  it("builds the cipher from the trustchain sdk", async () => {
+    const { trustchainSdk } = await rotate({ data: { accounts: [] }, version: 1 });
+    expect(makeCipher).toHaveBeenCalledWith(trustchainSdk);
+  });
+
+  it("reads the state at rotation time, not at construction time", async () => {
+    const wsState = { data: null as unknown, version: 0 };
+    const { trustchainSdk, lifecycle } = setup(wsState);
+    const finish = await lifecycle.onTrustchainRotation!(
+      trustchainSdk as never,
+      oldTrustchain as never,
+      memberCredentials as never,
+    );
+
+    // state appears only after the rotation started
+    wsState.data = { accounts: ["late"] };
+    wsState.version = 42;
+    await finish(newTrustchain as never);
+
+    expect(uploadData).toHaveBeenCalledWith(
+      "jwt-for-new-root",
+      liveSlug,
+      42,
+      "encrypted-payload",
+      newTrustchain,
+    );
+  });
+
+  it("propagates a delete failure without uploading", async () => {
+    deleteData.mockRejectedValueOnce(new Error("delete failed"));
+
+    await expect(rotate({ data: { accounts: [] }, version: 1 })).rejects.toThrow("delete failed");
+    expect(uploadData).not.toHaveBeenCalled();
+  });
+});

--- a/features/platform/wallet-sync/src/createWalletSyncWatchLoop.ts
+++ b/features/platform/wallet-sync/src/createWalletSyncWatchLoop.ts
@@ -1,0 +1,130 @@
+import { ZodType, z } from "zod";
+import { CloudSyncSDKInterface, MemberCredentials, Trustchain } from "@shared/cloud-sync";
+import { CloudSyncDataManager } from "@shared/cloud-sync-module";
+
+export type WatchConfig = {
+  notificationsEnabled?: boolean;
+  pollingInterval?: number;
+  initialTimeout?: number;
+  userIntentDebounce?: number;
+};
+
+export type VisualConfig = {
+  visualPendingTimeout: number;
+};
+
+export type CreateWalletSyncWatchLoopParams<
+  UserState,
+  LocalState,
+  Update,
+  Schema extends ZodType,
+  DistantState = z.infer<Schema>,
+> = {
+  watchConfig?: WatchConfig;
+  visualConfig?: VisualConfig;
+  walletsync: CloudSyncDataManager<LocalState, Update, Schema>;
+  walletSyncSdk: CloudSyncSDKInterface<DistantState>;
+  trustchain: Trustchain;
+  memberCredentials: MemberCredentials;
+  setVisualPending?: (b: boolean) => void;
+  onStartPolling?: () => void;
+  onTrustchainRefreshNeeded: (trustchain: Trustchain) => Promise<void>;
+  onError?: (e: unknown) => void;
+  getState: () => UserState;
+  localStateSelector: (state: UserState) => LocalState;
+  latestDistantStateSelector: (state: UserState) => DistantState | null;
+  localIncrementUpdate: () => Promise<void>;
+  isTrustchainRefreshError: (e: unknown) => boolean;
+};
+
+export function createWalletSyncWatchLoop<UserState, LocalState, Update, Schema extends ZodType>({
+  watchConfig,
+  visualConfig,
+  walletsync,
+  walletSyncSdk,
+  trustchain,
+  memberCredentials,
+  setVisualPending,
+  onStartPolling,
+  onTrustchainRefreshNeeded,
+  onError,
+  getState,
+  localStateSelector,
+  latestDistantStateSelector,
+  localIncrementUpdate,
+  isTrustchainRefreshError,
+}: CreateWalletSyncWatchLoopParams<UserState, LocalState, Update, Schema>): {
+  onUserRefreshIntent: () => void;
+  unsubscribe: () => void;
+} {
+  const visualPendingTimeout = visualConfig?.visualPendingTimeout || 1000;
+  let unsubscribed = false;
+  let pending = false;
+
+  async function loop() {
+    if (pending || unsubscribed) return;
+    pending = true;
+    const visualTimeout =
+      setVisualPending && setTimeout(() => setVisualPending(true), visualPendingTimeout);
+    try {
+      if (onStartPolling) onStartPolling();
+      await walletSyncSdk.pull(trustchain, memberCredentials);
+      if (unsubscribed) return;
+      await localIncrementUpdate();
+      if (unsubscribed) return;
+      const state = getState();
+      const diff = walletsync.diffLocalToDistant(
+        localStateSelector(state),
+        latestDistantStateSelector(state),
+      );
+      if (diff.hasChanges) {
+        await walletSyncSdk.push(trustchain, memberCredentials, diff.nextState);
+      }
+    } catch (e) {
+      if (isTrustchainRefreshError(e)) {
+        await onTrustchainRefreshNeeded(trustchain);
+        return;
+      }
+      if (unsubscribed) return;
+      if (onError) onError(e);
+      else console.error(e);
+    } finally {
+      pending = false;
+      if (visualTimeout) clearTimeout(visualTimeout);
+      if (setVisualPending) setVisualPending(false);
+    }
+  }
+
+  const notificationsEnabled = watchConfig?.notificationsEnabled || false;
+  const pollingInterval = watchConfig?.pollingInterval || 10000;
+  const initialTimeout = watchConfig?.initialTimeout || 1000;
+  const userIntentDebounce = watchConfig?.userIntentDebounce || 1000;
+
+  const callback = () => {
+    timeout = setTimeout(callback, pollingInterval);
+    loop();
+  };
+  let timeout = setTimeout(callback, initialTimeout);
+
+  let notificationsSub: { unsubscribe: () => void } | null = null;
+  if (notificationsEnabled) {
+    notificationsSub = walletSyncSdk
+      .listenNotifications(trustchain, memberCredentials)
+      .subscribe(() => {
+        loop();
+      });
+  }
+
+  return {
+    onUserRefreshIntent: () => {
+      if (unsubscribed) return;
+      clearTimeout(timeout);
+      timeout = setTimeout(callback, userIntentDebounce);
+    },
+    unsubscribe: () => {
+      unsubscribed = true;
+      clearTimeout(timeout);
+      if (notificationsSub) notificationsSub.unsubscribe();
+    },
+  };
+}

--- a/features/platform/wallet-sync/src/incrementalUpdates.ts
+++ b/features/platform/wallet-sync/src/incrementalUpdates.ts
@@ -1,0 +1,97 @@
+import { UpdateEvent } from "@shared/cloud-sync";
+import { CloudSyncDataManager } from "@shared/cloud-sync-module";
+import { ZodType, z } from "zod";
+
+export function makeSaveNewUpdate<
+  S,
+  LocalState,
+  Update,
+  Schema extends ZodType,
+  DistantState = z.infer<Schema>,
+>({
+  walletsync,
+  getState,
+  latestDistantStateSelector,
+  latestDistantVersionSelector,
+  localStateSelector,
+  saveUpdate,
+}: {
+  walletsync: CloudSyncDataManager<LocalState, Update, Schema, DistantState>;
+  getState: () => S;
+  latestDistantStateSelector: (state: S) => DistantState | null;
+  latestDistantVersionSelector: (state: S) => number;
+  localStateSelector: (state: S) => LocalState;
+  saveUpdate: (
+    data: DistantState | null,
+    version: number,
+    newLocalState: LocalState | null,
+  ) => Promise<void>;
+}): (event: UpdateEvent<DistantState>) => Promise<void> {
+  return async (event: UpdateEvent<DistantState>) => {
+    switch (event.type) {
+      case "new-data": {
+        const state = getState();
+        const latestVersion = latestDistantVersionSelector(state);
+        const latest = latestDistantStateSelector(state);
+        const local = localStateSelector(state);
+        const data = event.data;
+        const resolved = await walletsync.resolveIncrementalUpdate(local, latest, data);
+
+        if (resolved.hasChanges) {
+          const version = event.version;
+          const localState = localStateSelector(getState());
+          const newLocalState = walletsync.applyUpdate(localState, resolved.update);
+          await saveUpdate(data, version, newLocalState);
+        } else if (event.version !== latestVersion) {
+          await saveUpdate(data, event.version, null);
+        }
+        break;
+      }
+      case "pushed-data": {
+        await saveUpdate(event.data, event.version, null);
+        break;
+      }
+      case "deleted-data": {
+        await saveUpdate(null, 0, null);
+        break;
+      }
+    }
+  };
+}
+
+export function makeLocalIncrementalUpdate<
+  S,
+  LocalState,
+  Update,
+  Schema extends ZodType,
+  DistantState = z.infer<Schema>,
+>({
+  walletsync,
+  getState,
+  latestWalletStateSelector,
+  localStateSelector,
+  saveUpdate,
+}: {
+  walletsync: CloudSyncDataManager<LocalState, Update, Schema, DistantState>;
+  getState: () => S;
+  latestWalletStateSelector: (state: S) => { data: DistantState | null; version: number };
+  localStateSelector: (state: S) => LocalState;
+  saveUpdate: (
+    data: DistantState | null,
+    version: number,
+    newLocalState: LocalState | null,
+  ) => Promise<void>;
+}): () => Promise<void> {
+  return async () => {
+    const state = getState();
+    const { data, version } = latestWalletStateSelector(state);
+    const local = localStateSelector(state);
+    const resolved = await walletsync.resolveIncrementalUpdate(local, data, data);
+
+    if (resolved.hasChanges) {
+      const localState = localStateSelector(getState());
+      const newLocalState = walletsync.applyUpdate(localState, resolved.update);
+      await saveUpdate(data, version, newLocalState);
+    }
+  };
+}

--- a/features/platform/wallet-sync/src/index.ts
+++ b/features/platform/wallet-sync/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./createWalletSyncWatchLoop";
+export * from "./incrementalUpdates";
+export * from "./trustchainLifecycle";

--- a/features/platform/wallet-sync/src/trustchainLifecycle.ts
+++ b/features/platform/wallet-sync/src/trustchainLifecycle.ts
@@ -1,0 +1,37 @@
+import { TrustchainLifecycle, getCloudSyncApi, makeCipher } from "@shared/cloud-sync";
+
+export const liveSlug = "live";
+
+export function trustchainLifecycle({
+  cloudSyncApiBaseUrl,
+  getCurrentWSState,
+}: {
+  cloudSyncApiBaseUrl: string;
+  getCurrentWSState: () => { data: unknown; version: number };
+}): TrustchainLifecycle {
+  return {
+    onTrustchainRotation: async (trustchainSdk, oldTrustchain, memberCredentials) => {
+      const oldJwt = await trustchainSdk.withAuth(
+        oldTrustchain,
+        memberCredentials,
+        jwt => Promise.resolve(jwt),
+        "refresh",
+      );
+      return async newTrustchain => {
+        const api = getCloudSyncApi(cloudSyncApiBaseUrl);
+        await api.deleteData(oldJwt, liveSlug, oldTrustchain);
+        const newJwt = await trustchainSdk.withAuth(
+          newTrustchain,
+          memberCredentials,
+          jwt => Promise.resolve(jwt),
+          "refresh",
+        );
+        const { version, data } = getCurrentWSState();
+        if (!data) return;
+        const cipher = makeCipher(trustchainSdk);
+        const payload = await cipher.encrypt(newTrustchain, data);
+        await api.uploadData(newJwt, liveSlug, version, payload, newTrustchain);
+      };
+    },
+  };
+}

--- a/features/platform/wallet-sync/tsconfig.json
+++ b/features/platform/wallet-sync/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5223,6 +5223,37 @@ importers:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
 
+  features/platform/wallet-sync:
+    dependencies:
+      '@shared/cloud-sync':
+        specifier: workspace:^
+        version: link:../../../shared/cloud-sync
+      '@shared/cloud-sync-module':
+        specifier: workspace:^
+        version: link:../../../shared/cloud-sync-module
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.12.0
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0(@types/node@24.12.0)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
+
   libs/asset-aggregation:
     dependencies:
       '@domain/entity-currency':


### PR DESCRIPTION
### 📝 Description

Introduces `@features/platform-wallet-sync` — platform-level orchestration for WalletSync. Extracted from the exploratory PoC ([#19464](https://github.com/LedgerHQ/ledger-live/pull/19464)).

The package is a pure TypeScript library (`private: true`) with no app-layer or React dependencies. It only depends on `@shared/cloud-sync` and `@shared/cloud-sync-module`.

**Exports:**

| Symbol | Description |
|--------|-------------|
| `createWalletSyncWatchLoop` | Drives push/pull cycles using a `CloudSyncSDKInterface` |
| `makeSaveNewUpdate` | Processes incoming `UpdateEvent` and dispatches Redux-compatible saves |
| `makeLocalIncrementalUpdate` | Reconciles local state divergence on each poll tick |
| `trustchainLifecycle` | Handles data migration on trustchain rotation |
| `liveSlug` | Slug constant used to namespace cloud sync data |

**Consumer TLDR** (once the final-switch PR lands):

```ts
import { createWalletSyncWatchLoop, makeSaveNewUpdate, liveSlug } from "@features/platform-wallet-sync";

const { unsubscribe, onUserRefreshIntent } = createWalletSyncWatchLoop({
  walletsync, walletSyncSdk, trustchain, memberCredentials,
  localIncrementUpdate, getState, localStateSelector,
  latestDistantStateSelector, isTrustchainRefreshError, onTrustchainRefreshNeeded,
});
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35277](https://ledgerhq.atlassian.net/browse/LIVE-35277) — part of epic [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990)
- **ADR** (if any): n/a — follows the same DDD 4-layer pattern established in [#20308](https://github.com/LedgerHQ/ledger-live/pull/20308)–[#20311](https://github.com/LedgerHQ/ledger-live/pull/20311)

[LIVE-35277]: https://ledgerhq.atlassian.net/browse/LIVE-35277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ