### PR TITLE
test(contacts): share Lumen test harness (LIVE-35501)

### DIFF
--- a/.changeset/shared-lumen-test-harness.md
+++ b/.changeset/shared-lumen-test-harness.md
@@ -1,6 +1,6 @@
 ---
 "@features/flow-contacts": patch
-"@features/platform-jest-config": patch
+"@support/jest-features-flow": patch
 ---
 
 Use shared Lumen test primitives across Contacts tests.

--- a/.changeset/shared-lumen-test-harness.md
+++ b/.changeset/shared-lumen-test-harness.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": patch
+"@features/platform-jest-config": patch
+---
+
+Use shared Lumen test primitives across Contacts tests.

--- a/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/AddressNameDisclaimer/AddressNameDisclaimer.web.test.tsx
@@ -2,27 +2,6 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { AddressNameDisclaimer } from "./AddressNameDisclaimer.web";
 
-jest.mock("@ledgerhq/lumen-ui-react", () => {
-  const React = require("react");
-
-  return {
-    InteractiveIcon: ({
-      icon: _icon,
-      iconType: _iconType,
-      size: _size,
-      ...props
-    }: Omit<React.ComponentProps<"button">, "icon"> & {
-      icon: unknown;
-      iconType: string;
-      size: number;
-    }) => React.createElement("button", props),
-    Tooltip: ({ children }: { children: React.ReactNode }) => children,
-    TooltipTrigger: ({ children }: { children: React.ReactNode }) => children,
-    TooltipContent: ({ children }: { children: React.ReactNode }) =>
-      React.createElement("div", { role: "tooltip" }, children),
-  };
-});
-
 describe("AddressNameDisclaimer", () => {
   it("should render an accessible tooltip trigger with its description", () => {
     render(

--- a/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/components/SanctionedAddressBanner/SanctionedAddressBanner.native.test.tsx
@@ -2,34 +2,6 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { SanctionedAddressBanner } from "./SanctionedAddressBanner.native";
 
-jest.mock("@ledgerhq/lumen-ui-rnative", () => {
-  const React = require("react");
-
-  return {
-    Banner: ({
-      description,
-      primaryAction,
-      testID,
-    }: {
-      description: string;
-      primaryAction?: React.ReactNode;
-      testID?: string;
-    }) =>
-      React.createElement(
-        "Banner",
-        { testID },
-        React.createElement("Text", undefined, description),
-        primaryAction,
-      ),
-    Button: ({ children, onPress }: { children: React.ReactNode; onPress?: () => void }) =>
-      React.createElement(
-        "Button",
-        { onPress, testID: "sanctioned-address-banner-action" },
-        React.createElement("Text", undefined, children),
-      ),
-  };
-});
-
 describe("SanctionedAddressBanner", () => {
   it("should render the supplied feedback and invoke its action", () => {
     const onAction = jest.fn();
@@ -45,7 +17,7 @@ describe("SanctionedAddressBanner", () => {
     expect(screen.getByTestId("contacts-sanctioned-address-banner")).toBeVisible();
     expect(screen.getByText("This wallet address is sanctioned.")).toBeVisible();
 
-    fireEvent.press(screen.getByTestId("sanctioned-address-banner-action"));
+    fireEvent.press(screen.getByText("Learn more"));
 
     expect(onAction).toHaveBeenCalledTimes(1);
   });

--- a/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/utils/truncateContactAddress.web.test.ts
@@ -6,17 +6,17 @@ describe("truncateContactAddress", () => {
   });
 
   it("returns addresses up to the truncation length unchanged", () => {
-    const address = "0x1234567890123456789";
+    const address = "0x12345678901234567";
 
     expect(address).toHaveLength(19);
     expect(truncateContactAddress(address)).toBe(address);
   });
 
   it("truncates addresses longer than the truncation length", () => {
-    const address = "0x12345678901234567890";
+    const address = "0x123456789012345678";
 
     expect(address).toHaveLength(20);
-    expect(truncateContactAddress(address)).toBe("0x123456...34567890");
+    expect(truncateContactAddress(address)).toBe("0x123456...12345678");
   });
 
   it("truncates long addresses with ellipsis", () => {

--- a/support/jest-features-flow/README.md
+++ b/support/jest-features-flow/README.md
@@ -18,7 +18,9 @@ The Lumen barrels and subpaths (`@ledgerhq/lumen-ui-react`, `@ledgerhq/lumen-ui-
 and `@ledgerhq/crypto-icons` are heavy ESM packages with large peer graphs. Instead of
 transforming them and installing every peer, this package redirects them (via
 `moduleNameMapper`) to a generic **Proxy passthrough stub**: every named export becomes
-a component that just renders its children.
+a component that renders its children. Native `Banner` and `Button` expose their visible
+description, actions, and labels, while web tooltip primitives and `InteractiveIcon` retain their
+accessible test shape.
 
 As a result:
 

--- a/support/jest-features-flow/mocks/passthrough-native.js
+++ b/support/jest-features-flow/mocks/passthrough-native.js
@@ -1,10 +1,31 @@
 const React = require("react");
 
+function Banner({ children, description, primaryAction, secondaryAction, ...props }) {
+  return React.createElement(
+    "Banner",
+    { ...props, description, primaryAction, secondaryAction },
+    description === undefined ? null : React.createElement("Text", undefined, description),
+    children,
+    primaryAction,
+    secondaryAction,
+  );
+}
+
+function Button({ children, ...props }) {
+  return React.createElement(
+    "Button",
+    props,
+    typeof children === "string" || typeof children === "number"
+      ? React.createElement("Text", undefined, children)
+      : children,
+  );
+}
+
 // Generic Lumen (native) stub: every named export becomes a host element named after the
 // component (e.g. Text -> "Text"), so React Native Testing Library text queries still work.
 // Redirected here via moduleNameMapper — no per-component mocks, no peer installs.
 module.exports = new Proxy(
-  { __esModule: true },
+  { __esModule: true, Banner, Button },
   {
     get(target, prop) {
       if (prop in target) return target[prop];

--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -1,5 +1,21 @@
 const React = require("react");
 
+function InteractiveIcon({ icon: _icon, iconType: _iconType, size: _size, ...props }) {
+  return React.createElement("button", { type: "button", ...props });
+}
+
+function Tooltip({ children }) {
+  return React.createElement(React.Fragment, undefined, children);
+}
+
+function TooltipTrigger({ children }) {
+  return React.createElement(React.Fragment, undefined, children);
+}
+
+function TooltipContent({ children, ...props }) {
+  return React.createElement("div", { ...props, role: "tooltip" }, children);
+}
+
 function createPassthroughComponent() {
   return function LumenStub({ children, ...props }) {
     if (props.onChange !== undefined && props.value !== undefined) {
@@ -17,7 +33,7 @@ function createPassthroughComponent() {
 // Generic Lumen (web) stub: every named export becomes a component that forwards props
 // to a minimal DOM node so tests can query data-testid and fire events.
 module.exports = new Proxy(
-  { __esModule: true },
+  { __esModule: true, InteractiveIcon, Tooltip, TooltipContent, TooltipTrigger },
   {
     get(target, prop) {
       if (prop in target) return target[prop];


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Contacts Flow, Market Banner, and Pay Card Auth suites pass.
- [x] **Impact of the changes:**
      Contacts Flow tests now use the shared Lumen harness, with no direct Lumen component mocks remaining.

### 📝 Description

This PR removes the remaining local Lumen mocks from Contacts tests.

The shared Flow Jest passthrough now exposes the minimal accessible behavior required by native banners and web tooltips, while preserving the generic test harness for every Contacts test.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35501

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)