### PR TITLE
feat(coin-tron): expose sponsored-send savings estimate (LIVE-32776)

### DIFF
--- a/.changeset/tron-sponsored-savings-estimate.md
+++ b/.changeset/tron-sponsored-savings-estimate.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": minor
+---
+
+Expose a savings estimate for gas-sponsored (Tronify) Tron sends (LIVE-32776). When a send carries `energyProviderInfo`, `getTransactionStatus` now returns a `sponsoredEnergy` field on the transaction status: the disclosed energy provider (`{ id, name }`, resolved from a new in-module registry exported as `ENERGY_PROVIDERS`/`getEnergyProvider`) and `avoidedEnergyFees` — the native TRX (in SUN) that a non-sponsored USDT transfer would burn on energy (`energyRequired × energyFee`). The coin module stays fiat-agnostic: the front end converts the value to fiat and renders "Saved $X.XX with <provider>". It is informational only and does not change `estimatedFees`; pricing a sponsored send as energy-rented remains future work (LIVE-32892).

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -509,7 +509,10 @@ describe("getEstimatedFees", () => {
     });
 
     it("returns null for a 0-energy transfer (native/TRC10 — nothing to disclose)", async () => {
-      const breakdown: FeeResourceBreakdown = { ...baseBreakdown, energyRequired: new BigNumber(0) };
+      const breakdown: FeeResourceBreakdown = {
+        ...baseBreakdown,
+        energyRequired: new BigNumber(0),
+      };
       expect(await computeSponsoredEnergyEstimate(sponsoredTx, breakdown)).toBeNull();
     });
   });

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -6,7 +6,11 @@ import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/
 import { getChainParameters, getTronAccountNetwork } from "../network";
 import type { ChainParameters } from "../network/types";
 import type { Transaction } from "../types";
-import getEstimatedFees, { getFeeResourceBreakdown } from "./getEstimateFees";
+import getEstimatedFees, {
+  computeSponsoredEnergyEstimate,
+  getFeeResourceBreakdown,
+  type FeeResourceBreakdown,
+} from "./getEstimateFees";
 import { extractBandwidthInfo } from "./utils";
 
 // Mock typed functions
@@ -451,6 +455,62 @@ describe("getEstimatedFees", () => {
 
       expect(breakdown.energyRequired).toEqual(new BigNumber(0));
       expect(breakdown.energyEstimated).toBe(true);
+    });
+  });
+
+  // LIVE-32776: informational savings estimate exposed for sponsored (Tronify) sends.
+  describe("computeSponsoredEnergyEstimate", () => {
+    const baseBreakdown: FeeResourceBreakdown = {
+      energyRequired: new BigNumber(1000),
+      energyAvailable: new BigNumber(100_000),
+      bandwidthRequired: new BigNumber(200),
+      bandwidthAvailable: new BigNumber(5000),
+      energyEstimated: true,
+      networkInfo: mockTransaction.networkInfo!,
+    };
+    const sponsoredTx: Transaction = {
+      ...mockTransaction,
+      energyProviderInfo: { providerId: "tronify", orderId: "order-1" },
+    };
+
+    beforeEach(() => {
+      mockGetChainParameters.mockResolvedValue(chainParams);
+    });
+
+    it("returns provider + full energy cost (energyRequired × energyFee) for a sponsored send", async () => {
+      const estimate = await computeSponsoredEnergyEstimate(sponsoredTx, baseBreakdown);
+
+      expect(estimate).toEqual({
+        provider: { id: "tronify", name: "Tronify" },
+        avoidedEnergyFees: new BigNumber(210_000),
+      });
+    });
+
+    it("returns null (and skips the chain-params fetch) for a non-sponsored send", async () => {
+      expect(await computeSponsoredEnergyEstimate(mockTransaction, baseBreakdown)).toBeNull();
+      expect(mockGetChainParameters).not.toHaveBeenCalled();
+    });
+
+    it("returns null for an unknown provider id", async () => {
+      const tx: Transaction = {
+        ...mockTransaction,
+        energyProviderInfo: { providerId: "not-a-provider", orderId: "order-1" },
+      };
+      expect(await computeSponsoredEnergyEstimate(tx, baseBreakdown)).toBeNull();
+    });
+
+    it("returns null when energy could not be estimated (never derives from the failure sentinel)", async () => {
+      const breakdown: FeeResourceBreakdown = {
+        ...baseBreakdown,
+        energyEstimated: false,
+        energyRequired: new BigNumber(100_001),
+      };
+      expect(await computeSponsoredEnergyEstimate(sponsoredTx, breakdown)).toBeNull();
+    });
+
+    it("returns null for a 0-energy transfer (native/TRC10 — nothing to disclose)", async () => {
+      const breakdown: FeeResourceBreakdown = { ...baseBreakdown, energyRequired: new BigNumber(0) };
+      expect(await computeSponsoredEnergyEstimate(sponsoredTx, breakdown)).toBeNull();
     });
   });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -4,10 +4,11 @@ import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { estimateFees, getAccount } from "../logic";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { getEnergyProvider } from "../logic/energyProviders";
 import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/estimateFees";
 import { getChainParameters, getTronAccountNetwork } from "../network";
 import type { AccountTronAPI, ChainParameters } from "../network/types";
-import type { NetworkInfo, Transaction } from "../types";
+import type { NetworkInfo, SponsoredEnergyEstimate, Transaction } from "../types";
 import { extractBandwidthInfo, getEstimatedBlockSize } from "./utils";
 
 // see : https://developers.tron.network/docs/bandwith#section-bandwidth-points-consumption
@@ -52,8 +53,8 @@ export const getFeeResourceBreakdown = async (
   transaction: Transaction,
   tokenAccount?: TokenAccount | null,
 ): Promise<FeeResourceBreakdown> => {
-  // TODO(LIVE-32776/LIVE-32892): when `transaction.energyProviderInfo` is set, augment energy
-  // availability with rented (sponsored) energy. Dormant for now.
+  // TODO(LIVE-32892): when `transaction.energyProviderInfo` is set, augment energy availability with
+  // rented (sponsored) energy. Dormant for now — LIVE-32776 only exposes the informational estimate.
 
   // Energy is only required for an actual TRC20 transfer — native/TRC10 use none, non-"send" modes
   // don't transfer, and a zero-amount non-max send is headed for AmountRequired. Compute it up front
@@ -154,6 +155,33 @@ export const getFeeResourceBreakdown = async (
   }
 };
 
+// LIVE-32776: informational savings estimate for a sponsored send. Purely additive — it does NOT
+// change fees (that re-pricing is LIVE-32892). The avoided cost is the full energy cost of the
+// transfer (energyRequired × energyFee), independent of the user's own staked energy, matching the
+// PRD framing ("every USDT transfer burns ~6.4 TRX"). Returns null when the send isn't sponsored,
+// the provider id is unknown, or energy couldn't be reliably estimated (so we never surface a number
+// derived from the failure sentinel). Reuses the breakdown already computed by the status path, so
+// it adds no network round trips (getChainParameters is LRU-cached).
+export const computeSponsoredEnergyEstimate = async (
+  transaction: Transaction,
+  breakdown: FeeResourceBreakdown,
+): Promise<SponsoredEnergyEstimate | null> => {
+  const info = transaction.energyProviderInfo;
+  if (!info) return null;
+  const provider = getEnergyProvider(info.providerId);
+  if (!provider || !breakdown.energyEstimated) return null;
+  // Only an energy-bearing TRC20 transfer has a saving to disclose. Native/TRC10 and non-"send"
+  // modes report energyRequired 0 — surfacing a {provider, 0} estimate there would render a
+  // misleading "Saved $0.00 with <provider>" third-party disclosure on an unsponsored tx.
+  if (breakdown.energyRequired.lte(0)) return null;
+
+  const params: ChainParameters = await getChainParameters();
+  const avoidedEnergyFees = breakdown.energyRequired
+    .multipliedBy(params.energyFee)
+    .integerValue(BigNumber.ROUND_CEIL);
+  return { provider, avoidedEnergyFees };
+};
+
 // Energy-aware fee for an active-recipient TRC20 transfer: 0 when energy and bandwidth cover it, the
 // real shortfall otherwise, and the flat STANDARD_FEES_TRC_20 on any uncertainty.
 const computeActiveRecipientTrc20Fee = async (
@@ -162,8 +190,8 @@ const computeActiveRecipientTrc20Fee = async (
   tokenAccount: TokenAccount,
   breakdown?: FeeResourceBreakdown,
 ): Promise<BigNumber> => {
-  // TODO(LIVE-32776/LIVE-32892): when `transaction.energyProviderInfo` is set, price the send as
-  // energy-rented (sponsored) instead of burning TRX. Dormant for now.
+  // TODO(LIVE-32892): when `transaction.energyProviderInfo` is set, price the send as energy-rented
+  // (sponsored) instead of burning TRX. Dormant for now — LIVE-32776 only exposes the estimate.
 
   try {
     const resourceBreakdown =

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -175,11 +175,19 @@ export const computeSponsoredEnergyEstimate = async (
   // misleading "Saved $0.00 with <provider>" third-party disclosure on an unsponsored tx.
   if (breakdown.energyRequired.lte(0)) return null;
 
-  const params: ChainParameters = await getChainParameters();
-  const avoidedEnergyFees = breakdown.energyRequired
-    .multipliedBy(params.energyFee)
-    .integerValue(BigNumber.ROUND_CEIL);
-  return { provider, avoidedEnergyFees };
+  try {
+    const params: ChainParameters = await getChainParameters();
+    const avoidedEnergyFees = breakdown.energyRequired
+      .multipliedBy(params.energyFee)
+      .integerValue(BigNumber.ROUND_CEIL);
+    return { provider, avoidedEnergyFees };
+  } catch (err) {
+    // Informational only: a chain-params fetch failure must not break the whole status computation.
+    log("tron/computeSponsoredEnergyEstimate", "chain params unavailable, omitting estimate", {
+      err,
+    });
+    return null;
+  }
 };
 
 // Energy-aware fee for an active-recipient TRC20 transfer: 0 when energy and bandwidth cover it, the

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
@@ -290,12 +290,14 @@ describe("getTransactionStatus", () => {
     expect(mockTriggerConstantContract).not.toHaveBeenCalled();
   });
 
-  // LIVE-32775: adding the sponsoring context must be inert until later tickets (LIVE-32776 /
-  // LIVE-32892) price it. Presence of energyProviderInfo must not change fees or status yet.
-  describe("energyProviderInfo sponsoring context (LIVE-32775)", () => {
+  // LIVE-32776: the sponsoring context now exposes an informational savings estimate on the status,
+  // but must still NOT re-price the send — that is LIVE-32892. So fees/energy/warnings/errors stay
+  // identical to a standard send, and only the additive `sponsoredEnergy` field appears.
+  describe("energyProviderInfo sponsoring context (LIVE-32776)", () => {
     const energyProviderInfo = { providerId: "tronify", orderId: "order-123" };
+    const TRONIFY = { id: "tronify", name: "Tronify" };
 
-    it("does not change fee or status for a covered TRC20 send (standard crafting unchanged)", async () => {
+    it("adds the savings estimate without changing fee or status for a covered TRC20 send", async () => {
       const tokenAccount = createTrc20TokenAccount();
       const account = createAccount({ subAccounts: [tokenAccount] });
       mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
@@ -309,14 +311,37 @@ describe("getTransactionStatus", () => {
         createTransaction({ subAccountId: tokenAccount.id, energyProviderInfo }),
       );
 
+      // Re-pricing is out of scope (LIVE-32892): fees/energy/warnings/errors unchanged.
       expect(sponsored.estimatedFees).toEqual(baseline.estimatedFees);
       expect(sponsored.energyRequired).toEqual(baseline.energyRequired);
       expect(sponsored.energyAvailable).toEqual(baseline.energyAvailable);
       expect(sponsored.warnings).toEqual(baseline.warnings);
       expect(sponsored.errors).toEqual(baseline.errors);
+
+      // A standard send exposes no estimate; the sponsored one exposes provider + full energy cost
+      // (energyRequired × energyFee = 1000 × 210).
+      expect(baseline.sponsoredEnergy).toBeNull();
+      expect(sponsored.sponsoredEnergy?.provider).toEqual(TRONIFY);
+      expect(sponsored.sponsoredEnergy?.avoidedEnergyFees).toEqual(new BigNumber(210_000));
     });
 
-    it("does not change fee or status for an energy-short TRC20 send", async () => {
+    it("exposes the full-energy-cost saving even when the account has staked energy to cover it", async () => {
+      // Covered send (energyAvailable 100_000 >= energy_used 1000): a non-sponsored send would burn
+      // 0 TRX, yet the estimate reports the FULL energy cost, not the account-specific shortfall.
+      const tokenAccount = createTrc20TokenAccount();
+      const account = createAccount({ subAccounts: [tokenAccount] });
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
+
+      const sponsored = await getTransactionStatus(
+        account,
+        createTransaction({ subAccountId: tokenAccount.id, energyProviderInfo }),
+      );
+
+      expect(sponsored.estimatedFees.isZero()).toBe(true);
+      expect(sponsored.sponsoredEnergy?.avoidedEnergyFees).toEqual(new BigNumber(210_000));
+    });
+
+    it("adds the savings estimate without changing fee or status for an energy-short TRC20 send", async () => {
       const tokenAccount = createTrc20TokenAccount();
       const account = createAccount({ subAccounts: [tokenAccount] });
       const overrides = {
@@ -334,6 +359,27 @@ describe("getTransactionStatus", () => {
       expect(sponsored.estimatedFees).toEqual(baseline.estimatedFees);
       expect(sponsored.warnings).toEqual(baseline.warnings);
       expect(sponsored.errors).toEqual(baseline.errors);
+
+      expect(baseline.sponsoredEnergy).toBeNull();
+      expect(sponsored.sponsoredEnergy?.provider).toEqual(TRONIFY);
+      // Full energy cost = 31_895 × 210.
+      expect(sponsored.sponsoredEnergy?.avoidedEnergyFees).toEqual(new BigNumber(6_697_950));
+    });
+
+    it("exposes no estimate for an unknown provider id", async () => {
+      const tokenAccount = createTrc20TokenAccount();
+      const account = createAccount({ subAccounts: [tokenAccount] });
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 1000 });
+
+      const sponsored = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          energyProviderInfo: { providerId: "unknown", orderId: "order-123" },
+        }),
+      );
+
+      expect(sponsored.sponsoredEnergy).toBeNull();
     });
   });
 

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -17,7 +17,7 @@ import {
   getDelegatedResource,
   getTronSuperRepresentatives,
 } from "../network";
-import { Transaction, TransactionStatus, TronAccount } from "../types";
+import { SponsoredEnergyEstimate, Transaction, TransactionStatus, TronAccount } from "../types";
 import {
   NotEnoughGas,
   TronInvalidFreezeAmount,
@@ -36,7 +36,10 @@ import {
   TronUnfreezeNotExpired,
   TronVoteRequired,
 } from "../types/errors";
-import getEstimatedFees, { getFeeResourceBreakdown } from "./getEstimateFees";
+import getEstimatedFees, {
+  computeSponsoredEnergyEstimate,
+  getFeeResourceBreakdown,
+} from "./getEstimateFees";
 
 const getTransactionStatus = async (
   acc: TronAccount,
@@ -197,6 +200,8 @@ const getTransactionStatus = async (
   let bandwidthRequired = new BigNumber(0);
   let bandwidthAvailable = new BigNumber(0);
   let estimatedFees = new BigNumber(0);
+  // Informational savings estimate for a sponsored (Tronify) send (LIVE-32776); null otherwise.
+  let sponsoredEnergy: SponsoredEnergyEstimate | null = null;
 
   if (!hasErrors) {
     const resourceBreakdown = await getFeeResourceBreakdown(acc, transaction, tokenAccount);
@@ -205,6 +210,7 @@ const getTransactionStatus = async (
     bandwidthRequired = resourceBreakdown.bandwidthRequired;
     bandwidthAvailable = resourceBreakdown.bandwidthAvailable;
     estimatedFees = await getEstimatedFees(acc, transaction, tokenAccount, resourceBreakdown);
+    sponsoredEnergy = await computeSponsoredEnergyEstimate(transaction, resourceBreakdown);
   }
 
   const balance =
@@ -287,6 +293,7 @@ const getTransactionStatus = async (
     energyAvailable,
     bandwidthRequired,
     bandwidthAvailable,
+    sponsoredEnergy,
   });
 };
 

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -17,7 +17,12 @@ import {
   getDelegatedResource,
   getTronSuperRepresentatives,
 } from "../network";
-import { SponsoredEnergyEstimate, Transaction, TransactionStatus, TronAccount } from "../types";
+import type {
+  SponsoredEnergyEstimate,
+  Transaction,
+  TransactionStatus,
+  TronAccount,
+} from "../types";
 import {
   NotEnoughGas,
   TronInvalidFreezeAmount,

--- a/libs/coin-modules/coin-tron/src/index.ts
+++ b/libs/coin-modules/coin-tron/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 
 export { createBridges } from "./bridge/index";
 export { isAccountEmpty } from "./bridge/utils";
+export { ENERGY_PROVIDERS, TRONIFY_PROVIDER, getEnergyProvider } from "./logic/energyProviders";

--- a/libs/coin-modules/coin-tron/src/logic/energyProviders.test.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyProviders.test.ts
@@ -1,0 +1,16 @@
+import { ENERGY_PROVIDERS, TRONIFY_PROVIDER, getEnergyProvider } from "./energyProviders";
+
+describe("energyProviders", () => {
+  it("registers Tronify with a disclosable display name", () => {
+    expect(TRONIFY_PROVIDER).toEqual({ id: "tronify", name: "Tronify" });
+    expect(ENERGY_PROVIDERS).toContain(TRONIFY_PROVIDER);
+  });
+
+  it("resolves a known provider id to its metadata", () => {
+    expect(getEnergyProvider("tronify")).toEqual({ id: "tronify", name: "Tronify" });
+  });
+
+  it("returns undefined for an unknown provider id", () => {
+    expect(getEnergyProvider("unknown")).toBeUndefined();
+  });
+});

--- a/libs/coin-modules/coin-tron/src/logic/energyProviders.ts
+++ b/libs/coin-modules/coin-tron/src/logic/energyProviders.ts
@@ -1,0 +1,12 @@
+import type { EnergyProvider } from "../types";
+
+// Hardcoded energy-provider registry for gas sponsoring. Tronify is the only provider today; the
+// registry keeps the module vendor-agnostic-ready (PRD Workstream A) and gives the front end a
+// stable id -> display name so it can disclose the third party. No network fetch — a tiny static
+// disclosure map, mirroring coin-solana's LEDGER_VALIDATOR_LIST.
+export const TRONIFY_PROVIDER: EnergyProvider = { id: "tronify", name: "Tronify" };
+
+export const ENERGY_PROVIDERS: EnergyProvider[] = [TRONIFY_PROVIDER];
+
+export const getEnergyProvider = (id: string): EnergyProvider | undefined =>
+  ENERGY_PROVIDERS.find(p => p.id === id);

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -318,7 +318,8 @@ export type TronAccountRaw = AccountRaw & { tronResources: TronResourcesRaw };
 // estimatedFees (that re-pricing is LIVE-32892).
 export type SponsoredEnergyEstimate = {
   provider: EnergyProvider;
-  // TRX a non-sponsored USDT send would burn on energy (full energy cost: energyRequired × energyFee).
+  // What a non-sponsored USDT send would burn on energy, in SUN (native TRX's base unit) — the full
+  // energy cost energyRequired × energyFee. The front end converts SUN to fiat for display.
   avoidedEnergyFees: BigNumber;
 };
 // Additive resource-breakdown fields for the send-flow UI. Sufficiency is: energyRequired <=
@@ -329,7 +330,8 @@ export type TransactionStatus = TransactionStatusCommon & {
   energyAvailable: BigNumber;
   bandwidthRequired: BigNumber;
   bandwidthAvailable: BigNumber;
-  // Set only for sponsored sends (see SponsoredEnergyEstimate); absent for standard crafting.
+  // A SponsoredEnergyEstimate for sponsored sends; null for standard crafting. getTransactionStatus
+  // always sets the field (never omits it), so consumers can read it without a presence check.
   sponsoredEnergy?: SponsoredEnergyEstimate | null;
 };
 export type TransactionStatusRaw = TransactionStatusCommonRaw;

--- a/libs/coin-modules/coin-tron/src/types/bridge.ts
+++ b/libs/coin-modules/coin-tron/src/types/bridge.ts
@@ -47,6 +47,12 @@ export type EnergyProviderInfo = {
   providerId: string;
   orderId: string;
 };
+// A disclosable energy-rental provider (LIVE-32776). Resolved from EnergyProviderInfo.providerId via
+// the coin-tron energy-provider registry so the front end can name the third party.
+export type EnergyProvider = {
+  id: string;
+  name: string;
+};
 export type Transaction = TransactionCommon & {
   family: "tron";
   mode: TronOperationMode;
@@ -306,6 +312,15 @@ export function isTronAccount(account: Account): account is TronAccount {
 }
 export type TronAccount = Account & { tronResources: TronResources };
 export type TronAccountRaw = AccountRaw & { tronResources: TronResourcesRaw };
+// Informational savings estimate for a sponsored (Tronify) send (LIVE-32776). Native TRX (SUN); the
+// front end converts to fiat and renders "Saved $X.XX with <provider>". Present only when the send
+// is sponsored and the avoided cost could be estimated — purely informational, it does not change
+// estimatedFees (that re-pricing is LIVE-32892).
+export type SponsoredEnergyEstimate = {
+  provider: EnergyProvider;
+  // TRX a non-sponsored USDT send would burn on energy (full energy cost: energyRequired × energyFee).
+  avoidedEnergyFees: BigNumber;
+};
 // Additive resource-breakdown fields for the send-flow UI. Sufficiency is: energyRequired <=
 // energyAvailable && bandwidthRequired <= bandwidthAvailable. On a failed energy estimate,
 // energyRequired is a safe insufficient sentinel. Not mirrored to TransactionStatusRaw.
@@ -314,5 +329,7 @@ export type TransactionStatus = TransactionStatusCommon & {
   energyAvailable: BigNumber;
   bandwidthRequired: BigNumber;
   bandwidthAvailable: BigNumber;
+  // Set only for sponsored sends (see SponsoredEnergyEstimate); absent for standard crafting.
+  sponsoredEnergy?: SponsoredEnergyEstimate | null;
 };
 export type TransactionStatusRaw = TransactionStatusCommonRaw;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
Exposes the inputs the send flow needs to show the Tronify gas-sponsoring saving
("Saved $X.XX with Tronify … via a third party") for USDT (TRC20) transfers. The
coin module stays fiat-agnostic: it returns native TRX (SUN) values and the
provider identity; the front end handles fiat conversion and display.

`TransactionStatus` now carries an additive, optional `sponsoredEnergy` field,
populated only for sponsored sends:

- **`avoidedEnergyFees`** — the native TRX a non-sponsored USDT send would burn on
  energy, computed as the full energy cost `energyRequired × energyFee` (independent
  of the account's own staked energy).
- **`provider`** — the resolved `{ id, name }` from a small in-module energy-provider
  registry, so the front end can disclose the third party.

This is informational only — it does **not** re-price the send. `estimatedFees`,
`energyRequired/Available`, warnings and errors are unchanged vs. a standard send;
sponsored re-pricing remains scoped to LIVE-32892.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-32776](https://ledgerhq.atlassian.net/browse/LIVE-32776)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

## 🔀 Changes

- `types/bridge.ts` — new `EnergyProvider` and `SponsoredEnergyEstimate` types;
  optional `sponsoredEnergy?` on `TransactionStatus` (not mirrored to `…Raw`,
  matching the existing `energyRequired` precedent).
- `logic/energyProviders.ts` **(new)** — hardcoded provider registry
  (`TRONIFY_PROVIDER`, `ENERGY_PROVIDERS`, `getEnergyProvider`), re-exported from
  the package index.
- `bridge/getEstimateFees.ts` — new `computeSponsoredEnergyEstimate` helper,
  reusing the already-computed resource breakdown and the LRU-cached chain
  parameters (no extra network calls). Returns `null` for non-sponsored sends,
  unknown providers, unreliable energy estimates, and non-energy-bearing (0-energy)
  transfers.
- `bridge/getTransactionStatus.ts` — computes and returns `sponsoredEnergy`.
- Retargeted the two dormant sponsored-pricing `TODO`s to LIVE-32892.
