### PR TITLE
[LWDM] fix(post-onboarding): use legacy date in upsell eligibility

### DIFF
--- a/.changeset/legacy-upsell-eligibility.md
+++ b/.changeset/legacy-upsell-eligibility.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-large-screen-upsell": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Use legacy onboarding date fallback in large-screen upsell eligibility

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/__integrations__/LargeScreenUpsellModal.integration.test.tsx
@@ -611,7 +611,7 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
     await expectModalNotOpen();
   });
 
-  it("should not open when onboarding date is missing", async () => {
+  it("should open when onboarding date is missing using the legacy fallback", async () => {
     renderMount({
       ...eligibleState({
         devicesModelList: [DeviceModelId.nanoX],
@@ -621,7 +621,9 @@ describe("LargeScreenUpsellModalMount (integration)", () => {
       },
     });
 
-    await expectModalNotOpen();
+    await waitFor(() => {
+      expect(screen.getByTestId("large-screen-upsell-modal")).toBeVisible();
+    });
   });
 
   it("should not open when retries reach killThreshold 3 within the cadence window", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.test.ts
@@ -100,7 +100,7 @@ describe("LargeScreenUpsellQa utils", () => {
     expect(draftDisplayFromEffective(0, "30")).toBe("0");
   });
 
-  it("mirrors post-onboarding cooldown: null date is treated as today", () => {
+  it("mirrors post-onboarding cooldown: null date uses the legacy onboarding date", () => {
     const now = new Date("2026-07-17T12:00:00.000Z");
 
     expect(
@@ -109,7 +109,7 @@ describe("LargeScreenUpsellQa utils", () => {
         cooldownDays: 30,
         now,
       }),
-    ).toBe(false);
+    ).toBe(true);
 
     expect(
       isPostOnboardingCooldownPassed({

--- a/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/LargeScreenUpsell/screens/LargeScreenUpsellQa/utils.ts
@@ -1,3 +1,5 @@
+import { resolveOnboardingDateForUpsell } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
+
 const MS_PER_DAY = 86_400_000;
 
 type DisplayParamValue = string | number | boolean | null | undefined;
@@ -74,8 +76,7 @@ export function calendarDaysBetween(later: Date, earlier: Date): number {
 }
 
 /**
- * Mirrors getLargeScreenUpsellDecision: null onboardingDate is treated as `now`
- * (legacy installs wait the full cooldown unless cooldownDays is 0).
+ * Mirrors getLargeScreenUpsellDecision: null onboardingDate uses the legacy fallback date.
  */
 export function isPostOnboardingCooldownPassed({
   onboardingDate,
@@ -86,7 +87,7 @@ export function isPostOnboardingCooldownPassed({
   cooldownDays: number;
   now: Date;
 }): boolean {
-  const elapsedSinceDate = onboardingDate ?? now;
+  const elapsedSinceDate = resolveOnboardingDateForUpsell(onboardingDate);
   return calendarDaysBetween(now, elapsedSinceDate) >= cooldownDays;
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -7,6 +7,7 @@ import {
   isCooldownElapsed,
   shouldThrottle,
 } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
+import { resolveOnboardingDateForUpsell } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { setPostOnboardingDate } from "@ledgerhq/live-common/postOnboarding/actions";
 import {
@@ -100,7 +101,11 @@ function deriveDebugDecision({
   const resolvedCooldownDays =
     "cooldownDays" in eligibility ? eligibility.cooldownDays : cooldownDaysDefault;
 
-  const cooldownElapsed = isCooldownElapsed(onboardingDate, resolvedCooldownDays ?? 0, now);
+  const cooldownElapsed = isCooldownElapsed(
+    resolveOnboardingDateForUpsell(onboardingDate),
+    resolvedCooldownDays ?? 0,
+    now,
+  );
 
   const throttled =
     killThreshold != null && cadenceDays != null

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -150,15 +150,14 @@ describe("useLargeScreenUpsellEligibility", () => {
     expect(result.current).toEqual({ isEligible: false, reason: "model_disabled" });
   });
 
-  it("should treat a null onboarding date as today and apply cooldown", () => {
+  it("should treat a null onboarding date as the legacy date and apply cooldown", () => {
     const { result } = renderEligibility({
       knownDeviceModelIds: [DeviceModelId.nanoX],
       onboardingDate: null,
     });
 
     expect(result.current).toEqual({
-      isEligible: false,
-      reason: "cooldown",
+      isEligible: true,
       deviceModelId: DeviceModelId.nanoX,
       cooldownDays: 30,
     });

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/__tests__/useLargeScreenUpsellEligibility.test.ts
@@ -150,7 +150,7 @@ describe("useLargeScreenUpsellEligibility", () => {
     expect(result.current).toEqual({ isEligible: false, reason: "model_disabled" });
   });
 
-  it("should treat a null onboarding date as the legacy date and apply cooldown", () => {
+  it("should treat a null onboarding date as the legacy date and pass cooldown", () => {
     const { result } = renderEligibility({
       knownDeviceModelIds: [DeviceModelId.nanoX],
       onboardingDate: null,

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -1,3 +1,4 @@
+import { resolveOnboardingDateForUpsell } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
 import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
@@ -91,7 +92,7 @@ export function useLargeScreenUpsellEligibility(): LargeScreenUpsellEligibility 
   const deviceModelId = selectCooldownDeviceModelId(enabledNanoDeviceModelIds, params.cooldownDays);
   const cooldownDays = resolveCooldownDays(params.cooldownDays, deviceModelId);
   const now = new Date();
-  const onboardingDateForEligibility = onboardingDate ?? now;
+  const onboardingDateForEligibility = resolveOnboardingDateForUpsell(onboardingDate);
 
   if (!isCooldownElapsed(onboardingDateForEligibility, cooldownDays, now)) {
     return { isEligible: false, reason: "cooldown", deviceModelId, cooldownDays };

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.test.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.test.ts
@@ -85,7 +85,7 @@ describe("getLargeScreenUpsellDecision", () => {
     {
       description: "the onboarding date is null",
       userState: { onboardingDate: null },
-      expected: { shouldShow: false, reason: "cooldown", deviceModelId: "nanoX" },
+      expected: { shouldShow: true, deviceModelId: "nanoX" },
     },
     {
       description: "eligible and never displayed before",

--- a/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
+++ b/features/flow/large-screen-upsell/src/decision/getLargeScreenUpsellDecision.ts
@@ -1,4 +1,5 @@
 import { isCooldownElapsed } from "../internal/isCooldownElapsed";
+import { resolveOnboardingDateForUpsell } from "../internal/legacyOnboardingDate";
 import type {
   LargeScreenUpsellContext,
   LargeScreenUpsellDecision,
@@ -77,7 +78,7 @@ export function getLargeScreenUpsellDecision(
     enabledSeenNanoModelIds,
     cooldownDays,
   );
-  const onboardingDateForEligibility = onboardingDate ?? now;
+  const onboardingDateForEligibility = resolveOnboardingDateForUpsell(onboardingDate);
 
   if (
     !isCooldownElapsed({

--- a/features/flow/large-screen-upsell/src/internal/legacyOnboardingDate.ts
+++ b/features/flow/large-screen-upsell/src/internal/legacyOnboardingDate.ts
@@ -1,7 +1,15 @@
 /** Must stay in sync with @ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate */
 export const LEGACY_ONBOARDING_DATE = new Date("2026-01-01T00:00:00.000Z");
 
+function isKnownOnboardingDate(onboardingDate: Date): boolean {
+  return !Number.isNaN(onboardingDate.getTime());
+}
+
 /** Fallback when onboardingDate is unknown (legacy users pre-field). Used by upsell cooldown. */
 export function resolveOnboardingDateForUpsell(onboardingDate: Date | null): Date {
-  return onboardingDate ?? LEGACY_ONBOARDING_DATE;
+  if (onboardingDate != null && isKnownOnboardingDate(onboardingDate)) {
+    return onboardingDate;
+  }
+
+  return new Date(LEGACY_ONBOARDING_DATE);
 }

--- a/features/flow/large-screen-upsell/src/internal/legacyOnboardingDate.ts
+++ b/features/flow/large-screen-upsell/src/internal/legacyOnboardingDate.ts
@@ -1,0 +1,7 @@
+/** Must stay in sync with @ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate */
+export const LEGACY_ONBOARDING_DATE = new Date("2026-01-01T00:00:00.000Z");
+
+/** Fallback when onboardingDate is unknown (legacy users pre-field). Used by upsell cooldown. */
+export function resolveOnboardingDateForUpsell(onboardingDate: Date | null): Date {
+  return onboardingDate ?? LEGACY_ONBOARDING_DATE;
+}


### PR DESCRIPTION
### 📝 Description

After LIVE-35419 backfills legacy users with a fixed `2026-01-01` onboarding date, runtime upsell eligibility still treated `null` as `now`, incorrectly blocking the 30-day cooldown for legacy Nano X/SP users.

**Problem**: `onboardingDate ?? now` in eligibility paths meant any remaining null date (debug reset, pre-backfill race) behaved like a brand-new onboarding.

**Solution**: Replace `onboardingDate ?? now` with `resolveOnboardingDateForUpsell(onboardingDate)` in:
- Mobile `useLargeScreenUpsellEligibility`
- Desktop QA `isPostOnboardingCooldownPassed`
- Shared flow `getLargeScreenUpsellDecision` (internal mirror of the helper due to module boundaries)
- Mobile debug view model (cooldown readout consistency)

**Depends on:** [LIVE-35419 / PR #20456](https://github.com/LedgerHQ/ledger-live/pull/20456)

### 🔗 Context

- **JIRA issue**: [LIVE-35420](https://ledgerhq.atlassian.net/browse/LIVE-35420)
- **Blocks on**: [LIVE-35419](https://ledgerhq.atlassian.net/browse/LIVE-35419)

### ✅ Test plan

- [ ] Legacy user with `onboardingDate == null` → eligible for upsell when cooldown elapsed (mobile + desktop modal)
- [ ] User with recent onboarding date → still blocked during cooldown
- [ ] Desktop QA tool gate rows match production decision for null date
- [ ] Unit tests: `getLargeScreenUpsellDecision`, `useLargeScreenUpsellEligibility`, QA utils
- [ ] Integration: desktop modal opens when onboarding date is missing (legacy fallback)

Made with [Cursor](https://cursor.com)

[LIVE-35420]: https://ledgerhq.atlassian.net/browse/LIVE-35420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35419]: https://ledgerhq.atlassian.net/browse/LIVE-35419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ