### PR TITLE
ci(hardening): fix permission ceiling gaps in push and release

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -87,6 +87,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
     uses: LedgerHQ/ledger-live/.github/workflows/build-web-tools-reusable.yml@develop
     secrets: inherit
     with:

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -137,6 +137,11 @@ jobs:
   release-final:
     name: "Prepare Hotfix > Publish packages and apps"
     needs: prepare-release
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+      id-token: write
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
       # release from main if hotfixing the latest version, otherwise from the hotfix branch

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -94,6 +94,11 @@ jobs:
   release-final:
     name: "Prepare Release > Publish packages and apps"
     needs: prepare-release
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+      id-token: write
     uses: LedgerHQ/ledger-live/.github/workflows/release-final.yml@develop
     with:
       ref: main


### PR DESCRIPTION
### 📝 Description

Extend permissions for push and release in-line with actions

Fixes perm errors for https://github.com/LedgerHQ/ledger-live/pull/20145
