### PR TITLE
docs(e2e): add test_filter usage guide and link from READMEs

### DIFF
--- a/e2e/desktop/README.md
+++ b/e2e/desktop/README.md
@@ -82,6 +82,9 @@ pnpm e2e:desktop test:playwright <testFileName>
 For detailed setup, debugging, and contribution guidelines, see:
 [Ledger Wallet Desktop E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLD:E2ETesting)
 
+To run only selected specs when dispatching an E2E workflow, see
+[Using `test_filter` in the E2E workflows](../tooling/filter/test-filter-guide.md).
+
 ### 6. Custom feature flags with E2E_FEATURE_FLAGS_JSON override
 
 You can inject extra feature flags globally for Desktop E2E by setting `E2E_FEATURE_FLAGS_JSON`.

--- a/e2e/mobile/README.md
+++ b/e2e/mobile/README.md
@@ -100,6 +100,9 @@ pnpm test:android <testFileName>         # single file
 For complete setup, debugging, workflow, writing tests, and CI integration, see the official wiki:
 [Ledger Wallet Mobile E2E Wiki](https://github.com/LedgerHQ/ledger-live/wiki/LLM:End-to-end-testing)
 
+To run only selected specs when dispatching an E2E workflow, see
+[Using `test_filter` in the E2E workflows](../tooling/filter/test-filter-guide.md).
+
 ### 7. Custom feature flags with E2E_FEATURE_FLAGS_JSON
 
 You can inject extra feature flags globally for Mobile E2E by setting `E2E_FEATURE_FLAGS_JSON`.

--- a/e2e/tooling/filter/README.md
+++ b/e2e/tooling/filter/README.md
@@ -4,6 +4,9 @@ CI-time helpers (Node CLIs, run from the **repo root** by the E2E GitHub workflo
 that build and present the Playwright/Detox test filter. These are **not** imported by
 the test runtime (specs, page objects, fixtures) — they run inside GitHub Actions only.
 
+> Just want to filter a workflow run? See the user guide:
+> [`test-filter-guide.md`](./test-filter-guide.md). This README covers the internals.
+
 | File                 | Role                                                                                                                                                                                                                                                                                                                                                       |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `escaping.mjs`       | Single source of truth for the filter grammar: splits patterns on separators (`\|` / `,`) that are not backslash-escaped and is odd-backslash aware, defines the Playwright leaf anchor `(?! [^@])`, and unescapes regex-literal characters (`unescapeLiteral`) for display.                                                                               |

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -1,0 +1,48 @@
+# Using `test_filter` in the E2E workflows
+
+How to run **only the E2E specs you care about** when you dispatch an E2E workflow,
+instead of the whole suite. Applies to both apps:
+
+- **Mobile** — `[Mobile] - E2E Only - Scheduled/Manual` (`test-mobile-e2e-reusable.yml`)
+- **Desktop** — `test-ui-e2e-only-desktop.yml`
+
+> ⚠️ Leaving `test_filter` **empty runs every spec on every selected platform**. That is
+> slow, runner-heavy, and (with broadcast on) contends for shared on-chain accounts.
+> Filter down to what you need, and use `tests_type` to pick a single platform when you can.
+
+## The `test_filter` input
+
+Free-text field on the workflow dispatch form. Provide one or more patterns separated by
+`,` or `|` (escape a literal separator with a backslash):
+
+```text
+@smoke
+@bitcoin,@family-evm
+@generic-coin-framework,@solana
+addAccount deeplinks
+```
+
+### What a pattern matches
+
+| App                 | Matching (via `--runner`)                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| **Mobile** (detox)  | Whole **spec files** by path substring or a declared `@`-tag. It does **not** match individual test titles or file content — a TMS id or a `describe`/`it` title selects nothing. |
+| **Desktop** (playwright) | Test **titles** via `--grep` (a regex over the resolved patterns).                    |
+
+### Special tokens
+
+- `@generic-coin-framework` / `@generic-family` expands to all **enabled** generic-coin-framework
+  families (from `genericCoinFrameworkFamilies.json`).
+- `@smoke` is added automatically when you enable the **Smoke tests** toggle.
+
+## Verify your filter did what you meant
+
+1. Open the run's **Summary** → **Workflow Context** → **Resolved filtered pattern**.
+2. If a pattern matches nothing, the run emits a warning annotation, e.g.
+   `E2E filter has no matches` or `Missing E2E tag`. A filter that resolves to 0 specs
+   means **no tests run** — fix the pattern and re-dispatch.
+
+## See also
+
+- Filter grammar, escaping, and internals: [`README.md`](./README.md)
+

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -47,7 +47,8 @@ addAccount,deeplinks
 1. Open the run's **Summary** → **Workflow Context** → **Resolved filtered pattern**.
 2. If a pattern matches nothing, the run emits a warning annotation, e.g.
    `E2E filter has no matches` or `Missing E2E tag`. A filter that resolves to 0 specs
-   means **no tests run** — fix the pattern and re-dispatch.
+   is wasted — on **Mobile** the test jobs are skipped, on **Desktop** the run **fails**
+   ("No tests executed"). Fix the pattern and re-dispatch.
 
 ## See also
 

--- a/e2e/tooling/filter/test-filter-guide.md
+++ b/e2e/tooling/filter/test-filter-guide.md
@@ -12,15 +12,22 @@ instead of the whole suite. Applies to both apps:
 
 ## The `test_filter` input
 
-Free-text field on the workflow dispatch form. Provide one or more patterns separated by
-`,` or `|` (escape a literal separator with a backslash):
+Free-text field on the workflow dispatch form. Separate multiple patterns with `,` or `|`
+— a spec runs if it matches **any** of them (OR). Prefer simple tags (`@solana`) or a
+path/filename substring:
 
 ```text
 @smoke
 @bitcoin,@family-evm
 @generic-coin-framework,@solana
-addAccount deeplinks
+addAccount,deeplinks
 ```
+
+> **Separators and escaping differ per runner — keep patterns simple.** `,` and `|` work
+> on both runners. On **mobile**, whitespace *also* separates patterns (a space starts
+> another OR alternative) and backslash-escaping is **not** applied. On **desktop**, the
+> patterns become a `--grep` **regex**, so spaces and regex metacharacters are significant.
+> Avoid spaces inside a single pattern, and don't rely on escaping separators.
 
 ### What a pattern matches
 


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Docs-only change to non-published `e2e/` files — no package version impact, so no changeset._
- [ ] **Covered by automatic tests.** _Documentation only._
- [x] **Impact of the changes:**
  - No runtime/code impact. Adds a user-facing guide and three doc links.

### 📝 Description

Adds a canonical, user-facing guide explaining how to use the `test_filter` input when dispatching the E2E workflows (mobile `test-mobile-e2e-reusable.yml` and desktop `test-ui-e2e-only-desktop.yml`), so people run only the specs they need instead of the whole suite.

**Problem**: There was no user-facing doc for `test_filter`. The existing `e2e/tooling/filter/README.md` documents the internals/grammar only, and no guidance was surfaced from the app READMEs.

**Solution**:

- New `e2e/tooling/filter/test-filter-guide.md` — one canonical guide covering the empty-filter warning, pattern grammar (`,` / `|`), special tokens (`@generic-coin-framework`, `@smoke`), the mobile (detox, whole spec files by path/`@`-tag) vs desktop (playwright, test titles) matching difference, and how to verify via the run Summary.
- Linked it from `e2e/desktop/README.md`, `e2e/mobile/README.md`, and the internals `e2e/tooling/filter/README.md` (avoids duplicating the same content across two `docs/` folders, per the repo's canonicalization docs rules).

Depends on behavior introduced by #20160 (now merged into `develop`), which is why this is a separate follow-up PR.

### ❓ Context

- **JIRA or GitHub link**: N/A — documentation follow-up to #20160

