### PR TITLE
[LWDM] feat(generic-coin-framework): add family hooks and fee telemetry

### DIFF
--- a/.changeset/green-fans-relax.md
+++ b/.changeset/green-fans-relax.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/ledger-wallet-framework": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(generic-coin-framework): add family hooks and fee telemetry

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountBridge.ts
@@ -26,7 +26,8 @@ export async function getCoinFrameworkAccountBridge(
   customSigner?: CoinFrameworkSigner,
 ): Promise<AccountBridge<GenericTransaction>> {
   const signer = customSigner ?? (await getSigner(network));
-  const { assignFromAccountRaw, assignToAccountRaw } = await getAccountRawAssignHooks(network);
+  const { assignFromAccountRaw, assignToAccountRaw, fromOperationExtraRaw, toOperationExtraRaw } =
+    await getAccountRawAssignHooks(network);
   return {
     sync: makeSync({ getAccountShape: genericGetAccountShape(network, kind), postSync }),
     receive: makeAccountBridgeReceive(getAddressWrapper(signer.getAddress)),
@@ -40,6 +41,8 @@ export async function getCoinFrameworkAccountBridge(
     signRawOperation: genericSignRawOperation(network, kind)(signer.context),
     assignFromAccountRaw,
     assignToAccountRaw,
+    fromOperationExtraRaw,
+    toOperationExtraRaw,
     getSerializedAddressParameters, // NOTE: check whether it should be exposed by coin-module's api instead?
     validateAddress: genericValidateAddress(network, kind),
   } satisfies Partial<AccountBridge<GenericTransaction>>;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/accountRawAssign.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/accountRawAssign.ts
@@ -1,6 +1,26 @@
 import { loadAccountRawAssignForFamily } from "../../coin-modules/registry";
 import type { AccountRawAssignHooks } from "./types";
+import { frameworkExtraFromRaw, frameworkExtraToRaw, mergeExtra } from "./utils";
 
 export async function getAccountRawAssignHooks(network: string): Promise<AccountRawAssignHooks> {
-  return (await loadAccountRawAssignForFamily(network)) ?? {};
+  const hooks = (await loadAccountRawAssignForFamily(network)) ?? {};
+  const familyFromRaw = hooks.fromOperationExtraRaw;
+  const familyToRaw = hooks.toOperationExtraRaw;
+  // The serialization layer replaces `Operation.extra` wholesale with what these hooks return, so a
+  // family that maps only its own keys would drop `ledgerOpType`, `memo` and `stake` — whose `amount`
+  // is a `BigNumber` that survives a JSON round trip as a bare decimal string (bignumber.js sets
+  // `toJSON = toString`) and so revives as a `string`, not a `BigNumber`, unless the framework
+  // converts it here.
+  //
+  // Both directions are wrapped as soon as *either* family hook exists: the layer gates each
+  // direction on its own hook, so wrapping per-direction would convert `stake.amount` on one side
+  // only and leave the other reviving a string (or persisting a `BigNumber`).
+  if (!familyFromRaw && !familyToRaw) return hooks;
+  return {
+    ...hooks,
+    fromOperationExtraRaw: extraRaw =>
+      mergeExtra(extraRaw, familyFromRaw?.(extraRaw), frameworkExtraFromRaw(extraRaw)),
+    toOperationExtraRaw: extra =>
+      mergeExtra(extra, familyToRaw?.(extra), frameworkExtraToRaw(extra)),
+  };
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/estimateMaxSpendable.ts
@@ -38,6 +38,7 @@ export function genericEstimateMaxSpendable(
         draftTransaction,
         bridgeApi.computeIntentType,
         coinModuleApi.craftTransactionData,
+        bridgeApi.buildIntentData,
       ),
     );
     const estimation: FeeEstimation = {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -335,6 +335,15 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     if (chainSpecificValidation) {
       chainSpecificValidation.getAccountShape(address);
     }
+    // `getAccountInfo` (ADR-045) is fetched only when a family declares a mapper: coin-tezos
+    // implements the fetch without one, so an unconditional call would add a request to every tezos
+    // sync for a result nothing reads.
+    const buildShape = bridgeApi.buildAccountShape;
+    const chainSpecificShapePromise = buildShape
+      ? Promise.resolve(coinModuleApi.getAccountInfo?.(address)).then(accountInfo =>
+          buildShape(address, accountInfo),
+        )
+      : Promise.resolve(undefined);
     const accountId = encodeAccountId({
       type: "js",
       version: "2",
@@ -368,11 +377,12 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
         })
       : Promise.resolve(undefined);
 
-    const [blockInfo, balanceRes, validators, readiness] = await Promise.all([
+    const [blockInfo, balanceRes, validators, readiness, chainSpecificShape] = await Promise.all([
       coinModuleApi.lastBlock(),
       coinModuleApi.getBalance(address, bridgeApi.balanceOptions),
       validatorsPromise,
       readinessPromise,
+      chainSpecificShapePromise,
     ]);
 
     const nativeAsset = extractBalance(balanceRes, "native");
@@ -557,6 +567,7 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
       stakingResources?: StakingResources;
       stakingPositions?: StakingPositionOnAccount[];
     } = {
+      ...chainSpecificShape,
       id: accountId,
       // `||` (not `??`): a device getAddress may return an empty-string publicKey (e.g. when the
       // chain code is not requested); treat "" as absent and fall back rather than storing a blank xpub.

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getAccountShape.ts
@@ -338,6 +338,14 @@ export function genericGetAccountShape(network: string, kind: string): GetAccoun
     // `getAccountInfo` (ADR-045) is fetched only when a family declares a mapper: coin-tezos
     // implements the fetch without one, so an unconditional call would add a request to every tezos
     // sync for a result nothing reads.
+    //
+    // Deliberately uncaught, unlike `validatorsPromise` / `readinessPromise` below: those are the
+    // framework's own optional enrichments, whereas what this hook returns is the family's contract —
+    // it may be fields that family's screens require (a tron account derives `isAccountEmpty` from
+    // `tronResources.bandwidth.freeLimit`, so a missing `tronResources` breaks that check and hides
+    // its staking actions) or something cosmetic, and the framework cannot tell. Catching here would impose degradation on every family with no way back; a family whose
+    // contribution is optional catches inside its own hook and returns undefined, which this path
+    // already treats as nothing to contribute.
     const buildShape = bridgeApi.buildAccountShape;
     const chainSpecificShapePromise = buildShape
       ? Promise.resolve(coinModuleApi.getAccountInfo?.(address)).then(accountInfo =>

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -32,6 +32,7 @@ export function genericGetTransactionStatus(
       valAddress: transaction.valAddress,
       valId: transaction.valId,
       dstValAddress: transaction.dstValAddress,
+      familySpecificData: transaction.familySpecificData,
     };
 
     const chainSpecificValidation = bridgeApi.getChainSpecificRules;
@@ -48,6 +49,7 @@ export function genericGetTransactionStatus(
       draftTransaction,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
+      bridgeApi.buildIntentData,
     );
 
     const customFees = bigNumberToBigIntDeep({

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/getTransactionStatus.ts
@@ -44,12 +44,18 @@ export function genericGetTransactionStatus(
       }
     }
 
+    const buildIntentData = bridgeApi.buildIntentData;
     const intent = transactionToIntent(
       account,
       draftTransaction,
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
-      bridgeApi.buildIntentData,
+      // The real transaction, not the draft: the draft is a field-by-field allowlist, so a field it
+      // omits reads as `undefined` inside the hook with no type error, and this path would validate
+      // an intent whose `data` differs from the one `signOperation` hands the device. Everything the
+      // framework itself derives keeps using the draft, so families that declare no hook are
+      // untouched.
+      buildIntentData && (() => buildIntentData(transaction)),
     );
 
     const customFees = bigNumberToBigIntDeep({

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -10,6 +10,7 @@ import {
   transactionToIntent,
 } from "./utils";
 import BigNumber from "bignumber.js";
+import isEqual from "lodash/isEqual";
 import type { AssetInfo, FeeEstimation } from "@ledgerhq/coin-module-framework/api/types";
 import { decodeTokenAccountId } from "@ledgerhq/ledger-wallet-framework/account/index";
 import type { TokenCurrency } from "@domain/entity-currency-token";
@@ -113,6 +114,7 @@ export function genericPrepareTransaction(
       },
       bridgeApi.computeIntentType,
       coinModuleApi.craftTransactionData,
+      bridgeApi.buildIntentData,
     );
     const customFeesParameters = bigNumberToBigIntDeep({
       feesStrategy: transaction.feesStrategy ?? undefined,
@@ -141,11 +143,17 @@ export function genericPrepareTransaction(
         : computeUseAllAmount(estimation, getNativeSpendableAfterPending(account));
     }
 
+    // Part of the identity check: the fee *value* can hold while the breakdown behind it moves (a
+    // different recipient can change what a chain charges without changing the total), and a restored
+    // transaction has persisted fees but no `feeParameters` — returning early leaves it stale or unset.
+    const nextFeeParameters = estimation.parameters;
+
     if (
       bnEq(transaction.fees, fees) &&
       bnEq(transaction.amount, nextAmount) &&
       (transaction.assetReference ?? "") === assetReference &&
-      (transaction.assetOwner ?? "") === assetOwner
+      (transaction.assetOwner ?? "") === assetOwner &&
+      isEqual(transaction.feeParameters, nextFeeParameters)
     ) {
       return transaction;
     }
@@ -161,6 +169,11 @@ export function genericPrepareTransaction(
           fees: customParametersFees ? new BigNumber(customParametersFees.toString()) : undefined,
         },
       },
+      // Assigned wholesale, never merged: an estimation returning no parameters clears the previous
+      // figures rather than leaving them to be read as current for a new amount. A custom fee skips
+      // estimation entirely, so it clears them too — the breakdown belongs to a fee this transaction
+      // no longer uses.
+      feeParameters: nextFeeParameters,
     };
 
     // Propagate needed fields

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -170,9 +170,10 @@ export function genericPrepareTransaction(
         },
       },
       // Assigned wholesale, never merged: an estimation returning no parameters clears the previous
-      // figures rather than leaving them to be read as current for a new amount. A custom fee skips
-      // estimation entirely, so it clears them too — the breakdown belongs to a fee this transaction
-      // no longer uses.
+      // figures rather than leaving them to be read as current for a new amount. A custom fee that
+      // skips estimation clears them for the same reason — the breakdown belongs to a fee this
+      // transaction no longer uses. A custom fee *with* send-max still estimates (the max amount
+      // needs it), and keeps the breakdown that estimation produced.
       feeParameters: nextFeeParameters,
     };
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/prepareTransaction.ts
@@ -4,6 +4,7 @@ import { getBridgeApi } from "./bridge";
 import {
   bigNumberToBigIntDeep,
   computeUseAllAmount,
+  feeParametersToJsonSafe,
   getNativeSpendableAfterPending,
   getPendingTokenSpent,
   toGasOptionsFromUnknown,
@@ -146,7 +147,9 @@ export function genericPrepareTransaction(
     // Part of the identity check: the fee *value* can hold while the breakdown behind it moves (a
     // different recipient can change what a chain charges without changing the total), and a restored
     // transaction has persisted fees but no `feeParameters` — returning early leaves it stale or unset.
-    const nextFeeParameters = estimation.parameters;
+    // Normalised to a JSON-safe record (bigint → string) because this bag rides on the live
+    // transaction the swap flow serialises with `JSON.stringify`, which throws on a raw bigint.
+    const nextFeeParameters = feeParametersToJsonSafe(estimation.parameters);
 
     if (
       bnEq(transaction.fees, fees) &&

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -59,6 +59,7 @@ export const genericSignOperation =
             { ...transaction },
             bridgeApi.computeIntentType,
             coinModuleApi.craftTransactionData,
+            bridgeApi.buildIntentData,
           );
           transactionIntent.senderPublicKey = publicKey;
 
@@ -84,6 +85,7 @@ export const genericSignOperation =
           const txnSig = await signer.signTransaction(derivationPath, unsigned, {
             ...transaction.recipientDomain,
             derivationMode: account.derivationMode,
+            ...bridgeApi.getDeviceSignOptions?.(transaction, account),
           });
           return {
             unsigned,
@@ -103,7 +105,12 @@ export const genericSignOperation =
           signedInfo.txnSig,
           signedInfo.publicKey,
         );
-        const operation = buildOptimisticOperation(account, transaction, signedInfo.sequence);
+        const operation = buildOptimisticOperation(
+          account,
+          transaction,
+          signedInfo.sequence,
+          bridgeApi.describeOptimisticOperation,
+        );
         if (!operation.id) {
           log("Generic coin-framework", "buildOptimisticOperation", operation);
         }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/signOperation.ts
@@ -84,8 +84,8 @@ export const genericSignOperation =
           /* Sign on Ledger device */
           const txnSig = await signer.signTransaction(derivationPath, unsigned, {
             ...transaction.recipientDomain,
-            derivationMode: account.derivationMode,
             ...bridgeApi.getDeviceSignOptions?.(transaction, account),
+            derivationMode: account.derivationMode,
           });
           return {
             unsigned,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountBridge.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountBridge.test.ts
@@ -1,0 +1,34 @@
+import { getCoinFrameworkAccountBridge } from "../accountBridge";
+import type { CoinFrameworkSigner } from "../types";
+
+const assignFromAccountRawMock = jest.fn();
+const assignToAccountRawMock = jest.fn();
+const fromOperationExtraRawMock = jest.fn();
+const toOperationExtraRawMock = jest.fn();
+
+jest.mock("../accountRawAssign", () => ({
+  getAccountRawAssignHooks: jest.fn(async () => ({
+    assignFromAccountRaw: assignFromAccountRawMock,
+    assignToAccountRaw: assignToAccountRawMock,
+    fromOperationExtraRaw: fromOperationExtraRawMock,
+    toOperationExtraRaw: toOperationExtraRawMock,
+  })),
+}));
+
+describe("getCoinFrameworkAccountBridge — raw-assign hook wiring", () => {
+  const stubSigner: CoinFrameworkSigner = {
+    getAddress: async () => ({ address: "addr", path: "path", publicKey: "pub" }),
+    context: async (_deviceId, fn) => fn(undefined),
+  };
+
+  // `account/serialization.ts` reads `from/toOperationExtraRaw` off the bridge, so a hook declared
+  // but not returned silently leaves a family's revived operation extra un-deserialised.
+  it("exposes every declared raw-assign hook on the resolved account bridge", async () => {
+    const bridge = await getCoinFrameworkAccountBridge("networkx", "local", stubSigner);
+
+    expect(bridge.assignFromAccountRaw).toBe(assignFromAccountRawMock);
+    expect(bridge.assignToAccountRaw).toBe(assignToAccountRawMock);
+    expect(bridge.fromOperationExtraRaw).toBe(fromOperationExtraRawMock);
+    expect(bridge.toOperationExtraRaw).toBe(toOperationExtraRawMock);
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountRawAssign.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountRawAssign.test.ts
@@ -155,7 +155,7 @@ describe("getAccountRawAssignHooks — round trip through the serialization laye
       stake: { address: "v", amount: new BigNumber(2500) },
     });
 
-    const raw = toOperationRaw(op, undefined, toOperationExtraRaw);
+    const raw = toOperationRaw(op, undefined, toOperationExtraRaw) as any;
     expect(raw.extra.ledgerOpType).toBe("FREEZE");
     expect(raw.extra.memo).toBe("hi");
     expect(raw.extra.frozenAmount).toBe("1000");
@@ -164,7 +164,7 @@ describe("getAccountRawAssignHooks — round trip through the serialization laye
     const persisted = JSON.parse(JSON.stringify(raw));
     expect(persisted.extra.stake.amount).toBe("2500");
 
-    const revived = fromOperationRaw(persisted, "accId", null, fromOperationExtraRaw);
+    const revived = fromOperationRaw(persisted, "accId", null, fromOperationExtraRaw) as any;
     expect(revived.extra.ledgerOpType).toBe("FREEZE");
     expect(revived.extra.memo).toBe("hi");
     expect(revived.extra.frozenAmount).toEqual(new BigNumber(1000));
@@ -179,7 +179,7 @@ describe("getAccountRawAssignHooks — round trip through the serialization laye
     expect(persisted.extra.stake.amount).toBe("2500");
     expect(JSON.stringify(new BigNumber(2500))).toBe('"2500"');
 
-    const revived = fromOperationRaw(persisted, "accId", null, undefined);
+    const revived = fromOperationRaw(persisted, "accId", null, undefined) as any;
     expect(typeof revived.extra.stake.amount).toBe("string");
     expect(BigNumber.isBigNumber(revived.extra.stake.amount)).toBe(false);
   });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountRawAssign.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/accountRawAssign.test.ts
@@ -1,0 +1,186 @@
+import BigNumber from "bignumber.js";
+import type { Operation } from "@ledgerhq/types-live";
+import { fromOperationRaw, toOperationRaw } from "@ledgerhq/ledger-wallet-framework/serialization";
+import { getAccountRawAssignHooks } from "../accountRawAssign";
+
+const loadAccountRawAssignForFamilyMock = jest.fn();
+
+jest.mock("../../../coin-modules/registry", () => ({
+  loadAccountRawAssignForFamily: (...args: unknown[]) => loadAccountRawAssignForFamilyMock(...args),
+}));
+
+describe("getAccountRawAssignHooks — operation extra serialization", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("keeps the framework-owned keys a family hook does not map", async () => {
+    // The serialization layer replaces `extra` wholesale, so without the framework's own half a
+    // family mapping only `frozenAmount` would lose `ledgerOpType` and `memo` on every restore.
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      fromOperationExtraRaw: (extraRaw: any) => ({
+        frozenAmount: new BigNumber(extraRaw.frozenAmount),
+      }),
+    });
+
+    const { fromOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+    const revived = fromOperationExtraRaw!({
+      ledgerOpType: "FREEZE",
+      memo: "hello",
+      frozenAmount: "1000000",
+    }) as any;
+
+    expect(revived.ledgerOpType).toBe("FREEZE");
+    expect(revived.memo).toBe("hello");
+    expect(revived.frozenAmount).toEqual(new BigNumber(1_000_000));
+  });
+
+  it("serializes the framework's own stake amount and revives it", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      fromOperationExtraRaw: () => ({}),
+      toOperationExtraRaw: () => ({}),
+    });
+
+    const { fromOperationExtraRaw, toOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+
+    const raw = toOperationExtraRaw!({
+      stake: { address: "validator", amount: new BigNumber(2_500) },
+    }) as any;
+    expect(raw.stake).toEqual({ address: "validator", amount: "2500" });
+
+    const revived = fromOperationExtraRaw!(raw) as any;
+    expect(revived.stake.amount).toEqual(new BigNumber(2_500));
+  });
+
+  it("lets the family's own mapping win over the framework passthrough", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      toOperationExtraRaw: (extra: any) => ({ frozenAmount: extra.frozenAmount.toFixed() }),
+    });
+
+    const { toOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+    const raw = toOperationExtraRaw!({ frozenAmount: new BigNumber(42), memo: "kept" }) as any;
+
+    expect(raw.frozenAmount).toBe("42");
+    expect(raw.memo).toBe("kept");
+  });
+
+  it("keeps the framework half when a family hook returns nothing usable", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      toOperationExtraRaw: () => undefined,
+    });
+
+    const { toOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+    const raw = toOperationExtraRaw!({
+      ledgerOpType: "FREEZE",
+      stake: { address: "validator", amount: new BigNumber(7) },
+    }) as any;
+
+    expect(raw.ledgerOpType).toBe("FREEZE");
+    expect(raw.stake).toEqual({ address: "validator", amount: "7" });
+  });
+
+  it("converts the framework's stake even when the family hook spreads the whole bag", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      toOperationExtraRaw: (extra: any) => ({
+        ...extra,
+        frozenAmount: extra.frozenAmount.toFixed(),
+      }),
+    });
+
+    const { toOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+    const raw = toOperationExtraRaw!({
+      frozenAmount: new BigNumber(42),
+      stake: { address: "validator", amount: new BigNumber(2_500) },
+    }) as any;
+
+    expect(raw.frozenAmount).toBe("42");
+    expect(raw.stake).toEqual({ address: "validator", amount: "2500" });
+  });
+
+  it("converts both directions when the family declares only one", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      toOperationExtraRaw: (extra: any) => extra,
+    });
+
+    const { fromOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+
+    expect(fromOperationExtraRaw).toBeDefined();
+    const revived = fromOperationExtraRaw!({
+      stake: { address: "validator", amount: "2500" },
+    }) as any;
+    expect(revived.stake.amount).toEqual(new BigNumber(2_500));
+  });
+
+  it("declares no hook when the family declares none", async () => {
+    // `toOperationRaw` gates on the hook being present and persists `extra` verbatim otherwise, so
+    // wrapping unconditionally would change how every already-migrated family serializes.
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({ assignFromAccountRaw: jest.fn() });
+
+    const hooks = await getAccountRawAssignHooks("evm");
+
+    expect(hooks.fromOperationExtraRaw).toBeUndefined();
+    expect(hooks.toOperationExtraRaw).toBeUndefined();
+  });
+});
+
+describe("getAccountRawAssignHooks — round trip through the serialization layer", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  function baseOperation(extra: Record<string, unknown>): Operation {
+    return {
+      id: "accId_hash_OUT",
+      hash: "hash",
+      type: "OUT",
+      senders: ["s"],
+      recipients: ["r"],
+      accountId: "accId",
+      blockHash: "bh",
+      blockHeight: 1,
+      date: new Date("2026-01-01"),
+      value: new BigNumber(1),
+      fee: new BigNumber(1),
+      extra,
+    } as Operation;
+  }
+
+  it("keeps framework keys and converts stake.amount while a family maps only its own key", async () => {
+    loadAccountRawAssignForFamilyMock.mockResolvedValue({
+      toOperationExtraRaw: (extra: any) => ({ frozenAmount: extra.frozenAmount.toFixed() }),
+      fromOperationExtraRaw: (raw: any) => ({ frozenAmount: new BigNumber(raw.frozenAmount) }),
+    });
+    const { toOperationExtraRaw, fromOperationExtraRaw } = await getAccountRawAssignHooks("tron");
+
+    const op = baseOperation({
+      ledgerOpType: "FREEZE",
+      memo: "hi",
+      frozenAmount: new BigNumber(1000),
+      stake: { address: "v", amount: new BigNumber(2500) },
+    });
+
+    const raw = toOperationRaw(op, undefined, toOperationExtraRaw);
+    expect(raw.extra.ledgerOpType).toBe("FREEZE");
+    expect(raw.extra.memo).toBe("hi");
+    expect(raw.extra.frozenAmount).toBe("1000");
+    expect(raw.extra.stake).toEqual({ address: "v", amount: "2500" });
+
+    const persisted = JSON.parse(JSON.stringify(raw));
+    expect(persisted.extra.stake.amount).toBe("2500");
+
+    const revived = fromOperationRaw(persisted, "accId", null, fromOperationExtraRaw);
+    expect(revived.extra.ledgerOpType).toBe("FREEZE");
+    expect(revived.extra.memo).toBe("hi");
+    expect(revived.extra.frozenAmount).toEqual(new BigNumber(1000));
+    expect(revived.extra.stake.amount).toEqual(new BigNumber(2500));
+  });
+
+  it("revives an unconverted stake.amount as a string, not a BigNumber, without the framework hook", () => {
+    const op = baseOperation({ stake: { address: "v", amount: new BigNumber(2500) } });
+    const raw = toOperationRaw(op, undefined, undefined);
+    const persisted = JSON.parse(JSON.stringify(raw));
+
+    expect(persisted.extra.stake.amount).toBe("2500");
+    expect(JSON.stringify(new BigNumber(2500))).toBe('"2500"');
+
+    const revived = fromOperationRaw(persisted, "accId", null, undefined);
+    expect(typeof revived.extra.stake.amount).toBe("string");
+    expect(BigNumber.isBigNumber(revived.extra.stake.amount)).toBe(false);
+  });
+});

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/estimateMaxSpendable.test.ts
@@ -12,6 +12,11 @@ jest.mock("../createTransaction", () => ({
   createTransaction: jest.fn().mockReturnValue({}),
 }));
 
+const getBridgeApiMock = jest.fn().mockResolvedValue({});
+jest.mock("../bridge", () => ({
+  getBridgeApi: (...a: unknown[]) => getBridgeApiMock(...a),
+}));
+
 const mockedGetCoinModuleApi = coinframework.getCoinModuleApi as jest.Mock;
 
 describe("genericEstimateMaxSpendable", () => {
@@ -62,6 +67,31 @@ describe("genericEstimateMaxSpendable", () => {
     });
 
     expect(result.toString()).toBe("49990000");
+  });
+
+  it("prices the send-max against the family's own intent data", async () => {
+    const buildIntentData = jest.fn().mockReturnValue({ type: "familyx" });
+    getBridgeApiMock.mockResolvedValueOnce({ buildIntentData });
+    mockedGetCoinModuleApi.mockReturnValue({
+      estimateFees: estimateFeesMock.mockResolvedValue({ value: 10000n }),
+    });
+
+    const estimate = genericEstimateMaxSpendable("testnet", "local");
+    await estimate({
+      account: dummyAccount,
+      parentAccount: null,
+      transaction: { familySpecificData: { resource: "ENERGY" } } as any,
+    });
+
+    expect(buildIntentData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useAllAmount: true,
+        familySpecificData: { resource: "ENERGY" },
+      }),
+    );
+    expect(estimateFeesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { type: "familyx" } }),
+    );
   });
 
   it("subtracts additionalFees surfaced in parameters", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -38,7 +38,6 @@ const defaultBridgeApi = () => ({
   getChainSpecificRules: {
     getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
   },
-  buildAccountShape: (...a: any[]) => buildAccountShapeMock(...a),
   refreshOperations: (...a: any[]) => refreshOperationsMock(...a),
 });
 getBridgeApiMock.mockImplementation(defaultBridgeApi);
@@ -853,6 +852,13 @@ describe("genericGetAccountShape", () => {
     const currency = { id: "familyx", name: "FamilyX" };
 
     beforeEach(() => {
+      // Opted in here rather than in `defaultBridgeApi`, matching `getAccountReadiness` above: no
+      // family declares this hook, so the default bridge must keep modelling one that does not —
+      // and declaring it there makes every unrelated suite spend a `getAccountInfo` call.
+      getBridgeApiMock.mockImplementation(() => ({
+        ...defaultBridgeApi(),
+        buildAccountShape: (...a: any[]) => buildAccountShapeMock(...a),
+      }));
       getSyncHashMock.mockReturnValue("sync-hash");
       getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
       extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
@@ -862,6 +868,10 @@ describe("genericGetAccountShape", () => {
       mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps ?? []);
       cleanedOperationMock.mockImplementation((op: any) => op);
       inferSubOperationsMock.mockReturnValue([]);
+    });
+
+    afterEach(() => {
+      getBridgeApiMock.mockImplementation(defaultBridgeApi);
     });
 
     test("spreads a family-contributed account shape into the synced account", async () => {
@@ -946,7 +956,20 @@ describe("genericGetAccountShape", () => {
       ).rejects.toThrow(burnAddressError);
     });
 
-    test("a colliding framework-owned field from the family hook does not win", async () => {
+    test("fails the sync when the family mapper rejects, rather than persisting a partial account", async () => {
+      buildAccountShapeMock.mockRejectedValueOnce(new Error("trongrid down"));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+
+      await expect(
+        getShape(
+          { address: "addr5", initialAccount: undefined, currency, derivationMode: "" } as any,
+          { paginationConfig: {} as any },
+        ),
+      ).rejects.toThrow("trongrid down");
+    });
+
+    test("keeps operations and syncHash when the family hook collides with them", async () => {
       // Give the framework a real, non-empty `operations` result so a family-contributed
       // `operations: []` collision is actually observable (both would otherwise be `[]`).
       listOperationsMock.mockResolvedValueOnce({

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getAccountShape.test.ts
@@ -18,12 +18,15 @@ const getBalanceMock = jest.fn();
 const lastBlockMock = jest.fn();
 const getTokenFromAssetMock = jest.fn();
 const chainSpecificGetAccountShapeMock = jest.fn();
+const buildAccountShapeMock = jest.fn();
 const refreshOperationsMock = jest.fn();
+const getAccountInfoMock = jest.fn();
 jest.mock("../api", () => ({
   getCoinModuleApi: () => ({
     lastBlock: (...a: any[]) => lastBlockMock(...a),
     getBalance: (...a: any[]) => getBalanceMock(...a),
     listOperations: (...a: any[]) => listOperationsMock(...a),
+    getAccountInfo: (...a: any[]) => getAccountInfoMock(...a),
   }),
 }));
 const getBridgeApiMock = jest.fn();
@@ -35,6 +38,7 @@ const defaultBridgeApi = () => ({
   getChainSpecificRules: {
     getAccountShape: (...a: any[]) => chainSpecificGetAccountShapeMock(...a),
   },
+  buildAccountShape: (...a: any[]) => buildAccountShapeMock(...a),
   refreshOperations: (...a: any[]) => refreshOperationsMock(...a),
 });
 getBridgeApiMock.mockImplementation(defaultBridgeApi);
@@ -841,6 +845,135 @@ describe("genericGetAccountShape", () => {
       expect(attachedInternalOp?.hash).toBe(parentOpHash);
       expect(attachedInternalOp?.type).toBe("IN");
       expect((attachedInternalOp as any)?.extra?.internal).toBe(true);
+    });
+  });
+
+  describe("chain-specific account shape contribution", () => {
+    const network = "mainnet";
+    const currency = { id: "familyx", name: "FamilyX" };
+
+    beforeEach(() => {
+      getSyncHashMock.mockReturnValue("sync-hash");
+      getBalanceMock.mockResolvedValue([{ asset: { type: "native" }, value: 1000n, locked: 0n }]);
+      extractBalanceMock.mockReturnValue({ value: 1000n, locked: 0n });
+      listOperationsMock.mockResolvedValue({ items: [], next: undefined });
+      buildSubAccountsMock.mockReturnValue([]);
+      lastBlockMock.mockResolvedValue({ height: 1 });
+      mergeOpsMock.mockImplementation((_old: any[], newOps: any[]) => newOps ?? []);
+      cleanedOperationMock.mockImplementation((op: any) => op);
+      inferSubOperationsMock.mockReturnValue([]);
+    });
+
+    test("spreads a family-contributed account shape into the synced account", async () => {
+      buildAccountShapeMock.mockResolvedValueOnce({ familyResources: { energy: "1200" } });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "addr1", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(buildAccountShapeMock).toHaveBeenCalledWith("addr1", undefined);
+      expect((result as any).familyResources).toEqual({ energy: "1200" });
+    });
+
+    test("hands the coin module's getAccountInfo metadata to the family mapper", async () => {
+      // ADR-045: the framework makes the standard call; the family decides what the metadata feeds.
+      const accountInfo = { type: "familyx", meterLimit: 5000, meterA: 1200, meterB: 600 };
+      getAccountInfoMock.mockResolvedValueOnce(accountInfo);
+      buildAccountShapeMock.mockImplementationOnce((_address: string, info: any) => ({
+        familyResources: { a: String(info.meterA), b: String(info.meterB) },
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "addr3", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(getAccountInfoMock).toHaveBeenCalledWith("addr3");
+      expect(buildAccountShapeMock).toHaveBeenCalledWith("addr3", accountInfo);
+      expect((result as any).familyResources).toEqual({ a: "1200", b: "600" });
+    });
+
+    test("syncs unchanged when the family contributes no shape", async () => {
+      buildAccountShapeMock.mockResolvedValueOnce(undefined);
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "addr2", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(buildAccountShapeMock).toHaveBeenCalledWith("addr2", undefined);
+      expect(result.balance).toBeDefined();
+      expect((result as any).familyResources).toBeUndefined();
+    });
+
+    test("does not spend a getAccountInfo network call when the family declares no mapper", async () => {
+      getBridgeApiMock.mockImplementationOnce(() => ({
+        getTokenFromAsset: getTokenFromAssetMock,
+        refreshOperations: (...a: any[]) => refreshOperationsMock(...a),
+      }));
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      await getShape(
+        { address: "addr4", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(getAccountInfoMock).not.toHaveBeenCalled();
+    });
+
+    test("propagates a synchronous throw from the chain-specific hook (e.g. stellar's burn-address guard)", async () => {
+      const burnAddressError = new Error("burn address");
+      chainSpecificGetAccountShapeMock.mockImplementationOnce(() => {
+        throw burnAddressError;
+      });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+
+      await expect(
+        getShape(
+          {
+            address: "burn_addr",
+            initialAccount: undefined,
+            currency,
+            derivationMode: "",
+          } as any,
+          { paginationConfig: {} as any },
+        ),
+      ).rejects.toThrow(burnAddressError);
+    });
+
+    test("a colliding framework-owned field from the family hook does not win", async () => {
+      // Give the framework a real, non-empty `operations` result so a family-contributed
+      // `operations: []` collision is actually observable (both would otherwise be `[]`).
+      listOperationsMock.mockResolvedValueOnce({
+        items: [{ hash: "opA", type: "OUT", tx: { failed: false } }],
+        next: undefined,
+      });
+      adaptCoreOperationToLiveOperationMock.mockImplementationOnce((_accId: string, op: any) => ({
+        hash: op.hash,
+        type: op.type,
+        blockHeight: 5,
+        extra: {},
+      }));
+      buildAccountShapeMock.mockResolvedValueOnce({
+        operations: [],
+        syncHash: "hijacked",
+        familyOwnedField: "kept",
+      });
+
+      const getShape = genericGetAccountShape(network, currency.id);
+      const result = await getShape(
+        { address: "addr3", initialAccount: undefined, currency, derivationMode: "" } as any,
+        { paginationConfig: {} as any },
+      );
+
+      expect(result.operations).not.toEqual([]);
+      expect((result as any).syncHash).toBe("sync-hash");
+      expect((result as any).familyOwnedField).toBe("kept");
     });
   });
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
@@ -111,8 +111,26 @@ describe("genericGetTransactionStatus", () => {
       familySpecificData,
     } as any);
 
-    // The draft is a field-by-field allowlist: a field missing from it vanishes with no type error.
     expect(buildIntentData).toHaveBeenCalledWith(expect.objectContaining({ familySpecificData }));
+  });
+
+  it("builds the intent data from the real transaction, not the draft", async () => {
+    const buildIntentData = jest.fn().mockReturnValue({ type: "none" });
+    mockGetBridgeApi.mockResolvedValue({ buildIntentData });
+    const getStatus = genericGetTransactionStatus("mainnet", "evm");
+
+    const transaction = {
+      amount: new BigNumber(100),
+      useAllAmount: false,
+      recipient: "0xRecipient",
+      family: "evm",
+      withdrawId: "unbonding-7",
+      nonce: new BigNumber(4),
+      sponsored: true,
+    } as any;
+    await getStatus(account, transaction);
+
+    expect(buildIntentData).toHaveBeenCalledWith(transaction);
   });
 
   it("leaves the intent's data to the coin module when the family declares no buildIntentData", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/getTransactionStatus.test.ts
@@ -1,10 +1,15 @@
 import BigNumber from "bignumber.js";
 import { genericGetTransactionStatus } from "../getTransactionStatus";
 import { getCoinModuleApi } from "../api";
+import { getBridgeApi } from "../bridge";
 import * as utils from "../utils";
 
 jest.mock("../api", () => ({
   getCoinModuleApi: jest.fn(),
+}));
+
+jest.mock("../bridge", () => ({
+  getBridgeApi: jest.fn(),
 }));
 
 jest.mock("../utils", () => ({
@@ -13,6 +18,7 @@ jest.mock("../utils", () => ({
 }));
 
 const mockExtractBalances = utils.extractBalances as jest.Mock;
+const mockGetBridgeApi = getBridgeApi as jest.Mock;
 
 describe("genericGetTransactionStatus", () => {
   const account = {
@@ -39,6 +45,7 @@ describe("genericGetTransactionStatus", () => {
     validateIntent.mockResolvedValue(validateIntentResult);
     mockExtractBalances.mockReturnValue({});
     (getCoinModuleApi as jest.Mock).mockReturnValue({ validateIntent });
+    mockGetBridgeApi.mockResolvedValue({});
   });
 
   it.each([
@@ -88,5 +95,38 @@ describe("genericGetTransactionStatus", () => {
       expect.anything(),
       expect.anything(),
     );
+  });
+
+  it("carries familySpecificData through the draft transaction to the family's buildIntentData", async () => {
+    const familySpecificData = { chosenOption: "OPTION_A", chosenList: [], chosenCount: 3 };
+    const buildIntentData = jest.fn().mockReturnValue({ type: "none" });
+    mockGetBridgeApi.mockResolvedValue({ buildIntentData });
+    const getStatus = genericGetTransactionStatus("mainnet", "evm");
+
+    await getStatus(account, {
+      amount: new BigNumber(100),
+      useAllAmount: false,
+      recipient: "0xRecipient",
+      family: "evm",
+      familySpecificData,
+    } as any);
+
+    // The draft is a field-by-field allowlist: a field missing from it vanishes with no type error.
+    expect(buildIntentData).toHaveBeenCalledWith(expect.objectContaining({ familySpecificData }));
+  });
+
+  it("leaves the intent's data to the coin module when the family declares no buildIntentData", async () => {
+    const craftTransactionData = jest.fn().mockReturnValue({ type: "none" });
+    (getCoinModuleApi as jest.Mock).mockReturnValue({ validateIntent, craftTransactionData });
+    const getStatus = genericGetTransactionStatus("mainnet", "evm");
+
+    await getStatus(account, {
+      amount: new BigNumber(100),
+      useAllAmount: false,
+      recipient: "0xRecipient",
+      family: "evm",
+    } as any);
+
+    expect(craftTransactionData).toHaveBeenCalled();
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -310,12 +310,56 @@ describe("genericPrepareTransaction", () => {
     const result = await prepareTransaction(account, { ...baseTransaction });
 
     // The whole bag rides through, including the keys `propagateField` recognises — the framework
-    // does not curate what a family's fee descriptor is allowed to read.
+    // does not curate what a family's fee descriptor is allowed to read. `bigint` values are
+    // normalised to decimal strings so the bag stays JSON-safe (see the serialization test below).
     expect((result as any).feeParameters).toEqual({
-      gasLimit: 21000n,
+      gasLimit: "21000",
       energyRequired: "1200",
       bandwidthRequired: "268",
     });
+  });
+
+  it("keeps the prepared transaction JSON-serializable when the estimation returns bigint fees", async () => {
+    // The regression that crashed EVM swaps (LIVE-35482): `estimation.parameters` holds native
+    // `bigint`, and storing it raw on `feeParameters` made `JSON.stringify(transaction)` throw
+    // "Do not know how to serialize a BigInt" the moment the swap flow serialised the transaction.
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: 700n,
+        parameters: {
+          gasLimit: 21000n,
+          maxFeePerGas: 30_000_000_000n,
+          gasOptions: { fast: { maxFeePerGas: 30n, maxPriorityFeePerGas: 5n } },
+        },
+      }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, { ...baseTransaction });
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+    expect((result as any).feeParameters).toEqual({
+      gasLimit: "21000",
+      maxFeePerGas: "30000000000",
+      gasOptions: { fast: { maxFeePerGas: "30", maxPriorityFeePerGas: "5" } },
+    });
+  });
+
+  it("still hits the early return when a bigint estimation stringifies to the stored feeParameters", async () => {
+    // The identity check compares a previously-stored (already string) `feeParameters` against a
+    // fresh estimation whose values are `bigint`. Normalising the fresh bag to strings first keeps
+    // the two comparable, so an unchanged breakdown does not churn referential equality.
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: BigInt(baseTransaction.fees.toFixed()),
+        parameters: { gasLimit: 21000n },
+      }),
+    });
+
+    const original = { ...baseTransaction, feeParameters: { gasLimit: "21000" } } as any;
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+
+    expect(await prepareTransaction(account, original)).toBe(original);
   });
 
   it("refreshes feeParameters when the fee value is unchanged but the breakdown is not", async () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/prepareTransaction.test.ts
@@ -71,6 +71,7 @@ describe("genericPrepareTransaction", () => {
       expect.objectContaining(baseTransaction),
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -295,6 +296,75 @@ describe("genericPrepareTransaction", () => {
         customGasLimit: new BigNumber(22000),
       }),
     );
+  });
+
+  it("carries fee parameters the framework does not model onto feeParameters", async () => {
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: 700n,
+        parameters: { gasLimit: 21000n, energyRequired: "1200", bandwidthRequired: "268" },
+      }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, { ...baseTransaction });
+
+    // The whole bag rides through, including the keys `propagateField` recognises — the framework
+    // does not curate what a family's fee descriptor is allowed to read.
+    expect((result as any).feeParameters).toEqual({
+      gasLimit: 21000n,
+      energyRequired: "1200",
+      bandwidthRequired: "268",
+    });
+  });
+
+  it("refreshes feeParameters when the fee value is unchanged but the breakdown is not", async () => {
+    // `fees`/`amount`/asset all match here, so this isolates the `feeParameters` term of the
+    // early-return identity check: the total can hold while the breakdown behind it moves.
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: BigInt(baseTransaction.fees.toFixed()),
+        parameters: { energyRequired: "2400" },
+      }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, {
+      ...baseTransaction,
+      feeParameters: { energyRequired: "1200" },
+    } as any);
+
+    expect((result as any).feeParameters).toEqual({ energyRequired: "2400" });
+  });
+
+  it("returns the original transaction when the breakdown is unchanged too", async () => {
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({
+        value: BigInt(baseTransaction.fees.toFixed()),
+        parameters: { energyRequired: "1200" },
+      }),
+    });
+
+    const original = { ...baseTransaction, feeParameters: { energyRequired: "1200" } } as any;
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+
+    // Identity, not equality: the early return exists so an unchanged estimation does not churn
+    // referential equality for consumers that memoise on it.
+    expect(await prepareTransaction(account, original)).toBe(original);
+  });
+
+  it("clears stale feeParameters when a re-estimation returns none", async () => {
+    (getCoinModuleApi as jest.Mock).mockReturnValue({
+      estimateFees: jest.fn().mockResolvedValue({ value: 900n }),
+    });
+
+    const prepareTransaction = genericPrepareTransaction("testnet", "local");
+    const result = await prepareTransaction(account, {
+      ...baseTransaction,
+      feeParameters: { energyRequired: "1200" },
+    } as any);
+
+    expect((result as any).feeParameters).toBeUndefined();
   });
 
   it("uses customFees.parameters.fees without calling estimateFees", async () => {
@@ -535,6 +605,7 @@ describe("genericPrepareTransaction", () => {
         assetOwner: "test-account-address",
         assetReference: "usdc",
       },
+      undefined,
       undefined,
       undefined,
     );

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -140,6 +140,55 @@ describe("genericSignOperation", () => {
     );
   });
 
+  it("keeps the account's derivationMode when the family declares one of its own", async () => {
+    const getDeviceSignOptions = jest.fn().mockReturnValue({ derivationMode: "tezosSecp256k1" });
+    (getBridgeApi as jest.Mock).mockResolvedValue({ getDeviceSignOptions });
+
+    const signOperation = genericSignOperation("mainnet", "tezos")(mockSignerContext);
+    const observable = signOperation({
+      account: { ...account, derivationMode: "tezosbip32-ed25519" },
+      transaction,
+      deviceId: "",
+    });
+
+    await lastValueFrom(observable.pipe(toArray()));
+
+    expect(mockSigner.signTransaction).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ derivationMode: "tezosbip32-ed25519" }),
+    );
+  });
+
+  it("crafts from the family's own intent data", async () => {
+    const buildIntentData = jest.fn().mockReturnValue({ type: "familyx" });
+    (getBridgeApi as jest.Mock).mockResolvedValue({ buildIntentData });
+
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+    await lastValueFrom(signOperation({ account, transaction, deviceId: "" }).pipe(toArray()));
+
+    expect(buildIntentData).toHaveBeenCalledWith(transaction);
+    expect(craftTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { type: "familyx" } }),
+      expect.anything(),
+    );
+  });
+
+  it("hands the family's optimistic-operation descriptor to buildOptimisticOperation", async () => {
+    const describeOptimisticOperation = jest.fn();
+    (getBridgeApi as jest.Mock).mockResolvedValue({ describeOptimisticOperation });
+
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+    await lastValueFrom(signOperation({ account, transaction, deviceId: "" }).pipe(toArray()));
+
+    expect(buildOptimisticOperation).toHaveBeenCalledWith(
+      account,
+      transaction,
+      expect.anything(),
+      describeOptimisticOperation,
+    );
+  });
+
   it("throws FeeNotLoaded if fees are missing", async () => {
     const txWithoutFees = { ...transaction };
     delete txWithoutFees.fees;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/tests/signOperation.test.ts
@@ -4,10 +4,15 @@ import { toArray } from "rxjs/operators";
 import { genericSignOperation } from "../signOperation";
 import { FeeNotLoaded } from "@ledgerhq/ledger-wallet-framework/errors";
 import { getCoinModuleApi } from "../api";
+import { getBridgeApi } from "../bridge";
 import { buildOptimisticOperation } from "../utils";
 
 jest.mock("../api", () => ({
   getCoinModuleApi: jest.fn(),
+}));
+
+jest.mock("../bridge", () => ({
+  getBridgeApi: jest.fn(),
 }));
 
 jest.mock("../utils", () => ({
@@ -48,6 +53,7 @@ describe("genericSignOperation", () => {
     });
 
     (buildOptimisticOperation as jest.Mock).mockReturnValue({ id: "mock-op" });
+    (getBridgeApi as jest.Mock).mockResolvedValue({});
 
     mockSigner.getAddress.mockResolvedValue({ publicKey: "pubKey" });
     mockSigner.signTransaction.mockResolvedValue("sig");
@@ -113,6 +119,24 @@ describe("genericSignOperation", () => {
     expect(craftTransaction).toHaveBeenCalledWith(
       expect.objectContaining({ amount: 100000n }),
       expect.anything(),
+    );
+  });
+
+  it("hands the device signer whatever the family declares", async () => {
+    const getDeviceSignOptions = jest
+      .fn()
+      .mockReturnValue({ familyOwnedSignOption: { id: "asset-1", ledgerSignature: "sig" } });
+    (getBridgeApi as jest.Mock).mockResolvedValue({ getDeviceSignOptions });
+
+    const signOperation = genericSignOperation("mainnet", "xrp")(mockSignerContext);
+    const observable = signOperation({ account, transaction, deviceId: "" });
+
+    await lastValueFrom(observable.pipe(toArray()));
+
+    expect(mockSigner.signTransaction).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({ familyOwnedSignOption: { id: "asset-1", ledgerSignature: "sig" } }),
     );
   });
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -9,6 +9,21 @@ import type { GetAddressFn } from "@ledgerhq/ledger-wallet-framework/bridge/getA
 import type { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import BigNumber from "bignumber.js";
 
+/**
+ * Values that are JSON-serializable. Used for the parts of a transaction that are persisted
+ * verbatim, so a `BigNumber`, `bigint` or class instance is rejected at the point it is written
+ * rather than silently corrupted on revival.
+ */
+type JsonSafe =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonSafe[]
+  | { [key: string]: JsonSafe | undefined };
+
+export type JsonSafeRecord = { [key: string]: JsonSafe | undefined };
+
 type NetworkInfo = {
   fees: BigNumber;
 };
@@ -89,6 +104,27 @@ export type GenericTransaction = TransactionCommon & {
   valId?: string;
   withdrawId?: string;
   dstValAddress?: string;
+  /**
+   * Chain-specific transaction fields with no generic equivalent; the owning family maps them onto
+   * the intent's `TxData` via `BridgeApi.buildIntentData` (ADR-047). `JsonSafe` is load-bearing: the
+   * bag round-trips through `GenericTransactionRaw` verbatim; a non-JSON value corrupts on revival.
+   *
+   * Holds user inputs only. Chain-computed values travel in `feeParameters`, so nothing here has to
+   * be merged or invalidated between fee estimations.
+   */
+  familySpecificData?: JsonSafeRecord;
+  /**
+   * Fee telemetry the coin module returned in `FeeEstimation.parameters`; per ADR-050 extra fee
+   * data travels on the fee-estimation channel, not as bespoke transaction-status fields.
+   *
+   * Derived, so absent from `GenericTransactionRaw` — reviving it is how a stale figure survives
+   * a restore. `prepareTransaction` treats it as part of the transaction's identity, so it is
+   * recomputed even when the fee value has not moved.
+   *
+   * Typed exactly as its source so no assertion can lie; values are commonly `bigint`, hence not
+   * `JsonSafeRecord`.
+   */
+  feeParameters?: Record<string, unknown>;
 };
 
 export type GenericTransactionRaw = TransactionCommonRaw & {
@@ -121,6 +157,10 @@ export type GenericTransactionRaw = TransactionCommonRaw & {
   valId?: string;
   withdrawId?: string;
   dstValAddress?: string;
+  /** @see GenericTransaction.familySpecificData — carried verbatim, hence the identical type. */
+  familySpecificData?: JsonSafeRecord;
+  // `feeParameters` is deliberately absent: derived from the last fee estimation, so persisting it
+  // is how a stale figure survives a restore; the next `prepareTransaction` recomputes it.
 };
 
 export interface OperationCommon extends Operation {
@@ -144,6 +184,18 @@ export type CoinFrameworkSigner<S = unknown> = {
 export type AccountRawAssignHooks = {
   assignFromAccountRaw?: AccountBridge<GenericTransaction>["assignFromAccountRaw"];
   assignToAccountRaw?: AccountBridge<GenericTransaction>["assignToAccountRaw"];
+  /**
+   * Revive/serialize the family-owned part of `Operation.extra` (forwarded through
+   * `Operation.details.familyExtra`). Without these the bag is persisted verbatim, so a non-JSON
+   * value corrupts on revival. `AccountBridge` members on a different call path from the `assign*`
+   * pair — `fromSignedOperationRaw` has no account in hand.
+   *
+   * The serialization layer calls these with the **whole** `Operation.extra` — the family's keys
+   * merged with the framework's — and replaces `extra` wholesale with what is returned, so an
+   * implementation that maps only its own keys silently drops every framework-owned key.
+   */
+  fromOperationExtraRaw?: AccountBridge<GenericTransaction>["fromOperationExtraRaw"];
+  toOperationExtraRaw?: AccountBridge<GenericTransaction>["toOperationExtraRaw"];
 };
 
 export type SignTransactionOptions = {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -13,6 +13,9 @@ import BigNumber from "bignumber.js";
  * Values that are JSON-serializable. Used for the parts of a transaction that are persisted
  * verbatim, so a `BigNumber`, `bigint` or class instance is rejected at the point it is written
  * rather than silently corrupted on revival.
+ *
+ * `undefined` is permitted so that an optional field typechecks; a round trip drops it, so an absent
+ * key and an `undefined` value have to mean the same thing to every consumer.
  */
 type JsonSafe =
   | string
@@ -107,7 +110,12 @@ export type GenericTransaction = TransactionCommon & {
   /**
    * Chain-specific transaction fields with no generic equivalent; the owning family maps them onto
    * the intent's `TxData` via `BridgeApi.buildIntentData` (ADR-047). `JsonSafe` is load-bearing: the
-   * bag round-trips through `GenericTransactionRaw` verbatim; a non-JSON value corrupts on revival.
+   * bag is written to `GenericTransactionRaw` verbatim, so a non-JSON value corrupts on revival.
+   *
+   * Only the write half is generic. There is no generic raw-to-transaction converter — each family's
+   * own `fromTransactionRaw` enumerates the fields it revives (`families/evm/transaction.ts`) — so a
+   * family adopting this bag has to revive it there, or a flow rebuilding from
+   * `Operation.transactionRaw` crafts a different intent than the one that was signed.
    *
    * Holds user inputs only. Chain-computed values travel in `feeParameters`, so nothing here has to
    * be merged or invalidated between fee estimations.
@@ -191,8 +199,15 @@ export type AccountRawAssignHooks = {
    * pair — `fromSignedOperationRaw` has no account in hand.
    *
    * The serialization layer calls these with the **whole** `Operation.extra` — the family's keys
-   * merged with the framework's — and replaces `extra` wholesale with what is returned, so an
-   * implementation that maps only its own keys silently drops every framework-owned key.
+   * merged with the framework's — and replaces `extra` wholesale with what is returned. Mapping only
+   * the family's own keys is safe regardless: `accountRawAssign.ts` converts the framework-owned keys
+   * itself and spreads this result over them, so a family cannot drop `ledgerOpType` or `stake`.
+   *
+   * The cost of that is no key can be dropped: the untouched input is the merge's base layer, so a
+   * key these hooks omit is persisted verbatim rather than filtered out. A legacy bridge's hooks of
+   * the same name replace instead of merge, so an allowlist ported from one (`coin-sui`'s
+   * `bridge/formatters.ts` omits a `BigNumber` on purpose) stops filtering here — map such a key to a
+   * JSON-safe form rather than relying on omission.
    */
   fromOperationExtraRaw?: AccountBridge<GenericTransaction>["fromOperationExtraRaw"];
   toOperationExtraRaw?: AccountBridge<GenericTransaction>["toOperationExtraRaw"];

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/types.ts
@@ -17,7 +17,7 @@ import BigNumber from "bignumber.js";
  * `undefined` is permitted so that an optional field typechecks; a round trip drops it, so an absent
  * key and an `undefined` value have to mean the same thing to every consumer.
  */
-type JsonSafe =
+export type JsonSafe =
   | string
   | number
   | boolean
@@ -129,10 +129,12 @@ export type GenericTransaction = TransactionCommon & {
    * a restore. `prepareTransaction` treats it as part of the transaction's identity, so it is
    * recomputed even when the fee value has not moved.
    *
-   * Typed exactly as its source so no assertion can lie; values are commonly `bigint`, hence not
-   * `JsonSafeRecord`.
+   * `JsonSafeRecord`, not the raw estimation shape: this bag rides on the live `GenericTransaction`,
+   * which the swap flow serialises with `JSON.stringify` — and that throws on a `bigint`. So
+   * `prepareTransaction` normalises the estimation's `bigint` values to decimal strings before
+   * storing them here (see `feeParametersToJsonSafe`).
    */
-  feeParameters?: Record<string, unknown>;
+  feeParameters?: JsonSafeRecord;
 };
 
 export type GenericTransactionRaw = TransactionCommonRaw & {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -15,7 +15,12 @@ import { addPendingOperation } from "@ledgerhq/ledger-wallet-framework/account/i
 import BigNumber from "bignumber.js";
 import type { Operation as CoreOperation } from "@ledgerhq/coin-module-framework/api/types";
 import { Account, Operation } from "@ledgerhq/types-live";
-import { GenericTransaction, GenericTransactionMode, OperationCommon } from "./types";
+import {
+  GenericTransaction,
+  GenericTransactionMode,
+  GenericTransactionRaw,
+  OperationCommon,
+} from "./types";
 import * as craftTransactionDataModule from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
 
 jest.mock("@ledgerhq/coin-module-framework/logic/craftTransactionData", () => {
@@ -461,6 +466,73 @@ describe("coin-framework utils", () => {
 
       expect(operation.fee).toEqual(fees);
       expect(operation.value).toEqual(amount);
+    });
+
+    it("carries familySpecificData into transactionRaw so a pending operation survives restore", () => {
+      const familySpecificData = { chosenOption: "OPTION_A", chosenList: ["a", "b"] };
+      const operation = buildOptimisticOperation(
+        {
+          id: "parent-account-id",
+          freshAddress: "account-address",
+        } as Account,
+        {
+          family: "familyx",
+          amount: new BigNumber(100),
+          recipient: "TRecipient",
+          familySpecificData,
+        } as GenericTransaction,
+        3n,
+      );
+
+      expect(
+        (operation.transactionRaw as GenericTransactionRaw | undefined)?.familySpecificData,
+      ).toEqual(familySpecificData);
+    });
+
+    it("takes a described type and value from the family", () => {
+      const describeOptimisticOperation = jest.fn().mockReturnValue({
+        type: "FREEZE" as const,
+        value: new BigNumber(0),
+      });
+      const operation = buildOptimisticOperation(
+        {
+          id: "parent-account-id",
+          freshAddress: "account-address",
+        } as Account,
+        {
+          family: "familyx",
+          amount: new BigNumber(100),
+          recipient: "TRecipient",
+          mode: "stake",
+        } as GenericTransaction,
+        3n,
+        describeOptimisticOperation,
+      );
+
+      expect(operation.type).toBe("FREEZE");
+      expect(operation.value).toEqual(new BigNumber(0));
+      expect((operation.extra as Record<string, unknown>).ledgerOpType).toBe("FREEZE");
+    });
+
+    it("keeps generic behaviour when the family does not own the mode", () => {
+      const describeOptimisticOperation = jest.fn().mockReturnValue(undefined);
+      const operation = buildOptimisticOperation(
+        {
+          id: "parent-account-id",
+          freshAddress: "account-address",
+        } as Account,
+        {
+          family: "familyx",
+          amount: new BigNumber(100),
+          recipient: "TRecipient",
+          mode: "stake",
+        } as GenericTransaction,
+        3n,
+        describeOptimisticOperation,
+      );
+
+      expect(operation.type).toBe("STAKE");
+      expect(operation.value).toEqual(new BigNumber(100));
     });
   });
 
@@ -1401,6 +1473,46 @@ describe("coin-framework utils", () => {
     it("handles a large pending sequence without throwing (fixed-point, not exponential)", () => {
       // BigNumber(1e21).toString() is "1e+21", which BigInt() cannot parse; .toFixed() must be used.
       expect(nextSequenceWithPending([pendingOp(1e21)], 5n)).toBe(1000000000000000000001n);
+    });
+  });
+
+  describe("adaptCoreOperationToLiveOperation family extras", () => {
+    // Kept as a precise `CoreOperation` cast rather than `as any`.
+    const coreOperation: CoreOperation = {
+      id: "op1",
+      asset: { type: "native" },
+      type: "FREEZE",
+      value: BigInt(100),
+      senders: ["TSender"],
+      recipients: ["TRecipient"],
+      tx: {
+        hash: "hash1",
+        fees: BigInt(1),
+        block: {
+          hash: "blockhash1",
+          height: 1,
+          time: new Date("2026-01-01"),
+        },
+        date: new Date("2026-01-01"),
+        failed: false,
+      },
+      details: { ledgerOpType: "FREEZE", familyExtra: { frozenAmount: "42", votes: [] } },
+    };
+
+    it("forwards the family's own extras bag onto the operation", () => {
+      const operation = adaptCoreOperationToLiveOperation("accountId", coreOperation);
+
+      expect((operation.extra as Record<string, unknown>).frozenAmount).toBe("42");
+      expect((operation.extra as Record<string, unknown>).votes).toEqual([]);
+    });
+
+    it("never lets the family shadow a framework-owned extra", () => {
+      const operation = adaptCoreOperationToLiveOperation("accountId", {
+        ...coreOperation,
+        details: { ledgerOpType: "FREEZE", familyExtra: { ledgerOpType: "HIJACKED" } },
+      });
+
+      expect((operation.extra as Record<string, unknown>).ledgerOpType).toBe("FREEZE");
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -1577,6 +1577,56 @@ describe("coin-framework utils", () => {
 
       expect((operation.extra as Record<string, unknown>).familyExtra).toBeUndefined();
     });
+
+    it("normalises bigint/BigNumber inside familyExtra so the persisted operation stays JSON-safe", () => {
+      const operation = adaptCoreOperationToLiveOperation("accountId", {
+        ...coreOperation,
+        details: {
+          ledgerOpType: "FREEZE",
+          familyExtra: {
+            frozenAmount: 42n,
+            reward: new BigNumber(1000),
+            huge: new BigNumber("1e21"),
+            votes: ["v1"],
+          },
+        },
+      } as CoreOperation);
+
+      expect(() => JSON.stringify(operation)).not.toThrow();
+      expect((operation.extra as Record<string, unknown>).familyExtra).toEqual({
+        frozenAmount: "42",
+        reward: "1000",
+        huge: "1000000000000000000000",
+        votes: ["v1"],
+      });
+    });
+
+    it("normalises familyExtra exactly as a JSON round-trip would", () => {
+      const operation = adaptCoreOperationToLiveOperation("accountId", {
+        ...coreOperation,
+        details: {
+          ledgerOpType: "FREEZE",
+          familyExtra: {
+            claimedAt: new Date("2026-01-01T00:00:00.000Z"), // toJSON -> ISO string
+            keep: "x",
+            ok: true,
+            fn: () => {}, // dropped
+            sym: Symbol("s"), // dropped
+            bad: NaN, // -> null
+            gone: undefined, // dropped
+            seq: [1, undefined, NaN, "x"], // holes -> null, length preserved
+          },
+        },
+      } as CoreOperation);
+
+      expect((operation.extra as Record<string, unknown>).familyExtra).toEqual({
+        claimedAt: "2026-01-01T00:00:00.000Z",
+        keep: "x",
+        ok: true,
+        bad: null,
+        seq: [1, null, null, "x"],
+      });
+    });
   });
 
   describe("framework extra serialization", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.test.ts
@@ -7,6 +7,9 @@ import {
   extractBalance,
   extractBalances,
   findCryptoCurrencyByNetwork,
+  frameworkExtraFromRaw,
+  frameworkExtraToRaw,
+  mergeExtra,
   nextSequenceWithPending,
   toGasOptionsFromUnknown,
   transactionToIntent,
@@ -489,6 +492,28 @@ describe("coin-framework utils", () => {
       ).toEqual(familySpecificData);
     });
 
+    it("omits feeParameters from transactionRaw (derived, recomputed on restore)", () => {
+      const operation = buildOptimisticOperation(
+        {
+          id: "parent-account-id",
+          freshAddress: "account-address",
+        } as Account,
+        {
+          family: "familyx",
+          amount: new BigNumber(100),
+          recipient: "TRecipient",
+          feeParameters: { energyRequired: "1200" },
+        } as unknown as GenericTransaction,
+        3n,
+      );
+
+      const raw = operation.transactionRaw as
+        | (GenericTransactionRaw & { feeParameters?: unknown })
+        | undefined;
+      expect(raw?.feeParameters).toBeUndefined();
+      expect(raw && "feeParameters" in raw).toBe(false);
+    });
+
     it("takes a described type and value from the family", () => {
       const describeOptimisticOperation = jest.fn().mockReturnValue({
         type: "FREEZE" as const,
@@ -730,6 +755,26 @@ describe("coin-framework utils", () => {
 
         expect(craftTransactionDataMock).not.toHaveBeenCalled();
         expect(defaultCraftTransactionDataSpy).not.toHaveBeenCalled();
+      });
+
+      it("prefers transaction.data over a family buildIntentData too", () => {
+        const buildIntentData = jest.fn();
+        const craftTransactionDataMock = jest.fn();
+        const expectedData = Buffer.from("deadbeef", "hex");
+
+        const intent = transactionToIntent(
+          {
+            currency: { name: "ethereum", units: ["wei"] },
+          } as unknown as Account,
+          { data: expectedData } as unknown as GenericTransaction,
+          undefined,
+          craftTransactionDataMock,
+          buildIntentData,
+        );
+
+        expect(intent).toMatchObject({ data: { type: "buffer", value: expectedData } });
+        expect(buildIntentData).not.toHaveBeenCalled();
+        expect(craftTransactionDataMock).not.toHaveBeenCalled();
       });
     });
 
@@ -1502,17 +1547,101 @@ describe("coin-framework utils", () => {
     it("forwards the family's own extras bag onto the operation", () => {
       const operation = adaptCoreOperationToLiveOperation("accountId", coreOperation);
 
-      expect((operation.extra as Record<string, unknown>).frozenAmount).toBe("42");
-      expect((operation.extra as Record<string, unknown>).votes).toEqual([]);
+      expect((operation.extra as Record<string, unknown>).familyExtra).toEqual({
+        frozenAmount: "42",
+        votes: [],
+      });
     });
 
     it("never lets the family shadow a framework-owned extra", () => {
+      // Including `pagingToken`, which the framework only reads and never writes here.
       const operation = adaptCoreOperationToLiveOperation("accountId", {
         ...coreOperation,
-        details: { ledgerOpType: "FREEZE", familyExtra: { ledgerOpType: "HIJACKED" } },
+        details: {
+          ledgerOpType: "FREEZE",
+          familyExtra: { ledgerOpType: "HIJACKED", internal: true, pagingToken: "hijacked" },
+        },
+      });
+      const extra = operation.extra as Record<string, unknown>;
+
+      expect(extra.ledgerOpType).toBe("FREEZE");
+      expect(extra.internal).toBeUndefined();
+      expect(extra.pagingToken).toBeUndefined();
+    });
+
+    it("omits familyExtra entirely when the coin module sends none", () => {
+      const operation = adaptCoreOperationToLiveOperation("accountId", {
+        ...coreOperation,
+        details: { ledgerOpType: "FREEZE" },
       });
 
-      expect((operation.extra as Record<string, unknown>).ledgerOpType).toBe("FREEZE");
+      expect((operation.extra as Record<string, unknown>).familyExtra).toBeUndefined();
+    });
+  });
+
+  describe("framework extra serialization", () => {
+    describe("frameworkExtraToRaw", () => {
+      it("returns only the converted stake, never the rest of the bag", () => {
+        const converted = frameworkExtraToRaw({
+          ledgerOpType: "FREEZE",
+          stake: { address: "validator", amount: new BigNumber(2_500) },
+        }) as Record<string, unknown>;
+
+        expect(converted).toEqual({ stake: { address: "validator", amount: "2500" } });
+      });
+
+      it("returns undefined when there is nothing of its own to convert", () => {
+        expect(frameworkExtraToRaw({ ledgerOpType: "FREEZE" })).toBeUndefined();
+        expect(frameworkExtraToRaw(undefined)).toBeUndefined();
+        expect(frameworkExtraToRaw("not-a-bag")).toBeUndefined();
+      });
+
+      it("leaves a stake.amount it did not write alone rather than coercing it", () => {
+        expect(frameworkExtraToRaw({ stake: { address: "v", amount: 2500 } })).toBeUndefined();
+        expect(frameworkExtraToRaw({ stake: { address: "v", amount: "2500" } })).toBeUndefined();
+      });
+    });
+
+    describe("frameworkExtraFromRaw", () => {
+      it("revives the stake amount as a BigNumber", () => {
+        const revived = frameworkExtraFromRaw({
+          stake: { address: "validator", amount: "2500" },
+        }) as Record<string, any>;
+
+        expect(revived).toEqual({
+          stake: { address: "validator", amount: new BigNumber(2_500) },
+        });
+      });
+
+      it("returns undefined for an amount that is not a persisted string", () => {
+        expect(frameworkExtraFromRaw({ stake: { address: "v", amount: 2500 } })).toBeUndefined();
+        expect(frameworkExtraFromRaw({ ledgerOpType: "FREEZE" })).toBeUndefined();
+        expect(frameworkExtraFromRaw(undefined)).toBeUndefined();
+      });
+    });
+
+    describe("mergeExtra", () => {
+      it("layers passthrough, then the family, then the framework's own keys", () => {
+        expect(
+          mergeExtra({ memo: "kept", frozen: 1, stake: "raw" }, { frozen: 2 }, { stake: "owned" }),
+        ).toEqual({ memo: "kept", frozen: 2, stake: "owned" });
+      });
+
+      it("keeps the passthrough when the family maps nothing", () => {
+        expect(mergeExtra({ memo: "kept" }, undefined, undefined)).toEqual({ memo: "kept" });
+      });
+
+      it("falls back to the family's result when the passthrough is not a bag", () => {
+        expect(mergeExtra(undefined, { frozen: 1 }, undefined)).toEqual({ frozen: 1 });
+        expect(mergeExtra(undefined, undefined, undefined)).toBeUndefined();
+      });
+
+      it("creates own properties, so a __proto__ key cannot reach the prototype", () => {
+        const merged = mergeExtra({}, JSON.parse('{"__proto__":{"polluted":true}}'), undefined);
+
+        expect(Object.getPrototypeOf(merged)).toBe(Object.prototype);
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      });
     });
   });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -3,7 +3,13 @@ import {
   OPERATION_TYPE_OUT_FAMILY,
   OPERATION_TYPE_STAKE_FAMILY,
 } from "@ledgerhq/ledger-wallet-framework/operation";
-import type { Account, Operation, OperationType } from "@ledgerhq/types-live";
+import type {
+  Account,
+  Operation,
+  OperationExtra,
+  OperationExtraRaw,
+  OperationType,
+} from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { fromBigNumberToBigInt } from "@ledgerhq/coin-module-framework/utils";
 import type {
@@ -341,11 +347,58 @@ export function cleanedOperation(operation: OperationCommon): OperationCommon {
  */
 const FAMILY_EXTRA_DETAILS_KEY = "familyExtra";
 
-function readFamilyExtra(details: CoreOperation["details"]): Record<string, unknown> {
-  const familyExtra = details?.[FAMILY_EXTRA_DETAILS_KEY];
-  return familyExtra && typeof familyExtra === "object" && !Array.isArray(familyExtra)
-    ? (familyExtra as Record<string, unknown>)
-    : {};
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readFamilyExtra(details: CoreOperation["details"]): Record<string, unknown> | undefined {
+  return asRecord(details?.[FAMILY_EXTRA_DETAILS_KEY]);
+}
+
+/**
+ * Every framework-owned `extra` key is a JSON-safe string, string array or boolean except
+ * `stake.amount`, a `BigNumber`. These two return **only** that converted key, never the whole bag:
+ * `mergeExtra` applies them last, so the framework can serialize its own half
+ * (`accountRawAssign.ts`) without a family hook that spreads the input being able to put the
+ * unconverted value back.
+ *
+ * A `stake.amount` that is not the expected type is left alone rather than coerced: it belongs to a
+ * shape this layer did not write, and `new BigNumber()` on it would store a NaN over real data.
+ */
+export function frameworkExtraToRaw(extra: OperationExtra): Record<string, unknown> | undefined {
+  const stake = asRecord(asRecord(extra)?.stake);
+  if (!stake || !BigNumber.isBigNumber(stake.amount)) return undefined;
+  return { stake: { ...stake, amount: stake.amount.toFixed() } };
+}
+
+export function frameworkExtraFromRaw(
+  extraRaw: OperationExtraRaw,
+): Record<string, unknown> | undefined {
+  const stake = asRecord(asRecord(extraRaw)?.stake);
+  if (!stake || typeof stake.amount !== "string") return undefined;
+  return { stake: { ...stake, amount: new BigNumber(stake.amount) } };
+}
+
+/**
+ * Precedence is per key, not per bag. `passthrough` (the untouched input) carries every key neither
+ * side maps, so a family mapping only its own keys cannot drop `ledgerOpType` or `memo`;
+ * `frameworkOwned` is applied last, so a hook written as `extra => ({ ...extra, ...ownKeys })`
+ * cannot carry an unconverted `stake` back over the framework's conversion.
+ *
+ * A family hook returning nothing usable leaves the passthrough plus the framework's own keys, rather
+ * than handing the serialization layer `undefined` and dropping the whole bag.
+ */
+export function mergeExtra(
+  passthrough: unknown,
+  familyPart: unknown,
+  frameworkOwned: Record<string, unknown> | undefined,
+): unknown {
+  const base = asRecord(passthrough);
+  const family = asRecord(familyPart);
+  if (!base) return family ? { ...family, ...frameworkOwned } : passthrough;
+  return { ...base, ...family, ...frameworkOwned };
 }
 
 export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOperation): Operation {
@@ -364,6 +417,7 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
     internal?: boolean;
     feePayer?: string;
     stake?: { address: string; amount: BigNumber };
+    familyExtra?: Record<string, unknown>;
   } = {};
 
   if (op.details?.ledgerOpType !== undefined) {
@@ -407,6 +461,16 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
     extra.feePayer = op.tx.feesPayer;
   }
 
+  // Nested under one key the family owns rather than flattened beside the framework's. Every key
+  // above is written *conditionally*, and `pagingToken` is read but never written here, so a
+  // flattened bag would supply the framework's own answer on any operation where the framework
+  // wrote neither: a `familyExtra.internal` reroutes a plain transfer into the internal-operations
+  // bucket, a `familyExtra.pagingToken` becomes the next sync's cursor.
+  const familyExtra = readFamilyExtra(op.details);
+  if (familyExtra) {
+    extra.familyExtra = familyExtra;
+  }
+
   if (op.details?.stake && typeof op.details.stake === "object") {
     const s = op.details.stake as { address?: string; amount?: bigint };
     extra.stake = {
@@ -446,8 +510,7 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
       ? new BigNumber(op.details?.sequence.toString())
       : undefined,
     hasFailed,
-    // Family-owned keys first so a framework-owned key can never be shadowed by a coin module.
-    extra: { ...readFamilyExtra(op.details), ...extra },
+    extra,
   };
 
   return res;

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -28,6 +28,7 @@ import type {
   OperationCommon,
 } from "./types";
 import { craftTransactionData as defaultCraftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
+import type { BridgeApi } from "@ledgerhq/ledger-wallet-framework/api/types";
 
 type BigNumberToBigIntDeep<T> = T extends BigNumber
   ? bigint
@@ -333,6 +334,20 @@ export function cleanedOperation(operation: OperationCommon): OperationCommon {
   return { ...operation, extra: cleanedExtra };
 }
 
+/**
+ * The one `details` key a coin module owns outright; its contents are never inspected here. Only this
+ * reserved key is forwarded, never every unrecognised `details` key: `Operation.extra` is persisted,
+ * so a blanket forward would let a non-JSON value reach storage.
+ */
+const FAMILY_EXTRA_DETAILS_KEY = "familyExtra";
+
+function readFamilyExtra(details: CoreOperation["details"]): Record<string, unknown> {
+  const familyExtra = details?.[FAMILY_EXTRA_DETAILS_KEY];
+  return familyExtra && typeof familyExtra === "object" && !Array.isArray(familyExtra)
+    ? (familyExtra as Record<string, unknown>)
+    : {};
+}
+
 export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOperation): Operation {
   const opType = op.type as OperationType;
 
@@ -431,7 +446,8 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
       ? new BigNumber(op.details?.sequence.toString())
       : undefined,
     hasFailed,
-    extra,
+    // Family-owned keys first so a framework-owned key can never be shadowed by a coin module.
+    extra: { ...readFamilyExtra(op.details), ...extra },
   };
 
   return res;
@@ -494,6 +510,7 @@ export function transactionToIntent(
   transaction: GenericTransaction,
   computeIntentType?: (transaction: GenericTransaction) => string,
   craftTransactionData?: (intent: TransactionIntent) => TxData,
+  buildIntentData?: BridgeApi["buildIntentData"],
 ): GenericCoinFrameworkTransactionIntent {
   const intentType = (computeIntentType ?? defaultComputeIntentType)(transaction);
   const isStaking = ["stake", "unstake", "finalize_unstake"].includes(intentType);
@@ -544,15 +561,28 @@ export function transactionToIntent(
     res.memo = { type: "NO_MEMO" };
   }
 
-  if (!transaction.data || transaction.data.length === 0) {
-    const resolvedCraftTransactionData = craftTransactionData ?? defaultCraftTransactionData;
-    res.data = resolvedCraftTransactionData(res);
-  } else {
-    // We assume that if the transaction data is a buffer, the intent expect a buffer too
-    res.data = { type: "buffer", value: transaction.data };
-  }
+  res.data = resolveIntentData(transaction, res, craftTransactionData, buildIntentData);
 
   return res;
+}
+
+/**
+ * A transaction that already carries data wins over both crafting paths, since a buffer is already
+ * the crafted form. Otherwise the family's hook takes precedence over the coin module's crafting.
+ */
+function resolveIntentData(
+  transaction: GenericTransaction,
+  intent: GenericCoinFrameworkTransactionIntent,
+  craftTransactionData?: (intent: TransactionIntent) => TxData,
+  buildIntentData?: BridgeApi["buildIntentData"],
+): GenericCoinFrameworkTxData {
+  if (transaction.data && transaction.data.length > 0) {
+    return { type: "buffer", value: transaction.data };
+  }
+  if (buildIntentData) {
+    return buildIntentData(transaction);
+  }
+  return (craftTransactionData ?? defaultCraftTransactionData)(intent);
 }
 
 function toFeeDataRaw(data: FeeData): FeeDataRaw {
@@ -669,48 +699,48 @@ function toGenericTransactionRaw(transaction: GenericTransaction): GenericTransa
     raw.dstValAddress = transaction.dstValAddress;
   }
 
+  if ("familySpecificData" in transaction) {
+    raw.familySpecificData = transaction.familySpecificData;
+  }
+
   return raw;
+}
+
+function defaultOperationType(mode: GenericTransaction["mode"]): OperationType {
+  switch (mode) {
+    case "changeTrust":
+      return "OPT_IN";
+    case "delegate":
+      return "DELEGATE";
+    case "redelegate":
+      return "REDELEGATE";
+    case "undelegate":
+      return "UNDELEGATE";
+    case "withdraw":
+      return "WITHDRAW_UNBONDED";
+    case "stake":
+      return "STAKE";
+    case "unstake":
+      return "UNSTAKE";
+    case "finalize_unstake":
+      return "FINALIZE_UNSTAKE";
+    case "claimReward":
+    case "compoundReward":
+      return "REWARD";
+    default:
+      return "OUT";
+  }
 }
 
 export const buildOptimisticOperation = (
   account: Account,
   transaction: GenericTransaction,
   sequenceNumber?: bigint,
+  describeOptimisticOperation?: BridgeApi["describeOptimisticOperation"],
 ): Operation => {
-  let type: OperationType;
-  switch (transaction.mode) {
-    case "changeTrust":
-      type = "OPT_IN";
-      break;
-    case "delegate":
-      type = "DELEGATE";
-      break;
-    case "redelegate":
-      type = "REDELEGATE";
-      break;
-    case "undelegate":
-      type = "UNDELEGATE";
-      break;
-    case "withdraw":
-      type = "WITHDRAW_UNBONDED";
-      break;
-    case "stake":
-      type = "STAKE";
-      break;
-    case "unstake":
-      type = "UNSTAKE";
-      break;
-    case "finalize_unstake":
-      type = "FINALIZE_UNSTAKE";
-      break;
-    case "claimReward":
-    case "compoundReward":
-      type = "REWARD";
-      break;
-    default:
-      type = "OUT";
-      break;
-  }
+  const { mode } = transaction;
+  const described = mode !== undefined ? describeOptimisticOperation?.(mode, account) : undefined;
+  const type: OperationType = described?.type ?? defaultOperationType(mode);
   // toFixed, not toString: BigNumber goes exponential above 1e21, which BigInt can't parse.
   const fees = transaction.fees ? BigInt(transaction.fees.toFixed()) : 0n;
   const { subAccountId } = transaction;
@@ -726,7 +756,9 @@ export const buildOptimisticOperation = (
     id: encodeOperationId(account.id, "", parentType),
     hash: "",
     type: parentType,
-    value: subAccountId ? new BigNumber(fees.toString()) : transaction.amount, // match old behavior
+    value: subAccountId
+      ? new BigNumber(fees.toString()) // match old behavior
+      : (described?.value ?? transaction.amount),
     fee: new BigNumber(fees.toString()),
     blockHash: null,
     blockHeight: null,

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/utils.ts
@@ -31,6 +31,8 @@ import type {
   GasOptionsRaw,
   GenericTransaction,
   GenericTransactionRaw,
+  JsonSafe,
+  JsonSafeRecord,
   OperationCommon,
 } from "./types";
 import { craftTransactionData as defaultCraftTransactionData } from "@ledgerhq/coin-module-framework/logic/craftTransactionData";
@@ -57,6 +59,33 @@ export function bigNumberToBigIntDeep<T>(obj: T): BigNumberToBigIntDeep<T> {
     ) as BigNumberToBigIntDeep<T>;
 
   return obj as BigNumberToBigIntDeep<T>;
+}
+
+function toJsonSafe(value: unknown): JsonSafe | undefined {
+  const json = JSON.stringify(value, jsonSafeReplacer);
+  return json === undefined ? undefined : (JSON.parse(json) as JsonSafe);
+}
+
+function jsonSafeReplacer(this: Record<string, unknown>, key: string, value: unknown): unknown {
+  const raw = this[key];
+  if (typeof raw === "bigint") return raw.toString();
+  if (BigNumber.isBigNumber(raw)) return raw.toFixed();
+  if (typeof value === "bigint") return value.toString();
+  return value;
+}
+
+/**
+ * Normalises a fee-estimation parameter bag into a JSON-safe record for `GenericTransaction.feeParameters`.
+ * `bigint`/`BigNumber` values become decimal strings; everything else is carried through. The bag
+ * rides on the live transaction, which the swap flow serialises with `JSON.stringify` — storing the
+ * estimation's raw `bigint` values there crashed EVM swaps on mobile and stalled them on desktop
+ * (LIVE-35482). Returns `undefined` for a missing bag so callers keep clearing stale figures.
+ */
+export function feeParametersToJsonSafe(
+  parameters: Record<string, unknown> | undefined,
+): JsonSafeRecord | undefined {
+  if (!parameters) return undefined;
+  return toJsonSafe(parameters) as JsonSafeRecord;
 }
 
 function toFeeDataFromUnknown(value: unknown): FeeData {
@@ -353,8 +382,9 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
-function readFamilyExtra(details: CoreOperation["details"]): Record<string, unknown> | undefined {
-  return asRecord(details?.[FAMILY_EXTRA_DETAILS_KEY]);
+function readFamilyExtra(details: CoreOperation["details"]): JsonSafeRecord | undefined {
+  const raw = asRecord(details?.[FAMILY_EXTRA_DETAILS_KEY]);
+  return raw ? (toJsonSafe(raw) as JsonSafeRecord) : undefined;
 }
 
 /**
@@ -417,7 +447,7 @@ export function adaptCoreOperationToLiveOperation(accountId: string, op: CoreOpe
     internal?: boolean;
     feePayer?: string;
     stake?: { address: string; amount: BigNumber };
-    familyExtra?: Record<string, unknown>;
+    familyExtra?: JsonSafeRecord;
   } = {};
 
   if (op.details?.ledgerOpType !== undefined) {

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -1,10 +1,29 @@
-import type { AssetInfo, BalanceOptions } from "@ledgerhq/coin-module-framework/api/types";
+import type {
+  AccountInfo,
+  AssetInfo,
+  BalanceOptions,
+  TxData,
+} from "@ledgerhq/coin-module-framework/api/types";
 import type { CryptoCurrency, TokenCurrency } from "../types";
 import type {
+  Account,
   AccountReadiness,
   Operation as LiveOperation,
+  OperationType,
   StakingResources,
 } from "@ledgerhq/types-live";
+import type BigNumber from "bignumber.js";
+
+export type OptimisticOperationDescriptor = {
+  /** The operation type this mode produces. Absent defers to the generic mode mapping. */
+  type?: OperationType;
+  /**
+   * The native value the operation records. Absent keeps the transaction amount — pass
+   * `new BigNumber(0)` for a mode that only locks or releases the account's own funds, and the
+   * chain-computed figure for a payout the transaction carries no amount for.
+   */
+  value?: BigNumber;
+};
 
 export type ChainSpecificRules = {
   getAccountShape: (address: string) => void;
@@ -18,6 +37,54 @@ export type BridgeApi = {
   getTokenFromAsset?: (asset: AssetInfo) => Promise<TokenCurrency | undefined>;
   getAssetFromToken?: (token: TokenCurrency, owner: string) => AssetInfo;
   computeIntentType?: (transaction: Record<string, unknown>) => string;
+  /**
+   * Maps the family's own transaction fields onto the intent's `data` (the coin module's `TxData`);
+   * the generic layer never inspects the result. Absent leaves `data` to the coin module's own
+   * `craftTransactionData`; present, it replaces that call for every mode — plain sends included.
+   */
+  buildIntentData?: (transaction: Record<string, unknown>) => TxData;
+  /**
+   * Reinterprets a *generic* mode for one family, so the framework doesn't branch on it. `mode` is a
+   * `GENERIC_TRANSACTION_MODE` value — family-specific modes stay out of that union by design.
+   * Returning `undefined` keeps generic behaviour.
+   *
+   * Exists so the pending row's type matches the type the subsequent sync produces, rather than
+   * relabelling itself once the sync resolves the chain's real type.
+   */
+  describeOptimisticOperation?: (
+    mode: string,
+    account: Account,
+  ) => OptimisticOperationDescriptor | undefined;
+  /**
+   * Extra facts this family's device app needs alongside the unsigned payload — passed straight
+   * through as the third argument to `signer.signTransaction`, never interpreted by the framework.
+   *
+   * Unlike every other bag on this type, this one is spread *last* onto the framework's own device
+   * options, so a family can override `derivationMode` and `recipientDomain`. Deliberate: the family
+   * owns its own device app, and a wrong signing option fails loudly at the device rather than
+   * silently corrupting stored state.
+   */
+  getDeviceSignOptions?: (
+    transaction: Record<string, unknown>,
+    account: Account,
+  ) => Record<string, unknown> | undefined;
+  /**
+   * Family-owned account fields with no generic equivalent. The returned record is spread first into
+   * the account shape, so it cannot override the fields that shape sets explicitly. It *can* still
+   * land on a field nothing else assigns on that path — `stakingResources` and `stakingPositions` are
+   * only occupied when staking is enabled, and anything a later `postSync` fills is unprotected. The
+   * record is untyped by design, since the framework never inspects it.
+   *
+   * `accountInfo` is the coin module's own `getAccountInfo` output (ADR-045), `undefined` when the
+   * module does not implement it. This hook is the *mapper*: the framework performs the standard
+   * call, and the family decides which of its own account fields that metadata feeds, so nothing
+   * chain-shaped reaches the generic account. A family whose account fields need more than
+   * `getAccountInfo` exposes fetches the remainder here.
+   */
+  buildAccountShape?: (
+    address: string,
+    accountInfo?: AccountInfo,
+  ) => Promise<Record<string, unknown> | undefined> | Record<string, unknown> | undefined;
   refreshOperations?: (operations: LiveOperation[]) => Promise<LiveOperation[]>;
   validateTransaction?: (signature: string) => Promise<{ error: Error | undefined }>;
   /**

--- a/libs/ledger-wallet-framework/src/api/types.ts
+++ b/libs/ledger-wallet-framework/src/api/types.ts
@@ -25,6 +25,9 @@ export type OptimisticOperationDescriptor = {
   value?: BigNumber;
 };
 
+/** @see BridgeApi.buildAccountShape — anything but a field of `Account`. */
+export type FamilyAccountShape = Record<string, unknown> & Partial<Record<keyof Account, never>>;
+
 export type ChainSpecificRules = {
   getAccountShape: (address: string) => void;
   getTransactionStatus: {
@@ -50,6 +53,9 @@ export type BridgeApi = {
    *
    * Exists so the pending row's type matches the type the subsequent sync produces, rather than
    * relabelling itself once the sync resolves the chain's real type.
+   *
+   * Scoped to `signOperation`. `signRawOperation` builds its optimistic row from a pre-crafted blob
+   * that carries no mode, so there is nothing for this hook to reinterpret there.
    */
   describeOptimisticOperation?: (
     mode: string,
@@ -59,32 +65,41 @@ export type BridgeApi = {
    * Extra facts this family's device app needs alongside the unsigned payload — passed straight
    * through as the third argument to `signer.signTransaction`, never interpreted by the framework.
    *
-   * Unlike every other bag on this type, this one is spread *last* onto the framework's own device
-   * options, so a family can override `derivationMode` and `recipientDomain`. Deliberate: the family
-   * owns its own device app, and a wrong signing option fails loudly at the device rather than
-   * silently corrupting stored state.
+   * Spread over the framework's own device options, so a family can override `recipientDomain` — its
+   * device app is the authority on what that app needs. `derivationMode` is pinned after it though:
+   * tezos selects its signing curve from that option (`families/tezos/signer.ts`), and a device signs
+   * the wrong curve without complaining.
    */
   getDeviceSignOptions?: (
     transaction: Record<string, unknown>,
     account: Account,
   ) => Record<string, unknown> | undefined;
   /**
-   * Family-owned account fields with no generic equivalent. The returned record is spread first into
-   * the account shape, so it cannot override the fields that shape sets explicitly. It *can* still
-   * land on a field nothing else assigns on that path — `stakingResources` and `stakingPositions` are
-   * only occupied when staking is enabled, and anything a later `postSync` fills is unprotected. The
-   * record is untyped by design, since the framework never inspects it.
+   * Family-owned account fields with no generic equivalent — `stakingResources`, `stakingPositions`,
+   * whatever the family names — passed through without the framework inspecting them, hence the index
+   * signature. No field of `Account` may appear: pinning the ones the account shape sets is not
+   * enough, because `jsHelpers` merges `{ ...account, …derived, ...shape }` and re-pins only
+   * `operations` and `pendingOperations`, so a field the shape leaves unset — `freshAddress`,
+   * `currency`, `derivationMode` — would reach the persisted account straight from here. `keyof
+   * Account` rather than a list of names so a field added upstream is covered the day it lands;
+   * anything a later `postSync` fills is unprotected.
    *
    * `accountInfo` is the coin module's own `getAccountInfo` output (ADR-045), `undefined` when the
    * module does not implement it. This hook is the *mapper*: the framework performs the standard
    * call, and the family decides which of its own account fields that metadata feeds, so nothing
    * chain-shaped reaches the generic account. A family whose account fields need more than
    * `getAccountInfo` exposes fetches the remainder here.
+   *
+   * A rejection fails the sync, leaving the last good account in place for the next poll to retry —
+   * the framework cannot know whether these fields are load-bearing for the family. Return
+   * `undefined` (catching inside the hook) for a contribution the account is correct without. That
+   * only covers what this hook does itself: the `getAccountInfo` call feeding it is awaited first, so
+   * a rejection there fails the sync without ever reaching the hook.
    */
   buildAccountShape?: (
     address: string,
     accountInfo?: AccountInfo,
-  ) => Promise<Record<string, unknown> | undefined> | Record<string, unknown> | undefined;
+  ) => Promise<FamilyAccountShape | undefined> | FamilyAccountShape | undefined;
   refreshOperations?: (operations: LiveOperation[]) => Promise<LiveOperation[]>;
   validateTransaction?: (signature: string) => Promise<{ error: Error | undefined }>;
   /**


### PR DESCRIPTION
### 📝 Description

The generic coin framework has no way for a family to carry chain-specific transaction fields, which is what blocks TRON — and every family after it — from moving off a dedicated bridge. This adds that capability to the shared layer only; no family consumes it yet and the allowlist is untouched, so the five migrated families behave exactly as before.

Chain-specific fields travel in one designated slot rather than widening `GenericTransaction` per family. The alternative — forwarding every unrecognised transaction field — puts arbitrary values into a field that is persisted, so a non-JSON-safe value reaches storage.

Extra fee data travels on the fee-estimation channel, per [ADR-050](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7341375672/Coin+modules+-+ADR+050+-+FeeOption+abstraction). Putting it in dedicated transaction-status fields is that ADR's rejected option, and TRON is one of its two target chains, so this has to be right before Tronify builds on it.

Account sync can now get chain state from the family, asynchronously. This is temporary: [LIVE-32774](https://ledgerhq.atlassian.net/browse/LIVE-32774) replaces it with the framework's own `getAccountInfo`, and the hook retires with it.

One correctness fix rides along, outside the hooks: the optimistic operation formats its fee with `toFixed()` instead of `toString()`, because a large enough fee reaches `BigInt()` in exponential notation and throws.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35482](https://ledgerhq.atlassian.net/browse/LIVE-35482)
- **ADR** (if any): [ADR-047 ](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7289700580/Coin+modules+-+ADR-047+-+Aleo+transaction+intents+root+fee)(framework vs. local) · [ADR-050](https://ledgerhq.atlassian.net/wiki/spaces/CF/pages/7341375672/Coin+modules+-+ADR+050+-+FeeOption+abstraction) (fee options descriptor)
- **Consumer**: [LIVE-34994](https://ledgerhq.atlassian.net/browse/LIVE-34994) migrates coin-tron onto these hooks and flips the allowlist.

[LIVE-35482]: https://ledgerhq.atlassian.net/browse/LIVE-35482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-32774]: https://ledgerhq.atlassian.net/browse/LIVE-32774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ