### PR TITLE
[LWD] feat(contacts): add address name tooltip (LIVE-35523)

### DIFF
--- a/.changeset/bright-cats-listen.md
+++ b/.changeset/bright-cats-listen.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+---
+
+Replace the Desktop address name clear action with a help tooltip.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -487,6 +487,15 @@ describe("Contacts integration", () => {
     expect(addressNameInput).toHaveAttribute("maxlength", "32");
     expect(screen.getByTestId("contacts-add-address-confirm")).toBeDisabled();
 
+    const namingDisclaimer = screen.getByRole("button", {
+      name: "Address name information",
+    });
+    await user.hover(namingDisclaimer);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "This name appears on your Ledger device when you send to this address. Give it a name that makes it easy to find.",
+    );
+    expect(addressNameInput).toHaveValue("Ethereum");
+
     fireEvent.change(addressInput, {
       target: { value: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034" },
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -153,6 +153,10 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const addAddressNameLabels = useMemo<ContactsAddAddressNameLabels>(
     () => ({
       inputLabel: t("contacts.addAddressName.inputLabel"),
+      namingDisclaimer: t("contacts.addAddressName.namingDisclaimer"),
+      namingDisclaimerAccessibilityLabel: t(
+        "contacts.addAddressName.namingDisclaimerAccessibilityLabel",
+      ),
       continueToReview: t("contacts.addAddressName.continueToReview"),
       validAddress: t("contacts.addAddressEntry.validAddress"),
       validationErrors: {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9306,6 +9306,8 @@
     },
     "addAddressName": {
       "inputLabel": "Address name",
+      "namingDisclaimer": "This name appears on your Ledger device when you send to this address. Give it a name that makes it easy to find.",
+      "namingDisclaimerAccessibilityLabel": "Address name information",
       "continueToReview": "Continue to review",
       "invalidLabel": "Special characters are not allowed.",
       "duplicateLabel": "This address name is already used for this contact.",

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressNameView.web.test.tsx
@@ -27,6 +27,8 @@ function createProps(
     },
     labels: {
       inputLabel: "Address name",
+      namingDisclaimer: "Address naming disclaimer",
+      namingDisclaimerAccessibilityLabel: "Address name information",
       continueToReview: "Continue to review",
       validAddress: "Valid address",
       validationErrors: {

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/Input/ContactsAddAddressNameInput.web.test.tsx
@@ -32,6 +32,8 @@ function createProps(
     },
     labels: {
       inputLabel: "Address name",
+      namingDisclaimer: "Address naming disclaimer",
+      namingDisclaimerAccessibilityLabel: "Address name information",
       continueToReview: "Continue to review",
       validAddress: "Valid address",
       validationErrors: {

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/types.ts
@@ -8,6 +8,8 @@ import type {
 
 export type ContactsAddAddressNameLabels = Readonly<{
   inputLabel: string;
+  namingDisclaimer: string;
+  namingDisclaimerAccessibilityLabel: string;
   continueToReview: string;
   validAddress: string;
   validationErrors: Record<ContactAddressLabelValidationErrorName, string>;

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -1,17 +1,9 @@
 import React from "react";
-import {
-  AddressInput,
-  Banner,
-  Button,
-  InteractiveIcon,
-  TextInput,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@ledgerhq/lumen-ui-react";
-import { InformationFill, LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
+import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
+import { AddressNameDisclaimer } from "./components/AddressNameDisclaimer/AddressNameDisclaimer.web";
 
 export function ContactsAddAddressEntryView({
   value,
@@ -65,21 +57,10 @@ export function ContactsAddAddressEntryView({
           spellCheck={false}
           status={addressLabel.status === "invalid" ? "error" : undefined}
           suffix={
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <InteractiveIcon
-                  aria-label={nameLabels.namingDisclaimerAccessibilityLabel}
-                  data-testid="contacts-add-address-name-disclaimer"
-                  icon={InformationFill}
-                  iconType="filled"
-                  size={20}
-                  type="button"
-                />
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="max-w-256 text-center">{nameLabels.namingDisclaimer}</div>
-              </TooltipContent>
-            </Tooltip>
+            <AddressNameDisclaimer
+              accessibilityLabel={nameLabels.namingDisclaimerAccessibilityLabel}
+              description={nameLabels.namingDisclaimer}
+            />
           }
           value={addressLabel.value}
         />

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -1,6 +1,15 @@
 import React from "react";
-import { AddressInput, Banner, Button, TextInput } from "@ledgerhq/lumen-ui-react";
-import { LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
+import {
+  AddressInput,
+  Banner,
+  Button,
+  InteractiveIcon,
+  TextInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@ledgerhq/lumen-ui-react";
+import { InformationFill, LedgerLogo } from "@ledgerhq/lumen-ui-react/symbols";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsAddAddressEntryWebViewProps } from "./ContactsAddAddressEntry.web.types";
 
@@ -48,12 +57,30 @@ export function ContactsAddAddressEntryView({
           autoCorrect="off"
           data-testid="contacts-add-address-name-input"
           helperText={nameValidationMessage}
+          hideClearButton
           label={nameLabels.inputLabel}
           maxCount={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
           maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}
           onChange={onAddressLabelChange}
           spellCheck={false}
           status={addressLabel.status === "invalid" ? "error" : undefined}
+          suffix={
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <InteractiveIcon
+                  aria-label={nameLabels.namingDisclaimerAccessibilityLabel}
+                  data-testid="contacts-add-address-name-disclaimer"
+                  icon={InformationFill}
+                  iconType="filled"
+                  size={20}
+                  type="button"
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                <div className="max-w-256 text-center">{nameLabels.namingDisclaimer}</div>
+              </TooltipContent>
+            </Tooltip>
+          }
           value={addressLabel.value}
         />
       ) : null}

--- a/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/Flow/ContactsAddAddressFlowContent.web.test.tsx
@@ -41,6 +41,8 @@ const entryLabels: AddAddressEntryLabels = {
 };
 const nameLabels: ContactsAddAddressNameLabels = {
   inputLabel: "Address name",
+  namingDisclaimer: "Address naming disclaimer",
+  namingDisclaimerAccessibilityLabel: "Address name information",
   continueToReview: "Continue to review",
   validAddress: "Valid address",
   validationErrors: {} as Record<ContactAddressLabelValidationErrorName, string>,

--- a/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AddressNameDisclaimer } from "./AddressNameDisclaimer.web";
+
+jest.mock("@ledgerhq/lumen-ui-react", () => {
+  const React = require("react");
+
+  return {
+    InteractiveIcon: ({
+      icon: _icon,
+      iconType: _iconType,
+      size: _size,
+      ...props
+    }: Omit<React.ComponentProps<"button">, "icon"> & {
+      icon: unknown;
+      iconType: string;
+      size: number;
+    }) => React.createElement("button", props),
+    Tooltip: ({ children }: { children: React.ReactNode }) => children,
+    TooltipTrigger: ({ children }: { children: React.ReactNode }) => children,
+    TooltipContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { role: "tooltip" }, children),
+  };
+});
+
+describe("AddressNameDisclaimer", () => {
+  it("should render an accessible tooltip trigger with its description", () => {
+    render(
+      <AddressNameDisclaimer
+        accessibilityLabel="Address name information"
+        description="This name appears on your Ledger device."
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Address name information" })).toBeVisible();
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "This name appears on your Ledger device.",
+    );
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { InteractiveIcon, Tooltip, TooltipContent, TooltipTrigger } from "@ledgerhq/lumen-ui-react";
+import { InformationFill } from "@ledgerhq/lumen-ui-react/symbols";
+
+type AddressNameDisclaimerProps = Readonly<{
+  description: string;
+  accessibilityLabel: string;
+}>;
+
+export function AddressNameDisclaimer({
+  description,
+  accessibilityLabel,
+}: AddressNameDisclaimerProps): React.JSX.Element {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <InteractiveIcon
+          aria-label={accessibilityLabel}
+          data-testid="contacts-add-address-name-disclaimer"
+          icon={InformationFill}
+          iconType="filled"
+          size={20}
+          type="button"
+        />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="max-w-256 text-center">{description}</div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useContactsAddAddressEntryViewModel.web.test.ts
@@ -26,6 +26,8 @@ const RESOLVED_ADDRESS = ContactAddressValueSchema.parse(
 );
 const nameLabels: ContactsAddAddressNameLabels = {
   inputLabel: "Address name",
+  namingDisclaimer: "Address naming disclaimer",
+  namingDisclaimerAccessibilityLabel: "Address name information",
   continueToReview: "Continue to review",
   validAddress: "Valid address",
   validationErrors: {


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** Focused Flow tests pass; the Desktop integration suite is blocked before the affected scenario by the existing missing `scroll_sepolia` currency registry entry.
- [x] **Impact of the changes:**
      Verify that the prefilled Address name field has no clear control, its information button opens the tooltip on hover and keyboard focus, and manual editing plus the review flow still work.

### 📝 Description

The prefilled Desktop Contacts address-name input exposed Lumen’s default clear control, which conflicted with the intended help affordance.

This PR disables that clear control and replaces it with an accessible Lumen information tooltip using the specified copy. The name remains manually editable; validation, the 32-character counter, and the review flow are unchanged. It adds the English source translations, updates Flow label contracts and extends the Desktop Contacts integration scenario.

<img width="806" height="557" alt="image" src="https://github.com/user-attachments/assets/db5e1ac6-478a-41a2-855e-4140bc099b67" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35523

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)