### PR TITLE
ci(labeler): add devtools label for PRs (LIVE-35560)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,9 @@ ledgerjs:
 tools:
   - tools/**/*
 
+devtools:
+  - devtools/**/*
+
 automation:
   - .github/**/*
 


### PR DESCRIPTION
### 📝 Description

Adds a `devtools` GitHub label and wires it into the PR auto-labeler so any PR touching `devtools/**` gets tagged automatically, matching how `tools`, `wallet-cli`, and the other scope labels already work.

- Created the `devtools` GitHub label (color `#FFC98B`, description "Has changes in the DevTools packages").
- Added the auto-labeler rule in `.github/labeler.yml`:

```yaml
devtools:
  - devtools/**/*
```

No PR-title prefix change (`pr-title-from-labels.yml` is untouched) and no `support/` label — out of scope.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35560](https://ledgerhq.atlassian.net/browse/LIVE-35560)

[LIVE-35560]: https://ledgerhq.atlassian.net/browse/LIVE-35560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ