### PR TITLE
[LWDM] fix(cloud-sync): recover expired JWT instead of surfacing a 401

### DIFF
--- a/.changeset/cloud-sync-401-jwt-recovery.md
+++ b/.changeset/cloud-sync-401-jwt-recovery.md
@@ -1,0 +1,18 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": patch
+"@shared/cloud-sync": patch
+---
+
+Fix Ledger Sync surfacing a 401 instead of refreshing the expired JWT
+
+`@shared/cloud-sync` threw a bare `Error` carrying only `HTTP <status> on <method> <url>`, dropping
+both the HTTP status and the backend's response body. The trustchain JWT recovery in
+`genericWithJWT` could not classify it, so an expired token was rethrown instead of being refreshed
+and retried: the 401 reached the UI, and on mobile it fed the wallet-sync error into the account
+sync indicator ("Some account data couldn't load").
+
+`CloudSyncHttpError` now carries `status`, `url`, `method` and the backend's verbatim message, and
+`auth.ts` classifies 4xx from the numeric `status` rather than from the `LedgerAPI4xx` class name,
+so recovery no longer depends on which transport made the call. The error contract expected by the
+trustchain layer is documented in `auth.ts`; a transport whose errors are not `Error`-shaped must
+remap to it at its boundary.

--- a/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/unit/sdk.test.ts
@@ -235,7 +235,7 @@ describe("Trustchain SDK", () => {
     apiMocks.postAuthenticate.mockReturnValueOnce({ ...initialJwt, access_token: "NEW TOKEN" });
     await sdk.withAuth(trustchain, alice, async jwt => {
       if (jwt.accessToken === "NEW TOKEN") return;
-      throw new LedgerAPI4xx("Permission denied");
+      throw new LedgerAPI4xx("Permission denied", { status: 401 });
     });
 
     expect(apiMocks.getChalenge).toHaveBeenCalledTimes(2);

--- a/libs/ledger-key-ring-protocol/src/auth.test.ts
+++ b/libs/ledger-key-ring-protocol/src/auth.test.ts
@@ -1,0 +1,121 @@
+import { genericWithJWT } from "./auth";
+import { TrustchainNotAllowed, TrustchainOutdated } from "./errors";
+import { JWT } from "./types";
+
+const initialJwt = { accessToken: "initial" } as unknown as JWT;
+const refreshedJwt = { accessToken: "refreshed" } as unknown as JWT;
+const reauthedJwt = { accessToken: "reauthed" } as unknown as JWT;
+
+/** Shaped like @ledgerhq/live-network's LedgerAPI4xx, which always carries a status. */
+function ledgerNetworkError(message: string, status = 401) {
+  const error = new Error(message);
+  error.name = "LedgerAPI4xx";
+  Object.assign(error, { status });
+  return error;
+}
+
+/** Shaped like the plain fetch errors thrown by @shared/cloud-sync. */
+function fetchError(message: string, status = 401) {
+  const error = new Error(message);
+  error.name = "CloudSyncHttpError";
+  Object.assign(error, { status });
+  return error;
+}
+
+describe("genericWithJWT", () => {
+  const cases = [
+    ["live-network error", ledgerNetworkError],
+    ["fetch error carrying a status", fetchError],
+  ] as const;
+
+  describe.each(cases)("with a %s", (_label, makeError) => {
+    it("refreshes the jwt and retries the job when it expired and can be refreshed", async () => {
+      const auth = jest.fn().mockResolvedValue(reauthedJwt);
+      const refreshAuth = jest.fn().mockResolvedValue(refreshedJwt);
+      const job = jest
+        .fn()
+        .mockRejectedValueOnce(makeError("JWT is expired, please call /refresh"))
+        .mockResolvedValueOnce("done");
+
+      await expect(genericWithJWT(job, initialJwt, auth, refreshAuth)).resolves.toBe("done");
+
+      expect(refreshAuth).toHaveBeenCalledWith(initialJwt);
+      expect(auth).not.toHaveBeenCalled();
+      expect(job).toHaveBeenNthCalledWith(2, refreshedJwt);
+    });
+
+    it("re-authenticates and retries when the jwt expired without a refresh route", async () => {
+      const auth = jest.fn().mockResolvedValue(reauthedJwt);
+      const refreshAuth = jest.fn();
+      const job = jest
+        .fn()
+        .mockRejectedValueOnce(makeError("JWT is expired"))
+        .mockResolvedValueOnce("done");
+
+      await expect(genericWithJWT(job, initialJwt, auth, refreshAuth)).resolves.toBe("done");
+
+      expect(refreshAuth).not.toHaveBeenCalled();
+      expect(auth).toHaveBeenCalledTimes(1);
+      expect(job).toHaveBeenNthCalledWith(2, reauthedJwt);
+    });
+
+    it("re-authenticates and retries on an unrecognised 4xx", async () => {
+      const auth = jest.fn().mockResolvedValue(reauthedJwt);
+      const job = jest
+        .fn()
+        .mockRejectedValueOnce(makeError("Unauthorized"))
+        .mockResolvedValueOnce("done");
+
+      await expect(genericWithJWT(job, initialJwt, auth, jest.fn())).resolves.toBe("done");
+
+      expect(auth).toHaveBeenCalledTimes(1);
+      expect(job).toHaveBeenNthCalledWith(2, reauthedJwt);
+    });
+
+    it("maps a permission failure to TrustchainNotAllowed", async () => {
+      const job = jest.fn().mockRejectedValue(makeError("JWT contains no permission"));
+
+      await expect(genericWithJWT(job, initialJwt, jest.fn(), jest.fn())).rejects.toBeInstanceOf(
+        TrustchainNotAllowed,
+      );
+      expect(job).toHaveBeenCalledTimes(1);
+    });
+
+    it("maps a path mismatch to TrustchainOutdated", async () => {
+      const job = jest.fn().mockRejectedValue(makeError("path does not match"));
+
+      await expect(genericWithJWT(job, initialJwt, jest.fn(), jest.fn())).rejects.toBeInstanceOf(
+        TrustchainOutdated,
+      );
+    });
+  });
+
+  it("rethrows a 5xx without re-authenticating", async () => {
+    const auth = jest.fn();
+    const error = fetchError("Internal Server Error", 500);
+    const job = jest.fn().mockRejectedValue(error);
+
+    await expect(genericWithJWT(job, initialJwt, auth, jest.fn())).rejects.toBe(error);
+    expect(auth).not.toHaveBeenCalled();
+    expect(job).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows a transport error that carries no status", async () => {
+    const auth = jest.fn();
+    const error = new Error("Network request failed");
+    const job = jest.fn().mockRejectedValue(error);
+
+    await expect(genericWithJWT(job, initialJwt, auth, jest.fn())).rejects.toBe(error);
+    expect(auth).not.toHaveBeenCalled();
+  });
+
+  it("keys off the status rather than the error class name", async () => {
+    const auth = jest.fn().mockResolvedValue(reauthedJwt);
+    const namedButStatusless = new Error("JWT is expired");
+    namedButStatusless.name = "LedgerAPI4xx";
+    const job = jest.fn().mockRejectedValue(namedButStatusless);
+
+    await expect(genericWithJWT(job, initialJwt, auth, jest.fn())).rejects.toBe(namedButStatusless);
+    expect(auth).not.toHaveBeenCalled();
+  });
+});

--- a/libs/ledger-key-ring-protocol/src/auth.ts
+++ b/libs/ledger-key-ring-protocol/src/auth.ts
@@ -73,14 +73,32 @@ type JwtExpirationCheck = {
   isUncaughtClientError: boolean;
 };
 
+/**
+ * Contract for HTTP errors reaching this layer, which any transport used to call the trustchain
+ * or cloud-sync backends must satisfy — see `CloudSyncHttpError` in @shared/cloud-sync and
+ * `LedgerAPI4xx` in @ledgerhq/live-network:
+ *
+ *  - `status`: the numeric HTTP status. JWT recovery only engages on a 4xx.
+ *  - `message`: the backend's message, verbatim. The backend discriminates JWT failures through
+ *    it ("JWT is expired", "JWT contains no permission", "path does not match"), so a transport
+ *    that drops the response body silently downgrades every 4xx to a full re-authentication and
+ *    stops producing TrustchainNotAllowed / TrustchainOutdated.
+ *
+ * A transport whose errors are not Error-shaped (RTK Query's FetchBaseQueryError carries the body
+ * on `data` and has no `message`) must remap to this shape at its boundary.
+ */
+function isClientError(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status;
+  return typeof status === "number" && status >= 400 && status < 500;
+}
+
 function networkCheckJwtExpiration(error: unknown): JwtExpirationCheck {
   let hasExpired = false;
   let canBeRefreshed = false;
   let isNotPermitted = false;
   let isTrustchainOutdated = false;
   let isUncaughtClientError = false;
-  // this assume live-network is used and we adapt to its error's format
-  if ((error as { name?: string })?.name === "LedgerAPI4xx") {
+  if (isClientError(error)) {
     const message = (error as Error)?.message ?? "";
     if (message.includes("JWT is expired")) {
       hasExpired = true;

--- a/shared/cloud-sync/src/cloudsync/__tests__/api.test.ts
+++ b/shared/cloud-sync/src/cloudsync/__tests__/api.test.ts
@@ -84,6 +84,44 @@ describe("getApi", () => {
     );
   });
 
+  it("exposes the HTTP status on a 401 so JWT expiration handling can react", async () => {
+    server.use(
+      http.get(`${base}/atomic/v1/:slug`, () =>
+        HttpResponse.json({ message: "JWT is expired" }, { status: 401 }),
+      ),
+    );
+    const error = await api.fetchData(jwt, "live", undefined, trustchain).catch(e => e);
+    expect(error).toMatchObject({ status: 401, method: "GET" });
+    expect(error.message).toBe("JWT is expired");
+  });
+
+  it("exposes the HTTP status on a 401 upload", async () => {
+    server.use(
+      http.post(`${base}/atomic/v1/:slug`, () =>
+        HttpResponse.json({ message: "JWT is expired" }, { status: 401 }),
+      ),
+    );
+    const error = await api.uploadData(jwt, "live", 1, "payload", trustchain).catch(e => e);
+    expect(error).toMatchObject({ status: 401, method: "POST" });
+  });
+
+  it("exposes the HTTP status on a 401 delete", async () => {
+    server.use(
+      http.delete(`${base}/atomic/v1/:slug`, () =>
+        HttpResponse.json({ message: "JWT is expired" }, { status: 401 }),
+      ),
+    );
+    const error = await api.deleteData(jwt, "live", trustchain).catch(e => e);
+    expect(error).toMatchObject({ status: 401, method: "DELETE" });
+  });
+
+  it("falls back to a status message when the error body carries none", async () => {
+    server.use(http.get(`${base}/atomic/v1/:slug`, () => HttpResponse.json({}, { status: 403 })));
+    const error = await api.fetchData(jwt, "live", undefined, trustchain).catch(e => e);
+    expect(error.status).toBe(403);
+    expect(error.message).toContain("HTTP 403");
+  });
+
   it("fetchStatus returns service info", async () => {
     await expect(api.fetchStatus()).resolves.toEqual({ name: "cloud-sync", version: "1.0.0" });
   });

--- a/shared/cloud-sync/src/cloudsync/api.ts
+++ b/shared/cloud-sync/src/cloudsync/api.ts
@@ -35,10 +35,64 @@ const schemaAtomicPostResponse = z.discriminatedUnion("status", [
 ]);
 export type APISyncUpdateResponse = z.infer<typeof schemaAtomicPostResponse>;
 
+/**
+ * Satisfies the error contract documented in @ledgerhq/ledger-key-ring-protocol's `auth.ts`:
+ * a numeric `status` plus the backend's verbatim `message`. Both are required for JWT recovery —
+ * dropping either turns a recoverable expired token into a surfaced 401.
+ */
+export class CloudSyncHttpError extends Error {
+  override name = "CloudSyncHttpError";
+  readonly status: number;
+  readonly url: string;
+  readonly method: string;
+  constructor(message: string, fields: { status: number; url: string; method: string }) {
+    super(message);
+    this.status = fields.status;
+    this.url = fields.url;
+    this.method = fields.method;
+  }
+}
+
+function getErrorMessage(data: unknown): string | undefined {
+  if (!data) return undefined;
+  if (typeof data === "string") return data;
+  if (typeof data !== "object") return undefined;
+  const record = data as Record<string, unknown>;
+  const errors = record.errors;
+  if (Array.isArray(errors) && errors.length > 0) return getErrorMessage(errors[0]);
+  for (const key of ["message", "error_message", "error", "msg"]) {
+    const value = record[key];
+    if (typeof value === "string") return value;
+  }
+  return undefined;
+}
+
+function extractServerMessage(body: string): string | undefined {
+  if (!body) return undefined;
+  try {
+    const data: unknown = JSON.parse(body);
+    return getErrorMessage(Array.isArray(data) ? data[0] : data);
+  } catch {
+    return body;
+  }
+}
+
+async function makeHttpError(res: Response, url: string, method: string) {
+  let body = "";
+  try {
+    body = await res.text();
+  } catch {
+    body = "";
+  }
+  const message =
+    extractServerMessage(body) ?? `HTTP ${res.status} ${res.statusText} on ${method} ${url}`;
+  return new CloudSyncHttpError(message, { status: res.status, url, method });
+}
+
 async function apiFetch<T>(url: string, init: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status} ${res.statusText} on ${init.method} ${url}`);
+    throw await makeHttpError(res, url, init.method ?? "GET");
   }
   return res.json() as Promise<T>;
 }
@@ -98,7 +152,7 @@ function getApi(apiBaseURL: string) {
       method: "DELETE",
       headers: { Authorization: `Bearer ${jwt.accessToken}` },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText} on DELETE ${url}`);
+    if (!res.ok) throw await makeHttpError(res, url, "DELETE");
   }
 
   function listenNotifications(


### PR DESCRIPTION
### 📝 Description

Ledger Sync surfaced a `401` to the UI instead of refreshing an expired JWT.

**Previous behaviour** — `@shared/cloud-sync` threw a bare `Error` carrying only `HTTP <status> on <method> <url>`, dropping both the HTTP status and the backend's response body. `genericWithJWT` (`@ledgerhq/ledger-key-ring-protocol`) classified errors by testing `error.name === "LedgerAPI4xx"`, so a cloud-sync error was never recognised as a client error: the expired token was rethrown instead of being refreshed and retried. The 401 reached the UI, and on mobile the wallet-sync error fed the account sync indicator ("Some account data couldn't load").

**Fix**

- `CloudSyncHttpError` carries `status`, `url`, `method` and the backend's verbatim message (parsed from the response body, falling back to the status line).
- `auth.ts` classifies 4xx from the numeric `status` instead of the `LedgerAPI4xx` class name, so recovery no longer depends on which transport made the call.
- The error contract expected by the trustchain layer is now documented in `auth.ts`: a transport whose errors are not `Error`-shaped (e.g. RTK Query's `FetchBaseQueryError`, which carries the body on `data` and has no `message`) must remap to it at its boundary.

**Regression coverage** — `auth.test.ts` (new) runs the whole `genericWithJWT` matrix twice, once with live-network errors and once with fetch-shaped errors, asserting refresh / re-auth / `TrustchainNotAllowed` / `TrustchainOutdated` and that a 5xx or a status-less transport error is rethrown untouched. `api.test.ts` asserts the thrown error's `status` and that the backend message survives.

For a transport author, the contract is:

```ts
throw new CloudSyncHttpError(backendMessage, { status: 401, url, method });
// status → JWT recovery engages; message → discriminates expired / not-permitted / outdated
```

### 🔗 Context

- **JIRA / GitHub issue**: <!-- to fill -->
- **ADR** (if any): n/a
