### PR TITLE
fix(cloud-sync-module): drop Buffer from contract test helper

### DIFF
--- a/shared/cloud-sync-module/src/moduleRequirements.ts
+++ b/shared/cloud-sync-module/src/moduleRequirements.ts
@@ -10,6 +10,25 @@ type Fixtures<LocalState, DistantState> = {
   matchingDistantState?: DistantState;
 };
 
+/** UTF-8 byte length, without Buffer or TextEncoder so consumers need no node/dom types */
+function utf8ByteLength(value: string): number {
+  let bytes = 0;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4;
+      i++; // surrogate pair encodes as a single 4-byte sequence
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
 /**
  * Runs a generic contract test suite for a CloudSyncDataManager implementation.
  * Import and call this inside a describe block in your cloudSyncModule.test.ts.
@@ -107,7 +126,7 @@ export function describeCloudSyncModuleContract<
       expect(() => {
         serialized = JSON.stringify(nextState);
       }).not.toThrow();
-      expect(Buffer.byteLength(serialized!, "utf8")).toBeLessThan(1_000_000);
+      expect(utf8ByteLength(serialized!)).toBeLessThan(1_000_000);
       expect(() => JSON.parse(serialized!)).not.toThrow();
     });
 


### PR DESCRIPTION
> [!NOTE]
> Fixes a typecheck failure on `develop`.

### 📝 Description

`@shared/cloud-sync-module` is consumed as TypeScript source (`main`/`exports` point to `src/*.ts`), so its own `types` are not what matters — the consumer's are. `moduleRequirements.ts` used `Buffer.byteLength`, which forced every consumer to declare node types. `@domain/entity-recent-addresses` declares only `["jest"]`, so `nx run @domain/entity-recent-addresses:typecheck` failed on `develop`:

```
error TS2591: Cannot find name 'Buffer'. Do you need to install type definitions for node?
```

The 1MB size assertion now computes the UTF-8 byte length inline, so the shared contract helper needs neither node nor dom types.

Verified locally: `typecheck` + `test` pass for `@shared/cloud-sync-module`, `@domain/entity-recent-addresses` and `@domain/entity-account-name` (the two consumers of the contract helper).

### 🔗 Context

- **JIRA / GitHub issue**: follow-up to #20346 (LIVE-35277)
- **ADR** (if any): n/a
