### PR TITLE
chore(ci): use pnpm store cache for e2e desktop

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -67,7 +67,7 @@ jobs:
       contents: read
     needs: determine-affected
     if: ${{contains(needs.determine-affected.outputs.paths, 'ledger-live-desktop') && !github.event.pull_request.head.repo.fork}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-reusable.yml@feature/QAA-1412
     secrets: inherit
 
   codecheck-desktop:

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -222,7 +222,7 @@ jobs:
       contents: read
     needs: determine-affected
     if: ${{!github.event.pull_request.head.repo.fork && (contains(needs.determine-affected.outputs.paths, 'e2e/mobile') || contains(needs.determine-affected.outputs.paths, 'apps/ledger-live-mobile'))}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@feature/QAA-1412
     secrets: inherit
 
   test-desktop-e2e-lint:
@@ -232,7 +232,7 @@ jobs:
       contents: read
     needs: determine-affected
     if: ${{!github.event.pull_request.head.repo.fork && contains(needs.determine-affected.outputs.paths, 'e2e/desktop')}}
-    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-e2e-lint-reusable.yml@develop
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-e2e-lint-reusable.yml@feature/QAA-1412
     secrets: inherit
 
   notify-e2e-required:

--- a/.github/workflows/test-desktop-e2e-lint-reusable.yml
+++ b/.github/workflows/test-desktop-e2e-lint-reusable.yml
@@ -44,6 +44,7 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+          skip-pnpm-cache: false
 
       - name: Install dependencies
         run: pnpm i --filter="ledger-live-desktop-e2e-tests..." --filter="ledger-live-desktop..." --no-frozen-lockfile --unsafe-perm

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -83,7 +83,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup caches
         id: caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feature/QAA-1412
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -197,7 +197,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: Setup caches
         id: caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@feature/QAA-1412
         with:
           use-mise: true
           gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-desktop-reusable.yml
+++ b/.github/workflows/test-desktop-reusable.yml
@@ -93,6 +93,7 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+          skip-pnpm-cache: false
       - name: JFrog npm auth
         uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
         with:
@@ -206,6 +207,7 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+          skip-pnpm-cache: false
       - name: JFrog npm auth
         uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
         with:

--- a/.github/workflows/test-mobile-e2e-lint-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-lint-reusable.yml
@@ -44,6 +44,7 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+          skip-pnpm-cache: false
 
       - name: Install dependencies
         run: pnpm i --filter="ledger-live-mobile-e2e-tests..." --no-frozen-lockfile --unsafe-perm

--- a/.github/workflows/test-ui-e2e-only-desktop.yml
+++ b/.github/workflows/test-ui-e2e-only-desktop.yml
@@ -203,7 +203,6 @@ jobs:
       FORCE_COLOR: 3
       CI_OS: "ubuntu-latest"
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-      npm_config_loglevel: warn
       DO_NOT_TRACK: 1
       SPECULOS_IMAGE_TAG: ghcr.io/ledgerhq/speculos:${{ matrix.device == 'nanoS' && '1be65b91a8e0691866f880fd437ac05fce78af9d' || 'latest' }}
       SPECULOS_DEVICE: ${{ matrix.device }}
@@ -257,6 +256,7 @@ jobs:
           accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
           roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
           region: ${{ secrets.AWS_CACHE_REGION }}
+          skip-pnpm-cache: false
 
       - name: Pull Speculos docker image
         run: docker pull ${{ env.SPECULOS_IMAGE_TAG }}

--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "ui:crypto-icons": "pnpm --filter crypto-icons",
     "ui:shared": "pnpm --filter ui-shared",
     "actions": "pnpm --filter \"@actions/*\"",
-    "my-fake-script": "echo \"This is a fake script.\""
+    "my-fake-script": "echo \"This is a fake script!\""
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -222,7 +222,8 @@
     "ui:icons": "pnpm --filter icons-ui",
     "ui:crypto-icons": "pnpm --filter crypto-icons",
     "ui:shared": "pnpm --filter ui-shared",
-    "actions": "pnpm --filter \"@actions/*\""
+    "actions": "pnpm --filter \"@actions/*\"",
+    "my-fake-script": "echo \"This is a fake script.\""
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.0",

--- a/tools/actions/composites/setup-caches/action.yml
+++ b/tools/actions/composites/setup-caches/action.yml
@@ -81,11 +81,26 @@ runs:
         sudo apt-get update
         sudo apt-get install -y build-essential pkg-config
 
+    - name: Set pnpm store dir
+      shell: bash
+      run: |
+        store_dir="${{ github.workspace }}/.pnpm-store"
+        # Runner images may set npm_config_store_dir globally; env beats project .npmrc.
+        pnpm config set store-dir "$store_dir" --location project
+        echo "PNPM_STORE_DIR=$store_dir" >> "$GITHUB_ENV"
+        echo "npm_config_store_dir=$store_dir" >> "$GITHUB_ENV"
+
     - name: Get pnpm store directory
       id: get-store-path
       shell: bash
       run: |
-        echo "store-path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+        store_path="$(pnpm store path --silent)"
+        echo "store-path=$store_path" >> "$GITHUB_OUTPUT"
+        echo "Resolved pnpm store: $store_path"
+        expected="${{ github.workspace }}/.pnpm-store"
+        if [[ "$store_path" != "$expected"* ]]; then
+          echo "::warning::pnpm store path ($store_path) does not match expected ($expected)"
+        fi
 
     - name: Resolve Nx remote cache profile and apply S3 prefix
       id: nx-remote-cache
@@ -122,9 +137,9 @@ runs:
       if: steps.aws.conclusion == 'success' && inputs.skip-pnpm-cache != 'true'
       with:
         path: ${{ steps.get-store-path.outputs.store-path }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-pnpm-store-v2-
         accessKey: ${{ env.AWS_ACCESS_KEY_ID }}
         secretKey: ${{ env.AWS_SECRET_ACCESS_KEY }}
         sessionToken: ${{ env.AWS_SESSION_TOKEN}}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Use pnpm store cache for e2e desktop to reduce build time.

- [cold cache](https://github.com/LedgerHQ/ledger-live/actions/runs/31013233153/job/92330882254) pnpm install 1m 46.8s and overal setup step 4m 47s
- [warm cache](https://github.com/LedgerHQ/ledger-live/actions/runs/31014554330/job/92335483765?pr=20460) pnpm install 58.2s and overal setup step 2m 21s

time saving of ~2mins for e2e desktop smoke on PRs

please also note a tweak was needed to fix pnpm store dir in the config.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/QAA-1412
