### PR TITLE
test(e2e): reload buy/sell webview when stuck loading

### DIFF
--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -129,7 +129,7 @@ export class BuyAndSellPage extends WebViewAppPage {
               `after ${maxReloads + 1} attempts — webview stuck loading.`,
           );
         }
-        await webview.reload();
+        await webview.reload({ timeout: readyTimeout, waitUntil: "domcontentloaded" });
       }
     }
   }

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -104,13 +104,10 @@ export class BuyAndSellPage extends WebViewAppPage {
     await this.selectAssetInDrawer(account);
   }
 
-  /**
-   * Buy/Sell runs inside the PTX (swap) live app webview. That app occasionally
-   * stays stuck on its loading spinner and never renders the amount screen, so the
-   * crypto selector never appears and the flow times out on a bare `.textContent()`.
-   * Wait for the selector and, if it never shows, reload the webview and retry —
-   * the same recovery the Borrow webview uses (see borrow.page.ts).
-   */
+/**
+ * Workaround: PTX Buy/Sell web app can remain stuck loading; reload the webview and retry.
+ * Mirrors the recovery used in borrow.page.ts.
+ */
   @step("Wait for the Buy/Sell web app to finish loading")
   private async waitForCryptoSelectorReady() {
     const readyTimeout = 30_000;

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -98,11 +98,40 @@ export class BuyAndSellPage extends WebViewAppPage {
 
   @step("Choose crypto asset if not selected")
   async chooseAssetIfNotSelected(account: AccountType) {
+    await this.waitForCryptoSelectorReady();
     if (await this.isCorrectAssetAlreadySelected(account)) return;
-    const webview = await this.getWebView();
-    await expect(webview.getByTestId(this.cryptoCurrencySelector)).toBeEnabled();
     await this.clickElement(this.cryptoCurrencySelector);
     await this.selectAssetInDrawer(account);
+  }
+
+  /**
+   * Buy/Sell runs inside the PTX (swap) live app webview. That app occasionally
+   * stays stuck on its loading spinner and never renders the amount screen, so the
+   * crypto selector never appears and the flow times out on a bare `.textContent()`.
+   * Wait for the selector and, if it never shows, reload the webview and retry —
+   * the same recovery the Borrow webview uses (see borrow.page.ts).
+   */
+  @step("Wait for the Buy/Sell web app to finish loading")
+  private async waitForCryptoSelectorReady() {
+    const readyTimeout = 30_000;
+    const maxReloads = 2;
+    const webview = await this.getWebView();
+    const selector = webview.getByTestId(this.cryptoCurrencySelector);
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await expect(selector).toBeVisible({ timeout: readyTimeout });
+        return;
+      } catch {
+        if (attempt >= maxReloads) {
+          throw new Error(
+            `Buy/Sell web app did not render the crypto selector "${this.cryptoCurrencySelector}" ` +
+              `after ${maxReloads + 1} attempts — webview stuck loading.`,
+          );
+        }
+        await webview.reload();
+      }
+    }
   }
 
   private async isCorrectAssetAlreadySelected(account: AccountType): Promise<boolean> {

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -104,10 +104,10 @@ export class BuyAndSellPage extends WebViewAppPage {
     await this.selectAssetInDrawer(account);
   }
 
-/**
- * Workaround: PTX Buy/Sell web app can remain stuck loading; reload the webview and retry.
- * Mirrors the recovery used in borrow.page.ts.
- */
+  /**
+   * Workaround: PTX Buy/Sell web app can remain stuck loading; reload the webview and retry.
+   * Mirrors the recovery used in borrow.page.ts.
+   */
   @step("Wait for the Buy/Sell web app to finish loading")
   private async waitForCryptoSelectorReady() {
     const readyTimeout = 30_000;

--- a/e2e/desktop/tests/page/buyAndSell.page.ts
+++ b/e2e/desktop/tests/page/buyAndSell.page.ts
@@ -119,11 +119,12 @@ export class BuyAndSellPage extends WebViewAppPage {
       try {
         await expect(selector).toBeVisible({ timeout: readyTimeout });
         return;
-      } catch {
+      } catch (error) {
         if (attempt >= maxReloads) {
           throw new Error(
             `Buy/Sell web app did not render the crypto selector "${this.cryptoCurrencySelector}" ` +
               `after ${maxReloads + 1} attempts — webview stuck loading.`,
+            { cause: error },
           );
         }
         await webview.reload({ timeout: readyTimeout, waitUntil: "domcontentloaded" });


### PR DESCRIPTION
### Checklist

- [ ] `npx changeset` was attached. _N/A — E2E test-only change (`e2e/desktop`), no published package impacted (prior `test(e2e)` buySell commits shipped without one)._
- [ ] **Covered by automatic tests.** _This change is E2E test infrastructure; it is validated by re-running the Desktop E2E suite in CI rather than by unit tests._
- [x] **Impact of the changes:**
  - Desktop Buy/Sell E2E flows (`buySell.spec.ts`) — buy & sell from the portfolio, provider selection
  - No product/runtime code changed; only the `BuyAndSellPage` page object

### Description

The nightly Desktop E2E test `Sell [Tether USD] asset` (`buySell.spec.ts:212`) fails intermittently at `chooseAssetIfNotSelected` with:

```
TimeoutError: locator.textContent: Timeout 60000ms exceeded.
  - waiting for getByTestId('crypto-amount-option-button')
```

**Root cause.** The desktop Buy/Sell flow is rendered by the PTX (swap) live app (`swap-live-app-stg.ledger-test.com`) inside the `"buy"` webview — buy/sell/swap share the same app. Intermittently that app **stays stuck on its loading spinner** and never renders the amount screen, so `crypto-amount-option-button` never appears. The Allure artifacts confirm it: the failure screenshot shows the spinner under the "Buy or sell" header, the accessibility snapshot shows an empty `iframe`, and **all 43 webview requests return 200** (nothing failed at the network layer). The webview console shows a firebase remote-config load race (`Effective app config is null`, `ZodError: optimisticBalanceTtlMs Required`).

It is **flaky, not USDT-specific**: `Sell [Tether USD]` passed Aug 3 (nanoSP) and failed Jul 31 (nanoGen5) and Aug 4 (stax). `Sell [Ethereum]` and `Sell [Tether USD]` use the **same** Ethereum account (`0xE32ad14b…`), so the webview state is identical — it is per-app-instance load luck. USDT is sellable per the backend `sell/v1/cryptoLimitations`.

**Solution.** Add `waitForCryptoSelectorReady()` — wait for the crypto selector to be visible and, if the app is stuck, **reload the webview and retry** (2 reloads × 30 s) before failing with an explicit "webview stuck loading" message. It is called at the start of `chooseAssetIfNotSelected`. This mirrors the existing Borrow-webview recovery in `borrow.page.ts`.

> The stall itself originates in the external PTX/swap staging app; the durable fix (remote-config load race / staging stability) belongs to the PTX/swap team. This PR makes the E2E resilient and self-healing for the transient case.

### Context

- **JIRA or GitHub link**: _None linked yet — please associate with the relevant QAA ticket._
