### PR TITLE
chore(e2e): log detox retries at warn level (QAA-1456)

### DIFF
--- a/e2e/mobile/jest.globalSetup.ts
+++ b/e2e/mobile/jest.globalSetup.ts
@@ -43,6 +43,11 @@ export default async function setup(): Promise<void> {
   const maxRetries = detoxConfig.testRunner?.retries ?? 0;
   const isLastRetry = maxRetries > 0 && testSessionIndex >= maxRetries;
 
+  if (testSessionIndex > 0) {
+    // warn, not info: CI runs detox with `--loglevel warn`, which hides info lines.
+    log.warn(`[globalSetup] Detox retry: attempt ${testSessionIndex + 1}/${maxRetries + 1}`);
+  }
+
   const videoOptions: DetoxAllure2AdapterOptions["deviceVideos"] = {
     android: {
       recording: { bitRate: 1_000_000, maxSize: 720, codec: "h264" },


### PR DESCRIPTION
Part 3 of [QAA-1442](https://ledgerhq.atlassian.net/browse/QAA-1442) — [QAA-1456](https://ledgerhq.atlassian.net/browse/QAA-1456).

**Stacked on #20361** (base is `chore/e2e-QAA-1455-local-ci-parity`; review #20353 → #20361 → this).

Five lines, one file.

## Problem

CI retries a failed spec up to twice. When the retry passes, the run goes green — and the shard log says **nothing** about it. `jest.globalSetup.ts` already logged a retry note, but with `log.info`, and CI runs detox with `--loglevel warn`, so it was suppressed in the one place it mattered.

## Change

```ts
if (testSessionIndex > 0) {
  // warn, not info: CI runs detox with `--loglevel warn`, which hides info lines.
  log.warn(`[globalSetup] Detox retry: attempt ${testSessionIndex + 1}/${maxRetries + 1}`);
}
```

## Verification

Proven in production, not by fixtures — run [30893507644](https://github.com/LedgerHQ/ledger-live/actions/runs/30893507644) printed:

```
[globalSetup] Detox retry: attempt 2/3
[globalSetup] Detox retry: attempt 3/3
```

in Android shards 6 and 10. Also confirms CI still performs 3 attempts, i.e. #20361's local `retries: 1` did not override CI's `--retries 2`.

## Why this ticket shrank

It originally proposed three more surfaces (`::warning` annotations, a job-summary table, and an Allure `statusDetails.flaky` marker). All dropped, because the ticket's premise was wrong: **Allure already emits `retriesCount` per test with no work from us**, so a green test with a retry marker in the nightly report already identifies a retry-hidden flake. The dropped work would only have relocated information that already exists — at the cost of 63 lines of jq in an action **shared with desktop e2e** that cannot be validated before merge (workflows consume it as `@develop`).

The full reasoning, and the commit SHAs if we ever want that work back, are on QAA-1456.

## CI time

Neutral — one log line per retry session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QAA-1442]: https://ledgerhq.atlassian.net/browse/QAA-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QAA-1456]: https://ledgerhq.atlassian.net/browse/QAA-1456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ