### PR TITLE
[LWDM] feat(lwm): support bip21/eip681 amount in qr code scan new send flow

### DIFF
--- a/.changeset/pink-bikes-push.md
+++ b/.changeset/pink-bikes-push.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwm): support bip21/eip681 amount in qr code scan new send flow

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/BaseNavigator.ts
@@ -13,6 +13,7 @@ import { AppResult } from "@ledgerhq/live-common/hw/actions/app";
 import { Device } from "@ledgerhq/live-common/hw/actions/types";
 import type { PerpsSignResult } from "@ledgerhq/live-common/wallet-api/Perps/server";
 import type { SendFlowInitParams } from "@ledgerhq/live-common/flows/send/types";
+import type { DecodedURISchemePayment } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
 import type { AssetDetailNavigatorParamsList } from "LLM/features/AssetDetail/types";
 import type { AssetsNavigatorParamsList } from "LLM/features/Assets/types";
 import type { DeviceSelectionNavigatorParamsList } from "LLM/features/DeviceSelection/types";
@@ -194,6 +195,7 @@ export type BaseNavigatorStackParamList = {
     transaction?: Transaction;
     justScanned?: boolean;
     onScanned?: (address: string) => void;
+    onScannedURI?: (result: DecodedURISchemePayment) => void;
   };
   [ScreenName.BleDevicePairingFlow]: undefined;
   [ScreenName.AnalyticsOperations]: {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -172,15 +172,82 @@ describe("useSendHeaderViewModel", () => {
         accountId: mockAccount.id,
         parentId: undefined,
         transaction: undefined,
-        onScanned: expect.any(Function),
+        onScannedURI: expect.any(Function),
       }),
     );
 
-    const { onScanned } = mockNavigate.mock.calls[0][1] as {
-      onScanned: (address: string) => void;
+    const { onScannedURI } = mockNavigate.mock.calls[0][1] as {
+      onScannedURI: (result: { address: string }) => void;
     };
-    onScanned("0xscanned");
+    onScannedURI({ address: "0xscanned" });
 
     expect(mockSetRecipientSearchValue).toHaveBeenCalledWith("0xscanned");
+  });
+
+  it("prefills the transaction amount from a scanned EIP681 URI while staying on recipient", () => {
+    const amount = new BigNumber("1000000000000000000");
+    const mockUpdateTransaction = jest.fn();
+    const currentTransaction = {
+      family: "evm",
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+    };
+
+    mockedUseSendFlowData.mockReturnValue({
+      uiConfig: {
+        recipientSupportsDomain: true,
+      },
+      recipientSearch: mockRecipientSearch,
+      state: {
+        account: {
+          account: mockAccount,
+          parentAccount: null,
+          currency: mockAccount.currency,
+        },
+        transaction: {
+          transaction: currentTransaction,
+          status: {},
+          bridgeError: null,
+          bridgePending: false,
+        },
+        recipient: null,
+        operation: {
+          optimisticOperation: null,
+          transactionError: null,
+          signed: false,
+        },
+        isLoading: false,
+        flowStatus: "idle",
+      },
+    } as never);
+    mockedUseSendFlowActions.mockReturnValue({
+      close: jest.fn(),
+      transaction: {
+        updateTransaction: mockUpdateTransaction,
+      },
+      setRecipientSearchValue: mockSetRecipientSearchValue,
+      clearRecipientSearch: mockClearRecipientSearch,
+    } as never);
+
+    const { result } = renderHook(() => useSendHeaderViewModel());
+
+    result.current.handleQrCodeClick();
+
+    const { onScannedURI } = mockNavigate.mock.calls[0][1] as {
+      onScannedURI: (result: { address: string; amount?: BigNumber }) => void;
+    };
+    onScannedURI({ address: "0xscanned", amount });
+
+    expect(mockSetRecipientSearchValue).toHaveBeenCalledWith("0xscanned");
+    expect(mockUpdateTransaction).toHaveBeenCalledTimes(1);
+    const updater = mockUpdateTransaction.mock.calls[0][0];
+    expect(updater(currentTransaction)).toEqual(
+      expect.objectContaining({
+        amount,
+        useAllAmount: false,
+      }),
+    );
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -8,6 +8,10 @@ import type { BaseNavigationComposite } from "~/components/RootNavigator/types/h
 
 import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
 import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext";
+import {
+  buildTransactionPatchFromURIScheme,
+  type DecodedURISchemePayment,
+} from "@ledgerhq/live-common/flows/send/utils/uriScheme";
 import { useSendFlowData, useSendFlowActions } from "../context/SendFlowContext";
 import { useAvailableBalance } from "./useAvailableBalance";
 import { useCurrentSendFlowStep } from "./useCurrentSendFlowStep";
@@ -128,21 +132,35 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
     navigation.goBack();
   }, [isAmountStep, navigation, recipientFromTransaction, setRecipientSearchValue]);
 
+  const handleScannedURI = useCallback(
+    (decoded: DecodedURISchemePayment) => {
+      setRecipientSearchValue(decoded.address);
+
+      const currentTransaction = state.transaction.transaction;
+      if (currentTransaction) {
+        const patch = buildTransactionPatchFromURIScheme(currentTransaction, decoded);
+        if (Object.keys(patch).length > 0) {
+          transaction.updateTransaction(tx => ({ ...tx, ...patch }) as typeof tx);
+        }
+      }
+    },
+    [setRecipientSearchValue, state.transaction.transaction, transaction],
+  );
+
   const handleQrCodeClick = useCallback(() => {
-    const account = state.account.account;
-    if (!account) return;
+    if (!state.account.account) return;
 
     clearRecipientSearch();
     navigation.navigate(ScreenName.ScanRecipient, {
-      accountId: account.id,
+      accountId: state.account.account.id,
       parentId: state.account.parentAccount?.id,
       transaction: state.transaction.transaction ?? undefined,
-      onScanned: setRecipientSearchValue,
+      onScannedURI: handleScannedURI,
     });
   }, [
     clearRecipientSearch,
+    handleScannedURI,
     navigation,
-    setRecipientSearchValue,
     state.account.account,
     state.account.parentAccount?.id,
     state.transaction.transaction,

--- a/apps/ledger-live-mobile/src/screens/SendFunds/ScanRecipient.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/ScanRecipient.tsx
@@ -15,12 +15,20 @@ const ScanRecipient = ({ route, navigation }: NavigationProps) => {
   const { account, parentAccount } = useAccountScreen(route);
   const bridge = useAccountBridgeOrNull<Transaction>(account ?? null, parentAccount);
   const onScanned = route.params?.onScanned;
+  const onScannedURI = route.params?.onScannedURI;
 
   const onResult = useCallback(
     (result: string) => {
-      const { amount, address, currency: _currency, ...rest } = decodeURIScheme(result);
+      const decoded = decodeURIScheme(result);
+      const { amount, address, currency: _currency, ...rest } = decoded;
 
-      // New Send flow: hand the address back to the caller and dismiss the scanner.
+      // full decoded URI (address + optional amount)
+      if (onScannedURI) {
+        onScannedURI(decoded);
+        navigation.goBack();
+        return;
+      }
+
       if (onScanned) {
         onScanned(address);
         navigation.goBack();
@@ -56,7 +64,7 @@ const ScanRecipient = ({ route, navigation }: NavigationProps) => {
         },
       });
     },
-    [account, bridge, navigation, onScanned, parentAccount, route.params],
+    [account, bridge, navigation, onScanned, onScannedURI, parentAccount, route.params],
   );
 
   useEffect(() => {

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -674,6 +674,7 @@
     "src/flows/send/utils/gas.ts",
     "src/flows/send/utils/memoFamilyCurrencyId.ts",
     "src/flows/send/utils/networkFeesDisplay.ts",
+    "src/flows/send/utils/uriScheme.ts",
     "src/flows/send/utils.ts",
     "src/flows/wizard/types.ts",
     "src/genericAwarenessModal/build/buildCarousel.ts",

--- a/libs/ledger-live-common/src/flows/send/utils/__tests__/uriScheme.test.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/__tests__/uriScheme.test.ts
@@ -1,0 +1,163 @@
+import { BigNumber } from "bignumber.js";
+import type { Transaction } from "../../../../coin-modules/transaction-types";
+import { buildTransactionPatchFromURIScheme } from "../uriScheme";
+
+describe("buildTransactionPatchFromURIScheme", () => {
+  const baseTransaction: Transaction = {
+    family: "bitcoin",
+    amount: new BigNumber(0),
+    recipient: "",
+    useAllAmount: false,
+    utxoStrategy: {
+      strategy: 0,
+      excludeUTXOs: [],
+    },
+    rbf: false,
+    feePerByte: null,
+    networkInfo: null,
+  };
+
+  it("returns an empty patch when the URI has no amount or matching extras", () => {
+    expect(
+      buildTransactionPatchFromURIScheme(baseTransaction, {
+        address: "bc1qxy",
+      }),
+    ).toEqual({});
+  });
+
+  it("prefills amount and disables useAllAmount when amount is positive", () => {
+    const amount = new BigNumber("123450000");
+
+    expect(
+      buildTransactionPatchFromURIScheme(baseTransaction, {
+        address: "bc1qxy",
+        amount,
+      }),
+    ).toEqual({
+      amount,
+      useAllAmount: false,
+    });
+  });
+
+  it("ignores zero or missing amounts", () => {
+    expect(
+      buildTransactionPatchFromURIScheme(baseTransaction, {
+        address: "bc1qxy",
+        amount: new BigNumber(0),
+      }),
+    ).toEqual({});
+  });
+
+  it("applies coin-specific fields that already exist on the transaction", () => {
+    const ethTransaction: Transaction = {
+      family: "evm",
+      mode: "send",
+      nonce: 0,
+      gasLimit: new BigNumber(21000),
+      chainId: 1,
+      type: 0,
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+      gasPrice: new BigNumber(1),
+    };
+    const amount = new BigNumber("1000000000000000000");
+    const userGasLimit = new BigNumber(50000);
+    const gasPrice = new BigNumber(20);
+
+    expect(
+      buildTransactionPatchFromURIScheme(ethTransaction, {
+        address: "0xabc",
+        amount,
+        userGasLimit,
+        gasPrice,
+        family: "bitcoin",
+        recipient: "attacker-controlled-recipient",
+        useAllAmount: true,
+        mode: "delegate",
+        unknownField: "ignored",
+      }),
+    ).toEqual({
+      amount,
+      useAllAmount: false,
+      customGasLimit: userGasLimit,
+      gasPrice,
+    });
+  });
+
+  it("does not apply coin-specific fields absent from the transaction", () => {
+    const amount = new BigNumber("1000");
+
+    expect(
+      buildTransactionPatchFromURIScheme(baseTransaction, {
+        address: "bc1qxy",
+        amount,
+        userGasLimit: new BigNumber(50000),
+      }),
+    ).toEqual({
+      amount,
+      useAllAmount: false,
+    });
+  });
+
+  it("does not apply EVM fields to another transaction family with similar fields", () => {
+    const transactionWithGasLimit = Object.assign({}, baseTransaction, {
+      gasLimit: new BigNumber(21000),
+    });
+
+    expect(
+      buildTransactionPatchFromURIScheme(transactionWithGasLimit, {
+        address: "bc1qxy",
+        userGasLimit: new BigNumber(50000),
+      }),
+    ).toEqual({});
+  });
+
+  it("does not apply gasPrice to an EIP-1559 transaction", () => {
+    const eip1559Transaction: Transaction = {
+      family: "evm",
+      mode: "send",
+      nonce: 0,
+      gasLimit: new BigNumber(21000),
+      chainId: 1,
+      type: 2,
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+      gasPrice: undefined,
+      maxFeePerGas: new BigNumber(10),
+      maxPriorityFeePerGas: new BigNumber(1),
+    };
+
+    expect(
+      buildTransactionPatchFromURIScheme(eip1559Transaction, {
+        address: "0xabc",
+        gasPrice: new BigNumber(20),
+      }),
+    ).toEqual({});
+  });
+
+  it("ignores invalid values for allowlisted fields", () => {
+    const ethTransaction: Transaction = {
+      family: "evm",
+      mode: "send",
+      nonce: 0,
+      gasLimit: new BigNumber(21000),
+      chainId: 1,
+      type: 0,
+      amount: new BigNumber(0),
+      recipient: "",
+      useAllAmount: false,
+      gasPrice: new BigNumber(1),
+    };
+
+    expect(
+      buildTransactionPatchFromURIScheme(ethTransaction, {
+        address: "0xabc",
+        amount: new BigNumber(Infinity),
+        userGasLimit: "50000",
+        gasPrice: new BigNumber(Infinity),
+      }),
+    ).toEqual({});
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/utils/uriScheme.ts
+++ b/libs/ledger-live-common/src/flows/send/utils/uriScheme.ts
@@ -1,0 +1,80 @@
+import { BigNumber } from "bignumber.js";
+import type { Transaction } from "../../../coin-modules/transaction-types";
+
+/**
+ * Payment fields decoded from a URI scheme (BIP-0021 / EIP-681 style via `decodeURIScheme`).
+ * Callers apply the address to the recipient search field separately so the user can confirm it
+ * before leaving the recipient step
+ */
+export type DecodedURISchemePayment = {
+  address: string;
+  currency?: unknown;
+  amount?: BigNumber;
+  [key: string]: unknown;
+};
+
+type AllowedDecodedBigNumberField = "userGasLimit" | "gasPrice";
+type AllowedTransactionBigNumberField = "customGasLimit" | "gasPrice";
+
+const ALLOWED_TRANSACTION_BIG_NUMBER_FIELDS = new Map<
+  AllowedDecodedBigNumberField,
+  {
+    transactionField: AllowedTransactionBigNumberField;
+    isSupported: (transaction: Transaction) => boolean;
+  }
+>([
+  [
+    "userGasLimit",
+    {
+      transactionField: "customGasLimit",
+      isSupported: transaction =>
+        transaction.family === "evm" && BigNumber.isBigNumber(transaction.gasLimit),
+    },
+  ],
+  [
+    "gasPrice",
+    {
+      transactionField: "gasPrice",
+      isSupported: transaction =>
+        transaction.family === "evm" &&
+        transaction.type !== 2 &&
+        "gasPrice" in transaction &&
+        BigNumber.isBigNumber(transaction.gasPrice),
+    },
+  ],
+]);
+
+/**
+ * Builds a transaction patch from a decoded payment URI.
+ * Applies `amount` (and clears `useAllAmount`) plus supported coin-specific fields.
+ */
+export function buildTransactionPatchFromURIScheme(
+  transaction: Transaction,
+  decoded: DecodedURISchemePayment,
+): Partial<Transaction> {
+  const { amount } = decoded;
+  const patch: Partial<Transaction> & Partial<Record<AllowedTransactionBigNumberField, BigNumber>> =
+    {};
+
+  if (amount && BigNumber.isBigNumber(amount) && amount.isFinite() && amount.gt(0)) {
+    patch.amount = amount;
+    patch.useAllAmount = false;
+  }
+
+  for (const [
+    decodedField,
+    { transactionField, isSupported },
+  ] of ALLOWED_TRANSACTION_BIG_NUMBER_FIELDS) {
+    const value = decoded[decodedField];
+    if (
+      BigNumber.isBigNumber(value) &&
+      value.isFinite() &&
+      value.gte(0) &&
+      isSupported(transaction)
+    ) {
+      patch[transactionField] = value;
+    }
+  }
+
+  return patch;
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

In the new send flow (lwm), scanning a payment QR (BIP-0021 for BTC / EIP-681 for EVM) now prefills the amount when the URI includes one, not just the recipient address. The user stays on the recipient step to confirm the address; the amount step opens with the value already filled.

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35456)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
