### PR TITLE
[LWDM] feat(common): add transaction intent type to broadcast logs

### DIFF
--- a/.changeset/soft-pumas-draw.md
+++ b/.changeset/soft-pumas-draw.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+Add transaction intent type to broadcast logs for datadog dashboard

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationDevice.tsx
@@ -11,6 +11,7 @@ import { DeviceBlocker } from "~/renderer/components/DeviceAction/DeviceBlocker"
 import { useTransactionAction } from "~/renderer/hooks/useConnectAppAction";
 import { mevProtectionSelector } from "~/renderer/reducers/settings";
 import type { StepProps } from "../types";
+import { broadcastLogger } from "~/datadog/logs";
 
 const Result = (
   props:
@@ -46,7 +47,12 @@ export default function StepAssociationDevice(props: StepProps) {
   const mevProtected = useSelector(mevProtectionSelector);
   const action = useTransactionAction();
   const broadcastConfig = useMemo(() => ({ mevProtected }), [mevProtected]);
-  const broadcast = useBroadcast({ account, parentAccount, broadcastConfig });
+  const broadcast = useBroadcast({
+    account,
+    parentAccount,
+    broadcastConfig,
+    logger: broadcastLogger,
+  });
 
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || token;
 

--- a/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationDevice.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/hedera/ReceiveWithAssociationModal/steps/StepAssociationDevice.tsx
@@ -51,6 +51,7 @@ export default function StepAssociationDevice(props: StepProps) {
     account,
     parentAccount,
     broadcastConfig,
+    transaction,
     logger: broadcastLogger,
   });
 

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -6,6 +6,14 @@ import { act, renderHook } from "@testing-library/react";
 import { setEnv } from "@shared/env";
 import { getAccountBridge } from "../bridge/index";
 import { useBroadcast } from "./useBroadcast";
+import type {
+  Account,
+  AccountLike,
+  BroadcastConfig,
+  ResolvedAccountBridge,
+  SignedOperation,
+  TransactionCommon,
+} from "@ledgerhq/types-live";
 
 jest.mock("../bridge/index", () => ({
   getAccountBridge: jest.fn(),
@@ -15,13 +23,13 @@ jest.mock("../promise", () => ({
   execAndWaitAtLeast: <A>(_ms: number, cb: () => Promise<A>) => cb(),
 }));
 
-const defaultSignedOperation = { operation: { type: "OUT" } } as any;
+const defaultSignedOperation = { operation: { type: "OUT" } } as unknown as SignedOperation;
 
 describe("useBroadcast", () => {
   const mockBroadcast = jest.fn();
-  jest.mocked(getAccountBridge).mockReturnValue({
+  jest.mocked(getAccountBridge).mockResolvedValue({
     broadcast: mockBroadcast,
-  } as any);
+  } as unknown as ResolvedAccountBridge<any>);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -30,11 +38,18 @@ describe("useBroadcast", () => {
   it("does not broadcast when 'DISABLE_TRANSACTION_BROADCAST' is true", async () => {
     setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
-    const { result } = renderHook(() => useBroadcast({ account: {}, parentAccount: {} } as any));
+    const { result } = renderHook(() =>
+      useBroadcast({
+        account: {} as unknown as AccountLike,
+        parentAccount: {} as unknown as Account,
+      }),
+    );
 
     let value: unknown;
     await act(async () => {
-      value = await result.current({ operation: { id: "operation-id" } } as any);
+      value = await result.current({
+        operation: { id: "operation-id" },
+      } as unknown as SignedOperation);
     });
 
     expect(mockBroadcast).not.toHaveBeenCalled();
@@ -55,7 +70,7 @@ describe("useBroadcast", () => {
       "token-id",
     ],
   ])("%s", (_s, account, parentAccount, expectedTokenId) => {
-    const transaction = { useAllAmount: true } as any;
+    const transaction = { useAllAmount: true } as unknown as TransactionCommon;
 
     it("logs on success", async () => {
       const logger = jest.fn();
@@ -66,12 +81,14 @@ describe("useBroadcast", () => {
 
       const { result } = renderHook(() =>
         useBroadcast({
-          account,
-          parentAccount,
-          transaction,
-          broadcastConfig: { source: { type: "coin-module", name: "ledger-live-desktop" } },
+          account: account as unknown as AccountLike,
+          parentAccount: parentAccount as unknown as Account,
+          transaction: transaction as unknown as TransactionCommon,
+          broadcastConfig: {
+            source: { type: "coin-module", name: "ledger-live-desktop" },
+          } as unknown as BroadcastConfig,
           logger,
-        } as any),
+        }),
       );
 
       let value: unknown;
@@ -102,12 +119,14 @@ describe("useBroadcast", () => {
 
       const { result } = renderHook(() =>
         useBroadcast({
-          account,
-          parentAccount,
-          transaction,
-          broadcastConfig: { source: { type: "coin-module", name: "ledger-live-desktop" } },
+          account: account as unknown as AccountLike,
+          parentAccount: parentAccount as unknown as Account,
+          transaction: transaction as unknown as TransactionCommon,
+          broadcastConfig: {
+            source: { type: "coin-module", name: "ledger-live-desktop" },
+          } as unknown as BroadcastConfig,
           logger,
-        } as any),
+        }),
       );
 
       await act(async () => {
@@ -116,7 +135,7 @@ describe("useBroadcast", () => {
             signature: "signed-transaction",
             rawData: { raw_hex: "raw-hex" },
             operation: { type: "OUT" },
-          } as any),
+          } as unknown as SignedOperation),
         ).rejects.toThrow(new Error("Broadcast failed"));
       });
 
@@ -150,10 +169,10 @@ describe("useBroadcast", () => {
 
     const { result } = renderHook(() =>
       useBroadcast({
-        account,
-        parentAccount: account,
+        account: account as unknown as AccountLike,
+        parentAccount: account as unknown as Account,
         logger,
-      } as any),
+      }),
     );
 
     await act(async () => {
@@ -175,19 +194,19 @@ describe("useBroadcast", () => {
       id: "main-account-id",
       type: "Account",
       currency: { id: "ethereum_sepolia", family: "evm", isTestnetFor: "ethereum" },
-    };
+    } as unknown as AccountLike;
 
     const { result } = renderHook(() =>
       useBroadcast({
         account,
-        parentAccount: account,
+        parentAccount: account as unknown as Account,
         logger,
-        transaction: { mode: "send" },
-      } as any),
+        transaction: { mode: "send" } as unknown as TransactionCommon,
+      }),
     );
 
     await act(async () => {
-      await result.current({ operation: { type: "IN" } });
+      await result.current({ operation: { type: "IN" } } as unknown as SignedOperation);
     });
 
     expect(logger).toHaveBeenCalledWith(expect.objectContaining({ intentType: "send" }));
@@ -203,15 +222,15 @@ describe("useBroadcast", () => {
       id: "main-account-id",
       type: "Account",
       currency: { id: "ethereum_sepolia", family: "evm", isTestnetFor: "ethereum" },
-    };
+    } as unknown as AccountLike;
 
     const { result } = renderHook(() =>
       useBroadcast({
         account,
-        parentAccount: account,
+        parentAccount: account as unknown as Account,
         logger,
-        transaction: {},
-      } as any),
+        transaction: {} as unknown as TransactionCommon,
+      }),
     );
 
     await act(async () => {

--- a/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.test.ts
@@ -15,6 +15,8 @@ jest.mock("../promise", () => ({
   execAndWaitAtLeast: <A>(_ms: number, cb: () => Promise<A>) => cb(),
 }));
 
+const defaultSignedOperation = { operation: { type: "OUT" } } as any;
+
 describe("useBroadcast", () => {
   const mockBroadcast = jest.fn();
   jest.mocked(getAccountBridge).mockReturnValue({
@@ -74,7 +76,7 @@ describe("useBroadcast", () => {
 
       let value: unknown;
       await act(async () => {
-        value = await result.current({} as any);
+        value = await result.current(defaultSignedOperation);
       });
 
       expect(logger).toHaveBeenCalledWith({
@@ -86,6 +88,7 @@ describe("useBroadcast", () => {
         isTestnet: false,
         isSendMax: true,
         source: { type: "coin-module", name: "ledger-live-desktop" },
+        intentType: "OUT",
       });
       expect(value).toEqual({ id: "operation-id", date: new Date(2026, 3, 24) });
     });
@@ -112,6 +115,7 @@ describe("useBroadcast", () => {
           result.current({
             signature: "signed-transaction",
             rawData: { raw_hex: "raw-hex" },
+            operation: { type: "OUT" },
           } as any),
         ).rejects.toThrow(new Error("Broadcast failed"));
       });
@@ -127,6 +131,7 @@ describe("useBroadcast", () => {
         isSendMax: true,
         source: { type: "coin-module", name: "ledger-live-desktop" },
         txPayload: { signature: "signed-transaction", rawData: { raw_hex: "raw-hex" } },
+        intentType: "OUT",
       });
     });
   });
@@ -152,11 +157,67 @@ describe("useBroadcast", () => {
     );
 
     await act(async () => {
-      await result.current({} as any);
+      await result.current(defaultSignedOperation);
     });
 
     expect(logger).toHaveBeenCalledWith(
       expect.objectContaining({ currencyId: "ethereum_sepolia", isTestnet: true }),
     );
+  });
+
+  it("should log mode as intentType when available in transaction", async () => {
+    const logger = jest.fn();
+    mockBroadcast.mockResolvedValue({ id: "operation-id", date: new Date(2026, 3, 24) });
+    setEnv("LEDGER_CLIENT_VERSION", "llc/test");
+    setEnv("DISABLE_TRANSACTION_BROADCAST", false);
+
+    const account = {
+      id: "main-account-id",
+      type: "Account",
+      currency: { id: "ethereum_sepolia", family: "evm", isTestnetFor: "ethereum" },
+    };
+
+    const { result } = renderHook(() =>
+      useBroadcast({
+        account,
+        parentAccount: account,
+        logger,
+        transaction: { mode: "send" },
+      } as any),
+    );
+
+    await act(async () => {
+      await result.current({ operation: { type: "IN" } });
+    });
+
+    expect(logger).toHaveBeenCalledWith(expect.objectContaining({ intentType: "send" }));
+  });
+
+  it("should log type from operation as intentType when mode is not available in transaction", async () => {
+    const logger = jest.fn();
+    mockBroadcast.mockResolvedValue({ id: "operation-id", date: new Date(2026, 3, 24) });
+    setEnv("LEDGER_CLIENT_VERSION", "llc/test");
+    setEnv("DISABLE_TRANSACTION_BROADCAST", false);
+
+    const account = {
+      id: "main-account-id",
+      type: "Account",
+      currency: { id: "ethereum_sepolia", family: "evm", isTestnetFor: "ethereum" },
+    };
+
+    const { result } = renderHook(() =>
+      useBroadcast({
+        account,
+        parentAccount: account,
+        logger,
+        transaction: {},
+      } as any),
+    );
+
+    await act(async () => {
+      await result.current(defaultSignedOperation);
+    });
+
+    expect(logger).toHaveBeenCalledWith(expect.objectContaining({ intentType: "OUT" }));
   });
 });

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -22,6 +22,7 @@ type CommonLogEvent = {
   tokenId?: string;
   isTestnet: boolean;
   isSendMax: boolean;
+  intentType: string;
 };
 
 type ErrorLogEvent = {
@@ -72,6 +73,13 @@ export const useBroadcast = ({
         return Promise.resolve(signedOperation.operation);
       }
 
+      const transactionMode =
+        transaction &&
+        transaction !== null &&
+        "mode" in transaction &&
+        typeof transaction.mode === "string"
+          ? transaction.mode
+          : undefined;
       const commonLogEvent: CommonLogEvent = {
         appVersion: getEnv("LEDGER_CLIENT_VERSION"),
         source: broadcastConfig?.source,
@@ -80,6 +88,7 @@ export const useBroadcast = ({
         isTestnet: Boolean(mainAccount.currency.isTestnetFor),
         isSendMax: Boolean(transaction?.useAllAmount),
         ...(account.type === "TokenAccount" ? { tokenId: account.token.id } : {}),
+        intentType: transactionMode ?? signedOperation.operation.type,
       };
 
       return execAndWaitAtLeast(3000, async () => {

--- a/libs/ledger-live-common/src/hooks/useBroadcast.ts
+++ b/libs/ledger-live-common/src/hooks/useBroadcast.ts
@@ -22,7 +22,7 @@ type CommonLogEvent = {
   tokenId?: string;
   isTestnet: boolean;
   isSendMax: boolean;
-  intentType: string;
+  intentType?: string;
 };
 
 type ErrorLogEvent = {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add transaction intent type to broadcast logs for datadog dashboard

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-33126](https://ledgerhq.atlassian.net/browse/LIVE-33126?atlOrigin=eyJpIjoiYmFiNTRiNDc1NGZkNDhhM2IwZTNiM2U4MmVjOTljZmQiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-33126]: https://ledgerhq.atlassian.net/browse/LIVE-33126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ