### PR TITLE
[LWDM] feat(coin-tron): add sponsoring context to tx model (LIVE-32775)

### DIFF
--- a/.changeset/LIVE-32775-tron-sponsoring-context.md
+++ b/.changeset/LIVE-32775-tron-sponsoring-context.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+Add gas-sponsoring (Tronify) context to the Tron transaction model (LIVE-32775). A new optional `energyProviderInfo` field (`{ providerId, orderId }`) marks a send as sponsored; it is set by the front-end Send flow, round-trips through transaction serialization, and is threaded to the fee-estimation, validation and signing seams so later work can price a sponsored USDT send as energy-rented rather than burning TRX. Absent `energyProviderInfo` keeps the current standard-crafting behavior unchanged.

--- a/libs/coin-modules/coin-tron/src/bridge/createTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/createTransaction.ts
@@ -11,6 +11,8 @@ const createTransaction = (): Transaction => ({
   networkInfo: null,
   resource: null,
   votes: [],
+  // No sponsoring context by default → standard crafting. Set by the Send flow when sponsored.
+  energyProviderInfo: undefined,
 });
 
 export default createTransaction;

--- a/libs/coin-modules/coin-tron/src/bridge/createTransaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/createTransaction.ts
@@ -11,8 +11,7 @@ const createTransaction = (): Transaction => ({
   networkInfo: null,
   resource: null,
   votes: [],
-  // No sponsoring context by default → standard crafting. Set by the Send flow when sponsored.
-  energyProviderInfo: undefined,
+  // energyProviderInfo omitted by default (optional) → standard crafting; set by the Send flow.
 });
 
 export default createTransaction;

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -52,6 +52,10 @@ export const getFeeResourceBreakdown = async (
   transaction: Transaction,
   tokenAccount?: TokenAccount | null,
 ): Promise<FeeResourceBreakdown> => {
+  // SPONSORING SEAM (LIVE-32775): when `transaction.energyProviderInfo` is set, rented energy from a
+  // provider will augment `energyAvailable` below (LIVE-32776 savings estimate / LIVE-32892 crafting).
+  // Dormant for now — availability is computed from self-staked energy only, so behavior is unchanged.
+
   // Energy is only required for an actual TRC20 transfer — native/TRC10 use none, non-"send" modes
   // don't transfer, and a zero-amount non-max send is headed for AmountRequired. Compute it up front
   // so the network-failure path reports the "insufficient" sentinel only when energy is truly needed.
@@ -159,6 +163,11 @@ const computeActiveRecipientTrc20Fee = async (
   tokenAccount: TokenAccount,
   breakdown?: FeeResourceBreakdown,
 ): Promise<BigNumber> => {
+  // SPONSORING SEAM (LIVE-32775): when `transaction.energyProviderInfo` is set, a sponsored send rents
+  // energy from a provider instead of burning the sender's TRX, so the fee below changes once
+  // rented-energy pricing lands (LIVE-32776 savings estimate / LIVE-32892 crafting). Dormant for now —
+  // a sponsored tx is priced exactly like a standard one, so behavior is unchanged.
+
   try {
     const resourceBreakdown =
       breakdown ?? (await getFeeResourceBreakdown(account, transaction, tokenAccount));

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -52,9 +52,8 @@ export const getFeeResourceBreakdown = async (
   transaction: Transaction,
   tokenAccount?: TokenAccount | null,
 ): Promise<FeeResourceBreakdown> => {
-  // SPONSORING SEAM (LIVE-32775): when `transaction.energyProviderInfo` is set, rented energy from a
-  // provider will augment `energyAvailable` below (LIVE-32776 savings estimate / LIVE-32892 crafting).
-  // Dormant for now — availability is computed from self-staked energy only, so behavior is unchanged.
+  // TODO(LIVE-32776/LIVE-32892): when `transaction.energyProviderInfo` is set, augment energy
+  // availability with rented (sponsored) energy. Dormant for now.
 
   // Energy is only required for an actual TRC20 transfer — native/TRC10 use none, non-"send" modes
   // don't transfer, and a zero-amount non-max send is headed for AmountRequired. Compute it up front
@@ -163,10 +162,8 @@ const computeActiveRecipientTrc20Fee = async (
   tokenAccount: TokenAccount,
   breakdown?: FeeResourceBreakdown,
 ): Promise<BigNumber> => {
-  // SPONSORING SEAM (LIVE-32775): when `transaction.energyProviderInfo` is set, a sponsored send rents
-  // energy from a provider instead of burning the sender's TRX, so the fee below changes once
-  // rented-energy pricing lands (LIVE-32776 savings estimate / LIVE-32892 crafting). Dormant for now —
-  // a sponsored tx is priced exactly like a standard one, so behavior is unchanged.
+  // TODO(LIVE-32776/LIVE-32892): when `transaction.energyProviderInfo` is set, price the send as
+  // energy-rented (sponsored) instead of burning TRX. Dormant for now.
 
   try {
     const resourceBreakdown =

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
@@ -290,6 +290,53 @@ describe("getTransactionStatus", () => {
     expect(mockTriggerConstantContract).not.toHaveBeenCalled();
   });
 
+  // LIVE-32775: adding the sponsoring context must be inert until later tickets (LIVE-32776 /
+  // LIVE-32892) price it. Presence of energyProviderInfo must not change fees or status yet.
+  describe("energyProviderInfo sponsoring context (LIVE-32775)", () => {
+    const energyProviderInfo = { providerId: "tronify", orderId: "order-123" };
+
+    it("does not change fee or status for a covered TRC20 send (standard crafting unchanged)", async () => {
+      const tokenAccount = createTrc20TokenAccount();
+      const account = createAccount({ subAccounts: [tokenAccount] });
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
+
+      const baseline = await getTransactionStatus(
+        account,
+        createTransaction({ subAccountId: tokenAccount.id }),
+      );
+      const sponsored = await getTransactionStatus(
+        account,
+        createTransaction({ subAccountId: tokenAccount.id, energyProviderInfo }),
+      );
+
+      expect(sponsored.estimatedFees).toEqual(baseline.estimatedFees);
+      expect(sponsored.energyRequired).toEqual(baseline.energyRequired);
+      expect(sponsored.energyAvailable).toEqual(baseline.energyAvailable);
+      expect(sponsored.warnings).toEqual(baseline.warnings);
+      expect(sponsored.errors).toEqual(baseline.errors);
+    });
+
+    it("does not change fee or status for an energy-short TRC20 send", async () => {
+      const tokenAccount = createTrc20TokenAccount();
+      const account = createAccount({ subAccounts: [tokenAccount] });
+      const overrides = {
+        subAccountId: tokenAccount.id,
+        networkInfo: buildNetworkInfo({ energyLimit: new BigNumber(500) }),
+      };
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 31_895 });
+
+      const baseline = await getTransactionStatus(account, createTransaction(overrides));
+      const sponsored = await getTransactionStatus(
+        account,
+        createTransaction({ ...overrides, energyProviderInfo }),
+      );
+
+      expect(sponsored.estimatedFees).toEqual(baseline.estimatedFees);
+      expect(sponsored.warnings).toEqual(baseline.warnings);
+      expect(sponsored.errors).toEqual(baseline.errors);
+    });
+  });
+
   describe("transaction-mode validations", () => {
     it("send with zero amount → AmountRequired", async () => {
       const status = await getTransactionStatus(

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.test.ts
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js";
-import type { TransactionStatusRaw } from "../types";
-import { fromTransactionStatusRaw } from "./transaction";
+import type { EnergyProviderInfo, TransactionStatusRaw } from "../types";
+import createTransaction from "./createTransaction";
+import { fromTransactionRaw, fromTransactionStatusRaw, toTransactionRaw } from "./transaction";
 
 describe("fromTransactionStatusRaw", () => {
   it("defaults the live-derived resource fields to 0 (they are not persisted in Raw)", () => {
@@ -18,5 +19,26 @@ describe("fromTransactionStatusRaw", () => {
     expect(status.energyAvailable).toEqual(new BigNumber(0));
     expect(status.bandwidthRequired).toEqual(new BigNumber(0));
     expect(status.bandwidthAvailable).toEqual(new BigNumber(0));
+  });
+});
+
+// LIVE-32775: the sponsoring context must survive the Transaction <-> TransactionRaw boundary
+// (the Send flow sets it, then the tx is serialized to reach the signer), and stay absent otherwise.
+describe("energyProviderInfo serialization (LIVE-32775)", () => {
+  const energyProviderInfo: EnergyProviderInfo = { providerId: "tronify", orderId: "order-123" };
+
+  it("round-trips the sponsoring context through toTransactionRaw / fromTransactionRaw", () => {
+    const tx = { ...createTransaction(), energyProviderInfo };
+
+    const raw = toTransactionRaw(tx);
+    expect(raw.energyProviderInfo).toEqual(energyProviderInfo);
+
+    expect(fromTransactionRaw(raw).energyProviderInfo).toEqual(energyProviderInfo);
+  });
+
+  it("keeps it undefined when absent (standard crafting)", () => {
+    const raw = toTransactionRaw(createTransaction());
+    expect(raw.energyProviderInfo).toBeUndefined();
+    expect(fromTransactionRaw(raw).energyProviderInfo).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.ts
@@ -48,6 +48,8 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     resource: tr.resource || null,
     duration: tr.duration || 3,
     votes: tr.votes,
+    // All-string sponsoring context: round-trips as-is. Kept undefined when absent (no phantom key).
+    energyProviderInfo: tr.energyProviderInfo ?? undefined,
   };
 };
 
@@ -70,6 +72,8 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     resource: t.resource || null,
     duration: t.duration || 3,
     votes: t.votes,
+    // All-string sponsoring context: round-trips as-is. Kept undefined when absent (no phantom key).
+    energyProviderInfo: t.energyProviderInfo ?? undefined,
   };
 };
 

--- a/libs/coin-modules/coin-tron/src/bridge/transaction.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/transaction.ts
@@ -48,8 +48,8 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
     resource: tr.resource || null,
     duration: tr.duration || 3,
     votes: tr.votes,
-    // All-string sponsoring context: round-trips as-is. Kept undefined when absent (no phantom key).
-    energyProviderInfo: tr.energyProviderInfo ?? undefined,
+    // Sponsoring context: included only when present, so it stays absent for standard crafting.
+    ...(tr.energyProviderInfo ? { energyProviderInfo: tr.energyProviderInfo } : {}),
   };
 };
 
@@ -72,8 +72,8 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
     resource: t.resource || null,
     duration: t.duration || 3,
     votes: t.votes,
-    // All-string sponsoring context: round-trips as-is. Kept undefined when absent (no phantom key).
-    energyProviderInfo: t.energyProviderInfo ?? undefined,
+    // Sponsoring context: included only when present, so it stays absent for standard crafting.
+    ...(t.energyProviderInfo ? { energyProviderInfo: t.energyProviderInfo } : {}),
   };
 };
 

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -41,6 +41,14 @@ export type NetworkInfoRaw = {
   energyUsed: string;
   energyLimit: string;
 };
+// Gas-sponsoring (Tronify) context: marks a send as sponsored so the coin-module logic estimates
+// and validates it as energy-rented rather than burning TRX. Set by the front-end Send flow and
+// read by the fee/validation/signing seams. Absent (null/undefined) means standard crafting.
+// The shape is all-string, so it needs no separate Raw variant (it round-trips as-is).
+export type EnergyProviderInfo = {
+  providerId: string;
+  orderId: string;
+};
 export type Transaction = TransactionCommon & {
   family: "tron";
   mode: TronOperationMode;
@@ -48,6 +56,7 @@ export type Transaction = TransactionCommon & {
   networkInfo: NetworkInfo | null | undefined;
   duration: number | null | undefined;
   votes: Vote[];
+  energyProviderInfo?: EnergyProviderInfo | null | undefined;
 };
 export type TransactionRaw = TransactionCommonRaw & {
   mode: TronOperationMode;
@@ -56,6 +65,7 @@ export type TransactionRaw = TransactionCommonRaw & {
   networkInfo: NetworkInfoRaw | null | undefined;
   duration: number | null | undefined;
   votes: Vote[];
+  energyProviderInfo?: EnergyProviderInfo | null | undefined;
 };
 export type TrongridTxType =
   | "TransferContract"

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -41,10 +41,8 @@ export type NetworkInfoRaw = {
   energyUsed: string;
   energyLimit: string;
 };
-// Gas-sponsoring (Tronify) context: marks a send as sponsored so the coin-module logic estimates
-// and validates it as energy-rented rather than burning TRX. Set by the front-end Send flow and
-// read by the fee/validation/signing seams. Absent (null/undefined) means standard crafting.
-// The shape is all-string, so it needs no separate Raw variant (it round-trips as-is).
+// Gas-sponsoring (Tronify) context — marks a send as sponsored (LIVE-32775). Absent = standard
+// crafting. All-string, so it round-trips without a separate Raw variant.
 export type EnergyProviderInfo = {
   providerId: string;
   orderId: string;
@@ -56,7 +54,7 @@ export type Transaction = TransactionCommon & {
   networkInfo: NetworkInfo | null | undefined;
   duration: number | null | undefined;
   votes: Vote[];
-  energyProviderInfo?: EnergyProviderInfo | null | undefined;
+  energyProviderInfo?: EnergyProviderInfo | null;
 };
 export type TransactionRaw = TransactionCommonRaw & {
   mode: TronOperationMode;
@@ -65,7 +63,7 @@ export type TransactionRaw = TransactionCommonRaw & {
   networkInfo: NetworkInfoRaw | null | undefined;
   duration: number | null | undefined;
   votes: Vote[];
-  energyProviderInfo?: EnergyProviderInfo | null | undefined;
+  energyProviderInfo?: EnergyProviderInfo | null;
 };
 export type TrongridTxType =
   | "TransferContract"


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->
✅ Checklist

- [x] Changeset added (@ledgerhq/coin-tron patch)
- [x] Unit tests added/updated
- [x] pnpm nx build @ledgerhq/coin-tron green
- [x] pnpm --filter @ledgerhq/coin-tron test green (360 passed)

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
Adds gas-sponsoring (Tronify) context to the Tron transaction model — the data-model + plumbing foundation of the gas-sponsoring epic. A send can now be marked as sponsored so later work estimates/validates it as energy-rented rather than burning the hardcoded ~13.74 TRX.

What it does — a new optional energyProviderInfo?: { providerId, orderId } on Transaction/TransactionRaw: set by the Send flow, round-trips through serialization, and reachable by the fee/validation/signing paths (they already receive the transaction). Two SPONSORING SEAM (LIVE-32775) comments mark where rented-energy availability/pricing will branch.

Scope boundary — data-model + plumbing only, fully dormant: absent the field, behavior is byte-for-byte unchanged (locked by regression tests). Savings (LIVE-32776), refund guard (LIVE-32777), feature flag (LIVE-32778), and rental crafting (LIVE-32892) are separate tickets.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-32775](https://ledgerhq.atlassian.net/browse/LIVE-32775)
- **ADR** (if any): <!-- link to the relevant architectural decision record --> 
