### PR TITLE
feat(contacts): shared delete confirmation and EditAddress step

### DIFF
--- a/.changeset/contacts-address-edit-foundation.md
+++ b/.changeset/contacts-address-edit-foundation.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Extract shared delete confirmation dialog, signer UI state hook, and EditAddress rename step for contact addresses.

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -4,6 +4,8 @@ export * from "./steps/AddContact";
 export * from "./steps/AddContact/web";
 export * from "./steps/EditContact";
 export * from "./steps/EditContact/web";
+export * from "./steps/EditAddress";
+export * from "./steps/EditAddress/web";
 export * from "./steps/AddAddress";
 export * from "./steps/AddAddress/web";
 export * from "./steps/Introduction";

--- a/features/flow/contacts/src/steps/Detail/components/ContactsDeleteConfirmationDialog/ContactsDeleteConfirmationDialog.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsDeleteConfirmationDialog/ContactsDeleteConfirmationDialog.web.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { Trash } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ContactsDeleteConfirmationDialogProps } from "./types";
+
+export function ContactsDeleteConfirmationDialog({
+  isOpen,
+  isDeleting,
+  labels,
+  dialogTestId,
+  confirmTestId,
+  onConfirm,
+  onCancel,
+}: ContactsDeleteConfirmationDialogProps): React.ReactNode {
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onCancel();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="w-[400px] bg-canvas-sheet pb-24" data-testid={dialogTestId}>
+        <DialogHeader density="compact" onClose={onCancel} />
+        <DialogBody className="flex flex-col items-center gap-32 px-24 pb-24 text-center">
+          <div className="flex flex-col items-center gap-24">
+            <Spot appearance="icon" icon={Trash} size={56} />
+            <div className="flex flex-col gap-8">
+              <h2 className="heading-3-semi-bold text-base">{labels.title}</h2>
+              <p className="body-2 text-muted">{labels.description}</p>
+            </div>
+          </div>
+          <div className="flex w-full gap-16">
+            <Button appearance="gray" size="lg" isFull onClick={onCancel} disabled={isDeleting}>
+              {labels.cancel}
+            </Button>
+            <Button
+              appearance="red"
+              size="lg"
+              isFull
+              loading={isDeleting}
+              disabled={isDeleting}
+              onClick={() => void onConfirm()}
+              data-testid={confirmTestId}
+            >
+              {labels.confirm}
+            </Button>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactsDeleteConfirmationDialog/types.ts
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsDeleteConfirmationDialog/types.ts
@@ -1,0 +1,16 @@
+export type ContactsDeleteConfirmationDialogLabels = Readonly<{
+  title: string;
+  description: string;
+  confirm: string;
+  cancel: string;
+}>;
+
+export type ContactsDeleteConfirmationDialogProps = Readonly<{
+  isOpen: boolean;
+  isDeleting: boolean;
+  labels: ContactsDeleteConfirmationDialogLabels;
+  dialogTestId: string;
+  confirmTestId: string;
+  onConfirm: () => Promise<void>;
+  onCancel: () => void;
+}>;

--- a/features/flow/contacts/src/steps/Detail/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web.tsx
@@ -1,61 +1,15 @@
 import React from "react";
-import {
-  Button,
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogHeader,
-  Spot,
-} from "@ledgerhq/lumen-ui-react";
-import { Trash } from "@ledgerhq/lumen-ui-react/symbols";
+import { ContactsDeleteConfirmationDialog } from "../ContactsDeleteConfirmationDialog/ContactsDeleteConfirmationDialog.web";
 import type { ContactsDeleteContactDialogProps } from "./types";
 
-export function ContactsDeleteContactDialog({
-  isOpen,
-  isDeleting,
-  labels,
-  onConfirm,
-  onCancel,
-}: ContactsDeleteContactDialogProps): React.ReactNode {
-  const handleOpenChange = (open: boolean) => {
-    if (!open) {
-      onCancel();
-    }
-  };
-
+export function ContactsDeleteContactDialog(
+  props: ContactsDeleteContactDialogProps,
+): React.ReactNode {
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="w-[400px] bg-canvas-sheet pb-24"
-        data-testid="contacts-delete-contact-dialog"
-      >
-        <DialogHeader density="compact" onClose={onCancel} />
-        <DialogBody className="flex flex-col items-center gap-32 px-24 pb-24 text-center">
-          <div className="flex flex-col items-center gap-24">
-            <Spot appearance="icon" icon={Trash} size={56} />
-            <div className="flex flex-col gap-8">
-              <h2 className="heading-3-semi-bold text-base">{labels.title}</h2>
-              <p className="body-2 text-muted">{labels.description}</p>
-            </div>
-          </div>
-          <div className="flex w-full gap-16">
-            <Button appearance="gray" size="lg" isFull onClick={onCancel} disabled={isDeleting}>
-              {labels.cancel}
-            </Button>
-            <Button
-              appearance="red"
-              size="lg"
-              isFull
-              loading={isDeleting}
-              disabled={isDeleting}
-              onClick={() => void onConfirm()}
-              data-testid="contacts-delete-contact-confirm"
-            >
-              {labels.confirm}
-            </Button>
-          </div>
-        </DialogBody>
-      </DialogContent>
-    </Dialog>
+    <ContactsDeleteConfirmationDialog
+      {...props}
+      dialogTestId="contacts-delete-contact-dialog"
+      confirmTestId="contacts-delete-contact-confirm"
+    />
   );
 }

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -67,6 +67,8 @@ export type {
   ContactAddressDetailActionsPorts,
   ContactAddressDetailEditFlowPorts,
   ContactAddressDetailPort,
+  ContactAddressEditPort,
+  ContactAddressRenameInput,
   ContactDeletionPort,
   ContactDetailActionsPorts,
   ContactEditPort,

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -2,6 +2,7 @@ import type {
   Contact,
   ContactAddress,
   ContactAddressId,
+  ContactAddressLabel,
   ContactId,
   ContactInput,
 } from "@domain/entity-contact";
@@ -38,6 +39,16 @@ export type ContactAddressDeletionInput = Readonly<{
 
 export type ContactAddressDeletionPort = Readonly<{
   deleteAddress(input: ContactAddressDeletionInput): Promise<void>;
+}>;
+
+export type ContactAddressRenameInput = Readonly<{
+  contactId: ContactId;
+  addressId: ContactAddressId;
+  label: ContactAddressLabel;
+}>;
+
+export type ContactAddressEditPort = Readonly<{
+  renameAddressLabel(input: ContactAddressRenameInput): Promise<ContactAddress>;
 }>;
 
 export type ContactAddressDetailActionsPorts = Readonly<{

--- a/features/flow/contacts/src/steps/Detail/useContactDetailEditDeleteFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactDetailEditDeleteFlowViewModel.ts
@@ -2,12 +2,9 @@ import { selectContactById, type ContactId } from "@domain/entity-contact";
 import { useCallback, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import type { ContactDetailActionsPorts } from "./model/ports";
-import {
-  resolveEditUiStateOnPress,
-  resolveEditUiStateOnSignerCancel,
-  type SignerEditUiState,
-} from "./model/signerEditUiState";
 import { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
+import { useContactEditSignerUiState } from "./useContactEditSignerUiState";
+import type { SignerEditUiState } from "./model/signerEditUiState";
 
 export type ContactDetailEditUiState = SignerEditUiState;
 
@@ -52,7 +49,14 @@ export function useContactDetailEditDeleteFlowViewModel({
     deleteIntent,
     isSignerRequiredForEdit,
   } = useContactDetailActionsViewModel(contactId, ports);
-  const [editUiState, setEditUiState] = useState<ContactDetailEditUiState>("closed");
+  const {
+    editUiState,
+    openSignerDialog,
+    openEditDialog,
+    onSignerConfirm,
+    onSignerCancel,
+    onEditClose,
+  } = useContactEditSignerUiState();
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const canDelete = contact !== undefined && !contact.isMe;
@@ -60,27 +64,19 @@ export function useContactDetailEditDeleteFlowViewModel({
 
   const onEditPress = useCallback(() => {
     setIsActionsMenuOpen(false);
-    setEditUiState(resolveEditUiStateOnPress(isSignerRequiredForEdit));
-  }, [isSignerRequiredForEdit]);
+
+    if (isSignerRequiredForEdit) {
+      openSignerDialog();
+      return;
+    }
+
+    openEditDialog();
+  }, [isSignerRequiredForEdit, openEditDialog, openSignerDialog]);
 
   const onDeletePress = useCallback(() => {
     setIsActionsMenuOpen(false);
     openDelete();
   }, [openDelete]);
-
-  const onSignerConfirm = useCallback(() => {
-    setEditUiState("edit-open");
-  }, []);
-
-  const onSignerCancel = useCallback(() => {
-    // QueuedBottomSheet calls onClose when isRequestingToBeOpened becomes false — including
-    // after the user confirms and we transition to edit-open. Only cancel when still on signer.
-    setEditUiState(current => resolveEditUiStateOnSignerCancel(current));
-  }, []);
-
-  const onEditClose = useCallback(() => {
-    setEditUiState("closed");
-  }, []);
 
   const onOpenActionsMenu = useCallback(() => {
     setIsActionsMenuOpen(true);

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from "react";
+import type { SignerEditUiState } from "./model/signerEditUiState";
+
+export type UseContactEditSignerUiStateResult = Readonly<{
+  editUiState: SignerEditUiState;
+  openSignerDialog: () => void;
+  openEditDialog: () => void;
+  onSignerConfirm: () => void;
+  onSignerCancel: () => void;
+  onEditClose: () => void;
+  resetEditUiState: () => void;
+}>;
+
+export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult {
+  const [editUiState, setEditUiState] = useState<SignerEditUiState>("closed");
+
+  const openSignerDialog = useCallback(() => {
+    setEditUiState("signer-open");
+  }, []);
+
+  const openEditDialog = useCallback(() => {
+    setEditUiState("edit-open");
+  }, []);
+
+  const onSignerConfirm = useCallback(() => {
+    setEditUiState("edit-open");
+  }, []);
+
+  const onSignerCancel = useCallback(() => {
+    // QueuedBottomSheet calls onClose when isRequestingToBeOpened becomes false — including
+    // after the user confirms and we transition to edit-open. Only cancel when still on signer.
+    setEditUiState(current => (current === "signer-open" ? "closed" : current));
+  }, []);
+
+  const onEditClose = useCallback(() => {
+    setEditUiState("closed");
+  }, []);
+
+  const resetEditUiState = useCallback(() => {
+    setEditUiState("closed");
+  }, []);
+
+  return {
+    editUiState,
+    openSignerDialog,
+    openEditDialog,
+    onSignerConfirm,
+    onSignerCancel,
+    onEditClose,
+    resetEditUiState,
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { useContactEditSignerUiState } from "./useContactEditSignerUiState";
+
+describe("useContactEditSignerUiState", () => {
+  it("should open the signer dialog", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openSignerDialog();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+  });
+
+  it("should transition to edit-open after signer confirmation", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openSignerDialog();
+      result.current.onSignerConfirm();
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+  });
+
+  it("should keep edit-open when signer close fires after confirm", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openSignerDialog();
+      result.current.onSignerConfirm();
+      result.current.onSignerCancel();
+    });
+
+    expect(result.current.editUiState).toBe("edit-open");
+  });
+
+  it("should reset to closed when edit is closed or reset", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openEditDialog();
+      result.current.onEditClose();
+    });
+
+    expect(result.current.editUiState).toBe("closed");
+
+    act(() => {
+      result.current.openSignerDialog();
+      result.current.resetEditUiState();
+    });
+
+    expect(result.current.editUiState).toBe("closed");
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/web.ts
+++ b/features/flow/contacts/src/steps/Detail/web.ts
@@ -3,6 +3,8 @@ export { ContactAddressDetailDialog } from "./components/ContactAddressDetailDia
 export { ContactDetailActions } from "./components/ContactDetailActions/ContactDetailActions.web";
 export type { ContactDetailActionsProps } from "./components/ContactDetailActions/ContactDetailActions.web";
 export { ContactsDeleteContactDialog } from "./components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web";
+export { ContactsRenameAddressDialog } from "../EditAddress/ContactsRenameAddressDialog.web";
 export { ContactsEditSignerDialog } from "./components/ContactsEditSignerDialog/ContactsEditSignerDialog.web";
 export type { ContactsDeleteContactDialogProps } from "./components/ContactsDeleteContactDialog/types";
+export type { ContactsRenameAddressDialogProps } from "../EditAddress/types";
 export type { ContactsEditSignerDialogProps } from "./components/ContactsEditSignerDialog/types";

--- a/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  TextInput,
+} from "@ledgerhq/lumen-ui-react";
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import type { ContactsRenameAddressDialogProps } from "./types";
+
+export function ContactsRenameAddressDialog({
+  isOpen,
+  isConfirmEnabled,
+  isSaving,
+  draftLabel,
+  invalidLabelError,
+  labels,
+  onClose,
+  onDraftLabelChange,
+  onConfirm,
+}: ContactsRenameAddressDialogProps): React.ReactNode {
+  const labelValidationError =
+    invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="w-[400px] bg-canvas-sheet pb-24"
+        data-testid="contacts-rename-address-dialog"
+      >
+        <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
+        <DialogBody className="flex flex-col gap-32 px-24 pb-24">
+          <TextInput
+            autoComplete="off"
+            autoCorrect="off"
+            data-testid="contacts-rename-address-input"
+            helperText={labelValidationError}
+            label={labels.inputLabel}
+            maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+            maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
+            onChange={event => onDraftLabelChange(event.target.value)}
+            spellCheck={false}
+            status={labelValidationError ? "error" : undefined}
+            value={draftLabel}
+          />
+          <Button
+            appearance="base"
+            size="lg"
+            className="w-full"
+            disabled={!isConfirmEnabled}
+            loading={isSaving}
+            onClick={() => void onConfirm()}
+            data-testid="contacts-rename-address-confirm"
+          >
+            {labels.applyChanges}
+          </Button>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/contacts/src/steps/EditAddress/index.ts
+++ b/features/flow/contacts/src/steps/EditAddress/index.ts
@@ -1,0 +1,14 @@
+export { useRenameAddressViewModel } from "./useRenameAddressViewModel";
+export type { UseRenameAddressViewModelResult } from "./useRenameAddressViewModel";
+export { useRenameAddressDialogViewModel } from "./useRenameAddressDialogViewModel";
+export type { UseRenameAddressDialogViewModelOptions } from "./useRenameAddressDialogViewModel";
+export { createRenameAddressViewModel } from "./model/viewModel";
+export { createRenameAddressController } from "./model/controller";
+export type {
+  ContactsRenameAddressDialogProps,
+  ContactsRenameAddressDrawerProps,
+  ContactsRenameAddressLabels,
+  RenameAddressController,
+  RenameAddressDialogViewModel,
+  RenameAddressViewModel,
+} from "./types";

--- a/features/flow/contacts/src/steps/EditAddress/model/controller.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/controller.ts
@@ -1,0 +1,17 @@
+import { parseContactAddressLabel } from "@domain/entity-contact";
+import type { ContactAddressEditPort } from "../../Detail/model/ports";
+import { createRenameAddressViewModel } from "./viewModel";
+import type { RenameAddressController } from "../types";
+
+export function createRenameAddressController(
+  editPort: ContactAddressEditPort,
+): RenameAddressController {
+  return {
+    getViewModel: createRenameAddressViewModel,
+    save: async (contactId, addressId, draftLabel, existingLabels) => {
+      const label = parseContactAddressLabel(draftLabel, existingLabels);
+
+      return editPort.renameAddressLabel({ contactId, addressId, label });
+    },
+  };
+}

--- a/features/flow/contacts/src/steps/EditAddress/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/viewModel.ts
@@ -1,0 +1,19 @@
+import { getContactAddressLabelValidationError } from "@domain/entity-contact";
+import type { ContactAddressLabel } from "@domain/entity-contact";
+import type { RenameAddressViewModel } from "../types";
+
+export function createRenameAddressViewModel(
+  draftLabel: string,
+  currentLabel: string,
+  existingLabels: readonly ContactAddressLabel[],
+): RenameAddressViewModel {
+  const trimmedDraftLabel = draftLabel.trim();
+  const invalidLabelError = getContactAddressLabelValidationError(draftLabel, existingLabels);
+  const hasChanged = trimmedDraftLabel !== currentLabel.trim();
+
+  return {
+    draftLabel,
+    invalidLabelError,
+    isConfirmEnabled: hasChanged && trimmedDraftLabel.length > 0 && invalidLabelError === null,
+  };
+}

--- a/features/flow/contacts/src/steps/EditAddress/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/viewModel.web.test.ts
@@ -1,0 +1,29 @@
+import { ContactAddressLabelSchema } from "@domain/entity-contact";
+import { createRenameAddressViewModel } from "./viewModel";
+
+describe("createRenameAddressViewModel", () => {
+  const currentLabel = "Ethereum";
+  const existingLabels = [ContactAddressLabelSchema.parse("Polygon")];
+
+  it("should enable confirm when the label changed and is valid", () => {
+    expect(createRenameAddressViewModel("Main ETH", currentLabel, existingLabels)).toEqual({
+      draftLabel: "Main ETH",
+      invalidLabelError: null,
+      isConfirmEnabled: true,
+    });
+  });
+
+  it("should disable confirm when the label is unchanged", () => {
+    expect(createRenameAddressViewModel(currentLabel, currentLabel, existingLabels)).toEqual({
+      draftLabel: currentLabel,
+      invalidLabelError: null,
+      isConfirmEnabled: false,
+    });
+  });
+
+  it("should expose duplicate label validation errors", () => {
+    expect(
+      createRenameAddressViewModel("Polygon", currentLabel, existingLabels).invalidLabelError,
+    ).toBe("DuplicateContactAddressLabelError");
+  });
+});

--- a/features/flow/contacts/src/steps/EditAddress/types.ts
+++ b/features/flow/contacts/src/steps/EditAddress/types.ts
@@ -1,0 +1,71 @@
+import type {
+  ContactAddress,
+  ContactAddressId,
+  ContactAddressLabel,
+  ContactAddressLabelValidationErrorName,
+  ContactId,
+} from "@domain/entity-contact";
+import type { ContactAddressEditPort } from "../Detail/model/ports";
+
+export type RenameAddressViewModel = Readonly<{
+  draftLabel: string;
+  invalidLabelError: ContactAddressLabelValidationErrorName | null;
+  isConfirmEnabled: boolean;
+}>;
+
+export type RenameAddressDialogViewModel = RenameAddressViewModel &
+  Readonly<{
+    isOpen: boolean;
+    isSaving: boolean;
+    onOpen: () => void;
+    onClose: () => void;
+    onDraftLabelChange: (label: string) => void;
+    onConfirm: () => Promise<void>;
+  }>;
+
+export type UseRenameAddressDialogViewModelOptions = Readonly<{
+  contactId: ContactId;
+  addressId: ContactAddressId;
+  currentLabel: string;
+  existingLabels: readonly ContactAddressLabel[];
+  editPort: ContactAddressEditPort;
+  onSaveSuccess: () => void;
+}>;
+
+export type ContactsRenameAddressLabels = Readonly<{
+  title: string;
+  inputLabel: string;
+  applyChanges: string;
+  labelValidationErrors: Readonly<Record<ContactAddressLabelValidationErrorName, string>>;
+}>;
+
+export type ContactsRenameAddressDialogProps = RenameAddressDialogViewModel &
+  Readonly<{
+    labels: ContactsRenameAddressLabels;
+  }>;
+
+export type ContactsRenameAddressDrawerProps = RenameAddressDialogViewModel &
+  Readonly<{
+    bottomInset?: number;
+    labels: ContactsRenameAddressLabels;
+  }>;
+
+export type RenameAddressSaveInput = Readonly<{
+  contactId: ContactId;
+  addressId: ContactAddressId;
+  label: ContactAddressLabel;
+}>;
+
+export type RenameAddressController = Readonly<{
+  getViewModel: (
+    draftLabel: string,
+    currentLabel: string,
+    existingLabels: readonly ContactAddressLabel[],
+  ) => RenameAddressViewModel;
+  save: (
+    contactId: ContactId,
+    addressId: ContactAddressId,
+    draftLabel: string,
+    existingLabels: readonly ContactAddressLabel[],
+  ) => Promise<ContactAddress>;
+}>;

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
@@ -1,0 +1,78 @@
+import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import { useCallback, useEffect, useState } from "react";
+import { useRenameAddressViewModel } from "./useRenameAddressViewModel";
+import type { RenameAddressDialogViewModel, UseRenameAddressDialogViewModelOptions } from "./types";
+
+export function useRenameAddressDialogViewModel({
+  contactId,
+  addressId,
+  currentLabel,
+  existingLabels,
+  editPort,
+  isRequestedOpen,
+  onCloseRequest,
+  onSaveSuccess,
+}: UseRenameAddressDialogViewModelOptions &
+  Readonly<{
+    isRequestedOpen: boolean;
+    onCloseRequest: () => void;
+  }>): RenameAddressDialogViewModel {
+  const [draftLabel, setDraftLabel] = useState(currentLabel);
+  const [isSaving, setIsSaving] = useState(false);
+  const { invalidLabelError, isConfirmEnabled, save } = useRenameAddressViewModel(
+    contactId,
+    addressId,
+    currentLabel,
+    draftLabel,
+    existingLabels,
+    editPort,
+  );
+
+  useEffect(() => {
+    if (isRequestedOpen) {
+      setDraftLabel(currentLabel);
+    }
+  }, [currentLabel, isRequestedOpen]);
+
+  const onClose = useCallback(() => {
+    onCloseRequest();
+    setDraftLabel(currentLabel);
+  }, [currentLabel, onCloseRequest]);
+
+  const onDraftLabelChange = useCallback(
+    (label: string) => setDraftLabel(label.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH)),
+    [],
+  );
+
+  const onConfirm = useCallback(async () => {
+    if (!isConfirmEnabled || isSaving) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await save();
+      onSaveSuccess();
+      onCloseRequest();
+    } catch {
+      return;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isConfirmEnabled, isSaving, onCloseRequest, onSaveSuccess, save]);
+
+  return {
+    isOpen: isRequestedOpen,
+    isSaving,
+    draftLabel,
+    invalidLabelError,
+    isConfirmEnabled: isConfirmEnabled && !isSaving,
+    onOpen: () => undefined,
+    onClose,
+    onDraftLabelChange,
+    onConfirm,
+  };
+}
+
+export type { UseRenameAddressDialogViewModelOptions };

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from "@testing-library/react";
+import { contactAddress } from "@domain/entity-contact";
+import { mockContactWithAddress } from "@domain/entity-contact/schema.mock";
+import type { ContactAddressEditPort } from "../Detail/model/ports";
+import { useRenameAddressDialogViewModel } from "./useRenameAddressDialogViewModel";
+
+describe("useRenameAddressDialogViewModel", () => {
+  const contact = mockContactWithAddress();
+  const address = contact.addresses[0]!;
+
+  function createEditPort(overrides: Partial<ContactAddressEditPort> = {}): ContactAddressEditPort {
+    return {
+      renameAddressLabel: jest.fn().mockResolvedValue(
+        contactAddress({
+          ...address,
+          label: "Main ETH",
+        }),
+      ),
+      ...overrides,
+    };
+  }
+
+  it("should reset the draft when the dialog opens", () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const { result, rerender } = renderHook(
+      ({ isRequestedOpen }) =>
+        useRenameAddressDialogViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          currentLabel: address.label,
+          existingLabels: [],
+          editPort: createEditPort(),
+          isRequestedOpen,
+          onCloseRequest,
+          onSaveSuccess,
+        }),
+      { initialProps: { isRequestedOpen: false } },
+    );
+
+    act(() => {
+      result.current.onDraftLabelChange("Changed");
+    });
+    expect(result.current.draftLabel).toBe("Changed");
+
+    rerender({ isRequestedOpen: true });
+    expect(result.current.draftLabel).toBe(address.label);
+  });
+
+  it("should save, notify success, and close when confirm succeeds", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const renameAddressLabel = jest.fn().mockResolvedValue(
+      contactAddress({
+        ...address,
+        label: "Main ETH",
+      }),
+    );
+    const { result } = renderHook(() =>
+      useRenameAddressDialogViewModel({
+        contactId: contact.id,
+        addressId: address.id,
+        currentLabel: address.label,
+        existingLabels: [],
+        editPort: createEditPort({ renameAddressLabel }),
+        isRequestedOpen: true,
+        onCloseRequest,
+        onSaveSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.onDraftLabelChange("Main ETH");
+    });
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(renameAddressLabel).toHaveBeenCalledWith({
+      contactId: contact.id,
+      addressId: address.id,
+      label: "Main ETH",
+    });
+    expect(onSaveSuccess).toHaveBeenCalledTimes(1);
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
+    expect(result.current.isSaving).toBe(false);
+  });
+});

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
@@ -1,0 +1,34 @@
+import type { ContactAddress, ContactAddressId, ContactAddressLabel, ContactId } from "@domain/entity-contact";
+import { useCallback, useMemo } from "react";
+import type { ContactAddressEditPort } from "../Detail/model/ports";
+import { createRenameAddressController } from "./model/controller";
+import type { RenameAddressViewModel } from "./types";
+
+export type UseRenameAddressViewModelResult = RenameAddressViewModel &
+  Readonly<{
+    save: () => Promise<ContactAddress>;
+  }>;
+
+export function useRenameAddressViewModel(
+  contactId: ContactId,
+  addressId: ContactAddressId,
+  currentLabel: string,
+  draftLabel: string,
+  existingLabels: readonly ContactAddressLabel[],
+  editPort: ContactAddressEditPort,
+): UseRenameAddressViewModelResult {
+  const controller = useMemo(() => createRenameAddressController(editPort), [editPort]);
+  const viewModel = useMemo(
+    () => controller.getViewModel(draftLabel, currentLabel, existingLabels),
+    [controller, currentLabel, draftLabel, existingLabels],
+  );
+  const save = useCallback(
+    () => controller.save(contactId, addressId, draftLabel, existingLabels),
+    [addressId, contactId, controller, draftLabel, existingLabels],
+  );
+
+  return {
+    ...viewModel,
+    save,
+  };
+}

--- a/features/flow/contacts/src/steps/EditAddress/web.ts
+++ b/features/flow/contacts/src/steps/EditAddress/web.ts
@@ -1,0 +1,1 @@
+export { ContactsRenameAddressDialog } from "./ContactsRenameAddressDialog.web";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Shared foundation for contact address detail actions. This PR extracts reusable pieces that both the actions flow orchestration and app wiring layers depend on.

**Delete confirmation**
- New `ContactsDeleteConfirmationDialog` shared by contact and address delete flows
- `ContactsDeleteContactDialog` refactored to use the shared confirmation component

**Signer UI state**
- New `useContactEditSignerUiState` consolidates signer validation presentation logic
- `useContactDetailEditDeleteFlowViewModel` updated to use the shared hook

**EditAddress step**
- New `EditAddress/` step with rename controller, view model, and web dialog
- Mirrors the existing `EditContact` rename pattern for address labels
- Reuses domain validation from AddAddress (`getContactAddressLabelValidationError`)

### 🔗 Context

Stacked PR **1 of 4** for address detail actions (LIVE-33949 / LIVE-33950).

- **Next:** #20446 → #20408 → #20409

### ✅ Test plan

- [ ] `useContactEditSignerUiState` unit tests pass
- [ ] `EditAddress` model and dialog view model tests pass
- [ ] Contact delete dialog still works with shared confirmation component