### PR TITLE
[LWD] fix(desktop): coerce latest_testflight_build_number to integer

### DIFF
--- a/apps/ledger-live-desktop/fastlane/Fastfile
+++ b/apps/ledger-live-desktop/fastlane/Fastfile
@@ -113,7 +113,7 @@ platform :mac do
       platform: "osx",
       initial_build_number: 0
     )
-    build_number = latest + 1
+    build_number = latest.to_i + 1
     UI.message("Next MAS build number for #{ENV["APP_IDENTIFIER"]} #{version}: #{build_number}")
     if ENV["GITHUB_ENV"]
       File.open(ENV["GITHUB_ENV"], "a") { |f| f.puts("MAS_BUILD_NUMBER=#{build_number}") }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Manual uploads to testflight for MAS have used the format x.x.x which gets pulled as a string. This change casts it to integer for auto-incrementing
