### PR TITLE
[LWD] refactor(contacts): extract ghost-click guard logic to utility

### DIFF
--- a/.changeset/tidy-ghost-clicks-extract.md
+++ b/.changeset/tidy-ghost-clicks-extract.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Extract ghost-click guard logic to shared utility in EditName dialog

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/__integrations__/EditName.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/__integrations__/EditName.integration.test.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { render, screen, waitFor, fireEvent } from "tests/testSetup";
+import { render, screen, waitFor } from "tests/testSetup";
 import { Button } from "@ledgerhq/lumen-ui-react";
 import { ETH_ACCOUNT } from "LLD/features/__mocks__/accounts.mock";
 import { EditName } from "LLD/features/CryptoAddresses/components/EditName";
-
-/** How long the ghost-click guard blocks outside-click closes (must match the component). */
-const GHOST_CLICK_GUARD_MS = 300;
 
 const ASSET_NAME = "Ethereum";
 
@@ -19,40 +16,6 @@ const renderEditName = () => {
 };
 
 describe("EditName", () => {
-  it("stays open when outside is clicked within the ghost-click guard window", async () => {
-    const { user } = renderEditName();
-
-    await user.click(screen.getByTestId("edit-name-trigger"));
-    await waitFor(() => {
-      expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
-    });
-
-    // Immediately fire an outside pointerdown (within the 300ms guard window)
-    fireEvent.pointerDown(document);
-
-    // Dialog must still be open
-    expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
-  });
-
-  it("closes when outside is clicked after the ghost-click guard window", async () => {
-    const { user } = renderEditName();
-
-    await user.click(screen.getByTestId("edit-name-trigger"));
-    await waitFor(() => {
-      expect(screen.getByTestId("edit-crypto-address-name-dialog-content")).toBeVisible();
-    });
-
-    // Wait past the guard window then simulate an outside click
-    await new Promise(r => setTimeout(r, GHOST_CLICK_GUARD_MS + 50));
-    fireEvent.pointerDown(document);
-
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId("edit-crypto-address-name-dialog-content"),
-      ).not.toBeInTheDocument();
-    });
-  });
-
   it("should open dialog, interact with chips and input, confirm, then reopen and close via X", async () => {
     const { user, store } = renderEditName();
 

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/EditCryptoAddressNameDialog.tsx
@@ -14,9 +14,7 @@ import { normalizeName, MAX_ACCOUNT_NAME_LENGTH } from "@ledgerhq/live-wallet/ac
 import { Chip } from "./Chip";
 import { track } from "~/renderer/analytics/segment";
 import { CRYPTO_TRACKING_PAGE_NAME } from "../../../constants";
-
-/** How long after opening to ignore outside-click closes (ghost-click guard). */
-const GHOST_CLICK_GUARD_MS = 300;
+import { isWithinGhostClickGuard } from "./ghostClickGuard";
 
 type EditCryptoAddressNameDialogProps = {
   children: React.ReactNode;
@@ -52,7 +50,7 @@ export const EditCryptoAddressNameDialog = ({
   const handlePointerDownOutside: NonNullable<
     React.ComponentProps<typeof DialogContent>["onPointerDownOutside"]
   > = e => {
-    if (Date.now() - openedAtRef.current < GHOST_CLICK_GUARD_MS) {
+    if (isWithinGhostClickGuard(openedAtRef.current)) {
       e.preventDefault();
     }
   };

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/__tests__/ghostClickGuard.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/__tests__/ghostClickGuard.test.ts
@@ -1,0 +1,13 @@
+import { GHOST_CLICK_GUARD_MS, isWithinGhostClickGuard } from "../ghostClickGuard";
+
+describe("isWithinGhostClickGuard", () => {
+  const openedAt = 1_000;
+
+  it("should block outside clicks within the guard window", () => {
+    expect(isWithinGhostClickGuard(openedAt, openedAt + GHOST_CLICK_GUARD_MS - 1)).toBe(true);
+  });
+
+  it("should allow outside clicks once the guard window has elapsed", () => {
+    expect(isWithinGhostClickGuard(openedAt, openedAt + GHOST_CLICK_GUARD_MS)).toBe(false);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/ghostClickGuard.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/CryptoAddresses/components/EditName/components/ghostClickGuard.ts
@@ -1,0 +1,6 @@
+/** How long after opening to ignore outside-click closes (ghost-click guard). */
+export const GHOST_CLICK_GUARD_MS = 300;
+
+export function isWithinGhostClickGuard(openedAtMs: number, nowMs = Date.now()) {
+  return nowMs - openedAtMs < GHOST_CLICK_GUARD_MS;
+}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Fixes a flaky CI failure in `EditName.integration.test.tsx` (`stays open when outside is clicked within the ghost-click guard window`).

The removed tests opened the dialog, waited for it to appear, then fired `fireEvent.pointerDown(document)`. On slow CI, `waitFor` could exceed the 300ms ghost-click guard window, so the outside click legitimately closed the dialog and the assertion failed. Extra waits or `Date.now` mocks only shifted that race — they did not make the test stable.

This PR:
- Removes the two timing-dependent integration tests
- Extracts guard logic into `isWithinGhostClickGuard()` with deterministic unit tests (fixed timestamps)
- Keeps the existing full integration test, which already covers the real regression: opening via the trigger and interacting with the dialog without it immediately closing

No change to production behavior.

## Test plan

- [x] `pnpm desktop test:jest "src/mvvm/features/CryptoAddresses/components/EditName"`
- [ ] CI green on repeated runs

### 🔗 Context

[LIVE-35567](https://ledgerhq.atlassian.net/browse/LIVE-35567)


[LIVE-35567]: https://ledgerhq.atlassian.net/browse/LIVE-35567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ