### PR TITLE
feat(transport): add exponential-backoff reconnection

### DIFF
--- a/.changeset/hollow-parrot-dance.md
+++ b/.changeset/hollow-parrot-dance.md
@@ -1,0 +1,5 @@
+---
+"@devtools/transport": minor
+---
+
+Add exponential-backoff reconnection to WebSocket transport

--- a/devtools/transport/src/createTransport.test.ts
+++ b/devtools/transport/src/createTransport.test.ts
@@ -31,6 +31,7 @@ function makeTransport(
     url: "ws://localhost",
     origin: "test-origin",
     socketFactory: factory,
+    reconnection: { enabled: false },
     ...overrides,
   };
   const proto: TransportProtocol<TestMap> = {
@@ -244,6 +245,63 @@ describe("createTransport — setUrl()", () => {
     const { transport } = makeTransport();
     transport.setUrl("ws://newhost");
     expect(transport.getState().url).toBe("ws://newhost");
+  });
+});
+
+describe("createTransport — reconnection", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("should attempt reconnect after socket error once the delay elapses", () => {
+    const { transport, mock, factory } = makeTransport({
+      reconnection: { delay: 1000, factor: 1 },
+    });
+    transport.connect();
+    mock.error();
+    expect(transport.getState().status).toBe("error");
+    jest.advanceTimersByTime(1001); // past delay * 1^1 = 1000
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(transport.getState().status).toBe("connecting");
+  });
+
+  it("should attempt reconnect when the socket factory throws", () => {
+    let calls = 0;
+    const { socket } = makeMockSocket();
+    const factory = jest.fn(() => {
+      if (calls++ === 0) throw new Error("refused");
+      return socket;
+    });
+    const { transport } = makeTransport({
+      socketFactory: factory,
+      reconnection: { delay: 1000, factor: 1 },
+    });
+    transport.connect();
+    expect(transport.getState().status).toBe("error");
+    jest.advanceTimersByTime(1001);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not reconnect when reconnection is disabled", () => {
+    const { transport, mock, factory } = makeTransport({
+      reconnection: { enabled: false },
+    });
+    transport.connect();
+    mock.error();
+    jest.runAllTimers();
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop reconnecting once the connection opens", () => {
+    const { transport, mock, factory } = makeTransport({
+      reconnection: { delay: 1000, factor: 1 },
+    });
+    transport.connect();
+    mock.open();
+    jest.runAllTimers();
+    expect(factory).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/devtools/transport/src/createTransport.ts
+++ b/devtools/transport/src/createTransport.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 
 import { createSocketFactory } from "./socketFactory";
+import { createTimer } from "./timer";
 
 const isEnvelope = <M extends MessageMap>(value: unknown): value is Envelope<M> =>
   typeof value === "object" && value !== null && "kind" in value && "payload" in value;
@@ -20,6 +21,19 @@ export function createTransport<M extends MessageMap>(
 ): Transport<M> {
   const factory = config.socketFactory ?? createSocketFactory();
   const historyLimit = config.historyLimit ?? 500;
+
+  const timerConfig = {
+    enabled: config.reconnection?.enabled ?? true,
+    delay: config.reconnection?.delay ?? 1000,
+    maxDelay: config.reconnection?.maxDelay ?? 30000,
+    factor: config.reconnection?.factor ?? 1.5,
+    maxAttempts: config.reconnection?.maxAttempts ?? 20,
+    ...config.reconnection,
+  };
+
+  const timer = createTimer(timerConfig, () => {
+    transport.connect();
+  });
 
   // --- private state: the transport owns all of this ---
   let socket: WebSocketLike | null = null;
@@ -63,11 +77,13 @@ export function createTransport<M extends MessageMap>(
       if (socket) return;
       lastError = undefined;
       setStatus("connecting");
+      timer.start();
       try {
         const s = factory(url, config.wsSubProtocols);
         socket = s;
         s.onopen = () => {
           if (socket !== s) return;
+          timer.stop();
           setStatus("open");
           protocol.onOpen?.(transport);
         };
@@ -99,18 +115,21 @@ export function createTransport<M extends MessageMap>(
           setStatus("error");
           protocol.onError?.(lastError);
           protocol.onClose?.();
+          timer.start();
         };
         s.onclose = () => {
           if (socket !== s) return;
           socket = null;
           setStatus("closed");
           protocol.onClose?.();
+          timer.stop();
         };
       } catch (err) {
         lastError = new Error("websocket connection error", { cause: err });
         setStatus("error");
         protocol.onError?.(lastError);
         protocol.onClose?.();
+        timer.start();
       }
     },
 
@@ -120,6 +139,7 @@ export function createTransport<M extends MessageMap>(
       local?.close();
       setStatus("closed");
       protocol.onClose?.();
+      timer.stop();
     },
 
     send<K extends keyof M>(kind: K, payload: M[K]): Envelope<M, K> {

--- a/devtools/transport/src/timer.test.ts
+++ b/devtools/transport/src/timer.test.ts
@@ -1,0 +1,156 @@
+import { createTimer } from "./timer";
+import type { ReconnectionConfig } from "./types";
+
+const BASE: Required<ReconnectionConfig> = {
+  enabled: true,
+  delay: 1000,
+  factor: 2,
+  maxDelay: 30000,
+  maxAttempts: 3,
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe("createTimer — disabled", () => {
+  it("should return false for isRunning()", () => {
+    const timer = createTimer({ ...BASE, enabled: false }, jest.fn());
+    expect(timer.isRunning()).toBe(false);
+  });
+
+  it("should return 0 for getTime()", () => {
+    const timer = createTimer({ ...BASE, enabled: false }, jest.fn());
+    expect(timer.getTime()).toBe(0);
+  });
+
+  it("should not call func when start() is called and time advances", () => {
+    const func = jest.fn();
+    const timer = createTimer({ ...BASE, enabled: false }, func);
+    timer.start();
+    jest.runAllTimers();
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it("should not throw when calling stop() and reset()", () => {
+    const timer = createTimer({ ...BASE, enabled: false }, jest.fn());
+    expect(() => {
+      timer.stop();
+      timer.reset();
+    }).not.toThrow();
+  });
+});
+
+describe("createTimer — getTime()", () => {
+  it("should return delay * factor^1 as initial delay", () => {
+    const timer = createTimer(BASE, jest.fn());
+    expect(timer.getTime()).toBe(2000); // 1000 * 2^1
+  });
+
+  it("should cap the initial delay at maxDelay", () => {
+    const timer = createTimer({ ...BASE, maxDelay: 500 }, jest.fn());
+    expect(timer.getTime()).toBe(500);
+  });
+
+  it("should grow by factor after each invocation", () => {
+    const timer = createTimer(BASE, jest.fn());
+    const first = timer.getTime(); // 2000
+    timer.start();
+    jest.advanceTimersByTime(first);
+    expect(timer.getTime()).toBe(first * BASE.factor); // 4000
+  });
+
+  it("should cap delay at maxDelay after enough invocations", () => {
+    const timer = createTimer({ ...BASE, maxDelay: 2000 }, jest.fn());
+    timer.start();
+    jest.advanceTimersByTime(2000);
+    expect(timer.getTime()).toBe(2000);
+  });
+});
+
+describe("createTimer — start()", () => {
+  it("should not call func before the delay elapses", () => {
+    const func = jest.fn();
+    const timer = createTimer(BASE, func);
+    timer.start();
+    jest.advanceTimersByTime(timer.getTime() - 1);
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it("should call func after the delay elapses", () => {
+    const func = jest.fn();
+    const timer = createTimer(BASE, func);
+    timer.start();
+    jest.advanceTimersByTime(timer.getTime());
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call func exactly maxAttempts times then stop", () => {
+    const func = jest.fn();
+    const timer = createTimer(BASE, func);
+    timer.start();
+    jest.runAllTimers();
+    expect(func).toHaveBeenCalledTimes(BASE.maxAttempts);
+  });
+
+  it("should not call func after stop()", () => {
+    const func = jest.fn();
+    const timer = createTimer(BASE, func);
+    timer.start();
+    timer.stop();
+    jest.runAllTimers();
+    expect(func).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTimer — stop()", () => {
+  it("should cancel a pending callback", () => {
+    const func = jest.fn();
+    const timer = createTimer(BASE, func);
+    timer.start();
+    timer.stop();
+    jest.runAllTimers();
+    expect(func).not.toHaveBeenCalled();
+  });
+
+  it("should not throw when not running", () => {
+    const timer = createTimer(BASE, jest.fn());
+    expect(() => timer.stop()).not.toThrow();
+  });
+});
+
+describe("createTimer — reset()", () => {
+  it("should reset the delay back to the initial value after growth", () => {
+    const timer = createTimer(BASE, jest.fn());
+    const initial = timer.getTime();
+    timer.start();
+    jest.advanceTimersByTime(initial); // fires once, delay grows
+    timer.reset();
+    expect(timer.getTime()).toBe(initial);
+  });
+});
+
+describe("createTimer — isRunning()", () => {
+  it("should return false before start() is called", () => {
+    const timer = createTimer(BASE, jest.fn());
+    expect(timer.isRunning()).toBe(false);
+  });
+
+  it("should return true after start() is called", () => {
+    const timer = createTimer(BASE, jest.fn());
+    timer.start();
+    expect(timer.isRunning()).toBe(true);
+  });
+
+  it("should return false after stop() is called", () => {
+    const timer = createTimer(BASE, jest.fn());
+    timer.start();
+    timer.stop();
+    expect(timer.isRunning()).toBe(false);
+  });
+});

--- a/devtools/transport/src/timer.ts
+++ b/devtools/transport/src/timer.ts
@@ -1,0 +1,73 @@
+import type { ReconnectionConfig } from "./types";
+
+export type TimerState = {
+  /** Stop Timer */
+  stop: () => void;
+  /** Start Timer */
+  start: () => void;
+  /** Reset Timer */
+  reset: () => void;
+  /** Get current timer value */
+  getTime: () => number;
+  /** Check if timer is running */
+  isRunning: () => boolean;
+};
+
+export function createTimer(config: Required<ReconnectionConfig>, func: () => void): TimerState {
+  const { delay, maxDelay, factor, maxAttempts, enabled } = config;
+  let attempts = 1;
+  let cappedAttempts = Math.min(attempts, maxAttempts);
+  let currentDelay = Math.min(delay * factor ** cappedAttempts, maxDelay);
+  let timer: ReturnType<typeof setTimeout>;
+  let running = false;
+
+  if (!enabled) {
+    return {
+      start: () => {},
+      stop: () => {},
+      reset: () => {},
+      getTime: () => 0,
+      isRunning: () => false,
+    };
+  }
+
+  function start() {
+    running = true;
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      if (attempts > maxAttempts) {
+        return;
+      }
+      func();
+      attempts++;
+      cappedAttempts = Math.min(attempts, maxAttempts);
+      currentDelay = Math.min(delay * factor ** cappedAttempts, maxDelay);
+      start();
+    }, currentDelay);
+  }
+
+  function stop() {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    running = false;
+  }
+
+  function reset() {
+    attempts = 1;
+    cappedAttempts = Math.min(attempts, maxAttempts);
+    currentDelay = Math.min(delay * factor ** cappedAttempts, maxDelay);
+  }
+
+  function getTime() {
+    return currentDelay;
+  }
+
+  function isRunning() {
+    return running;
+  }
+
+  return { start, stop, reset, getTime, isRunning };
+}

--- a/devtools/transport/src/types.ts
+++ b/devtools/transport/src/types.ts
@@ -62,6 +62,19 @@ export interface TransportProtocol<M extends MessageMap> {
   onError?(err: Error): void;
 }
 
+export type ReconnectionConfig = {
+  /** Whether to reconnect after a disconnect. Defaults to `true`. */
+  enabled?: boolean;
+  /** Delay before reconnecting, in ms. Defaults to 1000. */
+  delay?: number;
+  /** Maximum delay before reconnecting, in ms. Defaults to 30000. */
+  maxDelay?: number;
+  /** Factor to multiply the delay by after each failed attempt. Defaults to 1.5. */
+  factor?: number;
+  /** Maximum number of reconnection attempts. Defaults to `20`. */
+  maxAttempts?: number;
+};
+
 /**
  * Minimal WebSocket surface the transport relies on.
  *
@@ -94,6 +107,8 @@ export type TransportConfig = {
    * global `WebSocket` when present; Node consumers pass a `ws`-backed factory.
    */
   socketFactory?: (url: string, protocols?: string | string[]) => WebSocketLike;
+  /** Reconnection configuration. */
+  reconnection?: ReconnectionConfig;
 };
 
 /**


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

  Adds automatic reconnection with exponential backoff to `@devtools/transport`, so a WebSocket transport recovers from
  transient errors and factory-level failures without any manual intervention from the caller.

  ### What changed

  - **`types.ts`** — adds `ReconnectionConfig` type (`enabled`, `delay`, `maxDelay`, `factor`, `maxAttempts`) and wires
  it as an optional `reconnection` field on `TransportConfig`.
  - **`timer.ts`** — new `createTimer` utility that schedules a callback with exponential backoff (`delay * factor^n`),
  capped at `maxDelay`, stopping after `maxAttempts`. Returns a `TimerState` handle (`start`, `stop`, `reset`,
  `getTime`, `isRunning`). When `enabled: false` all methods are no-ops.
  - **`createTransport.ts`** — instantiates the timer and hooks it into the connection lifecycle:
    - `timer.start()` on entering the error state (socket `onerror` or factory throw)
    - `timer.stop()` once the socket opens (`onopen`) or closes cleanly (`onclose`)
### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35406](https://ledgerhq.atlassian.net/browse/LIVE-35406) <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35406]: https://ledgerhq.atlassian.net/browse/LIVE-35406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ