### PR TITLE
refactor(account-name): move state and schema to schema.ts (LIVE-35356)

### DIFF
--- a/domain/entity/account-name/src/cloudSyncModule.ts
+++ b/domain/entity/account-name/src/cloudSyncModule.ts
@@ -1,9 +1,11 @@
-import { z } from "zod";
 import type { CloudSyncDataManager } from "@shared/cloud-sync-module";
+import {
+  AccountNamesDistantSchema,
+  type AccountNamesDistantState,
+  type AccountNamesState,
+} from "./schema";
 
-const schema = z.record(z.string(), z.string());
-
-function sameDistantState(a: Record<string, string>, b: Record<string, string>) {
+function sameDistantState(a: AccountNamesDistantState, b: AccountNamesDistantState) {
   const aEntries = Object.entries(a);
   if (aEntries.length !== Object.keys(b).length) return false;
   for (const [k, v] of aEntries) {
@@ -13,22 +15,22 @@ function sameDistantState(a: Record<string, string>, b: Record<string, string>) 
 }
 
 export const accountNamesSyncModule: CloudSyncDataManager<
-  Map<string, string>,
-  { replaceAllNames: Record<string, string> },
-  typeof schema
+  AccountNamesState,
+  { replaceAllNames: AccountNamesDistantState },
+  typeof AccountNamesDistantSchema
 > = {
-  schema,
+  schema: AccountNamesDistantSchema,
 
-  diffLocalToDistant(localData: Map<string, string>, latestState: Record<string, string> | null) {
+  diffLocalToDistant(localData: AccountNamesState, latestState: AccountNamesDistantState | null) {
     const nextState = Object.fromEntries(localData.entries());
     const hasChanges = !sameDistantState(latestState ?? {}, nextState);
     return { hasChanges, nextState };
   },
 
   async resolveIncrementalUpdate(
-    localData: Map<string, string>,
-    latestState: Record<string, string> | null,
-    incomingState: Record<string, string> | null,
+    localData: AccountNamesState,
+    latestState: AccountNamesDistantState | null,
+    incomingState: AccountNamesDistantState | null,
   ) {
     if (!incomingState) return { hasChanges: false as const };
     const hasChanges =
@@ -39,8 +41,8 @@ export const accountNamesSyncModule: CloudSyncDataManager<
   },
 
   applyUpdate(
-    _localData: Map<string, string>,
-    update: { replaceAllNames: Record<string, string> },
+    _localData: AccountNamesState,
+    update: { replaceAllNames: AccountNamesDistantState },
   ) {
     return new Map(Object.entries(update.replaceAllNames));
   },

--- a/domain/entity/account-name/src/index.ts
+++ b/domain/entity/account-name/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./accountName";
+export * from "./schema";
 export * from "./selectors";
 export * from "./slice";
 export { bulkSetAccountNames as setAccountNames } from "./slice";

--- a/domain/entity/account-name/src/schema.ts
+++ b/domain/entity/account-name/src/schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const AccountNamesDistantSchema = z.record(z.string(), z.string());
+export type AccountNamesDistantState = z.infer<typeof AccountNamesDistantSchema>;
+
+// Local state keeps a Map, so it is not Zod-inferable: the distant schema is its JSON projection.
+export type AccountNamesState = Map<string, string>;
+
+export const initialAccountNamesState: AccountNamesState = new Map();

--- a/domain/entity/account-name/src/selectors.ts
+++ b/domain/entity/account-name/src/selectors.ts
@@ -1,7 +1,5 @@
-import { type AccountNamesState } from "./slice";
+import { type AccountNamesState } from "./schema";
 import { getDefaultAccountName, type AccountForName } from "./accountName";
-
-export const initialAccountNamesState: AccountNamesState = new Map();
 
 export const accountNameSelector = (
   state: AccountNamesState,

--- a/domain/entity/account-name/src/slice.ts
+++ b/domain/entity/account-name/src/slice.ts
@@ -1,15 +1,14 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { enableMapSet } from "immer";
 import { getDefaultAccountName, type AccountForName } from "./accountName";
+import { initialAccountNamesState, type AccountNamesState } from "./schema";
 
 // RTK freezes state through Immer; this slice keeps its names in a Map.
 enableMapSet();
 
-export type AccountNamesState = Map<string, string>;
-
 export const accountNamesSlice = createSlice({
   name: "accountNames",
-  initialState: new Map<string, string>() as AccountNamesState,
+  initialState: initialAccountNamesState,
   reducers: {
     setAccountName: (
       state,


### PR DESCRIPTION

### 📝 Description

`@domain/entity-account-name` was the only entity package without a `schema.ts`. This adds one so it owns the CloudSync distant Zod schema, the local state type and the initial state, matching sibling entities and the `ddd-types-state-mocks` guideline. Public exports are unchanged, so no consumer edits were needed.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35356](https://ledgerhq.atlassian.net/browse/LIVE-35356)
- **ADR** (if any): n/a

[LIVE-35356]: https://ledgerhq.atlassian.net/browse/LIVE-35356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ