### PR TITLE
test(accounts): consolidate init tests for domain migration

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/accounts.test.ts
@@ -1,5 +1,6 @@
 import type { Account, AccountUserData } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import { initAccounts } from "./accounts";
 
 function fakeTuple(
@@ -14,7 +15,30 @@ function fakeTuple(
     derivationMode,
     name: `name-${id}`,
   } as unknown as Account;
-  const userData = { id, name: `custom-${id}` } as unknown as AccountUserData;
+  const userData = { id, name: `custom-${id}`, starredIds: [] } as unknown as AccountUserData;
+  return [account, userData];
+}
+
+/** An account the user starred but never renamed: its name is the default one. */
+function starredTupleWithDefaultName(
+  id: string,
+  currencyId: string,
+  index = 0,
+): [Account, AccountUserData] {
+  const currency = getCryptoCurrencyById(currencyId);
+  const account = {
+    id,
+    type: "Account",
+    currency,
+    derivationMode: "",
+    index,
+    name: `name-${id}`,
+  } as unknown as Account;
+  const userData = {
+    id,
+    name: getDefaultAccountName(account),
+    starredIds: [id],
+  } as unknown as AccountUserData;
   return [account, userData];
 }
 
@@ -44,5 +68,10 @@ describe("initAccounts", () => {
     ]);
 
     expect(action.payload.accounts.map(a => a.id)).toEqual(["btc-segwit"]);
+  });
+
+  it("does not leak default names into the account names payload", () => {
+    const action = initAccounts([starredTupleWithDefaultName("btc-default", "bitcoin")]);
+    expect(action.payload.accountsUserData.map(u => u.id)).toEqual([]);
   });
 });

--- a/apps/ledger-live-mobile/src/actions/accounts.test.ts
+++ b/apps/ledger-live-mobile/src/actions/accounts.test.ts
@@ -1,5 +1,6 @@
 import type { Account, AccountRaw, AccountUserData, DerivationMode } from "@ledgerhq/types-live";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { getDefaultAccountName } from "@ledgerhq/live-wallet/accountName";
 import accountModel from "../logic/accountModel";
 import { importStore } from "./accounts";
 
@@ -22,7 +23,29 @@ function fakeTuple(
     derivationMode: derivationMode as DerivationMode,
     name: `name-${id}`,
   } as unknown as Account;
-  const userData = { id, name: `custom-${id}` } as unknown as AccountUserData;
+  const userData = { id, name: `custom-${id}`, starredIds: [] } as unknown as AccountUserData;
+  return [account, userData];
+}
+
+/** An account the user starred but never renamed: its name is the default one. */
+function starredTupleWithDefaultName(
+  id: string,
+  currencyId: string,
+  index = 0,
+): [Account, AccountUserData] {
+  const account = {
+    id,
+    type: "Account",
+    currency: getCryptoCurrencyById(currencyId),
+    derivationMode: "" as DerivationMode,
+    index,
+    name: `name-${id}`,
+  } as unknown as Account;
+  const userData = {
+    id,
+    name: getDefaultAccountName(account),
+    starredIds: [id],
+  } as unknown as AccountUserData;
   return [account, userData];
 }
 
@@ -78,5 +101,12 @@ describe("importStore", () => {
     });
 
     expect(action.payload.accounts.map((a: Account) => a.id)).toEqual(["btc-segwit"]);
+  });
+
+  it("does not leak default names into the account names payload", async () => {
+    mockDecode.mockResolvedValueOnce(starredTupleWithDefaultName("btc-default", "bitcoin"));
+
+    const action = await importStore({ active: [{ data: { id: "btc-default" } as AccountRaw }] });
+    expect(action.payload.accountsUserData.map((u: AccountUserData) => u.id)).toEqual([]);
   });
 });


### PR DESCRIPTION
### 📝 Description

Test consolidation as part of the DDD/domain-entity migration — no behavior change.

Two improvements to the existing `initAccounts` (LLD) and `importStore` (LLM) test suites:

- `fakeTuple` now correctly sets `starredIds: []` on the `AccountUserData` shape
- Adds a `starredTupleWithDefaultName` helper for building fixtures where the user starred an account but kept its default name
- Adds one new case: **"does not leak default names into the account names payload"** — ensures accounts whose name equals the default are filtered from `accountsUserData` even when they have a `starredIds` entry

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34990](https://ledgerhq.atlassian.net/browse/LIVE-34990)

[LIVE-34990]: https://ledgerhq.atlassian.net/browse/LIVE-34990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ