### PR TITLE
[LWDM] feat(contacts): model "Me" as default self contact

### DIFF
--- a/.changeset/me-default-self-contact.md
+++ b/.changeset/me-default-self-contact.md
@@ -1,0 +1,8 @@
+---
+"@domain/entity-contact": minor
+"@features/flow-contacts": minor
+"live-mobile": minor
+"ledger-live-desktop": minor
+---
+
+Model Me as the default self contact with shared display-name formatting, external address counts, and a Ledger Wallet accounts intent.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -1,9 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 import type { ContactId } from "@domain/entity-contact";
 import {
   type AddAddressContact,
   useContactsMeContact,
+  useContactDetailSharedState,
   useEmptyContactDetail,
   usePopulatedContactDetail,
   useContactAddressDetailDialog,
@@ -29,6 +31,7 @@ export function useContactDetailPaneAdapter(
   onOpenContact: ContactsListViewProps["onOpenContact"];
 }> {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const meContact = useContactsMeContact();
   const currencyPort = useContactsAddressCurrencyAdapter();
   const [detailContactId, setDetailContactId] = useState<ContactId | undefined>(meContact.id);
@@ -58,10 +61,15 @@ export function useContactDetailPaneAdapter(
       emptyContactTitle: name => t("contacts.detail.emptyState.contactTitle", { name }),
       emptyMeDescription: t("contacts.detail.emptyState.meDescription"),
       emptyContactDescription: () => t("contacts.detail.emptyState.contactDescription"),
+      ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),
       formatMeDisplayName: name => t("contacts.detail.meDisplayName", { name }),
       formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
+  );
+  const detailSharedState = useContactDetailSharedState(
+    detailContactId,
+    labels.formatMeDisplayName,
   );
   const addressDetailDialogLabels = useMemo<ContactAddressDetailDialogLabels>(
     () => ({
@@ -75,6 +83,9 @@ export function useContactDetailPaneAdapter(
     }),
     [t],
   );
+  const onLedgerWalletAccountsPress = useCallback(() => {
+    navigate("/cryptos");
+  }, [navigate]);
   const openContact = useCallback(
     (contactId: ContactId) => {
       setDetailContactId(contactId);
@@ -83,38 +94,35 @@ export function useContactDetailPaneAdapter(
     [clearSelection],
   );
   const detail = useMemo<ContactDetailViewProps | undefined>(() => {
-    const baseDetail = {
-      labels,
-      meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
-    };
+    const contact = populatedContactDetail?.contact ?? emptyContact;
 
-    if (populatedContactDetail) {
-      return {
-        ...baseDetail,
-        contact: populatedContactDetail.contact,
-        onAddAddress: () => onAddAddress(populatedContactDetail.contact),
-        addressGroups: populatedContactDetail.addressGroups,
-        onAddressRowPress,
-        detailActions: editDeleteDialogs.detailActions,
-      };
-    }
-
-    if (!emptyContact) {
+    if (!contact) {
       return undefined;
     }
 
     return {
-      ...baseDetail,
-      contact: emptyContact,
-      onAddAddress: () => onAddAddress(emptyContact),
+      labels,
+      meAvatarSrc: MY_WALLET_AVATAR_USER_URL,
+      contact,
+      onAddAddress: () => onAddAddress(contact),
+      ledgerWalletAccountsIntent: detailSharedState?.ledgerWalletAccountsIntent,
+      onLedgerWalletAccountsPress,
+      ...(populatedContactDetail
+        ? {
+            addressGroups: populatedContactDetail.addressGroups,
+            onAddressRowPress,
+          }
+        : {}),
       detailActions: editDeleteDialogs.detailActions,
     };
   }, [
+    detailSharedState?.ledgerWalletAccountsIntent,
     emptyContact,
     editDeleteDialogs.detailActions,
     labels,
     onAddAddress,
     onAddressRowPress,
+    onLedgerWalletAccountsPress,
     populatedContactDetail,
   ]);
   const addressDetailDialog = useMemo<ContactAddressDetailDialogProps>(() => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -246,6 +246,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
       searchNoResults: t("contacts.searchNoResults"),
       addContact: t("contacts.addContact"),
       formatAddressCount: count => t("contacts.addressCount", { count }),
+      formatMeDisplayName: name => t("contacts.detail.meDisplayName", { name }),
     }),
     [t],
   );
@@ -260,11 +261,16 @@ export function useContactsViewModel(): ContactsPageViewModel {
   );
   const viewModel = useMemo(() => {
     if (searchQuery.trim().length > 0) {
-      return createContactsSearchViewModel(meContact, contacts, searchQuery);
+      return createContactsSearchViewModel(
+        meContact,
+        contacts,
+        searchQuery,
+        labels.formatMeDisplayName,
+      );
     }
 
-    return createContactsListViewModel(meContact, contacts);
-  }, [contacts, meContact, searchQuery]);
+    return createContactsListViewModel(meContact, contacts, labels.formatMeDisplayName);
+  }, [contacts, labels.formatMeDisplayName, meContact, searchQuery]);
   const onSearchInputChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(event.target.value);
   }, []);

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9339,6 +9339,7 @@
     },
     "detail": {
       "meDisplayName": "{{name}} (Me)",
+      "ledgerWalletAddresses": "Ledger Wallet addresses",
       "emptyState": {
         "meTitle": "No saved addresses for you",
         "contactTitle": "No saved addresses for {{name}}",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10239,6 +10239,7 @@
       "addressCount_other": "{{count}} addresses"
     },
     "detail": {
+      "meDisplayName": "{{name}} (Me)",
       "ledgerWalletAddresses": "Ledger Wallet addresses",
       "myAddresses": "My addresses",
       "emptyState": {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -13,6 +13,7 @@ import {
   type ContactDetailViewProps,
   resolveEligibleAddressCurrencyIds,
   useAddAddressFlowViewModel,
+  useContactDetailSharedState,
   useContactAddressDetailDialog,
   useContactsFeature,
   useEmptyContactDetail,
@@ -125,7 +126,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     },
     [addAddressFlowState, completeCurrencySelection],
   );
-  const onOpenLedgerWalletAddresses = useCallback(() => {
+  const onLedgerWalletAccountsPress = useCallback(() => {
     navigation.navigate(NavigatorName.Accounts, {
       screen: ScreenName.CryptoAddresses,
       params: {
@@ -162,9 +163,14 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       emptyContactDescription: name => t("contacts.detail.emptyState.contactDescription", { name }),
       ledgerWalletAddresses: t("contacts.detail.ledgerWalletAddresses"),
       myAddresses: t("contacts.detail.myAddresses"),
+      formatMeDisplayName: name => t("contacts.detail.meDisplayName", { name }),
       formatAddressCount: count => t("contacts.addressCount", { count }),
     }),
     [t],
+  );
+  const detailSharedState = useContactDetailSharedState(
+    route.params.contactId,
+    labels.formatMeDisplayName,
   );
   const addressDetailDialogLabels = useMemo<ContactAddressDetailDialogNativeLabels>(
     () => ({
@@ -226,7 +232,8 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     labels,
     meAvatarSrc: USER_AVATAR_URL,
     onAddAddress,
-    onOpenLedgerWalletAddresses,
+    ledgerWalletAccountsIntent: detailSharedState?.ledgerWalletAccountsIntent,
+    onLedgerWalletAccountsPress,
     ...(populatedContactDetail
       ? {
           addressGroups: populatedContactDetail.addressGroups,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -30,6 +30,7 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
         "contacts.ledgerSyncIntroduction.checkingAccessibilityLabel",
       ),
       formatAddressCount: count => t("contacts.addressCount", { count }),
+      formatMeDisplayName: name => t("contacts.detail.meDisplayName", { name }),
     }),
     [t],
   );
@@ -50,7 +51,7 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   const [ledgerSyncStatus] = useState<ContactsLedgerSyncStatus>("ready");
   const [isLedgerSyncIntroductionDismissed, setIsLedgerSyncIntroductionDismissed] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const viewModel = useContactsSearchViewModel(searchQuery);
+  const viewModel = useContactsSearchViewModel(searchQuery, labels.formatMeDisplayName);
   const onSearchQueryChange = useCallback((query: string) => setSearchQuery(query), []);
   const onOpenContact = useCallback<ContactsListViewNativeProps["onOpenContact"]>(
     contactId => {

--- a/domain/entity/contact/src/constants.ts
+++ b/domain/entity/contact/src/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_ME_CONTACT_ID = "contact-me";
+export const DEFAULT_ME_CONTACT_NAME = "Me";

--- a/domain/entity/contact/src/index.ts
+++ b/domain/entity/contact/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./constants";
 export * from "./schema";
 export * from "./types";
 export * from "./define";

--- a/domain/entity/contact/src/schema.mock.ts
+++ b/domain/entity/contact/src/schema.mock.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "./constants";
 import { contact, contactAddress } from "./define";
 import type { Contact, ContactAddress, ContactAddressInput, ContactInput } from "./types";
 
@@ -13,9 +14,9 @@ export function mockContactAddress(overrides?: Partial<ContactAddressInput>): Co
 
 export function mockMeContact(overrides?: Partial<ContactInput>): Contact {
   return contact({
-    id: "contact-me",
+    id: DEFAULT_ME_CONTACT_ID,
     isMe: true,
-    name: "Me",
+    name: DEFAULT_ME_CONTACT_NAME,
     addresses: [],
     ...overrides,
   });

--- a/domain/entity/contact/src/slice.ts
+++ b/domain/entity/contact/src/slice.ts
@@ -1,12 +1,13 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "./constants";
 import { contact } from "./define";
 import { normalizeContacts } from "./internals";
 import type { Contact, ContactAddress, ContactId, ContactName, ContactsState } from "./types";
 
 const defaultMeContact = contact({
-  id: "contact-me",
+  id: DEFAULT_ME_CONTACT_ID,
   isMe: true,
-  name: "Me",
+  name: DEFAULT_ME_CONTACT_NAME,
   addresses: [],
 });
 

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { createContactDetailLedgerWalletAccountsIntent } from "./model/contactDetailSharedState";
 import { createContactDetailAddressRowIntent } from "./model/viewModel";
 import type { ContactDetailLabels } from "./types";
 import { ContactDetailView } from "./ContactDetailView.native";
@@ -19,18 +20,23 @@ const labels: ContactDetailLabels = {
 };
 
 const onAddAddress = () => undefined;
-const onOpenLedgerWalletAddresses = () => undefined;
+const onLedgerWalletAccountsPress = () => undefined;
 
 const defaultProps = {
   labels,
   meAvatarSrc: "https://example.com/avatar.png",
   onAddAddress,
-  onOpenLedgerWalletAddresses,
+};
+
+const meDetailProps = {
+  ...defaultProps,
+  ledgerWalletAccountsIntent: createContactDetailLedgerWalletAccountsIntent(mockMeContact()),
+  onLedgerWalletAccountsPress,
 };
 
 describe("ContactDetailPage", () => {
   it("should render the Me empty state", () => {
-    render(<ContactDetailView {...defaultProps} contact={mockMeContact()} />);
+    render(<ContactDetailView {...meDetailProps} contact={mockMeContact()} />);
 
     expect(screen.getByTestId("contacts-detail-me-avatar")).toBeVisible();
     expect(screen.getByText("My addresses")).toBeVisible();
@@ -133,7 +139,7 @@ describe("ContactDetailPage", () => {
   it("should request adding an address when the action is pressed", () => {
     const onAddAddress = jest.fn();
     render(
-      <ContactDetailView {...defaultProps} contact={mockMeContact()} onAddAddress={onAddAddress} />,
+      <ContactDetailView {...meDetailProps} contact={mockMeContact()} onAddAddress={onAddAddress} />,
     );
 
     fireEvent.press(screen.getByTestId("contacts-detail-add-address"));
@@ -142,17 +148,19 @@ describe("ContactDetailPage", () => {
   });
 
   it("should request opening Ledger Wallet addresses for Me", () => {
-    const onOpenLedgerWalletAddresses = jest.fn();
+    const handleLedgerWalletAccountsPress = jest.fn();
     render(
       <ContactDetailView
-        {...defaultProps}
+        {...meDetailProps}
         contact={mockMeContact()}
-        onOpenLedgerWalletAddresses={onOpenLedgerWalletAddresses}
+        onLedgerWalletAccountsPress={handleLedgerWalletAccountsPress}
       />,
     );
 
     fireEvent.press(screen.getByTestId("contacts-detail-ledger-wallet-addresses"));
 
-    expect(onOpenLedgerWalletAddresses).toHaveBeenCalledTimes(1);
+    expect(handleLedgerWalletAccountsPress).toHaveBeenCalledWith({
+      type: "open-ledger-wallet-accounts",
+    });
   });
 });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.native.tsx
@@ -11,7 +11,8 @@ export function ContactDetailView({
   labels,
   meAvatarSrc,
   onAddAddress,
-  onOpenLedgerWalletAddresses,
+  ledgerWalletAccountsIntent,
+  onLedgerWalletAccountsPress,
   addressGroups,
   onAddressRowPress,
 }: ContactDetailViewProps): React.JSX.Element {
@@ -25,10 +26,11 @@ export function ContactDetailView({
         meAvatarSrc={meAvatarSrc}
         onAddAddress={onAddAddress}
       />
-      {contact.isMe && labels.ledgerWalletAddresses && onOpenLedgerWalletAddresses ? (
+      {ledgerWalletAccountsIntent && labels.ledgerWalletAddresses && onLedgerWalletAccountsPress ? (
         <LedgerWalletAddressesCard
           label={labels.ledgerWalletAddresses}
-          onPress={onOpenLedgerWalletAddresses}
+          intent={ledgerWalletAccountsIntent}
+          onPress={onLedgerWalletAccountsPress}
         />
       ) : null}
       {hasPopulatedAddresses ? (

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { createContactDetailLedgerWalletAccountsIntent } from "./model/contactDetailSharedState";
 import { createContactDetailAddressRowIntent } from "./model/viewModel";
 import type { ContactDetailLabels } from "./types";
 import { ContactDetailView } from "./ContactDetailView.web";
@@ -121,5 +122,43 @@ describe("ContactDetailView", () => {
     fireEvent.click(screen.getByTestId("contacts-detail-add-address"));
 
     expect(handleAddAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the Ledger Wallet addresses entry for Me", () => {
+    const handleLedgerWalletAccountsPress = jest.fn();
+
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockMeContact()}
+        labels={{ ...labels, ledgerWalletAddresses: "Ledger Wallet addresses" }}
+        ledgerWalletAccountsIntent={createContactDetailLedgerWalletAccountsIntent(mockMeContact())}
+        onLedgerWalletAccountsPress={handleLedgerWalletAccountsPress}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-detail-ledger-wallet-addresses")).toHaveTextContent(
+      "Ledger Wallet addresses",
+    );
+
+    fireEvent.click(screen.getByTestId("contacts-detail-ledger-wallet-addresses"));
+
+    expect(handleLedgerWalletAccountsPress).toHaveBeenCalledWith({
+      type: "open-ledger-wallet-accounts",
+    });
+  });
+
+  it("should not render the Ledger Wallet addresses entry for saved contacts", () => {
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockContact({ id: "contact-benoit", name: "Benoit" })}
+        labels={{ ...labels, ledgerWalletAddresses: "Ledger Wallet addresses" }}
+        ledgerWalletAccountsIntent={undefined}
+        onLedgerWalletAccountsPress={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByTestId("contacts-detail-ledger-wallet-addresses")).not.toBeInTheDocument();
   });
 });

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.tsx
@@ -4,12 +4,15 @@ import { ContactDetailActions } from "./components/ContactDetailActions/ContactD
 import { ContactDetailAddressList } from "./components/ContactDetailAddressList/ContactDetailAddressList.web";
 import { ContactDetailEmptyState } from "./components/ContactDetailEmptyState.web";
 import { ContactDetailHeader } from "./components/ContactDetailHeader.web";
+import { LedgerWalletAddressesCard } from "./components/LedgerWalletAddressesCard.web";
 
 export function ContactDetailView({
   contact,
   labels,
   meAvatarSrc,
   onAddAddress,
+  ledgerWalletAccountsIntent,
+  onLedgerWalletAccountsPress,
   addressGroups,
   onAddressRowPress,
   detailActions,
@@ -28,6 +31,13 @@ export function ContactDetailView({
         meAvatarSrc={meAvatarSrc}
         onAddAddress={onAddAddress}
       />
+      {ledgerWalletAccountsIntent && labels.ledgerWalletAddresses && onLedgerWalletAccountsPress ? (
+        <LedgerWalletAddressesCard
+          label={labels.ledgerWalletAddresses}
+          intent={ledgerWalletAccountsIntent}
+          onPress={onLedgerWalletAccountsPress}
+        />
+      ) : null}
       {hasPopulatedAddresses ? (
         <ContactDetailAddressList
           addressGroups={addressGroups}

--- a/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.native.tsx
@@ -8,18 +8,22 @@ import {
   CardTrailing,
 } from "@ledgerhq/lumen-ui-rnative";
 import { ChevronRight, Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
+import type { ContactDetailLedgerWalletAccountsIntent } from "../types";
+
 type LedgerWalletAddressesCardProps = Readonly<{
   label: string;
-  onPress: () => void;
+  intent: ContactDetailLedgerWalletAccountsIntent;
+  onPress: (intent: ContactDetailLedgerWalletAccountsIntent) => void;
 }>;
 
 export function LedgerWalletAddressesCard({
   label,
+  intent,
   onPress,
 }: LedgerWalletAddressesCardProps): React.JSX.Element {
   return (
     <Card
-      onPress={onPress}
+      onPress={() => onPress(intent)}
       testID="contacts-detail-ledger-wallet-addresses"
       lx={{ marginHorizontal: "s16", marginTop: "s32" }}
     >

--- a/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/LedgerWalletAddressesCard.web.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import {
+  ListItem,
+  ListItemContent,
+  ListItemLeading,
+  ListItemTitle,
+  ListItemTrailing,
+} from "@ledgerhq/lumen-ui-react";
+import { ChevronRight, Wallet } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ContactDetailLedgerWalletAccountsIntent } from "../types";
+
+type LedgerWalletAddressesCardProps = Readonly<{
+  label: string;
+  intent: ContactDetailLedgerWalletAccountsIntent;
+  onPress: (intent: ContactDetailLedgerWalletAccountsIntent) => void;
+}>;
+
+export function LedgerWalletAddressesCard({
+  label,
+  intent,
+  onPress,
+}: LedgerWalletAddressesCardProps): React.ReactNode {
+  return (
+    <ListItem
+      onClick={() => onPress(intent)}
+      data-testid="contacts-detail-ledger-wallet-addresses"
+    >
+      <ListItemLeading>
+        <Wallet size={20} aria-hidden />
+        <ListItemContent>
+          <ListItemTitle>{label}</ListItemTitle>
+        </ListItemContent>
+      </ListItemLeading>
+      <ListItemTrailing>
+        <ChevronRight size={20} aria-hidden />
+      </ListItemTrailing>
+    </ListItem>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/index.ts
+++ b/features/flow/contacts/src/steps/Detail/index.ts
@@ -1,5 +1,6 @@
 export { useEmptyContactDetail } from "./useEmptyContactDetail";
 export { usePopulatedContactDetail } from "./usePopulatedContactDetail";
+export { useContactDetailSharedState } from "./useContactDetailSharedState";
 export { useContactAddressDetailDialog } from "./useContactAddressDetailDialog";
 export { useContactDetailActionsViewModel } from "./useContactDetailActionsViewModel";
 export { createContactDetailActionsPorts } from "./createContactDetailActionsPorts";
@@ -27,6 +28,11 @@ export {
   createContactDetailAddressRowIntent,
   createPopulatedContactDetailViewModel,
 } from "./model/viewModel";
+export {
+  createContactDetailLedgerWalletAccountsIntent,
+  createContactDetailSharedState,
+} from "./model/contactDetailSharedState";
+export type { ContactDetailSharedState } from "./model/contactDetailSharedState";
 export {
   createContactDetailDeleteIntent,
   createContactDetailEditIntent,
@@ -84,6 +90,7 @@ export type {
   ContactDetailAddressRowIntent,
   ContactDetailDeleteIntent,
   ContactDetailEditIntent,
+  ContactDetailLedgerWalletAccountsIntent,
   ContactDetailLabels,
   ContactDetailViewProps,
   ContactDetailActionsLabels,

--- a/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.ts
@@ -1,0 +1,28 @@
+import type { Contact } from "@domain/entity-contact";
+import { identityFormatMeDisplayName, resolveMeContactDisplayName } from "../../../utils";
+import type { ContactDetailLedgerWalletAccountsIntent } from "../types";
+
+export function createContactDetailLedgerWalletAccountsIntent(
+  contact: Contact,
+): ContactDetailLedgerWalletAccountsIntent | undefined {
+  return contact.isMe ? { type: "open-ledger-wallet-accounts" } : undefined;
+}
+
+export type ContactDetailSharedState = Readonly<{
+  contact: Contact;
+  displayName: string;
+  addressCount: number;
+  ledgerWalletAccountsIntent: ContactDetailLedgerWalletAccountsIntent | undefined;
+}>;
+
+export function createContactDetailSharedState(
+  contact: Contact,
+  formatMeDisplayName: (name: string) => string = identityFormatMeDisplayName,
+): ContactDetailSharedState {
+  return {
+    contact,
+    displayName: resolveMeContactDisplayName(contact, formatMeDisplayName),
+    addressCount: contact.addresses.length,
+    ledgerWalletAccountsIntent: createContactDetailLedgerWalletAccountsIntent(contact),
+  };
+}

--- a/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.web.test.ts
@@ -1,0 +1,64 @@
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import {
+  createContactDetailLedgerWalletAccountsIntent,
+  createContactDetailSharedState,
+} from "./contactDetailSharedState";
+
+const formatMeDisplayName = (name: string) => `${name} (Me)`;
+
+describe("createContactDetailLedgerWalletAccountsIntent", () => {
+  it("returns the ledger wallet accounts intent for Me", () => {
+    expect(createContactDetailLedgerWalletAccountsIntent(mockMeContact())).toEqual({
+      type: "open-ledger-wallet-accounts",
+    });
+  });
+
+  it("returns undefined for saved contacts", () => {
+    expect(createContactDetailLedgerWalletAccountsIntent(mockContact())).toBeUndefined();
+  });
+});
+
+describe("createContactDetailSharedState", () => {
+  it("exposes the default Me display name and zero external addresses", () => {
+    expect(createContactDetailSharedState(mockMeContact(), formatMeDisplayName)).toEqual({
+      contact: mockMeContact(),
+      displayName: "Me",
+      addressCount: 0,
+      ledgerWalletAccountsIntent: { type: "open-ledger-wallet-accounts" },
+    });
+  });
+
+  it("exposes a renamed Me display name with the Me suffix", () => {
+    const me = mockMeContact({ name: "Brian" });
+
+    expect(createContactDetailSharedState(me, formatMeDisplayName)).toMatchObject({
+      displayName: "Brian (Me)",
+      addressCount: 0,
+      ledgerWalletAccountsIntent: { type: "open-ledger-wallet-accounts" },
+    });
+  });
+
+  it("counts only external addresses saved on Me", () => {
+    const me = mockMeContact({
+      addresses: [
+        {
+          id: "address-ethereum",
+          currencyId: "ethereum",
+          label: "Ethereum",
+          address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+        },
+      ],
+    });
+
+    expect(createContactDetailSharedState(me, formatMeDisplayName).addressCount).toBe(1);
+  });
+
+  it("does not expose the ledger wallet accounts intent for saved contacts", () => {
+    expect(
+      createContactDetailSharedState(mockContact({ name: "Ada" }), formatMeDisplayName),
+    ).toMatchObject({
+      displayName: "Ada",
+      ledgerWalletAccountsIntent: undefined,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -14,6 +14,10 @@ export type ContactDetailEditIntent = Readonly<{
   editRequirement: ContactEditRequirement;
 }>;
 
+export type ContactDetailLedgerWalletAccountsIntent = Readonly<{
+  type: "open-ledger-wallet-accounts";
+}>;
+
 export type ContactDetailDeleteIntent = Readonly<{
   type: "delete-contact";
   contactId: ContactId;
@@ -78,7 +82,8 @@ export type ContactDetailViewProps = Readonly<{
   labels: ContactDetailLabels;
   meAvatarSrc: string;
   onAddAddress: () => void;
-  onOpenLedgerWalletAddresses?: () => void;
+  ledgerWalletAccountsIntent?: ContactDetailLedgerWalletAccountsIntent;
+  onLedgerWalletAccountsPress?: (intent: ContactDetailLedgerWalletAccountsIntent) => void;
   addressGroups?: readonly ContactDetailAddressNetworkGroup[];
   onAddressRowPress?: (intent: ContactDetailAddressRowIntent) => void;
   detailActions?: Readonly<{

--- a/features/flow/contacts/src/steps/Detail/useContactDetailSharedState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactDetailSharedState.ts
@@ -1,0 +1,22 @@
+import { selectContactById, type ContactId } from "@domain/entity-contact";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { identityFormatMeDisplayName } from "../../utils";
+import { createContactDetailSharedState } from "./model/contactDetailSharedState";
+
+type ContactsStateRoot = Parameters<typeof selectContactById>[0];
+
+export function useContactDetailSharedState(
+  contactId: ContactId | undefined,
+  formatMeDisplayName?: (name: string) => string,
+) {
+  const contact = useSelector((state: ContactsStateRoot) =>
+    contactId ? selectContactById(state, contactId) : undefined,
+  );
+  const formatName = formatMeDisplayName ?? identityFormatMeDisplayName;
+
+  return useMemo(
+    () => (contact ? createContactDetailSharedState(contact, formatName) : undefined),
+    [contact, formatName],
+  );
+}

--- a/features/flow/contacts/src/steps/List/hooks/useContactsListViewModel.ts
+++ b/features/flow/contacts/src/steps/List/hooks/useContactsListViewModel.ts
@@ -4,9 +4,14 @@ import { createContactsListViewModel } from "../model/viewModel";
 import type { ContactsListViewModel } from "../types";
 import { useContactsMeContact } from "../../../hooks/useContactsMeContact";
 
-export function useContactsListViewModel(): ContactsListViewModel {
+export function useContactsListViewModel(
+  formatMeDisplayName?: (name: string) => string,
+): ContactsListViewModel {
   const meContact = useContactsMeContact();
   const contacts = useContacts();
 
-  return useMemo(() => createContactsListViewModel(meContact, contacts), [contacts, meContact]);
+  return useMemo(
+    () => createContactsListViewModel(meContact, contacts, formatMeDisplayName),
+    [contacts, formatMeDisplayName, meContact],
+  );
 }

--- a/features/flow/contacts/src/steps/List/hooks/useContactsSearchViewModel.ts
+++ b/features/flow/contacts/src/steps/List/hooks/useContactsSearchViewModel.ts
@@ -6,15 +6,16 @@ import { useContactsMeContact } from "../../../hooks/useContactsMeContact";
 
 export function useContactsSearchViewModel(
   query: string,
+  formatMeDisplayName?: (name: string) => string,
 ): ContactsListViewModel | ContactsSearchViewModel {
   const contacts = useContacts();
   const meContact = useContactsMeContact();
 
   return useMemo(() => {
     if (query.trim().length === 0) {
-      return createContactsListViewModel(meContact, contacts);
+      return createContactsListViewModel(meContact, contacts, formatMeDisplayName);
     }
 
-    return createContactsSearchViewModel(meContact, contacts, query);
-  }, [contacts, meContact, query]);
+    return createContactsSearchViewModel(meContact, contacts, query, formatMeDisplayName);
+  }, [contacts, formatMeDisplayName, meContact, query]);
 }

--- a/features/flow/contacts/src/steps/List/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/List/model/viewModel.ts
@@ -6,18 +6,28 @@ import type {
   EmptyContactsListViewModel,
   PopulatedContactsListViewModel,
 } from "../types";
+import { identityFormatMeDisplayName, resolveMeContactDisplayName } from "../../../utils";
 import { createContactsListSections } from "../utils";
 
-function createContactsListItem(contact: Contact): ContactsListItem {
+function createContactsListItem(
+  contact: Contact,
+  formatMeDisplayName?: (name: string) => string,
+): ContactsListItem {
+  const formatName = formatMeDisplayName ?? identityFormatMeDisplayName;
+
   return {
     contactId: contact.id,
-    name: contact.name,
+    name: resolveMeContactDisplayName(contact, formatName),
     initial: getNameInitial(contact.name),
     addressCount: contact.addresses.length,
   };
 }
 
-function createSavedContactsListItems(contacts: readonly Contact[], normalizedQuery = "") {
+function createSavedContactsListItems(
+  contacts: readonly Contact[],
+  normalizedQuery = "",
+  formatMeDisplayName?: (name: string) => string,
+) {
   return contacts
     .filter(
       contact =>
@@ -25,27 +35,42 @@ function createSavedContactsListItems(contacts: readonly Contact[], normalizedQu
         (normalizedQuery.length === 0 || isContactNameMatching(contact, normalizedQuery)),
     )
     .sort((left, right) => left.name.localeCompare(right.name))
-    .map(createContactsListItem);
+    .map(contact => createContactsListItem(contact, formatMeDisplayName));
 }
 
 function isContactNameMatching(contact: Contact, normalizedQuery: string): boolean {
   return contact.name.toLowerCase().includes(normalizedQuery);
 }
 
-export function createEmptyContactsListViewModel(me: Contact): EmptyContactsListViewModel {
+function isMeContactMatching(
+  me: Contact,
+  normalizedQuery: string,
+  formatMeDisplayName?: (name: string) => string,
+): boolean {
+  const formatName = formatMeDisplayName ?? identityFormatMeDisplayName;
+  const displayName = resolveMeContactDisplayName(me, formatName);
+
+  return displayName.toLowerCase().includes(normalizedQuery);
+}
+
+export function createEmptyContactsListViewModel(
+  me: Contact,
+  formatMeDisplayName?: (name: string) => string,
+): EmptyContactsListViewModel {
   return {
     displayMode: "empty",
-    me: createContactsListItem(me),
+    me: createContactsListItem(me, formatMeDisplayName),
   };
 }
 
 function createPopulatedContactsListViewModelFromSavedContacts(
   me: Contact,
   savedContacts: readonly ContactsListItem[],
+  formatMeDisplayName?: (name: string) => string,
 ): PopulatedContactsListViewModel {
   return {
     displayMode: "populated",
-    me: createContactsListItem(me),
+    me: createContactsListItem(me, formatMeDisplayName),
     savedContacts,
     sections: createContactsListSections(savedContacts),
   };
@@ -54,43 +79,51 @@ function createPopulatedContactsListViewModelFromSavedContacts(
 export function createPopulatedContactsListViewModel(
   me: Contact,
   contacts: readonly Contact[],
+  formatMeDisplayName?: (name: string) => string,
 ): PopulatedContactsListViewModel {
   return createPopulatedContactsListViewModelFromSavedContacts(
     me,
-    createSavedContactsListItems(contacts),
+    createSavedContactsListItems(contacts, "", formatMeDisplayName),
+    formatMeDisplayName,
   );
 }
 
 export function createContactsListViewModel(
   me: Contact,
   contacts: readonly Contact[],
+  formatMeDisplayName?: (name: string) => string,
 ): EmptyContactsListViewModel | PopulatedContactsListViewModel {
-  const savedContacts = createSavedContactsListItems(contacts);
+  const savedContacts = createSavedContactsListItems(contacts, "", formatMeDisplayName);
 
   if (savedContacts.length > 0) {
-    return createPopulatedContactsListViewModelFromSavedContacts(me, savedContacts);
+    return createPopulatedContactsListViewModelFromSavedContacts(
+      me,
+      savedContacts,
+      formatMeDisplayName,
+    );
   }
 
-  return createEmptyContactsListViewModel(me);
+  return createEmptyContactsListViewModel(me, formatMeDisplayName);
 }
 
 export function createContactsSearchViewModel(
   me: Contact,
   contacts: readonly Contact[],
   query: string,
+  formatMeDisplayName?: (name: string) => string,
 ): ContactsSearchViewModel {
   const normalizedQuery = query.trim().toLowerCase();
 
   if (normalizedQuery.length === 0) {
     return {
       status: "results",
-      ...createPopulatedContactsListViewModel(me, contacts),
+      ...createPopulatedContactsListViewModel(me, contacts, formatMeDisplayName),
     };
   }
 
-  const savedContacts = createSavedContactsListItems(contacts, normalizedQuery);
-  const matchingMe = isContactNameMatching(me, normalizedQuery)
-    ? createContactsListItem(me)
+  const savedContacts = createSavedContactsListItems(contacts, normalizedQuery, formatMeDisplayName);
+  const matchingMe = isMeContactMatching(me, normalizedQuery, formatMeDisplayName)
+    ? createContactsListItem(me, formatMeDisplayName)
     : undefined;
 
   if (savedContacts.length === 0 && !matchingMe) {

--- a/features/flow/contacts/src/steps/List/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/List/model/viewModel.web.test.ts
@@ -6,6 +6,8 @@ import {
   createPopulatedContactsListViewModel,
 } from "./viewModel";
 
+const formatMeDisplayName = (name: string) => `${name} (Me)`;
+
 describe("createEmptyContactsListViewModel", () => {
   it("returns the Me row with no addresses", () => {
     expect(createEmptyContactsListViewModel(mockMeContact())).toEqual({
@@ -25,15 +27,19 @@ describe("createEmptyContactsListViewModel", () => {
       addresses: [mockContactAddress()],
     });
 
-    expect(createEmptyContactsListViewModel(me)).toEqual({
+    expect(createEmptyContactsListViewModel(me, formatMeDisplayName)).toEqual({
       displayMode: "empty",
       me: {
         contactId: "contact-me",
-        name: "Élodie",
+        name: "Élodie (Me)",
         initial: "É",
         addressCount: 1,
       },
     });
+  });
+
+  it("keeps the default Me label when the stored name is Me", () => {
+    expect(createEmptyContactsListViewModel(mockMeContact(), formatMeDisplayName).me.name).toBe("Me");
   });
 });
 
@@ -41,15 +47,17 @@ describe("createContactsListViewModel", () => {
   it("returns an empty list when only Me is present", () => {
     const me = mockMeContact();
 
-    expect(createContactsListViewModel(me, [me])).toEqual(createEmptyContactsListViewModel(me));
+    expect(createContactsListViewModel(me, [me], formatMeDisplayName)).toEqual(
+      createEmptyContactsListViewModel(me, formatMeDisplayName),
+    );
   });
 
   it("returns a populated list when saved contacts exist", () => {
     const me = mockMeContact();
     const contacts = [me, mockContact({ id: "contact-ada", name: "Ada" })];
 
-    expect(createContactsListViewModel(me, contacts)).toEqual(
-      createPopulatedContactsListViewModel(me, contacts),
+    expect(createContactsListViewModel(me, contacts, formatMeDisplayName)).toEqual(
+      createPopulatedContactsListViewModel(me, contacts, formatMeDisplayName),
     );
   });
 });
@@ -70,7 +78,7 @@ describe("createPopulatedContactsListViewModel", () => {
       mockContact({ id: "contact-ada", name: "Ada" }),
     ];
 
-    expect(createPopulatedContactsListViewModel(me, contacts)).toEqual({
+    expect(createPopulatedContactsListViewModel(me, contacts, formatMeDisplayName)).toEqual({
       displayMode: "populated",
       me: {
         contactId: "contact-me",
@@ -233,12 +241,27 @@ describe("createContactsSearchViewModel", () => {
   it("should match Me using its renamed value", () => {
     const renamedMe = mockMeContact({ name: "Toto" });
 
-    expect(createContactsSearchViewModel(renamedMe, [renamedMe], "tOtO")).toMatchObject({
+    expect(createContactsSearchViewModel(renamedMe, [renamedMe], "tOtO", formatMeDisplayName)).toMatchObject({
       status: "results",
       me: {
         contactId: "contact-me",
-        name: "Toto",
+        name: "Toto (Me)",
         initial: "T",
+        addressCount: 0,
+      },
+      savedContacts: [],
+    });
+  });
+
+  it("should match Me when searching for Me on a renamed contact", () => {
+    const renamedMe = mockMeContact({ name: "Brian" });
+
+    expect(createContactsSearchViewModel(renamedMe, [renamedMe], "me", formatMeDisplayName)).toMatchObject({
+      status: "results",
+      me: {
+        contactId: "contact-me",
+        name: "Brian (Me)",
+        initial: "B",
         addressCount: 0,
       },
       savedContacts: [],

--- a/features/flow/contacts/src/steps/List/types.ts
+++ b/features/flow/contacts/src/steps/List/types.ts
@@ -59,6 +59,7 @@ export type ContactsListViewLabels = Readonly<{
   addContact: string;
   ledgerSyncCheckingAccessibilityLabel?: string;
   formatAddressCount: (count: number) => string;
+  formatMeDisplayName?: (name: string) => string;
 }>;
 
 export type ContactsPageSharedProps = Readonly<{

--- a/features/flow/contacts/src/utils/constants.ts
+++ b/features/flow/contacts/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_ME_CONTACT_NAME = "Me";
+export { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "@domain/entity-contact";

--- a/features/flow/contacts/src/utils/formatMeDisplayName.ts
+++ b/features/flow/contacts/src/utils/formatMeDisplayName.ts
@@ -1,0 +1,3 @@
+export type FormatMeDisplayName = (name: string) => string;
+
+export const identityFormatMeDisplayName: FormatMeDisplayName = name => name;

--- a/features/flow/contacts/src/utils/index.ts
+++ b/features/flow/contacts/src/utils/index.ts
@@ -1,2 +1,6 @@
 export { DEFAULT_ME_CONTACT_NAME } from "./constants";
+export {
+  identityFormatMeDisplayName,
+  type FormatMeDisplayName,
+} from "./formatMeDisplayName";
 export { resolveMeContactDisplayName } from "./resolveMeContactDisplayName";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

## Summary

Defines **Me** as the default self contact across the shared Contacts entity and flow layers, with app adapters consuming the new shared state.

- **`@domain/entity-contact`**: exports `DEFAULT_ME_CONTACT_ID` and `DEFAULT_ME_CONTACT_NAME`; default Me contact remains always present, non-deletable, and renameable
- **`@features/flow-contacts`**: adds shared detail state (`useContactDetailSharedState`) exposing resolved display name, external address count, and a `{ type: "open-ledger-wallet-accounts" }` intent for Me; applies `<name> (Me)` formatting in the contacts list; adds intent-based Ledger Wallet accounts entry on web and native detail views
- **Apps**: desktop and mobile wire `formatMeDisplayName` into list view models; mobile connects the Ledger Wallet accounts intent to Crypto Addresses navigation; desktop exposes shared intent state (navigation wiring deferred to a follow-up platform task)

Normal saved contacts keep existing edit/delete behavior. Me address count includes only external addresses saved on Me — Ledger Wallet accounts are a separate read-only entry and do not count as a Contacts address.


https://github.com/user-attachments/assets/b5affe5f-9218-400e-9e36-d47c91c42583


https://github.com/user-attachments/assets/3309ab28-9871-4c4a-90fd-9638fcb78045




## Test plan

- [x] `@domain/entity-contact` unit tests pass (Me initial state, rename, delete guard, normalization)
- [x] `@features/flow-contacts` unit tests pass (list Me display name, shared detail state, Ledger Wallet intent, web/native detail views)
- [ ] Desktop: open Contacts → Me row shows **Me** by default; rename Me → list and detail show **`<name> (Me)`**; delete action unavailable for Me
- [ ] Desktop: add external address on Me → address count updates; saved contacts still editable/deletable
- [ ] Mobile: Me detail shows Ledger Wallet addresses card → navigates to Crypto Addresses
- [ ] Mobile: renamed Me displays **`<name> (Me)`** in contacts list

### 🔗 Context


[LIVE-33996](https://ledgerhq.atlassian.net/browse/LIVE-33996)

[LIVE-33996]: https://ledgerhq.atlassian.net/browse/LIVE-33996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ