### PR TITLE
[LWDM] feat(llc): add addressbook properties in the descriptor

### DIFF
--- a/.changeset/slimy-yaks-marry.md
+++ b/.changeset/slimy-yaks-marry.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+feat(llc): add hasAddressBook feature registry descriptor

--- a/libs/ledger-live-common/src/bridge/descriptor.test.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor.test.ts
@@ -60,6 +60,7 @@ describe("getDescriptor", () => {
     const descriptor = getDescriptor(currency);
     expect(descriptor).toMatchObject({
       send: {
+        addressBook: true,
         inputs: { recipientSupportsDomain: true },
         fees: {
           hasPresets: true,
@@ -655,6 +656,20 @@ describe("sendFeatures", () => {
 
   it("should return impossible as default self transfer policy", () => {
     expect(sendFeatures.getSelfTransferPolicy(undefined)).toBe("impossible");
+  });
+
+  it.each([
+    ["ethereum", true],
+    ["tron", true],
+    ["bitcoin", false],
+    ["solana", false],
+  ])("should get address book support for %s", (currencyId, expected) => {
+    const currency = getCryptoCurrencyById(currencyId);
+    expect(sendFeatures.hasAddressBook(currency)).toBe(expected);
+  });
+
+  it("should return false for address book support when currency is undefined", () => {
+    expect(sendFeatures.hasAddressBook(undefined)).toBe(false);
   });
 
   it.each([

--- a/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/send/features.ts
@@ -116,6 +116,7 @@ export const sendFeatures = {
   getMemoOptions: fromDescriptor(d => d.inputs.memo?.options, undefined),
   getMemoDefaultOption: fromDescriptor(d => d.inputs.memo?.defaultOption, undefined),
   supportsDomain: fromDescriptor(d => d.inputs.recipientSupportsDomain, false),
+  hasAddressBook: fromDescriptor(d => d.addressBook, false),
   getSelfTransferPolicy: fromDescriptor(d => d.selfTransfer, defaultSelfTransferPolicy),
   getUserRefusedTransactionErrorName: fromDescriptor(
     d => d.errors?.userRefusedTransaction,

--- a/libs/ledger-live-common/src/bridge/descriptor/types.ts
+++ b/libs/ledger-live-common/src/bridge/descriptor/types.ts
@@ -356,6 +356,7 @@ export type SendDescriptor = {
   };
   fees: FeeDescriptor;
   amount?: SendAmountDescriptor;
+  addressBook?: boolean;
   selfTransfer?: SelfTransferPolicy; // Policy for sending to self (same address), defaults to "impossible"
   errors?: ErrorRegistry; // Registry of error class names for this coin
 };

--- a/libs/ledger-live-common/src/families/evm/descriptor/send/descriptor.ts
+++ b/libs/ledger-live-common/src/families/evm/descriptor/send/descriptor.ts
@@ -22,6 +22,7 @@ function getEstimatedMs(strategy: string): number {
 }
 
 export const evmSendDescriptor: SendDescriptor = {
+  addressBook: true,
   inputs: {
     recipientSupportsDomain: true,
   },

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.test.ts
@@ -25,6 +25,10 @@ describe("tron descriptor", () => {
     expect(descriptor.send.fees.hasCustom).toBe(false);
     expect(descriptor.send.fees.hasCoinControl).toBeUndefined();
   });
+
+  it("declares address book support", () => {
+    expect(descriptor.send.addressBook).toBe(true);
+  });
 });
 
 describe("tron descriptor - getNetworkFeesInfo", () => {

--- a/libs/ledger-live-common/src/families/tron/descriptor/index.ts
+++ b/libs/ledger-live-common/src/families/tron/descriptor/index.ts
@@ -51,6 +51,7 @@ function getNetworkFeesInfo({
 
 export const descriptor: CoinDescriptor = {
   send: {
+    addressBook: true,
     inputs: {},
     fees: {
       hasPresets: false,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adding the `addressBook` property on descriptor for the new send flow
and enabling it for tron and evm

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-34103)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
