### PR TITLE
chore(support): add the support layer to the workspace (LIVE-35541)

### DIFF
--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -68,7 +68,7 @@ jobs:
           registry: ${{ vars.ARTIFACTORY_URL }}
 
       - name: Install dependencies
-        run: pnpm i --filter="./features/**" --filter="./shared/**" --filter="./domain/**"
+        run: pnpm i --filter="@features/*..." --filter="./shared/**" --filter="./domain/**"
 
       - name: Run coverage on feature packages
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@ See examples:
 - **Entity packages** (`domain/entity/`): read `domain/entity/README.md`
 - **API packages** (`domain/api/`): read `domain/api/README.md`
 - **Shared packages** (`shared/**`): read `shared/README.md`
+- **Support packages** (`support/**`): read `support/README.md`

--- a/docs/new-library.md
+++ b/docs/new-library.md
@@ -55,6 +55,7 @@ The repo is moving toward a DDD layout (`domain/`, `features/`, `shared/`); it i
 | `domain/api/` | `@domain/api-<name>` | `@domain/api-crypto-asset` |
 | `features/platform/` | `@features/platform-<name>` | `@features/platform-feature-flags` |
 | `features/flow/` | `@features/flow-<name>` | `@features/flow-wallet` |
+| `support/` | `@support/<name>` | `@support/jest-devtools` |
 | `libs/` | `@ledgerhq/<name>` | `@ledgerhq/coin-evm` |
 
 Keep names short and self-describing. No cross-package relative imports — always use the npm package name.

--- a/docs/nx-tags.md
+++ b/docs/nx-tags.md
@@ -11,6 +11,10 @@ Workspace packages get **inferred tags** from their path (and a few well-known p
 | `scope:libs-ui` | Under `libs/ui/` |
 | `scope:libs-ledgerjs` | Under `libs/ledgerjs/` |
 | `scope:features` | Under `features/` |
+| `scope:domain` | Under `domain/` |
+| `scope:shared` | Under `shared/` |
+| `scope:support` | Under `support/` — development-only tooling, consumed as a `devDependency` |
+| `scope:devtools` | Under `devtools/` |
 | `scope:apps` | Desktop, mobile, CLI, web-tools, or Playwright/Detox E2E app projects (see type tags) |
 | `scope:e2e` | Under `e2e/` |
 | `scope:tools` | Under `tools/` |

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ packages:
   - "domain/api/*"
   - "shared/*"
   - "devtools/*"
+  - "support/*"
 
 catalog:
   "@jest/globals": 30.2.0

--- a/tools/nx-plugins/enforce-boundaries/constraints.js
+++ b/tools/nx-plugins/enforce-boundaries/constraints.js
@@ -9,25 +9,43 @@
  * A rule fires only when the source package has the sourceTag. Legacy
  * packages without matching tags (libs/, apps/, e2e/, tools/) are
  * unconstrained on purpose.
+ *
+ * `scope:support` is allowed as a target everywhere: support packages are development tooling,
+ * taken as devDependencies, and the Nx graph does not distinguish those from runtime dependencies.
+ * It has no rule as a *source* for the same reason — one would constrain a support package's own
+ * test-tooling dependencies (lumen, react-native) for no benefit.
  */
 const DEP_CONSTRAINTS = [
-  { sourceTag: "scope:shared", onlyDependOnLibsWithTags: ["scope:shared"] },
-  { sourceTag: "scope:domain", onlyDependOnLibsWithTags: ["scope:domain", "scope:shared"] },
+  { sourceTag: "scope:shared", onlyDependOnLibsWithTags: ["scope:shared", "scope:support"] },
+  {
+    sourceTag: "scope:domain",
+    onlyDependOnLibsWithTags: ["scope:domain", "scope:shared", "scope:support"],
+  },
   {
     sourceTag: "scope:features",
-    onlyDependOnLibsWithTags: ["scope:features", "scope:domain", "scope:shared"],
+    onlyDependOnLibsWithTags: ["scope:features", "scope:domain", "scope:shared", "scope:support"],
   },
   {
     sourceTag: "type:domain-entity",
-    onlyDependOnLibsWithTags: ["type:domain-entity", "scope:shared"],
+    onlyDependOnLibsWithTags: ["type:domain-entity", "scope:shared", "scope:support"],
   },
   {
     sourceTag: "type:domain-api",
-    onlyDependOnLibsWithTags: ["type:domain-entity", "type:domain-api", "scope:shared"],
+    onlyDependOnLibsWithTags: [
+      "type:domain-entity",
+      "type:domain-api",
+      "scope:shared",
+      "scope:support",
+    ],
   },
   {
     sourceTag: "type:feature-platform",
-    onlyDependOnLibsWithTags: ["type:feature-platform", "scope:domain", "scope:shared"],
+    onlyDependOnLibsWithTags: [
+      "type:feature-platform",
+      "scope:domain",
+      "scope:shared",
+      "scope:support",
+    ],
   },
   {
     sourceTag: "type:feature-flow",
@@ -36,6 +54,7 @@ const DEP_CONSTRAINTS = [
       "type:feature-platform",
       "scope:domain",
       "scope:shared",
+      "scope:support",
     ],
   },
 ];

--- a/tools/nx-plugins/project-tags/plugin.js
+++ b/tools/nx-plugins/project-tags/plugin.js
@@ -105,16 +105,10 @@ function inferTags(projectRoot, packageName) {
   } else if (projectRoot === "apps/web-tools" || packageName === "@ledgerhq/web-tools") {
     tags.add("scope:apps");
     tags.add("type:app-web-tools");
-  } else if (
-    packageName === "ledger-live-desktop-e2e-tests" ||
-    projectRoot === "e2e/desktop"
-  ) {
+  } else if (packageName === "ledger-live-desktop-e2e-tests" || projectRoot === "e2e/desktop") {
     tags.add("scope:apps");
     tags.add("type:e2e-desktop");
-  } else if (
-    packageName === "ledger-live-mobile-e2e-tests" ||
-    projectRoot === "e2e/mobile"
-  ) {
+  } else if (packageName === "ledger-live-mobile-e2e-tests" || projectRoot === "e2e/mobile") {
     tags.add("scope:apps");
     tags.add("type:e2e-mobile");
   }
@@ -134,7 +128,7 @@ const plugin = {
   createNodesV2: [
     combineGlobPatterns("package.json", "**/package.json"),
     (configFiles, _options, context) => {
-      const readJson = (f) => readJsonFile(path.join(context.workspaceRoot, f));
+      const readJson = f => readJsonFile(path.join(context.workspaceRoot, f));
       const patterns = buildPackageJsonPatterns(context.workspaceRoot, readJson);
       const isInPackageManagerWorkspaces = buildPackageJsonWorkspacesMatcher(patterns);
 
@@ -147,11 +141,7 @@ const plugin = {
         }
 
         const projectRoot = normalizeProjectRoot(file);
-        const siblingProjectJson = path.join(
-          context.workspaceRoot,
-          projectRoot,
-          "project.json",
-        );
+        const siblingProjectJson = path.join(context.workspaceRoot, projectRoot, "project.json");
         const nextToProjectJson = existsSync(siblingProjectJson);
 
         if (!isInPackageManagerWorkspaces(file) && !nextToProjectJson) {

--- a/tools/nx-plugins/project-tags/plugin.js
+++ b/tools/nx-plugins/project-tags/plugin.js
@@ -55,6 +55,10 @@ function inferTags(projectRoot, packageName) {
     tags.add("scope:devtools");
   }
 
+  if (projectRoot.startsWith("support/")) {
+    tags.add("scope:support");
+  }
+
   if (projectRoot.startsWith("e2e/")) {
     tags.add("scope:e2e");
   }

--- a/tools/nx-plugins/project-tags/plugin.test.js
+++ b/tools/nx-plugins/project-tags/plugin.test.js
@@ -36,6 +36,13 @@ test("shared/* gets scope:shared", () => {
   ]);
 });
 
+test("support/* gets scope:support", () => {
+  assert.deepEqual(inferTags("support/jest-devtools", "@support/jest-devtools"), [
+    "scope:no-apps",
+    "scope:support",
+  ]);
+});
+
 test("features/* (unclassified sub-path) gets scope:features only — no type tag (regression)", () => {
   const tags = inferTags("features/market-banner", "@features/market-banner");
   assert.deepEqual(tags, ["scope:features", "scope:no-apps"]);


### PR DESCRIPTION
### 📝 Description

Groundwork so any `@support/*` package can be added without touching workspace plumbing. **No package is created here** — this is the plumbing on its own, and it is the bottom of a three-PR stack.

`support/` is the layer for development-only tooling: shared test, TypeScript, lint and format configuration. It ships no runtime code, and consumers take it as a `devDependency`.

| Change | Why |
|---|---|
| `pnpm-workspace.yaml` | add the `support/*` glob |
| `tools/nx-plugins/project-tags/plugin.js` | infer `scope:support` from the path, beside the existing `devtools/` branch |
| `tools/nx-plugins/project-tags/plugin.test.js` | a case for it (`inferTags` is exported for exactly this) |
| `tools/nx-plugins/enforce-boundaries/constraints.js` | allow `scope:support` as a dependency **target** from every constrained scope |
| `docs/new-library.md` | the `support/` → `@support/<name>` naming row |
| `docs/nx-tags.md` | `scope:support`, plus the `scope:domain` / `scope:shared` / `scope:devtools` rows the doc was already missing |
| `AGENTS.md` | point at `support/README.md` alongside the other layer READMEs |
| `.github/workflows/test-features-reusable.yml` | select features by name with `@features/*...` so workspace dependencies come along |

**On the CI filter.** The Features job selected workspace projects by path and enumerated the layers, so a package under `support/` was never installed and its own dependencies were missing at test time. It surfaced on the top of this stack as `Cannot find module 'react'` from the flow jest preset's Lumen stubs, once that package moved out of `features/platform` and stopped matching `./features/**`.

Rather than adding `./support/**` to the list, the features selector becomes `@features/*...`; the trailing `...` pulls each project's workspace dependencies in as selected projects, so this stays correct the next time a features package depends on a new layer. The `./shared/**` and `./domain/**` filters stay — they select projects the job installs that are not reachable as dependencies of features packages, and dropping them would have removed 17 domain packages from the install.

Sonar needs no change: its `live-mobile...` and `ledger-live-desktop...` selectors already pull the apps' full workspace closure, which reaches both support packages. Verified by diffing the selections — identical with and without a support filter.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35541](https://ledgerhq.atlassian.net/browse/LIVE-35541), under epic [LIVE-34831 — Create base support packages with base configs](https://ledgerhq.atlassian.net/browse/LIVE-34831)
- **ADR**: [Shared Tooling Configuration via `support/` Packages](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7353892916/2026-07-23+ADR+Shared+Tooling+Configuration+via+support+Packages)

### 🧱 Stack

1. **#20488 — this PR**: the `support/` layer plumbing
2. [#20487](https://github.com/LedgerHQ/ledger-live/pull/20487): `@support/jest-devtools` + the `devtools/*` migration
3. [#20489](https://github.com/LedgerHQ/ledger-live/pull/20489): move `@features/platform-jest-config` to `@support/jest-features-flow`

### ✅ Verification

- `node --test tools/nx-plugins/project-tags/plugin.test.js` — 11/11, including the new `support/` case.
- `pnpm lint:boundaries` green, and green again with the allowlist reverted only because no support package exists yet at this layer.
- `oxfmt --check` clean on `tools/nx-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIVE-35541]: https://ledgerhq.atlassian.net/browse/LIVE-35541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ