### PR TITLE
fix(live-e2e-shared): extend token-approval review wait to 120s

### DIFF
--- a/libs/live-e2e-shared/src/families/evm.ts
+++ b/libs/live-e2e-shared/src/families/evm.ts
@@ -5,6 +5,7 @@ import {
   waitForReviewTransaction,
   pressUntilTextFound,
   waitFor,
+  SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS,
 } from "../speculos";
 import { getSpeculosModel, isTouchDevice } from "../speculosAppVersion";
 import {
@@ -132,7 +133,7 @@ async function getEnsScreenTexts(ensName: string): Promise<string[]> {
 }
 
 export async function approveTokenTouchDevices() {
-  await waitForReviewTransaction();
+  await waitForReviewTransaction(SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
   await pressUntilTextFound(DeviceLabels.HOLD_TO_SIGN);
   await longPressAndRelease(DeviceLabels.HOLD_TO_SIGN, 3);
 }
@@ -140,7 +141,7 @@ export async function approveTokenTouchDevices() {
 export const approveTokenButtonDevice = withDeviceController(
   ({ getButtonsController }) =>
     async () => {
-      await waitFor(DeviceLabels.REVIEW_TRANSACTION_TO);
+      await waitFor(DeviceLabels.REVIEW_TRANSACTION_TO, SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS);
       await pressUntilTextFound(DeviceLabels.SIGN_TRANSACTION);
       await getButtonsController().both();
     },

--- a/libs/live-e2e-shared/src/speculos.ts
+++ b/libs/live-e2e-shared/src/speculos.ts
@@ -68,7 +68,7 @@ const isSpeculosRemote = process.env.REMOTE_SPECULOS === "true";
 const SCREEN_POLL_INTERVAL_MS = 500;
 const SWAP_REVIEW_TRANSACTION_TIMEOUT_MS = 120_000;
 // Derived from timeout + interval so the budget can't silently drift if either changes.
-const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = Math.ceil(
+export const SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS = Math.ceil(
   SWAP_REVIEW_TRANSACTION_TIMEOUT_MS / SCREEN_POLL_INTERVAL_MS,
 );
 


### PR DESCRIPTION
### ✅ Checklist

- [x] No changeset required — `@ledgerhq/live-e2e-shared` is a **private, E2E-only** package with no publishable dependents.
- [ ] **Covered by automatic tests.** _This is E2E test-harness code, not unit-tested. The definitive validation is a CI mobile-E2E run of the token-approval spec on this branch (needs emulator + Speculos + broadcast, not runnable locally)._
- [x] **Impact of the changes:**
  - Mobile & desktop swap **token-approval / reapproval** E2E flows — specifically the on-device "Review transaction to → Approve" step.
  - No behaviour change to other device flows: send/swap reviews already used the 120 s budget; this only raises the approval wait to match.

### 📝 Description

**Problem.** In the Monday nightly ([run 30783657094](https://github.com/LedgerHQ/ledger-live/actions/runs/30783657094)), Android shard 5's `swap/tokenApprovalFlow/swapTokenApprovalRotatingProvider.spec.ts` failed 3× (all jest retries) with:

> `Text "Review transaction to" not found on device screen after 60 attempts. Last screen text: "Ethereum app is ready"`

The failure is in the `revokeTokenApproval` **setup** step, which performs a real on-chain revoke via a cold `ledger-live` CLI child that then presents the transaction to Speculos for the test to auto-approve. Evidence from the artifacts shows the transaction wasn't broken — the **failure-time Speculos screenshot on the same port shows "Review transaction to / Approve"** — the screen just arrived **late** (≈35 s). The token-approval device-review wait used the **default `waitFor` budget of 30 s** (60 × 500 ms), whereas the equivalent **send/swap** reviews already use **120 s**. During a runner-overload window (Android shards 4/6/11 also timed out on many unrelated tests), the cold CLI needed ~35 s to present the tx — past the 30 s budget — so the driver gave up before the (slow, not broken) screen appeared.

**Solution.** Export the existing `SWAP_REVIEW_TRANSACTION_MAX_ATTEMPTS` (120 s / 240 polls) from `speculos.ts` and use it in the two token-approval device drivers (`approveTokenButtonDevice`, `approveTokenTouchDevices`) so the approval review wait matches send/swap. Against this run's ≈35 s arrival that is a ~3.4× margin.

This targets the *test fragility* — an under-budgeted timeout that turned a transient slowdown into a hard, unrecoverable 3× failure. The deeper hardening (a timeout + kill in `runCliCommand`, so a genuinely hung CLI child surfaces a retryable `timeout` instead of poisoning `runTokenApprovalWithRetry`) is intentionally **deferred to a follow-up**.

### ❓ Context

- **Failing nightly run**: [Mobile E2E — run 30783657094](https://github.com/LedgerHQ/ledger-live/actions/runs/30783657094) — Android shard 5, `swapTokenApprovalRotatingProvider.spec.ts`.
- No dedicated Jira ticket for this specific timeout mode. Related prior work: the cross-platform shared-EOA nonce race (QAA-1411, `shouldRunBroadcastFlow` partition) was already active in this run and is a *different* failure mode.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
