### PR TITLE
[LWDM] feat(analytics): push pay tab card param to mixpanel (LIVE-35578)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -156,6 +156,16 @@ const getProductTourAttributes = () => {
   };
 };
 
+const getPayTabAttributes = () => {
+  if (!analyticsFeatureFlagMethod) return false;
+  const payTab = analyticsFeatureFlagMethod("lwdPayTab");
+
+  return {
+    isEnabled: payTab?.enabled ?? false,
+    card: payTab?.params?.card ?? false,
+  };
+};
+
 const getLargeScreenUpsellAttributes = () => {
   if (!analyticsFeatureFlagMethod) return {};
   const flag = analyticsFeatureFlagMethod("largeScreenUpsell");
@@ -286,6 +296,7 @@ const extraProperties = (store: ReduxStore) => {
   const addAccountAttributes = getAddAccountAttributes();
   const backupHubAttributes = getBackupHubAttributes();
   const productTourAttributes = getProductTourAttributes();
+  const payTabAttributes = getPayTabAttributes();
   const largeScreenUpsellAttributes = getLargeScreenUpsellAttributes();
 
   const deviceInfo = device
@@ -376,6 +387,7 @@ const extraProperties = (store: ReduxStore) => {
     totalStakeableAssets: combinedIds.size,
     stakeableAssets: stakeableAssetsList,
     wallet40Attributes,
+    payTabAttributes,
     finishOnboardingWidget: onboardingWidgetFlag?.enabled,
     ...onboardingCounterfeitWarningAttributes,
     newSendFlow,

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -292,6 +292,16 @@ const getProductTourAttributes = () => {
   };
 };
 
+const getPayTabAttributes = () => {
+  if (!analyticsFeatureFlagMethod) return false;
+  const payTab = analyticsFeatureFlagMethod("lwmPayTab");
+
+  return {
+    isEnabled: payTab?.enabled ?? false,
+    card: payTab?.params?.card ?? false,
+  };
+};
+
 const getLdmkAndSyncFlags = () => ({
   ldmkTransport: analyticsFeatureFlagMethod?.("ldmkTransport") ?? { enabled: false },
   ldmkConnectApp: analyticsFeatureFlagMethod?.("ldmkConnectApp") ?? { enabled: false },
@@ -430,6 +440,7 @@ const extraProperties = async (store: AppStore) => {
 
   const backupHubAttributes = getBackupHubAttributes();
   const productTourAttributes = getProductTourAttributes();
+  const payTabAttributes = getPayTabAttributes();
 
   return {
     ...mandatoryProperties,
@@ -479,6 +490,7 @@ const extraProperties = async (store: AppStore) => {
     totalStakeableAssets: combinedIds.size,
     stakeableAssets: stakeableAssetsList,
     wallet40Attributes,
+    payTabAttributes,
     quickActionsCtasVariant: quickActionsCtasVariantFlag?.enabled,
     finishOnboardingWidget: onboardingWidgetFlag?.enabled,
     ...onboardingCounterfeitWarningAttributes,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wire `lwdPayTab` / `lwmPayTab` into Segment `extraProperties` so Mixpanel receives `payTabAttributes` (`isEnabled` + `card`) as both user and event properties.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35578](https://ledgerhq.atlassian.net/browse/LIVE-35578), [LIVE-35579](https://ledgerhq.atlassian.net/browse/LIVE-35579) (parent epic [LIVE-33492](https://ledgerhq.atlassian.net/browse/LIVE-33492))
- **ADR** (if any): N/A

### ✅ Checklist

- [x] LWD: `getPayTabAttributes()` reads `lwdPayTab` and exposes `payTabAttributes`
- [x] LWM: `getPayTabAttributes()` reads `lwmPayTab` and exposes `payTabAttributes`
- [x] Properties flow through `extraProperties` (identify + track)

### 🧪 Test plan

- [ ] Enable `lwdPayTab` / `lwmPayTab` with `params.card` true/false in Feature Flags settings
- [ ] Confirm Segment identify payload includes `payTabAttributes.isEnabled` and `payTabAttributes.card`
- [ ] Confirm a tracked event includes the same `payTabAttributes`
- [ ] Confirm Mixpanel user + event properties update accordingly

[LIVE-35578]: https://ledgerhq.atlassian.net/browse/LIVE-35578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35579]: https://ledgerhq.atlassian.net/browse/LIVE-35579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33492]: https://ledgerhq.atlassian.net/browse/LIVE-33492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ