### PR TITLE
refactor(wallet-sync): derive entity types from zod schemas (LIVE-35355)

### DIFF
--- a/domain/entity/wallet-sync/package.json
+++ b/domain/entity/wallet-sync/package.json
@@ -18,7 +18,8 @@
     "unimported": "pnpm knip --directory ../../.. -W domain/entity/wallet-sync"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "catalog:"
+    "@reduxjs/toolkit": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@swc/core": "catalog:",

--- a/domain/entity/wallet-sync/src/schema.test.ts
+++ b/domain/entity/wallet-sync/src/schema.test.ts
@@ -1,0 +1,32 @@
+import { initialWalletSyncState, WalletSyncStateSchema, WSStateSchema } from "./schema";
+
+describe("WSStateSchema", () => {
+  it.each([
+    { data: null, version: 0 },
+    { data: {}, version: 1 },
+    { data: { accounts: [], settings: { foo: "bar" } }, version: 42 },
+  ])("accepts %p", state => {
+    expect(WSStateSchema.parse(state)).toEqual(state);
+  });
+
+  it.each([
+    { field: "data", value: [] },
+    { field: "data", value: "payload" },
+    { field: "data", value: undefined },
+    { field: "version", value: null },
+    { field: "version", value: "1" },
+    { field: "version", value: undefined },
+  ])("rejects $field of $value", ({ field, value }) => {
+    expect(() => WSStateSchema.parse({ data: null, version: 0, [field]: value })).toThrow();
+  });
+});
+
+describe("WalletSyncStateSchema", () => {
+  it("accepts the initial state", () => {
+    expect(WalletSyncStateSchema.parse(initialWalletSyncState)).toEqual(initialWalletSyncState);
+  });
+
+  it("rejects a state missing walletSyncState", () => {
+    expect(() => WalletSyncStateSchema.parse({})).toThrow();
+  });
+});

--- a/domain/entity/wallet-sync/src/schema.ts
+++ b/domain/entity/wallet-sync/src/schema.ts
@@ -1,11 +1,18 @@
-export type WSState = { data: Record<string, unknown> | null; version: number };
+import { z } from "zod";
 
-export type WalletSyncState = {
-  walletSyncState: WSState;
-};
+export const WSStateSchema = z.object({
+  data: z.record(z.string(), z.unknown()).nullable(),
+  version: z.number(),
+});
+
+export type WSState = z.infer<typeof WSStateSchema>;
+
+export const WalletSyncStateSchema = z.object({
+  walletSyncState: WSStateSchema,
+});
+
+export type WalletSyncState = z.infer<typeof WalletSyncStateSchema>;
 
 export const initialWalletSyncState: WalletSyncState = {
   walletSyncState: { data: null, version: 0 },
 };
-
-export type ExportedWalletSyncState = WalletSyncState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4400,6 +4400,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@swc/core':
         specifier: 'catalog:'


### PR DESCRIPTION

### 📝 Description

`@domain/entity-wallet-sync/src/schema.ts` held hardcoded TypeScript types instead of Zod schemas, diverging from every other entity package. It now defines `WSStateSchema` / `WalletSyncStateSchema` and infers the types with `z.infer<>`, plus the `schema.test.ts` the entity README requires.

The inferred types are structurally identical to the previous hand-written ones (verified with a bidirectional-assignability probe), so all consumers — Desktop, Mobile and web-tools — typecheck unchanged.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35355](https://ledgerhq.atlassian.net/browse/LIVE-35355)
- **ADR** (if any):


[LIVE-35355]: https://ledgerhq.atlassian.net/browse/LIVE-35355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ