### PR TITLE
fix(post-onboarding): legacy onboarding backfill

### DIFF
--- a/.changeset/legacy-onboarding-backfill.md
+++ b/.changeset/legacy-onboarding-backfill.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/live-common": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Use fixed legacy onboarding date for backfill instead of app-open date

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/backfillOnboardingDate.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/__tests__/backfillOnboardingDate.test.ts
@@ -1,13 +1,12 @@
 /**
  * @jest-environment jsdom
  */
+import { LEGACY_ONBOARDING_DATE } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { initialState as postOnboardingInitialState } from "@ledgerhq/live-common/postOnboarding/reducer";
 import createStore from "~/state-manager/configureStore";
 import type { State } from "~/renderer/reducers";
 import { INITIAL_STATE as settingsInitialState } from "~/renderer/reducers/settings";
 import { backfillOnboardingDate } from "../backfillOnboardingDate";
-
-const now = new Date("2026-01-02T03:04:05.000Z");
 
 function makeStore({
   hasCompletedOnboarding,
@@ -29,15 +28,17 @@ describe("backfillOnboardingDate", () => {
   it("should backfill onboardingDate for legacy users who completed onboarding", () => {
     const store = makeStore({ hasCompletedOnboarding: true, onboardingDate: null });
 
-    backfillOnboardingDate(store, now);
+    backfillOnboardingDate(store);
 
-    expect(store.getState().postOnboarding.onboardingDate).toBe(now.toISOString());
+    expect(store.getState().postOnboarding.onboardingDate).toBe(
+      LEGACY_ONBOARDING_DATE.toISOString(),
+    );
   });
 
   it("should not backfill when onboarding is not completed", () => {
     const store = makeStore({ hasCompletedOnboarding: false, onboardingDate: null });
 
-    backfillOnboardingDate(store, now);
+    backfillOnboardingDate(store);
 
     expect(store.getState().postOnboarding.onboardingDate).toBe(null);
   });
@@ -46,7 +47,7 @@ describe("backfillOnboardingDate", () => {
     const existingDate = "2024-03-04T05:06:07.000Z";
     const store = makeStore({ hasCompletedOnboarding: true, onboardingDate: existingDate });
 
-    backfillOnboardingDate(store, now);
+    backfillOnboardingDate(store);
 
     expect(store.getState().postOnboarding.onboardingDate).toBe(existingDate);
   });

--- a/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/backfillOnboardingDate.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/PostOnboardingHub/logic/backfillOnboardingDate.ts
@@ -1,4 +1,5 @@
 import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
+import { LEGACY_ONBOARDING_DATE } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import type { ReduxStore } from "~/state-manager/configureStore";
 import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
@@ -11,9 +12,9 @@ import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
  *
  * The DB middleware persists post-onboarding actions automatically.
  */
-export function backfillOnboardingDate(store: ReduxStore, now: Date = new Date()): void {
+export function backfillOnboardingDate(store: ReduxStore): void {
   const state = store.getState();
   if (hasCompletedOnboardingSelector(state) && onboardingDateSelector(state) == null) {
-    store.dispatch(setPostOnboardingDate({ onboardingDate: now }));
+    store.dispatch(setPostOnboardingDate({ onboardingDate: LEGACY_ONBOARDING_DATE }));
   }
 }

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/backfillOnboardingDate.test.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/__tests__/backfillOnboardingDate.test.ts
@@ -1,8 +1,7 @@
+import { LEGACY_ONBOARDING_DATE } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { createStore } from "@tests/test-renderer";
 import type { State } from "~/reducers/types";
 import { backfillOnboardingDate } from "../backfillOnboardingDate";
-
-const now = new Date("2026-01-02T03:04:05.000Z");
 
 function makeStore({
   hasCompletedOnboarding,
@@ -26,11 +25,11 @@ describe("backfillOnboardingDate", () => {
     const save = jest.fn().mockResolvedValue(undefined);
     const postOnboardingBefore = store.getState().postOnboarding;
 
-    backfillOnboardingDate(store, { now, save });
+    backfillOnboardingDate(store, { save });
 
     expect(store.getState().postOnboarding).toEqual({
       ...postOnboardingBefore,
-      onboardingDate: now.toISOString(),
+      onboardingDate: LEGACY_ONBOARDING_DATE.toISOString(),
     });
     expect(save).toHaveBeenCalledTimes(1);
   });
@@ -39,7 +38,7 @@ describe("backfillOnboardingDate", () => {
     const store = makeStore({ hasCompletedOnboarding: false, onboardingDate: null });
     const save = jest.fn().mockResolvedValue(undefined);
 
-    backfillOnboardingDate(store, { now, save });
+    backfillOnboardingDate(store, { save });
 
     expect(store.getState().postOnboarding.onboardingDate).toBe(null);
     expect(save).not.toHaveBeenCalled();
@@ -50,7 +49,7 @@ describe("backfillOnboardingDate", () => {
     const store = makeStore({ hasCompletedOnboarding: true, onboardingDate: existingDate });
     const save = jest.fn().mockResolvedValue(undefined);
 
-    backfillOnboardingDate(store, { now, save });
+    backfillOnboardingDate(store, { save });
 
     expect(store.getState().postOnboarding.onboardingDate).toBe(existingDate);
     expect(save).not.toHaveBeenCalled();

--- a/apps/ledger-live-mobile/src/logic/postOnboarding/backfillOnboardingDate.ts
+++ b/apps/ledger-live-mobile/src/logic/postOnboarding/backfillOnboardingDate.ts
@@ -1,5 +1,6 @@
 import type { Store } from "redux";
 import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
+import { LEGACY_ONBOARDING_DATE } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import {
   onboardingDateSelector,
   postOnboardingSelector,
@@ -10,7 +11,6 @@ import type { State } from "~/reducers/types";
 import logger from "~/logger";
 
 type BackfillDeps = {
-  now?: Date;
   save?: typeof savePostOnboardingState;
 };
 
@@ -22,11 +22,11 @@ type BackfillDeps = {
  */
 export function backfillOnboardingDate(
   store: Store<State>,
-  { now = new Date(), save = savePostOnboardingState }: BackfillDeps = {},
+  { save = savePostOnboardingState }: BackfillDeps = {},
 ): void {
   const state = store.getState();
   if (hasCompletedOnboardingSelector(state) && onboardingDateSelector(state) == null) {
-    store.dispatch(setPostOnboardingDate({ onboardingDate: now }));
+    store.dispatch(setPostOnboardingDate({ onboardingDate: LEGACY_ONBOARDING_DATE }));
     // Persist immediately because DBSave baselines after this migration runs.
     save(postOnboardingSelector(store.getState())).catch(error => logger.critical(error));
   }

--- a/libs/ledger-live-common/src/postOnboarding/logic/index.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/index.ts
@@ -1,2 +1,3 @@
 export { shouldRedirectToPostOnboardingOrRecoverUpsell } from "./shouldRedirectToPostOnboardingOrRecoverUpsell";
+export { LEGACY_ONBOARDING_DATE, resolveOnboardingDateForUpsell } from "./legacyOnboardingDate";
 export { isCooldownElapsed, shouldThrottle } from "./upsellFrequency";

--- a/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.test.ts
@@ -1,0 +1,17 @@
+import { LEGACY_ONBOARDING_DATE, resolveOnboardingDateForUpsell } from "./legacyOnboardingDate";
+
+describe("legacyOnboardingDate", () => {
+  it("should expose a fixed legacy onboarding date", () => {
+    expect(LEGACY_ONBOARDING_DATE.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("should resolve null to the legacy onboarding date", () => {
+    expect(resolveOnboardingDateForUpsell(null)).toBe(LEGACY_ONBOARDING_DATE);
+  });
+
+  it("should preserve a known onboarding date", () => {
+    const onboardingDate = new Date("2024-03-04T05:06:07.000Z");
+
+    expect(resolveOnboardingDateForUpsell(onboardingDate)).toBe(onboardingDate);
+  });
+});

--- a/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.test.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.test.ts
@@ -6,12 +6,27 @@ describe("legacyOnboardingDate", () => {
   });
 
   it("should resolve null to the legacy onboarding date", () => {
-    expect(resolveOnboardingDateForUpsell(null)).toBe(LEGACY_ONBOARDING_DATE);
+    expect(resolveOnboardingDateForUpsell(null).toISOString()).toBe(
+      LEGACY_ONBOARDING_DATE.toISOString(),
+    );
+  });
+
+  it("should resolve an invalid date to the legacy onboarding date", () => {
+    expect(resolveOnboardingDateForUpsell(new Date("invalid")).toISOString()).toBe(
+      LEGACY_ONBOARDING_DATE.toISOString(),
+    );
   });
 
   it("should preserve a known onboarding date", () => {
     const onboardingDate = new Date("2024-03-04T05:06:07.000Z");
 
     expect(resolveOnboardingDateForUpsell(onboardingDate)).toBe(onboardingDate);
+  });
+
+  it("should return a fresh date instance for the legacy fallback", () => {
+    const resolved = resolveOnboardingDateForUpsell(null);
+
+    expect(resolved).not.toBe(LEGACY_ONBOARDING_DATE);
+    expect(resolved.toISOString()).toBe(LEGACY_ONBOARDING_DATE.toISOString());
   });
 });

--- a/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.ts
@@ -1,6 +1,14 @@
 export const LEGACY_ONBOARDING_DATE = new Date("2026-01-01T00:00:00.000Z");
 
+function isKnownOnboardingDate(onboardingDate: Date): boolean {
+  return !Number.isNaN(onboardingDate.getTime());
+}
+
 /** Fallback when onboardingDate is unknown (legacy users pre-field). Used by upsell cooldown. */
 export function resolveOnboardingDateForUpsell(onboardingDate: Date | null): Date {
-  return onboardingDate ?? LEGACY_ONBOARDING_DATE;
+  if (onboardingDate != null && isKnownOnboardingDate(onboardingDate)) {
+    return onboardingDate;
+  }
+
+  return new Date(LEGACY_ONBOARDING_DATE);
 }

--- a/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.ts
+++ b/libs/ledger-live-common/src/postOnboarding/logic/legacyOnboardingDate.ts
@@ -1,0 +1,6 @@
+export const LEGACY_ONBOARDING_DATE = new Date("2026-01-01T00:00:00.000Z");
+
+/** Fallback when onboardingDate is unknown (legacy users pre-field). Used by upsell cooldown. */
+export function resolveOnboardingDateForUpsell(onboardingDate: Date | null): Date {
+  return onboardingDate ?? LEGACY_ONBOARDING_DATE;
+}


### PR DESCRIPTION
### 📝 Description

Legacy users who completed onboarding before `onboardingDate` existed had their missing date backfilled with the app-open date (`new Date()`). That incorrectly started the 30-day large-screen upsell cooldown from today instead of treating them as long-time users.

**Problem**: Backfill seeded `null` onboarding dates with today's date, blocking upsell eligibility for Nano X/SP users who onboarded long ago.

**Solution**: Introduce a shared `LEGACY_ONBOARDING_DATE` constant (`2026-01-01T00:00:00.000Z`) and `resolveOnboardingDateForUpsell()` helper in live-common. Mobile and desktop startup backfill now persist this fixed date for legacy users with completed onboarding and `onboardingDate == null`. Existing dates are never overwritten; new onboardings still set the real completion date via `POST_ONBOARDING_INIT`.

```ts
import { LEGACY_ONBOARDING_DATE, resolveOnboardingDateForUpsell } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";

resolveOnboardingDateForUpsell(null); // → 2026-01-01
```

**Out of scope (LIVE-35420)**: Runtime upsell eligibility still uses `onboardingDate ?? now` until the follow-up ticket.

### 🔗 Context

- **JIRA issue**: [LIVE-35419](https://ledgerhq.atlassian.net/browse/LIVE-35419)

### ✅ Test plan

- [ ] Legacy user (completed onboarding, `onboardingDate == null`) → backfill persists `2026-01-01` on app startup (mobile + desktop)
- [ ] New onboarding flow → `onboardingDate` remains today's date via `POST_ONBOARDING_INIT`
- [ ] User with existing `onboardingDate` → date not overwritten
- [ ] Unit tests: `legacyOnboardingDate`, mobile + desktop `backfillOnboardingDate`

Made with [Cursor](https://cursor.com)

[LIVE-35419]: https://ledgerhq.atlassian.net/browse/LIVE-35419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ