### PR TITLE
chore(gitleaks): allowlist shared test fixtures instead of line-pinned ignores

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,6 +19,23 @@ keywords = ["seed", "mnemonic", "pass", "recovery", "phrase"]
 id = "generic-api-key"
 
     [[rules.allowlists]]
+    description = "Ignore the throwaway LKRP member keypair shared by unit/integration tests (mocked endpoints only)."
+    regexes = [
+        '''873f500bd20783224f7e78d4f8cce3d2bf69eb8008fbd697d20bbea31a721a03''',
+    ]
+
+    [[rules.allowlists]]
+    condition = "AND"
+    description = "Ignore public base58 blockchain addresses declared as test constants."
+    regexTarget = "line"
+    regexes = [
+        '''(?i)(?:const|let|var)\s+\w*(?:ACCOUNT|ADDRESS|OWNER|MINT|PUBKEY)\w*\s*(?::[^=]+)?=\s*["'][1-9A-HJ-NP-Za-km-z]{32,44}["']''',
+    ]
+    paths = [
+        '''libs/coin-modules/.+\.(?:unit\.)?test\.ts''',
+    ]
+
+    [[rules.allowlists]]
     condition = "AND"
     description = "Ignore public blockchain contract/token addresses by network prefix in tokenId."
     regexTarget = "match"

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,0 @@
-# Test private keys used in ledger-key-ring-protocol unit/integration tests — not real secrets.
-libs/ledger-key-ring-protocol/src/__tests__/unit/utils.test.ts:generic-api-key:11
-libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts:generic-api-key:28


### PR DESCRIPTION
### 📝 Description

`generic-api-key` flags two non-secrets: the throwaway LKRP member keypair reused by 7 test files (endpoints are `*.test` TLDs, fully MSW-mocked) and a public Solana token-account address. Adding `path:rule:line` fingerprints to `.gitleaksignore` does not hold — they rot on any edit above the line and have to be re-minted per branch, which is what conflicted while merging `develop` into `support/release-merge-conflicts`. The existing `LKRPIdentityProvider.integration.test.ts:generic-api-key:28` entry is already dead: the finding sits at line 32 today.

This replaces both entries with value- and shape-based allowlists under `generic-api-key`, so they hold regardless of line number or branch, and deletes the now-redundant `.gitleaksignore`.

Verified with the pinned `gitleaks 8.30.1` over a `git archive HEAD` snapshot of all tracked files, before vs after:

- 7 findings suppressed — exactly the LKRP keypair occurrences (including `unit/sdk.test.ts:250`, which was missing from the reported list) and the Solana address
- 0 findings newly appearing, 230 pre-existing ones untouched
- Same result with `.gitleaksignore` deleted, confirming it is redundant

The base58 allowlist is scoped by path AND a `const NAME = "…"` shape AND the base58 charset capped at 44 chars, so it cannot swallow a 64-char hex key.

### 🔗 Context

- **JIRA / GitHub issue**: n/a
- **ADR** (if any): n/a
