### PR TITLE
[LWM] feat(lwm): skip Braze changeUser for opted-out users (LIVE-34718)

### DIFF
--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { userIdSelector } from "@domain/entity-client-identity";
+import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
 import { start, updateUserPreferences } from "./braze";
@@ -9,13 +10,22 @@ const HookNotifications = () => {
   const notifications = useSelector(notificationsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const userId = useSelector(userIdSelector);
+  const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
 
   const sync = useCallback(() => {
     if (notificationsStarted) return;
     setNotificationsStarted(true);
-    start(isTrackedUser, userId);
+    start(isTrackedUser, userId, {
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+    });
     updateUserPreferences(notifications);
-  }, [notificationsStarted, notifications, isTrackedUser, userId]);
+  }, [
+    notificationsStarted,
+    notifications,
+    isTrackedUser,
+    userId,
+    brazeOptOutIdentityCleanup?.enabled,
+  ]);
 
   useEffect(sync, [sync]);
 

--- a/apps/ledger-live-mobile/src/notifications/braze.test.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.test.ts
@@ -1,0 +1,68 @@
+import Braze from "@braze/react-native-sdk";
+import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
+import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
+import { start } from "./braze";
+
+jest.mock("@braze/react-native-sdk", () => ({
+  __esModule: true,
+  default: {
+    changeUser: jest.fn(),
+  },
+}));
+
+jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
+  generateAnonymousId: jest.fn(() => "anonymous_id_1"),
+}));
+
+const mockedChangeUser = jest.mocked(Braze.changeUser);
+const mockedGenerateAnonymousId = jest.mocked(generateAnonymousId);
+
+const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
+
+describe("start", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when brazeOptOutIdentityCleanup is off (legacy)", () => {
+    it("should call changeUser with real id when user is tracked", () => {
+      start(true, REAL_USER_ID);
+      expect(mockedChangeUser).toHaveBeenCalledWith(REAL_USER_ID.exportUserIdForBraze());
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+
+    it("should call changeUser with anonymous id when user is opted out", () => {
+      start(false, REAL_USER_ID);
+      expect(mockedGenerateAnonymousId).toHaveBeenCalled();
+      expect(mockedChangeUser).toHaveBeenCalledWith("anonymous_id_1");
+    });
+
+    it("should skip changeUser when user id is dummy", () => {
+      start(true, DUMMY_USER_ID);
+      expect(mockedChangeUser).not.toHaveBeenCalled();
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when brazeOptOutIdentityCleanup is on", () => {
+    const options = { brazeOptOutIdentityCleanup: true };
+
+    it("should call changeUser with real id when user is tracked", () => {
+      start(true, REAL_USER_ID, options);
+      expect(mockedChangeUser).toHaveBeenCalledWith(REAL_USER_ID.exportUserIdForBraze());
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+
+    it("should skip changeUser when user is opted out", () => {
+      start(false, REAL_USER_ID, options);
+      expect(mockedChangeUser).not.toHaveBeenCalled();
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+
+    it("should skip changeUser when user id is dummy", () => {
+      start(false, DUMMY_USER_ID, options);
+      expect(mockedChangeUser).not.toHaveBeenCalled();
+      expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -15,6 +15,8 @@ export const start = (
   if (isDummyUserId(userId)) return;
 
   if (brazeOptOutIdentityCleanup) {
+    // Opted-out: do not call changeUser. Prior Braze profile wipe/reset is handled
+    // separately before this flag is enabled in production (see LIVE-34717).
     if (isTrackedUser) {
       Braze.changeUser(userId.exportUserIdForBraze());
     }

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -3,10 +3,25 @@ import { type UserId, isDummyUserId } from "@domain/entity-client-identity";
 import { NotificationsSettings } from "../reducers/types";
 import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
 
-export const start = (isTrackedUser: boolean, userId: UserId) => {
-  if (!isDummyUserId(userId)) {
-    Braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : generateAnonymousId());
+export type StartBrazeOptions = {
+  brazeOptOutIdentityCleanup?: boolean;
+};
+
+export const start = (
+  isTrackedUser: boolean,
+  userId: UserId,
+  { brazeOptOutIdentityCleanup = false }: StartBrazeOptions = {},
+) => {
+  if (isDummyUserId(userId)) return;
+
+  if (brazeOptOutIdentityCleanup) {
+    if (isTrackedUser) {
+      Braze.changeUser(userId.exportUserIdForBraze());
+    }
+    return;
   }
+
+  Braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : generateAnonymousId());
 };
 
 export const updateUserPreferences = (notificationsPreferences: NotificationsSettings) => {

--- a/shared/feature-flags/src/flags/team-engagement/brazeOptOutIdentityCleanup.ts
+++ b/shared/feature-flags/src/flags/team-engagement/brazeOptOutIdentityCleanup.ts
@@ -1,0 +1,4 @@
+import { flag } from "../../define";
+
+/** Gates R1+R2 Braze opt-out identity cleanup atomically. Default off — do not enable in prod until wipeData is validated (PR-8). */
+export const brazeOptOutIdentityCleanup = flag();

--- a/shared/feature-flags/src/flags/team-engagement/brazeOptOutIdentityCleanup.ts
+++ b/shared/feature-flags/src/flags/team-engagement/brazeOptOutIdentityCleanup.ts
@@ -1,4 +1,4 @@
 import { flag } from "../../define";
 
-/** Gates R1+R2 Braze opt-out identity cleanup atomically. Default off — do not enable in prod until wipeData is validated (PR-8). */
+/** When enabled, skips Braze/Segment identity for opted-out users. See LIVE-34717. Default off. */
 export const brazeOptOutIdentityCleanup = flag();

--- a/shared/feature-flags/src/flags/team-engagement/index.ts
+++ b/shared/feature-flags/src/flags/team-engagement/index.ts
@@ -1,3 +1,4 @@
+export * from "./brazeOptOutIdentityCleanup";
 export * from "./brazePushNotifications";
 export * from "./buyDeviceFromLive";
 export * from "./lwdBackupHub";


### PR DESCRIPTION
## Summary

Part of [LIVE-34717](https://ledgerhq.atlassian.net/browse/LIVE-34717) (Braze opt-out identity cleanup — Release 1).

When a user opts out of analytics, the app currently still calls `Braze.changeUser()` with an anonymous ID on startup. That re-identifies the user in Braze and undermines the opt-out.

This PR introduces a feature-flagged path that **skips `changeUser` entirely for opted-out users**, while preserving the existing behavior when the flag is off.

- **New flag:** `brazeOptOutIdentityCleanup` (default **off** — do not enable in prod until wipeData is validated in PR-8).
- **`braze.start()`:** When flag is on:
  - Tracked user → `changeUser(realId)` (unchanged)
  - Opted-out user → **no `changeUser` call** (new)
  - Dummy user → skip (unchanged)
- **`HookNotifications`:** Reads the flag and passes it to `start()`.
- **Tests:** 6 unit tests covering legacy and flag-on paths.

## Test plan

- [x] Unit tests pass: `pnpm mobile test:jest "braze.test.ts"`
- [ ] **Flag off (legacy):** Opted-out user still gets anonymous `changeUser` on startup
- [ ] **Flag on:** Opted-out user does **not** get `changeUser` on startup
- [ ] **Flag on:** Tracked user still gets real `changeUser` on startup
- [ ] **Flag on:** Notification preferences still sync via `updateUserPreferences`
- [ ] Verify flag is **not enabled** in production remote config

[LIVE-34717]: https://ledgerhq.atlassian.net/browse/LIVE-34717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ