### PR TITLE
ci(e2e): give each app its own broadcast nightly day

### DIFF
--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -7,18 +7,23 @@ run-name: >
 # NB: test_filter is intentionally reduced to a bounded "filtered"/"all" token rather than embedded verbatim.
 # It is free-text and can be very long; the concurrency group name must stay under 400 characters.
 concurrency:
-  # Broadcast runs (enable_broadcast) share ONE group regardless of tests_type, so separate
-  # iOS-Only / Android-Only dispatches QUEUE instead of overlapping —
-  # they would otherwise race on the same on-chain accounts across machines, which no per-run
-  # mechanism can prevent. Non-broadcast runs keep the original per-ref/tests_type group.
+  # Broadcast runs (enable_broadcast, and the Wednesday/Friday broadcast nightlies) share ONE group
+  # regardless of tests_type, so separate iOS-Only / Android-Only dispatches QUEUE instead of
+  # overlapping — they would otherwise race on the same on-chain accounts across machines, which no
+  # per-run mechanism can prevent. Non-broadcast runs keep the original per-ref/tests_type group.
   group: >-
-    ${{ (inputs.enable_broadcast || (github.event_name == 'schedule' && github.event.schedule == '0 0 * * 1,3,5')) && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
+    ${{ (inputs.enable_broadcast || github.event.schedule == '0 0 * * 3' || github.event.schedule == '0 0 * * 5') && 'mobile-e2e-broadcast' || format('mobile-e2e-{0}-{1}-{2}-{3}', github.ref_name, inputs.ref || github.sha, github.event_name == 'schedule' && github.event.schedule || inputs.tests_type, inputs.test_filter && 'filtered' || 'all') }}
   cancel-in-progress: false
 
 on:
   schedule:
-    - cron: "0 0 * * 1,3,5"
-    - cron: "0 0 * * 2,4"
+    # One broadcast nightly per platform: iOS on Wednesday, Android on Friday. Both platforms still
+    # run every weekday, only broadcast rotates — a single broadcasting platform per run keeps the
+    # shared QAA on-chain accounts free of allowance/nonce races (desktop broadcasts on Monday).
+    # These cron expressions are matched verbatim in the env block below — keep both in sync.
+    - cron: "0 0 * * 3"
+    - cron: "0 0 * * 5"
+    - cron: "0 0 * * 1,2,4"
   workflow_dispatch:
     inputs:
       ref:
@@ -219,10 +224,13 @@ env:
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
   USERDATA_CACHE_ENABLED: ${{ !inputs.production_firebase }}
   E2E_GENERATED_USERDATA_DIR: ${{ !inputs.production_firebase && format('{0}/e2e/userdata/generated', github.workspace) || '' }}
-  # True only when a single run covers BOTH platforms (tests_type = "iOS & Android").
-  # broadcastRotation.ts uses it to pin each broadcast swap flow to one platform per run,
-  # avoiding the shared-EOA nonce race; single-platform runs keep full coverage. (QAA-1411)
-  E2E_BOTH_PLATFORMS: ${{ inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
+  # Broadcast on explicit request, or on the platform's own broadcast nightly (see the schedule above).
+  IOS_BROADCAST_ENABLED: ${{ inputs.enable_broadcast || github.event.schedule == '0 0 * * 3' }}
+  ANDROID_BROADCAST_ENABLED: ${{ inputs.enable_broadcast || github.event.schedule == '0 0 * * 5' }}
+  # True only when BOTH platforms broadcast in the same run, which the nightlies never do: only an
+  # explicit enable_broadcast dispatch covering both platforms. broadcastRotation.ts then pins each
+  # broadcast swap flow to one platform per run, avoiding the shared-EOA nonce race. (QAA-1411)
+  E2E_BOTH_PLATFORMS: ${{ inputs.enable_broadcast == true && inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
   # iOS Simulator configuration
   IOS_SIMULATOR_DEVICE: iPhone 15
   # Android AVD configuration
@@ -337,7 +345,6 @@ jobs:
           IOS_DEVICE: ${{ steps.devices.outputs.ios_device }}
           ANDROID_DEVICE: ${{ steps.devices.outputs.android_device }}
           BUILD_TYPE: ${{ inputs.production_firebase && 'production' || 'testing' }}
-          BROADCAST_ENABLED: ${{ inputs.enable_broadcast }}
           SMOKE_TESTS: ${{ inputs.smoke_tests }}
           TEST_EXECUTION_ANDROID: ${{ inputs.test_execution_android || '(not provided)' }}
           TEST_EXECUTION_IOS: ${{ inputs.test_execution_ios || '(not provided)' }}
@@ -369,7 +376,8 @@ jobs:
           echo "- **Test Execution ticket ID (Android):** $TEST_EXECUTION_ANDROID"
           echo "- **Test Execution ticket ID (iOS):** $TEST_EXECUTION_IOS"
           echo "- **Firebase env to target:** $BUILD_TYPE"
-          echo "- **Broadcast enabled:** $BROADCAST_ENABLED"
+          echo "- **Broadcast enabled (iOS):** $IOS_BROADCAST_ENABLED"
+          echo "- **Broadcast enabled (Android):** $ANDROID_BROADCAST_ENABLED"
           echo "- **Slack notification:** $SLACK_NOTIF_STATUS"
           echo "- **Android Feature Flags:** $ANDROID_FEATURE_FLAGS"
           echo "- **iOS Feature Flags:** $IOS_FEATURE_FLAGS"
@@ -701,7 +709,7 @@ jobs:
       - name: Set DISABLE_TRANSACTION_BROADCAST
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
         with:
-          enable_broadcast: ${{ inputs.enable_broadcast }}
+          enable_broadcast: ${{ env.IOS_BROADCAST_ENABLED }}
           build_type: ${{ inputs.production_firebase == true && 'js' || 'testing' }}
 
       - name: Get iOS device info
@@ -954,7 +962,7 @@ jobs:
       - name: Set DISABLE_TRANSACTION_BROADCAST
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
         with:
-          enable_broadcast: ${{ inputs.enable_broadcast }}
+          enable_broadcast: ${{ env.ANDROID_BROADCAST_ENABLED }}
           build_type: ${{ inputs.production_firebase == true && 'js' || 'testing' }}
 
       - name: Get Android device info

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -228,9 +228,11 @@ env:
   IOS_BROADCAST_ENABLED: ${{ inputs.enable_broadcast || github.event.schedule == '0 0 * * 3' }}
   ANDROID_BROADCAST_ENABLED: ${{ inputs.enable_broadcast || github.event.schedule == '0 0 * * 5' }}
   # True only when BOTH platforms broadcast in the same run, which the nightlies never do: only an
-  # explicit enable_broadcast dispatch covering both platforms. broadcastRotation.ts then pins each
-  # broadcast swap flow to one platform per run, avoiding the shared-EOA nonce race. (QAA-1411)
-  E2E_BOTH_PLATFORMS: ${{ inputs.enable_broadcast == true && inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
+  # explicit enable_broadcast dispatch covering both platforms. Equivalent to
+  # IOS_BROADCAST_ENABLED && ANDROID_BROADCAST_ENABLED, which the env context cannot express here.
+  # broadcastRotation.ts then pins each broadcast swap flow to one platform per run, avoiding the
+  # shared-EOA nonce race. (QAA-1411)
+  E2E_BROADCAST_BOTH_MOBILE_PLATFORMS: ${{ inputs.enable_broadcast == true && inputs.tests_type != 'iOS Only' && inputs.tests_type != 'Android Only' }}
   # iOS Simulator configuration
   IOS_SIMULATOR_DEVICE: iPhone 15
   # Android AVD configuration

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -4,8 +4,12 @@ run-name: >
 
 on:
   schedule:
-    - cron: "0 1 * * 1,3,5"
-    - cron: "0 1 * * 2,4"
+    # Monday is the desktop broadcast nightly: real on-chain transactions are sent.
+    # Mobile broadcasts on other days (Wednesday iOS, Friday Android) so the two apps never
+    # broadcast from the shared QAA accounts on the same day.
+    # The cron expression below is matched verbatim in the E2E_BROADCAST_ENABLED env — keep both in sync.
+    - cron: "0 1 * * 1"
+    - cron: "0 1 * * 2-5"
   workflow_dispatch:
     inputs:
       ref:
@@ -141,6 +145,8 @@ permissions:
 env:
   E2E_DESKTOP_FEATURE_FLAGS: ${{ inputs.feature_flags || 'defaults' }}
   E2E_FEATURE_FLAGS_JSON: ${{ inputs.feature_flags_json || '' }}
+  # Broadcast on explicit request, or on the Monday nightly (see the schedule above).
+  E2E_BROADCAST_ENABLED: ${{ inputs.enable_broadcast || github.event.schedule == '0 1 * * 1' }}
 
 jobs:
   prepare-devices:
@@ -285,7 +291,7 @@ jobs:
       - name: Configure test environment (API endpoints, broadcast settings)
         uses: LedgerHQ/ledger-live/tools/actions/composites/setup-e2e-env@develop
         with:
-          enable_broadcast: ${{ inputs.enable_broadcast }}
+          enable_broadcast: ${{ env.E2E_BROADCAST_ENABLED }}
           build_type: ${{ inputs.build_type }}
 
       - name: Build Playwright grep filter from inputs
@@ -307,7 +313,7 @@ jobs:
           FILTER_PATTERN: ${{ steps.test-filter.outputs.filter }}
           BUILD_TYPE: ${{ inputs.build_type || 'testing' }}
           TEST_EXECUTION: ${{ inputs.test_execution || '(not provided)' }}
-          BROADCAST_ENABLED: ${{ inputs.enable_broadcast }}
+          BROADCAST_ENABLED: ${{ env.E2E_BROADCAST_ENABLED }}
           REPEAT_EACH: ${{ inputs.repeat_each }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           TRIGGERED_BRANCH: ${{ inputs.ref || github.ref_name }}

--- a/e2e/mobile/helpers/broadcastRotation.ts
+++ b/e2e/mobile/helpers/broadcastRotation.ts
@@ -1,8 +1,8 @@
 /**
  * Decide whether this platform should run a broadcast-gated swap flow.
  *
- * On broadcast nightlies iOS+Android share the same on-chain account, so running both can race on
- * allowance/nonce. We pin each flow to one platform per run and rotate assignments.
+ * When iOS and Android broadcast in the same run they share the same on-chain account, so running
+ * both can race on allowance/nonce. We pin each flow to one platform per run and rotate assignments.
  * See: https://ledgerhq.atlassian.net/browse/QAA-1411
  */
 
@@ -27,12 +27,13 @@ function broadcastRotationIndex(): number {
 
 /**
  * Whether a broadcast flow should run in THIS platform's job on this run:
- *  - broadcast off                  → no (these flows are Monday-nightly / enable_broadcast only)
- *  - broadcast on, one platform     → yes (a single-platform run owns the account alone)
+ *  - broadcast off                  → no (broadcast is Wednesday for iOS, Friday for Android on the
+ *                                     nightlies, or an explicit enable_broadcast run)
+ *  - broadcast on, one platform     → yes (a single broadcasting platform owns the account alone)
  *  - broadcast on, both platforms   → only on the flow's assigned platform this run (rotated)
  *
- * `E2E_BOTH_PLATFORMS` is set by the workflow to `tests_type != 'iOS Only' && != 'Android Only'`
- * — i.e. whether both platform jobs run this workflow (the only case that can collide).
+ * `E2E_BOTH_PLATFORMS` is set by the workflow when both platforms broadcast in the same run — the
+ * only case that can collide. The nightlies never do: they broadcast one platform per day.
  */
 export function shouldRunBroadcastFlow(flow: BroadcastFlow): boolean {
   if (process.env.DISABLE_TRANSACTION_BROADCAST !== "0") return false;

--- a/e2e/mobile/helpers/broadcastRotation.ts
+++ b/e2e/mobile/helpers/broadcastRotation.ts
@@ -27,17 +27,17 @@ function broadcastRotationIndex(): number {
 
 /**
  * Whether a broadcast flow should run in THIS platform's job on this run:
- *  - broadcast off                  → no (broadcast is Wednesday for iOS, Friday for Android on the
- *                                     nightlies, or an explicit enable_broadcast run)
- *  - broadcast on, one platform     → yes (a single broadcasting platform owns the account alone)
- *  - broadcast on, both platforms   → only on the flow's assigned platform this run (rotated)
+ *  - broadcast off for this platform  → no
+ *  - broadcast on, this platform only → yes (it owns the shared account alone)
+ *  - broadcast on for both platforms  → only on the flow's assigned platform this run (rotated)
  *
- * `E2E_BOTH_PLATFORMS` is set by the workflow when both platforms broadcast in the same run — the
- * only case that can collide. The nightlies never do: they broadcast one platform per day.
+ * Broadcast is on for a platform on its own nightly (iOS Wednesday, Android Friday) or on an
+ * explicit enable_broadcast run. `E2E_BROADCAST_BOTH_MOBILE_PLATFORMS` marks the only case that
+ * can collide — both platforms broadcasting in the same run — which the nightlies never do.
  */
 export function shouldRunBroadcastFlow(flow: BroadcastFlow): boolean {
   if (process.env.DISABLE_TRANSACTION_BROADCAST !== "0") return false;
-  if (process.env.E2E_BOTH_PLATFORMS !== "true") return true;
+  if (process.env.E2E_BROADCAST_BOTH_MOBILE_PLATFORMS !== "true") return true;
 
   const assigned = PLATFORM_SLOTS[(broadcastRotationIndex() + flow) % PLATFORM_SLOTS.length];
   return currentPlatform() === assigned;

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenApprovalFlow.ts
@@ -18,9 +18,9 @@ export function runSwapTokenApprovalFlow(
   const runHere = shouldRunBroadcastFlow(BroadcastFlow.APPROVAL);
   if (!runHere) {
     const broadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
-    const bothPlatforms = process.env.E2E_BOTH_PLATFORMS === "true";
+    const bothPlatformsBroadcast = process.env.E2E_BROADCAST_BOTH_MOBILE_PLATFORMS === "true";
     console.warn(
-      broadcastEnabled && bothPlatforms
+      broadcastEnabled && bothPlatformsBroadcast
         ? "[approval.swap.spec] Skipping — rotated to the other platform for this run (avoids shared-account broadcast race)"
         : "[approval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0",
     );

--- a/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
+++ b/e2e/mobile/specs/swap/tokenApprovalFlow/swapTokenReapprovalFlow.ts
@@ -22,9 +22,9 @@ export function runSwapTokenReapprovalFlow(
   const runHere = shouldRunBroadcastFlow(BroadcastFlow.REAPPROVAL);
   if (!runHere) {
     const broadcastEnabled = process.env.DISABLE_TRANSACTION_BROADCAST === "0";
-    const bothPlatforms = process.env.E2E_BOTH_PLATFORMS === "true";
+    const bothPlatformsBroadcast = process.env.E2E_BROADCAST_BOTH_MOBILE_PLATFORMS === "true";
     console.warn(
-      broadcastEnabled && bothPlatforms
+      broadcastEnabled && bothPlatformsBroadcast
         ? "[reapproval.swap.spec] Skipping — rotated to the other platform for this run (avoids shared-account broadcast race)"
         : "[reapproval.swap.spec] Skipping — requires DISABLE_TRANSACTION_BROADCAST=0",
     );

--- a/tools/actions/composites/setup-e2e-env/action.yml
+++ b/tools/actions/composites/setup-e2e-env/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: "testing"
   enable_broadcast:
-    description: "Enable transaction broadcast"
+    description: "Enable transaction broadcast. Callers own the decision, including which scheduled runs broadcast."
     required: false
     default: "false"
 
@@ -17,7 +17,7 @@ runs:
       id: set-broadcast
       shell: bash
       run: |
-        if [[ "${INPUTS_ENABLE_BROADCAST}" == "true" || ("${{ github.event_name }}" == "schedule" && "$(date +%u)" == "1") ]]; then
+        if [[ "${INPUTS_ENABLE_BROADCAST}" == "true" ]]; then
           echo "DISABLE_TRANSACTION_BROADCAST=0" >> $GITHUB_ENV
         else
           echo "DISABLE_TRANSACTION_BROADCAST=1" >> $GITHUB_ENV


### PR DESCRIPTION
### ✅ Checklist

- [ ] `npx changeset` was attached. _Not applicable: CI workflow / composite action changes only. The one TypeScript edit is a doc comment, so no package needs a release._
- [ ] **Covered by automatic tests.** _Not unit-testable: this is GitHub Actions schedule wiring. Validated with `actionlint` (clean) and by resolving each expression by hand for the `schedule`, `workflow_dispatch` and `workflow_call` triggers._
- [x] **Impact of the changes:**
  - Desktop nightly on Monday must still broadcast (summary shows `Broadcast enabled: true`, `DISABLE_TRANSACTION_BROADCAST=0`).
  - Mobile nightly on Wednesday must broadcast on iOS only, Friday on Android only; the other platform runs with broadcast off.
  - Mobile nightlies on Monday, Tuesday and Thursday must not broadcast at all.
  - Manual dispatches with `enable_broadcast` still broadcast on every platform selected, and PR / push runs still never broadcast.
  - Mobile token approval + reapproval swap flows must actually run on the broadcasting platform (they are skipped when broadcast is off).

### 📝 Description

**Problem**: all three E2E nightlies broadcast real on-chain transactions on the same day. The rule lived in the shared `setup-e2e-env` composite action (`event_name == 'schedule' && date +%u == 1`), so Desktop, mobile iOS and mobile Android all broadcast on Monday and competed for the same QAA on-chain accounts.

**Solution**: give each app its own broadcast day and move the decision into the workflows, next to the crons.

| Day | Broadcast |
| --- | --- |
| Monday | Desktop |
| Wednesday | Mobile iOS |
| Friday | Mobile Android |

- `setup-e2e-env` no longer infers a day: it only honours the `enable_broadcast` input, so callers own the decision. This also removes a trap where a scheduled caller passing `enable_broadcast: false` would silently broadcast on Mondays.
- Each scheduled broadcast day now has its own cron expression, and the workflow keys the decision off `github.event.schedule` rather than the runner clock: Desktop `0 1 * * 1`, mobile `0 0 * * 3` (iOS) and `0 0 * * 5` (Android). Remaining weekdays keep running without broadcast, so test coverage per day is unchanged.
- Mobile resolves broadcast per platform (`IOS_BROADCAST_ENABLED` / `ANDROID_BROADCAST_ENABLED`), passes it to the matching Detox job, and reports both values in the run summary.
- `E2E_BOTH_PLATFORMS` now means "both platforms broadcast in the same run" instead of "both platform jobs run". Without this, the `broadcastRotation.ts` pinning added in QAA-1411 would have rotated the approval / reapproval swap flows onto the platform that is *not* broadcasting, skipping them about half the time.

**Note for reviewers**: the workflows reference the composite as `setup-e2e-env@develop`, so a branch run still picks up develop's version of it. The per-platform behaviour is only fully accurate once this is merged.

### ❓ Context

- **JIRA or GitHub link**: none — CI schedule change requested directly.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)