### PR TITLE
chore(ci): upgrade rsdoctor-action to v1.1.4

### DIFF
--- a/.github/workflows/rsdoctor-pr.yml
+++ b/.github/workflows/rsdoctor-pr.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm --filter live-mobile run doctor
 
       - name: Bundle Analysis (Desktop + Mobile)
-        uses: web-infra-dev/rsdoctor-action@71406dd7d0b4815e7e1be27928961544ed618530
+        uses: web-infra-dev/rsdoctor-action@2fbd50933702502f12d2bbef5273afbfd829a289 # v1.1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_path: rsdoctor/*/rsdoctor-data.json


### PR DESCRIPTION
### 📝 Description

Bumps the pinned `web-infra-dev/rsdoctor-action` SHA from `71406dd` (2026-01-28) to `2fbd509` (v1.1.4).

The trigger is [rsdoctor-action#50](https://github.com/web-infra-dev/rsdoctor-action/pull/50) — the baseline workflow lookup now uses full SHAs, so the PR-vs-develop bundle comparison resolves its baseline run reliably instead of intermittently finding nothing to diff against.

Other fixes picked up along the way:

| PR | Change |
| --- | --- |
| [#57](https://github.com/web-infra-dev/rsdoctor-action/pull/57) | no silent exit before posting the bundle diff comment |
| [#54](https://github.com/web-infra-dev/rsdoctor-action/pull/54) | `@rsdoctor/cli` bundled into `dist` |
| [#52](https://github.com/web-infra-dev/rsdoctor-action/pull/52) | gzip size reporting |
| [#53](https://github.com/web-infra-dev/rsdoctor-action/pull/53) | AI analysis skipped when the bundle is unchanged |
| [#49](https://github.com/web-infra-dev/rsdoctor-action/pull/49) | better artifact names |

All three inputs we pass (`github_token`, `file_path`, `target_branch`) are unchanged in the new `action.yml`, so no config migration is needed. The action runtime moved to `node24`.

> [!NOTE]
> `@rsdoctor/rspack-plugin` is intentionally left at `2.0.0-alpha.0` in the catalog — that is the newest published version. npm's `latest` (1.6.1) is the rspack-1 line, so moving to it would be a downgrade away from our `@rspack/core` 2.0.5.

> [!TIP]
> The action now defaults `enable_ai_analysis: true` with `claude-3-5-haiku-latest`. It requires an `AI_TOKEN` passed to the step; without it that part no-ops, so current behaviour is unaffected. We can opt in later if we want the degradation summaries.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — CI maintenance following [rsdoctor-action#50](https://github.com/web-infra-dev/rsdoctor-action/pull/50)
- **ADR** (if any): n/a
