### PR TITLE
fix(pay-card-auth): resolve platform entry points (LIVE-35273)

### DIFF
--- a/.changeset/quiet-cards-resolve.md
+++ b/.changeset/quiet-cards-resolve.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-pay-card-auth": patch
+---
+
+Fix platform-specific CardLogin entry point detection

--- a/features/flow/pay-card-auth/src/components/CardLogin/index.ts
+++ b/features/flow/pay-card-auth/src/components/CardLogin/index.ts
@@ -1,0 +1,2 @@
+export { CardLogin } from "./index.web";
+export type { CardLoginProps, OpenHostedLogin } from "./types";

--- a/features/flow/pay-card-auth/src/index.native.ts
+++ b/features/flow/pay-card-auth/src/index.native.ts
@@ -1,2 +1,2 @@
-export { CardLogin } from "./components/CardLogin";
-export type { CardLoginProps, OpenHostedLogin } from "./components/CardLogin";
+export { CardLogin } from "./components/CardLogin/index.native";
+export type { CardLoginProps, OpenHostedLogin } from "./components/CardLogin/types";

--- a/features/flow/pay-card-auth/src/index.ts
+++ b/features/flow/pay-card-auth/src/index.ts
@@ -1,2 +1,2 @@
-export { CardLogin } from "./components/CardLogin";
-export type { CardLoginProps, OpenHostedLogin } from "./components/CardLogin";
+export { CardLogin } from "./components/CardLogin/index.web";
+export type { CardLoginProps, OpenHostedLogin } from "./components/CardLogin/types";

--- a/features/flow/pay-card-auth/src/index.ts
+++ b/features/flow/pay-card-auth/src/index.ts
@@ -1,2 +1,2 @@
-export { CardLogin } from "./components/CardLogin/index.web";
+export { CardLogin } from "./components/CardLogin";
 export type { CardLoginProps, OpenHostedLogin } from "./components/CardLogin/types";


### PR DESCRIPTION
## Summary
- make web and native CardLogin barrels reference their platform implementations explicitly
- keep shared type exports suffixless and add release metadata

## Test plan
- [x] Run the full CI `unimported` command across all non-app projects
- [x] Run pay-card-auth lint
- [x] Run pay-card-auth formatting check

<img width="500" height="167" alt="image" src="https://github.com/user-attachments/assets/483daa00-734d-42c8-877c-acd0b7e8d093" />


Made with [Cursor](https://cursor.com)