### PR TITLE
[LWDM] feat(casper): craftTransaction method

### DIFF
--- a/.changeset/tame-rivers-craft.md
+++ b/.changeset/tame-rivers-craft.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-casper": minor
+---
+
+feat: craftTransaction method in coin-casper module

--- a/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.integ.test.ts
@@ -10,9 +10,10 @@ import {
   CASPER_NETWORK,
 } from "../constants";
 import { getCasperNodeRpcClient } from "../network/api";
+import type { CasperMemo } from "../types";
 
 describe("Casper Api (mainnet)", () => {
-  let api: CoinModuleApi;
+  let api: CoinModuleApi<CasperMemo>;
 
   beforeAll(() => {
     api = createApi(casperMainnetConfig);
@@ -64,6 +65,48 @@ describe("Casper Api (mainnet)", () => {
       expect(() => api.combine(unsignedTxJson, taggedSignature, undefined)).toThrow(
         "casper: combine requires the signer public key",
       );
+    });
+  });
+
+  describe("craftTransaction", () => {
+    it("crafts a native transfer with a transfer id that Transaction.fromJSON verifies", async () => {
+      const sender = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+      const recipient = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+
+      const { transaction } = await api.craftTransaction({
+        intentType: "transaction",
+        type: "send",
+        sender: sender.publicKey.toHex(),
+        recipient: recipient.publicKey.toHex(),
+        amount: 2_500_000_000n,
+        asset: { type: "native" },
+        memo: { type: "string", kind: "transferId", value: "123456" },
+      });
+
+      expect(() => Transaction.fromJSON(transaction)).not.toThrow();
+    });
+
+    it("produces a transaction that combine can sign end to end", async () => {
+      const sender = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+      const recipient = PrivateKey.generate(KeyAlgorithm.SECP256K1);
+
+      const { transaction } = await api.craftTransaction({
+        intentType: "transaction",
+        type: "send",
+        sender: sender.publicKey.toHex(),
+        recipient: recipient.publicKey.toHex(),
+        amount: 2_500_000_000n,
+        asset: { type: "native" },
+      });
+
+      const unsignedTx = Transaction.fromJSON(transaction);
+      const taggedSignature = Buffer.from(
+        sender.signAndAddAlgorithmBytes(new Uint8Array(unsignedTx.hash.toBytes())),
+      ).toString("hex");
+
+      const combined = await api.combine(transaction, taggedSignature, sender.publicKey.toHex());
+
+      expect(() => Transaction.fromJSON(combined)).not.toThrow();
     });
   });
 

--- a/libs/coin-modules/coin-casper/src/api/index.ts
+++ b/libs/coin-modules/coin-casper/src/api/index.ts
@@ -7,7 +7,6 @@ import type {
   CraftedTransaction,
   Cursor,
   FeeEstimation,
-  MemoNotSupported,
   Page,
   Reward,
   Stake,
@@ -18,11 +17,12 @@ import type {
 import { rejectBalanceOptions } from "@ledgerhq/coin-module-framework/api/getBalance/rejectBalanceOptions";
 import { setCoinConfig } from "../config";
 import { combine } from "../logic/combine";
+import { craftTransaction } from "../logic/craftTransaction";
 import { lastBlock } from "../logic/lastBlock";
 import { getBalance as getAccountBalance } from "../logic/getBalance";
-import type { CasperCoinConfig } from "../types";
+import type { CasperCoinConfig, CasperMemo } from "../types";
 
-export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSupported> {
+export function createApi(config: CasperCoinConfig): CoinModuleApi<CasperMemo> {
   setCoinConfig(config);
 
   return {
@@ -51,9 +51,7 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSuppor
     getRewards(_address: string, _cursor?: Cursor): Promise<Page<Reward>> {
       throw new Error("getRewards is not supported");
     },
-    craftTransaction(_intent: TransactionIntent<MemoNotSupported>): Promise<CraftedTransaction> {
-      throw new Error("craftTransaction is not supported");
-    },
+    craftTransaction,
     craftRawTransaction(
       _transaction: string,
       _sender: string,
@@ -62,7 +60,7 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSuppor
     ): Promise<CraftedTransaction> {
       throw new Error("craftRawTransaction is not supported");
     },
-    estimateFees(_intent: TransactionIntent<MemoNotSupported>): Promise<FeeEstimation> {
+    estimateFees(_intent: TransactionIntent<CasperMemo>): Promise<FeeEstimation> {
       throw new Error("estimateFees is not supported");
     },
     combine,
@@ -70,7 +68,7 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSuppor
       throw new Error("broadcast is not supported");
     },
     validateIntent(
-      _intent: TransactionIntent<MemoNotSupported>,
+      _intent: TransactionIntent<CasperMemo>,
       _balances: Balance[],
       _customFees?: FeeEstimation,
     ): Promise<TransactionValidation> {
@@ -82,7 +80,7 @@ export function createApi(config: CasperCoinConfig): CoinModuleApi<MemoNotSuppor
     validateAddress(_address: string, _parameters: unknown): Promise<boolean> {
       throw new Error("validateAddress is not supported");
     },
-    craftTransactionData(_intent: TransactionIntent<MemoNotSupported>) {
+    craftTransactionData(_intent: TransactionIntent<CasperMemo>) {
       throw new Error("craftTransactionData is not supported");
     },
   };

--- a/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
+++ b/libs/coin-modules/coin-casper/src/bridge/signOperation.ts
@@ -1,9 +1,9 @@
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
 import { log } from "@ledgerhq/logs";
 import { Account, AccountBridge } from "@ledgerhq/types-live";
-import { KeyAlgorithm } from "casper-js-sdk";
+import { KeyAlgorithm, Transaction as CasperTransaction } from "casper-js-sdk";
 import { Observable } from "rxjs";
-import { createNewTransaction } from "../logic/craftTransaction";
+import { craftTransaction } from "../logic/craftTransaction";
 import { getAddress } from "../logic/validateAddress";
 import { Transaction } from "../types";
 import { CasperSigner } from "../types";
@@ -20,7 +20,22 @@ export const buildSignOperation =
 
         const { recipient, amount, fees, transferId } = transaction;
         const { address, derivationPath } = getAddress(account);
-        const casperTx = await createNewTransaction(address, recipient, amount, fees, transferId);
+
+        const crafted = await craftTransaction(
+          {
+            intentType: "transaction",
+            type: "send",
+            sender: address,
+            recipient,
+            amount: BigInt(amount.toFixed(0)),
+            asset: { type: "native" },
+            ...(transferId !== undefined && {
+              memo: { type: "string" as const, kind: "transferId" as const, value: transferId },
+            }),
+          },
+          { value: BigInt(fees.toFixed(0)) },
+        );
+        const casperTx = CasperTransaction.fromJSON(crafted.transaction);
 
         // Serialize tx
         const txBytes = casperTx.toBytes();

--- a/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/craftTransaction.test.ts
@@ -1,0 +1,147 @@
+import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
+import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import BigNumber from "bignumber.js";
+import { Args, NativeTransferBuilder, Transaction } from "casper-js-sdk";
+import { TEST_ADDRESSES, TEST_TRANSFER_IDS } from "../__tests__/fixtures/addresses.fixture";
+import { CASPER_FEES_MOTES, CASPER_MAX_TRANSFER_ID } from "../constants";
+import { CasperInvalidTransferId } from "../errors";
+import type { CasperMemo } from "../types";
+import { craftTransaction } from "./craftTransaction";
+
+const baseIntent = (
+  overrides: Partial<TransactionIntent<CasperMemo>> = {},
+): TransactionIntent<CasperMemo> => {
+  return {
+    intentType: "transaction",
+    type: "send",
+    sender: TEST_ADDRESSES.SECP256K1,
+    recipient: TEST_ADDRESSES.RECIPIENT_SECP256K1,
+    amount: 2_500_000_000n,
+    asset: { type: "native" },
+    ...overrides,
+  };
+};
+
+const getArgs = (crafted: string): Args => {
+  return Transaction.fromJSON(crafted).getTransactionV1()!.payload.fields.args;
+};
+
+describe("craftTransaction", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("crafts a native transfer whose output round-trips through Transaction.fromJSON", async () => {
+    const { transaction } = await craftTransaction(baseIntent());
+
+    expect(() => Transaction.fromJSON(transaction)).not.toThrow();
+  });
+
+  it("includes the transfer id and preserves its exact value", async () => {
+    const idSpy = jest.spyOn(NativeTransferBuilder.prototype, "id");
+
+    const { transaction } = await craftTransaction(
+      baseIntent({
+        memo: {
+          type: "string",
+          kind: "transferId",
+          value: TEST_TRANSFER_IDS.VALID,
+        },
+      }),
+    );
+
+    expect(idSpy).toHaveBeenCalledWith(TEST_TRANSFER_IDS.VALID);
+    const idArg = getArgs(transaction).getByName("id");
+    expect(idArg?.option?.isEmpty()).toBe(false);
+    expect(idArg?.option?.value()?.ui64?.toString()).toBe(TEST_TRANSFER_IDS.VALID);
+  });
+
+  it.each([
+    ["no memo is provided", undefined],
+    ["the transfer id is an empty string", ""],
+  ])("omits the id argument entirely when %s", async (_case, value) => {
+    const idSpy = jest.spyOn(NativeTransferBuilder.prototype, "id");
+
+    const { transaction } = await craftTransaction(
+      baseIntent(
+        value === undefined ? {} : { memo: { type: "string", kind: "transferId", value } },
+      ),
+    );
+
+    expect(idSpy).not.toHaveBeenCalled();
+    expect(getArgs(transaction).getByName("id")).toBeUndefined();
+  });
+
+  it.each([
+    ["beyond Number.MAX_SAFE_INTEGER", "9007199254740993"],
+    ["just below the maximum", new BigNumber(CASPER_MAX_TRANSFER_ID).minus(1).toString()],
+  ])("preserves a transfer id %s without truncation", async (_case, value) => {
+    const { transaction } = await craftTransaction(
+      baseIntent({ memo: { type: "string", kind: "transferId", value } }),
+    );
+
+    expect(getArgs(transaction).getByName("id")?.option?.value()?.ui64?.toString()).toBe(value);
+  });
+
+  it("rejects a transfer id equal to the maximum (validateMemo is strictly less-than)", async () => {
+    await expect(
+      craftTransaction(
+        baseIntent({
+          memo: {
+            type: "string",
+            kind: "transferId",
+            value: CASPER_MAX_TRANSFER_ID,
+          },
+        }),
+      ),
+    ).rejects.toThrow(CasperInvalidTransferId);
+  });
+
+  it("rejects a non-numeric transfer id", async () => {
+    await expect(
+      craftTransaction(
+        baseIntent({
+          memo: {
+            type: "string",
+            kind: "transferId",
+            value: TEST_TRANSFER_IDS.INVALID,
+          },
+        }),
+      ),
+    ).rejects.toThrow(CasperInvalidTransferId);
+  });
+
+  it.each(["sender", "recipient"] as const)("rejects an invalid %s", async field => {
+    await expect(craftTransaction(baseIntent({ [field]: TEST_ADDRESSES.INVALID }))).rejects.toThrow(
+      InvalidAddress,
+    );
+  });
+
+  it("rejects a non-native asset", async () => {
+    await expect(
+      craftTransaction(baseIntent({ asset: { type: "cep18", assetReference: "hash-123" } })),
+    ).rejects.toThrow(/cep18/);
+  });
+
+  it("rejects a staking intent", async () => {
+    await expect(craftTransaction({ ...baseIntent(), intentType: "staking" })).rejects.toThrow(
+      /staking/,
+    );
+  });
+
+  it("uses customFees.value to override the default payment amount", async () => {
+    const paymentSpy = jest.spyOn(NativeTransferBuilder.prototype, "payment");
+
+    await craftTransaction(baseIntent(), { value: 999_000_000n });
+
+    expect(paymentSpy).toHaveBeenCalledWith(999_000_000);
+  });
+
+  it("defaults the payment amount from getEstimatedFees when customFees is omitted", async () => {
+    const paymentSpy = jest.spyOn(NativeTransferBuilder.prototype, "payment");
+
+    await craftTransaction(baseIntent());
+
+    expect(paymentSpy).toHaveBeenCalledWith(CASPER_FEES_MOTES);
+  });
+});

--- a/libs/coin-modules/coin-casper/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-casper/src/logic/craftTransaction.ts
@@ -1,37 +1,65 @@
+import type {
+  CraftedTransaction,
+  FeeEstimation,
+  TransactionIntent,
+} from "@ledgerhq/coin-module-framework/api/index";
 import { InvalidAddress } from "@ledgerhq/ledger-wallet-framework/errors";
-import { log } from "@ledgerhq/logs";
-import BigNumber from "bignumber.js";
-import { CasperNetwork, PublicKey, Transaction } from "casper-js-sdk";
-import { CASPER_DEFAULT_TTL, CASPER_NETWORK } from "../constants";
-import { getCasperNodeRpcClient } from "../network/api";
+import { NativeTransferBuilder, PublicKey } from "casper-js-sdk";
+import invariant from "invariant";
+import { CASPER_DEFAULT_TTL, CASPER_MAX_TRANSFER_ID, CASPER_NETWORK } from "../constants";
+import { CasperInvalidTransferId } from "../errors";
+import type { CasperMemo } from "../types";
+import { getEstimatedFees } from "./estimateFees";
+import { toSafeNumber } from "./utils";
 import { isAddressValid } from "./validateAddress";
+import { validateMemo } from "./validateMemo";
 
-export const createNewTransaction = async (
-  sender: string,
-  recipient: string,
-  amount: BigNumber,
-  fees: BigNumber,
-  transferId?: string,
-  network = CASPER_NETWORK,
-): Promise<Transaction> => {
-  log("debug", `Creating new Transaction: ${sender}, ${recipient}, ${network}`);
+export async function craftTransaction(
+  transactionIntent: TransactionIntent<CasperMemo>,
+  customFees?: FeeEstimation,
+): Promise<CraftedTransaction> {
+  invariant(transactionIntent.intentType !== "staking", "casper: staking is not supported");
+  invariant(
+    transactionIntent.asset.type === "native",
+    "casper: asset type %s is not supported",
+    transactionIntent.asset.type,
+  );
 
-  if (recipient && !isAddressValid(recipient)) {
+  const { sender, recipient, amount, expiration } = transactionIntent;
+
+  if (!isAddressValid(sender)) {
+    throw new InvalidAddress(`Invalid sender Address ${sender}`);
+  }
+
+  if (!isAddressValid(recipient)) {
     throw new InvalidAddress(`Invalid recipient Address ${recipient}`);
   }
 
-  const client = getCasperNodeRpcClient();
-  const helper = await CasperNetwork.create(client);
+  const memo = "memo" in transactionIntent ? transactionIntent.memo : undefined;
+  const transferId = memo?.type === "string" && memo.kind === "transferId" ? memo.value : undefined;
 
-  const tx = helper.createTransferTransaction(
-    PublicKey.fromHex(sender),
-    PublicKey.fromHex(recipient),
-    network,
-    amount.toString(),
-    fees.toNumber(),
-    CASPER_DEFAULT_TTL,
-    Number.parseInt(transferId ?? "0"),
-  );
+  if (typeof transferId === "string" && transferId.length > 0 && !validateMemo(transferId)) {
+    throw new CasperInvalidTransferId("", {
+      maxTransferId: CASPER_MAX_TRANSFER_ID,
+    });
+  }
 
-  return tx;
-};
+  const paymentMotes = customFees ? toSafeNumber(customFees.value) : getEstimatedFees().toNumber();
+
+  const builder = new NativeTransferBuilder()
+    .from(PublicKey.fromHex(sender))
+    .target(PublicKey.fromHex(recipient))
+    .amount(amount.toString())
+    .chainName(CASPER_NETWORK)
+    .payment(paymentMotes)
+    .ttl(expiration ?? CASPER_DEFAULT_TTL);
+
+  if (typeof transferId === "string" && transferId.length > 0) {
+    // @ts-expect-error - id() expects `number` but forwards it untouched; a string keeps large ids exact
+    builder.id(transferId);
+  }
+
+  const tx = builder.build();
+
+  return { transaction: JSON.stringify(tx.toJSON()) };
+}

--- a/libs/coin-modules/coin-casper/src/logic/operations.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/operations.test.ts
@@ -1,32 +1,8 @@
 import BigNumber from "bignumber.js";
 import { ITxnHistoryData } from "../types/network";
-import { TEST_ADDRESSES, TEST_TRANSFER_IDS } from "../__tests__/fixtures/addresses.fixture";
 import { createMockAccountShapeData } from "../__tests__/fixtures/sync.fixture";
-import { casperAccountHashFromPublicKey, isAddressValid } from "./validateAddress";
+import { casperAccountHashFromPublicKey } from "./validateAddress";
 import { getUnit, mapTxToOps } from "./listOperations";
-import { createNewTransaction as testCreateNewTransaction } from "./craftTransaction";
-
-// Import Casper SDK mock for direct access to mocks
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const mockCasperSDK = require("casper-js-sdk");
-
-// Mock the entire Casper SDK
-jest.mock("casper-js-sdk", () => {
-  const mockTransaction = { id: "mock-transaction" };
-  const mockHelper = {
-    createTransferTransaction: jest.fn().mockReturnValue(mockTransaction),
-  };
-
-  return {
-    CasperNetwork: {
-      create: jest.fn().mockResolvedValue(mockHelper),
-    },
-    PublicKey: {
-      fromHex: jest.fn().mockReturnValue({ value: "mocked-public-key" }),
-    },
-    Transaction: jest.fn().mockImplementation(() => mockTransaction),
-  };
-});
 
 jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
   encodeOperationId: jest.fn(
@@ -36,11 +12,6 @@ jest.mock("@ledgerhq/ledger-wallet-framework/operation", () => ({
 
 jest.mock("./validateAddress", () => ({
   casperAccountHashFromPublicKey: jest.fn((key: string) => `account-hash-${key}`),
-  isAddressValid: jest.fn(),
-}));
-
-jest.mock("../network/api", () => ({
-  getCasperNodeRpcClient: jest.fn(),
 }));
 
 describe("txn", () => {
@@ -331,46 +302,6 @@ describe("txn", () => {
       const operations = mapper(txData as any);
 
       expect(operations).toEqual([]);
-    });
-  });
-
-  describe("createNewTransaction", () => {
-    const { mockAddress: mockSender } = createMockAccountShapeData();
-    const mockRecipient = TEST_ADDRESSES.RECIPIENT_SECP256K1;
-    const mockAmount = new BigNumber("5000000000");
-    const mockFees = new BigNumber("100000000");
-    const mockTransferId = TEST_TRANSFER_IDS.VALID;
-
-    const mockCreateNetwork = mockCasperSDK.CasperNetwork.create;
-    const mockPublicKeyFromHex = mockCasperSDK.PublicKey.fromHex;
-
-    beforeEach(() => {
-      (isAddressValid as jest.Mock).mockReturnValue(true);
-    });
-
-    test("should throw error if recipient address is invalid", async () => {
-      (isAddressValid as jest.Mock).mockReturnValue(false);
-
-      await expect(
-        testCreateNewTransaction(mockSender, mockRecipient, mockAmount, mockFees),
-      ).rejects.toThrow();
-    });
-
-    test("should create a new transaction with valid parameters", async () => {
-      const expectedTransaction = { id: "mock-transaction" };
-
-      const result = await testCreateNewTransaction(
-        mockSender,
-        mockRecipient,
-        mockAmount,
-        mockFees,
-        mockTransferId,
-      );
-
-      expect(result).toEqual(expectedTransaction);
-      expect(mockCreateNetwork).toHaveBeenCalled();
-      expect(mockPublicKeyFromHex).toHaveBeenCalledWith(mockSender);
-      expect(mockPublicKeyFromHex).toHaveBeenCalledWith(mockRecipient);
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/logic/utils.test.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.test.ts
@@ -4,6 +4,7 @@ import {
   isError,
   methodToString,
   getRandomTransferID,
+  toSafeNumber,
 } from "./utils";
 
 describe("Casper utils", () => {
@@ -70,6 +71,25 @@ describe("Casper utils", () => {
 
       // There's a very small chance these could be the same, but it's extremely unlikely
       expect(new Set([id1, id2, id3]).size).toBeGreaterThan(0);
+    });
+  });
+
+  describe("toSafeNumber", () => {
+    test("should convert a bigint within the safe integer range", () => {
+      expect(toSafeNumber(999_000_000n)).toBe(999_000_000);
+    });
+
+    test("should accept the exact safe integer bounds", () => {
+      expect(toSafeNumber(BigInt(Number.MAX_SAFE_INTEGER))).toBe(Number.MAX_SAFE_INTEGER);
+      expect(toSafeNumber(BigInt(Number.MIN_SAFE_INTEGER))).toBe(Number.MIN_SAFE_INTEGER);
+    });
+
+    test("should throw for a value above the safe integer range", () => {
+      expect(() => toSafeNumber(BigInt(Number.MAX_SAFE_INTEGER) + 1n)).toThrow(RangeError);
+    });
+
+    test("should throw for a value below the safe integer range", () => {
+      expect(() => toSafeNumber(BigInt(Number.MIN_SAFE_INTEGER) - 1n)).toThrow(RangeError);
     });
   });
 });

--- a/libs/coin-modules/coin-casper/src/logic/utils.ts
+++ b/libs/coin-modules/coin-casper/src/logic/utils.ts
@@ -47,3 +47,11 @@ function randomIntFromInterval(min: number, max: number): string {
 export function getRandomTransferID(): string {
   return randomIntFromInterval(0, Number.MAX_SAFE_INTEGER);
 }
+
+export function toSafeNumber(value: bigint): number {
+  if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
+    throw new RangeError(`value ${value} exceeds the safe integer range`);
+  }
+
+  return Number(value);
+}

--- a/libs/coin-modules/coin-casper/src/types/coinframework.ts
+++ b/libs/coin-modules/coin-casper/src/types/coinframework.ts
@@ -1,0 +1,3 @@
+import { MemoNotSupported, StringMemo } from "@ledgerhq/coin-module-framework/api/types";
+
+export type CasperMemo = MemoNotSupported | StringMemo<"transferId">;

--- a/libs/coin-modules/coin-casper/src/types/index.ts
+++ b/libs/coin-modules/coin-casper/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./bridge";
+export * from "./coinframework";
 export * from "./config";
 export * from "./network";
 export * from "./signer";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

This PR Implements the `craftTransaction` coin-module API method for Casper, replacing previous "not supported" stub. 
It also adds a CasperMemo type (transferId string memo) so the coin-module API surface reflects Casper's actual memo support instead of MemoNotSupported.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- https://ledgerhq.atlassian.net/browse/LIVE-33294