### PR TITLE
[LWDM] feat(casper): combine method

### DIFF
--- a/.changeset/flat-experts-beg.md
+++ b/.changeset/flat-experts-beg.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": minor
+---
+
+feat: combine method in coin-casper module

--- a/libs/coin-modules/coin-casper/src/__tests__/fixtures/transaction.fixture.ts
+++ b/libs/coin-modules/coin-casper/src/__tests__/fixtures/transaction.fixture.ts
@@ -1,4 +1,11 @@
 import BigNumber from "bignumber.js";
+import {
+  KeyAlgorithm,
+  NativeTransferBuilder,
+  PrivateKey,
+  PublicKey,
+  Transaction as CasperTransaction,
+} from "casper-js-sdk";
 import { CASPER_MINIMUM_VALID_AMOUNT_MOTES } from "../../constants";
 import { getEstimatedFees } from "../../logic/estimateFees";
 import type { Transaction } from "../../types";
@@ -32,4 +39,50 @@ export const createMockTransactionSet = (): Transaction[] => {
     createMockTransaction({ transferId: TEST_TRANSFER_IDS.INVALID }),
     createMockTransaction({ useAllAmount: true }),
   ];
+};
+
+export type MockSignedTransaction = {
+  unsignedTx: string;
+  publicKey: string;
+  taggedSignature: string;
+  untaggedSignature: string;
+  wrongKeypairSignature: string;
+};
+
+const buildUnsignedTransferTx = (sender: PublicKey, recipient: PublicKey): CasperTransaction =>
+  new NativeTransferBuilder()
+    .from(sender)
+    .target(recipient)
+    .amount("25000000000")
+    .id(1)
+    .chainName("casper-net-1")
+    .payment(100_000_000)
+    .build();
+
+// Built via casper-js-sdk's own builder and signing path, not hand-written JSON, so a bad
+// hash/payload pair can't fail validate() for the wrong reason.
+export const createMockSignedTransaction = (): MockSignedTransaction => {
+  const sender = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+  const recipient = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+  const impostor = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+
+  const unsignedTx = JSON.stringify(
+    buildUnsignedTransferTx(sender.publicKey, recipient.publicKey).toJSON(),
+  );
+
+  const signedBySender = CasperTransaction.fromJSON(unsignedTx);
+  signedBySender.sign(sender);
+  const taggedSignature = signedBySender.approvals[0].signature.toHex();
+
+  const signedByImpostor = CasperTransaction.fromJSON(unsignedTx);
+  signedByImpostor.sign(impostor);
+  const wrongKeypairSignature = signedByImpostor.approvals[0].signature.toHex();
+
+  return {
+    unsignedTx,
+    publicKey: sender.publicKey.toHex(),
+    taggedSignature,
+    untaggedSignature: taggedSignature.slice(2),
+    wrongKeypairSignature,
+  };
 };

--- a/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
@@ -1,14 +1,70 @@
+import { Transaction, CasperNetwork, KeyAlgorithm, PrivateKey } from "casper-js-sdk";
 import type { CoinModuleApi } from "@ledgerhq/coin-module-framework/api/types";
 import { createApi } from "./index";
 import { FUNDED_MAINNET_PUBLIC_KEY } from "../__tests__/fixtures/addresses.fixture";
 import { casperMainnetConfig } from "../__tests__/fixtures/config.fixture";
-import { CASPER_DUMMY_ADDRESS } from "../constants";
+import {
+  CASPER_DEFAULT_TTL,
+  CASPER_DUMMY_ADDRESS,
+  CASPER_FEES_MOTES,
+  CASPER_NETWORK,
+} from "../constants";
+import { getCasperNodeRpcClient } from "../network/api";
 
 describe("Casper Api (mainnet)", () => {
   let api: CoinModuleApi;
 
   beforeAll(() => {
     api = createApi(casperMainnetConfig);
+  });
+
+  describe("combine", () => {
+    const craftUnsignedTransfer = async (sender: PrivateKey, recipient: PrivateKey) => {
+      const casperNetwork = await CasperNetwork.create(getCasperNodeRpcClient());
+      return casperNetwork.createTransferTransaction(
+        sender.publicKey,
+        recipient.publicKey,
+        CASPER_NETWORK,
+        "2500000000",
+        CASPER_FEES_MOTES,
+        CASPER_DEFAULT_TTL,
+        0,
+      );
+    };
+
+    it("attaches a signature to a real network-crafted transaction and produces a payload Transaction.fromJSON verifies", async () => {
+      const sender = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+      const recipient = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+
+      const unsignedTx = await craftUnsignedTransfer(sender, recipient);
+      const unsignedTxJson = JSON.stringify(unsignedTx.toJSON());
+
+      // Matches TransactionV1.sign()/validate(): the signed message is the transaction hash,
+      // not the serialized transaction bytes.
+      const taggedSignature = Buffer.from(
+        sender.signAndAddAlgorithmBytes(new Uint8Array(unsignedTx.hash.toBytes())),
+      ).toString("hex");
+
+      const combined = await api.combine(unsignedTxJson, taggedSignature, sender.publicKey.toHex());
+
+      expect(() => Transaction.fromJSON(combined)).not.toThrow();
+    });
+
+    it("throws when pubkey is missing", async () => {
+      const sender = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+      const recipient = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+
+      const unsignedTx = await craftUnsignedTransfer(sender, recipient);
+      const unsignedTxJson = JSON.stringify(unsignedTx.toJSON());
+
+      const taggedSignature = Buffer.from(
+        sender.signAndAddAlgorithmBytes(new Uint8Array(unsignedTx.hash.toBytes())),
+      ).toString("hex");
+
+      expect(() => api.combine(unsignedTxJson, taggedSignature, undefined)).toThrow(
+        "casper: combine requires the signer public key",
+      );
+    });
   });
 
   describe("lastBlock", () => {

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -17,6 +17,7 @@ import type {
 } from "@ledgerhq/coin-module-framework/api/index";
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
 import { setCoinConfig } from "../config";
+import { combine } from "../logic/combine";
 import { lastBlock } from "../logic/lastBlock";
 import { getBalance as getAccountBalance } from "../logic/getBalance";
 import type { CasperCoinConfig } from "../types";
@@ -64,9 +65,7 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSuppor
     estimateFees(_intent: TransactionIntent<MemoNotSupported>): Promise<FeeEstimation> {
       throw new Error("estimateFees is not supported");
     },
-    combine(_tx: string, _signature: string, _pubkey?: string): string {
-      throw new Error("combine is not supported");
-    },
+    combine,
     broadcast(_tx: string): Promise<string> {
       throw new Error("broadcast is not supported");
     },

--- a/libs/coin-modules/coin-casper/src/bridge/broadcast.integ.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/broadcast.integ.test.ts
@@ -1,4 +1,3 @@
-import BigNumber from "bignumber.js";
 import {
   CasperNetwork,
   KeyAlgorithm,
@@ -22,19 +21,20 @@ describe("Broadcast", () => {
     const senderHex = privateKey.publicKey.toHex();
 
     const casperNetwork = await CasperNetwork.create(getCasperNodeRpcClient());
-    const feeMotes = new BigNumber(CASPER_FEES_MOTES);
     const deploy: CasperDeployTransaction = casperNetwork.createTransferTransaction(
       PublicKey.fromHex(senderHex),
       PublicKey.fromHex(senderHex),
       CASPER_NETWORK,
       "1",
-      feeMotes.toNumber(),
+      CASPER_FEES_MOTES,
       CASPER_DEFAULT_TTL,
       0,
     );
 
+    // Matches TransactionV1.sign()/validate(): the signed message is the transaction hash,
+    // not the serialized transaction bytes.
     const signatureHex = Buffer.from(
-      privateKey.signAndAddAlgorithmBytes(new Uint8Array(deploy.toBytes())),
+      privateKey.signAndAddAlgorithmBytes(new Uint8Array(deploy.hash.toBytes())),
     ).toString("hex");
 
     await expect(

--- a/libs/coin-modules/coin-casper/src/bridge/broadcast.test.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/broadcast.test.ts
@@ -1,33 +1,29 @@
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
-import { Transaction as CasperTransaction, PublicKey } from "casper-js-sdk";
-import { broadcastTx } from "../network/api";
+import { Transaction as CasperTransaction } from "casper-js-sdk";
 import {
   createMockAccount,
   createMockTransaction,
   createMockSignedOperation,
 } from "../__tests__/fixtures";
+import { combine } from "../logic/combine";
+import { broadcastTx } from "../network/api";
 import { broadcast } from "./broadcast";
 
-// Mock the dependencies
-jest.mock("casper-js-sdk", () => {
-  return {
-    Transaction: {
-      fromJSON: jest.fn().mockReturnValue({
-        setSignature: jest.fn(),
-      }),
-    },
-    PublicKey: {
-      fromHex: jest.fn().mockReturnValue("mockedPublicKey"),
-    },
-  };
-});
+jest.mock("casper-js-sdk", () => ({
+  Transaction: {
+    fromJSON: jest.fn().mockReturnValue("mockedParsedTx"),
+  },
+}));
+
+jest.mock("../logic/combine", () => ({
+  combine: jest.fn().mockReturnValue("mockedCombinedTx"),
+}));
 
 jest.mock("../network/api", () => ({
   broadcastTx: jest.fn().mockResolvedValue("mockedTxHash"),
 }));
 
 describe("broadcast", () => {
-  // Create test fixtures
   const mockAccount = createMockAccount();
   const mockTransaction = createMockTransaction();
   const mockSignedOperation = createMockSignedOperation(mockAccount, mockTransaction, {
@@ -39,20 +35,24 @@ describe("broadcast", () => {
     jest.clearAllMocks();
   });
 
-  test("should successfully broadcast a transaction", async () => {
+  test("delegates to combine and broadcasts the combined transaction", async () => {
     const result = await broadcast({
       account: mockAccount,
       signedOperation: mockSignedOperation,
     });
 
-    // Assert the transaction was constructed and signed correctly
-    expect(CasperTransaction.fromJSON).toHaveBeenCalledWith(mockSignedOperation.rawData.tx);
-    expect(PublicKey.fromHex).toHaveBeenCalledWith(mockAccount.freshAddress);
+    expect(combine).toHaveBeenCalledTimes(1);
+    expect(combine).toHaveBeenCalledWith(
+      mockSignedOperation.rawData.tx,
+      mockSignedOperation.signature,
+      mockAccount.freshAddress,
+    );
 
-    // Assert the transaction was broadcast
-    expect(broadcastTx).toHaveBeenCalled();
+    expect(CasperTransaction.fromJSON).toHaveBeenCalledTimes(1);
+    expect(CasperTransaction.fromJSON).toHaveBeenCalledWith("mockedCombinedTx");
+    expect(broadcastTx).toHaveBeenCalledTimes(1);
+    expect(broadcastTx).toHaveBeenCalledWith("mockedParsedTx");
 
-    // Assert the operation was patched with the hash
     expect(result.hash).toBe("mockedTxHash");
     expect(result).toEqual({
       ...patchOperationWithHash(mockSignedOperation.operation, "mockedTxHash"),
@@ -61,10 +61,9 @@ describe("broadcast", () => {
   });
 
   test("should throw if rawData is missing", async () => {
-    // Create a type-safe but invalid signed operation for testing
     const invalidSignedOperation = {
       ...mockSignedOperation,
-      rawData: null as any, // Force type assertion for test
+      rawData: null as any,
     };
 
     await expect(
@@ -73,10 +72,27 @@ describe("broadcast", () => {
         signedOperation: invalidSignedOperation,
       }),
     ).rejects.toThrow("casper: rawData is required");
+
+    expect(combine).not.toHaveBeenCalled();
+  });
+
+  test("should throw if rawData.tx is not a string", async () => {
+    const invalidSignedOperation = {
+      ...mockSignedOperation,
+      rawData: { tx: { not: "a string" } } as any,
+    };
+
+    await expect(
+      broadcast({
+        account: mockAccount,
+        signedOperation: invalidSignedOperation,
+      }),
+    ).rejects.toThrow("casper: rawData.tx is required");
+
+    expect(combine).not.toHaveBeenCalled();
   });
 
   test("should throw if broadcast fails to return a hash", async () => {
-    // Mock broadcastTx to return null (failed broadcast)
     (broadcastTx as jest.Mock).mockResolvedValueOnce(null);
 
     await expect(

--- a/libs/coin-modules/coin-casper/src/bridge/broadcast.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/broadcast.ts
@@ -1,7 +1,8 @@
 import { patchOperationWithHash } from "@ledgerhq/ledger-wallet-framework/operation";
 import { AccountBridge } from "@ledgerhq/types-live";
-import { Transaction as CasperTransaction, PublicKey } from "casper-js-sdk";
+import { Transaction as CasperTransaction } from "casper-js-sdk";
 import invariant from "invariant";
+import { combine } from "../logic/combine";
 import { broadcastTx } from "../network/api";
 import { Transaction } from "../types";
 
@@ -10,8 +11,9 @@ export const broadcast: AccountBridge<Transaction>["broadcast"] = async ({
   signedOperation: { signature, operation, rawData },
 }) => {
   invariant(rawData, "casper: rawData is required");
-  const tx = CasperTransaction.fromJSON(rawData.tx);
-  tx.setSignature(Buffer.from(signature, "hex"), PublicKey.fromHex(account.freshAddress));
+  invariant(typeof rawData.tx === "string", "casper: rawData.tx is required and must be a string");
+  const combinedTx = combine(rawData.tx, signature, account.freshAddress);
+  const tx = CasperTransaction.fromJSON(combinedTx);
 
   const hash = await broadcastTx(tx);
   invariant(hash, "casper: failed to broadcast transaction and get transaction hash");

--- a/libs/coin-modules/coin-casper/src/logic/combine.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/combine.test.ts
@@ -1,0 +1,60 @@
+import { Transaction } from "casper-js-sdk";
+import { createMockSignedTransaction } from "../__tests__/fixtures/transaction.fixture";
+import { combine } from "./combine";
+
+describe("combine", () => {
+  it("attaches the signature as an approval that Transaction.fromJSON verifies without throwing", () => {
+    const { unsignedTx, taggedSignature, publicKey } = createMockSignedTransaction();
+
+    const combined = combine(unsignedTx, taggedSignature, publicKey);
+
+    expect(() => Transaction.fromJSON(combined)).not.toThrow();
+  });
+
+  it("throws when pubkey is missing", () => {
+    const { unsignedTx, taggedSignature } = createMockSignedTransaction();
+
+    expect(() => combine(unsignedTx, taggedSignature, undefined)).toThrow(
+      "casper: combine requires the signer public key",
+    );
+  });
+
+  it("produces a transaction that fails verification when the signature comes from a different keypair", () => {
+    const { unsignedTx, wrongKeypairSignature, publicKey } = createMockSignedTransaction();
+
+    const combined = combine(unsignedTx, wrongKeypairSignature, publicKey);
+
+    expect(() => Transaction.fromJSON(combined)).toThrow(Error);
+  });
+
+  it("throws on a malformed tx string", () => {
+    const { taggedSignature, publicKey } = createMockSignedTransaction();
+
+    expect(() => combine("not-json", taggedSignature, publicKey)).toThrow(Error);
+  });
+
+  it("throws when the signature contains non-hex characters", () => {
+    const { unsignedTx, taggedSignature, publicKey } = createMockSignedTransaction();
+    const invalidSignature = "zz" + taggedSignature.slice(2);
+
+    expect(() => combine(unsignedTx, invalidSignature, publicKey)).toThrow(
+      "casper: invalid hex signature",
+    );
+  });
+
+  it("throws when the signature has odd-length hex", () => {
+    const { unsignedTx, taggedSignature, publicKey } = createMockSignedTransaction();
+
+    expect(() => combine(unsignedTx, taggedSignature.slice(0, -1), publicKey)).toThrow(
+      "casper: combine expects a 65-byte (tag + signature) hex signature",
+    );
+  });
+
+  it("throws when the signature is the wrong length", () => {
+    const { unsignedTx, untaggedSignature, publicKey } = createMockSignedTransaction();
+
+    expect(() => combine(unsignedTx, untaggedSignature, publicKey)).toThrow(
+      "casper: combine expects a 65-byte (tag + signature) hex signature",
+    );
+  });
+});

--- a/libs/coin-modules/coin-casper/src/logic/combine.ts
+++ b/libs/coin-modules/coin-casper/src/logic/combine.ts
@@ -1,0 +1,32 @@
+import { PublicKey, Transaction } from "casper-js-sdk";
+import invariant from "invariant";
+
+// 1 algorithm-tag byte + 64 signature bytes, fixed length for both SECP256K1 and ED25519.
+const SIGNATURE_HEX_LENGTH = 130;
+
+/**
+ * `signature` must already carry its algorithm tag byte — the caller that produced it knows
+ * which algorithm the device used, so combine doesn't re-derive or prepend one.
+ *
+ * `pubkey` is required: unlike some chains, Casper can't recover a signer from its signature.
+ */
+export function combine(tx: string, signature: string, pubkey?: string): string {
+  invariant(pubkey, "casper: combine requires the signer public key");
+
+  invariant(
+    signature.length === SIGNATURE_HEX_LENGTH,
+    "casper: combine expects a 65-byte (tag + signature) hex signature",
+  );
+
+  const signatureBytes = Buffer.from(signature, "hex");
+
+  // Buffer.from(.., "hex") silently truncates at the first non-hex pair, so verify the
+  // round-trip to reject malformed hex with an actionable message.
+  const isValidHex = signatureBytes.toString("hex") === signature.toLowerCase();
+  invariant(isValidHex, "casper: invalid hex signature");
+
+  const transaction = Transaction.fromJSON(tx);
+  transaction.setSignature(signatureBytes, PublicKey.fromHex(pubkey));
+
+  return JSON.stringify(transaction.toJSON());
+}

--- a/libs/coin-modules/coin-casper/src/logic/index.ts
+++ b/libs/coin-modules/coin-casper/src/logic/index.ts
@@ -1,3 +1,4 @@
+export * from "./combine";
 export * from "./craftTransaction";
 export * from "./estimateFees";
 export * from "./lastBlock";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR implements the `combine` method for the Casper coin module, replacing the previous "not supported" stub.

It attaches a device-produced signature (tag byte + 64-byte signature, hex-encoded) plus the signer's public key to an unsigned Casper transaction, validating hex length/format before doing so. `broadcast` is refactored to delegate signing to this new `combine` function instead of calling `Transaction.setSignature` directly, and the fix corrects the signed message to be the transaction hash (not the serialized tx bytes), matching `TransactionV1.sign()/validate()` semantics.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-33292
