### PR TITLE
chore(contacts): add flow format checks

### DIFF
--- a/.changeset/bright-tigers-tap.md
+++ b/.changeset/bright-tigers-tap.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": patch
+---
+
+Add Contacts Flow format checks

--- a/features/flow/contacts/package.json
+++ b/features/flow/contacts/package.json
@@ -16,6 +16,8 @@
   },
   "sideEffects": false,
   "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -82,6 +84,7 @@
     "clsx": "catalog:",
     "jest": "catalog:",
     "jest-environment-jsdom": "catalog:",
+    "oxfmt": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-native": "catalog:",

--- a/features/flow/contacts/src/platform/contactSignerValidationPort.ts
+++ b/features/flow/contacts/src/platform/contactSignerValidationPort.ts
@@ -19,10 +19,7 @@ export type CreateMockContactSignerValidationPortOptions = Readonly<{
 export function createMockContactSignerValidationPort(
   options: CreateMockContactSignerValidationPortOptions = {},
 ): ContactSignerValidationPort {
-  const {
-    expectedSignerId = "signer-a",
-    currentSignerId = "signer-a",
-  } = options;
+  const { expectedSignerId = "signer-a", currentSignerId = "signer-a" } = options;
 
   return {
     getExpectedSignerId: async () => expectedSignerId,

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.web.test.tsx
@@ -3,7 +3,11 @@ import { configureStore } from "@reduxjs/toolkit";
 import { act, renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { contactsSlice } from "@domain/entity-contact";
-import { mockContactWithAddress, mockContactWithMultipleAddresses, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  mockContactWithAddress,
+  mockContactWithMultipleAddresses,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
 import { createMockContactSignerValidationPort } from "../../platform/contactSignerValidationPort";
 import type { ContactAddressDetailActionsPorts } from "./model/ports";
 import { useContactAddressDetailActionsFlowBindings } from "./useContactAddressDetailActionsFlowBindings";

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -2,8 +2,16 @@ import { createElement, type ReactNode } from "react";
 import { configureStore } from "@reduxjs/toolkit";
 import { act, renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
-import { ContactAddressIdSchema, contactsSlice, type ContactAddressId } from "@domain/entity-contact";
-import { mockContactAddress, mockContactWithAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  ContactAddressIdSchema,
+  contactsSlice,
+  type ContactAddressId,
+} from "@domain/entity-contact";
+import {
+  mockContactAddress,
+  mockContactWithAddress,
+  mockMeContact,
+} from "@domain/entity-contact/schema.mock";
 import {
   createMockContactSignerValidationPort,
   type ContactSignerValidationPort,
@@ -220,11 +228,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
       ReturnType<typeof useContactAddressDetailActionsFlowViewModel>,
       { addressId: ContactAddressId | undefined }
     >(
-      ({
-        addressId,
-      }: {
-        addressId: ContactAddressId | undefined;
-      }) =>
+      ({ addressId }: { addressId: ContactAddressId | undefined }) =>
         useContactAddressDetailActionsFlowViewModel({
           contactId: contact.id,
           addressId,

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
@@ -1,4 +1,9 @@
-import type { ContactAddress, ContactAddressId, ContactAddressLabel, ContactId } from "@domain/entity-contact";
+import type {
+  ContactAddress,
+  ContactAddressId,
+  ContactAddressLabel,
+  ContactId,
+} from "@domain/entity-contact";
 import { useCallback, useMemo } from "react";
 import type { ContactAddressEditPort } from "../Detail/model/ports";
 import { createRenameAddressController } from "./model/controller";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4701,6 +4701,9 @@ importers:
       jest-environment-jsdom:
         specifier: 'catalog:'
         version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
       react:
         specifier: 19.1.4
         version: 19.1.4


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** The relevant Web suites, Flow typecheck, and the full Libraries format matrix pass.
- [x] **Impact of the changes:**
      Adds Contacts Flow to the Nx format-check matrix and reformats the files it reports.

### 📝 Description

Contacts Flow had no `format` or `format:check` scripts, so Nx could not infer a format-check target and the Libraries CI matrix omitted this package.

This PR adds the inferred targets, declares the formatter dependency, and applies the formatter’s output to the four existing files it flags. No runtime behavior changes.

### ❓ Context

- **JIRA or GitHub link**: Depends on https://github.com/LedgerHQ/ledger-live/pull/20480 https://ledgerhq.atlassian.net/browse/LIVE-35529

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)