### PR TITLE
chore(e2e): align local and CI detox execution (QAA-1455)

### DIFF
--- a/e2e/mobile/detox.config.d.ts
+++ b/e2e/mobile/detox.config.d.ts
@@ -1,6 +1,9 @@
 // Detoxconfig
 declare let detoxConfig: {
   testRunner: Record<string, unknown>;
+  logger: Record<string, unknown>;
+  session: Record<string, unknown>;
+  artifacts: Record<string, unknown>;
   behavior: Record<string, unknown>;
   apps: {
     [key: string]: {

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -29,7 +29,7 @@ const getAndroidBinary = type =>
 const getAndroidTestBinary = type =>
   path.join(androidDir, `app/build/outputs/apk/androidTest/${type}/app-${type}-androidTest.apk`);
 
-const DEFAULT_RETRIES = 1;
+const DEFAULT_RETRIES = 0;
 // Detox requires a finite number, so anything unparseable falls back to the default. 0 is valid.
 const parseRetries = value => {
   const raw = (value ?? "").trim();

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -1,8 +1,12 @@
+const os = require("os");
 const path = require("path");
 const iosArch = "arm64";
 // Host-keyed so an inherited CI variable cannot select the wrong ABI. Override: E2E_ANDROID_ABI.
-const isAppleSilicon = process.platform === "darwin" && process.arch === "arm64";
-const androidArch = process.env.E2E_ANDROID_ABI || (isAppleSilicon ? "arm64-v8a" : "x86_64");
+// process.arch is "x64" under Rosetta; os.cpus() still reports the host's "Apple ..." brand string.
+const isAppleSiliconHost =
+  process.platform === "darwin" &&
+  (process.arch === "arm64" || (os.cpus()[0]?.model ?? "").startsWith("Apple"));
+const androidArch = process.env.E2E_ANDROID_ABI || (isAppleSiliconHost ? "arm64-v8a" : "x86_64");
 const gpuMode = process.env.CI ? "swiftshader_indirect" : "host";
 const SCHEME = "ledgerlivemobile";
 
@@ -25,6 +29,14 @@ const getAndroidBinary = type =>
 const getAndroidTestBinary = type =>
   path.join(androidDir, `app/build/outputs/apk/androidTest/${type}/app-${type}-androidTest.apk`);
 
+const DEFAULT_RETRIES = 1;
+// Detox requires a finite number, so anything unparseable falls back to the default. 0 is valid.
+const parseRetries = value => {
+  const raw = (value ?? "").trim();
+  const parsed = Number(raw);
+  return raw && Number.isInteger(parsed) && parsed >= 0 ? parsed : DEFAULT_RETRIES;
+};
+
 /** @type {Detox.DetoxConfig} */
 module.exports = {
   testRunner: {
@@ -38,7 +50,7 @@ module.exports = {
     },
     noRetryArgs: ["json", "outputFile"],
     // Local default. CI passes --retries on the CLI, which takes precedence.
-    retries: Number(process.env.E2E_RETRIES || 1),
+    retries: parseRetries(process.env.E2E_RETRIES),
     forwardEnv: true, // Used to forward DETOX_CONFIGURATION to Jest workers
   },
   logger: {

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -1,7 +1,8 @@
 const path = require("path");
 const iosArch = "arm64";
-// NOTE: Pass CI=1 if you want to build locally when you don't have a mac M1. This works better if you do export CI=1 for the whole session.
-const androidArch = process.env.CI ? "x86_64" : "arm64-v8a";
+// Host-keyed so an inherited CI variable cannot select the wrong ABI. Override: E2E_ANDROID_ABI.
+const isAppleSilicon = process.platform === "darwin" && process.arch === "arm64";
+const androidArch = process.env.E2E_ANDROID_ABI || (isAppleSilicon ? "arm64-v8a" : "x86_64");
 const gpuMode = process.env.CI ? "swiftshader_indirect" : "host";
 const SCHEME = "ledgerlivemobile";
 
@@ -36,7 +37,8 @@ module.exports = {
       teardownTimeout: 120000,
     },
     noRetryArgs: ["json", "outputFile"],
-    retries: 0,
+    // Local default. CI passes --retries on the CLI, which takes precedence.
+    retries: Number(process.env.E2E_RETRIES || 1),
     forwardEnv: true, // Used to forward DETOX_CONFIGURATION to Jest workers
   },
   logger: {

--- a/e2e/mobile/detox.config.js
+++ b/e2e/mobile/detox.config.js
@@ -56,6 +56,26 @@ module.exports = {
   logger: {
     level: process.env.DEBUG_DETOX ? "trace" : "info",
   },
+  session: {
+    // Only governs how long Detox waits before printing "The app is busy with: <resources>", which
+    // is the most useful clue when a wait never resolves. 10s is what was in force while this key
+    // sat under `behavior`, where Detox does not read it.
+    debugSynchronization: 10000,
+  },
+  // Specified in full rather than inherited from detox-allure2-adapter/preset-detox: `pnpm mobile
+  // e2e:build` installs only the app's dependencies, and that preset belongs to this package, so
+  // extending it fails the Detox build. It only ever contributed these same five plugins.
+  artifacts: {
+    rootDir: "artifacts",
+    plugins: {
+      log: "failing",
+      screenshot: "failing",
+      video: "none",
+      instruments: "none",
+      // jest.environment.ts already captures a hierarchy on failure; the preset captured one per test.
+      uiHierarchy: "disabled",
+    },
+  },
   behavior: {
     // NOTE: https://github.com/wix/Detox/blob/master/docs/APIRef.Configuration.md#behavior-configuration
     init: {
@@ -66,10 +86,6 @@ module.exports = {
     cleanup: {
       shutdownDevice: false,
     },
-    session: {
-      debugSynchronization: 60000,
-    },
-    extends: "detox-allure2-adapter/preset-detox",
   },
   apps: {
     "ios.debug": {
@@ -111,6 +127,8 @@ module.exports = {
       testBinaryPath: getAndroidTestBinary("detoxPreRelease"),
     },
   },
+  // jest.environment.ts resolves `${configuration.device}${JEST_WORKER_ID}` for every extra Jest
+  // worker and throws if the alias is absent; they must cover jest.config.js maxWorkers (3 on CI).
   devices: {
     simulator: {
       type: "ios.simulator",

--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -110,6 +110,8 @@ const config = {
 
   setupFilesAfterEnv: ["<rootDir>/setup.ts"],
   testMatch: ["<rootDir>/specs/**/*.spec.ts"],
+  // CI shards exclude `.skip.spec.ts` (apps/ledger-live-mobile/scripts/shard-tests.mjs).
+  testPathIgnorePatterns: ["\\.skip\\.spec\\.ts$"],
   testTimeout: 300_000,
   reporters: [
     "detox/runners/jest/reporter",

--- a/e2e/mobile/scripts/print-detox-config.mjs
+++ b/e2e/mobile/scripts/print-detox-config.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Prints the config Detox actually resolves, so config changes can be verified without a device.
+//
+//   node scripts/print-detox-config.mjs [configuration] [...extra detox CLI args]
+//   node scripts/print-detox-config.mjs android.emu.release --record-logs failing
+//
+// Pass the CLI flags CI uses to confirm a config change keeps CI parity.
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { composeDetoxConfig } = require("detox/src/configuration");
+
+const [configuration = "ios.sim.debug", ...rest] = process.argv.slice(2);
+
+// Detox parses its CLI with yargs, so scalars have to be coerced to match the config it resolves.
+const coerce = value => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return /^-?\d+$/.test(value) ? Number(value) : value;
+};
+
+const argv = { configuration };
+for (let i = 0; i < rest.length; i++) {
+  const arg = rest[i];
+  if (!arg.startsWith("--")) continue;
+  const eq = arg.indexOf("=");
+  if (eq !== -1) {
+    argv[arg.slice(2, eq)] = coerce(arg.slice(eq + 1));
+    continue;
+  }
+  const next = rest[i + 1];
+  const hasValue = next !== undefined && !next.startsWith("--");
+  argv[arg.slice(2)] = hasValue ? coerce(next) : true;
+  if (hasValue) i++;
+}
+
+const config = await composeDetoxConfig({ argv });
+
+console.log(
+  JSON.stringify(
+    {
+      configuration,
+      device: config.device,
+      retries: config.testRunner.retries,
+      logger: { level: config.logger.level },
+      session: { debugSynchronization: config.session.debugSynchronization },
+      artifacts: config.artifacts,
+    },
+    null,
+    2,
+  ),
+);

--- a/e2e/mobile/setup.ts
+++ b/e2e/mobile/setup.ts
@@ -5,43 +5,40 @@ import { sanitizeError } from "@ledgerhq/live-e2e-shared/index";
 import { close as closeBridge } from "./bridge/server";
 import { setAllureDescription } from "./helpers/allure/allure-helper";
 
+const LAUNCH_TIMEOUT = 150_000;
+const TEARDOWN_TIMEOUT = 60_000;
+
 const broadcastOriginalValue = getEnv("DISABLE_TRANSACTION_BROADCAST");
 setupEnvironment();
 
-beforeAll(
-  async () => {
-    const port = await launchApp({ newInstance: true });
-    await device.reverseTcpPort(8081);
-    await device.reverseTcpPort(port);
-    await device.reverseTcpPort(52619); // To allow the android emulator to access the dummy app
-    setAllureDescription();
-  },
-  process.env.CI ? 150_000 : 120_000,
-);
+beforeAll(async () => {
+  const port = await launchApp({ newInstance: true });
+  await device.reverseTcpPort(8081);
+  await device.reverseTcpPort(port);
+  await device.reverseTcpPort(52619); // To allow the android emulator to access the dummy app
+  setAllureDescription();
+}, LAUNCH_TIMEOUT);
 
-afterAll(
-  async () => {
-    setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
+afterAll(async () => {
+  setEnv("DISABLE_TRANSACTION_BROADCAST", broadcastOriginalValue);
 
-    if (process.env.CI) {
-      try {
-        await device.terminateApp();
-      } catch (e) {
-        log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);
-      }
-    }
-
+  if (process.env.CI) {
     try {
-      await app.common.removeSpeculos();
+      await device.terminateApp();
     } catch (e) {
-      log.warn(`setup afterAll removeSpeculos failed: ${sanitizeError(e)}`);
+      log.warn(`setup afterAll terminateApp failed: ${sanitizeError(e)}`);
     }
+  }
 
-    try {
-      closeBridge();
-    } catch (e) {
-      log.warn(`setup afterAll closeBridge failed: ${sanitizeError(e)}`);
-    }
-  },
-  process.env.CI ? 60_000 : 30_000,
-);
+  try {
+    await app.common.removeSpeculos();
+  } catch (e) {
+    log.warn(`setup afterAll removeSpeculos failed: ${sanitizeError(e)}`);
+  }
+
+  try {
+    closeBridge();
+  } catch (e) {
+    log.warn(`setup afterAll closeBridge failed: ${sanitizeError(e)}`);
+  }
+}, TEARDOWN_TIMEOUT);


### PR DESCRIPTION
Part 2 of [QAA-1442](https://ledgerhq.atlassian.net/browse/QAA-1442) — [QAA-1455](https://ledgerhq.atlassian.net/browse/QAA-1455), and it now also re-lands [QAA-1454](https://ledgerhq.atlassian.net/browse/QAA-1454).

**No longer stacked** — base is `develop`. #20353 (Part 1) was merged and then reverted by #20465 because it broke `Android Build Native`, so its fix is folded in here with the offending line removed. Scope is `e2e/mobile/**` only — 5 files.

## Problem

Local and CI are different harnesses, so a green CI run does not mean a green local run.

## Changes

| Change | Why |
|---|---|
| `jest.config.js` → `testPathIgnorePatterns: ["\\.skip\\.spec\\.ts$"]` | Locally jest collected **230** specs; CI shards collect 228 (`shard-tests.mjs:36` excludes `.skip.spec.ts`). Local was running two specs CI never runs. |
| `detox.config.js` → Android ABI keyed on the **host** instead of ambient `CI`, overridable with `E2E_ANDROID_ABI` | `process.env.CI ? "x86_64" : "arm64-v8a"` meant an inherited `CI` variable silently produced an x86_64 APK on an Apple Silicon machine — the footgun `e2e-mobile-onboard/SKILL.md:207` warns about. Keyed on `darwin && arm64`, so the iOS macOS/ARM64 runner is unaffected (it never builds Android). |
| `detox.config.js` → `retries: parseRetries(process.env.E2E_RETRIES)`, default **0** | Same value `develop` already has, so **local behaviour is unchanged** — it is now a named, overridable knob instead of a literal. **CI stays at 3 attempts**: its `--retries 2` comes from the dispatcher CLI, which overrides config. |
| `setup.ts` → single `LAUNCH_TIMEOUT` / `TEARDOWN_TIMEOUT` (150s / 60s) | Removes two more `process.env.CI ?` branches. Only raises the local values, so it cannot turn a passing test red. |
| `detox.config.js` → `session` and `artifacts` moved to the **config root** (QAA-1454) | Detox reads neither key under `behavior`. `session.debugSynchronization` was written as `60000` and silently ignored; it is now stated as the value actually in force, `10000` — which is what produces the `The app is busy with: <resources>` line, the most useful clue when a wait never resolves. |
| `detox.config.d.ts` → declare `logger` / `session` / `artifacts` | The missing declarations are the reason the misplaced keys typechecked. |
| `scripts/print-detox-config.mjs` (new) | Prints the config Detox actually resolves, so config changes are verifiable with no device. |

### What changed versus the reverted #20353

That PR also moved `extends: "detox-allure2-adapter/preset-detox"` to the root. **That line is gone here.** Under `behavior` it was inert; at the root it became load-bearing, and `pnpm mobile e2e:build` runs a *filtered* install that excludes `e2e/mobile`'s devDependencies — so the preset is not resolvable at build time and `Android Build Native` failed with `Failed to find the base Detox config specified in: "extends"`. The root `artifacts` block is therefore specified in full. The preset only ever contributed the same five plugins, so nothing is lost.

## Verification

**A test actually passing locally**, on `ios.sim.debug`:

```
DISABLE_TRANSACTION_BROADCAST=1 pnpm e2e:mobile test:ios:debug specs/settings/passwordUnlock.spec.ts

PASS  specs/settings/passwordUnlock.spec.ts (83.874 s)
Tests: 1 passed, 1 total
```

No retry on the passing run, which is correct — Detox only re-runs failures. Retries are off locally by default, so a local failure fails once and stops.

**The config resolves as intended** (`node scripts/print-detox-config.mjs <configuration> [flags]`):

| Context | `retries` | `debugSynchronization` | artifacts |
|---|---|---|---|
| local `ios.sim.debug`, no flags | **0** (1 attempt) | **10000** | log + screenshot enabled, failed-only; video / instruments / **uiHierarchy** off |
| CI `android.emu.release` with `--record-logs failing --take-screenshots failing --retries 2` | **2** (3 attempts) | **10000** | identical to the above, plus `swiftshader_indirect` + headless |
| `E2E_RETRIES=2` locally | **2** | — | — |
| `E2E_RETRIES=<garbage>` | **0** (falls back) | — | — |

The artifact values are exactly what CI computes today from its CLI flags, so this is a no-op for CI output. `uiHierarchy` stays **disabled** on purpose: the raw allure preset enables it, which would dump a view hierarchy on every test, and `jest.environment.ts` already captures one on failure.

**Spec collection:** 230 → 228, and the two excluded files are exactly the `.skip.spec.ts` pair.

Also run on the changed files: oxlint 0 warnings / 0 errors, `format:check` ✅.

## CI validation

| Workflow | Scope | Run |
|---|---|---|
| Mobile E2E | iOS & Android, Speculos nanoX | [run 31016459729](https://github.com/LedgerHQ/ledger-live/actions/runs/31016459729) |
| Mobile E2E (earlier revision) | `@smoke` (10 specs), iOS & Android, nanoX | [run 30831146061](https://github.com/LedgerHQ/ledger-live/actions/runs/30831146061) |

These are harness-configuration changes, so the run needs to prove execution, artifact capture and retry behaviour are intact — and, this time, that `Android Build Native` succeeds without the `extends` key.

## Deliberately out of scope

An earlier revision of this PR also cleaned up `apps/ledger-live-mobile/scripts/e2e-ci.mjs` (deduplicating the artifact flags now owned by config, and removing a dead `mock` default plus an unreachable `--shard` block). That file is outside `e2e/` and has been reverted to `develop` byte-for-byte — the cleanup can be proposed separately on its own merits.

[QAA-1442]: https://ledgerhq.atlassian.net/browse/QAA-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1454]: https://ledgerhq.atlassian.net/browse/QAA-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1455]: https://ledgerhq.atlassian.net/browse/QAA-1455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

