### PR TITLE
fix(contacts): correct flow typecheck inference

### DIFF
--- a/.changeset/tiny-owls-repair.md
+++ b/.changeset/tiny-owls-repair.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Fix the Contacts Flow typecheck for cleared address selections

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -216,7 +216,10 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
     const Wrapper = makeWrapper([mockMeContact(), contact]);
-    const { result, rerender } = renderHook(
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useContactAddressDetailActionsFlowViewModel>,
+      { addressId: ContactAddressId | undefined }
+    >(
       ({
         addressId,
       }: {
@@ -239,7 +242,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     expect(result.current.editUiState).toBe("signer-open");
 
-    rerender({ addressId: undefined } as { addressId: ContactAddressId | undefined });
+    rerender({ addressId: undefined });
 
     expect(result.current.editUiState).toBe("closed");
     expect(result.current.canSend).toBe(false);


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The affected Web test and the complete Libraries typecheck pass.
- [x] **Impact of the changes:**
      Restores the Libraries Codecheck by allowing the existing cleared-address test to rerender with an undefined address ID.

### 📝 Description

The Libraries Codecheck failed because React Testing Library inferred the hook test props from its initial, defined address ID. The later rerender with an undefined value was therefore rejected by TypeScript.

This PR explicitly types both the hook result and its rerender props, preserving the optional address ID exercised by the test. No production behavior changes.

### ❓ Context

- **JIRA or GitHub link**: https://github.com/LedgerHQ/ledger-live/actions/runs/31013487022/job/92331407630

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)