### PR TITLE
refactor(contacts): standardize validation input schemas (LIVE-35360)

### DIFF
--- a/.changeset/tidy-contacts-normalize.md
+++ b/.changeset/tidy-contacts-normalize.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-contact": patch
+---
+
+Standardize Contacts validation input schemas and error names

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -16,10 +16,11 @@ This package describes what Contacts flows manipulate:
 
 `currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to later flow or integration adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
 
-Address labels must contain at least one letter or number, and may also include punctuation and
-spaces, without a maximum length. The domain validation helpers treat a blank draft as incomplete
-without surfacing an error and can reject labels already used by the same contact. Duplicate
-comparison trims surrounding spaces, normalizes Unicode, and ignores casing.
+Address labels must contain at least one letter or number, may also include punctuation and spaces,
+and are limited to 32 characters. The domain validation helpers treat a blank draft as incomplete
+without surfacing an error and can reject labels already used by the same contact. Input schemas
+trim surrounding whitespace and normalize Unicode NFC before validation. Duplicate comparison
+ignores casing.
 
 It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, or UI.
 

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -1,17 +1,9 @@
-export const INVALID_CONTACT_NAME_ERROR_NAME = "InvalidContactNameError";
-export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "InvalidContactAddressLabelError";
-export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "DuplicateContactAddressLabelError";
-export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME =
-  "ContactAddressLabelTooLongError";
-
 export class ContactError extends Error {
   override name: string = "ContactError";
 }
 
 export class InvalidContactNameError extends ContactError {
-  override name = INVALID_CONTACT_NAME_ERROR_NAME;
+  override name = "InvalidContactNameError" as const;
 
   constructor() {
     super("Expected letters, spaces, apostrophes, or hyphens");
@@ -19,13 +11,13 @@ export class InvalidContactNameError extends ContactError {
 }
 
 export class InvalidContactAddressLabelError extends ContactError {
-  override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  override name = "InvalidContactAddressLabelError" as const;
 }
 
 export class DuplicateContactAddressLabelError extends ContactError {
-  override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+  override name = "DuplicateContactAddressLabelError" as const;
 }
 
 export class ContactAddressLabelTooLongError extends ContactError {
-  override name = CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
+  override name = "ContactAddressLabelTooLongError" as const;
 }

--- a/domain/entity/contact/src/errors.ts
+++ b/domain/entity/contact/src/errors.ts
@@ -1,9 +1,17 @@
+export const INVALID_CONTACT_NAME_ERROR_NAME = "InvalidContactNameError";
+export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "InvalidContactAddressLabelError";
+export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "DuplicateContactAddressLabelError";
+export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME =
+  "ContactAddressLabelTooLongError";
+
 export class ContactError extends Error {
   override name: string = "ContactError";
 }
 
 export class InvalidContactNameError extends ContactError {
-  override name = "InvalidContactNameError" as const;
+  override name = INVALID_CONTACT_NAME_ERROR_NAME;
 
   constructor() {
     super("Expected letters, spaces, apostrophes, or hyphens");
@@ -11,13 +19,13 @@ export class InvalidContactNameError extends ContactError {
 }
 
 export class InvalidContactAddressLabelError extends ContactError {
-  override name = "InvalidContactAddressLabelError" as const;
+  override name = INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
 }
 
 export class DuplicateContactAddressLabelError extends ContactError {
-  override name = "DuplicateContactAddressLabelError" as const;
+  override name = DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME;
 }
 
 export class ContactAddressLabelTooLongError extends ContactError {
-  override name = "ContactAddressLabelTooLongError" as const;
+  override name = CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -1,8 +1,10 @@
 import {
+  ContactAddressLabelInputSchema,
   ContactAddressLabelSchema,
   ContactAddressSchema,
   ContactAddressValueSchema,
   ContactCurrencyIdSchema,
+  ContactNameInputSchema,
   ContactNameSchema,
   ContactSchema,
 } from "./schema";
@@ -38,8 +40,10 @@ describe("ContactSchema", () => {
   });
 
   it("accepts international contact names", () => {
-    expect(ContactNameSchema.parse(" E\u0301lodie ")).toBe("E\u0301lodie");
-    expect(ContactNameSchema.parse("Jean-Luc O'Connor")).toBe("Jean-Luc O'Connor");
+    expect(ContactNameInputSchema.parse(" E\u0301lodie ")).toBe("Élodie");
+    expect(ContactNameSchema.parse("Jean-Luc O'Connor")).toBe(
+      "Jean-Luc O'Connor"
+    );
     expect(ContactNameSchema.parse("Алексей")).toBe("Алексей");
     expect(ContactNameSchema.parse("مريم")).toBe("مريم");
   });
@@ -71,7 +75,7 @@ describe("ContactAddressSchema", () => {
 
   it("parses a token currency id selected through MAD", () => {
     expect(ContactCurrencyIdSchema.parse("ethereum/erc20/usd-tether")).toBe(
-      "ethereum/erc20/usd-tether",
+      "ethereum/erc20/usd-tether"
     );
   });
 
@@ -84,9 +88,18 @@ describe("ContactAddressSchema", () => {
   });
 
   it("accepts printable ASCII address labels", () => {
-    expect(ContactAddressLabelSchema.parse("Aave v3 1INCH")).toBe("Aave v3 1INCH");
+    expect(ContactAddressLabelSchema.parse("Aave v3 1INCH")).toBe(
+      "Aave v3 1INCH"
+    );
     expect(ContactAddressLabelSchema.parse("USDC.e")).toBe("USDC.e");
     expect(ContactAddressLabelSchema.parse("123")).toBe("123");
+  });
+
+  it("normalizes address label input before applying the entity schema", () => {
+    expect(ContactAddressLabelInputSchema.parse("  Ethereum  ")).toBe(
+      "Ethereum"
+    );
+    expect(ContactAddressLabelInputSchema.parse("   ")).toBe("");
   });
 
   it("rejects non-ASCII, punctuation-only, emoji, and control-character address labels", () => {
@@ -95,7 +108,9 @@ describe("ContactAddressSchema", () => {
     expect(() => ContactAddressLabelSchema.parse("Кошелек")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("---")).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum 💎")).toThrow();
-    expect(() => ContactAddressLabelSchema.parse("Ethereum 1\uFE0F\u20E3")).toThrow();
+    expect(() =>
+      ContactAddressLabelSchema.parse("Ethereum 1\uFE0F\u20E3")
+    ).toThrow();
     expect(() => ContactAddressLabelSchema.parse("Ethereum\nWallet")).toThrow();
   });
 
@@ -117,7 +132,10 @@ describe("contact mock factories", () => {
     const contact = mockContactWithMultipleAddresses();
 
     expect(ContactSchema.parse(contact)).toEqual(contact);
-    expect(contact.addresses.map(address => address.currencyId)).toEqual(["polygon", "ethereum"]);
+    expect(contact.addresses.map((address) => address.currencyId)).toEqual([
+      "polygon",
+      "ethereum",
+    ]);
   });
 
   it("builds empty and populated contact lists", () => {
@@ -125,7 +143,7 @@ describe("contact mock factories", () => {
 
     const contacts = mockPopulatedContacts();
 
-    expect(contacts.map(contact => contact.name)).toEqual([
+    expect(contacts.map((contact) => contact.name)).toEqual([
       "Me",
       "Ada",
       "Ben",

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -5,9 +5,9 @@ import {
 } from "@shared/schema-primitives";
 import { z } from "zod";
 import {
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
+  ContactAddressLabelTooLongError,
+  InvalidContactAddressLabelError,
+  InvalidContactNameError,
 } from "./errors";
 
 export const ContactIdSchema = NonEmptyStringSchema;
@@ -25,8 +25,10 @@ export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;
 
 export const ContactNameSchema = z
   .string()
-  .min(1, { error: INVALID_CONTACT_NAME_ERROR_NAME })
-  .regex(ContactNamePattern, { error: INVALID_CONTACT_NAME_ERROR_NAME })
+  .min(1, { error: () => new InvalidContactNameError().name })
+  .regex(ContactNamePattern, {
+    error: () => new InvalidContactNameError().name,
+  })
   .brand<"ContactName">();
 
 export const ContactNameInputSchema = z
@@ -37,12 +39,12 @@ export const ContactNameInputSchema = z
 
 export const ContactAddressLabelSchema = z
   .string()
-  .min(1, { error: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME })
+  .min(1, { error: () => new InvalidContactAddressLabelError().name })
   .max(CONTACT_ADDRESS_LABEL_MAX_LENGTH, {
-    error: CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+    error: () => new ContactAddressLabelTooLongError().name,
   })
   .regex(ContactAddressLabelPattern, {
-    error: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+    error: () => new InvalidContactAddressLabelError().name,
   })
   .brand<"ContactAddressLabel">();
 

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -4,10 +4,18 @@ import {
   TokenCurrencyIdSchema,
 } from "@shared/schema-primitives";
 import { z } from "zod";
+import {
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "./errors";
 
 export const ContactIdSchema = NonEmptyStringSchema;
 export const ContactAddressIdSchema = NonEmptyStringSchema;
-export const ContactCurrencyIdSchema = z.union([CryptoCurrencyIdSchema, TokenCurrencyIdSchema]);
+export const ContactCurrencyIdSchema = z.union([
+  CryptoCurrencyIdSchema,
+  TokenCurrencyIdSchema,
+]);
 
 const ContactNamePattern =
   /^\p{L}[\p{L}\p{Mn}\p{Mc}]*(?:[\p{Zs}'\u2019-]\p{L}[\p{L}\p{Mn}\p{Mc}]*)*$/u;
@@ -15,14 +23,34 @@ const ContactAddressLabelPattern = /^(?=.*[A-Za-z0-9])[\x20-\x7E]+$/;
 
 export const CONTACT_ADDRESS_LABEL_MAX_LENGTH = 32;
 
-export const ContactNameSchema = NonEmptyStringSchema.regex(
-  ContactNamePattern,
-  "Expected letters, spaces, apostrophes, or hyphens",
-);
+export const ContactNameSchema = z
+  .string()
+  .min(1, { error: INVALID_CONTACT_NAME_ERROR_NAME })
+  .regex(ContactNamePattern, { error: INVALID_CONTACT_NAME_ERROR_NAME })
+  .brand<"ContactName">();
 
-export const ContactAddressLabelSchema = NonEmptyStringSchema.regex(ContactAddressLabelPattern).max(
-  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
-);
+export const ContactNameInputSchema = z
+  .string()
+  .trim()
+  .transform((name) => name.normalize("NFC"))
+  .pipe(z.union([z.literal(""), ContactNameSchema]));
+
+export const ContactAddressLabelSchema = z
+  .string()
+  .min(1, { error: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME })
+  .max(CONTACT_ADDRESS_LABEL_MAX_LENGTH, {
+    error: CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  })
+  .regex(ContactAddressLabelPattern, {
+    error: INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  })
+  .brand<"ContactAddressLabel">();
+
+export const ContactAddressLabelInputSchema = z
+  .string()
+  .trim()
+  .transform((label) => label.normalize("NFC"))
+  .pipe(z.union([z.literal(""), ContactAddressLabelSchema]));
 
 export const ContactAddressValueSchema = NonEmptyStringSchema;
 

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -3,10 +3,16 @@ import {
   DuplicateContactAddressLabelError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
-} from "./errors";
-import { ContactAddressLabelSchema } from "./schema";
-import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
+} from "./errors";
+import {
+  ContactAddressLabelInputSchema,
+  ContactAddressLabelSchema,
+} from "./schema";
+import {
   getContactAddressLabelValidationError,
   getContactNameValidationError,
   isValidContactAddressLabel,
@@ -14,9 +20,6 @@ import {
   normalizeContactAddressLabelForComparison,
   parseContactAddressLabel,
   parseContactName,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
 } from "./validation";
 
 describe("contact name validation", () => {
@@ -93,8 +96,14 @@ describe("contact address label validation", () => {
   });
 
   it("normalizes ASCII labels for comparison", () => {
-    expect(normalizeContactAddressLabelForComparison(" Ethereum ")).toBe(
-      normalizeContactAddressLabelForComparison("ETHEREUM")
+    expect(
+      normalizeContactAddressLabelForComparison(
+        ContactAddressLabelInputSchema.parse(" Ethereum ")
+      )
+    ).toBe(
+      normalizeContactAddressLabelForComparison(
+        ContactAddressLabelInputSchema.parse("ETHEREUM")
+      )
     );
   });
 

--- a/domain/entity/contact/src/validation.test.ts
+++ b/domain/entity/contact/src/validation.test.ts
@@ -3,16 +3,12 @@ import {
   DuplicateContactAddressLabelError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
+} from "./errors";
+import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
   DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
   INVALID_CONTACT_NAME_ERROR_NAME,
-} from "./errors";
-import {
-  ContactAddressLabelInputSchema,
-  ContactAddressLabelSchema,
-} from "./schema";
-import {
   getContactAddressLabelValidationError,
   getContactNameValidationError,
   isValidContactAddressLabel,
@@ -21,6 +17,10 @@ import {
   parseContactAddressLabel,
   parseContactName,
 } from "./validation";
+import {
+  ContactAddressLabelInputSchema,
+  ContactAddressLabelSchema,
+} from "./schema";
 
 describe("contact name validation", () => {
   it("does not report an error for an empty draft name", () => {

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -3,10 +3,6 @@ import {
   DuplicateContactAddressLabelError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
-  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
-  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
-  INVALID_CONTACT_NAME_ERROR_NAME,
 } from "./errors";
 import {
   ContactAddressLabelInputSchema,
@@ -14,13 +10,24 @@ import {
 } from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
-export type ContactNameValidationErrorName =
-  typeof INVALID_CONTACT_NAME_ERROR_NAME;
+export type ContactNameValidationErrorName = InvalidContactNameError["name"];
+
+export const INVALID_CONTACT_NAME_ERROR_NAME =
+  "InvalidContactNameError" satisfies ContactNameValidationErrorName;
 
 export type ContactAddressLabelValidationErrorName =
-  | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
-  | typeof CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
+  | InvalidContactAddressLabelError["name"]
+  | DuplicateContactAddressLabelError["name"]
+  | ContactAddressLabelTooLongError["name"];
+
+export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "InvalidContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+
+export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
+  "DuplicateContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+
+export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME =
+  "ContactAddressLabelTooLongError" satisfies ContactAddressLabelValidationErrorName;
 
 type ContactNameValidationResult = {
   readonly validationError: ContactNameValidationErrorName | null;

--- a/domain/entity/contact/src/validation.ts
+++ b/domain/entity/contact/src/validation.ts
@@ -3,120 +3,135 @@ import {
   DuplicateContactAddressLabelError,
   InvalidContactAddressLabelError,
   InvalidContactNameError,
+  CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
+  DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME,
+  INVALID_CONTACT_NAME_ERROR_NAME,
 } from "./errors";
 import {
-  CONTACT_ADDRESS_LABEL_MAX_LENGTH,
-  ContactAddressLabelSchema,
-  ContactNameSchema,
+  ContactAddressLabelInputSchema,
+  ContactNameInputSchema,
 } from "./schema";
 import type { ContactAddressLabel, ContactName } from "./types";
 
-export type ContactNameValidationErrorName = InvalidContactNameError["name"];
-
-export const INVALID_CONTACT_NAME_ERROR_NAME =
-  "InvalidContactNameError" satisfies ContactNameValidationErrorName;
+export type ContactNameValidationErrorName =
+  typeof INVALID_CONTACT_NAME_ERROR_NAME;
 
 export type ContactAddressLabelValidationErrorName =
-  | InvalidContactAddressLabelError["name"]
-  | DuplicateContactAddressLabelError["name"]
-  | ContactAddressLabelTooLongError["name"];
+  | typeof INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME
+  | typeof DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
+  | typeof CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
 
-export const INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "InvalidContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+type ContactNameValidationResult = {
+  readonly validationError: ContactNameValidationErrorName | null;
+  readonly value: ContactName | null;
+};
 
-export const DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME =
-  "DuplicateContactAddressLabelError" satisfies ContactAddressLabelValidationErrorName;
+type ContactAddressLabelValidationResult = {
+  readonly validationError: ContactAddressLabelValidationErrorName | null;
+  readonly value: ContactAddressLabel | null;
+};
 
-export const CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME =
-  "ContactAddressLabelTooLongError" satisfies ContactAddressLabelValidationErrorName;
+function validateContactNameInput(
+  draftName: string
+): ContactNameValidationResult {
+  const parsed = ContactNameInputSchema.safeParse(draftName);
+
+  if (!parsed.success) {
+    return { validationError: INVALID_CONTACT_NAME_ERROR_NAME, value: null };
+  }
+
+  return parsed.data === ""
+    ? { validationError: null, value: null }
+    : { validationError: null, value: parsed.data };
+}
 
 export function getContactNameValidationError(
   draftName: string
 ): ContactNameValidationErrorName | null {
-  const trimmedDraftName = draftName.trim();
-
-  if (trimmedDraftName.length === 0) {
-    return null;
-  }
-
-  return ContactNameSchema.safeParse(trimmedDraftName).success
-    ? null
-    : INVALID_CONTACT_NAME_ERROR_NAME;
+  return validateContactNameInput(draftName).validationError;
 }
 
 export function isValidContactName(draftName: string): boolean {
-  return (
-    draftName.trim().length > 0 &&
-    getContactNameValidationError(draftName) === null
-  );
+  const { validationError, value } = validateContactNameInput(draftName);
+
+  return validationError === null && value !== null;
 }
 
 export function parseContactName(draftName: string): ContactName {
-  if (
-    getContactNameValidationError(draftName) === INVALID_CONTACT_NAME_ERROR_NAME
-  ) {
+  const { validationError, value } = validateContactNameInput(draftName);
+
+  if (validationError === INVALID_CONTACT_NAME_ERROR_NAME || value === null) {
     throw new InvalidContactNameError();
   }
 
-  const parsed = ContactNameSchema.safeParse(draftName.trim());
-
-  if (!parsed.success) {
-    throw new InvalidContactNameError();
-  }
-
-  return parsed.data;
+  return value;
 }
 
 export function normalizeContactAddressLabelForComparison(
   label: string
 ): string {
-  return label.trim().normalize("NFC").toLocaleLowerCase("en-US");
+  return label.toLocaleLowerCase("en-US");
+}
+
+function validateContactAddressLabelInput(
+  draftLabel: string,
+  existingLabels: readonly ContactAddressLabel[]
+): ContactAddressLabelValidationResult {
+  const parsed = ContactAddressLabelInputSchema.safeParse(draftLabel);
+
+  if (!parsed.success) {
+    const validationError = parsed.error.issues.some(
+      (issue) => issue.message === CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME
+    )
+      ? CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME
+      : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
+
+    return { validationError, value: null };
+  }
+
+  if (parsed.data === "") {
+    return { validationError: null, value: null };
+  }
+
+  const comparisonLabel = normalizeContactAddressLabelForComparison(
+    parsed.data
+  );
+  const validationError = existingLabels.some(
+    (label) =>
+      normalizeContactAddressLabelForComparison(label) === comparisonLabel
+  )
+    ? DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
+    : null;
+
+  return { validationError, value: parsed.data };
 }
 
 export function getContactAddressLabelValidationError(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = []
 ): ContactAddressLabelValidationErrorName | null {
-  const trimmedDraftLabel = draftLabel.trim();
-
-  if (trimmedDraftLabel.length > CONTACT_ADDRESS_LABEL_MAX_LENGTH) {
-    return CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME;
-  }
-
-  const parsed = ContactAddressLabelSchema.safeParse(trimmedDraftLabel);
-
-  if (!parsed.success) {
-    return trimmedDraftLabel.length === 0
-      ? null
-      : INVALID_CONTACT_ADDRESS_LABEL_ERROR_NAME;
-  }
-
-  const comparisonLabel = normalizeContactAddressLabelForComparison(
-    parsed.data
-  );
-  return existingLabels.some(
-    (label) =>
-      normalizeContactAddressLabelForComparison(label) === comparisonLabel
-  )
-    ? DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME
-    : null;
+  return validateContactAddressLabelInput(draftLabel, existingLabels)
+    .validationError;
 }
 
 export function isValidContactAddressLabel(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = []
 ): boolean {
-  return (
-    draftLabel.trim().length > 0 &&
-    getContactAddressLabelValidationError(draftLabel, existingLabels) === null
+  const { validationError, value } = validateContactAddressLabelInput(
+    draftLabel,
+    existingLabels
   );
+
+  return validationError === null && value !== null;
 }
 
 export function parseContactAddressLabel(
   draftLabel: string,
   existingLabels: readonly ContactAddressLabel[] = []
 ): ContactAddressLabel {
-  const validationError = getContactAddressLabelValidationError(
+  const { validationError, value } = validateContactAddressLabelInput(
     draftLabel,
     existingLabels
   );
@@ -133,11 +148,9 @@ export function parseContactAddressLabel(
     throw new DuplicateContactAddressLabelError();
   }
 
-  const parsed = ContactAddressLabelSchema.safeParse(draftLabel.trim());
-
-  if (!parsed.success) {
+  if (value === null) {
     throw new InvalidContactAddressLabelError();
   }
 
-  return ContactAddressLabelSchema.parse(parsed.data.normalize("NFC"));
+  return value;
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.**
- [x] **Impact of the changes:**
  - Contact name and address-label input normalization
  - Validation error mapping for empty, invalid, duplicate, and overlong address labels
  - Contact form submit-state behavior

### 📝 Description

The Contacts domain currently duplicates trimming and NFC normalization across validation helpers, while validation error-name constants are separate from the classes that own them.

This PR introduces explicit input schemas for contact names and address labels. They trim and normalize NFC before piping into the branded entity schemas. Scoped Zod error customization now produces the existing stable error names directly, and each validation operation parses its input once. Empty form drafts retain the current non-error, disabled-submit behavior.

```ts
export const ContactAddressLabelInputSchema = z
  .string()
  .trim()
  .transform((label) => label.normalize("NFC"))
  .pipe(z.union([z.literal(""), ContactAddressLabelSchema]));
```

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35360](https://ledgerhq.atlassian.net/browse/LIVE-35360)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)

[LIVE-35360]: https://ledgerhq.atlassian.net/browse/LIVE-35360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ