### PR TITLE
fix(buy): navigate back on account drawer cancel (LIVE-26867)

### DIFF
--- a/.changeset/loud-bugs-return.md
+++ b/.changeset/loud-bugs-return.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fix infinite loader on Exchange when closing account selection drawer with no accounts

--- a/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/ExchangeLiveAppNavigator.tsx
@@ -35,6 +35,7 @@ const createExchangeScreen =
       referrer,
       mode,
       returnToPreviousScreenOnClose,
+      goBackOnAccountRequestCancel,
     } = props.route.params || {};
     const resolvedCurrency = currency
       ? findCryptoCurrencyByKeyword(currency)?.id
@@ -57,6 +58,7 @@ const createExchangeScreen =
             platform: platform || defaultPlatform,
             referrer: referrer,
             mode,
+            goBackOnAccountRequestCancel,
           },
         }}
       />

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
@@ -17,6 +17,7 @@ type ExchangeParams = CommonParams & {
   defaultTicker?: string;
   mode?: "offRamp" | "onRamp";
   returnToPreviousScreenOnClose?: boolean;
+  goBackOnAccountRequestCancel?: string;
 };
 
 export type PtxNavigatorParamList = {

--- a/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
+++ b/apps/ledger-live-mobile/src/components/RootNavigator/types/PtxNavigator.ts
@@ -17,7 +17,7 @@ type ExchangeParams = CommonParams & {
   defaultTicker?: string;
   mode?: "offRamp" | "onRamp";
   returnToPreviousScreenOnClose?: boolean;
-  goBackOnAccountRequestCancel?: string;
+  goBackOnAccountRequestCancel?: boolean;
 };
 
 export type PtxNavigatorParamList = {

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.test.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.test.ts
@@ -13,6 +13,9 @@ type DeviceIntentSignFlagOverride = {
 };
 
 const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+const mockCanGoBack = jest.fn().mockReturnValue(true);
+const mockOpenDrawer = jest.fn();
 
 jest.mock("@ledgerhq/live-common/wallet-api/helpers", () => ({
   getInitialURL: jest.fn(),
@@ -28,12 +31,15 @@ jest.mock("@ledgerhq/live-common/wallet-api/react", () => ({
 }));
 
 jest.mock("LLM/features/ModularDrawer", () => ({
-  useModularDrawerController: jest.fn(() => ({ openDrawer: jest.fn() })),
+  useModularDrawerController: jest.fn(() => ({ openDrawer: mockOpenDrawer })),
 }));
 
 jest.mock("@react-navigation/native", () => {
   const actual = jest.requireActual("@react-navigation/native");
-  return { ...actual, useNavigation: () => ({ navigate: mockNavigate }) };
+  return {
+    ...actual,
+    useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack, canGoBack: mockCanGoBack }),
+  };
 });
 
 jest.mock("@ledgerhq/live-common/wallet-api/ModularDrawer/useDrawerConfiguration", () => ({
@@ -291,5 +297,54 @@ describe("useUiHook - message.sign device-intent branching", () => {
       expect.objectContaining({ account, message, onSuccess, onError, onCancel }),
     );
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("useUiHook - account.request cancel navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
+  });
+
+  function invokeAccountRequest(goBackOnAccountRequestCancel?: boolean) {
+    const onSuccess = jest.fn();
+    const onCancel = jest.fn();
+    const { result } = renderHook(() =>
+      useUiHook({
+        manifest: mockManifest,
+        requestDeviceIntentSign: jest.fn(),
+        requestDeviceIntentSignMessage: jest.fn(),
+        goBackOnAccountRequestCancel,
+      }),
+    );
+    result.current["account.request"]!({
+      currencyIds: ["ethereum"],
+      onSuccess,
+      onCancel,
+      areCurrenciesFiltered: false,
+    });
+    const drawerCallArgs = mockOpenDrawer.mock.calls[0]?.[0];
+    return { onSuccess, onCancel, drawerCallArgs };
+  }
+
+  it("calls goBack when goBackOnAccountRequestCancel is true and user cancels", () => {
+    const { drawerCallArgs } = invokeAccountRequest(true);
+    drawerCallArgs.onCancel();
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call goBack when goBackOnAccountRequestCancel is not set and user cancels", () => {
+    const { drawerCallArgs } = invokeAccountRequest();
+    drawerCallArgs.onCancel();
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it("does not call goBack after an account was already selected", () => {
+    const { drawerCallArgs, onSuccess } = invokeAccountRequest(true);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    drawerCallArgs.onAccountSelected({ id: "acc-1" } as AccountLike, undefined);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    drawerCallArgs.onCancel();
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 });

--- a/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
+++ b/apps/ledger-live-mobile/src/components/Web3AppWebview/helpers.ts
@@ -140,6 +140,7 @@ export function useWebView(
     requestDeviceIntentSign: setDeviceIntentSignRequest,
     requestDeviceIntentSignMessage: setDeviceIntentSignMessageRequest,
     onPublicKeyUnavailable: setPublicKeyUnavailableError,
+    goBackOnAccountRequestCancel: inputs?.goBackOnAccountRequestCancel === "true",
   });
 
   const trackingEnabled = useSelector(trackingEnabledSelector);
@@ -516,6 +517,8 @@ export interface Props {
    * to the SignMessage stack.
    */
   requestDeviceIntentSignMessage: (request: WalletApiDeviceIntentSignMessageRequest) => void;
+  /** Opt-in: navigate back when account.request is cancelled (0-accounts Exchange flow only). */
+  goBackOnAccountRequestCancel?: boolean;
 }
 
 export function useUiHook({
@@ -524,8 +527,11 @@ export function useUiHook({
   onPublicKeyUnavailable,
   requestDeviceIntentSign,
   requestDeviceIntentSignMessage,
+  goBackOnAccountRequestCancel,
 }: Props): UiHook {
   const navigation = useNavigation();
+  // flips to false after first onSuccess so currency-change cancels don't trigger goBack
+  const shouldGoBackOnCancelRef = useRef(!!goBackOnAccountRequestCancel);
   const [device, setDevice] = useState<Device>();
   const { createDrawerConfiguration } = useDrawerConfiguration();
   const { openDrawer: openModularDrawer } = useModularDrawerController();
@@ -551,6 +557,7 @@ export function useUiHook({
       "account.request": async ({
         currencyIds,
         onSuccess,
+        onCancel,
         areCurrenciesFiltered,
         useCase,
         uiUseCase,
@@ -567,8 +574,14 @@ export function useUiHook({
           source: source,
           flow: flow,
           enableAccountSelection: true,
-          onAccountSelected: (account: AccountLike, parentAccount?: Account | undefined) =>
-            onSuccess(account, parentAccount),
+          onAccountSelected: (account: AccountLike, parentAccount?: Account | undefined) => {
+            shouldGoBackOnCancelRef.current = false;
+            onSuccess(account, parentAccount);
+          },
+          onCancel: () => {
+            onCancel?.();
+            if (shouldGoBackOnCancelRef.current && navigation.canGoBack()) navigation.goBack();
+          },
           currencies: areCurrenciesFiltered && shouldUseCurrencies ? currencyIds : undefined,
           areCurrenciesFiltered,
           useCase,

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
@@ -159,6 +159,7 @@ describe("useOpenBuySell (Market / QuickActions origin)", () => {
       screen: ScreenName.ExchangeBuy,
       params: {
         defaultCurrencyId: bitcoin.id,
+        goBackOnAccountRequestCancel: "true",
       },
     });
     expect(mockNavigate.mock.calls[0][1].params.defaultAccountId).toBeUndefined();
@@ -184,6 +185,7 @@ describe("useOpenBuySell (Market / QuickActions origin)", () => {
       screen: ScreenName.ExchangeBuy,
       params: {
         defaultCurrencyId: usdcToken.id,
+        goBackOnAccountRequestCancel: "true",
       },
     });
     expect(mockNavigate.mock.calls[0][1].params.defaultAccountId).toBeUndefined();

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/__tests__/useOpenBuySell.test.ts
@@ -159,7 +159,7 @@ describe("useOpenBuySell (Market / QuickActions origin)", () => {
       screen: ScreenName.ExchangeBuy,
       params: {
         defaultCurrencyId: bitcoin.id,
-        goBackOnAccountRequestCancel: "true",
+        goBackOnAccountRequestCancel: true,
       },
     });
     expect(mockNavigate.mock.calls[0][1].params.defaultAccountId).toBeUndefined();
@@ -185,7 +185,7 @@ describe("useOpenBuySell (Market / QuickActions origin)", () => {
       screen: ScreenName.ExchangeBuy,
       params: {
         defaultCurrencyId: usdcToken.id,
-        goBackOnAccountRequestCancel: "true",
+        goBackOnAccountRequestCancel: true,
       },
     });
     expect(mockNavigate.mock.calls[0][1].params.defaultAccountId).toBeUndefined();

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
@@ -16,7 +16,6 @@ const ASSET_DETAIL_SOURCE_SCREEN_NAME = "Asset Detail";
 type UseOpenBuySellProps = {
   currency?: CryptoOrTokenCurrency;
   sourceScreenName: string;
-  onCancel?: () => void;
 };
 
 type AccountWithParent = {
@@ -42,7 +41,7 @@ function getAccountsForCurrency(
     });
 }
 
-export function useOpenBuySell({ currency, sourceScreenName, onCancel }: UseOpenBuySellProps) {
+export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellProps) {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const shallowAccounts = useSelector(shallowAccountsSelector);
   const flattenedAccounts = useSelector(flattenAccountsSelector);
@@ -86,10 +85,9 @@ export function useOpenBuySell({ currency, sourceScreenName, onCancel }: UseOpen
         enableAccountSelection: true,
         onAccountSelected: (account, parentAccount) =>
           navigateToBuySell(mode, account, parentAccount),
-        onCancel,
       });
     },
-    [currency, openDrawer, sourceScreenName, navigateToBuySell, onCancel],
+    [currency, openDrawer, sourceScreenName, navigateToBuySell],
   );
 
   const handleOpenBuySell = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
@@ -16,6 +16,7 @@ const ASSET_DETAIL_SOURCE_SCREEN_NAME = "Asset Detail";
 type UseOpenBuySellProps = {
   currency?: CryptoOrTokenCurrency;
   sourceScreenName: string;
+  onCancel?: () => void;
 };
 
 type AccountWithParent = {
@@ -41,7 +42,7 @@ function getAccountsForCurrency(
     });
 }
 
-export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellProps) {
+export function useOpenBuySell({ currency, sourceScreenName, onCancel }: UseOpenBuySellProps) {
   const navigation = useNavigation<NativeStackNavigationProp<BaseNavigatorStackParamList>>();
   const shallowAccounts = useSelector(shallowAccountsSelector);
   const flattenedAccounts = useSelector(flattenAccountsSelector);
@@ -68,6 +69,7 @@ export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellPro
           ...(sourceScreenName === ASSET_DETAIL_SOURCE_SCREEN_NAME && {
             returnToPreviousScreenOnClose: true,
           }),
+          ...(!account && { goBackOnAccountRequestCancel: "true" }),
         },
       });
     },
@@ -84,9 +86,10 @@ export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellPro
         enableAccountSelection: true,
         onAccountSelected: (account, parentAccount) =>
           navigateToBuySell(mode, account, parentAccount),
+        onCancel,
       });
     },
-    [currency, openDrawer, sourceScreenName, navigateToBuySell],
+    [currency, openDrawer, sourceScreenName, navigateToBuySell, onCancel],
   );
 
   const handleOpenBuySell = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Buy/index.ts
@@ -68,7 +68,7 @@ export function useOpenBuySell({ currency, sourceScreenName }: UseOpenBuySellPro
           ...(sourceScreenName === ASSET_DETAIL_SOURCE_SCREEN_NAME && {
             returnToPreviousScreenOnClose: true,
           }),
-          ...(!account && { goBackOnAccountRequestCancel: "true" }),
+          ...(!account && { goBackOnAccountRequestCancel: true }),
         },
       });
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -30,12 +30,9 @@ import {
   type NetInfoUnknownState,
 } from "@react-native-community/netinfo";
 
-jest.mock(
-  "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency",
-  () => ({
-    useAcceptedCurrency: () => mockUseAcceptedCurrency(),
-  })
-);
+jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
+  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
+}));
 
 const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
@@ -118,7 +115,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should allow full navigation: asset → network → Device Selection, with back navigation at each step", async () => {
       const { getByText, getByTestId, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions
+        renderOptions,
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -147,10 +144,7 @@ describe.each(DRAWER_VARIANTS)(
     });
 
     it("should go directly to Device selection for Bitcoin", async () => {
-      const { getByText, user } = render(
-        <ModularDrawerSharedNavigator />,
-        renderOptions
-      );
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
       advanceTimers();
@@ -164,7 +158,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should allow searching for assets", async () => {
       const { getByText, queryByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions
+        renderOptions,
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -182,7 +176,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should show the empty state when no assets are found", async () => {
       const { getByText, queryByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions
+        renderOptions,
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -190,15 +184,13 @@ describe.each(DRAWER_VARIANTS)(
 
       await user.type(getByPlaceholderText(/search/i), "ttttttt");
 
-      await waitFor(() =>
-        expect(queryByText(/no assets found/i)).toBeVisible()
-      );
+      await waitFor(() => expect(queryByText(/no assets found/i)).toBeVisible());
     });
 
     it("should not crash when tapping search input with empty asset list", async () => {
       const { getByText, getByPlaceholderText, getByTestId, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions
+        renderOptions,
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -219,7 +211,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should expand to full height when tapping search input with non-empty list", async () => {
       const { getByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions
+        renderOptions,
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -275,23 +267,14 @@ describe.each(DRAWER_VARIANTS)(
     });
 
     it("should display generic error when a Backend error occurs", async () => {
-      server.use(
-        http.get("https://dada.api.ledger.com/v1/assets", () =>
-          HttpResponse.error()
-        )
-      );
-      const { getByText, user } = render(
-        <ModularDrawerSharedNavigator />,
-        renderOptions
-      );
+      server.use(http.get("https://dada.api.ledger.com/v1/assets", () => HttpResponse.error()));
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
       advanceTimers();
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
 
       expect(
-        await screen.findByText(
-          /Something went wrong on our end\. Please try again later/i
-        )
+        await screen.findByText(/Something went wrong on our end\. Please try again later/i),
       ).toBeVisible();
     });
 
@@ -302,21 +285,16 @@ describe.each(DRAWER_VARIANTS)(
         type: NetInfoStateType.none,
       });
 
-      const { getByText, user } = render(
-        <ModularDrawerSharedNavigator />,
-        renderOptions
-      );
+      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
       advanceTimers();
 
       await waitFor(() =>
-        expect(
-          getByText(/No internet connection. Please try again/i)
-        ).toBeVisible()
+        expect(getByText(/No internet connection. Please try again/i)).toBeVisible(),
       );
     });
-  }
+  },
 );
 
 describe("ModularDrawer — onCancel callback", () => {
@@ -327,11 +305,7 @@ describe("ModularDrawer — onCancel callback", () => {
     jest.mocked(mockUseAcceptedCurrency).mockReturnValue(() => true);
   });
 
-  const CancelCallbackTestComponent = ({
-    onCancel,
-  }: {
-    onCancel: () => void;
-  }) => {
+  const CancelCallbackTestComponent = ({ onCancel }: { onCancel: () => void }) => {
     const { openDrawer, closeDrawer, isOpen } = useModularDrawerController();
 
     const handleOpen = useCallback(() => {
@@ -342,23 +316,16 @@ describe("ModularDrawer — onCancel callback", () => {
       <>
         <Button onPress={handleOpen}>Open Drawer</Button>
         <Button onPress={closeDrawer}>Close Drawer</Button>
-        <ModularDrawer
-          isOpen={isOpen}
-          onClose={closeDrawer}
-          onAccountSelected={jest.fn()}
-        />
+        <ModularDrawer isOpen={isOpen} onClose={closeDrawer} onAccountSelected={jest.fn()} />
       </>
     );
   };
 
   it("should invoke onCancel when the drawer is closed without selecting an account", async () => {
-    const { getByText, user } = render(
-      <CancelCallbackTestComponent onCancel={mockOnCancel} />,
-      {
-        overrideInitialState: (state: State) =>
-          withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
-      }
-    );
+    const { getByText, user } = render(<CancelCallbackTestComponent onCancel={mockOnCancel} />, {
+      overrideInitialState: (state: State) =>
+        withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
+    });
 
     await user.press(getByText("Open Drawer"));
     act(() => {
@@ -374,13 +341,10 @@ describe("ModularDrawer — onCancel callback", () => {
   });
 
   it("should not invoke onCancel when the drawer is not closed", async () => {
-    const { getByText, user } = render(
-      <CancelCallbackTestComponent onCancel={mockOnCancel} />,
-      {
-        overrideInitialState: (state: State) =>
-          withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
-      }
-    );
+    const { getByText, user } = render(<CancelCallbackTestComponent onCancel={mockOnCancel} />, {
+      overrideInitialState: (state: State) =>
+        withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
+    });
 
     await user.press(getByText("Open Drawer"));
     act(() => jest.advanceTimersByTime(500));
@@ -403,7 +367,7 @@ describe("ModularDrawer — Lumen BottomSheet specific", () => {
   it("should show BottomSheetHeader title and hide legacy Title when Lumen path is active", async () => {
     const { getByText, queryByTestId, getByTestId, user } = render(
       <ModularDrawerSharedNavigator />,
-      lumenOverride
+      lumenOverride,
     );
 
     await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import {
   render,
   waitFor,
@@ -15,6 +15,8 @@ import {
   mockedAccounts,
   ARB_ACCOUNT,
 } from "./shared";
+import { ModularDrawer, useModularDrawerController } from "..";
+import { Button } from "@ledgerhq/native-ui";
 import { State } from "~/reducers/types";
 import { INITIAL_STATE } from "~/reducers/settings";
 
@@ -294,6 +296,68 @@ describe.each(DRAWER_VARIANTS)(
     });
   },
 );
+
+describe("ModularDrawer — onCancel callback", () => {
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(mockUseAcceptedCurrency).mockReturnValue(() => true);
+  });
+
+  const CancelCallbackTestComponent = ({ onCancel }: { onCancel: () => void }) => {
+    const { openDrawer, closeDrawer, isOpen } = useModularDrawerController();
+
+    const handleOpen = useCallback(() => {
+      openDrawer({ flow: "test", source: "test", onCancel });
+    }, [openDrawer, onCancel]);
+
+    return (
+      <>
+        <Button onPress={handleOpen}>Open Drawer</Button>
+        <Button onPress={closeDrawer}>Close Drawer</Button>
+        <ModularDrawer isOpen={isOpen} onClose={closeDrawer} onAccountSelected={jest.fn()} />
+      </>
+    );
+  };
+
+  it("should invoke onCancel when the drawer is closed without selecting an account", async () => {
+    const { getByText, user } = render(
+      <CancelCallbackTestComponent onCancel={mockOnCancel} />,
+      {
+        overrideInitialState: (state: State) =>
+          withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
+      },
+    );
+
+    await user.press(getByText("Open Drawer"));
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await user.press(getByText("Close Drawer"));
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not invoke onCancel when the drawer is not closed", async () => {
+    const { getByText, user } = render(
+      <CancelCallbackTestComponent onCancel={mockOnCancel} />,
+      {
+        overrideInitialState: (state: State) =>
+          withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
+      },
+    );
+
+    await user.press(getByText("Open Drawer"));
+    act(() => jest.advanceTimersByTime(500));
+
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+});
 
 describe("ModularDrawer — Lumen BottomSheet specific", () => {
   const lumenOverride = {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/__integrations__/modularDrawer.test.tsx
@@ -30,9 +30,12 @@ import {
   type NetInfoUnknownState,
 } from "@react-native-community/netinfo";
 
-jest.mock("@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency", () => ({
-  useAcceptedCurrency: () => mockUseAcceptedCurrency(),
-}));
+jest.mock(
+  "@ledgerhq/live-common/modularDrawer/hooks/useAcceptedCurrency",
+  () => ({
+    useAcceptedCurrency: () => mockUseAcceptedCurrency(),
+  })
+);
 
 const mockUseAcceptedCurrency = jest.fn(() => () => true);
 
@@ -115,7 +118,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should allow full navigation: asset → network → Device Selection, with back navigation at each step", async () => {
       const { getByText, getByTestId, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions,
+        renderOptions
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -144,7 +147,10 @@ describe.each(DRAWER_VARIANTS)(
     });
 
     it("should go directly to Device selection for Bitcoin", async () => {
-      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+      const { getByText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions
+      );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
       advanceTimers();
@@ -158,7 +164,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should allow searching for assets", async () => {
       const { getByText, queryByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions,
+        renderOptions
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -176,7 +182,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should show the empty state when no assets are found", async () => {
       const { getByText, queryByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions,
+        renderOptions
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -184,13 +190,15 @@ describe.each(DRAWER_VARIANTS)(
 
       await user.type(getByPlaceholderText(/search/i), "ttttttt");
 
-      await waitFor(() => expect(queryByText(/no assets found/i)).toBeVisible());
+      await waitFor(() =>
+        expect(queryByText(/no assets found/i)).toBeVisible()
+      );
     });
 
     it("should not crash when tapping search input with empty asset list", async () => {
       const { getByText, getByPlaceholderText, getByTestId, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions,
+        renderOptions
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -211,7 +219,7 @@ describe.each(DRAWER_VARIANTS)(
     it("should expand to full height when tapping search input with non-empty list", async () => {
       const { getByText, getByPlaceholderText, user } = render(
         <ModularDrawerSharedNavigator />,
-        renderOptions,
+        renderOptions
       );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
@@ -267,14 +275,23 @@ describe.each(DRAWER_VARIANTS)(
     });
 
     it("should display generic error when a Backend error occurs", async () => {
-      server.use(http.get("https://dada.api.ledger.com/v1/assets", () => HttpResponse.error()));
-      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+      server.use(
+        http.get("https://dada.api.ledger.com/v1/assets", () =>
+          HttpResponse.error()
+        )
+      );
+      const { getByText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions
+      );
       advanceTimers();
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
 
       expect(
-        await screen.findByText(/Something went wrong on our end\. Please try again later/i),
+        await screen.findByText(
+          /Something went wrong on our end\. Please try again later/i
+        )
       ).toBeVisible();
     });
 
@@ -285,16 +302,21 @@ describe.each(DRAWER_VARIANTS)(
         type: NetInfoStateType.none,
       });
 
-      const { getByText, user } = render(<ModularDrawerSharedNavigator />, renderOptions);
+      const { getByText, user } = render(
+        <ModularDrawerSharedNavigator />,
+        renderOptions
+      );
 
       await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));
       advanceTimers();
 
       await waitFor(() =>
-        expect(getByText(/No internet connection. Please try again/i)).toBeVisible(),
+        expect(
+          getByText(/No internet connection. Please try again/i)
+        ).toBeVisible()
       );
     });
-  },
+  }
 );
 
 describe("ModularDrawer — onCancel callback", () => {
@@ -305,7 +327,11 @@ describe("ModularDrawer — onCancel callback", () => {
     jest.mocked(mockUseAcceptedCurrency).mockReturnValue(() => true);
   });
 
-  const CancelCallbackTestComponent = ({ onCancel }: { onCancel: () => void }) => {
+  const CancelCallbackTestComponent = ({
+    onCancel,
+  }: {
+    onCancel: () => void;
+  }) => {
     const { openDrawer, closeDrawer, isOpen } = useModularDrawerController();
 
     const handleOpen = useCallback(() => {
@@ -316,7 +342,11 @@ describe("ModularDrawer — onCancel callback", () => {
       <>
         <Button onPress={handleOpen}>Open Drawer</Button>
         <Button onPress={closeDrawer}>Close Drawer</Button>
-        <ModularDrawer isOpen={isOpen} onClose={closeDrawer} onAccountSelected={jest.fn()} />
+        <ModularDrawer
+          isOpen={isOpen}
+          onClose={closeDrawer}
+          onAccountSelected={jest.fn()}
+        />
       </>
     );
   };
@@ -327,7 +357,7 @@ describe("ModularDrawer — onCancel callback", () => {
       {
         overrideInitialState: (state: State) =>
           withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
-      },
+      }
     );
 
     await user.press(getByText("Open Drawer"));
@@ -349,7 +379,7 @@ describe("ModularDrawer — onCancel callback", () => {
       {
         overrideInitialState: (state: State) =>
           withFlagOverrides({ ...mockedFF })(withReadOnlyDisabled(state)),
-      },
+      }
     );
 
     await user.press(getByText("Open Drawer"));
@@ -373,7 +403,7 @@ describe("ModularDrawer — Lumen BottomSheet specific", () => {
   it("should show BottomSheetHeader title and hide legacy Title when Lumen path is active", async () => {
     const { getByText, queryByTestId, getByTestId, user } = render(
       <ModularDrawerSharedNavigator />,
-      lumenOverride,
+      lumenOverride
     );
 
     await user.press(getByText(WITHOUT_ACCOUNT_SELECTION));

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -114,6 +114,29 @@ describe("useModularDrawerController", () => {
       expect(onCancel).not.toHaveBeenCalled();
       expect(onAccountSelected).toHaveBeenCalledTimes(1);
     });
+
+    it("should not invoke onCancel when handleCurrencySelected is used", () => {
+      const onCancel = jest.fn();
+      const onCurrencySelected = jest.fn();
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "test_flow",
+          source: "test_source",
+          completionMode: "currency",
+          onCancel,
+          onCurrencySelected,
+        });
+      });
+
+      act(() => {
+        result.current.handleCurrencySelected(mockEthCryptoCurrency);
+      });
+
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onCurrencySelected).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("handleAccountSelected", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -58,6 +58,45 @@ describe("useModularDrawerController", () => {
     expect(store.getState().modularDrawer.isOpen).toBe(false);
   });
 
+  describe("onCancel callback", () => {
+    it("should invoke onCancel when closeDrawer is called", () => {
+      const onCancel = jest.fn();
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({ flow: "test_flow", source: "test_source", onCancel });
+      });
+
+      act(() => {
+        result.current.closeDrawer();
+      });
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not invoke onCancel when handleAccountSelected is used", () => {
+      const onCancel = jest.fn();
+      const onAccountSelected = jest.fn();
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "test_flow",
+          source: "test_source",
+          onCancel,
+          onAccountSelected,
+        });
+      });
+
+      act(() => {
+        result.current.handleAccountSelected(mockAccount);
+      });
+
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onAccountSelected).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("handleAccountSelected", () => {
     it("should invoke registered onAccountSelected callback and close the drawer", () => {
       const onAccountSelected = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/__tests__/useModularDrawerController.test.ts
@@ -74,6 +74,25 @@ describe("useModularDrawerController", () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
+    it("should not invoke onCancel when a new drawer replaces the current one", () => {
+      const firstCancel = jest.fn();
+      const { result } = renderHook(() => useModularDrawerController());
+
+      act(() => {
+        result.current.openDrawer({
+          flow: "test_flow",
+          source: "test_source",
+          onCancel: firstCancel,
+        });
+      });
+
+      act(() => {
+        result.current.openDrawer({ flow: "other_flow", source: "test_source" });
+      });
+
+      expect(firstCancel).not.toHaveBeenCalled();
+    });
+
     it("should not invoke onCancel when handleAccountSelected is used", () => {
       const onCancel = jest.fn();
       const onAccountSelected = jest.fn();

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
@@ -1,6 +1,11 @@
 import { AccountLike } from "@ledgerhq/types-live";
 import { Registry } from "./Registry";
-import { AccountCallback, CancelCallback, CurrencyCallback, RegistryManager } from "./types";
+import {
+  AccountCallback,
+  CancelCallback,
+  CurrencyCallback,
+  RegistryManager,
+} from "./types";
 
 // Global registries that persist across re-renders
 export const callbackRegistry = new Registry<AccountCallback>();
@@ -20,13 +25,18 @@ export const registryActions: RegistryManager = {
   registerCallback: (id: string, callback: AccountCallback) =>
     callbackRegistry.register(id, callback),
 
-  getCallback: (id: string): AccountCallback | undefined => callbackRegistry.get(id),
+  getCallback: (id: string): AccountCallback | undefined =>
+    callbackRegistry.get(id),
 
   unregisterCallback: (id: string): boolean => callbackRegistry.unregister(id),
 
   hasCallback: (id: string): boolean => callbackRegistry.has(id),
 
-  executeCallback: (id: string, account: AccountLike, parentAccount?: AccountLike) => {
+  executeCallback: (
+    id: string,
+    account: AccountLike,
+    parentAccount?: AccountLike
+  ) => {
     const callback = callbackRegistry.get(id);
     if (callback) {
       callback(account, parentAccount);
@@ -34,7 +44,8 @@ export const registryActions: RegistryManager = {
     }
   },
 
-  registerCurrencyCallback: (id, callback) => currencyCallbackRegistry.register(id, callback),
+  registerCurrencyCallback: (id, callback) =>
+    currencyCallbackRegistry.register(id, callback),
 
   executeCurrencyCallback: (id, currency) => {
     const callback = currencyCallbackRegistry.get(id);
@@ -44,7 +55,8 @@ export const registryActions: RegistryManager = {
     }
   },
 
-  registerCancelCallback: (id, callback) => cancelCallbackRegistry.register(id, callback),
+  registerCancelCallback: (id, callback) =>
+    cancelCallbackRegistry.register(id, callback),
 
   executeCancelCallback: (id) => {
     const callback = cancelCallbackRegistry.get(id);
@@ -56,7 +68,10 @@ export const registryActions: RegistryManager = {
 
   clearCallbacks: () => resetAllRegistries(),
 
-  getCallbackKeys: (): string[] => [...callbackRegistry.keys(), ...currencyCallbackRegistry.keys()],
+  getCallbackKeys: (): string[] => [
+    ...callbackRegistry.keys(),
+    ...currencyCallbackRegistry.keys(),
+  ],
 
   resetAll: () => resetAllRegistries(),
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
@@ -1,10 +1,11 @@
 import { AccountLike } from "@ledgerhq/types-live";
 import { Registry } from "./Registry";
-import { AccountCallback, CurrencyCallback, RegistryManager } from "./types";
+import { AccountCallback, CancelCallback, CurrencyCallback, RegistryManager } from "./types";
 
 // Global registries that persist across re-renders
 export const callbackRegistry = new Registry<AccountCallback>();
 export const currencyCallbackRegistry = new Registry<CurrencyCallback>();
+export const cancelCallbackRegistry = new Registry<CancelCallback>();
 
 /**
  * Reset all registries - should be called during app reset/cleanup
@@ -12,6 +13,7 @@ export const currencyCallbackRegistry = new Registry<CurrencyCallback>();
 export const resetAllRegistries = () => {
   callbackRegistry.clear();
   currencyCallbackRegistry.clear();
+  cancelCallbackRegistry.clear();
 };
 
 export const registryActions: RegistryManager = {
@@ -39,6 +41,16 @@ export const registryActions: RegistryManager = {
     if (callback) {
       callback(currency);
       currencyCallbackRegistry.unregister(id);
+    }
+  },
+
+  registerCancelCallback: (id, callback) => cancelCallbackRegistry.register(id, callback),
+
+  executeCancelCallback: (id) => {
+    const callback = cancelCallbackRegistry.get(id);
+    if (callback) {
+      callback();
+      cancelCallbackRegistry.unregister(id);
     }
   },
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/registries.ts
@@ -1,11 +1,6 @@
 import { AccountLike } from "@ledgerhq/types-live";
 import { Registry } from "./Registry";
-import {
-  AccountCallback,
-  CancelCallback,
-  CurrencyCallback,
-  RegistryManager,
-} from "./types";
+import { AccountCallback, CancelCallback, CurrencyCallback, RegistryManager } from "./types";
 
 // Global registries that persist across re-renders
 export const callbackRegistry = new Registry<AccountCallback>();
@@ -25,18 +20,13 @@ export const registryActions: RegistryManager = {
   registerCallback: (id: string, callback: AccountCallback) =>
     callbackRegistry.register(id, callback),
 
-  getCallback: (id: string): AccountCallback | undefined =>
-    callbackRegistry.get(id),
+  getCallback: (id: string): AccountCallback | undefined => callbackRegistry.get(id),
 
   unregisterCallback: (id: string): boolean => callbackRegistry.unregister(id),
 
   hasCallback: (id: string): boolean => callbackRegistry.has(id),
 
-  executeCallback: (
-    id: string,
-    account: AccountLike,
-    parentAccount?: AccountLike
-  ) => {
+  executeCallback: (id: string, account: AccountLike, parentAccount?: AccountLike) => {
     const callback = callbackRegistry.get(id);
     if (callback) {
       callback(account, parentAccount);
@@ -44,8 +34,7 @@ export const registryActions: RegistryManager = {
     }
   },
 
-  registerCurrencyCallback: (id, callback) =>
-    currencyCallbackRegistry.register(id, callback),
+  registerCurrencyCallback: (id, callback) => currencyCallbackRegistry.register(id, callback),
 
   executeCurrencyCallback: (id, currency) => {
     const callback = currencyCallbackRegistry.get(id);
@@ -55,10 +44,9 @@ export const registryActions: RegistryManager = {
     }
   },
 
-  registerCancelCallback: (id, callback) =>
-    cancelCallbackRegistry.register(id, callback),
+  registerCancelCallback: (id, callback) => cancelCallbackRegistry.register(id, callback),
 
-  executeCancelCallback: (id) => {
+  executeCancelCallback: id => {
     const callback = cancelCallbackRegistry.get(id);
     if (callback) {
       callback();
@@ -66,11 +54,14 @@ export const registryActions: RegistryManager = {
     }
   },
 
+  unregisterCancelCallback: id => cancelCallbackRegistry.unregister(id),
+
   clearCallbacks: () => resetAllRegistries(),
 
   getCallbackKeys: (): string[] => [
     ...callbackRegistry.keys(),
     ...currencyCallbackRegistry.keys(),
+    ...cancelCallbackRegistry.keys(),
   ],
 
   resetAll: () => resetAllRegistries(),

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
@@ -16,6 +16,7 @@ export interface RegistryManager {
   executeCurrencyCallback: (id: string, currency: CryptoOrTokenCurrency | null) => void;
   registerCancelCallback: (id: string, callback: CancelCallback) => void;
   executeCancelCallback: (id: string) => void;
+  unregisterCancelCallback: (id: string) => void;
   clearCallbacks: () => void;
   getCallbackKeys: () => string[];
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useCallbackRegistry/types.ts
@@ -3,6 +3,7 @@ import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 
 export type AccountCallback = (account: AccountLike, parentAccount?: AccountLike) => void;
 export type CurrencyCallback = (currency: CryptoOrTokenCurrency | null) => void;
+export type CancelCallback = () => void;
 
 export interface RegistryManager {
   // Callback methods
@@ -13,6 +14,8 @@ export interface RegistryManager {
   executeCallback: (id: string, account: AccountLike, parentAccount?: AccountLike) => void;
   registerCurrencyCallback: (id: string, callback: CurrencyCallback) => void;
   executeCurrencyCallback: (id: string, currency: CryptoOrTokenCurrency | null) => void;
+  registerCancelCallback: (id: string, callback: CancelCallback) => void;
+  executeCancelCallback: (id: string) => void;
   clearCallbacks: () => void;
   getCallbackKeys: () => string[];
 

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -145,12 +145,16 @@ export const useModularDrawerController = () => {
       if (cancelCallbackId) {
         unregisterCancelCallback(cancelCallbackId);
       }
-      if (callbackId) {
-        executeCallback(callbackId, account, parentAccount);
+      try {
+        if (callbackId) {
+          executeCallback(callbackId, account, parentAccount);
+        }
+      } finally {
+        dispatch(closeModularDrawer());
+        resetAll();
       }
-      dispatch(closeModularDrawer());
     },
-    [callbackId, cancelCallbackId, dispatch, executeCallback, unregisterCancelCallback],
+    [callbackId, cancelCallbackId, dispatch, executeCallback, unregisterCancelCallback, resetAll],
   );
 
   const handleCurrencySelected = useCallback(
@@ -158,12 +162,16 @@ export const useModularDrawerController = () => {
       if (cancelCallbackId) {
         unregisterCancelCallback(cancelCallbackId);
       }
-      if (callbackId) {
-        executeCurrencyCallback(callbackId, currency);
+      try {
+        if (callbackId) {
+          executeCurrencyCallback(callbackId, currency);
+        }
+      } finally {
+        dispatch(closeModularDrawer());
+        resetAll();
       }
-      dispatch(closeModularDrawer());
     },
-    [callbackId, cancelCallbackId, dispatch, executeCurrencyCallback, unregisterCancelCallback],
+    [callbackId, cancelCallbackId, dispatch, executeCurrencyCallback, unregisterCancelCallback, resetAll],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -75,9 +75,6 @@ export const useModularDrawerController = () => {
       if (completionMode === "currency" && callbackId) {
         executeCurrencyCallback(callbackId, null);
       }
-      if (cancelCallbackId) {
-        executeCancelCallback(cancelCallbackId);
-      }
       resetAll();
 
       let callbackIdToUse: string | undefined;
@@ -113,10 +110,8 @@ export const useModularDrawerController = () => {
     },
     [
       callbackId,
-      cancelCallbackId,
       completionMode,
       dispatch,
-      executeCancelCallback,
       executeCurrencyCallback,
       registerCallback,
       registerCurrencyCallback,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -9,6 +9,16 @@ import { DrawerParams, DrawerRemoteParams } from "../types";
 import { useCallbackRegistry } from "./useCallbackRegistry";
 import { generateCallbackId } from "../utils/callbackIdGenerator";
 
+function resolveCallbackId<T>(
+  callback: T | undefined,
+  register: (id: string, cb: T) => void,
+): string | undefined {
+  if (!callback) return undefined;
+  const id = generateCallbackId();
+  register(id, callback);
+  return id;
+}
+
 /**
  * Hook to manage the global state of the Modular Drawer.
  *
@@ -77,28 +87,19 @@ export const useModularDrawerController = () => {
       }
       resetAll();
 
-      let callbackIdToUse: string | undefined;
-      if (onAccountSelected) {
-        const id = generateCallbackId();
-        const wrappedCallback = (account: AccountLike, parentAccount?: AccountLike) => {
-          const typedParentAccount =
-            parentAccount && "derivationMode" in parentAccount ? parentAccount : undefined;
-          onAccountSelected(account, typedParentAccount);
-        };
-        registerCallback(id, wrappedCallback);
-        callbackIdToUse = id;
-      } else if (onCurrencySelected) {
-        const id = generateCallbackId();
-        registerCurrencyCallback(id, onCurrencySelected);
-        callbackIdToUse = id;
-      }
+      const wrappedAccountCallback = onAccountSelected
+        ? (account: AccountLike, parentAccount?: AccountLike) => {
+            const typedParentAccount =
+              parentAccount && "derivationMode" in parentAccount ? parentAccount : undefined;
+            onAccountSelected(account, typedParentAccount);
+          }
+        : undefined;
 
-      let cancelCallbackIdToUse: string | undefined;
-      if (onCancel) {
-        const id = generateCallbackId();
-        registerCancelCallback(id, onCancel);
-        cancelCallbackIdToUse = id;
-      }
+      const callbackIdToUse =
+        resolveCallbackId(wrappedAccountCallback, registerCallback) ??
+        resolveCallbackId(onCurrencySelected, registerCurrencyCallback);
+
+      const cancelCallbackIdToUse = resolveCallbackId(onCancel, registerCancelCallback);
 
       const paramsWithIds: DrawerRemoteParams = {
         ...otherParams,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -75,6 +75,9 @@ export const useModularDrawerController = () => {
       if (completionMode === "currency" && callbackId) {
         executeCurrencyCallback(callbackId, null);
       }
+      if (cancelCallbackId) {
+        executeCancelCallback(cancelCallbackId);
+      }
       resetAll();
 
       let callbackIdToUse: string | undefined;
@@ -110,8 +113,10 @@ export const useModularDrawerController = () => {
     },
     [
       callbackId,
+      cancelCallbackId,
       completionMode,
       dispatch,
+      executeCancelCallback,
       executeCurrencyCallback,
       registerCallback,
       registerCurrencyCallback,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -172,7 +172,14 @@ export const useModularDrawerController = () => {
         resetAll();
       }
     },
-    [callbackId, cancelCallbackId, dispatch, executeCurrencyCallback, unregisterCancelCallback, resetAll],
+    [
+      callbackId,
+      cancelCallbackId,
+      dispatch,
+      executeCurrencyCallback,
+      unregisterCancelCallback,
+      resetAll,
+    ],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -152,12 +152,15 @@ export const useModularDrawerController = () => {
 
   const handleCurrencySelected = useCallback(
     (currency: CryptoOrTokenCurrency) => {
+      if (cancelCallbackId) {
+        unregisterCancelCallback(cancelCallbackId);
+      }
       if (callbackId) {
         executeCurrencyCallback(callbackId, currency);
       }
       dispatch(closeModularDrawer());
     },
-    [callbackId, dispatch, executeCurrencyCallback],
+    [callbackId, cancelCallbackId, dispatch, executeCurrencyCallback, unregisterCancelCallback],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -3,7 +3,10 @@ import { shallowEqual } from "react-redux";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { AccountLike } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
-import { openModularDrawer, closeModularDrawer } from "~/reducers/modularDrawer";
+import {
+  openModularDrawer,
+  closeModularDrawer,
+} from "~/reducers/modularDrawer";
 import type { State } from "~/reducers/types";
 import { DrawerParams, DrawerRemoteParams } from "../types";
 import { useCallbackRegistry } from "./useCallbackRegistry";
@@ -54,7 +57,7 @@ export const useModularDrawerController = () => {
       uiUseCase: state.modularDrawer.uiUseCase,
       areCurrenciesFiltered: state.modularDrawer.areCurrenciesFiltered,
     }),
-    shallowEqual,
+    shallowEqual
   );
 
   const {
@@ -69,7 +72,12 @@ export const useModularDrawerController = () => {
 
   const openDrawer = useCallback(
     (params?: DrawerParams) => {
-      const { onAccountSelected, onCurrencySelected, onCancel, ...otherParams } = params ?? {};
+      const {
+        onAccountSelected,
+        onCurrencySelected,
+        onCancel,
+        ...otherParams
+      } = params ?? {};
 
       if (completionMode === "currency" && callbackId) {
         executeCurrencyCallback(callbackId, null);
@@ -79,9 +87,14 @@ export const useModularDrawerController = () => {
       let callbackIdToUse: string | undefined;
       if (onAccountSelected) {
         const id = generateCallbackId();
-        const wrappedCallback = (account: AccountLike, parentAccount?: AccountLike) => {
+        const wrappedCallback = (
+          account: AccountLike,
+          parentAccount?: AccountLike
+        ) => {
           const typedParentAccount =
-            parentAccount && "derivationMode" in parentAccount ? parentAccount : undefined;
+            parentAccount && "derivationMode" in parentAccount
+              ? parentAccount
+              : undefined;
           onAccountSelected(account, typedParentAccount);
         };
         registerCallback(id, wrappedCallback);
@@ -116,7 +129,7 @@ export const useModularDrawerController = () => {
       registerCurrencyCallback,
       registerCancelCallback,
       resetAll,
-    ],
+    ]
   );
 
   const closeDrawer = useCallback(() => {
@@ -127,7 +140,14 @@ export const useModularDrawerController = () => {
       executeCancelCallback(cancelCallbackId);
     }
     dispatch(closeModularDrawer());
-  }, [callbackId, cancelCallbackId, completionMode, dispatch, executeCurrencyCallback, executeCancelCallback]);
+  }, [
+    callbackId,
+    cancelCallbackId,
+    completionMode,
+    dispatch,
+    executeCurrencyCallback,
+    executeCancelCallback,
+  ]);
 
   const handleAccountSelected = useCallback(
     (account: AccountLike, parentAccount?: AccountLike) => {
@@ -136,7 +156,7 @@ export const useModularDrawerController = () => {
       }
       dispatch(closeModularDrawer());
     },
-    [callbackId, dispatch, executeCallback],
+    [callbackId, dispatch, executeCallback]
   );
 
   const handleCurrencySelected = useCallback(
@@ -146,7 +166,7 @@ export const useModularDrawerController = () => {
       }
       dispatch(closeModularDrawer());
     },
-    [callbackId, dispatch, executeCurrencyCallback],
+    [callbackId, dispatch, executeCurrencyCallback]
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -128,6 +128,7 @@ export const useModularDrawerController = () => {
       executeCancelCallback(cancelCallbackId);
     }
     dispatch(closeModularDrawer());
+    resetAll();
   }, [
     callbackId,
     cancelCallbackId,
@@ -135,6 +136,7 @@ export const useModularDrawerController = () => {
     dispatch,
     executeCurrencyCallback,
     executeCancelCallback,
+    resetAll,
   ]);
 
   const handleAccountSelected = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -3,10 +3,7 @@ import { shallowEqual } from "react-redux";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { AccountLike } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
-import {
-  openModularDrawer,
-  closeModularDrawer,
-} from "~/reducers/modularDrawer";
+import { openModularDrawer, closeModularDrawer } from "~/reducers/modularDrawer";
 import type { State } from "~/reducers/types";
 import { DrawerParams, DrawerRemoteParams } from "../types";
 import { useCallbackRegistry } from "./useCallbackRegistry";
@@ -57,7 +54,7 @@ export const useModularDrawerController = () => {
       uiUseCase: state.modularDrawer.uiUseCase,
       areCurrenciesFiltered: state.modularDrawer.areCurrenciesFiltered,
     }),
-    shallowEqual
+    shallowEqual,
   );
 
   const {
@@ -67,17 +64,13 @@ export const useModularDrawerController = () => {
     executeCurrencyCallback,
     registerCancelCallback,
     executeCancelCallback,
+    unregisterCancelCallback,
     resetAll,
   } = useCallbackRegistry();
 
   const openDrawer = useCallback(
     (params?: DrawerParams) => {
-      const {
-        onAccountSelected,
-        onCurrencySelected,
-        onCancel,
-        ...otherParams
-      } = params ?? {};
+      const { onAccountSelected, onCurrencySelected, onCancel, ...otherParams } = params ?? {};
 
       if (completionMode === "currency" && callbackId) {
         executeCurrencyCallback(callbackId, null);
@@ -87,14 +80,9 @@ export const useModularDrawerController = () => {
       let callbackIdToUse: string | undefined;
       if (onAccountSelected) {
         const id = generateCallbackId();
-        const wrappedCallback = (
-          account: AccountLike,
-          parentAccount?: AccountLike
-        ) => {
+        const wrappedCallback = (account: AccountLike, parentAccount?: AccountLike) => {
           const typedParentAccount =
-            parentAccount && "derivationMode" in parentAccount
-              ? parentAccount
-              : undefined;
+            parentAccount && "derivationMode" in parentAccount ? parentAccount : undefined;
           onAccountSelected(account, typedParentAccount);
         };
         registerCallback(id, wrappedCallback);
@@ -129,7 +117,7 @@ export const useModularDrawerController = () => {
       registerCurrencyCallback,
       registerCancelCallback,
       resetAll,
-    ]
+    ],
   );
 
   const closeDrawer = useCallback(() => {
@@ -151,12 +139,15 @@ export const useModularDrawerController = () => {
 
   const handleAccountSelected = useCallback(
     (account: AccountLike, parentAccount?: AccountLike) => {
+      if (cancelCallbackId) {
+        unregisterCancelCallback(cancelCallbackId);
+      }
       if (callbackId) {
         executeCallback(callbackId, account, parentAccount);
       }
       dispatch(closeModularDrawer());
     },
-    [callbackId, dispatch, executeCallback]
+    [callbackId, cancelCallbackId, dispatch, executeCallback, unregisterCancelCallback],
   );
 
   const handleCurrencySelected = useCallback(
@@ -166,7 +157,7 @@ export const useModularDrawerController = () => {
       }
       dispatch(closeModularDrawer());
     },
-    [callbackId, dispatch, executeCurrencyCallback]
+    [callbackId, dispatch, executeCurrencyCallback],
   );
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -30,6 +30,7 @@ export const useModularDrawerController = () => {
     isOpen,
     preselectedCurrencies,
     callbackId,
+    cancelCallbackId,
     enableAccountSelection,
     completionMode,
     presentation,
@@ -43,6 +44,7 @@ export const useModularDrawerController = () => {
       isOpen: state.modularDrawer.isOpen,
       preselectedCurrencies: state.modularDrawer.preselectedCurrencies,
       callbackId: state.modularDrawer.callbackId,
+      cancelCallbackId: state.modularDrawer.cancelCallbackId,
       enableAccountSelection: state.modularDrawer.enableAccountSelection,
       completionMode: state.modularDrawer.completionMode,
       presentation: state.modularDrawer.presentation,
@@ -60,12 +62,14 @@ export const useModularDrawerController = () => {
     executeCallback,
     registerCurrencyCallback,
     executeCurrencyCallback,
+    registerCancelCallback,
+    executeCancelCallback,
     resetAll,
   } = useCallbackRegistry();
 
   const openDrawer = useCallback(
     (params?: DrawerParams) => {
-      const { onAccountSelected, onCurrencySelected, ...otherParams } = params ?? {};
+      const { onAccountSelected, onCurrencySelected, onCancel, ...otherParams } = params ?? {};
 
       if (completionMode === "currency" && callbackId) {
         executeCurrencyCallback(callbackId, null);
@@ -88,9 +92,17 @@ export const useModularDrawerController = () => {
         callbackIdToUse = id;
       }
 
+      let cancelCallbackIdToUse: string | undefined;
+      if (onCancel) {
+        const id = generateCallbackId();
+        registerCancelCallback(id, onCancel);
+        cancelCallbackIdToUse = id;
+      }
+
       const paramsWithIds: DrawerRemoteParams = {
         ...otherParams,
         callbackId: callbackIdToUse,
+        cancelCallbackId: cancelCallbackIdToUse,
       };
 
       dispatch(openModularDrawer(paramsWithIds));
@@ -102,6 +114,7 @@ export const useModularDrawerController = () => {
       executeCurrencyCallback,
       registerCallback,
       registerCurrencyCallback,
+      registerCancelCallback,
       resetAll,
     ],
   );
@@ -110,17 +123,20 @@ export const useModularDrawerController = () => {
     if (completionMode === "currency" && callbackId) {
       executeCurrencyCallback(callbackId, null);
     }
+    if (cancelCallbackId) {
+      executeCancelCallback(cancelCallbackId);
+    }
     dispatch(closeModularDrawer());
-  }, [callbackId, completionMode, dispatch, executeCurrencyCallback]);
+  }, [callbackId, cancelCallbackId, completionMode, dispatch, executeCurrencyCallback, executeCancelCallback]);
 
   const handleAccountSelected = useCallback(
     (account: AccountLike, parentAccount?: AccountLike) => {
       if (callbackId) {
         executeCallback(callbackId, account, parentAccount);
       }
-      closeDrawer();
+      dispatch(closeModularDrawer());
     },
-    [callbackId, executeCallback, closeDrawer],
+    [callbackId, dispatch, executeCallback],
   );
 
   const handleCurrencySelected = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -131,7 +131,6 @@ export const useModularDrawerController = () => {
       }
     } finally {
       dispatch(closeModularDrawer());
-      resetAll();
     }
   }, [
     callbackId,
@@ -140,7 +139,6 @@ export const useModularDrawerController = () => {
     dispatch,
     executeCurrencyCallback,
     executeCancelCallback,
-    resetAll,
   ]);
 
   const handleAccountSelected = useCallback(

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/hooks/useModularDrawerController.ts
@@ -122,14 +122,17 @@ export const useModularDrawerController = () => {
   );
 
   const closeDrawer = useCallback(() => {
-    if (completionMode === "currency" && callbackId) {
-      executeCurrencyCallback(callbackId, null);
+    try {
+      if (completionMode === "currency" && callbackId) {
+        executeCurrencyCallback(callbackId, null);
+      }
+      if (cancelCallbackId) {
+        executeCancelCallback(cancelCallbackId);
+      }
+    } finally {
+      dispatch(closeModularDrawer());
+      resetAll();
     }
-    if (cancelCallbackId) {
-      executeCancelCallback(cancelCallbackId);
-    }
-    dispatch(closeModularDrawer());
-    resetAll();
   }, [
     callbackId,
     cancelCallbackId,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -43,7 +43,9 @@ type CurrencyDrawerCompletion = {
 };
 
 export type DrawerParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
-  (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) &
+  (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) & {
+    onCancel?: () => void;
+  } &
   TExtras;
 
 type AccountOrDeviceDrawerRemoteCompletion = {
@@ -59,7 +61,9 @@ type CurrencyDrawerRemoteCompletion = {
 };
 
 export type DrawerRemoteParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
-  (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) &
+  (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) & {
+    cancelCallbackId?: string;
+  } &
   TExtras;
 
 export type OpenDrawer<TExtras extends object = DrawerExtras> = (

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -42,11 +42,11 @@ type CurrencyDrawerCompletion = {
   onCurrencySelected: (currency: CryptoOrTokenCurrency | null) => void;
 };
 
-export type DrawerParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
-  (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) & {
-    onCancel?: () => void;
-  } &
-  TExtras;
+export type DrawerParams<TExtras extends object = DrawerExtras> =
+  DrawerBaseParams &
+    (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) & {
+      onCancel?: () => void;
+    } & TExtras;
 
 type AccountOrDeviceDrawerRemoteCompletion = {
   callbackId?: string;
@@ -60,12 +60,12 @@ type CurrencyDrawerRemoteCompletion = {
   presentation?: ModularDrawerPresentation;
 };
 
-export type DrawerRemoteParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
-  (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) & {
-    cancelCallbackId?: string;
-  } &
-  TExtras;
+export type DrawerRemoteParams<TExtras extends object = DrawerExtras> =
+  DrawerBaseParams &
+    (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) & {
+      cancelCallbackId?: string;
+    } & TExtras;
 
 export type OpenDrawer<TExtras extends object = DrawerExtras> = (
-  params?: DrawerParams<TExtras>,
+  params?: DrawerParams<TExtras>
 ) => void;

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/types.ts
@@ -42,11 +42,10 @@ type CurrencyDrawerCompletion = {
   onCurrencySelected: (currency: CryptoOrTokenCurrency | null) => void;
 };
 
-export type DrawerParams<TExtras extends object = DrawerExtras> =
-  DrawerBaseParams &
-    (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) & {
-      onCancel?: () => void;
-    } & TExtras;
+export type DrawerParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
+  (AccountOrDeviceDrawerCompletion | CurrencyDrawerCompletion) & {
+    onCancel?: () => void;
+  } & TExtras;
 
 type AccountOrDeviceDrawerRemoteCompletion = {
   callbackId?: string;
@@ -60,12 +59,11 @@ type CurrencyDrawerRemoteCompletion = {
   presentation?: ModularDrawerPresentation;
 };
 
-export type DrawerRemoteParams<TExtras extends object = DrawerExtras> =
-  DrawerBaseParams &
-    (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) & {
-      cancelCallbackId?: string;
-    } & TExtras;
+export type DrawerRemoteParams<TExtras extends object = DrawerExtras> = DrawerBaseParams &
+  (AccountOrDeviceDrawerRemoteCompletion | CurrencyDrawerRemoteCompletion) & {
+    cancelCallbackId?: string;
+  } & TExtras;
 
 export type OpenDrawer<TExtras extends object = DrawerExtras> = (
-  params?: DrawerParams<TExtras>
+  params?: DrawerParams<TExtras>,
 ) => void;

--- a/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
+++ b/apps/ledger-live-mobile/src/reducers/modularDrawer.ts
@@ -14,6 +14,7 @@ export interface ModularDrawerState {
   isOpen: boolean;
   preselectedCurrencies: string[];
   callbackId?: string;
+  cancelCallbackId?: string;
   enableAccountSelection?: boolean;
   completionMode?: ModularDrawerCompletionMode;
   presentation: ModularDrawerPresentation;
@@ -32,6 +33,7 @@ export const INITIAL_STATE: ModularDrawerState = {
   isOpen: false,
   preselectedCurrencies: [],
   callbackId: undefined,
+  cancelCallbackId: undefined,
   enableAccountSelection: false,
   completionMode: undefined,
   presentation: "drawer",
@@ -78,6 +80,7 @@ const modularDrawerSlice = createSlice({
       const {
         currencies,
         callbackId,
+        cancelCallbackId,
         enableAccountSelection,
         completionMode,
         presentation,
@@ -96,6 +99,7 @@ const modularDrawerSlice = createSlice({
         state.preselectedCurrencies = currencies;
       }
       state.callbackId = callbackId;
+      state.cancelCallbackId = cancelCallbackId;
       state.completionMode = completionMode;
       state.presentation = completionMode === "currency" ? (presentation ?? "drawer") : "drawer";
       if (isEmbeddedCurrency) {
@@ -134,6 +138,7 @@ const modularDrawerSlice = createSlice({
       state.isOpen = false;
       state.preselectedCurrencies = [];
       state.callbackId = undefined;
+      state.cancelCallbackId = undefined;
       state.enableAccountSelection = false;
       state.completionMode = undefined;
       state.presentation = "drawer";

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -44,6 +44,8 @@ export function PtxScreen({ route, config }: Props) {
   const devMode = useEnv("MANAGER_DEV_MODE").toString();
   const { theme } = useTheme();
   const { platform, ...params } = route.params || {};
+  const goBackOnAccountRequestCancel = (route.params as { goBackOnAccountRequestCancel?: boolean } | undefined)
+    ?.goBackOnAccountRequestCancel;
   const searchParams = route.path
     ? new URL("ledgerlive://" + route.path).searchParams
     : new URLSearchParams();
@@ -129,6 +131,9 @@ export function PtxScreen({ route, config }: Props) {
             providerTestId: localManifest?.providerTestId,
           }),
           ...customParams,
+          ...(goBackOnAccountRequestCancel !== undefined && {
+            goBackOnAccountRequestCancel: goBackOnAccountRequestCancel ? "true" : "false",
+          }),
           ...searchInput,
         }}
         config={config}

--- a/apps/ledger-live-mobile/src/screens/PTX/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/PTX/index.tsx
@@ -44,8 +44,9 @@ export function PtxScreen({ route, config }: Props) {
   const devMode = useEnv("MANAGER_DEV_MODE").toString();
   const { theme } = useTheme();
   const { platform, ...params } = route.params || {};
-  const goBackOnAccountRequestCancel = (route.params as { goBackOnAccountRequestCancel?: boolean } | undefined)
-    ?.goBackOnAccountRequestCancel;
+  const goBackOnAccountRequestCancel = (
+    route.params as { goBackOnAccountRequestCancel?: boolean } | undefined
+  )?.goBackOnAccountRequestCancel;
   const searchParams = route.path
     ? new URL("ledgerlive://" + route.path).searchParams
     : new URLSearchParams();


### PR DESCRIPTION
### 📝 Description

**Previous behaviour:** When a user has zero accounts for a currency and opens the Buy/Sell screen, the Exchange app immediately requests account selection via a drawer. If the user closes the drawer without selecting an account, the Exchange screen is left with an infinite loader — there is no way to recover without force-quitting the app.

**Root cause:** The `account.request` wallet-api handler in `helpers.ts` was opening the account selection drawer but never forwarding the `onCancel` callback to `openModularDrawer`. When the drawer was closed without a selection, Exchange received no signal and kept waiting.

**Fix:**
- Added a `cancelCallbackId` mechanism to `ModularDrawer` so `onCancel` callbacks survive the Redux serialisation boundary.
- Added an opt-in flag `goBackOnAccountRequestCancel` (set only by the zero-accounts Buy/Sell navigation path) that triggers `navigation.goBack()` when the drawer is cancelled, returning the user to the previous screen.
- A `shouldGoBackOnCancelRef` flips to `false` after the first successful account selection, preventing unintended back-navigation when the user later changes currency from within Exchange (1-account regression fix).

**Automated checks:** Unit tests cover all three ref-state scenarios (goBack fires, goBack skipped, ref flips on success). An integration test mounts the full `ModularDrawer` stack and asserts the `onCancel` callback is invoked on close and not on account selection.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-26867]

Before fix:
https://github.com/user-attachments/assets/11e87f58-5d0f-4ee2-9c43-8e272a172032

After fix:
https://github.com/user-attachments/assets/c470dc25-a41f-484b-acc3-df8dc09b00bf



[LIVE-26867]: https://ledgerhq.atlassian.net/browse/LIVE-26867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ