### PR TITLE
[LWD] feat(lwd): bip21 and eip681 scan for lwd

### DIFF
--- a/.changeset/forty-flowers-kiss.md
+++ b/.changeset/forty-flowers-kiss.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+feat(lwd): bip21 and eip681 scan for lwd

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BigNumber } from "bignumber.js";
 import { act } from "tests/testSetup";
 import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
 import { useSendHeaderModel } from "../useSendHeaderModel";
@@ -313,7 +314,17 @@ describe("useSendHeaderModel", () => {
     const baseState = {
       account: { currency: { ticker: "ETH" }, account: {} },
       recipient: null,
-      transaction: { status: {} },
+      transaction: {
+        status: {},
+        transaction: {
+          family: "evm",
+          amount: { isZero: () => true },
+          recipient: "",
+          useAllAmount: false,
+          userGasLimit: undefined,
+          gasPrice: undefined,
+        },
+      },
     };
 
     it("is closed by default and toggles open then closed, tracking both", () => {
@@ -383,12 +394,33 @@ describe("useSendHeaderModel", () => {
     });
 
     it("sets the decoded address and closes the scanner on a successful scan", () => {
-      mockActions();
+      const { updateTransaction } = mockActions();
       const search = mockData(baseState);
       mockRecipientStep();
       (decodeURIScheme as jest.Mock).mockReturnValue({
         address: "0xAbC",
-        amount: 1,
+        currency: { id: "ethereum" },
+      });
+
+      renderHook();
+      act(() => latestVM?.handleQrCodeClick());
+      act(() => latestVM?.handleScanPicked("ethereum:0xAbC"));
+
+      expect(decodeURIScheme).toHaveBeenCalledWith("ethereum:0xAbC");
+      expect(search.setValue).toHaveBeenCalledWith("0xAbC");
+      expect(search.setValue).toHaveBeenCalledTimes(1);
+      expect(updateTransaction).not.toHaveBeenCalled();
+      expect(latestVM?.isScannerOpen).toBe(false);
+    });
+
+    it("prefills the transaction amount from a BIP21/EIP-681 URI while staying on recipient", () => {
+      const amount = new BigNumber(1);
+      const { updateTransaction } = mockActions();
+      const search = mockData(baseState);
+      mockRecipientStep();
+      (decodeURIScheme as jest.Mock).mockReturnValue({
+        address: "0xAbC",
+        amount,
         currency: { id: "ethereum" },
       });
 
@@ -396,9 +428,15 @@ describe("useSendHeaderModel", () => {
       act(() => latestVM?.handleQrCodeClick());
       act(() => latestVM?.handleScanPicked("ethereum:0xAbC?value=1"));
 
-      expect(decodeURIScheme).toHaveBeenCalledWith("ethereum:0xAbC?value=1");
       expect(search.setValue).toHaveBeenCalledWith("0xAbC");
-      expect(search.setValue).toHaveBeenCalledTimes(1);
+      expect(updateTransaction).toHaveBeenCalledTimes(1);
+      const updater = (updateTransaction as jest.Mock).mock.calls[0][0];
+      expect(updater({ family: "evm", amount: new BigNumber(0), useAllAmount: true })).toEqual(
+        expect.objectContaining({
+          amount,
+          useAllAmount: false,
+        }),
+      );
       expect(latestVM?.isScannerOpen).toBe(false);
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -7,6 +7,7 @@ import {
   getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
 } from "@ledgerhq/live-common/flows/send/utils";
+import { buildTransactionPatchFromURIScheme } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
 import {
   SendFlowBusinessContext,
   useSendFlowActions,
@@ -165,11 +166,20 @@ export function useSendHeaderModel({
 
   const handleScanPicked = useCallback(
     (code: string) => {
-      const { address } = decodeURIScheme(code);
-      recipientSearch.setValue(address);
+      const decoded = decodeURIScheme(code);
+      recipientSearch.setValue(decoded.address);
+
+      const currentTransaction = state.transaction.transaction;
+      if (currentTransaction) {
+        const patch = buildTransactionPatchFromURIScheme(currentTransaction, decoded);
+        if (Object.keys(patch).length > 0) {
+          transaction.updateTransaction(tx => ({ ...tx, ...patch }) as typeof tx);
+        }
+      }
+
       closeScanner();
     },
-    [closeScanner, recipientSearch],
+    [closeScanner, recipientSearch, state.transaction.transaction, transaction],
   );
 
   const transactionError = state.transaction.status?.errors?.transaction;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

In the new send flow (lwd), scanning a payment QR (BIP-0021 for BTC / EIP-681 for EVM) now prefills the amount when the URI includes one, not just the recipient address. The user stays on the recipient step to confirm the address; the amount step opens with the value already filled.

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35456)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
