### PR TITLE
fix(e2e): move detox session and artifacts to config root (QAA-1454)

### DIFF
--- a/e2e/mobile/detox.config.d.ts
+++ b/e2e/mobile/detox.config.d.ts
@@ -1,6 +1,10 @@
 // Detoxconfig
 declare let detoxConfig: {
+  extends: string;
   testRunner: Record<string, unknown>;
+  logger: Record<string, unknown>;
+  session: Record<string, unknown>;
+  artifacts: Record<string, unknown>;
   behavior: Record<string, unknown>;
   apps: {
     [key: string]: {

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -26,6 +26,7 @@ const getAndroidTestBinary = type =>
 
 /** @type {Detox.DetoxConfig} */
 module.exports = {
+  extends: "detox-allure2-adapter/preset-detox",
   testRunner: {
     $0: "jest",
     args: {
@@ -42,6 +43,19 @@ module.exports = {
   logger: {
     level: process.env.DEBUG_DETOX ? "trace" : "info",
   },
+  session: {
+    debugSynchronization: 10000,
+  },
+  artifacts: {
+    rootDir: "artifacts",
+    plugins: {
+      log: "failing",
+      screenshot: "failing",
+      video: "none",
+      instruments: "none",
+      uiHierarchy: "disabled",
+    },
+  },
   behavior: {
     // NOTE: https://github.com/wix/Detox/blob/master/docs/APIRef.Configuration.md#behavior-configuration
     init: {
@@ -52,10 +66,6 @@ module.exports = {
     cleanup: {
       shutdownDevice: false,
     },
-    session: {
-      debugSynchronization: 60000,
-    },
-    extends: "detox-allure2-adapter/preset-detox",
   },
   apps: {
     "ios.debug": {
@@ -97,6 +107,8 @@ module.exports = {
       testBinaryPath: getAndroidTestBinary("detoxPreRelease"),
     },
   },
+  // Workers past the first resolve `${configuration.device}${JEST_WORKER_ID}` (jest.environment.ts),
+  // so the numbered aliases have no static reference and their count caps E2E_WORKER_COUNT.
   devices: {
     simulator: {
       type: "ios.simulator",

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -107,8 +107,8 @@ module.exports = {
       testBinaryPath: getAndroidTestBinary("detoxPreRelease"),
     },
   },
-  // Workers past the first resolve `${configuration.device}${JEST_WORKER_ID}` (jest.environment.ts),
-  // so the numbered aliases have no static reference and their count caps E2E_WORKER_COUNT.
+  // jest.environment.ts resolves `${configuration.device}${JEST_WORKER_ID}` for every extra Jest
+  // worker and throws if the alias is absent; they must cover jest.config.js maxWorkers (3 on CI).
   devices: {
     simulator: {
       type: "ios.simulator",

--- a/e2e/mobile/scripts/print-detox-config.mjs
+++ b/e2e/mobile/scripts/print-detox-config.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Prints the config Detox actually resolves, so config changes can be verified without a device.
+//
+//   node scripts/print-detox-config.mjs [configuration] [...extra detox CLI args]
+//   node scripts/print-detox-config.mjs android.emu.release --record-logs failing
+//
+// Pass the CLI flags CI uses to confirm a config change keeps CI parity.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { composeDetoxConfig } = require("detox/src/configuration");
+
+const [configuration = "ios.sim.debug", ...rest] = process.argv.slice(2);
+
+const argv = { configuration };
+for (let i = 0; i < rest.length; i++) {
+  const flag = rest[i];
+  if (!flag.startsWith("--")) continue;
+  const next = rest[i + 1];
+  const hasValue = next !== undefined && !next.startsWith("--");
+  argv[flag.slice(2)] = hasValue ? next : true;
+  if (hasValue) i++;
+}
+
+const config = await composeDetoxConfig({ argv });
+
+console.log(
+  JSON.stringify(
+    {
+      configuration,
+      device: config.device,
+      retries: config.testRunner.retries,
+      logger: { level: config.logger.level },
+      session: { debugSynchronization: config.session.debugSynchronization },
+      artifacts: config.artifacts,
+    },
+    null,
+    2,
+  ),
+);

--- a/e2e/mobile/scripts/print-detox-config.mjs
+++ b/e2e/mobile/scripts/print-detox-config.mjs
@@ -12,13 +12,25 @@ const { composeDetoxConfig } = require("detox/src/configuration");
 
 const [configuration = "ios.sim.debug", ...rest] = process.argv.slice(2);
 
+// Detox parses its CLI with yargs, so scalars have to be coerced to match the config it resolves.
+const coerce = value => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return /^-?\d+$/.test(value) ? Number(value) : value;
+};
+
 const argv = { configuration };
 for (let i = 0; i < rest.length; i++) {
-  const flag = rest[i];
-  if (!flag.startsWith("--")) continue;
+  const arg = rest[i];
+  if (!arg.startsWith("--")) continue;
+  const eq = arg.indexOf("=");
+  if (eq !== -1) {
+    argv[arg.slice(2, eq)] = coerce(arg.slice(eq + 1));
+    continue;
+  }
   const next = rest[i + 1];
   const hasValue = next !== undefined && !next.startsWith("--");
-  argv[flag.slice(2)] = hasValue ? next : true;
+  argv[arg.slice(2)] = hasValue ? coerce(next) : true;
   if (hasValue) i++;
 }
 


### PR DESCRIPTION
Part 1 of [QAA-1442](https://ledgerhq.atlassian.net/browse/QAA-1442) — [QAA-1454](https://ledgerhq.atlassian.net/browse/QAA-1454).

First PR of a stack. Config-only; no test or helper behaviour changes.

## Problem

`detox.config.js` nested `session` and `extends` **inside `behavior`**, where Detox never reads them — both are only resolved at the config root. Two consequences:

1. `detox-allure2-adapter/preset-detox` provides the repo's `artifacts` block, and it was silently inert. Locally that meant `log: none` and no automatic failure screenshot, so **a local failure produced no device log** — one reason a failure that reproduces locally is hard to diagnose while CI (which sets `--record-logs failing --take-screenshots failing` on the CLI) looks fine.
2. `debugSynchronization: 60000` never applied; the effective value was Detox's 10 s seed.

## Changes

- Move `extends` and `session` to the config root.
- Set `debugSynchronization: 10000` explicitly. This is what was *already* in force, and it is the value we want: the setting only controls how long Detox waits before printing `The app is busy with: <resources>`, and that breakdown is the most useful clue when a wait never resolves. Moving `60000` up verbatim would have made debugging worse.
- Add a root `artifacts` block that **narrows** the now-live preset. The preset enables `uiHierarchy` for every test; `jest.environment.ts` already captures a hierarchy and a screenshot on failure, so we keep it disabled.
- Declare the root keys in `detox.config.d.ts` — that file is why the misplaced keys type-checked.
- Add `scripts/print-detox-config.mjs` so config changes can be verified without a device.
- Comment on `devices` recording that the numbered aliases are **not** dead config: `jest.environment.ts` resolves `${configuration.device}${JEST_WORKER_ID}` for every worker past the first, so their count caps `E2E_WORKER_COUNT`. (I nearly deleted them — a grep cannot see that reference.)

## Verification

`scripts/print-detox-config.mjs` resolves the real config; `--config-path` points it at the pre-change file for a before/after diff.

**CI is unchanged.** With CI's flags (`--record-logs failing --take-screenshots failing --retries 2`), old and new resolve **identically** on both `ios.sim.release` and `android.emu.release`. No new artifact is captured, so no CI time is added.

**Local gains the missing evidence.** `ios.sim.debug`, no CLI flags:

```diff
 "log": {
-  "enabled": false,
-  "keepOnlyFailedTestsArtifacts": false
+  "enabled": true,
+  "keepOnlyFailedTestsArtifacts": true
 },
 "screenshot": {
-  "shouldTakeAutomaticSnapshots": false,
-  "keepOnlyFailedTestsArtifacts": false
+  "shouldTakeAutomaticSnapshots": true,
+  "keepOnlyFailedTestsArtifacts": true
 }
```

`uiHierarchy` stays disabled in both, which is the point of the narrowing.

Also run: `pnpm typecheck` ✅, `pnpm format:check` ✅, `pnpm lint` → 0 errors on the changed files (the 32 warnings on `develop` are pre-existing and in untouched files).

## CI validation

Mobile E2E dispatched on this branch, scoped to `@smoke` (10 specs, incl. `verifyAddress/receiveFlow`, `verifyAddressETH`, `deeplinks`, `addAccountBTC`) on **both** platforms with Speculos nanoX — enough to prove the harness still runs and that artifact capture behaves, without paying for the full suite on a config-only change.

| Workflow | Scope | Run |
|---|---|---|
| Mobile E2E | `@smoke`, iOS & Android, nanoX | [run 30826486653](https://github.com/LedgerHQ/ledger-live/actions/runs/30826486653) |

No changeset: `ledger-live-mobile-e2e-tests` is a private package and Danger does not require one for it.

## Stack

1. **this PR** — config says what it does
2. `QAA-1455` — make local == CI (`.skip.spec.ts`, ABI/GPU/headless knobs, retries knob, `e2e-ci.mjs` cleanup)
3. `QAA-1456` — surface "passed on retry" in CI
4. `QAA-1457` — scroll engine on Detox's native bounded search
5. `QAA-1460` — `revealById` + testID seams
6. `QAA-1458` — delete the workarounds
7. `QAA-1459` — authoring rules + lint guardrails

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1442]: https://ledgerhq.atlassian.net/browse/QAA-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1454]: https://ledgerhq.atlassian.net/browse/QAA-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ