### PR TITLE
fix(git-conventions): refine docs around scope in PR titles (LIVE-35363)

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: create-pr
-description: Create a pull request with proper description, changeset, and all required elements
+description: Create a pull request with a valid title, description, changeset, and all required elements
 disable-model-invocation: true
 ---
 
+> [!TIP]
+> 
+> Note: this skill is for manual, user-invocation only. 
+> Agents should only read this only when it is specifically invoked. 
+> Canonical [Git conventions](../../../docs/contributing/git-conventions.md) take precedence over this command.
+
 # Create PR
 
-Create a pull request with proper description, changeset, and all required elements.
+Create a pull request with a valid title, description, changeset, and all required elements.
 
 ## Prompt Variables
 
@@ -24,7 +30,7 @@ $CHANGE_TYPE
 
 $CHANGE_SCOPE
 
-> What packages are impacted? (e.g., live-mobile, ledger-live-desktop, @ledgerhq/live-common)
+> Summarise the scope in a single term? (e.g. architecture, coin-evm, counter-values, e2e, portfolio, swap)
 
 $TEST_COVERAGE
 
@@ -40,52 +46,20 @@ $HAS_UI_CHANGES
 
 ## Instructions
 
-**IMPORTANT**: Before any git commit, read and follow the `.agents/skills/git-conventions/SKILL.md` skill. All commit messages MUST use the Conventional Commits format defined there (`type(scope): description`). Analyze the staged diff to pick the correct type and scope.
-
 ### Step 1: Analyze the changes
 
-1. Read `.agents/skills/git-conventions/SKILL.md` to load commit conventions
+1. Follow `docs/contributing/git-conventions.md` for valid commit messages
 2. Run `git status` and `git diff` to understand current changes
 3. Run `git log develop..HEAD --oneline` to see commits on this branch
 4. Identify all modified packages for the changeset
 
 ### Step 2: Create the changeset
 
-Use the `create-changeset` skill to add a changeset for the modified packages.
+1. Use the `create-changeset` skill to add a changeset for the modified packages.
 
 ### Step 3: Prepare the PR
 
-Generate the PR body using this template, filled with the provided information:
-
-```markdown
-### ✅ Checklist
-
-- [x] `npx changeset` was attached.
-- [{{TEST_CHECKBOX}}] **Covered by automatic tests.** {{TEST_EXPLANATION}}
-- [x] **Impact of the changes:**
-      {{QA_FOCUS_AREAS}}
-
-### 📝 Description
-
-{{DESCRIPTION}}
-
-{{SCREENSHOTS_SECTION}}
-
-### ❓ Context
-
-- **JIRA or GitHub link**: {{TICKET_LINK}}
-
----
-
-### 🧐 Checklist for the PR Reviewers
-
-- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
-- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
-- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
-- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
-- **Any new dependencies** have been justified and documented.
-- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
-```
+Generate the PR body using [.github/pull_request_template.md](../../../.github/pull_request_template.md).
 
 ### Step 4: Create the Pull Request
 
@@ -132,40 +106,28 @@ Use the `slack-pr-message` skill (`.agents/skills/slack-pr-message/SKILL.md`) to
    - Example: `feat(mobile): add dark mode toggle`
    - Example: `fix(desktop): resolve transaction signing issue`
 
-2. **TEST_CHECKBOX**:
-
-   - `x` if $TEST_COVERAGE is "yes"
-   - ` ` (space) if "no" or "partial"
-
-3. **TEST_EXPLANATION**:
-
-   - Empty if fully covered
-   - Add explanation in italics if partial/no: `_Explanation here_`
-
-4. **QA_FOCUS_AREAS**: Format as bullet list from $QA_FOCUS_AREAS
-
-5. **DESCRIPTION**: Generate from $TICKET_DESCRIPTION:
+2. **DESCRIPTION**: Generate from $TICKET_DESCRIPTION:
 
    - First paragraph: Problem statement
    - Second paragraph: Solution approach
    - Include code samples for library changes
    - Include before/after for bug fixes
 
-6. **SCREENSHOTS_SECTION**:
+3. **SCREENSHOTS_SECTION**:
 
    - If $HAS_UI_CHANGES is "yes":
      - Add the table with placeholders:
        ```
-       | Before | After |
-       | ------ | ----- |
+       | Before                        | After                         |
+       |-------------------------------|-------------------------------|
        | _Drag & drop screenshot here_ | _Drag & drop screenshot here_ |
        ```
      - Tell the user: "Click '...' → 'Edit' on the PR description, then drag & drop your screenshots into the table."
    - If "no", omit the section entirely
 
-7. **TICKET_LINK**: Format properly:
-   - JIRA: `[LIVE-1234](https://ledgerhq.atlassian.net/browse/LIVE-1234)`
-   - GitHub: `#123`
+4. **CONTEXT**: Link to issues and references:
+   - `**JIRA issue**: [LIVE-1234](https://ledgerhq.atlassian.net/browse/LIVE-1234)`
+   - `**ADR** (if any): https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/1234`
 
 ## Example Output
 
@@ -176,14 +138,6 @@ For a feature adding portfolio analytics:
 **PR Body**:
 
 ```markdown
-### ✅ Checklist
-
-- [x] `npx changeset` was attached.
-- [x] **Covered by automatic tests.**
-- [x] **Impact of the changes:**
-  - Portfolio screen rendering and performance
-  - Analytics data fetching and caching
-  - Chart interactions and accessibility
 
 ### 📝 Description
 
@@ -199,7 +153,7 @@ This PR introduces a new analytics dashboard to the portfolio feature, providing
 
 ### ❓ Context
 
-- **JIRA or GitHub link**: [LIVE-5678](https://ledgerhq.atlassian.net/browse/LIVE-5678)
+- **JIRA issue**: [LIVE-5678](https://ledgerhq.atlassian.net/browse/LIVE-5678)
 ```
 
 **Slack Message**: Generated via the `slack-pr-message` skill.

--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-conventions
-description: Read before naming branches, commits, pull requests, or merge commits
+description: Read for naming branches, commit messages, pull request titles and merge commits
 ---
 
 Follow the canonical [Git conventions](../../../docs/contributing/git-conventions.md) for naming branches, commit messages, pull request titles and merge commits.

--- a/docs/contributing/git-conventions.md
+++ b/docs/contributing/git-conventions.md
@@ -2,34 +2,40 @@
 
 This is the canonical guidance for Git conventions in this repo.
 
-The goal is for Git history to surface the **type** and **scope** of changes, and reference a related Jira ticket when possible.
+Our Git history should always surface the **type**, **scope** and description of changes, 
+and when possible, link to a Jira ticket.
 
 ## Summary
 
-The structure below is based on [Conventional Commits](https://www.conventionalcommits.org/):
+The structure is required for **commit messages** and **PR titles** and optional for **branch names**.
+
+Structure:
 
 ```text
-branch:    <type>/<scope>-<ticket>-<short-description>
-commit:    <type>(<scope>): <description>
-PR title:  <type>(<scope>): <description> (<ticket>)
+commit message:  <type>(<scope>): <description>
+PR title:        <type>(<scope>): <description> (<optional-ticket>)
+branch name:     <type>/<scope>-<ticket>-<short-description>
 ```
 
-e.g.
+Valid examples:
 
 ```text
-branch: feat/ui-LIVE-1234-add-dark-mode-toggle
-commit: feat(ui): add dark mode toggle
-PR title: feat(ui): add dark mode toggle (LIVE-1234)
+commit message:  feat(ui): add dark mode toggle
+PR title:        feat(ui): add dark mode toggle
+PR title:        feat(ui): add dark mode toggle (LIVE-1234)
+branch name:     feat/ui-LIVE-1234-add-dark-mode-toggle
 ```
 
-We will enforce this struture for commit messages and PR titles (which will be used for merge commits).
-This makes it easier to extract reliable data from Git history.
+Invalid examples:
 
-Consistent naming of branches is entirely optional as these do not remain in Git History.
+```text
+commit message:  feat: add dark mode toggle
+PR title:        feat: add dark mode toggle (LIVE-1234)
+```
 
 ## Type
 
-Types come from Conventional Commit types:
+Types are listed in [commitlint.types.js](../../commitlint.types.js):
 
 - `build`
 - `chore`
@@ -47,7 +53,7 @@ Do not use the legacy `bugfix` or `support`. Use `fix` for bug fixes and `chore`
 
 ## Scope
 
-Scopes give context around the changes. They name the related concern, domain or feature related to the work.
+Scopes give context around the changes. They name the concern, domain or feature related to the work.
 
 Examples:
 
@@ -62,7 +68,7 @@ Avoid multiple scopes – prefer a single more informative value, e.g. use `port
 
 Avoid broad scopes – prefer specifics, e.g. use `coin-modules` instead of `shared`.
 
-Do not use ticket IDs as scope: `fix(LIVE-1234)` is not a valid scope. Use in the PR title instead.
+Do not use ticket IDs as scope: `fix(LIVE-1234)` is not a valid scope.
 
 ## Tickets
 
@@ -72,13 +78,13 @@ Internal contributions should be related to a Jira ticket. If a ticket does not 
 
 A short description of the changes. This should add to the information provided by type and scope.
 
-## Branch names
+## Branch names (optional guidance)
 
 e.g. `feat/ui-LIVE-1234-add-dark-mode-toggle`
 
 Use kebab-case, keep branch names short and keep each branch focused on one concern.
 
-Rules are not enforced on branch names. Following this structure is entirely optional.
+_Rules are not enforced on branch names. Following this structure is entirely optional._
 
 ## Commit messages
 
@@ -86,7 +92,7 @@ e.g. `feat(ui): add dark mode toggle`
 
 Rules:
 
-- `type` and `scope` are required – see guidelines above
+- `type` and `scope` are required.
 - `description` is imperative, lowercase and has no trailing period.
 - Keep the subject line at or below 72 characters.
 - Do not use gitmoji.
@@ -98,12 +104,13 @@ Use `pnpm commit` to create a valid commit message, using tab-completion for typ
 
 Use `pnpm commitlint --from <target-branch>` to check every commit on the branch.
 
-## Pull request and merge titles
+## Pull request titles
 
 e.g. `feat(ui): add dark mode toggle (LIVE-1234)`
 
-Pull request titles use the same Conventional Commit shape as commit messages, with the Jira ticket at the end when one exists.
+Pull request titles use the same structure as commit messages, with the option of a Jira ticket at the end.
 
-A GitHub workflow may automatically prepend a platform prefix based on PR labels, e.g. "LWD" or "LWM". Leave that prefix in place if automation adds it.
+A GitHub workflow may automatically prepend a platform prefix based on PR labels, e.g. "LWD" or "LWM". 
+Leave that prefix in place if automation adds it.
 
-When creating a merge commit for a pull request, use the pull request title as the merge commit title.
+When creating a merge commit for a pull request, use a valid pull request title as the merge commit title.


### PR DESCRIPTION
### 📝 Description

Koda (the AI agent) was generating PR titles and commit messages without a `scope`, e.g. `docs: flag new .png assets` instead of the required `docs(assets): flag new .png assets`. This violates the `type(scope): description` structure enforced by commitlint.

The fix clarifies the canonical git-conventions doc with explicit valid/invalid examples, and updates both agent skills (`git-conventions` and `create-pr`) to point directly at that doc and emphasise that `scope` is required — not optional.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35363](https://ledgerhq.atlassian.net/browse/LIVE-35363)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

[LIVE-35363]: https://ledgerhq.atlassian.net/browse/LIVE-35363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ