### PR TITLE
[LWDM] feat(coin-tron): implement getAccountInfo (LIVE-32774)

### DIFF
--- a/.changeset/LIVE-32774-tron-getaccountinfo.md
+++ b/.changeset/LIVE-32774-tron-getaccountinfo.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Implement `getAccountInfo` in coin-tron (ADR-045). It polls `wallet/getaccountresource` and returns the Tron account metadata `{ type: "tron", energyLimit, energy, bandwidth }`, where `energy` and `bandwidth` are the available amounts (limit − used) and `energyLimit` is the total energy limit.

--- a/libs/coin-modules/coin-tron/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.integ.test.ts
@@ -77,6 +77,26 @@ describe("API", () => {
     });
   });
 
+  it("getAccountInfo returns tron account resources", async () => {
+    const info = await module.getAccountInfo!("TPswDDCAWhJAZGdHPidFg5nEf8TkNToDX1");
+
+    expect(info).toMatchObject({
+      type: "tron",
+      energyLimit: expect.any(Number),
+      energy: expect.any(Number),
+      bandwidth: expect.any(Number),
+    });
+    // available amounts and the limit are never negative
+    const { energyLimit, energy, bandwidth } = info as {
+      energyLimit: number;
+      energy: number;
+      bandwidth: number;
+    };
+    expect(energyLimit).toBeGreaterThanOrEqual(0);
+    expect(energy).toBeGreaterThanOrEqual(0);
+    expect(bandwidth).toBeGreaterThanOrEqual(0);
+  });
+
   it("getBlockInfo returns valid block info", async () => {
     const lastBlockInfo = await module.lastBlock();
     const blockHeight = lastBlockInfo.height - 10;

--- a/libs/coin-modules/coin-tron/src/api/index.test.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.test.ts
@@ -10,6 +10,7 @@ import {
   combine,
   craftTransaction,
   estimateFees,
+  getAccountInfo,
   getBalance,
   lastBlock,
   listOperations,
@@ -24,6 +25,7 @@ jest.mock("../logic", () => ({
   combine: jest.fn(),
   craftTransaction: jest.fn(),
   estimateFees: jest.fn(),
+  getAccountInfo: jest.fn(),
   getBalance: jest.fn(),
   listOperations: jest.fn().mockResolvedValue({ items: [], next: undefined }),
   lastBlock: jest.fn(),
@@ -78,6 +80,7 @@ describe("createApi", () => {
     await api.craftTransaction(intent);
     await api.estimateFees(intent);
     await api.getBalance("address");
+    await api.getAccountInfo!("address");
     await api.lastBlock();
     const minHeight = 14;
     await api.listOperations("address", { minHeight, order: "asc" });
@@ -88,6 +91,7 @@ describe("createApi", () => {
     expect(estimateFees).toHaveBeenCalledWith(intent);
     expect(craftTransaction).toHaveBeenCalledWith(intent);
     expect(getBalance).toHaveBeenCalledWith("address");
+    expect(getAccountInfo).toHaveBeenCalledWith("address");
     expect(lastBlock).toHaveBeenCalled();
     expect(listOperations).toHaveBeenCalledWith("address", {
       limit: 200,

--- a/libs/coin-modules/coin-tron/src/api/index.ts
+++ b/libs/coin-modules/coin-tron/src/api/index.ts
@@ -20,6 +20,7 @@ import {
   combine,
   craftTransaction,
   estimateFees,
+  getAccountInfo,
   getBalance,
   getBlock,
   getBlockInfo,
@@ -53,6 +54,7 @@ export function createApi(config: TronConfig): CoinModuleApi<TronMemo> {
       throw new Error("craftRawTransaction is not supported");
     },
     estimateFees: estimate,
+    getAccountInfo,
     getBalance: (address: string, options?: BalanceOptions) =>
       rejectBalanceOptions(() => getBalance(address), options),
     lastBlock,

--- a/libs/coin-modules/coin-tron/src/logic/getAccountInfo.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getAccountInfo.test.ts
@@ -1,0 +1,93 @@
+import BigNumber from "bignumber.js";
+import { getTronAccountNetwork } from "../network";
+import type { NetworkInfo } from "../types";
+import { getAccountInfo, TronAccountInfo } from "./getAccountInfo";
+
+jest.mock("../network", () => ({
+  getTronAccountNetwork: jest.fn(),
+}));
+
+const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
+
+const buildNetworkInfo = (overrides: Partial<NetworkInfo> = {}): NetworkInfo => ({
+  family: "tron",
+  freeNetUsed: new BigNumber(0),
+  freeNetLimit: new BigNumber(0),
+  netUsed: new BigNumber(0),
+  netLimit: new BigNumber(0),
+  energyUsed: new BigNumber(0),
+  energyLimit: new BigNumber(0),
+  ...overrides,
+});
+
+describe("getAccountInfo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("polls wallet/getaccountresource for the given address", async () => {
+    mockGetTronAccountNetwork.mockResolvedValueOnce(buildNetworkInfo());
+
+    await getAccountInfo("TXYZ");
+
+    expect(mockGetTronAccountNetwork).toHaveBeenCalledWith("TXYZ");
+  });
+
+  it("returns available energy/bandwidth and the raw energy limit", async () => {
+    mockGetTronAccountNetwork.mockResolvedValueOnce(
+      buildNetworkInfo({
+        energyLimit: new BigNumber(100_000),
+        energyUsed: new BigNumber(58_000),
+        freeNetLimit: new BigNumber(600),
+        freeNetUsed: new BigNumber(100),
+        netLimit: new BigNumber(5_400),
+        netUsed: new BigNumber(4_400),
+      }),
+    );
+
+    const info = (await getAccountInfo("TXYZ")) as TronAccountInfo;
+
+    expect(info).toEqual({
+      type: "tron",
+      energyLimit: 100_000,
+      energy: 42_000, // 100_000 - 58_000
+      bandwidth: 1_500, // (600 - 100) + (5_400 - 4_400)
+    });
+  });
+
+  it("clamps available amounts to zero when usage exceeds the limit", async () => {
+    mockGetTronAccountNetwork.mockResolvedValueOnce(
+      buildNetworkInfo({
+        energyLimit: new BigNumber(1_000),
+        energyUsed: new BigNumber(1_500),
+        freeNetLimit: new BigNumber(100),
+        freeNetUsed: new BigNumber(250),
+        netLimit: new BigNumber(300),
+        netUsed: new BigNumber(50),
+      }),
+    );
+
+    const info = (await getAccountInfo("TXYZ")) as TronAccountInfo;
+
+    // energy clamped to 0; bandwidth = max(0, 100-250) + max(0, 300-50) = 0 + 250
+    expect(info).toEqual({
+      type: "tron",
+      energyLimit: 1_000,
+      energy: 0,
+      bandwidth: 250,
+    });
+  });
+
+  it("returns zeroed metadata for an account with no resources", async () => {
+    mockGetTronAccountNetwork.mockResolvedValueOnce(buildNetworkInfo());
+
+    const info = (await getAccountInfo("TXYZ")) as TronAccountInfo;
+
+    expect(info).toEqual({
+      type: "tron",
+      energyLimit: 0,
+      energy: 0,
+      bandwidth: 0,
+    });
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/getAccountInfo.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getAccountInfo.ts
@@ -1,4 +1,4 @@
-import { AccountInfo } from "@ledgerhq/coin-module-framework/api/types";
+import type { AccountInfo } from "@ledgerhq/coin-module-framework/api/types";
 import BigNumber from "bignumber.js";
 import { getTronAccountNetwork } from "../network";
 

--- a/libs/coin-modules/coin-tron/src/logic/getAccountInfo.ts
+++ b/libs/coin-modules/coin-tron/src/logic/getAccountInfo.ts
@@ -1,0 +1,43 @@
+import { AccountInfo } from "@ledgerhq/coin-module-framework/api/types";
+import BigNumber from "bignumber.js";
+import { getTronAccountNetwork } from "../network";
+
+/**
+ * Tron-specific account metadata exposed through the generic `getAccountInfo`
+ * contract (ADR-045). The framework contract is the open `AccountInfo` type
+ * (`{ type: string } & Record<string, unknown>`); each family keeps its concrete
+ * shape internally, discriminated by `type`.
+ *
+ * - `energyLimit` — total energy limit (raw `EnergyLimit` from the node).
+ * - `energy` — *available* energy, i.e. `max(0, EnergyLimit - EnergyUsed)`.
+ * - `bandwidth` — *available* bandwidth: the free daily allowance plus the
+ *   staked (net) allowance, both net of what has already been used, mirroring
+ *   the availability convention used in `estimateFees`.
+ */
+export type TronAccountInfo = {
+  type: "tron";
+  energyLimit: number;
+  energy: number;
+  bandwidth: number;
+};
+
+export async function getAccountInfo(address: string): Promise<AccountInfo> {
+  const networkInfo = await getTronAccountNetwork(address);
+
+  const energy = BigNumber.maximum(0, networkInfo.energyLimit.minus(networkInfo.energyUsed));
+  const freeBandwidth = BigNumber.maximum(
+    0,
+    networkInfo.freeNetLimit.minus(networkInfo.freeNetUsed),
+  );
+  const stakedBandwidth = BigNumber.maximum(0, networkInfo.netLimit.minus(networkInfo.netUsed));
+  const bandwidth = freeBandwidth.plus(stakedBandwidth);
+
+  const accountInfo: TronAccountInfo = {
+    type: "tron",
+    energyLimit: networkInfo.energyLimit.toNumber(),
+    energy: energy.toNumber(),
+    bandwidth: bandwidth.toNumber(),
+  };
+
+  return accountInfo;
+}

--- a/libs/coin-modules/coin-tron/src/logic/index.ts
+++ b/libs/coin-modules/coin-tron/src/logic/index.ts
@@ -2,6 +2,7 @@ export * from "./broadcast";
 export * from "./combine";
 export * from "./craftTransaction";
 export * from "./estimateFees";
+export * from "./getAccountInfo";
 export * from "./getBalance";
 export * from "./getBlock";
 export * from "./listOperations";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: 0.4.3
       version: 0.4.3
     '@ledgerhq/coin-module-framework':
-      specifier: 4.0.2
-      version: 4.0.2
+      specifier: 4.3.0
+      version: 4.3.0
     '@ledgerhq/coin-stellar':
       specifier: 6.26.4
       version: 6.26.4
@@ -937,7 +937,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/coin-zcash':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-zcash
@@ -1677,7 +1677,7 @@ importers:
         version: link:../../libs/coin-modules/coin-filecoin
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-multiversx
@@ -2437,7 +2437,7 @@ importers:
         version: link:../../libs/coin-modules/coin-evm
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/coin-solana':
         specifier: workspace:^
         version: link:../../libs/coin-modules/coin-solana
@@ -2635,7 +2635,7 @@ importers:
         version: link:../../features/platform/style
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.23)(@ledgerhq/lumen-ui-react@0.1.49(@ledgerhq/lumen-design-core@0.1.23)(@radix-ui/react-checkbox@1.3.2(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-slot@1.2.4(@types/react@19.0.14)(react@19.1.4))(@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.0.0(@types/react@19.0.14))(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@tanstack/react-table@8.5.11(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(class-variance-authority@0.7.1)(clsx@2.1.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(tailwind-merge@3.4.0))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
@@ -5344,7 +5344,7 @@ importers:
     devDependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/disable-network-setup':
         specifier: workspace:^
         version: link:../disable-network-setup
@@ -5386,7 +5386,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -5459,7 +5459,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5538,7 +5538,7 @@ importers:
         version: 3.1.3(got@11.8.5)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -5626,7 +5626,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5774,7 +5774,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -5853,7 +5853,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -5935,7 +5935,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6014,7 +6014,7 @@ importers:
         version: link:../coin-evm
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -6117,7 +6117,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/concordium-core':
         specifier: workspace:^
         version: link:../../concordium-core
@@ -6214,7 +6214,7 @@ importers:
         version: 0.12.306
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6305,7 +6305,7 @@ importers:
         version: 5.7.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/evm-tools':
         specifier: workspace:^
         version: link:../../evm-tools
@@ -6393,7 +6393,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -6481,7 +6481,7 @@ importers:
         version: 2.78.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -6566,7 +6566,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6651,7 +6651,7 @@ importers:
         version: 2.14.0(@dfinity/agent@2.4.1(@dfinity/candid@2.4.1(@dfinity/principal@2.4.1))(@dfinity/principal@2.4.1))(@dfinity/candid@2.4.1(@dfinity/principal@2.4.1))(@dfinity/principal@2.4.1)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6724,7 +6724,7 @@ importers:
         version: 1.2.0
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -6830,7 +6830,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -6906,7 +6906,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -6976,7 +6976,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -7067,7 +7067,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7128,7 +7128,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7231,7 +7231,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -7334,7 +7334,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7428,7 +7428,7 @@ importers:
         version: 1.0.11(graphql@16.13.2)
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/hw-app-sui':
         specifier: workspace:^
         version: link:../../ledgerjs/packages/hw-app-sui
@@ -7516,7 +7516,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7586,7 +7586,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/ledger-wallet-framework':
         specifier: workspace:^
         version: link:../../ledger-wallet-framework
@@ -7662,7 +7662,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -7747,7 +7747,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -7829,7 +7829,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../../ledgerjs/packages/devices
@@ -8130,7 +8130,7 @@ importers:
         version: link:../../coin-modules/coin-cosmos
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/coin-tester':
         specifier: workspace:^
         version: link:../../coin-tester
@@ -8334,7 +8334,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0
       '@ledgerhq/coin-polkadot':
         specifier: workspace:^
         version: link:../../coin-modules/coin-polkadot
@@ -9517,7 +9517,7 @@ importers:
         version: link:../coin-modules/coin-mina
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/coin-multiversx':
         specifier: workspace:^
         version: link:../coin-modules/coin-multiversx
@@ -10142,7 +10142,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/devices':
         specifier: workspace:*
         version: link:../ledgerjs/packages/devices
@@ -13778,7 +13778,7 @@ importers:
     dependencies:
       '@ledgerhq/coin-module-framework':
         specifier: 'catalog:'
-        version: 4.0.2
+        version: 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/live-network':
         specifier: workspace:^
         version: link:../live-network
@@ -18782,6 +18782,11 @@ packages:
 
   '@ledgerhq/coin-module-framework@4.0.2':
     resolution: {integrity: sha512-uYbsVd6t5qzgSEyINEhfuruTO74wAEi+lpMvAPF67F9gWAsFC7109kxlG1AgRdIQmmW5cCMYaSMt69DrhN0BuQ==}
+
+  '@ledgerhq/coin-module-framework@4.3.0':
+    resolution: {integrity: sha512-ntj6HbhI6fV30sW7qDSyAVxE/U9Gy3QpGnkgMqsFLoZ469aJxIdA1gDyimv4MkvjXv3czmTpYtvs03BSXB7J+g==}
+    peerDependencies:
+      '@ledgerhq/live-network': ^3.0.0
 
   '@ledgerhq/coin-stellar@6.26.4':
     resolution: {integrity: sha512-KZgJHQ2TcK20ZXK+2qM06lS45bi44uk2dXJ69iXK6ZUVBEtWuMrxbvqVjrlrfuFZzZ/EN8bZ468LyRT00yqxQQ==}
@@ -46903,7 +46908,7 @@ snapshots:
 
   '@ledgerhq/coin-hypercore@0.4.3(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':
     dependencies:
-      '@ledgerhq/coin-module-framework': 4.0.2
+      '@ledgerhq/coin-module-framework': 4.3.0(@ledgerhq/live-network@libs+live-network)
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
       '@ledgerhq/live-network': link:libs/live-network
       '@ledgerhq/logs': link:libs/ledgerjs/packages/logs
@@ -46911,6 +46916,17 @@ snapshots:
   '@ledgerhq/coin-module-framework@4.0.2':
     dependencies:
       '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
+      bignumber.js: 9.1.2
+
+  '@ledgerhq/coin-module-framework@4.3.0':
+    dependencies:
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
+      bignumber.js: 9.1.2
+
+  '@ledgerhq/coin-module-framework@4.3.0(@ledgerhq/live-network@libs+live-network)':
+    dependencies:
+      '@ledgerhq/errors': link:libs/ledgerjs/packages/errors
+      '@ledgerhq/live-network': link:libs/live-network
       bignumber.js: 9.1.2
 
   '@ledgerhq/coin-stellar@6.26.4(@ledgerhq/live-network@libs+live-network)(@ledgerhq/logs@libs+ledgerjs+packages+logs)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -209,7 +209,7 @@ catalog:
   oxfmt: 0.36.0
   # Modules published by coin-modules
   "@ledgerhq/coin-hypercore": 0.4.3
-  "@ledgerhq/coin-module-framework": 4.0.2
+  "@ledgerhq/coin-module-framework": 4.3.0
   "@ledgerhq/coin-stellar": 6.26.4
   "@ledgerhq/coin-xrp": 7.25.2
   detox: 20.51.3


### PR DESCRIPTION
##  Checklist

- [x] Changeset added (`@ledgerhq/coin-tron` minor)
- [x] Unit tests added/updated
- [x] Integration test added

##  Description

Implements `getAccountInfo` for the coin-tron Alpaca module, per **ADR-045**.

JIRA: [LIVE-32774](https://ledgerhq.atlassian.net/browse/LIVE-32774)

### What it does

Adds the optional `getAccountInfo(address)` method to coin-tron's
`CoinModuleApi`. It polls `wallet/getaccountresource` (via the existing
`getTronAccountNetwork`) and returns Tron-specific account metadata:

```ts
{
  type: "tron",
  energyLimit, // total energy limit (raw EnergyLimit)
  energy,      // available energy: max(0, EnergyLimit - EnergyUsed)
  bandwidth,   // available bandwidth: free allowance + staked (net)
               // allowance, each net of usage and clamped at 0
}

energy and bandwidth are available amounts (limit − used), mirroring
the availability convention already used in estimateFees. The concrete
shape is returned through the framework's open AccountInfo contract
({ type: string } & Record<string, unknown>), discriminated by type.

[LIVE-32774]: https://ledgerhq.atlassian.net/browse/LIVE-32774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ