### PR TITLE
fix(transport-panel): raise test timeout to fix flaky native tests

### DIFF
--- a/devtools/transport-panel/jest.config.js
+++ b/devtools/transport-panel/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
       },
     ],
   },
+  testTimeout: 30_000,
   moduleFileExtensions: ["web.tsx", "web.ts", "tsx", "ts", "js", "jsx", "json", "node"],
   testPathIgnorePatterns: ["\\.native\\.test\\."],
   modulePaths: ["<rootDir>"],

--- a/devtools/transport-panel/jest.native.config.js
+++ b/devtools/transport-panel/jest.native.config.js
@@ -29,6 +29,7 @@ module.exports = {
     "^@sbaiahmed1/react-native-blur$": "<rootDir>/jest/mocks/react-native-blur.tsx",
     "^react-native-worklets$": "<rootDir>/jest/mocks/react-native-worklets.js",
   },
+  testTimeout: 30_000,
   setupFilesAfterEnv: ["<rootDir>/jest/setup.native.ts"],
   coverageReporters: [
     "json",


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Raises `testTimeout` from the Jest default (5 s) to 15 s

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
