### PR TITLE
feat(contacts): guard Ledger Sync mutations (LIVE-33957)

### DIFF
--- a/.changeset/live-33869-contacts-ledger-sync.md
+++ b/.changeset/live-33869-contacts-ledger-sync.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Add a shared Contacts Ledger Sync mutation guard that preserves add-contact and add-address intents until activation succeeds.

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -12,4 +12,5 @@ export * from "./steps/Detail";
 export * from "./steps/Detail/native";
 export * from "./components/index.native";
 export * from "./hooks";
+export * from "./ledgerSync";
 export * from "./featureFlags";

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -14,4 +14,5 @@ export * from "./steps/Detail";
 export * from "./steps/Detail/web";
 export * from "./components";
 export * from "./hooks";
+export * from "./ledgerSync";
 export * from "./featureFlags";

--- a/features/flow/contacts/src/ledgerSync/index.ts
+++ b/features/flow/contacts/src/ledgerSync/index.ts
@@ -1,0 +1,6 @@
+export type { ContactsLedgerSyncStatus } from "./types";
+export {
+  useContactsLedgerSyncMutationGuard,
+  type ContactsLedgerSyncMutationIntent,
+  type ContactsLedgerSyncMutationRequest,
+} from "./useContactsLedgerSyncMutationGuard";

--- a/features/flow/contacts/src/ledgerSync/types.ts
+++ b/features/flow/contacts/src/ledgerSync/types.ts
@@ -1,0 +1,1 @@
+export type ContactsLedgerSyncStatus = "ready" | "checking" | "inactive";

--- a/features/flow/contacts/src/ledgerSync/useContactsLedgerSyncMutationGuard.ts
+++ b/features/flow/contacts/src/ledgerSync/useContactsLedgerSyncMutationGuard.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import type { ContactId } from "@domain/entity-contact";
+import type { ContactsLedgerSyncStatus } from "./types";
+
+export type ContactsLedgerSyncMutationIntent =
+  | Readonly<{ kind: "addContact" }>
+  | Readonly<{ kind: "addAddress"; contactId: ContactId }>;
+
+export type ContactsLedgerSyncMutationRequest =
+  | Readonly<{ status: "allowed"; intent: ContactsLedgerSyncMutationIntent }>
+  | Readonly<{ status: "blocked"; intent: ContactsLedgerSyncMutationIntent }>
+  | Readonly<{ status: "checking" }>;
+
+export function useContactsLedgerSyncMutationGuard() {
+  const [pendingIntent, setPendingIntent] = useState<ContactsLedgerSyncMutationIntent>();
+
+  const requestMutation = useCallback(
+    (
+      intent: ContactsLedgerSyncMutationIntent,
+      ledgerSyncStatus: ContactsLedgerSyncStatus,
+    ): ContactsLedgerSyncMutationRequest => {
+      if (ledgerSyncStatus === "ready") {
+        return { status: "allowed", intent };
+      }
+
+      if (ledgerSyncStatus === "checking") {
+        return { status: "checking" };
+      }
+
+      setPendingIntent(intent);
+      return { status: "blocked", intent };
+    },
+    [],
+  );
+
+  const consumePendingIntent = useCallback(
+    (ledgerSyncStatus: ContactsLedgerSyncStatus) => {
+      if (ledgerSyncStatus !== "ready" || !pendingIntent) {
+        return undefined;
+      }
+
+      setPendingIntent(undefined);
+      return pendingIntent;
+    },
+    [pendingIntent],
+  );
+
+  const dismissPendingIntent = useCallback(() => setPendingIntent(undefined), []);
+
+  return {
+    pendingIntent,
+    requestMutation,
+    consumePendingIntent,
+    dismissPendingIntent,
+  };
+}

--- a/features/flow/contacts/src/ledgerSync/useContactsLedgerSyncMutationGuard.web.test.ts
+++ b/features/flow/contacts/src/ledgerSync/useContactsLedgerSyncMutationGuard.web.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+import { ContactIdSchema } from "@domain/entity-contact";
+import {
+  type ContactsLedgerSyncMutationIntent,
+  useContactsLedgerSyncMutationGuard,
+} from "./useContactsLedgerSyncMutationGuard";
+
+describe("useContactsLedgerSyncMutationGuard", () => {
+  it("allows a mutation only when Ledger Sync is ready", () => {
+    const { result } = renderHook(() => useContactsLedgerSyncMutationGuard());
+
+    expect(result.current.requestMutation({ kind: "addContact" }, "ready")).toEqual({
+      status: "allowed",
+      intent: { kind: "addContact" },
+    });
+    expect(result.current.pendingIntent).toBeUndefined();
+  });
+
+  it("blocks while Ledger Sync is checking without opening an intent", () => {
+    const { result } = renderHook(() => useContactsLedgerSyncMutationGuard());
+
+    expect(result.current.requestMutation({ kind: "addContact" }, "checking")).toEqual({
+      status: "checking",
+    });
+    expect(result.current.pendingIntent).toBeUndefined();
+  });
+
+  it("preserves an address intent until activation succeeds", () => {
+    const { result } = renderHook(() => useContactsLedgerSyncMutationGuard());
+    const contactId = ContactIdSchema.parse("contact-ben");
+
+    act(() => {
+      expect(result.current.requestMutation({ kind: "addAddress", contactId }, "inactive")).toEqual(
+        {
+          status: "blocked",
+          intent: { kind: "addAddress", contactId },
+        },
+      );
+    });
+
+    expect(result.current.pendingIntent).toEqual({ kind: "addAddress", contactId });
+    expect(result.current.consumePendingIntent("inactive")).toBeUndefined();
+
+    let resumed: ContactsLedgerSyncMutationIntent | undefined;
+    act(() => {
+      resumed = result.current.consumePendingIntent("ready");
+    });
+
+    expect(resumed).toEqual({ kind: "addAddress", contactId });
+    expect(result.current.pendingIntent).toBeUndefined();
+  });
+
+  it("clears a pending intent when activation is dismissed", () => {
+    const { result } = renderHook(() => useContactsLedgerSyncMutationGuard());
+
+    act(() => {
+      result.current.requestMutation({ kind: "addContact" }, "inactive");
+    });
+    act(() => {
+      result.current.dismissPendingIntent();
+    });
+
+    expect(result.current.pendingIntent).toBeUndefined();
+    expect(result.current.consumePendingIntent("ready")).toBeUndefined();
+  });
+});

--- a/features/flow/contacts/src/steps/Introduction/index.ts
+++ b/features/flow/contacts/src/steps/Introduction/index.ts
@@ -20,7 +20,6 @@ export type {
   ContactsFeatureIntroductionHighlight,
   ContactsFeatureIntroductionHighlightIcon,
   ContactsLedgerSyncIntroduction,
-  ContactsLedgerSyncStatus,
 } from "./types";
 export type { ContactsLedgerSyncIntroductionContentProps } from "./LedgerSync";
 export type { ContactsFeatureIntroductionContentProps } from "./Feature";

--- a/features/flow/contacts/src/steps/Introduction/resolver.ts
+++ b/features/flow/contacts/src/steps/Introduction/resolver.ts
@@ -1,4 +1,4 @@
-import type { ContactsLedgerSyncStatus } from "./types";
+import type { ContactsLedgerSyncStatus } from "../../ledgerSync";
 
 export type ContactsFeatureIntroductionRequestInput = Readonly<{
   isContactsEntryAvailable: boolean;

--- a/features/flow/contacts/src/steps/Introduction/types.ts
+++ b/features/flow/contacts/src/steps/Introduction/types.ts
@@ -1,5 +1,3 @@
-export type ContactsLedgerSyncStatus = "ready" | "checking" | "inactive";
-
 export type ContactsLedgerSyncIntroduction = Readonly<{
   isOpen: boolean;
   description: string;

--- a/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
+++ b/features/flow/contacts/src/steps/List/ContactsListView.web.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ContactId } from "@domain/entity-contact";
 import { mockMeContact, mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
 import type { ContactsPageViewModel } from "./types";
-import type { ContactsLedgerSyncStatus } from "../Introduction";
+import type { ContactsLedgerSyncStatus } from "../../ledgerSync";
 import {
   createContactsSearchViewModel,
   createEmptyContactsListViewModel,

--- a/features/flow/contacts/src/steps/List/types.ts
+++ b/features/flow/contacts/src/steps/List/types.ts
@@ -4,8 +4,8 @@ import type { ContactDetailViewProps } from "../Detail/types";
 import type {
   ContactsFeatureIntroduction,
   ContactsLedgerSyncIntroduction,
-  ContactsLedgerSyncStatus,
 } from "../Introduction/types";
+import type { ContactsLedgerSyncStatus } from "../../ledgerSync";
 
 export type ContactsListItem = Readonly<{
   contactId: ContactId;


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** A focused web unit test covers ready, checking, inactive, dismissal, and address intent preservation.
- [x] **Impact of the changes:**
      Shared Contacts flow only. The guard and its Ledger Sync status contract live in `src/ledgerSync/`, independently from the Contacts introduction screen. Desktop, Mobile, and Contacts Cloud Sync registration remain out of scope for this ticket.

### 📝 Description

Adds a shared guard for Contacts mutations. It allows mutations when Ledger Sync is ready, blocks while the status is checking, and preserves an add-contact or add-address intent while inactive until the activation flow succeeds. Dismissing activation clears the preserved intent.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-33957

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)