### PR TITLE
ci(harden): scope GitHub App token permissions, fix template injection

### DIFF
--- a/.github/workflows/account-migration.yml
+++ b/.github/workflows/account-migration.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: read
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.base_ref || inputs.ref }}

--- a/.github/workflows/build-desktop-reusable.yml
+++ b/.github/workflows/build-desktop-reusable.yml
@@ -142,6 +142,8 @@ jobs:
         with:
           client-id: ${{ secrets.GH_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ needs.build-desktop-app.outputs.linux == 'success' }}

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-actions: write
+          permission-issues: write
+          permission-members: read
 
       - name: Parse comment and dispatch
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/publish-wallet-cli-npm.yml
+++ b/.github/workflows/publish-wallet-cli-npm.yml
@@ -35,6 +35,8 @@ jobs:
           repositories: |
             ledger-live
             ledger-live-build
+          permission-contents: read
+          permission-actions: write
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/release-create-hotfix.yml
+++ b/.github/workflows/release-create-hotfix.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Generate ref/tag version to use during main checkout
         uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: develop

--- a/.github/workflows/release-prepare-hotfix.yml
+++ b/.github/workflows/release-prepare-hotfix.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Generate ref/tag version to use when running changeset status
         uses: LedgerHQ/ledger-live/tools/actions/composites/generate-tag@develop

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           app-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout Repo
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:

--- a/.github/workflows/release-rollback.yml
+++ b/.github/workflows/release-rollback.yml
@@ -49,6 +49,8 @@ jobs:
           repositories: |
             ledger-live
             ledger-live-build
+          permission-contents: write
+          permission-actions: write
 
       - name: Checkout repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           app-id: ${{ secrets.PUBLIC_RENOVATE_APP_ID }}
           private-key: ${{ secrets.PUBLIC_RENOVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/test-mobile-e2e-reusable.yml
+++ b/.github/workflows/test-mobile-e2e-reusable.yml
@@ -277,6 +277,7 @@ jobs:
           repositories: |
             coin-apps
             ledger-live
+          permission-contents: read
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/test-mobile-mock-reusable.yml
+++ b/.github/workflows/test-mobile-mock-reusable.yml
@@ -344,6 +344,8 @@ jobs:
         with:
           client-id: ${{ secrets.GH_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
       - name: Create mobile metafile
         run: |
           echo "{

--- a/tools/actions/composites/setup-speculos_image/action.yml
+++ b/tools/actions/composites/setup-speculos_image/action.yml
@@ -29,6 +29,7 @@ runs:
         repositories: |
           coin-apps
           ledger-live
+        permission-contents: read
 
     - name: Retrieving coin apps
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/tools/actions/composites/stop-usage-sampler/action.yml
+++ b/tools/actions/composites/stop-usage-sampler/action.yml
@@ -17,11 +17,14 @@ runs:
     - name: Stop sampler
       id: stop
       shell: bash
+      env:
+        SAMPLER_PID: ${{ inputs.sampler_pid }}
+        CSV_PATH: ${{ inputs.csv_path }}
       run: |
-        kill "${{ inputs.sampler_pid }}" 2>/dev/null || true
+        kill -- "$SAMPLER_PID" 2>/dev/null || true
         # Only upload when the sampler actually produced a CSV — skip silently
         # otherwise so a sampler that never started adds no failing/noisy step.
-        if [ -n "${{ inputs.csv_path }}" ] && [ -f "${{ inputs.csv_path }}" ]; then
+        if [ -n "$CSV_PATH" ] && [ -f "$CSV_PATH" ]; then
           echo "csv_exists=true" >> "$GITHUB_OUTPUT"
         else
           echo "csv_exists=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
- Add permission-* inputs to all create-github-app-token steps so each token is issued with only the rights it uses (contents, pull-requests, actions, or issues — write or read as appropriate).
- Move ${{ inputs.sampler_pid }} and ${{ inputs.csv_path }} from the run: shell block into an env: map in stop-usage-sampler, eliminating the template-injection vectors flagged by zizmor.