### PR TITLE
[LWDM] fix(lwdm): fix sanctionned ens address check

### DIFF
--- a/.changeset/smooth-years-divide.md
+++ b/.changeset/smooth-years-divide.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+fix(lwdm): fix sanctionned ens address check

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -190,6 +190,52 @@ describe("useAddressValidation", () => {
     });
   });
 
+  it("revalidates sanctions against the resolved ENS address", async () => {
+    const ensResolution = {
+      domain: "sanctioned.eth",
+      address: "0xSanctioned",
+      type: "forward" as const,
+      registry: "ens" as const,
+    };
+    const validationProps = {
+      searchValue: ensResolution.domain,
+      currency: mockEthereumAccount.currency,
+      account: mockEthereumAccount,
+      recipientSupportsDomain: true,
+    };
+    mockedUseDomain.mockReturnValue({ status: "loading" });
+    mockedIsAddressSanctioned.mockImplementation(
+      async (_currency, address) => address === ensResolution.address,
+    );
+
+    const { result, rerender } = renderHook(
+      (props: typeof validationProps) => useAddressValidation(props),
+      { initialProps: validationProps },
+    );
+
+    await waitFor(() => {
+      expect(mockedIsAddressSanctioned).toHaveBeenCalledWith(
+        mockEthereumAccount.currency,
+        ensResolution.domain,
+      );
+    });
+
+    mockedUseDomain.mockReturnValue({
+      status: "loaded",
+      resolutions: [ensResolution],
+      updatedAt: Date.now(),
+    });
+    rerender(validationProps);
+
+    await waitFor(() => {
+      expect(result.current.result.status).toBe("sanctioned");
+    });
+    expect(mockedIsAddressSanctioned).toHaveBeenCalledWith(
+      mockEthereumAccount.currency,
+      ensResolution.address,
+    );
+  });
+
   it("shows loading state during ENS resolution", () => {
     mockedUseDomain.mockReturnValue({
       status: "loading",

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -100,7 +100,7 @@ export function useAddressValidation({
     isSanctioned: false,
   });
 
-  const lastSearchValueRef = useRef<string>("");
+  const lastValidationKeyRef = useRef<string>("");
   const validationTriggeredRef = useRef<boolean>(false);
 
   const allAccounts = useSelector(accountsSelector);
@@ -125,6 +125,8 @@ export function useAddressValidation({
     () => (account ? getMainAccount(account, parentAccount) : null),
     [account, parentAccount],
   );
+  const sanctionCurrency = currency.type === "TokenCurrency" ? mainAccount?.currency : currency;
+  const validationKey = `${sanctionCurrency?.id ?? ""}:${addressForBridgeValidation}`;
 
   // Bridge validation for recipient/sender errors and warnings
   const bridgeValidation = useBridgeRecipientValidation({
@@ -234,7 +236,6 @@ export function useAddressValidation({
     try {
       const addressToCheck = ensResolution?.address ?? searchValue;
 
-      const sanctionCurrency = currency.type === "TokenCurrency" ? mainAccount?.currency : currency;
       if (sanctionCurrency) {
         const sanctioned = await isAddressSanctioned(sanctionCurrency, addressToCheck);
         if (sanctioned) {
@@ -268,11 +269,11 @@ export function useAddressValidation({
         isSanctioned: false,
       });
     }
-  }, [searchValue, ensResolution, currency, mainAccount]);
+  }, [searchValue, ensResolution, sanctionCurrency]);
 
-  // Auto-validate when searchValue changes
-  if (searchValue !== lastSearchValueRef.current) {
-    lastSearchValueRef.current = searchValue;
+  // Revalidate when the effective address changes, including after ENS resolution.
+  if (validationKey !== lastValidationKeyRef.current) {
+    lastValidationKeyRef.current = validationKey;
     validationTriggeredRef.current = false;
     // If searchValue is cleared, immediately reset validation state
     if (!searchValue) {
@@ -280,8 +281,12 @@ export function useAddressValidation({
     }
   }
 
-  // Trigger validation once when searchValue changes
-  if (searchValue && !validationTriggeredRef.current && validationState.status !== "loading") {
+  // Trigger validation once for each effective address.
+  if (
+    addressForBridgeValidation &&
+    !validationTriggeredRef.current &&
+    validationState.status !== "loading"
+  ) {
     validationTriggeredRef.current = true;
     // Use queueMicrotask to trigger validation after render
     queueMicrotask(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -184,6 +184,52 @@ describe("useAddressValidation", () => {
     });
   });
 
+  it("revalidates sanctions against the resolved ENS address", async () => {
+    const ensResolution = {
+      domain: "sanctioned.eth",
+      address: "0xSanctioned",
+      type: "forward" as const,
+      registry: "ens" as const,
+    };
+    const validationProps = {
+      searchValue: ensResolution.domain,
+      currency: mockEthereumAccount.currency,
+      account: mockEthereumAccount,
+      recipientSupportsDomain: true,
+    };
+    mockedUseDomain.mockReturnValue({ status: "loading" });
+    mockedIsAddressSanctioned.mockImplementation(
+      async (_currency, address) => address === ensResolution.address,
+    );
+
+    const { result, rerender } = renderHook(
+      (props: typeof validationProps) => useAddressValidation(props),
+      { initialProps: validationProps },
+    );
+
+    await waitFor(() => {
+      expect(mockedIsAddressSanctioned).toHaveBeenCalledWith(
+        mockEthereumAccount.currency,
+        ensResolution.domain,
+      );
+    });
+
+    mockedUseDomain.mockReturnValue({
+      status: "loaded",
+      resolutions: [ensResolution],
+      updatedAt: Date.now(),
+    });
+    rerender(validationProps);
+
+    await waitFor(() => {
+      expect(result.current.result.status).toBe("sanctioned");
+    });
+    expect(mockedIsAddressSanctioned).toHaveBeenCalledWith(
+      mockEthereumAccount.currency,
+      ensResolution.address,
+    );
+  });
+
   it("shows loading state during ENS resolution", () => {
     mockedUseDomain.mockReturnValue({
       status: "loading",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -72,7 +72,7 @@ export function useAddressValidation({
     isSanctioned: false,
   });
 
-  const lastSearchValueRef = useRef<string>("");
+  const lastValidationKeyRef = useRef<string>("");
   const validationTriggeredRef = useRef<boolean>(false);
 
   const allAccounts = useSelector(accountsSelector);
@@ -97,6 +97,8 @@ export function useAddressValidation({
     () => (account ? getMainAccount(account, parentAccount) : null),
     [account, parentAccount],
   );
+  const sanctionCurrency = currency.type === "TokenCurrency" ? mainAccount?.currency : currency;
+  const validationKey = `${sanctionCurrency?.id ?? ""}:${addressForBridgeValidation}`;
 
   // Bridge validation for recipient/sender errors and warnings
   const bridgeValidation = useBridgeRecipientValidation({
@@ -213,7 +215,6 @@ export function useAddressValidation({
     try {
       const addressToCheck = ensResolution?.address ?? searchValue;
 
-      const sanctionCurrency = currency.type === "TokenCurrency" ? mainAccount?.currency : currency;
       if (sanctionCurrency) {
         const sanctioned = await isAddressSanctioned(sanctionCurrency, addressToCheck);
         if (sanctioned) {
@@ -247,11 +248,11 @@ export function useAddressValidation({
         isSanctioned: false,
       });
     }
-  }, [searchValue, ensResolution, currency, mainAccount]);
+  }, [searchValue, ensResolution, sanctionCurrency]);
 
-  // Auto-validate when searchValue changes
-  if (searchValue !== lastSearchValueRef.current) {
-    lastSearchValueRef.current = searchValue;
+  // Revalidate when the effective address changes, including after ENS resolution.
+  if (validationKey !== lastValidationKeyRef.current) {
+    lastValidationKeyRef.current = validationKey;
     validationTriggeredRef.current = false;
     // If searchValue is cleared, immediately reset validation state
     if (!searchValue) {
@@ -259,8 +260,12 @@ export function useAddressValidation({
     }
   }
 
-  // Trigger validation once when searchValue changes
-  if (searchValue && !validationTriggeredRef.current && validationState.status !== "loading") {
+  // Trigger validation once for each effective address.
+  if (
+    addressForBridgeValidation &&
+    !validationTriggeredRef.current &&
+    validationState.status !== "loading"
+  ) {
     validationTriggeredRef.current = true;
     // Use queueMicrotask to trigger validation after render
     queueMicrotask(() => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Previously, recipient sanction checks ran against the raw ENS domain instead of the resolved address, so sanctioned destinations could be missed. This is revalidating sanctions whenever the effective address changes including after ENS resolution and uses the parent chain currency for token sends

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35547)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
