### PR TITLE
ci(rsdoctor): add path filters to pull_request trigger

### DIFF
--- a/.github/workflows/rsdoctor-pr.yml
+++ b/.github/workflows/rsdoctor-pr.yml
@@ -6,6 +6,19 @@ name: "[Rsdoctor] - Bundle reports on PR"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "apps/ledger-live-desktop/**"
+      - "apps/ledger-live-mobile/**"
+      - "libs/**"
+      - "domain/**"
+      - "features/**"
+      - "shared/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "nx.json"
+      - "nx.workspace.json"
+      - ".github/workflows/rsdoctor-pr.yml"
   push:
     branches:
       - develop


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

**What**

Adds a paths filter to the pull_request trigger in the Rsdoctor bundle analysis workflow.

**Why**

The workflow currently runs on every PR regardless of what changed. It builds both the Desktop and Mobile apps in full, so a 20-minute CI job fires even for PRs that only touch docs, e2e tests, scripts, or CI config unrelated to either app. The paths filter skips the job when none of the relevant source is touched.

The push trigger on develop/main is left unfiltered — the rsdoctor-action compares PR bundles against the base branch, so a current baseline needs to exist on develop at all times.