### PR TITLE
feat(contacts): render sanctioned address banner

### DIFF
--- a/.changeset/gentle-address-validation-feedback.md
+++ b/.changeset/gentle-address-validation-feedback.md
@@ -1,0 +1,7 @@
+---
+"@features/platform-address-validation": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Add reusable sanctioned address validation feedback to Send.

--- a/.changeset/soft-contacts-address-validation-flow.md
+++ b/.changeset/soft-contacts-address-validation-flow.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Render injected sanctioned address validation feedback in the add-address Flow.

--- a/apps/ledger-live-desktop/package.json
+++ b/apps/ledger-live-desktop/package.json
@@ -80,6 +80,7 @@
     "@features/flow-card": "workspace:^",
     "@features/flow-contacts": "workspace:^",
     "@features/flow-large-screen-upsell": "workspace:^",
+    "@features/platform-address-validation": "workspace:^",
     "@features/platform-currencies": "workspace:^",
     "@features/platform-feature-flags": "workspace:^",
     "@features/platform-style": "workspace:^",

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
-import { Banner, Button } from "@ledgerhq/lumen-ui-react";
+import { Banner } from "@ledgerhq/lumen-ui-react";
+import { SanctionedAddressBanner } from "@features/platform-address-validation";
 import { useTranslation } from "react-i18next";
 import { openURL } from "~/renderer/linking";
 import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
@@ -34,16 +35,12 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (props.type === "sanctioned") {
     return (
-      <Banner
-        appearance="error"
+      <SanctionedAddressBanner
         title="Flagged address"
         description={t("newSendFlow.sanctioned.description")}
-        primaryAction={
-          <Button appearance="transparent" size="sm" onClick={handleHelpCenter}>
-            {t("newSendFlow.sanctioned.helpCenter")}
-          </Button>
-        }
-        data-testid="sanctioned-address-banner"
+        actionLabel={t("newSendFlow.sanctioned.helpCenter")}
+        onAction={handleHelpCenter}
+        testID="sanctioned-address-banner"
       />
     );
   }

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -110,6 +110,7 @@
     "@features/flow-card": "workspace:^",
     "@features/flow-contacts": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
+    "@features/platform-address-validation": "workspace:^",
     "@features/platform-currencies": "workspace:^",
     "@features/platform-env": "workspace:*",
     "@features/platform-feature-flags": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/ValidationBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
-import { Banner, Button } from "@ledgerhq/lumen-ui-rnative";
+import { Banner } from "@ledgerhq/lumen-ui-rnative";
+import { SanctionedAddressBanner } from "@features/platform-address-validation";
 import { useTranslation } from "~/context/Locale";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
@@ -34,16 +35,12 @@ export function ValidationBanner(props: ValidationBannerProps) {
 
   if (props.type === "sanctioned") {
     return (
-      <Banner
-        appearance="error"
+      <SanctionedAddressBanner
         title={t("send.newSendFlow.sanctioned.title")}
         description={t("send.newSendFlow.sanctioned.description")}
-        primaryAction={
-          <Button appearance="transparent" size="sm" onPress={handleHelpCenter}>
-            {t("send.newSendFlow.sanctioned.helpCenter")}
-          </Button>
-        }
-        data-testid="sanctioned-address-banner"
+        actionLabel={t("send.newSendFlow.sanctioned.helpCenter")}
+        onAction={handleHelpCenter}
+        testID="sanctioned-address-banner"
       />
     );
   }

--- a/features/flow/contacts/jest.config.js
+++ b/features/flow/contacts/jest.config.js
@@ -1,1 +1,9 @@
-module.exports = require("@features/platform-jest-config").createFlowJestConfig();
+const { createFlowJestConfig } = require("@features/platform-jest-config");
+
+const config = createFlowJestConfig();
+const nativeConfig = config.projects.find(project => project.displayName === "native");
+
+nativeConfig.moduleNameMapper["^@features/platform-address-validation$"] =
+  "<rootDir>/../../platform/address-validation/src/index.native.ts";
+
+module.exports = config;

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -26,6 +26,7 @@
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
     "@ledgerhq/crypto-icons": "catalog:",
+    "@features/platform-address-validation": "workspace:^",
     "@features/platform-feature-flags": "workspace:^",
     "@shared/feature-flags": "workspace:^",
     "@shared/qr-code": "workspace:*"

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
@@ -177,6 +177,36 @@ describe("ContactsAddAddressEntry", () => {
     expect(screen.getByTestId("contacts-add-address-confirm").props.disabled).toBe(true);
   });
 
+  it("should render the sanctioned banner without a redundant helper", () => {
+    render(
+      <ContactsAddAddressEntry
+        addressEntry={{
+          status: "invalid",
+          value: VALID_ADDRESS,
+          resolvedAddress: null,
+          inputMethod: "manual",
+          error: "sanctioned",
+        }}
+        labels={labels}
+        sanctionedBanner={{
+          description: "This wallet address is sanctioned.",
+          actionLabel: "Learn more",
+          onAction: jest.fn(),
+          testID: "contacts-sanctioned-address-banner",
+        }}
+        onChangeText={jest.fn()}
+        onConfirm={jest.fn()}
+        onQrCodeClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-input").props).toMatchObject({
+      helperText: undefined,
+      status: "error",
+    });
+    expect(screen.getByTestId("contacts-sanctioned-address-banner")).toBeTruthy();
+  });
+
   it("should render validation unavailability as a blocking error", () => {
     renderEntry({
       status: "unavailable",

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.types.ts
@@ -1,8 +1,10 @@
 import type { AddAddressEntryLabels, AddAddressEntryState, AddAddressInputSource } from "./types";
+import type { SanctionedAddressBannerProps } from "@features/platform-address-validation";
 
 export type ContactsAddAddressEntryProps = Readonly<{
   addressEntry: AddAddressEntryState;
   labels: AddAddressEntryLabels;
+  sanctionedBanner?: SanctionedAddressBannerProps;
   bottomOffset?: number;
   onChangeText: (value: string, inputMethod: AddAddressInputSource) => void;
   onConfirm: () => void;
@@ -16,6 +18,7 @@ export type ContactsAddAddressEntryViewProps = Readonly<{
   bottomPadding: number;
   inputStatus?: "error" | "success";
   helperText?: string;
+  sanctionedBanner?: SanctionedAddressBannerProps;
   showEnsDisclaimer: boolean;
   isConfirmEnabled: boolean;
   onAddressChange: (value: string) => void;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
@@ -1,5 +1,6 @@
 import type { ChangeEvent, ClipboardEvent } from "react";
 import type { ContactsAddAddressNameLabels } from "./AddressName/types";
+import type { SanctionedAddressBannerProps } from "@features/platform-address-validation";
 import type {
   AddAddressEntryLabels,
   AddAddressEntryState,
@@ -36,6 +37,7 @@ type WithoutAddressLabelViewConfiguration = Readonly<{
 type ContactsAddAddressEntryWebBaseProps = Readonly<{
   addressEntry: AddAddressEntryState;
   labels: AddAddressEntryLabels;
+  sanctionedBanner?: SanctionedAddressBannerProps;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onConfirm?: () => void;
 }>;
@@ -49,6 +51,7 @@ type ContactsAddAddressEntryWebViewBaseProps = Readonly<{
   labels: AddAddressEntryLabels;
   inputStatus?: "error" | "success";
   helperText?: string;
+  sanctionedBanner?: SanctionedAddressBannerProps;
   showEnsDisclaimer: boolean;
   isConfirmEnabled: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   Button,
 } from "@ledgerhq/lumen-ui-rnative";
+import { SanctionedAddressBanner } from "@features/platform-address-validation";
 import type { ContactsAddAddressEntryViewProps } from "./ContactsAddAddressEntry.types";
 
 export function ContactsAddAddressEntryView({
@@ -16,6 +17,7 @@ export function ContactsAddAddressEntryView({
   bottomPadding,
   inputStatus,
   helperText,
+  sanctionedBanner,
   showEnsDisclaimer,
   isConfirmEnabled,
   onAddressChange,
@@ -44,6 +46,7 @@ export function ContactsAddAddressEntryView({
             autoCorrect={false}
             spellCheck={false}
           />
+          {sanctionedBanner ? <SanctionedAddressBanner {...sanctionedBanner} /> : null}
           {showEnsDisclaimer ? (
             <Banner
               testID="contacts-add-address-ens-disclaimer"

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { SanctionedAddressBanner } from "@features/platform-address-validation";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
 
@@ -9,6 +10,7 @@ export function ContactsAddAddressEntryView({
   labels,
   inputStatus,
   helperText,
+  sanctionedBanner,
   showEnsDisclaimer,
   addressLabel,
   nameLabels,
@@ -35,6 +37,7 @@ export function ContactsAddAddressEntryView({
         status={inputStatus}
         value={value}
       />
+      {sanctionedBanner ? <SanctionedAddressBanner {...sanctionedBanner} /> : null}
       {showEnsDisclaimer ? (
         <Banner
           appearance="info"

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ContactsAddAddressEntry } from "../ContactsAddAddressEntry.web";
 import { ContactsAddAddressNameInput } from "../AddressName/Input/ContactsAddAddressNameInput.web";
 import type { ContactsAddAddressNameLabels } from "../AddressName/types";
+import type { SanctionedAddressBannerProps } from "@features/platform-address-validation";
 import { ContactsAddAddressCompletion } from "../Completion/ContactsAddAddressCompletion.web";
 import type {
   AddAddressCompletionLabels,
@@ -20,6 +21,7 @@ export type ContactsAddAddressFlowContentProps = Readonly<{
   entryLabels: AddAddressEntryLabels;
   nameLabels: ContactsAddAddressNameLabels;
   completionLabels: AddAddressCompletionLabels;
+  sanctionedBanner?: SanctionedAddressBannerProps;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onContinueFromAddressDetails: () => void;
   onAddressLabelChange: (value: string) => void;
@@ -58,6 +60,7 @@ export function ContactsAddAddressFlowContent({
   entryLabels,
   nameLabels,
   completionLabels,
+  sanctionedBanner,
   onAddressChange,
   onContinueFromAddressDetails,
   onAddressLabelChange,
@@ -73,6 +76,7 @@ export function ContactsAddAddressFlowContent({
           addressLabel={state.addressLabel}
           labels={entryLabels}
           nameLabels={nameLabels}
+          sanctionedBanner={sanctionedBanner}
           onAddressChange={onAddressChange}
           onAddressLabelChange={onAddressLabelChange}
           onConfirm={onContinueFromAddressDetails}

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.native.ts
@@ -87,6 +87,7 @@ function resolveAddressInputPresentation(
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
   labels,
+  sanctionedBanner,
   bottomOffset = 0,
   onChangeText,
   onConfirm,
@@ -102,13 +103,17 @@ export function useContactsAddAddressEntryViewModel({
     [addressEntry.value, onChangeText],
   );
 
+  const shouldShowSanctionedBanner =
+    addressEntry.status === "invalid" && addressEntry.error === "sanctioned" && sanctionedBanner;
+
   return {
     value: addressEntry.value,
     labels,
     bottomOffset,
     bottomPadding: 32,
     inputStatus: presentation.status,
-    helperText: presentation.helperText,
+    helperText: shouldShowSanctionedBanner ? undefined : presentation.helperText,
+    ...(shouldShowSanctionedBanner ? { sanctionedBanner } : {}),
     showEnsDisclaimer: presentation.showEnsDisclaimer,
     isConfirmEnabled: presentation.isConfirmEnabled,
     onAddressChange,

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -157,6 +157,27 @@ describe("useContactsAddAddressEntryViewModel", () => {
     });
   });
 
+  it("should expose a sanctioned banner alongside the Desktop helper", () => {
+    const sanctionedBanner = {
+      description: "This wallet address is sanctioned.",
+      actionLabel: "Learn more",
+      onAction: jest.fn(),
+    };
+    const { result } = renderViewModel({
+      addressEntry: {
+        status: "invalid",
+        value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        resolvedAddress: null,
+        inputMethod: "manual",
+        error: "sanctioned",
+      },
+      sanctionedBanner,
+    });
+
+    expect(result.current.sanctionedBanner).toBe(sanctionedBanner);
+    expect(result.current.helperText).toBe("This address is sanctioned and cannot be used.");
+  });
+
   it("should require a valid address label for the combined Desktop form", () => {
     const onAddressLabelChange = jest.fn();
     const { result } = renderViewModel({

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -75,6 +75,7 @@ function resolveAddressInputPresentation(
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
   labels,
+  sanctionedBanner,
   onAddressChange,
   onConfirm,
   ...addressLabelProps
@@ -126,6 +127,9 @@ export function useContactsAddAddressEntryViewModel({
     value: addressEntry.value,
     labels,
     ...presentation,
+    ...(addressEntry.status === "invalid" && addressEntry.error === "sanctioned" && sanctionedBanner
+      ? { sanctionedBanner }
+      : {}),
     ...addressLabelViewProps,
     isConfirmEnabled: presentation.isConfirmEnabled && isNameValid && onConfirm !== undefined,
     onChange,

--- a/features/platform/address-validation/README.md
+++ b/features/platform/address-validation/README.md
@@ -1,0 +1,12 @@
+# @features/platform-address-validation
+
+> [!CAUTION]
+> **Status: UNSTABLE** — Shared address-validation feedback primitives are being introduced for Send and Contacts.
+
+Reusable, domain-aware presentation primitives for address-validation feedback shared by multiple user flows.
+
+## Public API
+
+- `SanctionedAddressBanner` renders an error banner with an optional title and an injected action.
+
+Consumers provide translated copy and handle navigation themselves, so this package has no app routing, URL, or localization dependency.

--- a/features/platform/address-validation/jest.config.js
+++ b/features/platform/address-validation/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@features/platform-jest-config").createFlowJestConfig();

--- a/features/platform/address-validation/package.json
+++ b/features/platform/address-validation/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@features/platform-address-validation",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cross-flow address-validation feedback primitives",
+  "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "coverage": "jest --coverage"
+  },
+  "peerDependencies": {
+    "react": ">=19.0.0",
+    "react-native": ">=0.70.0",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@features/platform-jest-config": "workspace:*",
+    "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@swc/core": "catalog:",
+    "@swc/jest": "catalog:",
+    "@testing-library/dom": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
+    "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/features/platform/address-validation/project.json
+++ b/features/platform/address-validation/project.json
@@ -1,0 +1,8 @@
+{
+  "name": "@features/platform-address-validation",
+  "targets": {
+    "build": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/features/platform/address-validation/src/SanctionedAddressBanner.native.test.tsx
+++ b/features/platform/address-validation/src/SanctionedAddressBanner.native.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { SanctionedAddressBanner } from "./SanctionedAddressBanner.native";
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const React = require("react");
+
+  return {
+    Banner: ({
+      description,
+      primaryAction,
+      testID,
+    }: {
+      description: string;
+      primaryAction?: React.ReactNode;
+      testID?: string;
+    }) =>
+      React.createElement(
+        "Banner",
+        { testID },
+        React.createElement("Text", undefined, description),
+        primaryAction,
+      ),
+    Button: ({ children, onPress }: { children: React.ReactNode; onPress?: () => void }) =>
+      React.createElement("Button", { onPress }, React.createElement("Text", undefined, children)),
+  };
+});
+
+describe("SanctionedAddressBanner", () => {
+  it("should render the injected content and invoke its action", () => {
+    const onAction = jest.fn();
+
+    render(
+      <SanctionedAddressBanner
+        description="This address is blocked."
+        actionLabel="Learn more"
+        onAction={onAction}
+        testID="sanctioned-address-banner"
+      />,
+    );
+
+    expect(screen.getByTestId("sanctioned-address-banner")).toBeTruthy();
+    expect(screen.getByText("This address is blocked.")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Learn more"));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/platform/address-validation/src/SanctionedAddressBanner.native.tsx
+++ b/features/platform/address-validation/src/SanctionedAddressBanner.native.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Banner, Button } from "@ledgerhq/lumen-ui-rnative";
+import type { SanctionedAddressBannerProps } from "./types";
+
+export function SanctionedAddressBanner({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  testID,
+}: SanctionedAddressBannerProps): React.JSX.Element {
+  return (
+    <Banner
+      appearance="error"
+      title={title}
+      description={description}
+      primaryAction={
+        <Button appearance="transparent" size="sm" onPress={onAction}>
+          {actionLabel}
+        </Button>
+      }
+      testID={testID}
+    />
+  );
+}

--- a/features/platform/address-validation/src/SanctionedAddressBanner.web.test.tsx
+++ b/features/platform/address-validation/src/SanctionedAddressBanner.web.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SanctionedAddressBanner } from "./SanctionedAddressBanner.web";
+
+jest.mock("@ledgerhq/lumen-ui-react", () => {
+  const React = require("react");
+
+  return {
+    Banner: ({
+      description,
+      primaryAction,
+      "data-testid": testID,
+    }: {
+      description: string;
+      primaryAction?: React.ReactNode;
+      "data-testid"?: string;
+    }) => React.createElement("div", { "data-testid": testID }, description, primaryAction),
+    Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) =>
+      React.createElement("button", { type: "button", onClick }, children),
+  };
+});
+
+describe("SanctionedAddressBanner", () => {
+  it("should render the injected content and invoke its action", () => {
+    const onAction = jest.fn();
+
+    render(
+      <SanctionedAddressBanner
+        title="Flagged address"
+        description="This address is blocked."
+        actionLabel="Learn more"
+        onAction={onAction}
+        testID="sanctioned-address-banner"
+      />,
+    );
+
+    expect(screen.getByTestId("sanctioned-address-banner")).toBeVisible();
+    expect(screen.getByText("This address is blocked.")).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Learn more" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/platform/address-validation/src/SanctionedAddressBanner.web.tsx
+++ b/features/platform/address-validation/src/SanctionedAddressBanner.web.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Banner, Button } from "@ledgerhq/lumen-ui-react";
+import type { SanctionedAddressBannerProps } from "./types";
+
+export function SanctionedAddressBanner({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  testID,
+}: SanctionedAddressBannerProps): React.JSX.Element {
+  return (
+    <Banner
+      appearance="error"
+      title={title}
+      description={description}
+      primaryAction={
+        <Button appearance="transparent" size="sm" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      }
+      data-testid={testID}
+    />
+  );
+}

--- a/features/platform/address-validation/src/index.native.ts
+++ b/features/platform/address-validation/src/index.native.ts
@@ -1,0 +1,2 @@
+export { SanctionedAddressBanner } from "./SanctionedAddressBanner.native";
+export type { SanctionedAddressBannerProps } from "./types";

--- a/features/platform/address-validation/src/index.ts
+++ b/features/platform/address-validation/src/index.ts
@@ -1,0 +1,2 @@
+export { SanctionedAddressBanner } from "./SanctionedAddressBanner.web";
+export type { SanctionedAddressBannerProps } from "./types";

--- a/features/platform/address-validation/src/types.ts
+++ b/features/platform/address-validation/src/types.ts
@@ -1,0 +1,7 @@
+export type SanctionedAddressBannerProps = Readonly<{
+  title?: string;
+  description: string;
+  actionLabel: string;
+  onAction: () => void;
+  testID?: string;
+}>;

--- a/features/platform/address-validation/tsconfig.json
+++ b/features/platform/address-validation/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "paths": { "*": ["./*"] },
+    "noEmit": true,
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -893,6 +893,9 @@ importers:
       '@features/flow-large-screen-upsell':
         specifier: workspace:^
         version: link:../../features/flow/large-screen-upsell
+      '@features/platform-address-validation':
+        specifier: workspace:^
+        version: link:../../features/platform/address-validation
       '@features/platform-currencies':
         specifier: workspace:^
         version: link:../../features/platform/currencies
@@ -1630,6 +1633,9 @@ importers:
       '@features/flow-fear-and-greed':
         specifier: workspace:^
         version: link:../../features/flow/fear-and-greed
+      '@features/platform-address-validation':
+        specifier: workspace:^
+        version: link:../../features/platform/address-validation
       '@features/platform-currencies':
         specifier: workspace:^
         version: link:../../features/platform/currencies
@@ -4984,6 +4990,63 @@ importers:
       '@oxlint/binding-win32-x64-msvc':
         specifier: 1.51.0
         version: 1.51.0
+
+  features/platform/address-validation:
+    devDependencies:
+      '@features/platform-jest-config':
+        specifier: workspace:*
+        version: link:../jest-config
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.49(@ledgerhq/lumen-design-core@0.1.23)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.52(@ledgerhq/lumen-design-core@0.1.23)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@swc/core':
+        specifier: 'catalog:'
+        version: 1.15.11
+      '@swc/jest':
+        specifier: 'catalog:'
+        version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@types/jest':
+        specifier: 'catalog:'
+        version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
+      jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      jest-environment-jsdom:
+        specifier: 'catalog:'
+        version: 30.2.0
+      react:
+        specifier: 19.1.4
+        version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
+      typescript:
+        specifier: 'catalog:'
+        version: '@typescript/typescript6@6.0.2'
 
   features/platform/aggregated-assets:
     devDependencies:
@@ -47408,6 +47471,18 @@ snapshots:
       react-native-reanimated: 4.3.0(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-safe-area-context: 5.6.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       react-native-svg: 15.15.1(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@ledgerhq/lumen-ui-rnative@0.1.52(@ledgerhq/lumen-design-core@0.1.23)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      '@ledgerhq/lumen-design-core': 0.1.23
+      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
+      '@types/react': 19.0.14
+      i18next: 23.10.1
+      react: 19.1.4
+      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
     transitivePeerDependencies:
       - react-dom
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4687,6 +4687,9 @@ importers:
       '@domain/entity-currency-token':
         specifier: workspace:*
         version: link:../../../domain/entity/currency-token
+      '@features/platform-address-validation':
+        specifier: workspace:^
+        version: link:../../platform/address-validation
       '@features/platform-feature-flags':
         specifier: workspace:^
         version: link:../../platform/feature-flags


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Targeted Web and Native Contacts Flow tests.
- [x] **Impact of the changes:**
      The Flow can render app-injected sanctioned-address feedback while retaining the existing validation block.

### 📝 Description

Adds the Contacts Flow integration for `@features/platform-address-validation`. The Flow accepts optional banner props and renders the sanctioned state on both platforms; it contains no translation or external-navigation logic.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33925 and https://ledgerhq.atlassian.net/browse/LIVE-33926

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)