### PR TITLE
docs(architecture): mark currency and api-services packages as STABLE

### DIFF
--- a/domain/entity/currency-crypto/README.md
+++ b/domain/entity/currency-crypto/README.md
@@ -1,7 +1,7 @@
 # @domain/entity-currency-crypto
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Zod-first canonical schema and static registry for the `CryptoCurrency` domain entity.
 

--- a/domain/entity/currency-fiat/README.md
+++ b/domain/entity/currency-fiat/README.md
@@ -1,7 +1,7 @@
 # @domain/entity-currency-fiat
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Zod-first canonical schema and static registry for the `FiatCurrency` domain entity.
 

--- a/shared/api-services/README.md
+++ b/shared/api-services/README.md
@@ -1,7 +1,7 @@
 # @shared/api-services
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 One **endpoint-less** RTK Query api per backend service. Each service owns everything about *reaching*
 one backend — base URL, base query, retry policy, reducer path and the thunk `extraArgument` contract —


### PR DESCRIPTION
## Context

Three packages were still flagged `UNSTABLE` in their READMEs while their public APIs have in fact settled and are used in production by both apps. This aligns their lifecycle markers with reality — and with their already-`STABLE` siblings.

## What changed

README status markers flipped from `UNSTABLE` (`> [!CAUTION]`) to `STABLE` (`> [!NOTE]`), per the convention in [`docs/new-library.md`](../blob/develop/docs/new-library.md#readme-status-marker):

| Package | Before | After |
| --- | --- | --- |
| `@domain/entity-currency-crypto` | UNSTABLE | **STABLE** |
| `@domain/entity-currency-fiat` | UNSTABLE | **STABLE** |
| `@shared/api-services` | UNSTABLE | **STABLE** |

The rest of the `@domain/entity-currency-*` family (`@domain/entity-currency`, `-currency-token`, `-currency-unit`) was already `STABLE`, so the whole family is now consistent.

## Notes

- Documentation-only: 6 lines across 3 README files, no source or config touched.
- No changeset — all three packages are `private: true`, and the precedent commit that introduced these markers repo-wide (`a48cb2fa28`, 130 READMEs) shipped without one.
