### PR TITLE
[LWD] feat(contacts): add address validation feedback

### DIFF
--- a/.changeset/fresh-geckos-clap.md
+++ b/.changeset/fresh-geckos-clap.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Add invalid and sanctioned address feedback to the Desktop Contacts flow.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import type { ContactId } from "@domain/entity-contact";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { resolveEligibleAddressCurrencyIds } from "@features/flow-contacts";
+import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import {
   mockContact,
   mockMeContact,
@@ -22,9 +23,11 @@ import { useContactsViewModel } from "LLD/features/Contacts/screens/Contacts/use
 import ContextMenuContext from "LLD/features/MyWallet/components/ContextMenuContext";
 import { ContextMenu } from "LLD/features/MyWallet/components/ContextMenu";
 import { CONTEXT_MENU_VIEW } from "LLD/features/MyWallet/components/ContextMenu/types";
+import { openURL } from "~/renderer/linking";
 
 const mockNavigate = jest.fn();
 const mockClose = jest.fn();
+const mockValidateAddress = jest.fn();
 const meContactId = mockMeContact().id;
 const savedContactId = mockContact({ id: "contact-ada" }).id;
 
@@ -44,8 +47,16 @@ jest.mock("@ledgerhq/live-common/bridge/index", () => ({
     "@ledgerhq/live-common/bridge/index",
   ),
   getAccountBridgeByFamily: jest.fn().mockResolvedValue({
-    validateAddress: jest.fn().mockResolvedValue(true),
+    validateAddress: (...args: unknown[]) => mockValidateAddress(...args),
   }),
+}));
+
+jest.mock("@ledgerhq/ledger-wallet-framework/sanction/index", () => ({
+  isAddressSanctioned: jest.fn(),
+}));
+
+jest.mock("~/renderer/linking", () => ({
+  openURL: jest.fn(),
 }));
 
 const contextMenuValue = {
@@ -138,6 +149,8 @@ function ContactsViewModelProbe({
 describe("Contacts integration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockValidateAddress.mockResolvedValue(true);
+    jest.mocked(isAddressSanctioned).mockResolvedValue(false);
   });
 
   it("should not render the Contacts button when lwdContacts is disabled", () => {
@@ -578,6 +591,63 @@ describe("Contacts integration", () => {
     await user.click(screen.getByRole("button", { name: "Continue address review" }));
 
     expect(screen.getByTestId("contacts-add-address-flow-state")).toHaveTextContent("closed");
+  });
+
+  it("should render an invalid-format helper and block address confirmation", async () => {
+    mockValidateAddress.mockResolvedValue(false);
+    const { store, user } = renderContactsScreen();
+
+    await user.click(screen.getByTestId("contacts-me-row"));
+    await user.click(screen.getByTestId("contacts-detail-add-address"));
+    act(() => {
+      store
+        .getState()
+        .modularDialog.dialogParams?.onAssetSelected?.(getCryptoCurrencyById("ethereum"));
+    });
+
+    const addressInput = await screen.findByTestId("contacts-add-address-input");
+    fireEvent.change(addressInput, {
+      target: { value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Incorrect address format.")).toBeVisible();
+      expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
+    });
+    expect(screen.queryByTestId("contacts-sanctioned-address-banner")).not.toBeInTheDocument();
+  });
+
+  it("should render sanctioned feedback, block confirmation, and open the Help Center", async () => {
+    jest.mocked(isAddressSanctioned).mockResolvedValue(true);
+    const { store, user } = renderContactsScreen();
+
+    await user.click(screen.getByTestId("contacts-me-row"));
+    await user.click(screen.getByTestId("contacts-detail-add-address"));
+    act(() => {
+      store
+        .getState()
+        .modularDialog.dialogParams?.onAssetSelected?.(getCryptoCurrencyById("ethereum"));
+    });
+
+    const addressInput = await screen.findByTestId("contacts-add-address-input");
+    fireEvent.change(addressInput, {
+      target: { value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Sanctioned address.")).toBeVisible();
+      expect(screen.getByTestId("contacts-sanctioned-address-banner")).toBeVisible();
+      expect(
+        screen.getByText(
+          "This wallet address is sanctioned by international laws and regulations.",
+        ),
+      ).toBeVisible();
+      expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Learn more" }));
+
+    expect(openURL).toHaveBeenCalledTimes(1);
   });
 
   it("should expose the Add Address session started for Me", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/ContactsAddAddressFlowDialog.tsx
@@ -12,6 +12,7 @@ import type { ContactsAddAddressFlowDialogProps } from "./types";
 export function ContactsAddAddressFlowDialog({
   state,
   entryLabels,
+  sanctionedAddressBanner,
   nameLabels,
   reviewLabels,
   onAddressChange,
@@ -40,6 +41,7 @@ export function ContactsAddAddressFlowDialog({
             <ContactsAddAddressFlowContent
               completionLabels={reviewLabels}
               entryLabels={entryLabels}
+              sanctionedAddressBanner={sanctionedAddressBanner}
               nameLabels={nameLabels}
               onAddressChange={onAddressChange}
               onAddressLabelChange={onAddressLabelChange}

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/components/ContactsAddAddressFlowDialog/types.ts
@@ -4,6 +4,7 @@ import type {
   AddAddressInputSource,
   ContactsAddAddressEntryLabels,
   ContactsAddAddressNameLabels,
+  SanctionedAddressBannerProps,
 } from "@features/flow-contacts";
 
 export type ContactsAddAddressReviewLabels = AddAddressCompletionLabels;
@@ -11,6 +12,7 @@ export type ContactsAddAddressReviewLabels = AddAddressCompletionLabels;
 export type ContactsAddAddressFlowDialogProps = Readonly<{
   state: AddAddressFlowState;
   entryLabels: ContactsAddAddressEntryLabels;
+  sanctionedAddressBanner: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
   reviewLabels: ContactsAddAddressReviewLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
+import { urls } from "~/config/urls";
+import { useLocalizedUrl } from "~/renderer/hooks/useLocalizedUrls";
+import { openURL } from "~/renderer/linking";
 import { v4 as uuid } from "uuid";
 import {
   CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME,
@@ -54,6 +57,10 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const helpCenterUrl = useLocalizedUrl(urls.helpModal.helpCenter);
+  const handleSanctionedAddressLearnMore = useCallback(() => {
+    openURL(helpCenterUrl);
+  }, [helpCenterUrl]);
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
@@ -180,6 +187,11 @@ export function useContactsViewModel(): ContactsPageViewModel {
     () => ({
       state: addAddressFlowState,
       entryLabels: addAddressEntryLabels,
+      sanctionedAddressBanner: {
+        description: t("contacts.addAddressEntry.sanctioned.description"),
+        actionLabel: t("contacts.addAddressEntry.sanctioned.learnMore"),
+        onAction: handleSanctionedAddressLearnMore,
+      },
       nameLabels: addAddressNameLabels,
       reviewLabels: addAddressReviewLabels,
       onAddressChange: (address, inputMethod) => {
@@ -195,6 +207,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
     }),
     [
       addAddressEntryLabels,
+      handleSanctionedAddressLearnMore,
       addAddressNameLabels,
       addAddressReviewLabels,
       addAddressFlowState,
@@ -206,6 +219,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       continueFromName,
       saveAddressFromReview,
       completeMockConfirmation,
+      t,
     ],
   );
   const { detail, addressDetailDialog, editDeleteDialogs, onOpenMe, onOpenContact } =

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9298,9 +9298,13 @@
       "confirmAddress": "Continue to review",
       "validatingAddress": "Validating address",
       "validAddress": "Valid address",
-      "invalidAddress": "Invalid address",
+      "invalidAddress": "Incorrect address format.",
       "domainNotFound": "Domain not found",
-      "sanctionedAddress": "This address is sanctioned and cannot be used.",
+      "sanctionedAddress": "Sanctioned address.",
+      "sanctioned": {
+        "description": "This wallet address is sanctioned by international laws and regulations.",
+        "learnMore": "Learn more"
+      },
       "validationUnavailable": "Address validation is temporarily unavailable.",
       "ensDisclaimer": "This ENS name resolves to the address shown above."
     },

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -77,6 +77,7 @@
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
     "@testing-library/react-native": "catalog:",
+    "@testing-library/user-event": "catalog:",
     "@types/jest": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.web.types.ts
@@ -1,5 +1,6 @@
 import type { ChangeEvent, ClipboardEvent } from "react";
 import type { ContactsAddAddressNameLabels } from "./AddressName/types";
+import type { SanctionedAddressBannerProps } from "./ContactsAddAddressEntry.types";
 import type {
   AddAddressEntryLabels,
   AddAddressEntryState,
@@ -36,6 +37,7 @@ type WithoutAddressLabelViewConfiguration = Readonly<{
 type ContactsAddAddressEntryWebBaseProps = Readonly<{
   addressEntry: AddAddressEntryState;
   labels: AddAddressEntryLabels;
+  sanctionedAddressBanner?: SanctionedAddressBannerProps;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
   onConfirm?: () => void;
 }>;
@@ -49,6 +51,7 @@ type ContactsAddAddressEntryWebViewBaseProps = Readonly<{
   labels: AddAddressEntryLabels;
   inputStatus?: "error" | "success";
   helperText?: string;
+  sanctionedAddressBanner?: SanctionedAddressBannerProps;
   showEnsDisclaimer: boolean;
   isConfirmEnabled: boolean;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
 import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import { SanctionedAddressBanner } from "./components/SanctionedAddressBanner/SanctionedAddressBanner.web";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
 import { AddressNameDisclaimer } from "./components/AddressNameDisclaimer/AddressNameDisclaimer.web";
 
@@ -10,6 +11,7 @@ export function ContactsAddAddressEntryView({
   labels,
   inputStatus,
   helperText,
+  sanctionedAddressBanner,
   showEnsDisclaimer,
   addressLabel,
   nameLabels,
@@ -65,6 +67,7 @@ export function ContactsAddAddressEntryView({
           value={addressLabel.value}
         />
       ) : null}
+      {sanctionedAddressBanner ? <SanctionedAddressBanner {...sanctionedAddressBanner} /> : null}
       <Button
         appearance="base"
         className="w-full"

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.tsx
@@ -9,6 +9,7 @@ import type {
   AddAddressFlowState,
   AddAddressInputSource,
 } from "../types";
+import type { SanctionedAddressBannerProps } from "../ContactsAddAddressEntry.types";
 
 export type AddAddressWebFlowStep = "currency" | "address" | "name" | "review" | "success";
 
@@ -18,6 +19,7 @@ type AddAddressFlowContentState = Exclude<OpenAddAddressFlowState, { status: "se
 export type ContactsAddAddressFlowContentProps = Readonly<{
   state: AddAddressFlowContentState;
   entryLabels: AddAddressEntryLabels;
+  sanctionedAddressBanner?: SanctionedAddressBannerProps;
   nameLabels: ContactsAddAddressNameLabels;
   completionLabels: AddAddressCompletionLabels;
   onAddressChange: (address: string, inputMethod: AddAddressInputSource) => void;
@@ -59,6 +61,7 @@ export function shouldUseAddAddressFlowBackNavigation(state: OpenAddAddressFlowS
 export function ContactsAddAddressFlowContent({
   state,
   entryLabels,
+  sanctionedAddressBanner,
   nameLabels,
   completionLabels,
   onAddressChange,
@@ -76,6 +79,7 @@ export function ContactsAddAddressFlowContent({
           addressEntry={state.addressEntry}
           addressLabel={state.addressLabel}
           labels={entryLabels}
+          sanctionedAddressBanner={sanctionedAddressBanner}
           nameLabels={nameLabels}
           onAddressChange={onAddressChange}
           onAddressLabelChange={onAddressLabelChange}

--- a/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.test.tsx
@@ -15,10 +15,7 @@ jest.mock("@ledgerhq/lumen-ui-react", () => {
       description: string;
       primaryAction?: React.ReactNode;
     }) => React.createElement("div", props, description, primaryAction),
-    Button: ({
-      children,
-      ...props
-    }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
       React.createElement("button", { type: "button", ...props }, children),
   };
 });
@@ -33,15 +30,11 @@ describe("SanctionedAddressBanner", () => {
         description="This wallet address is sanctioned."
         actionLabel="Learn more"
         onAction={onAction}
-      />
+      />,
     );
 
-    expect(
-      screen.getByTestId("contacts-sanctioned-address-banner")
-    ).toBeVisible();
-    expect(
-      screen.getByText("This wallet address is sanctioned.")
-    ).toBeVisible();
+    expect(screen.getByTestId("contacts-sanctioned-address-banner")).toBeVisible();
+    expect(screen.getByText("This wallet address is sanctioned.")).toBeVisible();
 
     await user.click(screen.getByRole("button", { name: "Learn more" }));
 

--- a/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SanctionedAddressBanner } from "./SanctionedAddressBanner.web";
+
+jest.mock("@ledgerhq/lumen-ui-react", () => {
+  const React = require("react");
+
+  return {
+    Banner: ({
+      description,
+      primaryAction,
+      ...props
+    }: {
+      description: string;
+      primaryAction?: React.ReactNode;
+    }) => React.createElement("div", props, description, primaryAction),
+    Button: ({
+      children,
+      ...props
+    }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+      React.createElement("button", { type: "button", ...props }, children),
+  };
+});
+
+describe("SanctionedAddressBanner", () => {
+  it("should render the supplied feedback and invoke its action", async () => {
+    const onAction = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SanctionedAddressBanner
+        description="This wallet address is sanctioned."
+        actionLabel="Learn more"
+        onAction={onAction}
+      />
+    );
+
+    expect(
+      screen.getByTestId("contacts-sanctioned-address-banner")
+    ).toBeVisible();
+    expect(
+      screen.getByText("This wallet address is sanctioned.")
+    ).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Learn more" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.web.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Banner, Button } from "@ledgerhq/lumen-ui-react";
+import type { SanctionedAddressBannerProps } from "../../ContactsAddAddressEntry.types";
+
+export const SanctionedAddressBanner = ({
+  description,
+  actionLabel,
+  onAction,
+  testID,
+}: SanctionedAddressBannerProps): React.JSX.Element => (
+  <Banner
+    appearance="error"
+    data-testid={testID ?? "contacts-sanctioned-address-banner"}
+    description={description}
+    primaryAction={
+      <Button appearance="transparent" size="sm" onClick={onAction}>
+        {actionLabel}
+      </Button>
+    }
+  />
+);

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -142,6 +142,7 @@ describe("useContactsAddAddressEntryViewModel", () => {
   });
 
   it("should expose a sanctioned address as a blocking error", () => {
+    const onAction = jest.fn();
     const { result } = renderViewModel({
       addressEntry: {
         status: "invalid",
@@ -150,12 +151,22 @@ describe("useContactsAddAddressEntryViewModel", () => {
         inputMethod: "manual",
         error: "sanctioned",
       },
+      sanctionedAddressBanner: {
+        description: "This wallet address is sanctioned.",
+        actionLabel: "Learn more",
+        onAction,
+      },
     });
 
     expect(result.current).toMatchObject({
       inputStatus: "error",
       helperText: "This address is sanctioned and cannot be used.",
       isConfirmEnabled: false,
+    });
+    expect(result.current.sanctionedAddressBanner).toEqual({
+      description: "This wallet address is sanctioned.",
+      actionLabel: "Learn more",
+      onAction,
     });
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.ts
@@ -75,6 +75,7 @@ function resolveAddressInputPresentation(
 export function useContactsAddAddressEntryViewModel({
   addressEntry,
   labels,
+  sanctionedAddressBanner,
   onAddressChange,
   onConfirm,
   ...addressLabelProps
@@ -112,6 +113,10 @@ export function useContactsAddAddressEntryViewModel({
   const isNameValid =
     addressLabelConfiguration === undefined ||
     addressLabelConfiguration.addressLabel.status === "valid";
+  const shouldShowSanctionedAddressBanner =
+    addressEntry.status === "invalid" &&
+    addressEntry.error === "sanctioned" &&
+    sanctionedAddressBanner !== undefined;
 
   const addressLabelViewProps = addressLabelConfiguration
     ? {
@@ -126,6 +131,9 @@ export function useContactsAddAddressEntryViewModel({
     value: addressEntry.value,
     labels,
     ...presentation,
+    sanctionedAddressBanner: shouldShowSanctionedAddressBanner
+      ? sanctionedAddressBanner
+      : undefined,
     ...addressLabelViewProps,
     isConfirmEnabled: presentation.isConfirmEnabled && isNameValid && onConfirm !== undefined,
     onChange,

--- a/features/flow/contacts/src/steps/AddAddress/web.ts
+++ b/features/flow/contacts/src/steps/AddAddress/web.ts
@@ -1,5 +1,6 @@
 export { ContactsAddAddressEntry } from "./ContactsAddAddressEntry.web";
 export type { ContactsAddAddressEntryWebProps as ContactsAddAddressEntryProps } from "./ContactsAddAddressEntry.web.types";
+export type { SanctionedAddressBannerProps } from "./ContactsAddAddressEntry.types";
 export type { AddAddressEntryLabels as ContactsAddAddressEntryLabels } from "./types";
 export { ContactsAddAddressNameInput as ContactsAddAddressName } from "./AddressName/Input/ContactsAddAddressNameInput.web";
 export { ContactsAddAddressCompletion } from "./Completion/ContactsAddAddressCompletion.web";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4731,6 +4731,9 @@ importers:
       '@testing-library/react-native':
         specifier: 'catalog:'
         version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/user-event':
+        specifier: 'catalog:'
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Flow Web tests and Desktop Contacts integration tests cover invalid format, sanctioned addresses, confirmation blocking, and the Learn more action.
- [x] **Impact of the changes:**
      Contacts → Add address: verify invalid-format helper text, sanctioned-address banner, disabled confirmation, and localized Help Center redirection.

### 📝 Description

Implements LIVE-33925 and LIVE-33928 for the Desktop Contacts address-entry flow.

- Renders an inline error for invalid address format.
- Renders the sanctioned-address helper and a Flow-owned error banner with a Learn more CTA.
- Keeps the validation and confirmation-blocking rules unchanged.
- Injects English copies and the localized Help Center action from Desktop.

### Screenshots

<img width="586" height="728" alt="image" src="https://github.com/user-attachments/assets/e08ff95b-6f2f-4841-8386-7fe1a201680a" />


### ❓ Context

- **JIRA or GitHub link**: [LIVE-33925](https://ledgerhq.atlassian.net/browse/LIVE-33925) and [LIVE-33928](https://ledgerhq.atlassian.net/browse/LIVE-33928)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira issues.
- **The PR description clearly documents the changes** made and explains the Flow/Desktop ownership boundary.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and the covered validation states are listed above.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account.

[LIVE-33925]: https://ledgerhq.atlassian.net/browse/LIVE-33925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33928]: https://ledgerhq.atlassian.net/browse/LIVE-33928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ