### PR TITLE
[LWDM] feat(coin-casper): add estimateFees from chainspec lanes (LIVE-33293)

### DIFF
--- a/.changeset/slimy-drinks-tap.md
+++ b/.changeset/slimy-drinks-tap.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": minor
+---
+
+Implement `estimateFees` in the Casper CoinModuleApi, resolving the native transfer payment from the chainspec native mint lane limit, with `CASPER_FEES_MOTES` as fallback.

--- a/libs/coin-modules/coin-casper/src/__tests__/fixtures/chain.ts
+++ b/libs/coin-modules/coin-casper/src/__tests__/fixtures/chain.ts
@@ -1,0 +1,19 @@
+export const chainspecToml = (nativeMintLimit = "100_000_000"): string => `
+[protocol]
+version = '2.2.2'
+
+[core]
+pricing_handling = { type = 'payment_limited' }
+fee_handling = { type = 'burn' }
+refund_handling = { type = 'refund', refund_ratio = [75, 100] }
+
+[transactions]
+native_mint_lane    = [0, 2048,   1024, ${nativeMintLimit},       325]
+native_auction_lane = [1, 3096,   2048, 2_500_000_000,     325]
+install_upgrade_lane= [2, 750000, 2048, 1_000_000_000_000, 1]
+native_transfer_minimum_motes = 2_500_000_000
+
+[system_costs.auction_costs]
+delegate   = 2_500_000_000
+undelegate = 2_500_000_000
+`;

--- a/libs/coin-modules/coin-casper/src/__tests__/fixtures/index.ts
+++ b/libs/coin-modules/coin-casper/src/__tests__/fixtures/index.ts
@@ -1,5 +1,6 @@
 export * from "./account.fixture";
 export * from "./addresses.fixture";
+export * from "./chain";
 export * from "./config.fixture";
 export * from "./indexer.fixture";
 export * from "./operation.fixture";

--- a/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
@@ -1,15 +1,36 @@
 import { Transaction, CasperNetwork, KeyAlgorithm, PrivateKey } from "casper-js-sdk";
-import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/types";
+import type {
+  CoinModuleApi,
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
 import { createApi } from "./index";
+import { casperMainnetConfig } from "../__tests__/fixtures/config.fixture";
 import {
   BUSY_MAINNET_PUBLIC_KEY,
   FUNDED_MAINNET_PUBLIC_KEY,
   UNFUNDED_MAINNET_PUBLIC_KEY,
+  TEST_ADDRESSES,
 } from "../__tests__/fixtures/addresses.fixture";
-import { casperMainnetConfig } from "../__tests__/fixtures/config.fixture";
-import { CASPER_DEFAULT_TTL, CASPER_FEES_MOTES, CASPER_NETWORK } from "../constants";
+import {
+  CASPER_DEFAULT_TTL,
+  CASPER_FEES_MOTES,
+  CASPER_NETWORK,
+  CASPER_DUMMY_ADDRESS,
+} from "../constants";
 import { getCasperNodeRpcClient } from "../network/api";
 import type { CasperMemo } from "../types";
+import { LANE_KEYS, LANE_LIMIT_TUPLE_INDEX } from "../constants";
+import { fetchChainspecToml } from "../network/api";
+
+const nativeTransferIntent: TransactionIntent<MemoNotSupported> = {
+  intentType: "transaction",
+  type: "send",
+  sender: TEST_ADDRESSES.SECP256K1,
+  recipient: CASPER_DUMMY_ADDRESS,
+  amount: 3_000_000_000n,
+  asset: { type: "native" },
+};
 
 describe("Casper Api (mainnet)", () => {
   let api: CoinModuleApi<CasperMemo>;
@@ -237,6 +258,28 @@ describe("Casper Api (mainnet)", () => {
       const balances = await api.getBalance(UNFUNDED_MAINNET_PUBLIC_KEY);
 
       expect(balances).toEqual([{ value: 0n, asset: { type: "native" } }]);
+    });
+  });
+
+  describe("estimateFees", () => {
+    it("estimates a native transfer at the live native mint lane limit", async () => {
+      // Parsed independently: a hardcoded limit goes stale on the next protocol upgrade, and
+      // reusing the implementation's regex would hide a bug in it.
+      const toml = await fetchChainspecToml();
+      const laneLine = toml
+        .split("\n")
+        .map(line => line.trim())
+        .find(line => line.startsWith(LANE_KEYS.nativeMint));
+      if (!laneLine) throw new Error(`live chainspec has no ${LANE_KEYS.nativeMint} entry`);
+
+      const tuple = laneLine.slice(laneLine.indexOf("[") + 1, laneLine.indexOf("]")).split(",");
+      const expected = BigInt(tuple[LANE_LIMIT_TUPLE_INDEX].replace(/_/g, "").trim());
+      expect(expected).toBeGreaterThan(0n);
+
+      await expect(api.estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: expected,
+        parameters: { source: "chainspec", lane: "native_mint" },
+      });
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -22,6 +22,7 @@ import { craftTransaction } from "../logic/craftTransaction";
 import { lastBlock } from "../logic/lastBlock";
 import { getBalance as getAccountBalance } from "../logic/getBalance";
 import { listOperations } from "../logic/listOperations";
+import { estimateFees } from "../logic/estimateFees";
 import type { CasperCoinConfig, CasperMemo } from "../types";
 
 export function createApi(config: CasperCoinConfig): CoinModuleApi<CasperMemo> {
@@ -60,11 +61,9 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<CasperMemo> {
     ): Promise<CraftedTransaction> {
       throw new Error("craftRawTransaction is not supported");
     },
-    estimateFees(_intent: TransactionIntent<CasperMemo>): Promise<FeeEstimation> {
-      throw new Error("estimateFees is not supported");
-    },
     combine,
     broadcast,
+    estimateFees,
     validateIntent(
       _intent: TransactionIntent<CasperMemo>,
       _balances: Balance[],

--- a/libs/coin-modules/coin-casper/src/constants.ts
+++ b/libs/coin-modules/coin-casper/src/constants.ts
@@ -3,18 +3,25 @@ import { InvalidMinimumAmount, MayBlockAccount } from "./errors";
 export const CASPER_DUMMY_ADDRESS =
   "02030d18d5bed9f5015824D89367EF448041E912F358655184412E48557491aAdB85";
 
-export const CASPER_FEES_MOTES = 0.1 * 1e9;
+export const CASPER_FEES_MOTES = 100_000_000;
 export const CASPER_FEES_CSPR = 0.1;
 export const CASPER_MINIMUM_VALID_AMOUNT_MOTES = 2.5 * 1e9;
 export const CASPER_MINIMUM_VALID_AMOUNT_CSPR = 2.5;
 export const CASPER_NETWORK = "casper";
 export const CASPER_CHECKSUM_HEX_LEN = 32;
 export const CASPER_DEFAULT_TTL = 1800000;
-
 export const CASPER_MAX_TRANSFER_ID = "18446744073709551615";
-
 /** Largest page the indexer accepts; above it the request is a 400. */
 export const CASPER_INDEXER_MAX_PAGE_SIZE = 250;
+
+export const LANE_KEYS = {
+  nativeMint: "native_mint_lane",
+  // add the other lanes here if/when used
+} as const;
+
+// Chainspec `[transactions]` lane tuples are
+// [id, max_serialized_length, max_args_length, max_transaction_gas_limit, max_transaction_count].
+export const LANE_LIMIT_TUPLE_INDEX = 3;
 
 export const MayBlockAccountError = new MayBlockAccount("", {
   minAmount: `${CASPER_MINIMUM_VALID_AMOUNT_CSPR + CASPER_FEES_CSPR} CSPR`,

--- a/libs/coin-modules/coin-casper/src/logic/estimateFees.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/estimateFees.test.ts
@@ -1,0 +1,157 @@
+import type {
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import { CASPER_FEES_MOTES } from "../constants";
+import { chainspecToml, TEST_ADDRESSES } from "../__tests__/fixtures";
+import { estimateFees, getEstimatedFees, nativeMintLaneLimitCache } from "./estimateFees";
+
+const mockFetchChainspecToml = jest.fn<Promise<string>, []>();
+const mockLog = jest.fn();
+
+jest.mock("@ledgerhq/logs", () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}));
+
+jest.mock("../network/api", () => ({
+  fetchChainspecToml: () => mockFetchChainspecToml(),
+}));
+
+const nativeTransferIntent: TransactionIntent<MemoNotSupported> = {
+  intentType: "transaction",
+  type: "send",
+  sender: TEST_ADDRESSES.SECP256K1,
+  recipient: TEST_ADDRESSES.RECIPIENT_ED25519,
+  amount: 3_000_000_000n,
+  asset: { type: "native" },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nativeMintLaneLimitCache.reset();
+  mockFetchChainspecToml.mockResolvedValue(chainspecToml());
+});
+
+describe("estimateFees", () => {
+  it("returns the native mint lane limit for a native transfer", async () => {
+    await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+      value: 100_000_000n,
+      parameters: { source: "chainspec", lane: "native_mint" },
+    });
+  });
+
+  it("follows the chainspec when the native mint lane limit differs from the constant", async () => {
+    mockFetchChainspecToml.mockResolvedValue(chainspecToml("250_000_000"));
+
+    await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+      value: 250_000_000n,
+      parameters: { source: "chainspec", lane: "native_mint" },
+    });
+  });
+
+  it("ignores customFeesParameters and options", async () => {
+    await expect(
+      estimateFees(nativeTransferIntent, { source: "nonsense" }, { feeOptionId: "standard" }),
+    ).resolves.toEqual({
+      value: 100_000_000n,
+      parameters: { source: "chainspec", lane: "native_mint" },
+    });
+  });
+
+  it("throws for a non-native asset", async () => {
+    await expect(
+      estimateFees({
+        ...nativeTransferIntent,
+        asset: { type: "cep18", assetReference: "0xdeadbeef" },
+      }),
+    ).rejects.toThrow('estimateFees is not supported for asset type "cep18"');
+  });
+
+  it("throws for a staking intent, without reaching the network", async () => {
+    await expect(estimateFees({ ...nativeTransferIntent, intentType: "staking" })).rejects.toThrow(
+      "estimateFees is not supported for staking transactions",
+    );
+    expect(mockFetchChainspecToml).not.toHaveBeenCalled();
+  });
+
+  describe("fallback", () => {
+    it("falls back to CASPER_FEES_MOTES when the chainspec cannot be fetched", async () => {
+      mockFetchChainspecToml.mockRejectedValue(new Error("node unreachable"));
+
+      await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: BigInt(CASPER_FEES_MOTES),
+        parameters: { source: "fallback", lane: "native_mint" },
+      });
+    });
+
+    it("falls back when the chainspec has no native mint lane", async () => {
+      mockFetchChainspecToml.mockResolvedValue(
+        "[transactions]\ninstall_upgrade_lane = [2, 1, 1]\n",
+      );
+
+      await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: BigInt(CASPER_FEES_MOTES),
+        parameters: { source: "fallback", lane: "native_mint" },
+      });
+      expect(mockLog).toHaveBeenCalledWith(
+        "error",
+        "Casper chainspec has no native_mint_lane gas limit",
+      );
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back when the native mint lane limit is not an integer", async () => {
+      mockFetchChainspecToml.mockResolvedValue(chainspecToml("'oops'"));
+
+      await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: BigInt(CASPER_FEES_MOTES),
+        parameters: { source: "fallback", lane: "native_mint" },
+      });
+    });
+  });
+
+  describe("chainspec caching", () => {
+    it("fetches the chainspec once for repeated estimates", async () => {
+      await Promise.all([estimateFees(nativeTransferIntent), estimateFees(nativeTransferIntent)]);
+      await estimateFees(nativeTransferIntent);
+
+      expect(mockFetchChainspecToml).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs a missing native mint lane once, not on every estimate", async () => {
+      mockFetchChainspecToml.mockResolvedValue(
+        "[transactions]\ninstall_upgrade_lane = [2, 1, 1]\n",
+      );
+
+      await estimateFees(nativeTransferIntent);
+      await estimateFees(nativeTransferIntent);
+
+      expect(mockLog).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries after a failed fetch instead of caching the failure", async () => {
+      mockFetchChainspecToml.mockRejectedValueOnce(new Error("node unreachable"));
+
+      await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: BigInt(CASPER_FEES_MOTES),
+        parameters: { source: "fallback", lane: "native_mint" },
+      });
+      await expect(estimateFees(nativeTransferIntent)).resolves.toEqual({
+        value: 100_000_000n,
+        parameters: { source: "chainspec", lane: "native_mint" },
+      });
+      expect(mockFetchChainspecToml).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("getEstimatedFees", () => {
+  it("returns the CASPER_FEES_MOTES fallback", () => {
+    expect(getEstimatedFees().toFixed()).toBe(BigInt(CASPER_FEES_MOTES).toString());
+  });
+
+  it("never hits the network", () => {
+    getEstimatedFees();
+    expect(mockFetchChainspecToml).not.toHaveBeenCalled();
+  });
+});

--- a/libs/coin-modules/coin-casper/src/logic/estimateFees.ts
+++ b/libs/coin-modules/coin-casper/src/logic/estimateFees.ts
@@ -1,5 +1,69 @@
+import type {
+  EstimateFeesOptions,
+  FeeEstimation,
+  MemoNotSupported,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
+import { hours, makeLRUCache } from "@ledgerhq/live-network/cache";
+import { log } from "@ledgerhq/logs";
 import BigNumber from "bignumber.js";
-import { CASPER_FEES_MOTES } from "../constants";
+import { CASPER_FEES_MOTES, LANE_KEYS, LANE_LIMIT_TUPLE_INDEX } from "../constants";
+import { fetchChainspecToml } from "../network/api";
+
+const NATIVE_MINT_LANE_PATTERN = new RegExp(
+  String.raw`^\s*${LANE_KEYS.nativeMint}\s*=\s*\[([^\]]*)\]`,
+  "m",
+);
+
+const parseNativeMintLaneLimit = (toml: string): bigint | undefined => {
+  const match = NATIVE_MINT_LANE_PATTERN.exec(toml);
+  if (!match) return undefined;
+
+  const raw = match[1].split(",")[LANE_LIMIT_TUPLE_INDEX]?.replace(/_/g, "").trim();
+  return raw && /^\d+$/.test(raw) ? BigInt(raw) : undefined;
+};
+
+// The lane limit only moves on a protocol upgrade, so an hour of staleness is harmless.
+// Exported so tests can `.reset()` it.
+export const nativeMintLaneLimitCache = makeLRUCache(
+  async (): Promise<bigint | undefined> => {
+    const limit = parseNativeMintLaneLimit(await fetchChainspecToml());
+    if (limit === undefined) {
+      log("error", `Casper chainspec has no ${LANE_KEYS.nativeMint} gas limit`);
+    }
+
+    return limit;
+  },
+  () => "",
+  hours(1),
+);
+
+export const estimateFees = async (
+  transactionIntent: TransactionIntent<MemoNotSupported>,
+  _customFeesParameters?: FeeEstimation["parameters"],
+  _options?: EstimateFeesOptions,
+): Promise<FeeEstimation> => {
+  if (transactionIntent.intentType === "staking") {
+    throw new Error("estimateFees is not supported for staking transactions");
+  }
+  if (transactionIntent.asset.type !== "native") {
+    throw new Error(
+      `estimateFees is not supported for asset type "${transactionIntent.asset.type}"`,
+    );
+  }
+
+  const limit = await nativeMintLaneLimitCache().catch(() => undefined);
+
+  // Never pad this: unspent gas is only 75% refunded, so any safety margin is money burned.
+  // https://docs.casper.network/concepts/economics/gas-concepts
+  return {
+    value: limit ?? BigInt(CASPER_FEES_MOTES),
+    parameters: {
+      source: limit === undefined ? "fallback" : "chainspec",
+      lane: "native_mint",
+    },
+  };
+};
 
 export function getEstimatedFees(): BigNumber {
   return new BigNumber(CASPER_FEES_MOTES);

--- a/libs/coin-modules/coin-casper/src/network/api.test.ts
+++ b/libs/coin-modules/coin-casper/src/network/api.test.ts
@@ -11,6 +11,7 @@ import {
   fetchAccountStateInfo,
   fetchBalance,
   fetchLastBlock,
+  fetchChainspecToml,
   fetchTxs,
   broadcastTx,
   getCasperNodeRpcClient,
@@ -90,6 +91,7 @@ const createMockRpcClient = (methodOverrides: Partial<Record<keyof RpcClient, je
     getBalanceByStateRootHash: jest.fn(),
     getLatestBlock: jest.fn(),
     putTransaction: jest.fn(),
+    getChainspec: jest.fn(),
   };
 
   // Create a combined mock with defaultMethods overridden by methodOverrides
@@ -308,6 +310,40 @@ describe("Casper API Unit Tests", () => {
 
       await expect(fetchLastBlock()).rejects.toThrow("Failed to fetch last block");
       expect(log).toHaveBeenCalledWith("error", "Failed to fetch last block", mockError);
+    });
+  });
+
+  describe("fetchChainspecToml", () => {
+    it("should decode the hex-encoded chainspec to TOML", async () => {
+      const toml = "[transactions]\nnative_mint_lane = [0, 2048, 1024, 100_000_000, 325]\n";
+
+      createMockRpcClient({
+        getChainspec: jest.fn().mockResolvedValue({
+          chainspecBytes: { chainspecBytes: Buffer.from(toml, "utf8").toString("hex") },
+        }),
+      });
+
+      await expect(fetchChainspecToml()).resolves.toBe(toml);
+    });
+
+    it("should throw when the response carries no chainspec bytes", async () => {
+      createMockRpcClient({
+        getChainspec: jest.fn().mockResolvedValue({ chainspecBytes: {} }),
+      });
+
+      await expect(fetchChainspecToml()).rejects.toThrow("Chainspec bytes missing from response");
+      expect(log).toHaveBeenCalledWith("error", "Failed to fetch chainspec", expect.any(Error));
+    });
+
+    it("should throw error when the chainspec fetch fails", async () => {
+      const mockError = new Error("node unreachable");
+
+      createMockRpcClient({
+        getChainspec: jest.fn().mockRejectedValue(mockError),
+      });
+
+      await expect(fetchChainspecToml()).rejects.toThrow("node unreachable");
+      expect(log).toHaveBeenCalledWith("error", "Failed to fetch chainspec", mockError);
     });
   });
 

--- a/libs/coin-modules/coin-casper/src/network/api.ts
+++ b/libs/coin-modules/coin-casper/src/network/api.ts
@@ -111,6 +111,20 @@ export const fetchLastBlock = async (): Promise<{ height: number; hash: string; 
   }
 };
 
+export const fetchChainspecToml = async (): Promise<string> => {
+  const client = getCasperNodeRpcClient();
+  try {
+    const { chainspecBytes } = await client.getChainspec();
+    const hex = chainspecBytes.chainspecBytes;
+    if (!hex) throw new Error("Chainspec bytes missing from response");
+
+    return Buffer.from(hex, "hex").toString("utf8");
+  } catch (error) {
+    log("error", "Failed to fetch chainspec", error);
+    throw error;
+  }
+};
+
 /**
  * Fetch one page of an account's deploy feed, newest first.
  *


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Implement `estimateFees` in the Casper CoinModuleApi, resolving the native transfer payment from the chainspec native mint lane limit, with `CASPER_FEES_MOTES` as fallback.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-33293