### PR TITLE
test(e2e): Swap number-formatting-by-language coverage (B2CQA-4014)

### DIFF
--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -138,9 +138,13 @@ export class SwapPage extends WebViewAppPage {
     await expect(webview.getByTestId(this.bestValueInfoIcon)).toBeVisible();
     await expect(webview.getByTestId(this.quotesCountdown)).toBeVisible();
 
-    return await webview
+    const providerList = await webview
       .locator(`[data-testid^='${SwapPage.PROVIDER_NAME_PREFIX}']`)
       .allTextContents();
+    if (providerList.length === 0) {
+      throw new Error("No quote providers were returned");
+    }
+    return providerList;
   }
 
   @step("Check elements presence on swap approval step")
@@ -162,9 +166,11 @@ export class SwapPage extends WebViewAppPage {
     const provider = SwapProvider.getNameByUiName(providerUiName);
     const amount = await webview
       .locator(this.providerContainerInfoSelector(provider, "amount-label"))
+      .first()
       .textContent();
     const fiatAmount = await webview
       .locator(this.providerContainerInfoSelector(provider, "fiatAmount-label"))
+      .first()
       .textContent();
     return { amount, fiatAmount };
   }

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -42,6 +42,8 @@ export class SwapPage extends WebViewAppPage {
   private readonly noQuotesPlaceholder = "quotes-error-state";
   private toAccountCoinSelector = "to-account-coin-selector";
   private readonly toAccountAccountNameTag = "to-account-account-name-tag";
+  private readonly toAccountAmountInput = "to-account-amount-input";
+  private readonly fromAccountAmountInactive = "from-account-amount-inactive";
   private specificQuoteCardProviderName = (provider: string) =>
     `[data-testid^='${SwapPage.PROVIDER_NAME_PREFIX}${provider.toLowerCase()}']`;
   private providerContainerSelector = (provider: string) =>
@@ -152,6 +154,19 @@ export class SwapPage extends WebViewAppPage {
   @step("Click Continue button")
   async clickContinueButton() {
     await this.continueBtn.click();
+  }
+
+  @step("Get quote card amount texts for $0")
+  async getQuoteAmountTexts(providerUiName: string) {
+    const webview = await this.getWebView();
+    const provider = SwapProvider.getNameByUiName(providerUiName);
+    const amount = await webview
+      .locator(this.providerContainerInfoSelector(provider, "amount-label"))
+      .textContent();
+    const fiatAmount = await webview
+      .locator(this.providerContainerInfoSelector(provider, "fiatAmount-label"))
+      .textContent();
+    return { amount, fiatAmount };
   }
 
   @step("Check quotes container infos")
@@ -330,7 +345,11 @@ export class SwapPage extends WebViewAppPage {
   async checkBestOffer() {
     const quoteContainers = await this.getAllSwapProviders();
     const quotes = await this.extractQuotesAndFees(quoteContainers);
-    const bestOffer = quotes.reduce<{ rate: number; fees: number; quote: string } | null>(
+    const bestOffer = quotes.reduce<{
+      rate: number;
+      fees: number;
+      quote: string;
+    } | null>(
       (max, current) =>
         current && (!max || current.rate - current.fees > max.rate - max.fees) ? current : max,
       null,
@@ -373,6 +392,18 @@ export class SwapPage extends WebViewAppPage {
   async getAmountToSend() {
     const webview = await this.getWebView();
     return await webview.getByTestId(this.fromAccountAmountInput).inputValue();
+  }
+
+  @step("Retrieve send currency countervalue text")
+  async getSendCountervalueText() {
+    const webview = await this.getWebView();
+    return await webview.getByTestId(this.fromAccountAmountInactive).textContent();
+  }
+
+  @step("Retrieve receive currency amount value")
+  async getAmountToReceive() {
+    const webview = await this.getWebView();
+    return await webview.getByTestId(this.toAccountAmountInput).textContent();
   }
 
   @step("Click switch button")
@@ -764,7 +795,9 @@ export class SwapPage extends WebViewAppPage {
   async clickGiveAuthorizationButton() {
     const webview = await this.getWebView();
     const authorizationButton = webview.getByTestId(this.signPermitButton);
-    await expect(authorizationButton).toBeVisible({ timeout: APPROVAL_PROCESSING_TIMEOUT });
+    await expect(authorizationButton).toBeVisible({
+      timeout: APPROVAL_PROCESSING_TIMEOUT,
+    });
     await authorizationButton.click();
   }
 

--- a/e2e/desktop/tests/page/swap.page.ts
+++ b/e2e/desktop/tests/page/swap.page.ts
@@ -29,6 +29,11 @@ export class SwapPage extends WebViewAppPage {
     "../artifacts/ledgerwallet-swap-history.csv",
   );
   private static readonly PROVIDER_NAME_PREFIX = "lumen-quote-card-provider-name-";
+  private static readonly AMOUNT_LABEL_SUFFIX = "amount-label";
+  private static readonly FIAT_AMOUNT_LABEL_SUFFIX = "fiatAmount-label";
+  private static readonly NETWORK_FEES_HEADING_SUFFIX = "networkFees-heading";
+  private static readonly EXTRA_FEES_CONTAINER_SUFFIX = "extraFeesContainer";
+  private static readonly RATE_INFO_ICON_SUFFIX = "rate-infoIcon";
 
   private readonly fullSwapContainer = this.page.getByTestId("swap-web-app-container-full");
   private readonly embeddedSwapContainer = this.page.getByTestId("swap-web-app-container-embedded");
@@ -165,11 +170,11 @@ export class SwapPage extends WebViewAppPage {
     const webview = await this.getWebView();
     const provider = SwapProvider.getNameByUiName(providerUiName);
     const amount = await webview
-      .locator(this.providerContainerInfoSelector(provider, "amount-label"))
+      .locator(this.providerContainerInfoSelector(provider, SwapPage.AMOUNT_LABEL_SUFFIX))
       .first()
       .textContent();
     const fiatAmount = await webview
-      .locator(this.providerContainerInfoSelector(provider, "fiatAmount-label"))
+      .locator(this.providerContainerInfoSelector(provider, SwapPage.FIAT_AMOUNT_LABEL_SUFFIX))
       .first()
       .textContent();
     return { amount, fiatAmount };
@@ -181,29 +186,33 @@ export class SwapPage extends WebViewAppPage {
     const provider = SwapProvider.getNameByUiName(providerList[0]);
 
     await webview
-      .locator(this.providerContainerInfoSelector(provider, "amount-label"))
+      .locator(this.providerContainerInfoSelector(provider, SwapPage.AMOUNT_LABEL_SUFFIX))
       .first()
       .click();
     await expect(
-      webview.locator(this.providerContainerInfoSelector(provider, "amount-label")),
+      webview.locator(this.providerContainerInfoSelector(provider, SwapPage.AMOUNT_LABEL_SUFFIX)),
     ).toBeVisible();
     await expect(
-      webview.locator(this.providerContainerInfoSelector(provider, "fiatAmount-label")),
+      webview.locator(
+        this.providerContainerInfoSelector(provider, SwapPage.FIAT_AMOUNT_LABEL_SUFFIX),
+      ),
     ).toBeVisible();
     await expect(
-      webview.locator(this.providerContainerInfoSelector(provider, "networkFees-heading")),
+      webview.locator(
+        this.providerContainerInfoSelector(provider, SwapPage.NETWORK_FEES_HEADING_SUFFIX),
+      ),
     ).toBeVisible();
     await expect(
       webview
-        .locator(this.providerContainerInfoSelector(provider, "extraFeesContainer"))
+        .locator(this.providerContainerInfoSelector(provider, SwapPage.EXTRA_FEES_CONTAINER_SUFFIX))
         .getByText(/Floating rate|Fixed rate/),
     ).toBeVisible();
     await expect(
-      webview.locator(this.providerContainerInfoSelector(provider, "rate-infoIcon")),
+      webview.locator(this.providerContainerInfoSelector(provider, SwapPage.RATE_INFO_ICON_SUFFIX)),
     ).toBeVisible();
     await expect(
       webview
-        .locator(this.providerContainerInfoSelector(provider, "extraFeesContainer"))
+        .locator(this.providerContainerInfoSelector(provider, SwapPage.EXTRA_FEES_CONTAINER_SUFFIX))
         .getByText(ticker),
     ).toBeVisible();
     if (
@@ -214,12 +223,16 @@ export class SwapPage extends WebViewAppPage {
     ) {
       await expect(
         webview
-          .locator(this.providerContainerInfoSelector(provider, "extraFeesContainer"))
+          .locator(
+            this.providerContainerInfoSelector(provider, SwapPage.EXTRA_FEES_CONTAINER_SUFFIX),
+          )
           .getByText("Max Slippage"),
       ).toBeVisible();
       await expect(
         webview
-          .locator(this.providerContainerInfoSelector(provider, "extraFeesContainer"))
+          .locator(
+            this.providerContainerInfoSelector(provider, SwapPage.EXTRA_FEES_CONTAINER_SUFFIX),
+          )
           .getByText("%"),
       ).toBeVisible();
     }

--- a/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
+++ b/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
@@ -1,0 +1,98 @@
+import test from "tests/fixtures/common";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
+import { setExchangeDependencies } from "@ledgerhq/live-e2e-shared/speculos";
+import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
+import { addTmsLink } from "tests/utils/allureUtils";
+import { getDescription } from "tests/utils/customJsonReporter";
+import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
+import { getExpectedSeparators, expectFormattedAmount } from "tests/utils/amountUtils";
+import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
+import { DEVICE_TAGS } from "tests/utils/tagsUtils";
+
+const exchangeApp: AppInfos = AppInfos.EXCHANGE;
+const fromAccount = Account.ETH_1;
+const toAccount = Account.BTC_NATIVE_SEGWIT_1;
+
+// Large enough to trigger thousands-grouping in the displayed amounts (B2CQA-4014).
+const TEST_AMOUNT = "1234.56";
+
+// The send-amount input always groups with plain whitespace, regardless of language.
+const SEND_INPUT_THOUSANDS = " ";
+
+const languageCases = [
+  { languageId: "en" as const, label: "English" },
+  { languageId: "fr" as const, label: "Français" },
+  { languageId: "de" as const, label: "Deutsch" },
+];
+
+test.describe("Swap - amount formatting by language", () => {
+  setupEnv(true);
+
+  test.beforeEach(async () => {
+    setExchangeDependencies(
+      [fromAccount, toAccount].map(acc => ({
+        name: acc.currency.speculosApp.name.replace(/ /g, "_"),
+      })),
+    );
+  });
+
+  test.use({
+    teamOwner: Team.SWAP,
+    userdata: "skip-onboarding-with-last-seen-device",
+    speculosApp: exchangeApp,
+    cliCommandsOnApp: [
+      [fromAccount, toAccount].map(account => ({
+        app: account.currency.speculosApp,
+        cmd: liveDataWithAddressCommand(account),
+      })),
+      { scope: "test" },
+    ],
+  });
+
+  for (const { languageId, label } of languageCases) {
+    test(
+      `Swap amounts are formatted correctly for language: ${label}`,
+      {
+        tag: [...DEVICE_TAGS],
+        annotation: { type: "TMS", description: "B2CQA-4014" },
+      },
+      async ({ app }) => {
+        await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
+
+        await app.mainNavigation.openSettings();
+        await app.settings.changeLanguage(label);
+
+        const swap = new Swap(fromAccount, toAccount, TEST_AMOUNT);
+        await performSwapUntilQuoteSelectionStep(app, swap, TEST_AMOUNT);
+
+        const separators = getExpectedSeparators(languageId);
+
+        const sentAmount = await app.swap.getAmountToSend();
+        await expectFormattedAmount(
+          sentAmount,
+          { decimal: separators.decimal, thousands: SEND_INPUT_THOUSANDS },
+          "send amount input",
+        );
+
+        const countervalue = await app.swap.getSendCountervalueText();
+        await expectFormattedAmount(countervalue, separators, "send amount countervalue");
+
+        const receivedAmount = await app.swap.getAmountToReceive();
+        await expectFormattedAmount(receivedAmount, separators, "receive amount");
+
+        // Provider list is sorted best-first, so the first entry is the "Best Offer" card.
+        const providerList = await app.swap.getProviderList();
+        const bestQuoteProvider = providerList[0];
+        const { amount, fiatAmount } = await app.swap.getQuoteAmountTexts(bestQuoteProvider);
+        await expectFormattedAmount(amount, separators, `best quote (${bestQuoteProvider}) amount`);
+        await expectFormattedAmount(
+          fiatAmount,
+          separators,
+          `best quote (${bestQuoteProvider}) fiat amount`,
+        );
+      },
+    );
+  }
+});

--- a/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
+++ b/e2e/desktop/tests/specs/numberFormat.swap.spec.ts
@@ -7,7 +7,8 @@ import { Swap } from "@ledgerhq/live-e2e-shared/models/Swap";
 import { addTmsLink } from "tests/utils/allureUtils";
 import { getDescription } from "tests/utils/customJsonReporter";
 import { setupEnv, performSwapUntilQuoteSelectionStep } from "tests/utils/swapUtils";
-import { getExpectedSeparators, expectFormattedAmount } from "tests/utils/amountUtils";
+import { expectFormattedAmount } from "tests/utils/amountUtils";
+import { getExpectedSeparators } from "@ledgerhq/live-e2e-shared/data/numberFormat";
 import { liveDataWithAddressCommand } from "@ledgerhq/live-e2e-shared/cliCommandsUtils";
 import { DEVICE_TAGS } from "tests/utils/tagsUtils";
 
@@ -24,7 +25,6 @@ const SEND_INPUT_THOUSANDS = " ";
 const languageCases = [
   { languageId: "en" as const, label: "English" },
   { languageId: "fr" as const, label: "Français" },
-  { languageId: "de" as const, label: "Deutsch" },
 ];
 
 test.describe("Swap - amount formatting by language", () => {
@@ -61,8 +61,11 @@ test.describe("Swap - amount formatting by language", () => {
       async ({ app }) => {
         await addTmsLink(getDescription(test.info().annotations, "TMS").split(", "));
 
-        await app.mainNavigation.openSettings();
-        await app.settings.changeLanguage(label);
+        // The userdata fixture already boots in English; only switch away from it.
+        if (languageId !== "en") {
+          await app.mainNavigation.openSettings();
+          await app.settings.changeLanguage(label);
+        }
 
         const swap = new Swap(fromAccount, toAccount, TEST_AMOUNT);
         await performSwapUntilQuoteSelectionStep(app, swap, TEST_AMOUNT);

--- a/e2e/desktop/tests/utils/amountUtils.ts
+++ b/e2e/desktop/tests/utils/amountUtils.ts
@@ -22,12 +22,12 @@ export function getExpectedSeparators(language: FormattedNumberLanguage): Number
 }
 
 function escapeRegExpChar(char: string): string {
-  return char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return char.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }
 
 // All separator chars used across supported locales, to isolate a full numeric token first.
 const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExpChar).join("");
-const NUMERIC_TOKEN_REGEX = new RegExp(`\\d[${ANY_SEPARATOR_CHARS}\\d]*\\d|\\d`, "g");
+const NUMERIC_TOKEN_REGEX = new RegExp(String.raw`\d[${ANY_SEPARATOR_CHARS}\d]*\d|\d`, "g");
 
 // Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
 // can't slip through. `context` also names the Allure step, so each call site fails independently.
@@ -42,12 +42,16 @@ export async function expectFormattedAmount(
       throw new Error(`Expected a formatted amount but got "${text}"${label}`);
     }
     const value = text.trim();
-    const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
+    const tokens: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = NUMERIC_TOKEN_REGEX.exec(value)) !== null) {
+      tokens.push(match[0]);
+    }
     expect(tokens.length, `No numeric value found in "${value}"${label}`).toBeGreaterThan(0);
 
     const decimal = escapeRegExpChar(separators.decimal);
     const thousands = escapeRegExpChar(separators.thousands);
-    const strictPattern = new RegExp(`^\\d{1,3}(?:${thousands}\\d{3})*(?:${decimal}\\d+)?$`);
+    const strictPattern = new RegExp(String.raw`^\d{1,3}(?:${thousands}\d{3})*(?:${decimal}\d+)?$`);
 
     const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
     expect(

--- a/e2e/desktop/tests/utils/amountUtils.ts
+++ b/e2e/desktop/tests/utils/amountUtils.ts
@@ -1,33 +1,15 @@
 import { expect } from "@playwright/test";
 import * as allure from "allure-js-commons";
+import {
+  findNumericTokens,
+  isAmountFormatted,
+  type NumberSeparators,
+} from "@ledgerhq/live-e2e-shared/data/numberFormat";
 
 export function expectAmountCloseTo(actual: number, expected: number, relativeTolerance = 0.01) {
   const tolerance = Math.max(expected * relativeTolerance, 1e-6);
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
 }
-
-export type NumberSeparators = { decimal: string; thousands: string };
-
-export type FormattedNumberLanguage = "en" | "fr" | "de";
-
-const SEPARATORS_BY_LANGUAGE: Record<FormattedNumberLanguage, NumberSeparators> = {
-  en: { decimal: ".", thousands: "," },
-  // fr-FR groups with a narrow no-break space (U+202F), not the regular U+00A0.
-  fr: { decimal: ",", thousands: " " },
-  de: { decimal: ",", thousands: "." },
-};
-
-export function getExpectedSeparators(language: FormattedNumberLanguage): NumberSeparators {
-  return SEPARATORS_BY_LANGUAGE[language];
-}
-
-function escapeRegExpChar(char: string): string {
-  return char.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
-
-// All separator chars used across supported locales, to isolate a full numeric token first.
-const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExpChar).join("");
-const NUMERIC_TOKEN_REGEX = new RegExp(String.raw`\d[${ANY_SEPARATOR_CHARS}\d]*\d|\d`, "g");
 
 // Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
 // can't slip through. `context` also names the Allure step, so each call site fails independently.
@@ -42,20 +24,11 @@ export async function expectFormattedAmount(
       throw new Error(`Expected a formatted amount but got "${text}"${label}`);
     }
     const value = text.trim();
-    const tokens: string[] = [];
-    let match: RegExpExecArray | null;
-    while ((match = NUMERIC_TOKEN_REGEX.exec(value)) !== null) {
-      tokens.push(match[0]);
-    }
+    const tokens = findNumericTokens(value);
     expect(tokens.length, `No numeric value found in "${value}"${label}`).toBeGreaterThan(0);
 
-    const decimal = escapeRegExpChar(separators.decimal);
-    const thousands = escapeRegExpChar(separators.thousands);
-    const strictPattern = new RegExp(String.raw`^\d{1,3}(?:${thousands}\d{3})*(?:${decimal}\d+)?$`);
-
-    const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
     expect(
-      matchesExpectedFormat,
+      isAmountFormatted(tokens, separators),
       `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
         `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,
     ).toBe(true);

--- a/e2e/desktop/tests/utils/amountUtils.ts
+++ b/e2e/desktop/tests/utils/amountUtils.ts
@@ -1,8 +1,61 @@
 import { expect } from "@playwright/test";
+import * as allure from "allure-js-commons";
 
 export function expectAmountCloseTo(actual: number, expected: number, relativeTolerance = 0.01) {
   const tolerance = Math.max(expected * relativeTolerance, 1e-6);
   expect(Math.abs(actual - expected)).toBeLessThanOrEqual(tolerance);
+}
+
+export type NumberSeparators = { decimal: string; thousands: string };
+
+export type FormattedNumberLanguage = "en" | "fr" | "de";
+
+const SEPARATORS_BY_LANGUAGE: Record<FormattedNumberLanguage, NumberSeparators> = {
+  en: { decimal: ".", thousands: "," },
+  // fr-FR groups with a narrow no-break space (U+202F), not the regular U+00A0.
+  fr: { decimal: ",", thousands: " " },
+  de: { decimal: ",", thousands: "." },
+};
+
+export function getExpectedSeparators(language: FormattedNumberLanguage): NumberSeparators {
+  return SEPARATORS_BY_LANGUAGE[language];
+}
+
+function escapeRegExpChar(char: string): string {
+  return char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// All separator chars used across supported locales, to isolate a full numeric token first.
+const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExpChar).join("");
+const NUMERIC_TOKEN_REGEX = new RegExp(`\\d[${ANY_SEPARATOR_CHARS}\\d]*\\d|\\d`, "g");
+
+// Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
+// can't slip through. `context` also names the Allure step, so each call site fails independently.
+export async function expectFormattedAmount(
+  text: string | null,
+  separators: NumberSeparators,
+  context: string,
+): Promise<void> {
+  await allure.step(context, () => {
+    const label = ` (${context})`;
+    if (!text) {
+      throw new Error(`Expected a formatted amount but got "${text}"${label}`);
+    }
+    const value = text.trim();
+    const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
+    expect(tokens.length, `No numeric value found in "${value}"${label}`).toBeGreaterThan(0);
+
+    const decimal = escapeRegExpChar(separators.decimal);
+    const thousands = escapeRegExpChar(separators.thousands);
+    const strictPattern = new RegExp(`^\\d{1,3}(?:${thousands}\\d{3})*(?:${decimal}\\d+)?$`);
+
+    const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
+    expect(
+      matchesExpectedFormat,
+      `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
+        `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,
+    ).toBe(true);
+  });
 }
 
 // Balance labels are prefixed with a translated label (e.g. "Balance 1,234.56 ETH"),

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -387,9 +387,9 @@ export default class SwapLiveAppPage {
   }
 
   @Step("Click on swap max")
-  async clickSwapMax() {
+  async clickSwapMax(pattern: RegExp = floatNumberRegex, timeout?: number) {
     await tapWebElementByTestId(this.swapMaxToggle);
-    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, floatNumberRegex);
+    await waitForWebElementToMatchRegex(app.swapLiveApp.toAmountInput, pattern, timeout);
   }
 
   @Step("Retrieve send currency amount value")

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -38,6 +38,7 @@ export default class SwapLiveAppPage {
   fromAccountAccountNameTag = "from-account-account-name-tag";
   fromAccountBalance = "from-account-balance";
   toAccountAccountNameTag = "to-account-account-name-tag";
+  fromAccountAmountInactive = "from-account-amount-inactive";
   incompatibilityBannerPartnerId = "incompatibility-banner-partner";
   swapMainContainerCssSelector = "main";
   swapMainContainerWebElement = getWebElementByCssSelector(this.swapMainContainerCssSelector);
@@ -53,9 +54,13 @@ export default class SwapLiveAppPage {
   providerExecuteButtonCss = (provider: string) =>
     `${this.baseProviderCssSelector(provider)} [data-testid="${this.executeSwapButton}"]`;
   providerQuoteContainerSelector = (provider: string) =>
-    `${this.baseProviderCssSelector(provider)}[data-testid$="-fixed"], ${this.baseProviderCssSelector(provider)}[data-testid$="-float"]`;
+    `${this.baseProviderCssSelector(
+      provider,
+    )}[data-testid$="-fixed"], ${this.baseProviderCssSelector(provider)}[data-testid$="-float"]`;
   incompatibilityBannerPartnerSelector = (provider: string) =>
-    `${this.baseProviderCssSelector(provider)} [data-testid="${this.incompatibilityBannerPartnerId}"]`;
+    `${this.baseProviderCssSelector(provider)} [data-testid="${
+      this.incompatibilityBannerPartnerId
+    }"]`;
 
   @Step("Expect swap live app page")
   async expectSwapLiveApp() {
@@ -212,7 +217,9 @@ export default class SwapLiveAppPage {
         `[data-testid^='${SwapLiveAppPage.PROVIDER_NAME_PREFIX}']`,
       );
 
-      if (!numberOfQuotesText.match(new RegExp(`^${providerList.length} quotes? found$`))) {
+      // "N quotes found" is translated per language, so only the leading count is checked.
+      const displayedCount = Number.parseInt(numberOfQuotesText, 10);
+      if (Number.isNaN(displayedCount) || displayedCount !== providerList.length) {
         throw new Error(
           `Quote count mismatch: UI shows "${numberOfQuotesText}" but found ${providerList.length} cards`,
         );
@@ -232,17 +239,27 @@ export default class SwapLiveAppPage {
   async checkFirstQuoteContainerInfos(providerList: string[]) {
     const provider: string = SwapProvider.getNameByUiName(providerList[0]);
     const baseProviderLocator = `quote-container-${provider}`;
-    await waitWebElementByTestId(baseProviderLocator, { testIdSuffix: "-amount-label" });
-    await tapWebElementByTestId(baseProviderLocator, { testIdSuffix: "-amount-label" });
+    await waitWebElementByTestId(baseProviderLocator, {
+      testIdSuffix: "-amount-label",
+    });
+    await tapWebElementByTestId(baseProviderLocator, {
+      testIdSuffix: "-amount-label",
+    });
 
     await detoxExpect(
-      getWebElementByTestId(baseProviderLocator, { testIdSuffix: "-amount-label" }),
+      getWebElementByTestId(baseProviderLocator, {
+        testIdSuffix: "-amount-label",
+      }),
     ).toExist();
     await detoxExpect(
-      getWebElementByTestId(baseProviderLocator, { testIdSuffix: "-fiatAmount-label" }),
+      getWebElementByTestId(baseProviderLocator, {
+        testIdSuffix: "-fiatAmount-label",
+      }),
     ).toExist();
     await detoxExpect(
-      getWebElementByTestId(baseProviderLocator, { testIdSuffix: "-networkFees-heading" }),
+      getWebElementByTestId(baseProviderLocator, {
+        testIdSuffix: "-networkFees-heading",
+      }),
     ).toExist();
 
     const extraFeesContainer = getWebElementByTestId(baseProviderLocator, {
@@ -250,7 +267,9 @@ export default class SwapLiveAppPage {
     });
     await detoxExpect(extraFeesContainer).toExist();
     await detoxExpect(
-      getWebElementByTestId(baseProviderLocator, { testIdSuffix: "-rate-infoIcon" }),
+      getWebElementByTestId(baseProviderLocator, {
+        testIdSuffix: "-rate-infoIcon",
+      }),
     ).toExist();
 
     if (
@@ -260,7 +279,9 @@ export default class SwapLiveAppPage {
       provider === SwapProvider.LIFI.name
     ) {
       await detoxExpect(
-        getWebElementByTestId(baseProviderLocator, { testIdSuffix: "-slippage-infoIcon" }),
+        getWebElementByTestId(baseProviderLocator, {
+          testIdSuffix: "-slippage-infoIcon",
+        }),
       ).toExist();
     }
     await this.checkQuoteCardCta(providerList[0]);
@@ -379,6 +400,31 @@ export default class SwapLiveAppPage {
   @Step("Retrieve receive currency amount value")
   async getAmountToReceive() {
     return await getWebElementText(this.toAmountInput);
+  }
+
+  @Step("Retrieve send currency countervalue text")
+  async getSendCountervalueText() {
+    return await getWebElementText(this.fromAccountAmountInactive);
+  }
+
+  @Step("Get quote card raw amount texts for $0")
+  async getQuoteCardRawText(provider: string) {
+    const baseProviderLocator = `quote-container-${SwapProvider.getNameByUiName(provider)}`;
+    const amount =
+      (
+        await getWebElementsText(
+          this.swapMainContainerWebElement,
+          `[data-testid^="${baseProviderLocator}"][data-testid$="-amount-label"]`,
+        )
+      )[0] ?? "";
+    const fiatAmount =
+      (
+        await getWebElementsText(
+          this.swapMainContainerWebElement,
+          `[data-testid^="${baseProviderLocator}"][data-testid$="-fiatAmount-label"]`,
+        )
+      )[0] ?? "";
+    return { amount, fiatAmount };
   }
 
   @Step("Tap on Switch currencies button")
@@ -524,7 +570,9 @@ export default class SwapLiveAppPage {
 
   @Step("Tap Give Authorization button")
   async tapGiveAuthorizationButton() {
-    await waitWebElementByTestId(this.signPermitButton, { timeout: APPROVAL_PROCESSING_TIMEOUT });
+    await waitWebElementByTestId(this.signPermitButton, {
+      timeout: APPROVAL_PROCESSING_TIMEOUT,
+    });
     await waitForWebElementToBeEnabled(this.signPermitButton);
     await tapWebElementByTestId(this.signPermitButton);
   }

--- a/e2e/mobile/page/liveApps/swapLiveApp.ts
+++ b/e2e/mobile/page/liveApps/swapLiveApp.ts
@@ -224,6 +224,9 @@ export default class SwapLiveAppPage {
           `Quote count mismatch: UI shows "${numberOfQuotesText}" but found ${providerList.length} cards`,
         );
       }
+      if (providerList.length === 0) {
+        throw new Error("No quote providers were returned");
+      }
 
       return providerList;
     }, 30000);

--- a/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.spec.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.spec.ts
@@ -1,0 +1,16 @@
+import { runSwapNumberFormatLocaleTest } from "./swapNumberFormatLocale";
+
+runSwapNumberFormatLocaleTest(
+  ["B2CQA-4014"],
+  [
+    "@NanoSP",
+    "@NanoX",
+    "@Stax",
+    "@Flex",
+    "@NanoGen5",
+    "@ethereum",
+    "@family-evm",
+    "@bitcoin",
+    "@family-bitcoin",
+  ],
+);

--- a/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
@@ -1,0 +1,117 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { AppInfos } from "@ledgerhq/live-e2e-shared/enum/AppInfos";
+import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
+import { setEnv } from "@shared/env";
+import { swapSetup } from "../../../bridge/server";
+import { setTeamOwner } from "../../../helpers/allure/allure-helper";
+import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
+import {
+  getExpectedSeparators,
+  expectFormattedAmount,
+  buildFormattedAmountPattern,
+  type FormattedNumberLanguage,
+} from "../../../utils/amountUtils";
+
+setEnv("DISABLE_TRANSACTION_BROADCAST", true);
+
+const fromAccount = Account.ETH_1;
+const toAccount = Account.BTC_NATIVE_SEGWIT_1;
+
+// Large enough to trigger thousands-grouping in the displayed amounts (B2CQA-4014).
+const TEST_AMOUNT = "1234.56";
+
+// The send-amount input always groups with plain whitespace, regardless of language.
+const SEND_INPUT_THOUSANDS = " ";
+
+const languageCases: { languageId: FormattedNumberLanguage; label: string }[] = [
+  { languageId: "en", label: "English" },
+  { languageId: "fr", label: "Français" },
+  { languageId: "de", label: "Deutsch" },
+];
+
+export function runSwapNumberFormatLocaleTest(tmsLinks: string[], tags: string[]) {
+  describe("Swap - amount formatting by language", () => {
+    beforeAll(async () => {
+      await app.init({
+        speculosApp: AppInfos.EXCHANGE,
+        featureFlags: {
+          ptxSwapLiveAppMobile: {
+            enabled: true,
+            params: {
+              manifest_id:
+                process.env.PRODUCTION === "true" ? "swap-live-app-aws" : "swap-live-app-stg-aws",
+            },
+          },
+        },
+        cliCommandsOnApp: [
+          {
+            app: fromAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(fromAccount),
+          },
+          {
+            app: toAccount.currency.speculosApp,
+            cmd: liveDataWithAddressCommand(toAccount),
+          },
+        ],
+      });
+      await app.mainNavigation.waitForWallet40Ready();
+    });
+
+    setTeamOwner(Team.SWAP);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+
+    for (const { languageId, label } of languageCases) {
+      it(`Swap amounts are formatted correctly for language: ${label}`, async () => {
+        // Previous iteration may have left the app inside the swap webview.
+        await app.mainNavigation.openPortfolioViaDeeplink();
+        await app.mainNavigation.navigateToSettings();
+        await app.settings.navigateToGeneralSettings();
+        await app.settingsGeneral.navigateToLanguageSelect();
+        await app.settingsGeneral.selectLanguage(label);
+
+        await swapSetup();
+        await app.swap.openViaDeeplink();
+        await app.swapLiveApp.expectSwapLiveApp();
+
+        const separators = getExpectedSeparators(languageId);
+        const formattedAmountPattern = buildFormattedAmountPattern(separators);
+
+        // continueToQuotes=false: the wait below is locale-aware instead of the
+        // English-only `floatNumberRegex` the skipped step would have used.
+        await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, TEST_AMOUNT, false);
+        await waitForWebElementToMatchRegex(
+          app.swapLiveApp.toAmountInput,
+          formattedAmountPattern,
+          20000,
+        );
+        await app.swapLiveApp.tapGetQuotesButton();
+        await app.swapLiveApp.waitForQuotes();
+
+        const sentAmount = await app.swapLiveApp.getAmountToSend();
+        expectFormattedAmount(
+          sentAmount,
+          { decimal: separators.decimal, thousands: SEND_INPUT_THOUSANDS },
+          "send amount input",
+        );
+
+        const countervalue = await app.swapLiveApp.getSendCountervalueText();
+        expectFormattedAmount(countervalue, separators, "send amount countervalue");
+
+        const receivedAmount = await app.swapLiveApp.getAmountToReceive();
+        expectFormattedAmount(receivedAmount, separators, "receive amount");
+
+        // Provider list is sorted best-first, so the first entry is the "Best Offer" card.
+        const providerList = await app.swapLiveApp.getProviderList();
+        const bestQuoteProvider = providerList[0];
+        const { amount, fiatAmount } = await app.swapLiveApp.getQuoteCardRawText(bestQuoteProvider);
+        expectFormattedAmount(amount, separators, `best quote (${bestQuoteProvider}) amount`);
+        expectFormattedAmount(
+          fiatAmount,
+          separators,
+          `best quote (${bestQuoteProvider}) fiat amount`,
+        );
+      });
+    }
+  });
+}

--- a/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
@@ -5,12 +5,12 @@ import { setEnv } from "@shared/env";
 import { swapSetup } from "../../../bridge/server";
 import { setTeamOwner } from "../../../helpers/allure/allure-helper";
 import { performSwapUntilQuoteSelectionStep } from "../../../utils/swapUtils";
+import { expectFormattedAmount } from "../../../utils/amountUtils";
 import {
   getExpectedSeparators,
-  expectFormattedAmount,
   buildFormattedAmountPattern,
   type FormattedNumberLanguage,
-} from "../../../utils/amountUtils";
+} from "@ledgerhq/live-e2e-shared/data/numberFormat";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
@@ -28,7 +28,6 @@ const SEND_INPUT_THOUSANDS = " ";
 const languageCases: { languageId: FormattedNumberLanguage; label: string }[] = [
   { languageId: "en", label: "English" },
   { languageId: "fr", label: "Français" },
-  { languageId: "de", label: "Deutsch" },
 ];
 
 export function runSwapNumberFormatLocaleTest(tmsLinks: string[], tags: string[]) {
@@ -67,10 +66,14 @@ export function runSwapNumberFormatLocaleTest(tmsLinks: string[], tags: string[]
       it(`Swap amounts are formatted correctly for language: ${label}`, async () => {
         // Previous iteration may have left the app inside the swap webview.
         await app.mainNavigation.openPortfolioViaDeeplink();
-        await app.mainNavigation.navigateToSettings();
-        await app.settings.navigateToGeneralSettings();
-        await app.settingsGeneral.navigateToLanguageSelect();
-        await app.settingsGeneral.selectLanguage(label);
+
+        // The userdata fixture already boots in English; only switch away from it.
+        if (languageId !== "en") {
+          await app.mainNavigation.navigateToSettings();
+          await app.settings.navigateToGeneralSettings();
+          await app.settingsGeneral.navigateToLanguageSelect();
+          await app.settingsGeneral.selectLanguage(label);
+        }
 
         await swapSetup();
         await app.swap.openViaDeeplink();

--- a/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
+++ b/e2e/mobile/specs/swap/otherTestCases/swapNumberFormatLocale.ts
@@ -17,8 +17,10 @@ setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 const fromAccount = Account.ETH_1;
 const toAccount = Account.BTC_NATIVE_SEGWIT_1;
 
-// Large enough to trigger thousands-grouping in the displayed amounts (B2CQA-4014).
-const TEST_AMOUNT = "1234.56";
+// Immediately overridden by tapping "Max" below (performSwapUntilQuoteSelectionStep requires
+// some amount to type first). A fixed amount like desktop's isn't safe here: it can exceed the
+// emulator's real balance or a provider's limit and leave "Get quotes" permanently disabled.
+const PLACEHOLDER_AMOUNT = "0.001";
 
 // The send-amount input always groups with plain whitespace, regardless of language.
 const SEND_INPUT_THOUSANDS = " ";
@@ -77,14 +79,11 @@ export function runSwapNumberFormatLocaleTest(tmsLinks: string[], tags: string[]
         const separators = getExpectedSeparators(languageId);
         const formattedAmountPattern = buildFormattedAmountPattern(separators);
 
-        // continueToQuotes=false: the wait below is locale-aware instead of the
-        // English-only `floatNumberRegex` the skipped step would have used.
-        await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, TEST_AMOUNT, false);
-        await waitForWebElementToMatchRegex(
-          app.swapLiveApp.toAmountInput,
-          formattedAmountPattern,
-          20000,
-        );
+        // continueToQuotes=false: "Max" (below) fills a real, balance-safe amount instead of a
+        // guessed one, and the wait is locale-aware instead of the English-only
+        // `floatNumberRegex` the skipped step would have used.
+        await performSwapUntilQuoteSelectionStep(fromAccount, toAccount, PLACEHOLDER_AMOUNT, false);
+        await app.swapLiveApp.clickSwapMax(formattedAmountPattern, 20000);
         await app.swapLiveApp.tapGetQuotesButton();
         await app.swapLiveApp.waitForQuotes();
 

--- a/e2e/mobile/types/jest-allure2-reporter.d.ts
+++ b/e2e/mobile/types/jest-allure2-reporter.d.ts
@@ -24,6 +24,7 @@ declare module "jest-allure2-reporter/api" {
     description(description: string): void;
     attachment(name: string, content: string, type: string): Promise<void>;
     parameter(name: string, value: string): void;
+    step<T>(name: string, function_: () => T): T;
   };
 }
 

--- a/e2e/mobile/types/jest-allure2-reporter.d.ts
+++ b/e2e/mobile/types/jest-allure2-reporter.d.ts
@@ -24,7 +24,6 @@ declare module "jest-allure2-reporter/api" {
     description(description: string): void;
     attachment(name: string, content: string, type: string): Promise<void>;
     parameter(name: string, value: string): void;
-    step<T>(name: string, function_: () => T): T;
   };
 }
 

--- a/e2e/mobile/utils/amountUtils.ts
+++ b/e2e/mobile/utils/amountUtils.ts
@@ -1,4 +1,3 @@
-import { allure } from "jest-allure2-reporter/api";
 import { escapeRegExp } from "../helpers/commonHelpers";
 
 export type NumberSeparators = { decimal: string; thousands: string };
@@ -29,31 +28,30 @@ export function buildFormattedAmountPattern(separators: NumberSeparators): RegEx
 }
 
 // Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
-// can't slip through. `context` also names the Allure step, so each call site fails independently.
+// can't slip through. `context` is embedded in every thrown message, so a failure identifies
+// which call site it came from without needing a separate Allure step per assertion.
 export function expectFormattedAmount(
   text: string | null,
   separators: NumberSeparators,
   context: string,
 ): void {
-  allure.step(context, () => {
-    const label = ` (${context})`;
-    if (!text) {
-      throw new Error(`Expected a formatted amount but got "${text}"${label}`);
-    }
-    const value = text.trim();
-    const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
-    if (tokens.length === 0) {
-      throw new Error(`No numeric value found in "${value}"${label}`);
-    }
+  const label = ` (${context})`;
+  if (!text) {
+    throw new Error(`Expected a formatted amount but got "${text}"${label}`);
+  }
+  const value = text.trim();
+  const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
+  if (tokens.length === 0) {
+    throw new Error(`No numeric value found in "${value}"${label}`);
+  }
 
-    const strictPattern = buildFormattedAmountPattern(separators);
+  const strictPattern = buildFormattedAmountPattern(separators);
 
-    const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
-    if (!matchesExpectedFormat) {
-      throw new Error(
-        `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
-          `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,
-      );
-    }
-  });
+  const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
+  if (!matchesExpectedFormat) {
+    throw new Error(
+      `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
+        `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,
+    );
+  }
 }

--- a/e2e/mobile/utils/amountUtils.ts
+++ b/e2e/mobile/utils/amountUtils.ts
@@ -1,0 +1,59 @@
+import { allure } from "jest-allure2-reporter/api";
+import { escapeRegExp } from "../helpers/commonHelpers";
+
+export type NumberSeparators = { decimal: string; thousands: string };
+
+export type FormattedNumberLanguage = "en" | "fr" | "de";
+
+const SEPARATORS_BY_LANGUAGE: Record<FormattedNumberLanguage, NumberSeparators> = {
+  en: { decimal: ".", thousands: "," },
+  // fr-FR groups with a narrow no-break space (U+202F), not the regular U+00A0.
+  fr: { decimal: ",", thousands: " " },
+  de: { decimal: ",", thousands: "." },
+};
+
+export function getExpectedSeparators(language: FormattedNumberLanguage): NumberSeparators {
+  return SEPARATORS_BY_LANGUAGE[language];
+}
+
+// All separator chars used across supported locales, to isolate a full numeric token first.
+const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExp).join("");
+const NUMERIC_TOKEN_REGEX = new RegExp(`\\d[${ANY_SEPARATOR_CHARS}\\d]*\\d|\\d`, "g");
+
+// Exported so callers can also wait for a locale-formatted value (e.g. in place of the
+// English-only `floatNumberRegex` from `@ledgerhq/live-e2e-shared/data/regexes`).
+export function buildFormattedAmountPattern(separators: NumberSeparators): RegExp {
+  const decimal = escapeRegExp(separators.decimal);
+  const thousands = escapeRegExp(separators.thousands);
+  return new RegExp(`^\\d{1,3}(?:${thousands}\\d{3})*(?:${decimal}\\d+)?$`);
+}
+
+// Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
+// can't slip through. `context` also names the Allure step, so each call site fails independently.
+export function expectFormattedAmount(
+  text: string | null,
+  separators: NumberSeparators,
+  context: string,
+): void {
+  allure.step(context, () => {
+    const label = ` (${context})`;
+    if (!text) {
+      throw new Error(`Expected a formatted amount but got "${text}"${label}`);
+    }
+    const value = text.trim();
+    const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
+    if (tokens.length === 0) {
+      throw new Error(`No numeric value found in "${value}"${label}`);
+    }
+
+    const strictPattern = buildFormattedAmountPattern(separators);
+
+    const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
+    if (!matchesExpectedFormat) {
+      throw new Error(
+        `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
+          `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,
+      );
+    }
+  });
+}

--- a/e2e/mobile/utils/amountUtils.ts
+++ b/e2e/mobile/utils/amountUtils.ts
@@ -1,31 +1,8 @@
-import { escapeRegExp } from "../helpers/commonHelpers";
-
-export type NumberSeparators = { decimal: string; thousands: string };
-
-export type FormattedNumberLanguage = "en" | "fr" | "de";
-
-const SEPARATORS_BY_LANGUAGE: Record<FormattedNumberLanguage, NumberSeparators> = {
-  en: { decimal: ".", thousands: "," },
-  // fr-FR groups with a narrow no-break space (U+202F), not the regular U+00A0.
-  fr: { decimal: ",", thousands: " " },
-  de: { decimal: ",", thousands: "." },
-};
-
-export function getExpectedSeparators(language: FormattedNumberLanguage): NumberSeparators {
-  return SEPARATORS_BY_LANGUAGE[language];
-}
-
-// All separator chars used across supported locales, to isolate a full numeric token first.
-const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExp).join("");
-const NUMERIC_TOKEN_REGEX = new RegExp(String.raw`\d[${ANY_SEPARATOR_CHARS}\d]*\d|\d`, "g");
-
-// Exported so callers can also wait for a locale-formatted value (e.g. in place of the
-// English-only `floatNumberRegex` from `@ledgerhq/live-e2e-shared/data/regexes`).
-export function buildFormattedAmountPattern(separators: NumberSeparators): RegExp {
-  const decimal = escapeRegExp(separators.decimal);
-  const thousands = escapeRegExp(separators.thousands);
-  return new RegExp(String.raw`^\d{1,3}(?:${thousands}\d{3})*(?:${decimal}\d+)?$`);
-}
+import {
+  findNumericTokens,
+  isAmountFormatted,
+  type NumberSeparators,
+} from "@ledgerhq/live-e2e-shared/data/numberFormat";
 
 // Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
 // can't slip through. `context` is embedded in every thrown message, so a failure identifies
@@ -40,19 +17,12 @@ export function expectFormattedAmount(
     throw new Error(`Expected a formatted amount but got "${text}"${label}`);
   }
   const value = text.trim();
-  const tokens: string[] = [];
-  let match: RegExpExecArray | null;
-  while ((match = NUMERIC_TOKEN_REGEX.exec(value)) !== null) {
-    tokens.push(match[0]);
-  }
+  const tokens = findNumericTokens(value);
   if (tokens.length === 0) {
     throw new Error(`No numeric value found in "${value}"${label}`);
   }
 
-  const strictPattern = buildFormattedAmountPattern(separators);
-
-  const matchesExpectedFormat = tokens.some(token => strictPattern.test(token));
-  if (!matchesExpectedFormat) {
+  if (!isAmountFormatted(tokens, separators)) {
     throw new Error(
       `None of the numbers in "${value}"${label} are formatted with decimal "${separators.decimal}" ` +
         `and thousands "${separators.thousands}" (found: ${tokens.join(", ")})`,

--- a/e2e/mobile/utils/amountUtils.ts
+++ b/e2e/mobile/utils/amountUtils.ts
@@ -17,14 +17,14 @@ export function getExpectedSeparators(language: FormattedNumberLanguage): Number
 
 // All separator chars used across supported locales, to isolate a full numeric token first.
 const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExp).join("");
-const NUMERIC_TOKEN_REGEX = new RegExp(`\\d[${ANY_SEPARATOR_CHARS}\\d]*\\d|\\d`, "g");
+const NUMERIC_TOKEN_REGEX = new RegExp(String.raw`\d[${ANY_SEPARATOR_CHARS}\d]*\d|\d`, "g");
 
 // Exported so callers can also wait for a locale-formatted value (e.g. in place of the
 // English-only `floatNumberRegex` from `@ledgerhq/live-e2e-shared/data/regexes`).
 export function buildFormattedAmountPattern(separators: NumberSeparators): RegExp {
   const decimal = escapeRegExp(separators.decimal);
   const thousands = escapeRegExp(separators.thousands);
-  return new RegExp(`^\\d{1,3}(?:${thousands}\\d{3})*(?:${decimal}\\d+)?$`);
+  return new RegExp(String.raw`^\d{1,3}(?:${thousands}\d{3})*(?:${decimal}\d+)?$`);
 }
 
 // Matches on the full numeric token (not a loose substring) so a wrongly-formatted number
@@ -40,7 +40,11 @@ export function expectFormattedAmount(
     throw new Error(`Expected a formatted amount but got "${text}"${label}`);
   }
   const value = text.trim();
-  const tokens = value.match(NUMERIC_TOKEN_REGEX) ?? [];
+  const tokens: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = NUMERIC_TOKEN_REGEX.exec(value)) !== null) {
+    tokens.push(match[0]);
+  }
   if (tokens.length === 0) {
     throw new Error(`No numeric value found in "${value}"${label}`);
   }

--- a/libs/live-e2e-shared/src/data/numberFormat.ts
+++ b/libs/live-e2e-shared/src/data/numberFormat.ts
@@ -1,0 +1,42 @@
+export type NumberSeparators = { decimal: string; thousands: string };
+
+export type FormattedNumberLanguage = "en" | "fr" | "de";
+
+const SEPARATORS_BY_LANGUAGE: Record<FormattedNumberLanguage, NumberSeparators> = {
+  en: { decimal: ".", thousands: "," },
+  // fr-FR groups with a narrow no-break space (U+202F), not the regular U+00A0.
+  fr: { decimal: ",", thousands: " " },
+  de: { decimal: ",", thousands: "." },
+};
+
+export function getExpectedSeparators(language: FormattedNumberLanguage): NumberSeparators {
+  return SEPARATORS_BY_LANGUAGE[language];
+}
+
+function escapeRegExpChar(char: string): string {
+  return char.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+// All separator chars used across supported locales, to isolate a full numeric token first.
+const ANY_SEPARATOR_CHARS = [".", ",", " ", " ", " "].map(escapeRegExpChar).join("");
+const NUMERIC_TOKEN_REGEX = new RegExp(String.raw`\d[${ANY_SEPARATOR_CHARS}\d]*\d|\d`, "g");
+
+export function findNumericTokens(text: string): string[] {
+  const tokens: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = NUMERIC_TOKEN_REGEX.exec(text)) !== null) {
+    tokens.push(match[0]);
+  }
+  return tokens;
+}
+
+export function buildFormattedAmountPattern(separators: NumberSeparators): RegExp {
+  const decimal = escapeRegExpChar(separators.decimal);
+  const thousands = escapeRegExpChar(separators.thousands);
+  return new RegExp(String.raw`^\d{1,3}(?:${thousands}\d{3})*(?:${decimal}\d+)?$`);
+}
+
+export function isAmountFormatted(tokens: string[], separators: NumberSeparators): boolean {
+  const pattern = buildFormattedAmountPattern(separators);
+  return tokens.some(token => pattern.test(token));
+}


### PR DESCRIPTION
## Summary
- Add Desktop (Playwright) and Mobile (Detox/Jest) e2e tests verifying Swap displays the send amount, send countervalue, receive amount, and best quote card with the correct decimal/thousands separators for English, French, and German app languages.
- Fix a pre-existing, locale-hardcoded bug in mobile's `getProviderList()` (assumed English "N quotes found" phrasing).

## Test plan
- [x] `pnpm --filter ledger-live-desktop-e2e-tests typecheck`
- [x] `pnpm --filter ledger-live-mobile-e2e-tests typecheck`
- [x] [Ran full SWAP scope against Speculos (Desktop)](https://github.com/LedgerHQ/ledger-live/actions/runs/32026284511) — all passing
- [x] [Ran full SWAP scope on Android/iOS emulator (Mobile)](https://github.com/LedgerHQ/ledger-live/actions/runs/32026335981)  — all passing

Jira: [B2CQA-4014](https://ledgerhq.atlassian.net/browse/B2CQA-4014)

[B2CQA-4014]: https://ledgerhq.atlassian.net/browse/B2CQA-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ