### PR TITLE
feat(devtools): add relay QR-code discovery and mobile QR scanner

### DIFF
--- a/.changeset/spicy-wolves-dance.md
+++ b/.changeset/spicy-wolves-dance.md
@@ -1,0 +1,6 @@
+---
+"@devtools/relay": minor
+"@devtools/transport-panel": minor
+---
+
+Add relay QR-code discovery and mobile QR scanner for one-tap Wi-Fi connection

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,7 @@ libs/oxc-live-libs/                                      @ledgerhq/platform
 devtools/transport/                                      @ledgerhq/platform
 devtools/protocols/                                      @ledgerhq/platform
 devtools/wire/                                           @ledgerhq/platform
+devtools/relay/                                          @ledgerhq/platform
 
 # Wallet — libs
 libs/live-countervalues-react/                           @ledgerhq/wallet-xp

--- a/devtools/relay/README.md
+++ b/devtools/relay/README.md
@@ -4,7 +4,7 @@ A localhost WebSocket relay server for pairing DevTools clients. Dev-only — ne
 
 ## What it does
 
-Most WebSocket relays are dumb forwarders: bytes in, bytes out. This one is a **pairing broker** built for the two-role model in `@devtools/transport`.
+This is a **pairing broker** built for the two-role model in `@devtools/transport`.
 
 Every connection declares its identity in the connect URL (no in-band hello frame):
 
@@ -69,3 +69,29 @@ pnpm dev:remote
 ```
 
 Both the relay and the Rsbuild dev server start together. The relay exits cleanly when you kill the process.
+
+## Mobile Discovery
+
+The relay is accessible via `localhost` or `127.0.0.1` for desktop apps and mobile emulators.
+Mobile devices are a bit harder to handle. Here are the methods to connect to the relay on mobile:
+
+- **Port reverse**: On Android devices, when plugged in via USB, you can use the following command to forward the relay port to the device:
+  ```sh
+  adb reverse tcp:9090 tcp:9090
+  ```
+  This makes the relay accessible at `localhost:9090` on the device.
+  Unfortunately, port reversing is not available on iOS, so the second method is needed.
+
+- **Wi-Fi**: The relay can also be accessed using an address on the local network. Only devices on the same Wi-Fi network can use the IP. To be accessible from any interface, `0.0.0.0` is used for the relay server. To prevent unknown devices from connecting, a token is required. Devices connecting via `localhost` or `127.0.0.1` do not need the token. On mobile devices, you can scan the QR code on the transport page to easily connect to the relay. The QR code is displayed in the relay's terminal.
+
+In any case, the token is printed in the terminal at boot.
+
+## Parameters
+
+You can run the start script with the following parameters:
+
+- `--quiet`: Don't display messages sent on the server, only connections and disconnections
+- `--no-sec`: Disable token security — anyone on the same Wi-Fi can access the relay
+- `--log <path>`: Output the logs to a file rather than the terminal
+
+

--- a/devtools/relay/package.json
+++ b/devtools/relay/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@devtools/transport": "workspace:*",
+    "qrcode-terminal": "^0.12.0",
     "ws": "catalog:"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
+    "@types/qrcode-terminal": "^0.12.0",
     "@types/ws": "catalog:",
     "jest": "catalog:",
     "tsx": "catalog:",

--- a/devtools/relay/src/index.ts
+++ b/devtools/relay/src/index.ts
@@ -1,1 +1,2 @@
 export { createRelayHub } from "./relay";
+export type { Logger, LanIpResolver } from "./types";

--- a/devtools/relay/src/ip.test.ts
+++ b/devtools/relay/src/ip.test.ts
@@ -1,0 +1,47 @@
+import { networkInterfaces } from "os";
+import { getLanIp } from "./ip";
+
+jest.mock("os");
+
+const mockNetworkInterfaces = jest.mocked(networkInterfaces);
+
+function makeIface(address: string, internal = false) {
+  return [{ family: "IPv4", address, internal, netmask: "255.255.255.0", mac: "", cidr: null }];
+}
+
+describe("getLanIp", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns the address of a preferred interface (en0)", () => {
+    mockNetworkInterfaces.mockReturnValue({ en0: makeIface("192.168.1.10") } as any);
+    expect(getLanIp()).toBe("192.168.1.10");
+  });
+
+  it("prefers en0 over en1 when both are present", () => {
+    mockNetworkInterfaces.mockReturnValue({
+      en0: makeIface("192.168.1.10"),
+      en1: makeIface("10.0.0.5"),
+    } as any);
+    expect(getLanIp()).toBe("192.168.1.10");
+  });
+
+  it("falls back to a non-preferred interface when no preferred one is present", () => {
+    mockNetworkInterfaces.mockReturnValue({ wlan0: makeIface("10.0.0.5") } as any);
+    expect(getLanIp()).toBe("10.0.0.5");
+  });
+
+  it("skips VPN interfaces (utun)", () => {
+    mockNetworkInterfaces.mockReturnValue({ utun0: makeIface("10.8.0.1") } as any);
+    expect(getLanIp()).toBeNull();
+  });
+
+  it("skips internal (loopback) interfaces", () => {
+    mockNetworkInterfaces.mockReturnValue({ lo: makeIface("127.0.0.1", true) } as any);
+    expect(getLanIp()).toBeNull();
+  });
+
+  it("returns null when no interfaces are available", () => {
+    mockNetworkInterfaces.mockReturnValue({} as any);
+    expect(getLanIp()).toBeNull();
+  });
+});

--- a/devtools/relay/src/ip.ts
+++ b/devtools/relay/src/ip.ts
@@ -1,0 +1,27 @@
+import { networkInterfaces, type NetworkInterfaceInfo } from "node:os";
+
+function isVpnLike(name: string): boolean {
+  return name.startsWith("utun") || name.startsWith("tun") || name.startsWith("vpn");
+}
+
+function isExternalIpv4(net: NetworkInterfaceInfo): boolean {
+  return net.family === "IPv4" && !net.internal;
+}
+
+export function getLanIp(): string | null {
+  const nets = networkInterfaces();
+  const preferred = ["en0", "en1", "eth0"];
+
+  for (const name of preferred) {
+    for (const net of nets[name] ?? []) {
+      if (isExternalIpv4(net)) return net.address;
+    }
+  }
+  for (const [name, iface] of Object.entries(nets)) {
+    if (isVpnLike(name)) continue;
+    for (const net of iface ?? []) {
+      if (isExternalIpv4(net)) return net.address;
+    }
+  }
+  return null;
+}

--- a/devtools/relay/src/log.test.ts
+++ b/devtools/relay/src/log.test.ts
@@ -1,0 +1,94 @@
+import { createWriteStream } from "node:fs";
+import { createLogger } from "./log";
+
+jest.mock("node:fs");
+
+const mockCreateWriteStream = jest.mocked(createWriteStream);
+
+function mockStream() {
+  const stream = { write: jest.fn(), end: jest.fn() };
+  mockCreateWriteStream.mockReturnValue(stream as any);
+  return stream;
+}
+
+describe("createLogger — console mode", () => {
+  let spyLog: jest.SpyInstance;
+  let spyWarn: jest.SpyInstance;
+  let spyStdout: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    spyLog = jest.spyOn(console, "log").mockImplementation(() => {});
+    spyWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    spyStdout = jest.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    spyLog.mockRestore();
+    spyWarn.mockRestore();
+    spyStdout.mockRestore();
+  });
+
+  it("routes log to console.log", () => {
+    createLogger({}).log("hello");
+    expect(spyLog).toHaveBeenCalledWith("hello");
+  });
+
+  it("routes warn to console.warn", () => {
+    createLogger({}).warn("oops");
+    expect(spyWarn).toHaveBeenCalledWith("oops");
+  });
+
+  it("trace calls log when verbose is true (default)", () => {
+    createLogger({ verbose: true }).trace("tracing");
+    expect(spyLog).toHaveBeenCalledWith("tracing");
+  });
+
+  it("trace is silent when verbose is false", () => {
+    createLogger({ verbose: false }).trace("tracing");
+    expect(spyLog).not.toHaveBeenCalled();
+  });
+
+  it("routes write to process.stdout.write", () => {
+    createLogger({}).write("raw");
+    expect(spyStdout).toHaveBeenCalledWith("raw");
+  });
+
+  it("close is a no-op when there is no stream", () => {
+    expect(() => createLogger({}).close()).not.toThrow();
+  });
+});
+
+describe("createLogger — file mode", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("opens the file with append flag", () => {
+    mockStream();
+    createLogger({ logFile: "/tmp/relay.log" });
+    expect(mockCreateWriteStream).toHaveBeenCalledWith("/tmp/relay.log", { flags: "a" });
+  });
+
+  it("log writes the message with a trailing newline", () => {
+    const stream = mockStream();
+    createLogger({ logFile: "/tmp/relay.log" }).log("hello");
+    expect(stream.write).toHaveBeenCalledWith("hello\n");
+  });
+
+  it("warn writes the message with [warn] prefix and newline", () => {
+    const stream = mockStream();
+    createLogger({ logFile: "/tmp/relay.log" }).warn("oops");
+    expect(stream.write).toHaveBeenCalledWith("[warn] oops\n");
+  });
+
+  it("write routes to stream.write without adding a newline", () => {
+    const stream = mockStream();
+    createLogger({ logFile: "/tmp/relay.log" }).write("raw");
+    expect(stream.write).toHaveBeenCalledWith("raw");
+  });
+
+  it("close calls stream.end", () => {
+    const stream = mockStream();
+    createLogger({ logFile: "/tmp/relay.log" }).close();
+    expect(stream.end).toHaveBeenCalledTimes(1);
+  });
+});

--- a/devtools/relay/src/log.ts
+++ b/devtools/relay/src/log.ts
@@ -1,0 +1,20 @@
+import { createWriteStream } from "node:fs";
+import type { Logger } from "./types";
+
+export function createLogger({
+  verbose = true,
+  logFile,
+}: {
+  verbose?: boolean;
+  logFile?: string;
+}): Logger {
+  const stream = logFile ? createWriteStream(logFile, { flags: "a" }) : null;
+  const log = (msg: string) => (stream ? stream.write(msg + "\n") : console.log(msg));
+  const warn = (msg: string) => (stream ? stream.write("[warn] " + msg + "\n") : console.warn(msg));
+  const trace = (msg: string) => {
+    if (verbose) log(msg);
+  };
+  const write = (s: string) => (stream ? stream.write(s) : process.stdout.write(s));
+  const close = () => stream?.end();
+  return { log, warn, trace, write, close };
+}

--- a/devtools/relay/src/messages.test.ts
+++ b/devtools/relay/src/messages.test.ts
@@ -1,0 +1,76 @@
+import { msg } from "./messages";
+
+describe("msg", () => {
+  it("listening includes the port", () => {
+    expect(msg.listening(9090)).toContain("9090");
+  });
+
+  it("wifiUrl includes the URL", () => {
+    expect(msg.wifiUrl("ws://1.2.3.4:9090")).toContain("ws://1.2.3.4:9090");
+  });
+
+  it("noWifiIp mentions Wi-Fi", () => {
+    expect(msg.noWifiIp).toContain("Wi-Fi");
+  });
+
+  it("tokenRejected includes the remote address", () => {
+    expect(msg.tokenRejected("192.168.1.1")).toContain("192.168.1.1");
+  });
+
+  it("invalidIdentity includes the URL", () => {
+    expect(msg.invalidIdentity("/?role=bad")).toContain("/?role=bad");
+  });
+
+  it("sessionless includes the tool id", () => {
+    expect(msg.sessionless("web-tools")).toContain("web-tools");
+  });
+
+  it("evicted includes the role and host id", () => {
+    const m = msg.evicted("host", "app");
+    expect(m).toContain("host");
+    expect(m).toContain("app");
+  });
+
+  it("attached includes role, id, and host id", () => {
+    const m = msg.attached("tool", "web-tools", "desktop");
+    expect(m).toContain("tool");
+    expect(m).toContain("web-tools");
+    expect(m).toContain("desktop");
+  });
+
+  it("paired includes the host id", () => {
+    expect(msg.paired("desktop")).toContain("desktop");
+  });
+
+  it("forwarded includes sender, peer role, and message kind", () => {
+    const m = msg.forwarded("web-tools", "host", "text");
+    expect(m).toContain("web-tools");
+    expect(m).toContain("host");
+    expect(m).toContain("text");
+  });
+
+  it("dropped includes the sender id and missing peer role", () => {
+    const m = msg.dropped("web-tools", "text", "host");
+    expect(m).toContain("web-tools");
+    expect(m).toContain("host");
+  });
+
+  it("disconnectedPeer includes role, id, and host id", () => {
+    const m = msg.disconnectedPeer("tool", "web-tools", "desktop");
+    expect(m).toContain("tool");
+    expect(m).toContain("web-tools");
+    expect(m).toContain("desktop");
+  });
+
+  it("disconnected includes the tool id", () => {
+    expect(msg.disconnected("web-tools")).toContain("web-tools");
+  });
+
+  it("socketError includes the error message", () => {
+    expect(msg.socketError("connection reset")).toContain("connection reset");
+  });
+
+  it("serverError includes the error message", () => {
+    expect(msg.serverError("EADDRINUSE")).toContain("EADDRINUSE");
+  });
+});

--- a/devtools/relay/src/messages.ts
+++ b/devtools/relay/src/messages.ts
@@ -1,0 +1,22 @@
+export const msg = {
+  listening: (port: number) => `[relay] listening on ws://localhost:${port}`,
+  wifiUrl: (url: string) => `[relay] Wi-Fi: ${url}`,
+  noWifiIp: `[relay] no Wi-Fi IP detected — is the network connected?`,
+  tokenRejected: (from: string | undefined) =>
+    `[relay] connection rejected — invalid or missing token (from ${from})`,
+  invalidIdentity: (url: string | undefined) =>
+    `[relay] connection without valid identity (url=${url}) — closing`,
+  sessionless: (id: string) =>
+    `[relay] tool "${id}" connected without a target — idle, cannot pair`,
+  evicted: (role: string, id: string) => `[relay] evicted previous ${role} of "${id}"`,
+  attached: (role: string, id: string, hostId: string) => `[relay] ${role} "${id}" → "${hostId}"`,
+  paired: (id: string) => `[relay] paired tool ⇄ host "${id}"`,
+  forwarded: (id: string, peer: string, kind: string) => `[relay] "${id}" → ${peer} (${kind})`,
+  dropped: (id: string, kind: string, peer: string) =>
+    `[relay] "${id}" dropped ${kind} — no ${peer} connected`,
+  disconnectedPeer: (role: string, id: string, hostId: string) =>
+    `[relay] ${role} "${id}" disconnected from "${hostId}"`,
+  disconnected: (id: string) => `[relay] tool "${id}" disconnected`,
+  socketError: (err: string) => `[relay] socket error: ${err}`,
+  serverError: (err: string) => `[relay] server error: ${err}`,
+};

--- a/devtools/relay/src/mocks/index.ts
+++ b/devtools/relay/src/mocks/index.ts
@@ -1,0 +1,13 @@
+import type { Logger, LanIpResolver } from "../types";
+
+export function createMockLogger(): Logger {
+  return {
+    log: jest.fn(),
+    warn: jest.fn(),
+    trace: jest.fn(),
+    write: jest.fn(),
+    close: jest.fn(),
+  };
+}
+
+export const nullLanIp: LanIpResolver = () => null;

--- a/devtools/relay/src/relay.test.ts
+++ b/devtools/relay/src/relay.test.ts
@@ -1,6 +1,7 @@
 import { WebSocket } from "ws";
 import type { AddressInfo } from "node:net";
 import { createRelayHub } from "./relay";
+import { createMockLogger, nullLanIp } from "./mocks";
 
 type Hub = ReturnType<typeof createRelayHub>;
 
@@ -34,7 +35,12 @@ describe("relay hub — invalid connections", () => {
   let base: string;
 
   beforeEach(async () => {
-    hub = createRelayHub({ port: 0, host: "127.0.0.1" });
+    hub = createRelayHub({
+      port: 0,
+      host: "127.0.0.1",
+      logger: createMockLogger(),
+      getLanIp: nullLanIp,
+    });
     await waitForListening(hub);
     base = `ws://127.0.0.1:${(hub.ws.address() as AddressInfo).port}`;
   });
@@ -61,7 +67,12 @@ describe("relay hub — message forwarding", () => {
   let base: string;
 
   beforeEach(async () => {
-    hub = createRelayHub({ port: 0, host: "127.0.0.1" });
+    hub = createRelayHub({
+      port: 0,
+      host: "127.0.0.1",
+      logger: createMockLogger(),
+      getLanIp: nullLanIp,
+    });
     await waitForListening(hub);
     base = `ws://127.0.0.1:${(hub.ws.address() as AddressInfo).port}`;
   });
@@ -111,12 +122,47 @@ describe("relay hub — message forwarding", () => {
   });
 });
 
+describe("relay hub — close", () => {
+  it("terminates all connected clients and resolves", async () => {
+    const hub = createRelayHub({
+      port: 0,
+      host: "127.0.0.1",
+      logger: createMockLogger(),
+      getLanIp: nullLanIp,
+    });
+    await waitForListening(hub);
+    const base = `ws://127.0.0.1:${(hub.ws.address() as AddressInfo).port}`;
+
+    const host = await open(`${base}/?role=host&id=app`);
+    const closed = waitForClose(host);
+    await hub.close();
+    await closed;
+    expect(host.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  it("resolves even when no clients are connected", async () => {
+    const hub = createRelayHub({
+      port: 0,
+      host: "127.0.0.1",
+      logger: createMockLogger(),
+      getLanIp: nullLanIp,
+    });
+    await waitForListening(hub);
+    await expect(hub.close()).resolves.toBeUndefined();
+  });
+});
+
 describe("relay hub — eviction", () => {
   let hub: Hub;
   let base: string;
 
   beforeEach(async () => {
-    hub = createRelayHub({ port: 0, host: "127.0.0.1" });
+    hub = createRelayHub({
+      port: 0,
+      host: "127.0.0.1",
+      logger: createMockLogger(),
+      getLanIp: nullLanIp,
+    });
     await waitForListening(hub);
     base = `ws://127.0.0.1:${(hub.ws.address() as AddressInfo).port}`;
   });

--- a/devtools/relay/src/relay.ts
+++ b/devtools/relay/src/relay.ts
@@ -1,12 +1,28 @@
 import { WebSocketServer, WebSocket } from "ws";
+import qrcode from "qrcode-terminal";
 import { parseIdentity } from "@devtools/transport";
 import { createSessionRegistry } from "./sessionRegistry";
+import { getLanIp as defaultGetLanIp } from "./ip";
+import { generateToken, isLoopback, validateToken } from "./token";
+import { createLogger } from "./log";
+import type { Logger, LanIpResolver } from "./types";
+import { msg } from "./messages";
 
 export type RelayHubOptions = {
-  /** Bind address. Defaults to 127.0.0.1 (localhost). Overriding this may expose the server to the network. */
+  /** Bind address. Defaults to 0.0.0.0 (all interfaces, including Wi-Fi). */
   host?: string;
   /** Port. Defaults to 9090. */
   port?: number;
+  /** Enable token-based auth for non-loopback connections. Defaults to true. Set to false only on trusted networks (e.g. USB localhost). */
+  secure?: boolean;
+  /** Log per-message events. Defaults to true. Set to false to reduce noise. */
+  verbose?: boolean;
+  /** Redirect all logs to a file instead of stdout. */
+  logFile?: string;
+  /** Injectable logger. Defaults to createLogger({ verbose, logFile }). */
+  logger?: Logger;
+  /** Injectable LAN IP resolver. Defaults to node:os networkInterfaces lookup. */
+  getLanIp?: LanIpResolver;
 };
 
 /**
@@ -19,60 +35,91 @@ export type RelayHubOptions = {
  */
 
 export function createRelayHub(options: RelayHubOptions = {}) {
-  const host = options.host ?? "127.0.0.1";
+  const host = options.host ?? "0.0.0.0";
   const port = options.port ?? 9090;
+  const token = (options.secure ?? true) ? generateToken() : null;
+  const {
+    log,
+    warn,
+    trace,
+    write,
+    close: closeLogger,
+  } = options.logger ??
+  createLogger({
+    verbose: options.verbose,
+    logFile: options.logFile,
+  });
+  const getLanIp = options.getLanIp ?? defaultGetLanIp;
 
   const registry = createSessionRegistry<WebSocket>();
-  const ws = new WebSocketServer({ port: port, host: host });
+  const ws = new WebSocketServer({ port, host });
 
   ws.once("listening", () => {
     const address = ws.address();
     const actualPort = typeof address === "object" && address ? address.port : port;
-    console.log(`[relay] listening on ws://${host}:${actualPort}`);
+    const lanIp = getLanIp();
+    log(msg.listening(actualPort));
+    if (lanIp) {
+      const url = token
+        ? `ws://${lanIp}:${actualPort}?token=${token}`
+        : `ws://${lanIp}:${actualPort}`;
+      log(msg.wifiUrl(url) + "\n");
+      qrcode.generate(url, { small: true }, s => write(s));
+    } else {
+      warn(msg.noWifiIp);
+    }
   });
 
   ws.on("connection", (socket, req) => {
+    const remoteAddress = req.socket.remoteAddress;
+
+    if (token && !isLoopback(remoteAddress)) {
+      if (!validateToken(req.url, token)) {
+        warn(msg.tokenRejected(remoteAddress));
+        socket.terminate();
+        return;
+      }
+    }
+
     const me = parseIdentity(req.url);
     if (!me) {
-      console.warn(`[relay] connection without valid identity (url=${req.url}) — closing`);
+      warn(msg.invalidIdentity(req.url));
       socket.terminate();
       return;
     }
 
     const attached = registry.attach(me, socket);
     if (attached.status === "sessionless") {
-      console.warn(`[relay] tool "${me.id}" connected without a target — idle, cannot pair`);
+      warn(msg.sessionless(me.id));
     } else {
-      if (attached.evicted)
-        console.log(`[relay] evicted previous ${attached.role} of "${attached.hostId}"`);
-      console.log(`[relay] ${attached.role} "${me.id}" → "${attached.hostId}"`);
-      if (attached.paired) console.log(`[relay] paired tool ⇄ host "${attached.hostId}"`);
+      if (attached.evicted) log(msg.evicted(attached.role, attached.hostId));
+      log(msg.attached(attached.role, me.id, attached.hostId));
+      if (attached.paired) log(msg.paired(attached.hostId));
     }
 
     const peerRole = me.role === "tool" ? "host" : "tool";
     socket.on("message", (data, isBinary) => {
       const peer = registry.peerOf(socket);
+      const kind = isBinary ? "binary" : "text";
       if (peer && peer.readyState === WebSocket.OPEN) {
         peer.send(data, { binary: isBinary });
-        console.log(`[relay] "${me.id}" → ${peerRole} (${isBinary ? "binary" : "text"})`);
+        trace(msg.forwarded(me.id, peerRole, kind));
       } else {
-        console.log(
-          `[relay] "${me.id}" dropped ${isBinary ? "binary" : "text"} — no ${peerRole} connected`,
-        );
+        trace(msg.dropped(me.id, kind, peerRole));
       }
     });
 
     socket.on("close", () => {
       const entry = registry.detach(socket);
-      if (entry)
-        console.log(`[relay] ${entry.role} "${me.id}" disconnected from "${entry.hostId}"`);
-      else console.log(`[relay] tool "${me.id}" disconnected`);
+      if (entry) log(msg.disconnectedPeer(entry.role, me.id, entry.hostId));
+      else log(msg.disconnected(me.id));
+      closeLogger();
     });
 
-    socket.on("error", err => console.error("[relay] socket error:", err.message));
+    socket.on("error", err => warn(msg.socketError(err.message)));
   });
 
-  ws.on("error", err => console.error("[relay] server error:", err.message));
+  ws.on("error", err => warn(msg.serverError(err.message)));
 
   return {
     ws,

--- a/devtools/relay/src/server.ts
+++ b/devtools/relay/src/server.ts
@@ -1,3 +1,14 @@
 import { createRelayHub } from "./relay";
 
-createRelayHub();
+const argv = process.argv;
+const insecure = argv.includes("--no-sec") || process.env.RELAY_INSECURE === "true";
+const verbose = !argv.includes("--quiet");
+const logFileIndex = argv.indexOf("--log");
+const logFile = logFileIndex !== -1 ? argv[logFileIndex + 1] : undefined;
+
+if (logFileIndex !== -1 && !logFile) {
+  console.error("Error: --log option requires a file path argument.");
+  process.exit(1);
+}
+
+createRelayHub({ secure: !insecure, verbose, logFile });

--- a/devtools/relay/src/token.test.ts
+++ b/devtools/relay/src/token.test.ts
@@ -1,0 +1,47 @@
+import { generateToken, isLoopback, validateToken } from "./token";
+
+describe("generateToken", () => {
+  it("returns a 32-character hex string", () => {
+    expect(generateToken()).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("returns a different value on each call", () => {
+    expect(generateToken()).not.toBe(generateToken());
+  });
+});
+
+describe("isLoopback", () => {
+  it("returns true for IPv4 loopback", () => {
+    expect(isLoopback("127.0.0.1")).toBe(true);
+  });
+
+  it("returns true for IPv6 loopback", () => {
+    expect(isLoopback("::1")).toBe(true);
+  });
+
+  it("returns false for a LAN address", () => {
+    expect(isLoopback("192.168.1.42")).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isLoopback(undefined)).toBe(false);
+  });
+});
+
+describe("validateToken", () => {
+  it("returns true when the URL carries the correct token", () => {
+    expect(validateToken("/?role=tool&token=abc123", "abc123")).toBe(true);
+  });
+
+  it("returns false when the token param is wrong", () => {
+    expect(validateToken("/?token=wrong", "abc123")).toBe(false);
+  });
+
+  it("returns false when the token param is missing", () => {
+    expect(validateToken("/?role=tool", "abc123")).toBe(false);
+  });
+
+  it("returns false for an undefined URL", () => {
+    expect(validateToken(undefined, "abc123")).toBe(false);
+  });
+});

--- a/devtools/relay/src/token.ts
+++ b/devtools/relay/src/token.ts
@@ -1,0 +1,14 @@
+import { randomBytes } from "node:crypto";
+
+export function generateToken(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function isLoopback(address: string | undefined): boolean {
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+export function validateToken(reqUrl: string | undefined, token: string): boolean {
+  const url = new URL(reqUrl ?? "", "ws://localhost");
+  return url.searchParams.get("token") === token;
+}

--- a/devtools/relay/src/types.ts
+++ b/devtools/relay/src/types.ts
@@ -1,0 +1,10 @@
+export type Logger = {
+  log: (msg: string) => void;
+  warn: (msg: string) => void;
+  trace: (msg: string) => void;
+  /** Raw write — no newline appended. Used for QR code output. */
+  write: (s: string) => void;
+  close: () => void;
+};
+
+export type LanIpResolver = () => string | null;

--- a/devtools/transport-panel/jest.native.config.js
+++ b/devtools/transport-panel/jest.native.config.js
@@ -27,6 +27,7 @@ module.exports = {
       "<rootDir>/node_modules/@ledgerhq/lumen-ui-rnative/src/index.ts",
     "^@ledgerhq/lumen-design-core$": "<rootDir>/node_modules/@ledgerhq/lumen-design-core",
     "^@sbaiahmed1/react-native-blur$": "<rootDir>/jest/mocks/react-native-blur.tsx",
+    "^react-native-vision-camera$": "<rootDir>/jest/mocks/react-native-vision-camera.tsx",
     "^react-native-worklets$": "<rootDir>/jest/mocks/react-native-worklets.js",
   },
   testTimeout: 30_000,

--- a/devtools/transport-panel/jest/mocks/react-native-vision-camera.tsx
+++ b/devtools/transport-panel/jest/mocks/react-native-vision-camera.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { View } from "react-native";
+
+export const Camera = Object.assign(
+  ({ children }: { children?: React.ReactNode }) => <View>{children}</View>,
+  { requestCameraPermission: jest.fn().mockResolvedValue("granted") },
+);
+
+export const useCameraDevice = jest.fn().mockReturnValue(undefined);
+export const useCameraPermission = jest.fn().mockReturnValue({ hasPermission: false });
+export const useCodeScanner = jest.fn().mockReturnValue({});

--- a/devtools/transport-panel/package.json
+++ b/devtools/transport-panel/package.json
@@ -59,6 +59,7 @@
     "jest-sonar": "0.2.16",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react-native-vision-camera": "4.7.3",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-utils-shared": "catalog:",
     "@radix-ui/react-dialog": "catalog:",
@@ -73,6 +74,7 @@
   },
   "peerDependencies": {
     "react": ">=19",
+    "react-native-vision-camera": ">=4",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@radix-ui/react-dialog": "catalog:",

--- a/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.test.tsx
+++ b/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, act } from "jest/render";
+import { QRScannerSheet } from "./QRScannerSheet.native";
+
+jest.mock("react-native-vision-camera", () => ({
+  Camera: "Camera",
+  useCameraPermission: jest.fn(),
+  useCameraDevice: jest.fn(),
+  useCodeScanner: jest.fn().mockReturnValue({}),
+}));
+
+const rnvc = jest.requireMock("react-native-vision-camera");
+
+function makeRef() {
+  return { current: null } as React.RefObject<any>;
+}
+
+describe("QRScannerSheet (native)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: false });
+    rnvc.useCameraDevice.mockReturnValue(null);
+    rnvc.useCodeScanner.mockReturnValue({});
+  });
+
+  it("renders the 'Scan relay QR' header", () => {
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={jest.fn()} />);
+    expect(screen.getByText("Scan relay QR")).toBeOnTheScreen();
+  });
+
+  it("shows 'Camera permission required' when permission is not granted", () => {
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={jest.fn()} />);
+    expect(screen.getByText("Camera permission required")).toBeOnTheScreen();
+  });
+
+  it("shows 'Camera permission required' when no back camera device is available", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={jest.fn()} />);
+    expect(screen.getByText("Camera permission required")).toBeOnTheScreen();
+  });
+
+  it("hides the fallback text when permission is granted and a device is available", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    rnvc.useCameraDevice.mockReturnValue({ id: "back" });
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={jest.fn()} />);
+    expect(screen.queryByText("Camera permission required")).toBeNull();
+  });
+
+  it("calls onScan with the scanned value when a QR code is detected", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    rnvc.useCameraDevice.mockReturnValue({ id: "back" });
+    const onScan = jest.fn();
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={onScan} />);
+    const { onCodeScanned } = rnvc.useCodeScanner.mock.calls[0][0];
+    act(() => onCodeScanned([{ value: "ws://relay:9090?token=abc" }]));
+    expect(onScan).toHaveBeenCalledWith("ws://relay:9090?token=abc");
+  });
+
+  it("dismisses the bottom sheet after a successful scan", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    rnvc.useCameraDevice.mockReturnValue({ id: "back" });
+    const ref = makeRef();
+    render(<QRScannerSheet bottomSheetRef={ref} onScan={jest.fn()} />);
+    const dismissSpy = jest.spyOn(ref.current, "dismiss");
+    const { onCodeScanned } = rnvc.useCodeScanner.mock.calls[0][0];
+    act(() => onCodeScanned([{ value: "ws://relay:9090?token=abc" }]));
+    expect(dismissSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores empty code lists without calling onScan or dismiss", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    rnvc.useCameraDevice.mockReturnValue({ id: "back" });
+    const onScan = jest.fn();
+    const ref = makeRef();
+    render(<QRScannerSheet bottomSheetRef={ref} onScan={onScan} />);
+    const dismissSpy = jest.spyOn(ref.current, "dismiss");
+    const { onCodeScanned } = rnvc.useCodeScanner.mock.calls[0][0];
+    act(() => onCodeScanned([]));
+    expect(onScan).not.toHaveBeenCalled();
+    expect(dismissSpy).not.toHaveBeenCalled();
+  });
+
+  it("ignores scan results with an undefined value", () => {
+    rnvc.useCameraPermission.mockReturnValue({ hasPermission: true });
+    rnvc.useCameraDevice.mockReturnValue({ id: "back" });
+    const onScan = jest.fn();
+    render(<QRScannerSheet bottomSheetRef={makeRef()} onScan={onScan} />);
+    const { onCodeScanned } = rnvc.useCodeScanner.mock.calls[0][0];
+    act(() => onCodeScanned([{ value: undefined }]));
+    expect(onScan).not.toHaveBeenCalled();
+  });
+});

--- a/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.tsx
+++ b/devtools/transport-panel/src/components/QRScannerSheet/QRScannerSheet.native.tsx
@@ -1,0 +1,58 @@
+import { useCallback, type RefObject } from "react";
+import {
+  Camera,
+  useCameraDevice,
+  useCameraPermission,
+  useCodeScanner,
+} from "react-native-vision-camera";
+import {
+  BottomSheet,
+  BottomSheetView,
+  BottomSheetHeader,
+  Box,
+  Text,
+} from "@ledgerhq/lumen-ui-rnative";
+
+interface Props {
+  readonly bottomSheetRef: RefObject<any>;
+  readonly onScan: (value: string) => void;
+}
+
+export function QRScannerSheet({ bottomSheetRef, onScan }: Props) {
+  const { hasPermission } = useCameraPermission();
+  const device = useCameraDevice("back");
+
+  const codeScanner = useCodeScanner({
+    codeTypes: ["qr"],
+    onCodeScanned: useCallback(
+      codes => {
+        const value = codes[0]?.value;
+        if (value) {
+          onScan(value);
+          bottomSheetRef.current?.dismiss();
+        }
+      },
+      [onScan, bottomSheetRef],
+    ),
+  });
+
+  return (
+    <BottomSheet ref={bottomSheetRef} snapPoints="fullWithOffset">
+      <BottomSheetView>
+        <BottomSheetHeader title="Scan relay QR" density="compact" />
+        <Box lx={{ alignItems: "center", padding: "s16" }}>
+          {hasPermission && device ? (
+            <Camera
+              device={device}
+              isActive
+              style={{ width: 280, height: 280, borderRadius: 16 }}
+              codeScanner={codeScanner}
+            />
+          ) : (
+            <Text>Camera permission required</Text>
+          )}
+        </Box>
+      </BottomSheetView>
+    </BottomSheet>
+  );
+}

--- a/devtools/transport-panel/src/components/QRScannerSheet/index.native.ts
+++ b/devtools/transport-panel/src/components/QRScannerSheet/index.native.ts
@@ -1,0 +1,1 @@
+export { QRScannerSheet } from "./QRScannerSheet.native";

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.test.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.test.tsx
@@ -3,6 +3,15 @@ import { render, screen, fireEvent } from "jest/render";
 import { mockTransport, mockTransportPanelProps } from "jest/mocks/transport";
 import { TransportPanelContent } from "./TransportPanelContent";
 
+jest.mock("react-native-vision-camera", () => ({
+  Camera: { requestCameraPermission: jest.fn().mockResolvedValue("granted") },
+  useCameraPermission: jest.fn().mockReturnValue({ hasPermission: false }),
+  useCameraDevice: jest.fn().mockReturnValue(null),
+  useCodeScanner: jest.fn().mockReturnValue({}),
+}));
+
+const { Camera } = jest.requireMock("react-native-vision-camera");
+
 function makeRef() {
   return { current: null } as React.RefObject<unknown>;
 }
@@ -59,5 +68,20 @@ describe("TransportPanelContent (native)", () => {
       <TransportPanelContent bottomSheetRef={makeRef()} transport={mockTransportPanelProps()} />,
     );
     expect(screen.getByRole("button", { name: "Debug websocket" })).toBeOnTheScreen();
+  });
+
+  it("renders the QR scan button next to the Hub URL field", () => {
+    render(
+      <TransportPanelContent bottomSheetRef={makeRef()} transport={mockTransportPanelProps()} />,
+    );
+    expect(screen.getByRole("button", { name: "Scan QR code" })).toBeOnTheScreen();
+  });
+
+  it("calls Camera.requestCameraPermission when the QR scan button is pressed", async () => {
+    render(
+      <TransportPanelContent bottomSheetRef={makeRef()} transport={mockTransportPanelProps()} />,
+    );
+    fireEvent.press(screen.getByRole("button", { name: "Scan QR code" }));
+    expect(Camera.requestCameraPermission).toHaveBeenCalledTimes(1);
   });
 });

--- a/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.tsx
+++ b/devtools/transport-panel/src/components/TransportPanelContent/TransportPanelContent.native.tsx
@@ -7,7 +7,9 @@ import {
   IconButton,
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
-import { Refresh, Repair } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Refresh, Repair, QrCodeScanner } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { Camera } from "react-native-vision-camera";
+import { QRScannerSheet } from "../QRScannerSheet/index";
 import { TransportPanelProps } from "../../types";
 import type { MessageMap } from "@devtools/transport";
 import { TransportDebug } from "../TransportDebug";
@@ -24,6 +26,7 @@ export function TransportPanelContent<M extends MessageMap>({
   transport,
 }: Readonly<TransportPanelContentProps<M>>) {
   const debugBottomSheetRef = useBottomSheetRef();
+  const scannerBottomSheetRef = useBottomSheetRef();
 
   return (
     <Box>
@@ -47,11 +50,24 @@ export function TransportPanelContent<M extends MessageMap>({
               />
             )}
 
-            <TextInput
-              label="Hub URL"
-              value={transport.hubUrl}
-              onChangeText={transport.setHubUrl}
-            />
+            <Box lx={{ flexDirection: "row", alignItems: "flex-end", gap: "s8" }}>
+              <Box lx={{ flex: 1 }}>
+                <TextInput
+                  label="Hub URL"
+                  value={transport.hubUrl}
+                  onChangeText={transport.setHubUrl}
+                />
+              </Box>
+              <IconButton
+                icon={QrCodeScanner}
+                accessibilityLabel="Scan QR code"
+                appearance="gray"
+                onPress={async () => {
+                  await Camera.requestCameraPermission();
+                  scannerBottomSheetRef.current?.present();
+                }}
+              />
+            </Box>
             <Box lx={{ flexDirection: "row", justifyContent: "space-evenly", gap: "s16" }}>
               <IconButton
                 icon={Refresh}
@@ -72,6 +88,7 @@ export function TransportPanelContent<M extends MessageMap>({
         </BottomSheetView>
       </BottomSheet>
       <TransportDebug bottomSheetRef={debugBottomSheetRef} transport={transport} />
+      <QRScannerSheet bottomSheetRef={scannerBottomSheetRef} onScan={transport.setHubUrl} />
     </Box>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3157,6 +3157,9 @@ importers:
       '@devtools/transport':
         specifier: workspace:*
         version: link:../transport
+      qrcode-terminal:
+        specifier: ^0.12.0
+        version: 0.12.0
       ws:
         specifier: 'catalog:'
         version: 8.18.3
@@ -3173,6 +3176,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.0
+      '@types/qrcode-terminal':
+        specifier: ^0.12.0
+        version: 0.12.2
       '@types/ws':
         specifier: 'catalog:'
         version: 8.5.10
@@ -3463,6 +3469,9 @@ importers:
       react-native-svg:
         specifier: 'catalog:'
         version: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native-vision-camera:
+        specifier: 4.7.3
+        version: 4.7.3(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-worklets:
         specifier: 'catalog:'
         version: 0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -24400,6 +24409,9 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
+  '@types/qrcode-terminal@0.12.2':
+    resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
+
   '@types/qrcode@1.5.5':
     resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
 
@@ -34832,6 +34844,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qrcode-terminal@0.11.0:
@@ -37718,6 +37731,10 @@ packages:
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
+
+  undici@6.19.2:
+    resolution: {integrity: sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==}
+    engines: {node: '>=18.17'}
 
   undici@6.21.1:
     resolution: {integrity: sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==}
@@ -44207,7 +44224,7 @@ snapshots:
       structured-headers: 0.4.1
       tar: 7.4.3
       terminal-link: 2.1.1
-      undici: 6.21.1
+      undici: 6.19.2
       wrap-ansi: 7.0.0
       ws: 8.21.0
     transitivePeerDependencies:
@@ -44374,7 +44391,7 @@ snapshots:
 
   '@expo/code-signing-certificates@0.0.5':
     dependencies:
-      node-forge: 1.3.1
+      node-forge: 1.4.0
       nullthrows: 1.1.1
 
   '@expo/code-signing-certificates@0.0.6':
@@ -55113,6 +55130,8 @@ snapshots:
   '@types/prop-types@15.7.12': {}
 
   '@types/q@1.5.8': {}
+
+  '@types/qrcode-terminal@0.12.2': {}
 
   '@types/qrcode@1.5.5':
     dependencies:
@@ -66457,7 +66476,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.7
+      metro: 0.83.7(metro-transform-worker@0.83.7)
       metro-babel-transformer: 0.83.7
       metro-cache: 0.83.7
       metro-cache-key: 0.83.7
@@ -66655,6 +66674,53 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  metro@0.83.7(metro-transform-worker@0.83.7):
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.28.5
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      accepts: 2.0.0
+      ci-info: 2.0.0
+      connect: 3.7.0
+      debug: 4.4.3
+      error-stack-parser: 2.1.4
+      flow-enums-runtime: 0.0.6
+      graceful-fs: 4.2.11
+      hermes-parser: 0.35.0
+      image-size: 1.1.1
+      invariant: 2.2.4
+      jest-worker: 29.7.0(metro@0.83.7)
+      jsc-safe-url: 0.2.4
+      lodash.throttle: 4.1.1
+      metro-babel-transformer: 0.83.7
+      metro-cache: 0.83.7
+      metro-cache-key: 0.83.7
+      metro-config: 0.83.7(metro-transform-worker@0.83.7)
+      metro-core: 0.83.7
+      metro-file-map: 0.83.7(metro@0.83.7)
+      metro-resolver: 0.83.7
+      metro-runtime: 0.83.7
+      metro-source-map: 0.83.7
+      metro-symbolicate: 0.83.7
+      metro-transform-plugins: 0.83.7
+      metro-transform-worker: 0.83.7
+      mime-types: 3.0.1
+      nullthrows: 1.1.1
+      serialize-error: 2.1.0
+      source-map: 0.5.7
+      throat: 5.0.0
+      ws: 7.5.10
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - metro-transform-worker
       - supports-color
       - utf-8-validate
 
@@ -69821,6 +69887,13 @@ snapshots:
     optionalDependencies:
       react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(@babel/core@7.28.5)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
 
+  react-native-vision-camera@4.7.3(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4):
+    dependencies:
+      react: 19.1.4
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+    optionalDependencies:
+      react-native-reanimated: 4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+
   react-native-web@0.19.10(react-dom@19.1.4(react@19.1.4))(react@19.1.4):
     dependencies:
       '@babel/runtime': 7.28.4
@@ -70929,7 +71002,7 @@ snapshots:
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.11
-      node-forge: 1.3.1
+      node-forge: 1.4.0
 
   semver-compare@1.0.0:
     optional: true
@@ -73108,6 +73181,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@6.19.2: {}
 
   undici@6.21.1: {}
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

 Extends `@devtools/relay` and `@devtools/transport-panel` so a mobile device
  can discover and connect to the relay hub by scanning a QR code — no manual
  URL entry required.

  ### What changed
  
  **`@devtools/relay`**
  - On startup, the relay resolves the host LAN IP, builds the full WebSocket URL
    (with a one-time token), and renders a QR code in the terminal via
    `qrcode-terminal`.
  - Token-based auth is enforced for all non-loopback (Wi-Fi) connections;
    loopback (`127.0.0.1` / `::1`) bypasses the check so local desktop
    development works without a token.
  - Internal refactor: extracted `log.ts`, `messages.ts`, `token.ts`, and
    `wifi.ts` from the relay module to keep each concern small and independently
    testable.

  **`@devtools/transport-panel`**
  - New `QRScannerSheet` (native-only) — a bottom sheet backed by
    `react-native-vision-camera` that scans a QR code and resolves its value.
  - `TransportPanelContent.native.tsx` gains a QR scan button next to the Hub URL
    field; tapping it requests camera permission, opens the scanner, and writes
    the scanned URL directly into the field.

  ### How to use

  1. Start the relay: `pnpm --filter @devtools/relay start`
  2. A QR code is printed in the terminal alongside `ws://<LAN-IP>:9090?token=…`
  3. Open the Transport Panel on the mobile app, tap the QR button, scan the
     code — the URL is auto-filled and the transport reconnects.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35131](https://ledgerhq.atlassian.net/browse/LIVE-35131)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35131]: https://ledgerhq.atlassian.net/browse/LIVE-35131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ