### PR TITLE
fix(e2e): retry 5xx/NetworkDown errors wrapped by live-network

### DIFF
--- a/.changeset/fix-e2e-retry-wrapped-5xx.md
+++ b/.changeset/fix-e2e-retry-wrapped-5xx.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-e2e-shared": patch
+---
+
+fix(e2e): retry Speculos 5xx/NetworkDown errors that live-network wraps into non-Axios errors

--- a/libs/live-e2e-shared/src/deviceInteraction/retryAxiosRequest.ts
+++ b/libs/live-e2e-shared/src/deviceInteraction/retryAxiosRequest.ts
@@ -30,13 +30,6 @@ export async function retryAxiosRequest<T>(
 
       const ax = axios.isAxiosError(error) ? error : null;
 
-      // `live-network` installs a GLOBAL axios response interceptor that rewrites
-      // transport failures into `@ledgerhq/errors` classes before they ever reach
-      // this catch: 5xx/4xx responses become LedgerAPI5xx/LedgerAPI4xx (which carry
-      // a numeric `.status`), and no-response failures become NetworkDown. In that
-      // runtime the caught value is no longer an AxiosError, so gating retries on
-      // `axios.isAxiosError` alone silently disables them — we must also inspect the
-      // transformed error's own shape.
       const err = error as { status?: number; name?: string; code?: string } | null;
       const status = ax?.response?.status ?? err?.status;
       const code = ax?.code ?? err?.code;

--- a/libs/live-e2e-shared/src/deviceInteraction/retryAxiosRequest.ts
+++ b/libs/live-e2e-shared/src/deviceInteraction/retryAxiosRequest.ts
@@ -30,14 +30,25 @@ export async function retryAxiosRequest<T>(
 
       const ax = axios.isAxiosError(error) ? error : null;
 
-      const isRetryableStatus = !!ax?.response && retryableStatusCodes.includes(ax.response.status);
+      // `live-network` installs a GLOBAL axios response interceptor that rewrites
+      // transport failures into `@ledgerhq/errors` classes before they ever reach
+      // this catch: 5xx/4xx responses become LedgerAPI5xx/LedgerAPI4xx (which carry
+      // a numeric `.status`), and no-response failures become NetworkDown. In that
+      // runtime the caught value is no longer an AxiosError, so gating retries on
+      // `axios.isAxiosError` alone silently disables them — we must also inspect the
+      // transformed error's own shape.
+      const err = error as { status?: number; name?: string; code?: string } | null;
+      const status = ax?.response?.status ?? err?.status;
+      const code = ax?.code ?? err?.code;
+      const message = error instanceof Error ? error.message : String(error);
 
-      const isNetworkError = !!ax && !ax.response;
+      const isRetryableStatus = typeof status === "number" && retryableStatusCodes.includes(status);
 
-      const socketHangUp =
-        !!ax && typeof ax.message === "string" && ax.message.includes("socket hang up");
+      const isNetworkError = (!!ax && !ax.response) || err?.name === "NetworkDown";
 
-      const isRetryableCode = !!ax?.code && RETRYABLE_NODE_CODES.has(ax.code);
+      const socketHangUp = message.includes("socket hang up");
+
+      const isRetryableCode = !!code && RETRYABLE_NODE_CODES.has(code);
 
       if (
         (isRetryableStatus || isNetworkError || socketHangUp || isRetryableCode) &&
@@ -47,8 +58,8 @@ export async function retryAxiosRequest<T>(
         console.warn(
           `Axios request failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms...`,
           {
-            status: ax?.response?.status ?? "network error",
-            message: ax?.message ?? (error as Error).message,
+            status: status ?? err?.name ?? "network error",
+            message,
           },
         );
         await new Promise(resolve => setTimeout(resolve, delay));


### PR DESCRIPTION
### Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** _Verified with a runtime harness; no unit test committed (package has no Jest setup)._
- [x] **Impact of the changes:**
      - Touch-device signing E2E (`/finger`) via `retryAxiosRequest`
      - Mobile/desktop E2E resilience to transient Speculos `5xx`

### Description

`retryAxiosRequest` was meant to retry `5xx`/`504` but never did: `live-network`'s global axios interceptor rewrites the error into a `LedgerAPI5xx` (not an `AxiosError`), so the `axios.isAxiosError()` gate never matched.

**Fix:** also inspect the transformed error (`error.status`, `NetworkDown`, `socket hang up`), not just `AxiosError`s. `4xx` stays excluded.

Fixes the nightly `[ADA] - Delegate` `504` on `/finger`.

> ⏸️ **Paused** — see the pinned comment. A re-run hit a separate account-state blocker before signing, so CI hasn't exercised the retry yet.

### Context

- **JIRA or GitHub link**: _No ticket — E2E flakiness fix. Failing run: [30963424477](https://github.com/LedgerHQ/ledger-live/actions/runs/30963424477)_

---

### Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
