### PR TITLE
refactor(contacts): standardize validation errors (LIVE-35066)

### DIFF
--- a/.changeset/silent-otters-judge.md
+++ b/.changeset/silent-otters-judge.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-contact": patch
+---
+
+Standardize contact validation error contracts.

--- a/domain/entity/contact/src/errors.test.ts
+++ b/domain/entity/contact/src/errors.test.ts
@@ -1,10 +1,21 @@
-import { InvalidContactNameError, INVALID_CONTACT_NAME_ERROR_NAME } from "./errors";
+import {
+  ContactAddressLabelTooLongError,
+  DuplicateContactAddressLabelError,
+  InvalidContactAddressLabelError,
+  InvalidContactNameError,
+} from "./errors";
 
 describe("errors", () => {
-  it("InvalidContactNameError extends Error and keeps the stable name", () => {
-    const error = new InvalidContactNameError();
-
+  it.each([
+    [new InvalidContactNameError(), "InvalidContactNameError"],
+    [new InvalidContactAddressLabelError(), "InvalidContactAddressLabelError"],
+    [
+      new DuplicateContactAddressLabelError(),
+      "DuplicateContactAddressLabelError",
+    ],
+    [new ContactAddressLabelTooLongError(), "ContactAddressLabelTooLongError"],
+  ])("%s extends Error and keeps the stable name", (error, name) => {
     expect(error).toBeInstanceOf(Error);
-    expect(error.name).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(error.name).toBe(name);
   });
 });

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -1,39 +1,23 @@
 export class ContactError extends Error {
-  override name = "ContactError";
+  override name: string = "ContactError";
 }
 
 export class InvalidContactNameError extends ContactError {
-  override name = "InvalidContactNameError";
+  override name = "InvalidContactNameError" as const;
 
   constructor() {
     super("Expected letters, spaces, apostrophes, or hyphens");
   }
 }
 
-export type ContactNameValidationErrorName = "InvalidContactNameError";
-
-export const INVALID_CONTACT_NAME_ERROR_NAME =
-  "InvalidContactNameError" satisfies ContactNameValidationErrorName;
-
-export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME = "InvalidContactAddressLabelError";
-
-export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME = "DuplicateContactAddressLabelError";
-
-export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME = "ContactAddressLabelTooLongError";
-
-export type ContactAddressLabelValidationErrorName =
-  | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
-
 export class InvalidContactAddressLabelError extends ContactError {
-  override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  override name = "InvalidContactAddressLabelError" as const;
 }
 
 export class DuplicateContactAddressLabelError extends ContactError {
-  override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  override name = "DuplicateContactAddressLabelError" as const;
 }
 
 export class ContactAddressLabelTooLongError extends ContactError {
-  override name = CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
+  override name = "ContactAddressLabelTooLongError" as const;
 }

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -1,15 +1,12 @@
 import {
   ContactAddressLabelTooLongError,
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DuplicateContactAddressLabelError,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   InvalidContactAddressLabelError,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   InvalidContactNameError,
-  INVALID_CONTACT_NAME_ERROR_NAME,
 } from "./errors";
 import { ContactAddressLabelSchema } from "./schema";
 import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   getContactAddressLabelValidationError,
   getContactNameValidationError,
   isValidContactAddressLabel,
@@ -17,6 +14,9 @@ import {
   normalizeContactAddressLabelForComparison,
   parseContactAddressLabel,
   parseContactName,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
 } from "./validation";
 
 describe("contact name validation", () => {
@@ -30,7 +30,9 @@ describe("contact name validation", () => {
   });
 
   it("reports the stable InvalidContactNameError name for a non-empty invalid draft name", () => {
-    expect(getContactNameValidationError("Olive2")).toBe(INVALID_CONTACT_NAME_ERROR_NAME);
+    expect(getContactNameValidationError("Olive2")).toBe(
+      INVALID_CONTACT_NAME_ERROR_NAME
+    );
   });
 
   it("validates trimmed names consistently", () => {
@@ -60,7 +62,7 @@ describe("contact address label validation", () => {
 
     expect(getContactAddressLabelValidationError("Ethereum")).toBeNull();
     expect(getContactAddressLabelValidationError(longLabel)).toBe(
-      CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+      CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME
     );
     expect(isValidContactAddressLabel(longLabel)).toBe(false);
   });
@@ -68,13 +70,15 @@ describe("contact address label validation", () => {
   it("ignores surrounding whitespace when checking the address label length", () => {
     const labelWithWhitespace = `  ${"a".repeat(32)}  `;
 
-    expect(getContactAddressLabelValidationError(labelWithWhitespace)).toBeNull();
+    expect(
+      getContactAddressLabelValidationError(labelWithWhitespace)
+    ).toBeNull();
     expect(parseContactAddressLabel(labelWithWhitespace)).toBe("a".repeat(32));
   });
 
   it("reports invalid non-ASCII characters for a non-empty draft label", () => {
     expect(getContactAddressLabelValidationError("Ethér")).toBe(
-      INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+      INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
     );
     expect(isValidContactAddressLabel("Ethér")).toBe(false);
   });
@@ -82,15 +86,15 @@ describe("contact address label validation", () => {
   it("reports a duplicate within the existing labels", () => {
     const existingLabels = [ContactAddressLabelSchema.parse("Ethereum")];
 
-    expect(getContactAddressLabelValidationError(" ethereum ", existingLabels)).toBe(
-      DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-    );
+    expect(
+      getContactAddressLabelValidationError(" ethereum ", existingLabels)
+    ).toBe(DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME);
     expect(isValidContactAddressLabel("ETHEREUM", existingLabels)).toBe(false);
   });
 
   it("normalizes ASCII labels for comparison", () => {
     expect(normalizeContactAddressLabelForComparison(" Ethereum ")).toBe(
-      normalizeContactAddressLabelForComparison("ETHEREUM"),
+      normalizeContactAddressLabelForComparison("ETHEREUM")
     );
   });
 
@@ -101,12 +105,14 @@ describe("contact address label validation", () => {
   it("throws the matching domain error for invalid and duplicate labels", () => {
     const existingLabels = [ContactAddressLabelSchema.parse("Ethereum")];
 
-    expect(() => parseContactAddressLabel("Ethereum 💎")).toThrow(InvalidContactAddressLabelError);
+    expect(() => parseContactAddressLabel("Ethereum 💎")).toThrow(
+      InvalidContactAddressLabelError
+    );
     expect(() => parseContactAddressLabel("ethereum", existingLabels)).toThrow(
-      DuplicateContactAddressLabelError,
+      DuplicateContactAddressLabelError
     );
     expect(() => parseContactAddressLabel("Ethereum ".repeat(50))).toThrow(
-      ContactAddressLabelTooLongError,
+      ContactAddressLabelTooLongError
     );
   });
 });

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -1,14 +1,8 @@
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   ContactAddressLabelTooLongError,
   DuplicateContactAddressLabelError,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
-  type ContactAddressLabelValidationErrorName,
-  type ContactNameValidationErrorName,
 } from "./errors";
 import {
   CONTACT_ADDRESS_LABEL_MAX_LENGTH,
@@ -17,8 +11,27 @@ import {
 } from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
+export type ContactNameValidationErrorName = InvalidContactNameError["name"];
+
+export const INVALID_CONTACT_NAME_ERROR_NAME =
+  "InvalidContactNameError" satisfies ContactNameValidationErrorName;
+
+export type ContactAddressLabelValidationErrorName =
+  | InvalidContactAddressLabelError["name"]
+  | DuplicateContactAddressLabelError["name"]
+  | ContactAddressLabelTooLongError["name"];
+
+export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "InvalidContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+
+export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "DuplicateContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+
+export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME =
+  "ContactAddressLabelTooLongError" satisfies ContactAddressLabelValidationErrorName;
+
 export function getContactNameValidationError(
-  draftName: string,
+  draftName: string
 ): ContactNameValidationErrorName | null {
   const trimmedDraftName = draftName.trim();
 
@@ -32,10 +45,19 @@ export function getContactNameValidationError(
 }
 
 export function isValidContactName(draftName: string): boolean {
-  return draftName.trim().length > 0 && getContactNameValidationError(draftName) === null;
+  return (
+    draftName.trim().length > 0 &&
+    getContactNameValidationError(draftName) === null
+  );
 }
 
 export function parseContactName(draftName: string): ContactName {
+  if (
+    getContactNameValidationError(draftName) === INVALID_CONTACT_NAME_ERROR_NAME
+  ) {
+    throw new InvalidContactNameError();
+  }
+
   const parsed = ContactNameSchema.safeParse(draftName.trim());
 
   if (!parsed.success) {
@@ -45,13 +67,15 @@ export function parseContactName(draftName: string): ContactName {
   return parsed.data;
 }
 
-export function normalizeContactAddressLabelForComparison(label: string): string {
+export function normalizeContactAddressLabelForComparison(
+  label: string
+): string {
   return label.trim().normalize("NFC").toLocaleLowerCase("en-US");
 }
 
 export function getContactAddressLabelValidationError(
   draftLabel: string,
-  existingLabels: readonly ContactAddressLabel[] = [],
+  existingLabels: readonly ContactAddressLabel[] = []
 ): ContactAddressLabelValidationErrorName | null {
   const trimmedDraftLabel = draftLabel.trim();
 
@@ -62,12 +86,17 @@ export function getContactAddressLabelValidationError(
   const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
 
   if (!parsed.success) {
-    return trimmedDraftLabel.length === 0 ? null : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+    return trimmedDraftLabel.length === 0
+      ? null
+      : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
   }
 
-  const comparisonLabel = normalizeContactAddressLabelForComparison(parsed.data);
+  const comparisonLabel = normalizeContactAddressLabelForComparison(
+    parsed.data
+  );
   return existingLabels.some(
-    label => normalizeContactAddressLabelForComparison(label) === comparisonLabel,
+    (label) =>
+      normalizeContactAddressLabelForComparison(label) === comparisonLabel
   )
     ? DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
     : null;
@@ -75,7 +104,7 @@ export function getContactAddressLabelValidationError(
 
 export function isValidContactAddressLabel(
   draftLabel: string,
-  existingLabels: readonly ContactAddressLabel[] = [],
+  existingLabels: readonly ContactAddressLabel[] = []
 ): boolean {
   return (
     draftLabel.trim().length > 0 &&
@@ -85,22 +114,29 @@ export function isValidContactAddressLabel(
 
 export function parseContactAddressLabel(
   draftLabel: string,
-  existingLabels: readonly ContactAddressLabel[] = [],
+  existingLabels: readonly ContactAddressLabel[] = []
 ): ContactAddressLabel {
-  const trimmedDraftLabel = draftLabel.trim();
+  const validationError = getContactAddressLabelValidationError(
+    draftLabel,
+    existingLabels
+  );
 
-  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
+  if (validationError === CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME) {
     throw new ContactAddressLabelTooLongError();
   }
 
-  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
-
-  if (!parsed.success) {
+  if (validationError === INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME) {
     throw new InvalidContactAddressLabelError();
   }
 
-  if (getContactAddressLabelValidationError(parsed.data, existingLabels) !== null) {
+  if (validationError === DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME) {
     throw new DuplicateContactAddressLabelError();
+  }
+
+  const parsed = ContactAddressLabelSchema.safeParse(draftLabel.trim());
+
+  if (!parsed.success) {
+    throw new InvalidContactAddressLabelError();
   }
 
   return ContactAddressLabelSchema.parse(parsed.data.normalize("NFC"));


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
      - Contact name and address-label validation contracts
      - Validation-error mapping in Contacts flows

### 📝 Description

This foundation refactor resolves the inconsistency between error classes and exported error-name constants in the Contacts domain.

It keeps `errors.ts` limited to native error classes with stable names, moves validation codes to `validation.ts`, and preserves existing root exports. Field validation continues to return serializable codes, while parsing throws the exact corresponding domain error.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35360

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35066]: https://ledgerhq.atlassian.net/browse/LIVE-35066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ