### PR TITLE
feat(live-signer-zcash): Ironwood PCZT v2 LW signer bridge (LIVE-32888)

### DIFF
--- a/.changeset/live-signer-zcash-ironwood-types.md
+++ b/.changeset/live-signer-zcash-ironwood-types.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-signer-zcash": minor
+---
+
+Add Ironwood PCZT v2 type re-exports to the live-signer-zcash bridge

--- a/libs/live-signer-zcash/src/DmkSignerZcash.ts
+++ b/libs/live-signer-zcash/src/DmkSignerZcash.ts
@@ -263,13 +263,14 @@ export class DmkSignerZcash implements ZcashSigner {
   }
 
   /**
-   * Sign an Orchard PCZT via the DMK signer.
+   * Sign a PCZT via the DMK signer (Orchard V5 and Ironwood V6).
    *
    * Delegates to the DMK `signPcztTransaction` device action, which streams the
    * PCZT bundle to the device and collects all spend-authorization signatures
    * atomically. Returns `SignPcztTransactionResult` containing per-action Orchard
-   * signatures and per-input transparent signatures — callers must not reorder
-   * them before passing to `finalizeTransaction`.
+   * signatures (`orchard`), per-action Ironwood signatures (`ironwood`), and
+   * per-input transparent signatures (`transparentInputSigs`) — callers must not
+   * reorder any of these arrays before passing to `finalizeTransaction`.
    *
    * `skipOpenApp: true` is consistent with the other signer methods; the caller
    * (signOperation orchestration) is responsible for ensuring the Zcash app is open.

--- a/libs/live-signer-zcash/src/types.ts
+++ b/libs/live-signer-zcash/src/types.ts
@@ -4,12 +4,22 @@
  * the device action consumes/produces — no local mirror to keep in sync.
  */
 import type {
+  IronwoodActionSignature,
   OrchardActionSignature,
+  PcztIronwoodAction,
+  PcztIronwoodBundle,
   PcztTransaction,
   SignPcztTransactionResult,
 } from "@ledgerhq/device-signer-kit-zcash";
 
-export type { OrchardActionSignature, PcztTransaction, SignPcztTransactionResult };
+export type {
+  IronwoodActionSignature,
+  OrchardActionSignature,
+  PcztIronwoodAction,
+  PcztIronwoodBundle,
+  PcztTransaction,
+  SignPcztTransactionResult,
+};
 
 export type ZcashAppConfig = {
   version: string;

--- a/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
+++ b/libs/live-signer-zcash/tests/DmkSignerZcash.test.ts
@@ -536,6 +536,7 @@ describe("DmkSignerZcash", () => {
   describe("signPcztTransaction", () => {
     const orchardSig = new Uint8Array(64).fill(0xab);
     const transparentSig = new Uint8Array(72).fill(0xcd);
+    const ironwoodSig = new Uint8Array(64).fill(0xef);
 
     // Minimal valid-shaped PCZT — the mock doesn't inspect fields
     const minimalPczt: PcztTransaction = {
@@ -553,8 +554,50 @@ describe("DmkSignerZcash", () => {
       orchardBundle: null,
     };
 
+    const minimalV6Pczt: PcztTransaction = {
+      global: {
+        txVersion: 6,
+        versionGroupId: 0xd884b698, // V6_VERSION_GROUP_ID (ZIP-229 / NU6.3)
+        consensusBranchId: 0x37a5165b, // BranchId::Nu6_3 (Ironwood)
+        fallbackLockTime: null,
+        expiryHeight: 0,
+        coinType: 133,
+        txModifiable: 0,
+      },
+      transparentInputs: [],
+      transparentOutputs: [],
+      orchardBundle: null,
+      ironwoodBundle: {
+        actions: [
+          {
+            cvNet: new Uint8Array(32).fill(0x10),
+            nullifier: new Uint8Array(32).fill(0x11),
+            rk: new Uint8Array(32).fill(0x12),
+            spendRecipient: new Uint8Array(43).fill(0x13),
+            spendValue: 1000n,
+            spendRho: new Uint8Array(32).fill(0x14),
+            spendRseed: new Uint8Array(32).fill(0x15),
+            alpha: new Uint8Array(32).fill(0x16),
+            signingPath: "32'/133'/0'",
+            cmx: new Uint8Array(32).fill(0x17),
+            ephemeralKey: new Uint8Array(32).fill(0x18),
+            encCiphertext: new Uint8Array(580).fill(0x19),
+            outCiphertext: new Uint8Array(80).fill(0x1a),
+            recipient: new Uint8Array(43).fill(0x1b),
+            value: 900n,
+            rseed: new Uint8Array(32).fill(0x1c),
+            rcv: new Uint8Array(32).fill(0x1d),
+            notePlaintextVersion: 3,
+          },
+        ],
+        flags: 2,
+        valueBalance: 0n,
+        anchor: new Uint8Array(32).fill(0x1e),
+      },
+    };
+
     it("returns orchard spendAuthSigs and empty transparentInputSigs for a pure-Orchard transaction", async () => {
-      const result = { orchard: [{ spendAuthSig: orchardSig }], transparentInputSigs: [] };
+      const result = { orchard: [{ spendAuthSig: orchardSig }], transparentInputSigs: [], ironwood: [] };
       mockSignerZcash.signPcztTransaction.mockReturnValue({
         observable: createCompletedObservable(result),
       });
@@ -570,6 +613,7 @@ describe("DmkSignerZcash", () => {
       const result = {
         orchard: sigs.map(spendAuthSig => ({ spendAuthSig })),
         transparentInputSigs: [],
+        ironwood: [],
       };
       mockSignerZcash.signPcztTransaction.mockReturnValue({
         observable: createCompletedObservable(result),
@@ -587,6 +631,7 @@ describe("DmkSignerZcash", () => {
       const result = {
         orchard: [{ spendAuthSig: orchardSig }],
         transparentInputSigs: [transparentSig],
+        ironwood: [],
       };
       mockSignerZcash.signPcztTransaction.mockReturnValue({
         observable: createCompletedObservable(result),
@@ -638,6 +683,51 @@ describe("DmkSignerZcash", () => {
       await expect(signer.signPcztTransaction(minimalPczt)).rejects.toThrow(
         "Unexpected device action status: stopped",
       );
+    });
+
+    it("returns ironwood spendAuthSigs for a V6 transaction with an Ironwood bundle", async () => {
+      const result = { orchard: [], transparentInputSigs: [], ironwood: [{ spendAuthSig: ironwoodSig }] };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      const out = await signer.signPcztTransaction(minimalV6Pczt);
+
+      expect(out.ironwood).toHaveLength(1);
+      expect(out.ironwood[0].spendAuthSig).toBe(ironwoodSig);
+      expect(mockSignerZcash.signPcztTransaction).toHaveBeenCalledWith(minimalV6Pczt, {
+        skipOpenApp: true,
+      });
+    });
+
+    it("preserves ironwood sig order for multiple Ironwood actions", async () => {
+      const ironwoodSigs = [0x01, 0x02, 0x03].map(b => new Uint8Array(64).fill(b));
+      const result = {
+        orchard: [],
+        transparentInputSigs: [],
+        ironwood: ironwoodSigs.map(spendAuthSig => ({ spendAuthSig })),
+      };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      const out = await signer.signPcztTransaction(minimalV6Pczt);
+
+      expect(out.ironwood).toHaveLength(3);
+      out.ironwood.forEach((sig, i) => {
+        expect(sig.spendAuthSig[0]).toBe(i + 1);
+      });
+    });
+
+    it("returns an empty ironwood array when the V6 transaction has no Ironwood actions signed", async () => {
+      const result = { orchard: [], transparentInputSigs: [], ironwood: [] };
+      mockSignerZcash.signPcztTransaction.mockReturnValue({
+        observable: createCompletedObservable(result),
+      });
+
+      const out = await signer.signPcztTransaction(minimalV6Pczt);
+
+      expect(out.ironwood).toEqual([]);
     });
   });
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Bumps `@ledgerhq/device-signer-kit-zcash` to `0.5.0` and exposes the Ironwood PCZT v2 types through the `@ledgerhq/live-signer-zcash` public surface.

**What changed**

- `package.json` — dependency bumped from `0.4.3` to `0.5.0`.
- `src/types.ts` — three new types re-exported alongside the existing Orchard ones:
  - `IronwoodActionSignature` — the per-action RedPallas spend-authorization signature returned by the device for V6 transactions.
  - `PcztIronwoodAction` — the per-action input shape for the Ironwood bundle (mirrors `PcztOrchardAction` with an added `notePlaintextVersion` field).
  - `PcztIronwoodBundle` — the Ironwood bundle wrapper (`actions`, `flags`, `valueBalance`, `anchor`).
- `tests/DmkSignerZcash.test.ts` — three new test cases covering the V6 Ironwood path (`signPcztTransaction` with an Ironwood bundle, multi-action ordering, empty result).

**Why no logic change in `DmkSignerZcash.ts`**

`signPcztTransaction` already delegates transparently to the DMK signer and returns whatever `SignPcztTransactionResult` the signer produces. The signer-kit `0.5.0` extends that result with `ironwood: IronwoodActionSignature[]`; the bridge forwards it unchanged. The only observable difference for callers is that `PcztTransaction.ironwoodBundle` is now accepted and `SignPcztTransactionResult.ironwood` is now populated.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32888](https://ledgerhq.atlassian.net/browse/LIVE-32888)



[LIVE-32888]: https://ledgerhq.atlassian.net/browse/LIVE-32888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ