### PR TITLE
test(e2e): fix mobile earn cold start - pin Q2 flags (LIVE-35026)

### DIFF
--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -6,7 +6,7 @@ export default class EarnV2DashboardPage {
   maxPotentialRewards = "max-potential-rewards";
   walletHeaderAmount = "wallet-header-amount";
   rewardsSummary = "rewards-summary";
-  tokensToEarnBanner = "tokens-to-earn-banner";
+  crowdFavourites = "crowd-favourites";
   iceColdStartEarnCta = "ice-cold-start-earn-cta";
   assetItemTicker = (ticker: string) => `asset-item-ticker-${ticker}`;
   assetEarnCta = (ticker: string) => `asset-earn-cta-${ticker}`;
@@ -45,7 +45,7 @@ export default class EarnV2DashboardPage {
 
   @Step("Verify cold start page")
   async verifyColdStartPage() {
-    await waitWebElementByTestId(this.tokensToEarnBanner);
+    await waitWebElementByTestId(this.crowdFavourites);
   }
 
   @Step("Verify asset ready to earn")

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -3,14 +3,18 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setEnv } from "@shared/env";
 import { waitEarnReady } from "../../bridge/server";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { FF_LWM_WALLET_40_Q2 } from "utils/featureFlagUtils";
 
 import type { ApplicationOptions } from "page";
-import type { PartialFeatures } from "@shared/feature-flags";
+import type { OptionalFeatureMap, PartialFeatures } from "@shared/feature-flags";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
-const EARN_V2_FLAGS: PartialFeatures = {
+// Pinned so E2E_MOBILE_FEATURE_FLAGS can't downgrade earnUpselling and change the earn UI.
+// https://ledgerhq.atlassian.net/browse/LIVE-35026
+const EARN_V2_FLAGS: OptionalFeatureMap = {
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
+  ...FF_LWM_WALLET_40_Q2,
 };
 
 // Pins the ETH deposit webview to the `basic_sorting` cohort (mirrors the desktop


### PR DESCRIPTION
### 📝 Description

Fixes a broken mobile Earn v2 E2E assertion caused by wallet Q2 flag interactions. Mirrors the desktop fix in #19623.

#### Cold start asserted an unreachable element (LIVE-35026)

`verifyColdStartPage()` waited for `tokens-to-earn-banner`, which cannot render under the Q2 flags mobile E2E defaults to:

- `TokensToEarnBannerNative` returns `null` when `isAtLeast("v3")`
- `ColdStart.native.tsx` independently gates it behind `{!isAtLeast("v3") && ...}`

`lwmWallet40.earnUpselling: true` means v3, so the assertion could never pass. Now asserts `crowd-favourites` (rendered via `withV3(...)` on both cold start and ice cold start) and the dead selector is gone.

`EARN_V2_FLAGS` also declares `lwmWallet40` explicitly instead of inheriting it from `getMergedFeatureFlags`, so the earn UI version is identical locally and in CI — previously `E2E_MOBILE_FEATURE_FLAGS=wallet40-q1` would silently downgrade to Q1 (`earnUpselling: false`) and change which elements render.

Mobile's flag defaults are the **inverse** of desktop's: `getMergedFeatureFlags` defaults to Q2 and the env preset map only offers `wallet40-q1`, whereas desktop defaults to Q1 and opts into Q2.

`iceColdStartEarnCta` is deliberately kept — unlike desktop, `EligibleCryptoMobile` renders unconditionally on mobile.

---

> **Note:** swapToEarn deposit route coverage (originally part of this PR) has been split to #20649 pending Xray ticket creation.

### 🔗 Context

- **JIRA**: [LIVE-35026](https://ledgerhq.atlassian.net/browse/LIVE-35026)
- **Xray**: [B2CQA-4719](https://ledgerhq.atlassian.net/browse/B2CQA-4719) / [B2CQA-4640](https://ledgerhq.atlassian.net/browse/B2CQA-4640)
- **Related**: #19623 (desktop equivalent), #20649 (swapToEarn deposit coverage)

[LIVE-35026]: https://ledgerhq.atlassian.net/browse/LIVE-35026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ