### PR TITLE
fix(desktop): remove allure parameter in swap tests

### DIFF
--- a/e2e/desktop/tests/page/speculos.page.ts
+++ b/e2e/desktop/tests/page/speculos.page.ts
@@ -1,6 +1,5 @@
 import { AppPage } from "./abstractClasses";
 import { step } from "../misc/reporters/step";
-import * as allure from "allure-js-commons";
 import {
   activateLedgerSync,
   expectValidAddressDevice,
@@ -61,7 +60,6 @@ export class SpeculosPage extends AppPage {
   @step("Verify amounts and accept swap")
   async verifyAmountsAndAcceptSwap(swap: Swap, amount: string) {
     const scenario = formatSwapScenario(swap, amount);
-    await allure.parameter("Swap scenario", scenario);
     try {
       await verifyAmountsAndAcceptSwap(swap, amount);
     } catch (error) {


### PR DESCRIPTION
### 📝 Description

Removes the `allure.parameter("Swap scenario", …)` call from `SpeculosPage.verifyAmountsAndAcceptSwap`.

**Why:** the "Swap scenario" parameter embedded the provider name. When a send-swap test failed and was retried with a fallback provider, Allure keyed the retry by that changed parameter and recorded it as a **new test** instead of a retry of the same one — producing incoherent, duplicated entries in the Allure report.

Removing the parameter keeps retries grouped under the same test. Swap-scenario context is **not** lost: it is still appended to the thrown error message in the `catch` block, so failing runs keep their debugging detail. The now-unused `allure-js-commons` import is removed as well.

### 🔗 Context

- **JIRA / GitHub issue**: N/A
- **ADR** (if any): N/A
