### PR TITLE
[LWDM] fix(coin-evm): reserve L1 data-fee headroom for send-max and fix OP-s…

### DIFF
--- a/.changeset/fix-evm-send-max-l2-data-fee.md
+++ b/.changeset/fix-evm-send-max-l2-data-fee.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Fix EVM send-max on L2s (Scroll, Blast, Base) failing at broadcast with `InsufficientFunds`
+
+The send-max amount is `balance - fees`, but the L2 → L1 data fee (`additionalFees`) was reserved with no headroom, unlike L2 execution gas which already carries ~2x headroom via `maxFeePerGas`. Because the L1 data fee tracks the volatile Ethereum L1 base fee, any upward drift between fee estimation and broadcast (device signing takes seconds) made the transaction overspend and the node rejected it.
+
+- Reserve a 2x headroom on the L1 data fee for send-max only (normal sends keep an exact fee display).
+- Query the OP-stack L1 gas oracle for Blast and Base on the Ledger node — they were falling through to a `0` L1 fee and being under-reserved.
+- Point the external RPC node at the canonical OP-stack `GasPriceOracle` predeploy (`0x420000000000000000000000000000000000000F`) so the L1-fee lookup succeeds on all OP-stack chains.

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.test.ts
@@ -421,6 +421,39 @@ describe("estimateFees", () => {
     });
   });
 
+  it("buffers the L2 additional fees for send-max to absorb L1 base-fee drift before broadcast", async () => {
+    nodeApiMock.getGasEstimation.mockResolvedValue(new BigNumber("21000"));
+    nodeApiMock.getTransactionCount.mockResolvedValue(42);
+    nodeApiMock.getFeeData.mockResolvedValue({
+      gasPrice: new BigNumber("20000000000"),
+      maxFeePerGas: null,
+      maxPriorityFeePerGas: null,
+      nextBaseFee: null,
+    });
+    mockGetGasTracker.mockReturnValue(null);
+    nodeApiMock.getOptimismAdditionalFees.mockResolvedValue(new BigNumber(8000));
+
+    const result = await estimateFees(
+      {
+        ...mockCurrency,
+        id: CryptoCurrencyIdSchema.parse("optimism"),
+        ethereumLikeInfo: { chainId: 10 },
+      },
+      {
+        intentType: "transaction",
+        type: "send-legacy",
+        amount: BigInt("1000000000000000000"),
+        asset: { type: "native" },
+        recipient: "0x7b2C7232f9E38F30E2868f0E5Bf311Cd83554b5A",
+        sender: "0xsender",
+        data: { type: "buffer", value: Buffer.from([]) },
+        useAllAmount: true,
+      },
+    );
+    // 8000 (raw L1 fee) x SEND_MAX_L1_FEE_BUFFER (2) = 16000
+    expect(result.parameters?.additionalFees).toBe(16000n);
+  });
+
   it("gives 0 additional fees if the transaction is not serializable", async () => {
     nodeApiMock.getGasEstimation.mockResolvedValue(new BigNumber("21000"));
     nodeApiMock.getTransactionCount.mockResolvedValue(42);

--- a/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-evm/src/logic/estimateFees.ts
@@ -17,6 +17,8 @@ import { STAKING_CONTRACTS } from "../staking";
 import { getTransactionType, prepareUnsignedTxParams } from "./common";
 import { getNextSequence } from "./getNextSequence";
 
+const SEND_MAX_L1_FEE_BUFFER = new BigNumber(2);
+
 async function computeAdditionalFees(
   currency: CryptoCurrency,
   unsignedTransaction: TransactionLike,
@@ -213,7 +215,11 @@ export async function estimateFees(
     value,
     chainId,
   };
-  const additionalFees = await computeAdditionalFees(currency, unsignedTransaction);
+  const rawAdditionalFees = await computeAdditionalFees(currency, unsignedTransaction);
+  const additionalFees =
+    transactionIntent.useAllAmount && rawAdditionalFees
+      ? rawAdditionalFees.multipliedBy(SEND_MAX_L1_FEE_BUFFER).integerValue(BigNumber.ROUND_CEIL)
+      : rawAdditionalFees;
 
   // delegate send-max: expose reserve/scale so the bridge can compute the amount (it has the balance)
   const stakingConfig = STAKING_CONTRACTS[currency.id];

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.test.ts
@@ -618,6 +618,47 @@ describe("EVM Family", () => {
           ),
         ).toEqual(new BigNumber("100000000"));
       });
+
+      it.each(["blast", "blast_sepolia", "base", "base_sepolia"])(
+        "should query the OP-stack gas oracle for %s (not return 0)",
+        async currencyId => {
+          const api = createLedgerNodeApi(ledgerConfig);
+          jest.spyOn(axios, "request").mockImplementationOnce(async () => ({
+            data: [
+              {
+                info: {
+                  contract: "0x420000000000000000000000000000000000000F",
+                  data: "0xSerializedTransaction",
+                  blockNumber: 123,
+                },
+                response: "100000000",
+              },
+            ],
+          }));
+
+          const transaction = Transaction.from({
+            to: "0x6cBCD73CD8e8a42844662f0A0e76D7F79Afd933d",
+            value: 1n,
+            gasLimit: 2n,
+            chainId: 1,
+            nonce: 0,
+            gasPrice: 3n,
+            type: 0,
+            signature: {
+              r: "0xffffffffffffffffffffffffffffffffffffffff",
+              s: "0xffffffffffffffffffffffffffffffffffffffff",
+              v: 27,
+            },
+          });
+
+          expect(
+            await api.getOptimismAdditionalFees(
+              { ...currency, id: CryptoCurrencyIdSchema.parse(currencyId) },
+              transaction.serialized,
+            ),
+          ).toEqual(new BigNumber("100000000"));
+        },
+      );
     });
 
     describe("getScrollAdditionalFees", () => {

--- a/libs/coin-modules/coin-evm/src/network/node/ledger.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/ledger.ts
@@ -280,7 +280,11 @@ async function getOptimismAdditionalFees(
   currency: CryptoCurrency,
   transaction: string,
 ): Promise<BigNumber> {
-  if (!["optimism", "optimism_sepolia"].includes(currency.id)) {
+  if (
+    !["optimism", "optimism_sepolia", "blast", "blast_sepolia", "base", "base_sepolia"].includes(
+      currency.id,
+    )
+  ) {
     return new BigNumber(0);
   }
   if (!transaction) {

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -812,9 +812,9 @@ async function getOptimismAdditionalFees(
   }
 
   const optimismGasOracle = new ethers.Contract(
-    // contract address provided here
-    // @see https://community.optimism.io/docs/developers/build/transaction-fees/#displaying-fees-to-users
-    "0x4f1db3c6AbD250ba86E0928471A8F7DB3AFd88F1",
+    // Canonical OP-stack GasPriceOracle predeploy, present on all OP-stack chains
+    // (Optimism, Base, Blast). @see https://docs.optimism.io/stack/transactions/fees
+    "0x420000000000000000000000000000000000000F",
     OptimismGasPriceOracleAbi,
     api,
   );


### PR DESCRIPTION
…tack L1 fee lookup

<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Fixes EVM **send-max** failing at broadcast with `InsufficientFunds` on L2s (Scroll, Blast, Base).

The send-max amount is computed as `balance - fees`. The L2 → L1 data fee (`additionalFees`) was reserved with **no headroom**, unlike L2 execution gas which already carries ~2× headroom via `maxFeePerGas`. Since the L1 data fee tracks the volatile Ethereum L1 base fee, any upward drift between fee estimation and broadcast (the seconds spent signing on the device) pushed the real fee above what was reserved, so the transaction overspent and the node rejected it.

Two separate defects made it worse on some chains:
- **Blast / Base** returned a **0** L1 fee on the Ledger node (missing from the OP-stack allowlist), so nothing was reserved for the L1 cost at all.
- The **external RPC node** called a non-predeploy contract address for the OP-stack gas oracle, so the L1-fee lookup could fail there too.

## 🔧 What changed

- `coin-evm/logic/estimateFees.ts`: reserve a **2× headroom** on the L1 data fee **for send-max only** (`SEND_MAX_L1_FEE_BUFFER`). Normal sends are unaffected and keep an exact fee display.
- `coin-evm/network/node/ledger.ts`: add `blast`, `blast_sepolia`, `base`, `base_sepolia` to `getOptimismAdditionalFees`.
- `coin-evm/network/node/rpc.common.ts`: use the canonical OP-stack `GasPriceOracle` predeploy `0x420000000000000000000000000000000000000F`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35296](https://ledgerhq.atlassian.net/browse/LIVE-35296)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35296]: https://ledgerhq.atlassian.net/browse/LIVE-35296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ