### PR TITLE
[LWDM] fix(send-flow): keep ton comment text a string when memo is empty

### DIFF
--- a/.changeset/plump-donkeys-wonder.md
+++ b/.changeset/plump-donkeys-wonder.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/live-common": minor
+"@ledgerhq/coin-ton": minor
+---
+
+Fix TON send flow hanging when the comment field is left empty

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -133,6 +133,20 @@ describe("getTransactionStatus", () => {
           }),
         );
       });
+
+      it("should report a malformed comment as an error instead of throwing", async () => {
+        const transaction = {
+          ...baseTransaction,
+          amount: new BigNumber("1"),
+          comment: { isEncrypted: false, text: undefined as unknown as string },
+        };
+        const res = await getTransactionStatus(account, transaction);
+        expect(res.errors).toEqual(
+          expect.objectContaining({
+            transaction: new TonCommentInvalid(),
+          }),
+        );
+      });
     });
 
     describe("Successful transaction", () => {

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/utils.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/utils.unit.test.ts
@@ -158,6 +158,24 @@ describe("Build TON transaction", () => {
     });
   });
 
+  test("Build TON transaction when the comment text is missing", () => {
+    const transaction = {
+      ...baseTransaction,
+      comment: { isEncrypted: false, text: undefined as unknown as string },
+    };
+
+    const tonTransaction = buildTonTransaction(transaction, seqno, account);
+
+    expect({ ...tonTransaction, to: tonTransaction.to.toString() }).toEqual({
+      to: Address.parse(transaction.recipient).toString(),
+      seqno,
+      amount: BigInt(transaction.amount.toString()),
+      bounce: false,
+      timeout: getTransferExpirationTime(),
+      sendMode: 3,
+    });
+  });
+
   test("Build TON transaction when useAllAmount is true and there is a comment", () => {
     const transaction = {
       ...baseTransaction,

--- a/libs/coin-modules/coin-ton/src/logic/validateMemo.test.ts
+++ b/libs/coin-modules/coin-ton/src/logic/validateMemo.test.ts
@@ -34,6 +34,16 @@ describe("validateMemo", () => {
     },
   );
 
+  it("should return false when the comment is missing", () => {
+    expect(validateMemo(undefined)).toEqual(false);
+  });
+
+  it("should return false when the comment text is not a string", () => {
+    const comment = { isEncrypted: false, text: undefined } as unknown as TonComment;
+
+    expect(validateMemo(comment)).toEqual(false);
+  });
+
   it.each([
     "a",
     "Hello World",

--- a/libs/coin-modules/coin-ton/src/logic/validateMemo.ts
+++ b/libs/coin-modules/coin-ton/src/logic/validateMemo.ts
@@ -8,12 +8,15 @@ import { TonComment } from "../types";
  * coin modules, TON uses a "comment" instead.
  * The validation checks multiple fields, not only text value.
  *
- * @param comment - TON comment object containing text and encryption flag
+ * @param comment - TON comment object containing text and encryption flag. A missing or
+ *   malformed comment is reported invalid rather than throwing, so a bad transaction patch
+ *   surfaces as a validation error instead of wedging the send flow.
  * @returns true if the comment is valid, false otherwise
  */
-export function validateMemo(comment: TonComment): boolean {
-  return (
-    comment.isEncrypted ||
-    (comment.text.length <= MAX_COMMENT_BYTES && /^[\x20-\x7F]*$/.test(comment.text))
-  );
+export function validateMemo(comment: TonComment | undefined): boolean {
+  if (!comment) return false;
+  if (comment.isEncrypted) return true;
+  if (typeof comment.text !== "string") return false;
+
+  return comment.text.length <= MAX_COMMENT_BYTES && /^[\x20-\x7F]*$/.test(comment.text);
 }

--- a/libs/coin-modules/coin-ton/src/utils.ts
+++ b/libs/coin-modules/coin-ton/src/utils.ts
@@ -126,12 +126,14 @@ export function buildTonTransaction(
     payload,
   };
 
-  if (commentTx.text.length) {
-    tonTransaction.payload = { type: "comment", text: commentTx.text };
+  const commentText = typeof commentTx?.text === "string" ? commentTx.text : "";
+
+  if (commentText.length) {
+    tonTransaction.payload = { type: "comment", text: commentText };
   }
 
   if (subAccount) {
-    const forwardPayload = commentTx.text.length ? comment(commentTx.text) : null;
+    const forwardPayload = commentText.length ? comment(commentText) : null;
 
     const currencyConfig = getCoinConfig();
     const knownJettons = currencyConfig.infra.KNOWN_JETTONS;

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.test.ts
@@ -19,6 +19,12 @@ describe("applyMemoToTransaction", () => {
     it("unknown family: empty string clears the generic memo", () => {
       expect(applyMemoToTransaction("algorand", "")).toEqual({ memo: undefined });
     });
+
+    it("ton: empty string keeps the comment text an empty string, not undefined", () => {
+      expect(
+        applyMemoToTransaction("ton", "", undefined, { comment: { isEncrypted: false, text: "" } }),
+      ).toEqual({ comment: { isEncrypted: false, text: "" } });
+    });
   });
 
   describe("non-empty values are applied per family", () => {
@@ -64,6 +70,18 @@ describe("buildRecipientTransactionPatch", () => {
         kind: "transfer",
         uiState: { memo: "solana memo" },
       },
+    });
+  });
+
+  it("keeps ton comment text a string when the memo is left untouched", () => {
+    expect(
+      buildRecipientTransactionPatch(
+        { family: "ton", comment: { isEncrypted: false, text: "" } },
+        { address: "ton-address", memo: { value: "", type: undefined } },
+      ),
+    ).toEqual({
+      recipient: "ton-address",
+      comment: { isEncrypted: false, text: "" },
     });
   });
 

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
@@ -39,7 +39,8 @@ const memoApplicationRegistry: Record<string, MemoApplicationFn> = {
     return {
       comment: {
         ...currentComment,
-        text: memo,
+        // ton stores the memo as a required string, so a cleared memo is "" and never undefined
+        text: memo == null ? "" : String(memo),
       },
     };
   },

--- a/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/memo.ts
@@ -40,7 +40,7 @@ const memoApplicationRegistry: Record<string, MemoApplicationFn> = {
       comment: {
         ...currentComment,
         // ton stores the memo as a required string, so a cleared memo is "" and never undefined
-        text: memo == null ? "" : String(memo),
+        text: String(memo ?? ""),
       },
     };
   },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

TON sends were broken on the new send flow: typing a recipient address wedged the flow, with no error shown and no way forward. An empty Comment produced `comment.text: undefined`, which violates TON's required-string contract and threw out of `getTransactionStatus`.

Fixed in the TON memo applier rather than at the shared `"" → undefined` normalization, which is correct for flat-field families like `xrp` and `casper`. `validateMemo` and `buildTonTransaction` now report a malformed comment instead of throwing, so a bad patch degrades to a validation error rather than a hang. Four regression tests cover it.

Follow-ups filed separately: the bridge-validation catch that swallows throws into a silent dead end (affects all families), TON's missing memo `maxLength`, the missing `errors.RecipientRequired.title` on desktop, and TON absent from the desktop e2e memo list.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34825](https://ledgerhq.atlassian.net/browse/LIVE-34825?atlOrigin=eyJpIjoiMTk5NTA0ZmFiNDJmNDc4ZTkxMjEwNmViOGI3NzYxZjciLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34825]: https://ledgerhq.atlassian.net/browse/LIVE-34825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ