### PR TITLE
[LWDM] fix(coin-ton): don't hide NotEnoughBalance error

### DIFF
--- a/.changeset/LIVE-34418-ton-minimum-balance-error-precedence.md
+++ b/.changeset/LIVE-34418-ton-minimum-balance-error-precedence.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-ton": patch
+---
+
+Fix error precedence in `validateAmount`: `TonMinimumRequired` no longer overwrites `NotEnoughBalance` when both conditions are true. The keep-alive minimum error now only surfaces when it is the binding constraint.

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/getTransactionStatus.unit.test.ts
@@ -6,7 +6,7 @@ import {
   RecipientRequired,
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import BigNumber from "bignumber.js";
-import { TonCommentInvalid, TonExcessFee } from "../../errors";
+import { TonCommentInvalid, TonExcessFee, TonMinimumRequired } from "../../errors";
 import getTransactionStatus from "../../getTransactionStatus";
 import {
   account,
@@ -89,6 +89,58 @@ describe("getTransactionStatus", () => {
           amount: new NotEnoughBalance(),
         }),
       );
+    });
+
+    it("should return NotEnoughBalance (not TonMinimumRequired) when balance is below 0.02 and amount exceeds balance", async () => {
+      const lowBalanceAccount = { ...account, balance: new BigNumber("10000000") };
+      const transaction = {
+        ...baseTransaction,
+        amount: new BigNumber("200000000"),
+        fees: new BigNumber("1000"),
+      };
+      const res = await getTransactionStatus(lowBalanceAccount, transaction);
+      expect(res.errors).toEqual(
+        expect.objectContaining({
+          amount: new NotEnoughBalance(),
+        }),
+      );
+    });
+
+    it("should return TonMinimumRequired when balance is below 0.02 and the amount is otherwise affordable", async () => {
+      const lowBalanceAccount = { ...account, balance: new BigNumber("15000000") };
+      const transaction = {
+        ...baseTransaction,
+        amount: new BigNumber("1000000"),
+        fees: new BigNumber("1000"),
+      };
+      const res = await getTransactionStatus(lowBalanceAccount, transaction);
+      expect(res.errors).toEqual(
+        expect.objectContaining({
+          amount: new TonMinimumRequired(),
+        }),
+      );
+    });
+
+    it("should return AmountRequired (not TonMinimumRequired) when amount is zero and balance is below 0.02", async () => {
+      const lowBalanceAccount = { ...account, balance: new BigNumber("10000000") };
+      const transaction = { ...baseTransaction, amount: new BigNumber(0) };
+      const res = await getTransactionStatus(lowBalanceAccount, transaction);
+      expect(res.errors).toEqual(
+        expect.objectContaining({
+          amount: new AmountRequired(),
+        }),
+      );
+    });
+
+    it("should not trigger TonMinimumRequired when balance is exactly 0.02 TON", async () => {
+      const boundaryAccount = { ...account, balance: new BigNumber("20000000") };
+      const transaction = {
+        ...baseTransaction,
+        amount: new BigNumber("1000000"),
+        fees: new BigNumber("1000"),
+      };
+      const res = await getTransactionStatus(boundaryAccount, transaction);
+      expect(res.errors.amount).toBeUndefined();
     });
 
     it("should detect the amount is greater than the spendable amount of the token account and have an error", async () => {

--- a/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-ton/src/getTransactionStatus.ts
@@ -97,10 +97,11 @@ const validateAmount = (
       errors.amount = new TonNotEnoughBalanceInParentAccount(); // "Sorry, insufficient funds in the parent account"
     }
     warnings.amount = new TonExcessFee();
-  } else {
-    if (account.balance.isLessThan(new BigNumber(toNano(MINIMUM_REQUIRED_BALANCE).toString()))) {
-      errors.amount = new TonMinimumRequired();
-    }
+  } else if (
+    !errors.amount &&
+    account.balance.isLessThan(new BigNumber(toNano(MINIMUM_REQUIRED_BALANCE).toString()))
+  ) {
+    errors.amount = new TonMinimumRequired();
   }
 
   return [errors, warnings];


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`validateAmount` in `coin-ton` set `TonMinimumRequired` unconditionally after `NotEnoughBalance`, overwriting it whenever the account balance was both insufficient for the transaction and below the 0.02 TON keep-alive minimum. The user saw "minimum required balance is 0.02 GRAM" instead of the actionable "insufficient funds" message.

Fix: add a `!errors.amount` guard so `TonMinimumRequired` only fires when it is the binding constraint — i.e. when the account balance is below 0.02 TON but the requested amount is otherwise affordable.

Regression covered by four new unit tests: the overwrite case (`NotEnoughBalance` wins), the binding-constraint case (`TonMinimumRequired` fires correctly), the zero-amount case (`AmountRequired` wins), and the exact-boundary case (balance of exactly 0.02 TON does not trigger `TonMinimumRequired`).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34418](https://ledgerhq.atlassian.net/browse/LIVE-34418)
- **ADR** (if any): N/A

[LIVE-34418]: https://ledgerhq.atlassian.net/browse/LIVE-34418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ