### PR TITLE
feat(e2e): add QAA Allure report buttons to slack notification

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -1201,6 +1201,8 @@ jobs:
     continue-on-error: true
     needs: [detox-tests-ios]
     timeout-minutes: 15
+    outputs:
+      report_url: ${{ steps.qaa-allure-upload.outputs.report_url }}
     steps:
       - name: Download Allure Results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1209,6 +1211,7 @@ jobs:
           pattern: ios-test-artifacts*
           merge-multiple: true
       - name: Upload to qaa-allure (sandbox)
+        id: qaa-allure-upload
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report-qaa@develop
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
@@ -1224,6 +1227,8 @@ jobs:
     continue-on-error: true
     needs: [detox-tests-android]
     timeout-minutes: 15
+    outputs:
+      report_url: ${{ steps.qaa-allure-upload.outputs.report_url }}
     steps:
       - name: Download Allure Results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1238,6 +1243,7 @@ jobs:
           path: report-attachments
           pattern: usage-metrics-android-*
       - name: Upload to qaa-allure (sandbox)
+        id: qaa-allure-upload
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report-qaa@develop
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
@@ -1318,7 +1324,7 @@ jobs:
   report-on-slack:
     name: "Test Mobile E2E > Slack Report"
     runs-on: ubuntu-22.04
-    needs: [determine-builds, allure-report-android, allure-report-ios]
+    needs: [determine-builds, allure-report-android, allure-report-ios, qaa-allure-upload-ios, qaa-allure-upload-android]
     if: ${{ !cancelled() && (needs.allure-report-ios.outputs.finalStatus || needs.allure-report-android.outputs.finalStatus) }}
     env:
       REF: ${{ inputs.ref || github.ref_name }}
@@ -1347,20 +1353,18 @@ jobs:
           row1_device: ${{ needs.determine-builds.outputs.ios_device }}
           row1_summary: ${{ needs.allure-report-ios.outputs.summary_message }}
           row1_report_url: ${{ needs.allure-report-ios.outputs.report-url }}
-          row1_report_title: "Allure Report iOS"
-          row1_report_link_text: "Allure Report iOS"
           row1_status: ${{ needs.allure-report-ios.outputs.finalStatus }}
           row1_missing_shards: ${{ needs.allure-report-ios.outputs.missingShards }}
+          row1_qaa_url: ${{ needs.qaa-allure-upload-ios.outputs.report_url }}
           row2_emoji: "🤖"
           row2_label: ${{ env.ANDROID_LABEL }}
           row2_flags: ${{ env.ANDROID_FEATURE_FLAGS }}
           row2_device: ${{ needs.determine-builds.outputs.android_device }}
           row2_summary: ${{ needs.allure-report-android.outputs.summary_message }}
           row2_report_url: ${{ needs.allure-report-android.outputs.report-url }}
-          row2_report_title: "Allure Report Android"
-          row2_report_link_text: "Allure Report Android"
           row2_status: ${{ needs.allure-report-android.outputs.finalStatus }}
           row2_missing_shards: ${{ needs.allure-report-android.outputs.missingShards }}
+          row2_qaa_url: ${{ needs.qaa-allure-upload-android.outputs.report_url }}
 
   merge-ios-timings:
     name: Merge iOS Timing Files

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -505,6 +505,8 @@ jobs:
     if: ${{ !cancelled() }}
     continue-on-error: true
     timeout-minutes: 15
+    outputs:
+      report_url: ${{ steps.qaa-allure-upload.outputs.report_url }}
     env:
       ALLURE_RESULTS: "allure-results"
     steps:
@@ -515,6 +517,7 @@ jobs:
           path: ${{ env.ALLURE_RESULTS }}
 
       - name: Upload to qaa-allure (sandbox)
+        id: qaa-allure-upload
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report-qaa@develop
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
@@ -530,6 +533,8 @@ jobs:
     if: ${{ !cancelled() && needs.prepare-devices.outputs.is_dual == 'true' }}
     continue-on-error: true
     timeout-minutes: 15
+    outputs:
+      report_url: ${{ steps.qaa-allure-upload.outputs.report_url }}
     env:
       ALLURE_RESULTS: "allure-results-device2"
     steps:
@@ -540,6 +545,7 @@ jobs:
           path: ${{ env.ALLURE_RESULTS }}
 
       - name: Upload to qaa-allure (sandbox)
+        id: qaa-allure-upload
         uses: LedgerHQ/ledger-live/tools/actions/composites/upload-allure-report-qaa@develop
         with:
           api_key: ${{ secrets.QAA_ALLURE_API_KEY }}
@@ -593,7 +599,7 @@ jobs:
   notify-to-slack:
     name: "Notify to Slack"
     runs-on: [ledger-live-medium]
-    needs: [prepare-devices, report-to-allure, report-to-allure-device2]
+    needs: [prepare-devices, report-to-allure, report-to-allure-device2, qaa-allure-upload, qaa-allure-upload-device2]
     if: ${{ always() && (inputs.slack_notif || github.event_name == 'schedule') }}
     env:
       IS_DUAL: ${{ needs.prepare-devices.outputs.is_dual }}
@@ -618,19 +624,16 @@ jobs:
           row1_flags: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}
           row1_summary: ${{ needs.report-to-allure.outputs.summary_message }}
           row1_report_url: ${{ needs.report-to-allure.outputs.report-url }}
-          row1_report_title: ${{ env.IS_DUAL == 'true' && format('Allure Report ({0})', env.DEVICE_1) || 'Allure Report' }}
-          row1_report_link_text: ${{ env.IS_DUAL == 'true' && format('allure-results-{0}', env.DEVICE_1) || 'allure-results-linux' }}
           row1_status: ${{ needs.report-to-allure.outputs.status }}
+          row1_qaa_url: ${{ needs.qaa-allure-upload.outputs.report_url }}
           # Row 2 only renders on dual-device runs (empty label = dropped).
           row2_emoji: "🐧"
           row2_label: ${{ env.IS_DUAL == 'true' && format('linux ({0})', env.DEVICE_2) || '' }}
           row2_flags: ${{ env.E2E_DESKTOP_FEATURE_FLAGS }}
           row2_summary: ${{ needs.report-to-allure-device2.outputs.summary_message }}
           row2_report_url: ${{ needs.report-to-allure-device2.outputs.report-url }}
-          row2_report_title: ${{ env.IS_DUAL == 'true' && format('Allure Report ({0})', env.DEVICE_2) || '' }}
-          row2_report_link_text: ${{ env.IS_DUAL == 'true' && format('allure-results-{0}', env.DEVICE_2) || '' }}
           row2_status: ${{ needs.report-to-allure-device2.outputs.status }}
+          row2_qaa_url: ${{ needs.qaa-allure-upload-device2.outputs.report_url }}
           # Xray link: single-device runs with export_to_xray only (matches previous behavior).
-          extra_field_title: ${{ (env.IS_DUAL != 'true' && inputs.export_to_xray) && 'Xray Link' || '' }}
+          extra_field_title: ${{ (env.IS_DUAL != 'true' && inputs.export_to_xray) && '🎫 Xray Link' || '' }}
           extra_field_url: "https://ledgerhq.atlassian.net/browse/${{ github.event.inputs.test_execution }}"
-          extra_field_link_text: "Test Execution"

--- a/tools/actions/composites/e2e-slack-report/action.yml
+++ b/tools/actions/composites/e2e-slack-report/action.yml
@@ -53,20 +53,16 @@ inputs:
   row1_report_url:
     required: false
     default: ""
-  row1_report_title:
-    description: 'Bold label of the Allure field, e.g. "Allure Report iOS".'
-    required: false
-    default: ""
-  row1_report_link_text:
-    description: "Link text of the Allure field."
-    required: false
-    default: ""
   row1_status:
     description: "'success' when the row passed; any other non-empty value counts as failed."
     required: false
     default: ""
   row1_missing_shards:
     description: "Comma-separated shard ids that produced no results (adds a warning block)."
+    required: false
+    default: ""
+  row1_qaa_url:
+    description: "QAA Allure portal report URL for row 1 (renders a green button). Empty = no button."
     required: false
     default: ""
 
@@ -89,16 +85,13 @@ inputs:
   row2_report_url:
     required: false
     default: ""
-  row2_report_title:
-    required: false
-    default: ""
-  row2_report_link_text:
-    required: false
-    default: ""
   row2_status:
     required: false
     default: ""
   row2_missing_shards:
+    required: false
+    default: ""
+  row2_qaa_url:
     required: false
     default: ""
 
@@ -107,9 +100,6 @@ inputs:
     required: false
     default: ""
   extra_field_url:
-    required: false
-    default: ""
-  extra_field_link_text:
     required: false
     default: ""
 
@@ -135,23 +125,20 @@ runs:
         ROW1_DEVICE: ${{ inputs.row1_device }}
         ROW1_SUMMARY: ${{ inputs.row1_summary }}
         ROW1_REPORT_URL: ${{ inputs.row1_report_url }}
-        ROW1_REPORT_TITLE: ${{ inputs.row1_report_title }}
-        ROW1_REPORT_LINK_TEXT: ${{ inputs.row1_report_link_text }}
         ROW1_STATUS: ${{ inputs.row1_status }}
         ROW1_MISSING_SHARDS: ${{ inputs.row1_missing_shards }}
+        ROW1_QAA_URL: ${{ inputs.row1_qaa_url }}
         ROW2_EMOJI: ${{ inputs.row2_emoji }}
         ROW2_LABEL: ${{ inputs.row2_label }}
         ROW2_FLAGS: ${{ inputs.row2_flags }}
         ROW2_DEVICE: ${{ inputs.row2_device }}
         ROW2_SUMMARY: ${{ inputs.row2_summary }}
         ROW2_REPORT_URL: ${{ inputs.row2_report_url }}
-        ROW2_REPORT_TITLE: ${{ inputs.row2_report_title }}
-        ROW2_REPORT_LINK_TEXT: ${{ inputs.row2_report_link_text }}
         ROW2_STATUS: ${{ inputs.row2_status }}
         ROW2_MISSING_SHARDS: ${{ inputs.row2_missing_shards }}
+        ROW2_QAA_URL: ${{ inputs.row2_qaa_url }}
         EXTRA_FIELD_TITLE: ${{ inputs.extra_field_title }}
         EXTRA_FIELD_URL: ${{ inputs.extra_field_url }}
-        EXTRA_FIELD_LINK_TEXT: ${{ inputs.extra_field_link_text }}
       with:
         script: |
           const path = require("path");

--- a/tools/actions/composites/e2e-slack-report/build-slack-payload.js
+++ b/tools/actions/composites/e2e-slack-report/build-slack-payload.js
@@ -36,10 +36,9 @@ function rowsFromEnv(env) {
       device: env[`ROW${i}_DEVICE`] || "",
       summary: env[`ROW${i}_SUMMARY`] || "No test results",
       reportUrl: env[`ROW${i}_REPORT_URL`] || "",
-      reportTitle: env[`ROW${i}_REPORT_TITLE`] || "Allure Report",
-      reportLinkText: env[`ROW${i}_REPORT_LINK_TEXT`] || "Allure Report",
       status: env[`ROW${i}_STATUS`] || "",
       missingShards: env[`ROW${i}_MISSING_SHARDS`] || "",
+      qaaUrl: env[`ROW${i}_QAA_URL`] || "",
     });
   }
   return rows;
@@ -52,11 +51,7 @@ function rowsFromEnv(env) {
 function modelFromEnv(env) {
   const smokeSuffix = env.SMOKE_TESTS === "true" ? " (Smoke Tests)" : "";
   const extraField = env.EXTRA_FIELD_TITLE
-    ? {
-        title: env.EXTRA_FIELD_TITLE,
-        url: env.EXTRA_FIELD_URL || "",
-        linkText: env.EXTRA_FIELD_LINK_TEXT || env.EXTRA_FIELD_TITLE,
-      }
+    ? { title: env.EXTRA_FIELD_TITLE, url: env.EXTRA_FIELD_URL || "" }
     : null;
   return {
     product: env.PRODUCT || "",
@@ -73,14 +68,6 @@ function modelFromEnv(env) {
 function resultLine(row) {
   const deviceMid = row.device ? ` · ${row.device}` : "";
   return `${row.emoji} ${row.label} · FF '${row.flags}'${deviceMid} : ${row.summary}`;
-}
-
-/** Allure link field, with a "No Allure Report" fallback when no URL is available. */
-function allureField(row) {
-  const text = row.reportUrl
-    ? `*${row.reportTitle}*\n<${row.reportUrl}|${row.reportLinkText}>`
-    : `*${row.reportTitle}*\nNo Allure Report`;
-  return { type: "mrkdwn", text };
 }
 
 /**
@@ -131,25 +118,39 @@ function buildSlackPayload(model) {
     });
   }
 
-  const infoFields = rows.map(allureField);
-  infoFields.push({
-    type: "mrkdwn",
-    text: `*Workflow*\n<${runUrl}|Workflow run>`,
-  });
   blocks.push({ type: "divider" });
-  blocks.push({ type: "section", fields: infoFields });
 
-  if (extraField) {
+  // Primary call to action: the new QAA Allure portal — one green button per row with a report.
+  const qaaRows = rows.filter(row => row.qaaUrl);
+  if (qaaRows.length > 0) {
     blocks.push({
       type: "section",
-      fields: [
-        {
-          type: "mrkdwn",
-          text: `*${extraField.title}*\n<${extraField.url}|${extraField.linkText}>`,
-        },
-      ],
+      text: { type: "mrkdwn", text: "🆕 *New QAA Allure report*" },
+    });
+    blocks.push({
+      type: "actions",
+      elements: qaaRows.map((row, i) => ({
+        type: "button",
+        text: { type: "plain_text", text: `${row.emoji} ${row.label}`, emoji: true },
+        url: row.qaaUrl,
+        style: "primary",
+        action_id: `qaa_report_${i}`,
+      })),
     });
   }
+
+  // Secondary links demoted to one muted line: legacy Allure per row, workflow run, optional extra.
+  const secondary = [];
+  const legacyLinks = rows
+    .filter(row => row.reportUrl)
+    .map(row => `<${row.reportUrl}|${row.emoji} ${row.label}>`);
+  if (legacyLinks.length > 0) secondary.push(`Legacy Allure: ${legacyLinks.join(" · ")}`);
+  secondary.push(`<${runUrl}|⚙️ Workflow run>`);
+  if (extraField) secondary.push(`<${extraField.url}|${extraField.title}>`);
+  blocks.push({
+    type: "context",
+    elements: [{ type: "mrkdwn", text: secondary.join("   ·   ") }],
+  });
 
   return {
     text: " ",


### PR DESCRIPTION
## What

Adds the new QAA Allure portal report as a prominent green button per platform/device in the mobile and desktop e2e Slack notifications, and tidies the notification layout to cut duplication and cognitive load.

## How it works

- The four `qaa-allure-upload*` jobs now expose the composite's `report_url` as a job output (step `id: qaa-allure-upload`).
- Each notify job passes it per row (`row*_qaa_url`) into the `e2e-slack-report` composite.
- The builder renders the report as a green `primary` button per row under a `📊 QAA Allure report` heading.
- Secondary links (the legacy old-server Allure per platform + the workflow run, plus the Xray link on desktop) are demoted to a single **muted context line** — each link once, no more duplicated bold-title-then-same-link fields.

## Behavior during migration

- The legacy old-server Allure link is **kept** (in the muted context line) alongside the new QAA button.
- The QAA upload jobs are experimental (`continue-on-error: true`); if an upload is skipped or produces no URL, that row's button is simply omitted and the notification **still sends with the legacy link** (notify jobs are gated `always()` / `!cancelled()`, independent of the QAA upload).

## Preview

<img width="1082" height="350" alt="image" src="https://github.com/user-attachments/assets/36b0dd53-8631-4090-b560-1b740a602cfd" />

## Testing

Validated on live runs (composite temporarily branch-pinned, posting to a private test channel — not part of this PR):

- Desktop single (nanoSP) — ✅ 1 QAA button
- Mobile iOS & Android — ✅ 2 QAA buttons (iOS + Android)
- Desktop dual (nanoSP + stax) — ✅ 2 QAA buttons

All three green; notify jobs succeeded; buttons linked to real `allure-new.aws.sbx.ldg-tech.com/reports/<id>` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
