### PR TITLE
[LWD] feat(devtools): add pay-card tool bindings (LIVE-35497)

### DIFF
--- a/.changeset/pay-card-devtools-bindings.md
+++ b/.changeset/pay-card-devtools-bindings.md
@@ -1,0 +1,5 @@
+---
+"@devtools/bindings": minor
+---
+
+Add `usePayCardToolProps` to bridge feature flags and Card onboarding into the pay-card DevTool (LIVE-35497).

--- a/apps/ledger-live-desktop/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
@@ -25,6 +25,7 @@ jest.mock("@devtools/shell", () => ({
 
 jest.mock("@devtools/bindings", () => ({
   useFeatureFlagsToolProps: () => ({ marker: "ff-props" }),
+  usePayCardToolProps: () => ({ marker: "pay-card-props" }),
 }));
 
 jest.mock("@devtools/wire", () => {
@@ -47,12 +48,15 @@ describe("DevToolsScreen", () => {
     devToolsSpy.mockClear();
   });
 
-  it("mounts the DevTools shell with the feature-flags tool config", () => {
+  it("mounts the DevTools shell with feature-flags and pay-card tool configs", () => {
     render(<DevToolsScreen />);
 
     expect(devToolsSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        config: [{ id: "feature-flags", config: { marker: "ff-props" } }],
+        config: [
+          { id: "feature-flags", config: { marker: "ff-props" } },
+          { id: "pay-card", config: { marker: "pay-card-props" } },
+        ],
       }),
     );
   });

--- a/apps/ledger-live-desktop/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
@@ -1,17 +1,21 @@
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router";
-import { useFeatureFlagsToolProps } from "@devtools/bindings";
+import { useFeatureFlagsToolProps, usePayCardToolProps } from "@devtools/bindings";
 import type { DevToolsConfig } from "@devtools/shell";
 import { useDevToolsRelay } from "./useDevToolsRelay";
 
 export function useDevToolsScreenViewModel() {
   const navigate = useNavigate();
   const featureFlagsToolProps = useFeatureFlagsToolProps();
+  const payCardToolProps = usePayCardToolProps();
   const { wire, wireState } = useDevToolsRelay();
 
   const config: DevToolsConfig = useMemo(
-    () => [{ id: "feature-flags", config: featureFlagsToolProps }],
-    [featureFlagsToolProps],
+    () => [
+      { id: "feature-flags", config: featureFlagsToolProps },
+      { id: "pay-card", config: payCardToolProps },
+    ],
+    [featureFlagsToolProps, payCardToolProps],
   );
 
   const onClose = useCallback(() => navigate(-1), [navigate]);

--- a/devtools/bindings/src/index.ts
+++ b/devtools/bindings/src/index.ts
@@ -1,1 +1,3 @@
 export { useFeatureFlagsToolProps } from "./useFeatureFlagsToolProps";
+export { usePayCardToolProps } from "./usePayCardToolProps";
+export type { UsePayCardToolPropsOptions } from "./usePayCardToolProps";

--- a/devtools/bindings/src/usePayCardToolProps.test.tsx
+++ b/devtools/bindings/src/usePayCardToolProps.test.tsx
@@ -1,0 +1,135 @@
+import React, { type PropsWithChildren } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import featureFlagsReducer, { createFeatureFlagsMiddleware } from "@shared/feature-flags";
+import { usePayCardToolProps } from "./usePayCardToolProps";
+
+function buildStore() {
+  return configureStore({
+    reducer: { featureFlags: featureFlagsReducer },
+    middleware: gdm => gdm().concat(createFeatureFlagsMiddleware({ resolutionConfig: {} })),
+  });
+}
+
+function withStore(store: ReturnType<typeof buildStore>) {
+  return ({ children }: PropsWithChildren) => <Provider store={store}>{children}</Provider>;
+}
+
+describe("usePayCardToolProps", () => {
+  let store: ReturnType<typeof buildStore>;
+
+  beforeEach(() => {
+    store = buildStore();
+  });
+
+  it("exposes desktop onboarding steps and default flag values", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    expect(result.current.onboarding.steps.map(step => step.id)).toEqual([
+      "kyc",
+      "claim",
+      "topup",
+      "purchase",
+    ]);
+    expect(result.current.flags.payTabEnabled).toBe(false);
+    expect(result.current.flags.ptxCardEnabled).toBe(false);
+  });
+
+  it("includes walletPay when platform is native", () => {
+    const { result } = renderHook(() => usePayCardToolProps({ platform: "native" }), {
+      wrapper: withStore(store),
+    });
+
+    expect(result.current.onboarding.steps.map(step => step.id)).toEqual([
+      "kyc",
+      "claim",
+      "topup",
+      "walletPay",
+      "purchase",
+    ]);
+  });
+
+  it("setPayTabEnabled overrides lwdPayTab on web", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.flags.setPayTabEnabled(true);
+    });
+
+    expect(store.getState().featureFlags.overrides.lwdPayTab?.enabled).toBe(true);
+    expect(store.getState().featureFlags.overrides.lwmPayTab).toBeUndefined();
+    expect(result.current.flags.payTabEnabled).toBe(true);
+  });
+
+  it("setPayTabEnabled overrides lwmPayTab on native", () => {
+    const { result } = renderHook(() => usePayCardToolProps({ platform: "native" }), {
+      wrapper: withStore(store),
+    });
+
+    act(() => {
+      result.current.flags.setPayTabEnabled(true);
+    });
+
+    expect(store.getState().featureFlags.overrides.lwmPayTab?.enabled).toBe(true);
+    expect(store.getState().featureFlags.overrides.lwdPayTab).toBeUndefined();
+    expect(result.current.flags.payTabEnabled).toBe(true);
+  });
+
+  it("setCardParam updates params.card on lwdPayTab on web", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.flags.setPayTabEnabled(true);
+    });
+    act(() => {
+      result.current.flags.setCardParam(false);
+    });
+
+    expect(store.getState().featureFlags.overrides.lwdPayTab?.params?.card).toBe(false);
+    expect(store.getState().featureFlags.overrides.lwmPayTab).toBeUndefined();
+    expect(result.current.flags.cardParam).toBe(false);
+  });
+
+  it("setCardParam updates params.card on lwmPayTab on native", () => {
+    const { result } = renderHook(() => usePayCardToolProps({ platform: "native" }), {
+      wrapper: withStore(store),
+    });
+
+    act(() => {
+      result.current.flags.setPayTabEnabled(true);
+    });
+    act(() => {
+      result.current.flags.setCardParam(false);
+    });
+
+    expect(store.getState().featureFlags.overrides.lwmPayTab?.params?.card).toBe(false);
+    expect(store.getState().featureFlags.overrides.lwdPayTab).toBeUndefined();
+    expect(result.current.flags.cardParam).toBe(false);
+  });
+
+  it("setPtxCardEnabled overrides ptxCard", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.flags.setPtxCardEnabled(true);
+    });
+
+    expect(store.getState().featureFlags.overrides.ptxCard?.enabled).toBe(true);
+    expect(result.current.flags.ptxCardEnabled).toBe(true);
+  });
+
+  it("setStepDone toggles a single step and supports resetting all", () => {
+    const { result } = renderHook(() => usePayCardToolProps(), { wrapper: withStore(store) });
+
+    act(() => {
+      result.current.onboarding.setStepDone("kyc", true);
+    });
+    expect(result.current.onboarding.steps.find(step => step.id === "kyc")?.done).toBe(true);
+
+    act(() => {
+      result.current.onboarding.setStepDone("all", false);
+    });
+    expect(result.current.onboarding.steps.every(step => !step.done)).toBe(true);
+  });
+});

--- a/devtools/bindings/src/usePayCardToolProps.ts
+++ b/devtools/bindings/src/usePayCardToolProps.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useState } from "react";
+import { useDispatch } from "react-redux";
+import { setOverride } from "@shared/feature-flags";
+import { useFeature } from "@features/platform-feature-flags";
+import type { DevToolsConfig } from "@devtools/registry";
+
+type PayCardToolProps = Extract<DevToolsConfig[number], { id: "pay-card" }>["config"];
+type OnboardingStep = PayCardToolProps["onboarding"]["steps"][number];
+
+export type UsePayCardToolPropsOptions = {
+  /** Pass `"native"` on mobile to include the `walletPay` onboarding step. */
+  readonly platform?: "web" | "native";
+};
+
+const LEADING_ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  { id: "kyc", label: "Kyc", done: false },
+  { id: "claim", label: "Claim card", done: false },
+  { id: "topup", label: "Top up", done: false },
+];
+
+// Mobile-only, injected just before the final purchase step.
+const NATIVE_ONLY_STEP: OnboardingStep = {
+  id: "walletPay",
+  label: "Apple/Google Pay",
+  done: false,
+};
+
+const PURCHASE_STEP: OnboardingStep = { id: "purchase", label: "First Purchase", done: false };
+
+function initialSteps(platform: "web" | "native"): readonly OnboardingStep[] {
+  return platform === "native"
+    ? [...LEADING_ONBOARDING_STEPS, NATIVE_ONLY_STEP, PURCHASE_STEP]
+    : [...LEADING_ONBOARDING_STEPS, PURCHASE_STEP];
+}
+
+/**
+ * Builds the Card / Pay tool's props from the host's feature-flag overrides and
+ * a local onboarding-step debug state. Apps consume this instead of re-implementing
+ * the wiring in each host.
+ */
+export function usePayCardToolProps(options: UsePayCardToolPropsOptions = {}): PayCardToolProps {
+  const platform = options.platform ?? "web";
+  const dispatch = useDispatch();
+  const payTabKey = platform === "native" ? "lwmPayTab" : "lwdPayTab";
+  const payTab = useFeature(payTabKey);
+  const ptxCard = useFeature("ptxCard");
+
+  const [steps, setSteps] = useState<readonly OnboardingStep[]>(() => initialSteps(platform));
+
+  const payTabEnabled = !!payTab?.enabled;
+  const cardParam = !!payTab?.params?.card;
+  const ptxCardEnabled = !!ptxCard?.enabled;
+
+  const setPayTabEnabled = useCallback(
+    (enabled: boolean) => {
+      const params = { card: cardParam };
+      dispatch(setOverride({ key: payTabKey, value: { enabled, params } }));
+    },
+    [cardParam, dispatch, payTabKey],
+  );
+
+  const setCardParam = useCallback(
+    (card: boolean) => {
+      const params = { card };
+      dispatch(setOverride({ key: payTabKey, value: { enabled: payTabEnabled, params } }));
+    },
+    [dispatch, payTabEnabled, payTabKey],
+  );
+
+  const setPtxCardEnabled = useCallback(
+    (enabled: boolean) => {
+      dispatch(setOverride({ key: "ptxCard", value: { enabled } }));
+    },
+    [dispatch],
+  );
+
+  const setStepDone = useCallback((id: string, done: boolean) => {
+    setSteps(current => {
+      if (id === "all") {
+        return current.map(step => (step.done === done ? step : { ...step, done }));
+      }
+      return current.map(step => (step.id === id && step.done !== done ? { ...step, done } : step));
+    });
+  }, []);
+
+  const flags = useMemo(
+    () => ({
+      payTabEnabled,
+      cardParam,
+      ptxCardEnabled,
+      setPayTabEnabled,
+      setCardParam,
+      setPtxCardEnabled,
+    }),
+    [payTabEnabled, cardParam, ptxCardEnabled, setPayTabEnabled, setCardParam, setPtxCardEnabled],
+  );
+
+  const onboarding = useMemo(() => ({ steps, setStepDone }), [steps, setStepDone]);
+
+  return useMemo(() => ({ flags, onboarding }), [flags, onboarding]);
+}


### PR DESCRIPTION
## Summary
- Add `usePayCardToolProps` in `@devtools/bindings` to build `PayCardToolProps` from feature flags (`lwdPayTab` / `lwmPayTab` / `ptxCard`) and local onboarding step state
- Support `platform: "web" | "native"` so mobile hosts can include the `walletPay` step
- Intentionally skips mock scenario wiring (depends on LIVE-35495) — flags + onboarding only for now

## Test plan
- [ ] `pnpm --filter @devtools/bindings test`
- [ ] `pnpm --filter @devtools/bindings typecheck`
- [ ] Confirm export is available from `@devtools/bindings`
- [ ] Follow-up: wire into LWD/LWM DevTools hosts (LIVE-35499 / LIVE-35498)

### 🔗 Context
- **JIRA**: [LIVE-35497](https://ledgerhq.atlassian.net/browse/LIVE-35497) 
- Stacks on: #20462 (web UI) → #20461 (foundation)

[LIVE-35497]: https://ledgerhq.atlassian.net/browse/LIVE-35497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ