### PR TITLE
[LWM] fix(LIVE-34366): update pending operation CTA label

### DIFF
--- a/.changeset/swift-clocks-shine.md
+++ b/.changeset/swift-clocks-shine.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Change swap pending operation CTA from "Go to history" to "See details"

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/__integrations__/NotificationsPromptSwapFlow.test.tsx
@@ -218,7 +218,7 @@ describe("NotificationsPrompt swap flow", () => {
         "attempt_to_trigger_push_notification_drawer_after_action",
       );
 
-      await user.press(screen.getByText(/go to history/i));
+      await user.press(screen.getByText(/see details/i));
       await waitFor(() => {
         expect(screen.getByText(/your previous swaps will appear here/i)).toBeVisible();
       });

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/PendingOperation.tsx
@@ -1,6 +1,6 @@
 import { CommonActions, useTheme } from "@react-navigation/native";
 import React, { useCallback, useEffect, useRef } from "react";
-import { Trans } from "~/context/Locale";
+import { Trans, useTranslation } from "~/context/Locale";
 import { StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -36,6 +36,8 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
   const completeSwapFlow = useCallback(() => {
     notifyFlowCompleted("swap");
   }, [notifyFlowCompleted]);
+
+  const { t } = useTranslation();
 
   const navigateToSwapForm = useCallback(() => {
     if (allowRemovalRef.current) return;
@@ -143,7 +145,7 @@ export function PendingOperation({ route, navigation }: PendingOperationParamLis
         <Button
           event="SwapDone"
           type="primary"
-          title={<Trans i18nKey={"transfer.swap.history.button"} />}
+          title={t("transfer.swap.pendingOperation.cta")}
           onPress={onComplete}
         />
       </View>

--- a/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/Swap/SubScreens/__tests__/PendingOperation.test.tsx
@@ -79,7 +79,7 @@ describe("PendingOperation", () => {
       <PendingOperation route={route as never} navigation={navigation as never} />,
     );
 
-    await user.press(screen.getByText(/go to history/i));
+    await user.press(screen.getByText(/see details/i));
 
     expect(navigation.dispatch).toHaveBeenCalledWith(
       CommonActions.reset({
@@ -106,7 +106,7 @@ describe("PendingOperation", () => {
       <PendingOperation route={route as never} navigation={navigation as never} />,
     );
 
-    await user.press(screen.getByText(/go to history/i));
+    await user.press(screen.getByText(/see details/i));
 
     expect(navigation.dispatch).toHaveBeenCalledWith(
       CommonActions.reset({


### PR DESCRIPTION
Changed the swap pending operation CTA label from "Go to history" to "See details" using the existing transfer.swap.pendingOperation.cta i18n key (already translated in all 12 supported locales). Updated tests to match the new label.

🔗 Context
JIRA issue: [LIVE-34366]
ADR (if any): N/A

[LIVE-34366]: https://ledgerhq.atlassian.net/browse/LIVE-34366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ