### PR TITLE
fix(e2e): derive expected base account count from scan

### DIFF
--- a/e2e/mobile/page/accounts/addAccount.drawer.ts
+++ b/e2e/mobile/page/accounts/addAccount.drawer.ts
@@ -45,6 +45,16 @@ export default class AddAccountDrawer extends CommonPage {
     );
   }
 
+  @Step("Get number of accounts displayed by the blockchain scan")
+  async getNumberOfScannedAccounts(): Promise<number> {
+    await this.waitAccountsDiscovery();
+    const scannedAccounts = await countElements(getElementsById(this.accountItemRegExp()));
+    if (scannedAccounts === 0) {
+      throw new Error("No account found on the blockchain scan screen");
+    }
+    return scannedAccounts;
+  }
+
   @Step("Finish account discovery")
   async finishAccountsDiscovery() {
     await retryUntilTimeout(async () => {

--- a/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
+++ b/e2e/mobile/specs/verifyAddress/receiveFlow.spec.ts
@@ -61,6 +61,7 @@ describe("Receive", () => {
     await app.modularDrawer.selectCurrencyByTicker(Account.ETH_1.currency.ticker);
     await app.modularDrawer.selectNetwork(Currency.BASE.name);
     await app.modularDrawer.tapAddNewOrExistingAccountButtonMAD();
+    const scannedAccounts = await app.addAccount.getNumberOfScannedAccounts();
 
     await app.receive.continueCreateAccount();
     await app.receive.doNotVerifyAddress();
@@ -75,7 +76,7 @@ describe("Receive", () => {
 
     await app.modularDrawer.selectCurrencyByTicker(Account.ETH_1.currency.ticker);
     await app.modularDrawer.selectNetwork(Currency.BASE.name);
-    await app.modularDrawer.validateNumberOfAccounts(3);
+    await app.modularDrawer.validateNumberOfAccounts(scannedAccounts - 1);
   });
 
   $TmsLink("B2CQA-650");


### PR DESCRIPTION
## Context

`Receive > Should create an account on a network` failed in the iOS nightly of 2026-08-04 with:

```
expect(received).toBe(expected)
Expected: 3
Received: 4
    at ModularDrawer.validateNumberOfAccounts (e2e/mobile/page/drawer/modular.drawer.ts:57)
```

[Allure report](https://allure-new.aws.sbx.ldg-tech.com/api/v1/reports/f8a48613-44a0-4f3e-9ec9-b2585393aaa7/view/allure2/index.html) · [workflow run](https://github.com/LedgerHQ/ledger-live/actions/runs/30865604485)

It had passed 13 consecutive nightlies before this one, and failed all 3 retries — not flaky, deterministic.

## Root cause

On-chain state drift, not a product regression. The `scanAccounts` log from the run:

| index | derivation | address | txs | used |
|---|---|---|---|---|
| 0 | `44'/60'/0'/0/0` | `0xE32ad14b…b75a` | 493 | ✅ |
| 1 | `44'/60'/1'/0/0` | `0xc79c7a29…0307` | 422 | ✅ |
| 2 | `44'/60'/2'/0/0` | `0xD3b4d15c…3A15` | 8 | ✅ |
| 3 | `44'/60'/3'/0/0` | `0xc3ffAe59…097B` | **1** | ✅ |
| 4 | `44'/60'/4'/0/0` | `0x28FC268b…994a` | 0 | ❌ → stop |

The add-accounts screen splits the scan into `importable` (used accounts, `defaultSelected: true`) and `creatable` (the one new account, `defaultSelected: false`) — see `groupAddAccounts` in `libs/live-wallet/src/addAccounts.ts`. The spec confirms without touching the selection, so only the used accounts are imported, which matches the run's `saved 4 accounts`.

The hardcoded `3` was therefore just the number of *used* Base accounts at the time the assertion was written. Derivation index 3 received its first transaction between the 08-03 and 08-04 nightlies (balance $0.00, 1 tx — the usual dust/token spam to a publicly known test address), moving it from `creatable` to `importable` and taking the count to 4.

Since the seed's Base addresses are public, any absolute count asserted against live discovery will keep drifting. Bumping `3` → `4` would go green tonight and break again when index 4 gets its first transfer.

## Change

Read the expected number from the scan screen instead of hardcoding it:

- `addAccount.drawer.ts`: new `getNumberOfScannedAccounts()` returning every account row on the scan screen (gated on `waitAccountsDiscovery()`, so the count is read after the scan settles — while scanning, the footer renders "Stop scanning" and `add-accounts-continue-button` does not exist yet).
- `receiveFlow.spec.ts`: assert the drawer shows `scannedAccounts - 1`, the `- 1` being the new account left unselected.

The test flow is unchanged — no extra taps, the "New account" row is still left alone.

This is also stricter than the literal was: it fails if the drawer drops or duplicates an imported account, and it fails if the unselected new account ever gets imported (the drawer would show `scannedAccounts`).

The `- 1` assumes the scan yields exactly one new account, which holds for a single derivation scheme. Extra scheme rows only appear when `newAccountSchemes.length > 1`, not the case for EVM/Base.

## Not covered here

`B2CQA-1861` reads as "create an account", but because `creatable` is unselected by default the flow only ever imports pre-existing used accounts — it never adds the new one. Covering that properly means selecting the "New account" row before confirming, and identifying it needs a handle on the section (the `View` wrapping `ScannedAccountsSection` has no `testID`). Left out of this PR to keep it to the nightly fix; happy to follow up if Wallet XP wants that coverage.

## Testing

Assertion logic reviewed against the failing run's artifacts. Not yet executed on a device — the scan-screen row count via `accountItemRegExp()` should be confirmed by a local run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
