### PR TITLE
[LWDM] feat(contacts): render mobile address detail actions (LIVE-33950)

### DIFF
--- a/.changeset/live-33950-address-detail-actions.md
+++ b/.changeset/live-33950-address-detail-actions.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"live-mobile": minor
+---
+
+Wire mobile contact address detail send, edit, and delete actions with confirmation sheets.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
@@ -47,6 +47,7 @@ export function useContactDetailEditDeleteAdapter(
     namePlaceholder: t("contacts.editContact.namePlaceholder"),
     namingDisclaimer: t("contacts.editContact.namingDisclaimer"),
     applyChanges: t("contacts.editContact.applyChanges"),
+    confirmName: t("contacts.editContact.confirmName"),
     nameValidationErrors: {
       [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.editContact.invalidNameError"),
       [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9363,6 +9363,7 @@
       "namePlaceholder": "Contact name",
       "namingDisclaimer": "For your privacy, avoid full names and surnames. Use a nickname or just a first name + initial, e.g. 'John S.'",
       "applyChanges": "Apply changes",
+      "confirmName": "Confirm name",
       "invalidNameError": "Special characters are not allowed."
     },
     "deleteContact": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10209,12 +10209,12 @@
       "invalidAddress": "Invalid address",
       "domainNotFound": "No address found for this domain",
       "sanctionedAddress": "This address is sanctioned and cannot be used.",
-      "sanctioned": {
-        "description": "This wallet address is sanctioned by international laws and regulations.",
-        "learnMore": "Learn more"
-      },
       "validationUnavailable": "Address validation is temporarily unavailable",
-      "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing."
+      "ensDisclaimer": "ENS names resolve to wallet addresses. Always verify the resolved address before continuing.",
+      "sanctioned": {
+        "description": "This address has been flagged and Ledger doesn't allow sending to it",
+        "learnMore": "Learn more"
+      }
     },
     "addAddressName": {
       "title": "Name address",
@@ -10273,6 +10273,18 @@
       "mobileDescription": "Removing this contact will erase all associated addresses.",
       "confirm": "Delete",
       "cancel": "Cancel"
+    },
+    "deleteAddress": {
+      "title": "Delete address?",
+      "description": "This address will be removed from the contact.",
+      "confirm": "Delete",
+      "cancel": "Cancel"
+    },
+    "editAddress": {
+      "title": "Edit address",
+      "inputLabel": "Address name",
+      "applyChanges": "Apply changes",
+      "invalidLabelError": "Special characters are not allowed."
     },
     "editSigner": {
       "title": "Confirm on your device",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -24,6 +24,11 @@ import { useMyWalletHeaderViewModel } from "LLM/features/MyWallet/views/Header/u
 import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import { mockEthCryptoCurrency } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 
+const mockHandleOpenSendFlow = jest.fn();
+jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
+  useOpenSendFlow: () => ({ handleOpenSendFlow: mockHandleOpenSendFlow }),
+}));
+
 jest.mock("LLM/features/MyWallet/views/Header/useMyWalletHeaderViewModel");
 jest.mock("LLM/features/Contacts/hooks/useContactsAddressValidationAdapter", () => ({
   useContactsAddressValidationAdapter: () => ({
@@ -822,6 +827,114 @@ describe("Contacts integration", () => {
     await waitFor(() => {
       expect(setString).toHaveBeenCalledWith("0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034");
       expect(screen.getByTestId("contacts-address-detail-copy")).toHaveTextContent("Copied");
+    });
+  });
+
+  it("should open the send flow from the address detail sheet", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Send"));
+
+    expect(mockHandleOpenSendFlow).toHaveBeenCalledWith({
+      currencyIds: ["ethereum"],
+      recipient: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    });
+  });
+
+  it("should open the delete address sheet from the address detail sheet", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByTestId("contacts-address-detail-delete"));
+
+    expect(await screen.findByTestId("contacts-delete-address-confirm")).toBeVisible();
+    expect(screen.getByText("Delete address?")).toBeVisible();
+  });
+
+  it("should delete an address and close the address detail sheet", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByTestId("contacts-address-detail-delete"));
+    await user.press(await screen.findByTestId("contacts-delete-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-delete-address-confirm")).toBeNull();
+      expect(screen.queryByTestId("contacts-address-detail-dialog")).toBeNull();
+      expect(screen.getByText("1 address")).toBeVisible();
+      expect(screen.queryByTestId("contacts-detail-address-row-address-ethereum")).toBeNull();
+      expect(screen.getByTestId("contacts-detail-address-row-address-polygon")).toBeVisible();
+    });
+  });
+
+  it("should open the signer sheet before editing an address", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Edit"));
+
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+    expect(screen.getByText("Confirm on your device")).toBeVisible();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(screen.getByTestId("contacts-rename-address-confirm")).toBeVisible();
+    });
+  });
+
+  it("should rename an address after confirming on the signer sheet", async () => {
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts: mockPopulatedContacts() } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
+    await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.press(await screen.findByText("Edit"));
+    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
+    const renameInput = await screen.findByDisplayValue("Ethereum");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Exchange wallet");
+    await user.press(screen.getByTestId("contacts-rename-address-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-rename-address-confirm")).toBeNull();
+      expect(screen.queryByTestId("contacts-address-detail-dialog")).toBeNull();
+      expect(screen.getByText("Exchange wallet")).toBeVisible();
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -1,0 +1,148 @@
+import { ContactIdSchema, type ContactAddressId, type ContactId } from "@domain/entity-contact";
+import {
+  type ContactAddressDetailSendIntent,
+  type ContactsDeleteAddressDrawerProps,
+  type ContactsEditSignerDrawerProps,
+  type ContactsRenameAddressDrawerProps,
+  type ContactAddressDetailDialogNativeProps,
+  useContactAddressDetailActionsFlowBindings,
+  useContactsAddressDetailActionsPorts,
+} from "@features/flow-contacts";
+import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
+import { useCallback, useMemo } from "react";
+import { ScreenName } from "~/const";
+import { useTranslation } from "~/context/Locale";
+
+export type ContactAddressDetailActionsFlowProps = Readonly<{
+  addressDetailDialog: Pick<
+    ContactAddressDetailDialogNativeProps,
+    "onSend" | "onEdit" | "onDelete" | "canSend" | "canEdit" | "canDelete"
+  >;
+  deleteSheet: ContactsDeleteAddressDrawerProps;
+  renameSheet: ContactsRenameAddressDrawerProps;
+  signerSheet: ContactsEditSignerDrawerProps;
+}>;
+
+export function useContactAddressDetailActionsAdapter(
+  contactId: ContactId | undefined,
+  addressId: ContactAddressId | undefined,
+  onCloseAddressDetail: () => void,
+): ContactAddressDetailActionsFlowProps {
+  const { t } = useTranslation();
+  const ports = useContactsAddressDetailActionsPorts();
+  const { handleOpenSendFlow } = useOpenSendFlow({
+    sourceScreenName: ScreenName.MyWalletContactDetail,
+  });
+  const isSelectionActive = contactId !== undefined && addressId !== undefined;
+  const onSend = useCallback(
+    (intent: ContactAddressDetailSendIntent) => {
+      handleOpenSendFlow({
+        currencyIds: [intent.currencyId],
+        recipient: intent.address,
+      });
+      onCloseAddressDetail();
+    },
+    [handleOpenSendFlow, onCloseAddressDetail],
+  );
+  const deleteLabels = useMemo(
+    () => ({
+      title: t("contacts.deleteAddress.title"),
+      description: t("contacts.deleteAddress.description"),
+      confirm: t("contacts.deleteAddress.confirm"),
+      cancel: t("contacts.deleteAddress.cancel"),
+    }),
+    [t],
+  );
+  const renameLabels = useMemo(
+    () => ({
+      title: t("contacts.editAddress.title"),
+      inputLabel: t("contacts.editAddress.inputLabel"),
+      applyChanges: t("contacts.editAddress.applyChanges"),
+      labelValidationErrors: {
+        InvalidContactAddressLabelError: t("contacts.editAddress.invalidLabelError"),
+        DuplicateContactAddressLabelError: t("contacts.addAddressName.duplicateLabel"),
+        ContactAddressLabelTooLongError: t("contacts.addAddressName.labelTooLong"),
+      },
+    }),
+    [t],
+  );
+  const signerLabels = useMemo(
+    () => ({
+      title: t("contacts.editSigner.title"),
+      description: t("contacts.editSigner.description"),
+      confirm: t("contacts.editSigner.confirm"),
+      cancel: t("contacts.editSigner.cancel"),
+    }),
+    [t],
+  );
+  const { flow, renameViewModel } = useContactAddressDetailActionsFlowBindings({
+    contactId: contactId ?? ContactIdSchema.parse("contact-me"),
+    addressId: isSelectionActive ? addressId : undefined,
+    ports,
+    onSend,
+    onCloseAddressDetail,
+  });
+
+  if (!isSelectionActive) {
+    return {
+      addressDetailDialog: {
+        canSend: false,
+        canEdit: false,
+        canDelete: false,
+      },
+      deleteSheet: {
+        isOpen: false,
+        isDeleting: false,
+        labels: deleteLabels,
+        onConfirm: async () => undefined,
+        onCancel: () => undefined,
+      },
+      renameSheet: {
+        isOpen: false,
+        isSaving: false,
+        draftLabel: "",
+        invalidLabelError: null,
+        isConfirmEnabled: false,
+        labels: renameLabels,
+        onOpen: () => undefined,
+        onClose: () => undefined,
+        onDraftLabelChange: () => undefined,
+        onConfirm: async () => undefined,
+      },
+      signerSheet: {
+        isOpen: false,
+        labels: signerLabels,
+        onConfirm: () => undefined,
+        onCancel: () => undefined,
+      },
+    };
+  }
+
+  return {
+    addressDetailDialog: {
+      onSend: flow.onSendPress,
+      onEdit: flow.onEditPress,
+      onDelete: flow.onDeletePress,
+      canSend: flow.canSend,
+      canEdit: flow.canEdit,
+      canDelete: flow.canDelete,
+    },
+    deleteSheet: {
+      isOpen: flow.deleteLifecycle.status === "open",
+      isDeleting: flow.isDeleting,
+      labels: deleteLabels,
+      onConfirm: flow.confirmDelete,
+      onCancel: flow.cancelDelete,
+    },
+    renameSheet: {
+      ...renameViewModel,
+      labels: renameLabels,
+    },
+    signerSheet: {
+      isOpen: flow.editUiState === "signer-open",
+      labels: signerLabels,
+      onConfirm: flow.onSignerConfirm,
+      onCancel: flow.onSignerCancel,
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/index.ts
@@ -1,2 +1,3 @@
 export { ContactsButton } from "./components/ContactsButton";
 export { ContactsScreen } from "./screens/ContactsPage";
+export type { ContactAddressDetailActionsFlowProps } from "./hooks/useContactAddressDetailActionsAdapter";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactAddressDetailActionsSheets/index.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback } from "react";
+import {
+  ContactsDeleteAddressDialog,
+  ContactsEditSignerDialog,
+  ContactsRenameAddressDialog,
+} from "@features/flow-contacts";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import QueuedBottomSheet from "LLM/components/QueuedDrawer/QueuedBottomSheet";
+import type { ContactAddressDetailActionsFlowProps } from "LLM/features/Contacts";
+
+type ContactAddressDetailActionsSheetsProps = Pick<
+  ContactAddressDetailActionsFlowProps,
+  "deleteSheet" | "renameSheet" | "signerSheet"
+>;
+
+export function ContactAddressDetailActionsSheets({
+  deleteSheet,
+  renameSheet,
+  signerSheet,
+}: ContactAddressDetailActionsSheetsProps): React.JSX.Element {
+  const { bottom: bottomInset } = useSafeAreaInsets();
+  const onCloseDelete = useCallback(() => {
+    deleteSheet.onCancel();
+  }, [deleteSheet]);
+  const onCloseSigner = useCallback(() => {
+    signerSheet.onCancel();
+  }, [signerSheet]);
+
+  return (
+    <>
+      <QueuedBottomSheet
+        isRequestingToBeOpened={deleteSheet.isOpen}
+        isForcingToBeOpened={deleteSheet.isOpen}
+        onClose={onCloseDelete}
+        testID="contacts-delete-address-sheet"
+        enableDynamicSizing
+      >
+        <ContactsDeleteAddressDialog {...deleteSheet} bottomInset={bottomInset} />
+      </QueuedBottomSheet>
+      <QueuedBottomSheet
+        isRequestingToBeOpened={signerSheet.isOpen}
+        isForcingToBeOpened={signerSheet.isOpen}
+        onClose={onCloseSigner}
+        testID="contacts-address-detail-signer-sheet"
+        enableDynamicSizing
+      >
+        <ContactsEditSignerDialog {...signerSheet} bottomInset={bottomInset} />
+      </QueuedBottomSheet>
+      <QueuedBottomSheet
+        isRequestingToBeOpened={renameSheet.isOpen}
+        isForcingToBeOpened={renameSheet.isOpen}
+        onClose={renameSheet.onClose}
+        testID="contacts-rename-address-sheet"
+        enableDynamicSizing
+      >
+        <ContactsRenameAddressDialog {...renameSheet} bottomInset={bottomInset} />
+      </QueuedBottomSheet>
+    </>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactsAddAddressFlowDrawer/useContactsAddAddressFlowDrawerViewModel.ts
@@ -9,7 +9,7 @@ import { useTranslation } from "~/context/Locale";
 import { shouldUseKeyboardAvoidance, useKeyboardVisible } from "~/logic/keyboardVisible";
 import { useLocalizedUrl } from "LLM/hooks/useLocalizedUrls";
 import { urls } from "~/utils/urls";
-import { useContactsCurrencySelectionAdapter } from "../../../../hooks/useContactsCurrencySelectionAdapter";
+import { useContactsCurrencySelectionAdapter } from "LLM/features/Contacts/hooks/useContactsCurrencySelectionAdapter";
 import type { ContactsAddAddressDrawerStep, ContactsAddAddressFlowDrawerProps } from "./types";
 
 function resolveDrawerStep(

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -53,6 +53,7 @@ export function useContactDetailEditDeleteAdapter(
       namePlaceholder: t("contacts.editContact.namePlaceholder"),
       namingDisclaimer: t("contacts.editContact.namingDisclaimer"),
       applyChanges: t("contacts.editContact.applyChanges"),
+      confirmName: t("contacts.editContact.confirmName"),
       nameValidationErrors: {
         [INVALID_CONTACT_NAME_ERROR_NAME]: t("contacts.editContact.invalidNameError"),
         [DUPLICATE_CONTACT_NAME_ERROR_NAME]: t("contacts.addContactDrawer.duplicateNameError"),

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ContactDetailView } from "@features/flow-contacts";
 import { TrackScreen } from "~/analytics";
 import { ContactsAddAddressFlowDrawer } from "./components/ContactsAddAddressFlowDrawer";
+import { ContactAddressDetailActionsSheets } from "./components/ContactAddressDetailActionsSheets";
 import { ContactAddressDetailDialogSheet } from "./components/ContactAddressDetailDialogSheet";
 import { ContactDetailEditDeleteSheets } from "./components/ContactDetailEditDeleteSheets";
 import { useContactDetailNavigationViewModel } from "./hooks/useContactDetailNavigationViewModel";
@@ -26,6 +27,11 @@ export function ContactDetailScreen(): React.JSX.Element | null {
         <ContactsAddAddressFlowDrawer {...viewModel.addAddressFlowProps} />
       ) : null}
       <ContactAddressDetailDialogSheet {...viewModel.addressDetailDialog} />
+      <ContactAddressDetailActionsSheets
+        deleteSheet={viewModel.addressDetailActions.deleteSheet}
+        renameSheet={viewModel.addressDetailActions.renameSheet}
+        signerSheet={viewModel.addressDetailActions.signerSheet}
+      />
       <ContactDetailEditDeleteSheets {...viewModel.editDeleteFlow} />
     </>
   );

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -29,6 +29,7 @@ import { useContactsAddressValidationAdapter } from "../../hooks/useContactsAddr
 import type { ContactsAddAddressFlowDrawerProps } from "./components/ContactsAddAddressFlowDrawer/types";
 import type { ContactDetailEditDeleteFlowProps } from "./hooks/useContactDetailEditDeleteAdapter";
 import { useContactDetailEditDeleteAdapter } from "./hooks/useContactDetailEditDeleteAdapter";
+import { useContactAddressDetailActionsAdapter } from "../../hooks/useContactAddressDetailActionsAdapter";
 
 const MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS = 200;
 
@@ -40,6 +41,7 @@ type ContactDetailScreenViewModel =
       addAddressFlowProps: ContactsAddAddressFlowDrawerProps;
       pageProps: ContactDetailViewProps;
       addressDetailDialog: ContactAddressDetailDialogNativeProps;
+      addressDetailActions: ReturnType<typeof useContactAddressDetailActionsAdapter>;
       editDeleteFlow: ContactDetailEditDeleteFlowProps;
     }>;
 
@@ -182,6 +184,27 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     navigation.navigate(ScreenName.MyWalletContacts);
   }, [navigation]);
   const editDeleteFlow = useContactDetailEditDeleteAdapter(route.params.contactId, onDeleteSuccess);
+  const addressDetailActions = useContactAddressDetailActionsAdapter(
+    route.params.contactId,
+    selection?.row?.addressId,
+    onCloseAddressDetail,
+  );
+  const onCloseAddressDetailSheet = useCallback(() => {
+    if (
+      addressDetailActions.deleteSheet.isOpen ||
+      addressDetailActions.renameSheet.isOpen ||
+      addressDetailActions.signerSheet.isOpen
+    ) {
+      return;
+    }
+
+    onCloseAddressDetail();
+  }, [
+    addressDetailActions.deleteSheet.isOpen,
+    addressDetailActions.renameSheet.isOpen,
+    addressDetailActions.signerSheet.isOpen,
+    onCloseAddressDetail,
+  ]);
   const shouldRedirect = !isEnabled || !contact;
 
   useLayoutEffect(() => {
@@ -234,8 +257,10 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       row: selection?.row,
       network: selection?.network,
       labels: addressDetailDialogLabels,
-      onClose: onCloseAddressDetail,
+      onClose: onCloseAddressDetailSheet,
+      ...addressDetailActions.addressDetailDialog,
     },
+    addressDetailActions,
     editDeleteFlow,
   };
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsFeatureIntroductionSheet/index.tsx
@@ -6,7 +6,7 @@ import {
 } from "@features/flow-contacts";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import QueuedBottomSheet from "LLM/components/QueuedDrawer/QueuedBottomSheet";
-import { useSingleFireDismiss } from "../../../../hooks/useSingleFireDismiss";
+import { useSingleFireDismiss } from "LLM/features/Contacts/hooks/useSingleFireDismiss";
 
 export type ContactsFeatureIntroductionSheetProps = ContactsFeatureIntroduction;
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useOpenSendFlow.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { act, renderHook, waitFor, withFlagOverrides } from "@tests/test-renderer";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import type { TokenAccount } from "@ledgerhq/types-live";
@@ -73,6 +73,41 @@ describe("useOpenSendFlow", () => {
     });
   });
 
+  it("forwards a recipient override to the new send flow", () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const account = genAccount("send-account-selection-with-recipient", { currency });
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    const { result } = renderHook(
+      () =>
+        useOpenSendFlow({
+          currency,
+          recipient,
+          sourceScreenName: "Contact Detail",
+        }),
+      {
+        overrideInitialState: withFlagOverrides({
+          newSendFlow: {
+            enabled: true,
+            params: { families: ["evm"], excludedCurrencyIds: [] },
+          },
+        }),
+      },
+    );
+
+    act(() => result.current.handleOpenSendFlow());
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    act(() => onAccountSelected(account));
+
+    expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFlow, {
+      params: {
+        account,
+        parentAccount: undefined,
+        fromMAD: true,
+        recipient,
+      },
+    });
+  });
+
   it("falls back to the legacy recipient screen when the selected account is not eligible", () => {
     const currency = getCryptoCurrencyById("ethereum");
     const account = genAccount("legacy-send-account-selection", { currency });
@@ -93,6 +128,36 @@ describe("useOpenSendFlow", () => {
         accountId: account.id,
         parentId: undefined,
       },
+    });
+  });
+
+  it("prefills the legacy recipient when a recipient override is provided", async () => {
+    const currency = getCryptoCurrencyById("ethereum");
+    const account = genAccount("legacy-send-with-recipient", { currency });
+    const recipient = "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034";
+    const { result } = renderHook(() =>
+      useOpenSendFlow({
+        currency,
+        recipient,
+        sourceScreenName: "Contact Detail",
+      }),
+    );
+
+    act(() => result.current.handleOpenSendFlow());
+    const onAccountSelected = mockOpenDrawer.mock.calls[0][0].onAccountSelected;
+    await act(async () => {
+      onAccountSelected(account);
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+        screen: ScreenName.SendSelectRecipient,
+        params: expect.objectContaining({
+          accountId: account.id,
+          parentId: undefined,
+          transaction: expect.objectContaining({ recipient }),
+        }),
+      });
     });
   });
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useOpenSendFlow.ts
@@ -3,6 +3,7 @@ import { useNavigation } from "@react-navigation/native";
 import type { NavigatorScreenParams } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
 import { NavigatorName, ScreenName } from "~/const";
@@ -12,35 +13,71 @@ import { useModularDrawerController } from "LLM/features/ModularDrawer";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
 import { useNewSendFlowFeature } from "./useNewSendFlowFeature";
 
+type OpenSendFlowOverride = Readonly<{
+  currencyIds?: string[];
+  recipient?: string;
+}>;
+
 type UseOpenSendFlowProps = Readonly<{
   currency?: CryptoOrTokenCurrency;
   currencyIds?: string[];
+  recipient?: string;
   sourceScreenName: string;
 }>;
 
-export function useOpenSendFlow({ currency, currencyIds, sourceScreenName }: UseOpenSendFlowProps) {
+export function useOpenSendFlow({
+  currency,
+  currencyIds,
+  recipient,
+  sourceScreenName,
+}: UseOpenSendFlowProps) {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const { openDrawer } = useModularDrawerController();
   const { isEnabledForFamily, getFamilyFromAccount, getCurrencyIdFromAccount } =
     useNewSendFlowFeature();
 
   const navigateToLegacyRecipient = useCallback(
-    (account: AccountLike) => {
+    async (account: AccountLike, parentAccount?: Account, prefilledRecipient?: string) => {
+      const params: SendFundsNavigatorStackParamList[typeof ScreenName.SendSelectRecipient] = {
+        accountId: account.id,
+        parentId: account.type === "TokenAccount" ? account.parentId : undefined,
+      };
+
+      const canPrefillRecipient = Boolean(
+        prefilledRecipient && !(account.type === "TokenAccount" && !parentAccount),
+      );
+
+      if (canPrefillRecipient && prefilledRecipient) {
+        try {
+          const bridge = await getAccountBridge(account, parentAccount);
+          const mainAccount = getMainAccount(account, parentAccount ?? null);
+          const subAccountId = account.type !== "Account" ? account.id : undefined;
+          let transaction = await bridge.createTransaction(mainAccount);
+
+          if (subAccountId) {
+            transaction = { ...transaction, subAccountId };
+          }
+
+          params.transaction = bridge.updateTransaction(transaction, {
+            recipient: prefilledRecipient,
+          });
+        } catch {
+          // Fall back to navigating without a prefilled transaction.
+        }
+      }
+
       navigation.navigate(NavigatorName.SendFunds, {
         screen: ScreenName.SendSelectRecipient,
-        params: {
-          accountId: account.id,
-          parentId: account.type === "TokenAccount" ? account.parentId : undefined,
-        },
+        params,
       });
     },
     [navigation],
   );
 
   const navigateAfterAccountSelection = useCallback(
-    (account: AccountLike, parentAccount?: Account) => {
+    (account: AccountLike, parentAccount?: Account, prefilledRecipient?: string) => {
       if (account.type === "TokenAccount" && !parentAccount) {
-        navigateToLegacyRecipient(account);
+        void navigateToLegacyRecipient(account, parentAccount, prefilledRecipient);
         return;
       }
 
@@ -54,6 +91,7 @@ export function useOpenSendFlow({ currency, currencyIds, sourceScreenName }: Use
             account,
             parentAccount: mainAccount === account ? undefined : mainAccount,
             fromMAD: true,
+            recipient: prefilledRecipient,
           },
         });
         return;
@@ -74,7 +112,7 @@ export function useOpenSendFlow({ currency, currencyIds, sourceScreenName }: Use
         return;
       }
 
-      navigateToLegacyRecipient(account);
+      void navigateToLegacyRecipient(account, parentAccount, prefilledRecipient);
     },
     [
       getCurrencyIdFromAccount,
@@ -85,17 +123,23 @@ export function useOpenSendFlow({ currency, currencyIds, sourceScreenName }: Use
     ],
   );
 
-  const handleOpenSendFlow = useCallback(() => {
-    const hasCurrencyIds = Boolean(currencyIds?.length);
-    openDrawer({
-      currencies: hasCurrencyIds ? currencyIds : currency ? [currency.id] : [],
-      flow: "send",
-      source: sourceScreenName,
-      areCurrenciesFiltered: hasCurrencyIds || Boolean(currency),
-      enableAccountSelection: true,
-      onAccountSelected: navigateAfterAccountSelection,
-    });
-  }, [currency, currencyIds, navigateAfterAccountSelection, openDrawer, sourceScreenName]);
+  const handleOpenSendFlow = useCallback(
+    (override?: OpenSendFlowOverride) => {
+      const resolvedCurrencyIds = override?.currencyIds ?? currencyIds;
+      const resolvedRecipient = override?.recipient ?? recipient;
+      const hasCurrencyIds = Boolean(resolvedCurrencyIds?.length);
+      openDrawer({
+        currencies: hasCurrencyIds ? resolvedCurrencyIds : currency ? [currency.id] : [],
+        flow: "send",
+        source: sourceScreenName,
+        areCurrenciesFiltered: hasCurrencyIds || Boolean(currency),
+        enableAccountSelection: true,
+        onAccountSelected: (account, parentAccount) =>
+          navigateAfterAccountSelection(account, parentAccount, resolvedRecipient),
+      });
+    },
+    [currency, currencyIds, navigateAfterAccountSelection, openDrawer, recipient, sourceScreenName],
+  );
 
   return { handleOpenSendFlow };
 }

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -3,6 +3,8 @@ export * from "./steps/List/native";
 export * from "@features/flow-contacts-add-contact";
 export * from "./steps/EditContact";
 export * from "./steps/EditContact/native";
+export * from "./steps/EditAddress";
+export * from "./steps/EditAddress/native";
 export * from "./steps/AddAddress";
 export * from "./steps/AddAddress/native";
 export * from "./steps/Introduction";

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailActions.native.tsx
@@ -7,12 +7,24 @@ type ContactAddressDetailActionsProps = Readonly<{
   labels: ContactAddressDetailDialogNativeLabels;
   hasCopied: boolean;
   onCopy: () => void;
+  onSend?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  canSend?: boolean;
+  canEdit?: boolean;
+  canDelete?: boolean;
 }>;
 
 export function ContactAddressDetailActions({
   labels,
   hasCopied,
   onCopy,
+  onSend,
+  onEdit,
+  onDelete,
+  canSend = false,
+  canEdit = false,
+  canDelete = false,
 }: ContactAddressDetailActionsProps): React.JSX.Element {
   return (
     <Box lx={{ marginTop: "s16", gap: "s32", width: "full", alignItems: "center" }}>
@@ -26,10 +38,22 @@ export function ContactAddressDetailActions({
         {hasCopied ? labels.copied : labels.copyAddress}
       </Link>
       <Box lx={{ flexDirection: "row", gap: "s8", width: "full" }}>
-        <TileButton icon={ArrowUp} disabled isFull lx={{ flex: 1 }}>
+        <TileButton
+          icon={ArrowUp}
+          disabled={!canSend || !onSend}
+          onPress={onSend}
+          isFull
+          lx={{ flex: 1 }}
+        >
           {labels.send}
         </TileButton>
-        <TileButton icon={PenEdit} disabled isFull lx={{ flex: 1 }}>
+        <TileButton
+          icon={PenEdit}
+          disabled={!canEdit || !onEdit}
+          onPress={onEdit}
+          isFull
+          lx={{ flex: 1 }}
+        >
           {labels.edit}
         </TileButton>
         <TileButton icon={Share} disabled isFull lx={{ flex: 1 }}>
@@ -38,7 +62,8 @@ export function ContactAddressDetailActions({
         <TileButton
           icon={Trash}
           appearance="red"
-          disabled
+          disabled={!canDelete || !onDelete}
+          onPress={onDelete}
           isFull
           lx={{ flex: 1 }}
           testID="contacts-address-detail-delete"

--- a/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactAddressDetailDialog/ContactAddressDetailDialog.native.tsx
@@ -15,6 +15,12 @@ export function ContactAddressDetailDialog({
   labels,
   bottomInset = 0,
   onCopyAddress,
+  onSend,
+  onEdit,
+  onDelete,
+  canSend = false,
+  canEdit = false,
+  canDelete = false,
 }: ContactAddressDetailDialogNativeProps): React.JSX.Element {
   const { hasSelection, hasCopied, onCopy } = useContactAddressDetailDialogViewModel({
     isOpen,
@@ -37,7 +43,17 @@ export function ContactAddressDetailDialog({
               network={network}
               formatNetworkTag={labels.formatNetworkTag}
             />
-            <ContactAddressDetailActions labels={labels} hasCopied={hasCopied} onCopy={onCopy} />
+            <ContactAddressDetailActions
+              labels={labels}
+              hasCopied={hasCopied}
+              onCopy={onCopy}
+              onSend={onSend}
+              onEdit={onEdit}
+              onDelete={onDelete}
+              canSend={canSend}
+              canEdit={canEdit}
+              canDelete={canDelete}
+            />
           </Box>
         </>
       ) : null}

--- a/features/flow/contacts/src/steps/Detail/components/ContactsDeleteAddressDialog/ContactsDeleteAddressDialog.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsDeleteAddressDialog/ContactsDeleteAddressDialog.native.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Trash } from "@ledgerhq/lumen-ui-rnative/symbols";
+import { ContactConfirmationBottomSheet } from "../ContactConfirmationBottomSheet/ContactConfirmationBottomSheet.native";
+import type { ContactsDeleteAddressDrawerProps } from "./types";
+
+export function ContactsDeleteAddressDialog({
+  isOpen,
+  isDeleting,
+  bottomInset = 0,
+  labels,
+  onConfirm,
+  onCancel,
+}: ContactsDeleteAddressDrawerProps): React.JSX.Element {
+  return (
+    <ContactConfirmationBottomSheet
+      isOpen={isOpen}
+      bottomInset={bottomInset}
+      icon={Trash}
+      labels={labels}
+      confirmAppearance="red"
+      confirmLoading={isDeleting}
+      confirmDisabled={isDeleting}
+      confirmTestID="contacts-delete-address-confirm"
+      onConfirm={() => void onConfirm()}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/native.ts
+++ b/features/flow/contacts/src/steps/Detail/native.ts
@@ -3,6 +3,8 @@ export { ContactAddressDetailDialog } from "./components/ContactAddressDetailDia
 export { ContactDetailActionsMenu } from "./components/ContactDetailActionsMenu/ContactDetailActionsMenu.native";
 export type { ContactDetailActionsMenuProps } from "./components/ContactDetailActionsMenu/ContactDetailActionsMenu.native";
 export { ContactsDeleteContactDialog } from "./components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.native";
+export { ContactsDeleteAddressDialog } from "./components/ContactsDeleteAddressDialog/ContactsDeleteAddressDialog.native";
 export { ContactsEditSignerDialog } from "./components/ContactsEditSignerDialog/ContactsEditSignerDialog.native";
 export type { ContactsDeleteContactDrawerProps } from "./components/ContactsDeleteContactDialog/types";
+export type { ContactsDeleteAddressDrawerProps } from "./components/ContactsDeleteAddressDialog/types";
 export type { ContactsEditSignerDrawerProps } from "./components/ContactsEditSignerDialog/types";

--- a/features/flow/contacts/src/steps/Detail/web.ts
+++ b/features/flow/contacts/src/steps/Detail/web.ts
@@ -4,9 +4,7 @@ export { ContactDetailActions } from "./components/ContactDetailActions/ContactD
 export type { ContactDetailActionsProps } from "./components/ContactDetailActions/ContactDetailActions.web";
 export { ContactsDeleteContactDialog } from "./components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web";
 export { ContactsDeleteAddressDialog } from "./components/ContactsDeleteAddressDialog/ContactsDeleteAddressDialog.web";
-export { ContactsRenameAddressDialog } from "../EditAddress/ContactsRenameAddressDialog.web";
 export { ContactsEditSignerDialog } from "./components/ContactsEditSignerDialog/ContactsEditSignerDialog.web";
 export type { ContactsDeleteContactDialogProps } from "./components/ContactsDeleteContactDialog/types";
 export type { ContactsDeleteAddressDialogProps } from "./components/ContactsDeleteAddressDialog/types";
-export type { ContactsRenameAddressDialogProps } from "../EditAddress/types";
 export type { ContactsEditSignerDialogProps } from "./components/ContactsEditSignerDialog/types";

--- a/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDrawer.native.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  BottomSheetHeader,
+  BottomSheetView,
+  Box,
+  Button,
+  TextInput,
+} from "@ledgerhq/lumen-ui-rnative";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import type { ContactsRenameAddressDrawerProps } from "./types";
+
+export function ContactsRenameAddressDialog({
+  isOpen,
+  isConfirmEnabled,
+  isSaving,
+  draftLabel,
+  invalidLabelError,
+  bottomInset = 0,
+  labels,
+  onDraftLabelChange,
+  onConfirm,
+}: ContactsRenameAddressDrawerProps): React.JSX.Element {
+  const labelValidationError =
+    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+
+  return (
+    <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
+      {isOpen ? (
+        <Box lx={{ gap: "s24" }}>
+          <BottomSheetHeader density="expanded" title={labels.title} />
+          <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
+            <TextInput
+              autoComplete="off"
+              autoCorrect={false}
+              helperText={labelValidationError}
+              label={labels.inputLabel}
+              maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+              onChangeText={onDraftLabelChange}
+              status={labelValidationError ? "error" : undefined}
+              value={draftLabel}
+            />
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              disabled={!isConfirmEnabled}
+              loading={isSaving}
+              onPress={() => void onConfirm()}
+              testID="contacts-rename-address-confirm"
+            >
+              {labels.applyChanges}
+            </Button>
+          </Box>
+        </Box>
+      ) : null}
+    </BottomSheetView>
+  );
+}

--- a/features/flow/contacts/src/steps/EditAddress/native.ts
+++ b/features/flow/contacts/src/steps/EditAddress/native.ts
@@ -1,0 +1,1 @@
+export { ContactsRenameAddressDialog } from "./ContactsRenameAddressDrawer.native";

--- a/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDrawer.native.tsx
+++ b/features/flow/contacts/src/steps/EditContact/ContactsRenameContactDrawer.native.tsx
@@ -24,7 +24,7 @@ export function ContactsRenameContactDrawer({
       bottomInset={bottomInset}
       keyboardInset={keyboardInset}
       labels={labels}
-      confirmLabel={labels.applyChanges}
+      confirmLabel={labels.confirmName}
       confirmTestID="contacts-rename-contact-confirm"
       onDraftNameChange={onDraftNameChange}
       onConfirm={onConfirm}

--- a/features/flow/contacts/src/steps/EditContact/types.ts
+++ b/features/flow/contacts/src/steps/EditContact/types.ts
@@ -29,6 +29,7 @@ export type ContactsRenameContactLabels = Readonly<{
   namePlaceholder: string;
   namingDisclaimer: string;
   applyChanges: string;
+  confirmName: string;
   nameValidationErrors: Readonly<Record<ContactNameValidationErrorName, string>>;
 }>;
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire the address detail sheet quick actions to shared flow-contacts state and mobile navigation adapters so send, edit, and delete work from contact detail.

**Mobile app (`ledger-live-mobile`)**
- New `useContactAddressDetailActionsAdapter` bridges flow bindings to mobile navigation:
  - **Send** → opens send flow with currency + recipient via `useOpenSendFlow`
  - **Edit** → signer bottom sheet → rename drawer
  - **Delete** → delete confirmation bottom sheet
- `ContactAddressDetailActionsSheets` renders rename, delete, and signer sheets
- `ContactDetail` screen wires adapter output to sheets and send flow

**Native flow surfaces (`@features/flow-contacts`)**
- Native address detail action callbacks and delete/rename drawers
- `ContactsDeleteAddressDialog.native` and `ContactsRenameAddressDrawer.native`


https://github.com/user-attachments/assets/09656a5d-fd81-4e8e-916c-e422fb750843



### 🔗 Context

Stacked PR **4 of 4** for address detail actions.

- **Depends on:** #20445 → #20446 → #20408

[LIVE-33950](https://ledgerhq.atlassian.net/browse/LIVE-33950)

### ✅ Test plan

- [ ] Open contact detail → tap address → Send opens send flow with recipient
- [ ] Edit → signer sheet → rename drawer → label updates
- [ ] Delete → confirmation sheet → address removed
- [ ] Mobile contacts integration tests pass

[LIVE-33950]: https://ledgerhq.atlassian.net/browse/LIVE-33950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ