### PR TITLE
[LWD] feat(die): add lwd shell tracking (LIVE-33003)

### DIFF
--- a/.changeset/die-lwd-shell-tracking.md
+++ b/.changeset/die-lwd-shell-tracking.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add Device Intent Executor shell tracking (lifecycle, errors, dialog dismiss).

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/DeviceDisconnected.tsx
@@ -1,26 +1,64 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { DeviceDisconnectedComponent } from "@ledgerhq/device-intent";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "./TrackDIEScreen";
+import {
+  DEVICE_ACTION_BUTTON,
+  getConnectedDeviceTrackingProperties,
+  PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
+} from "../utils/trackDeviceIntent";
 
-export const DeviceDisconnected: DeviceDisconnectedComponent = ({ onRetry, onClose }) => {
+export const DeviceDisconnected: DeviceDisconnectedComponent = ({ device, onRetry, onClose }) => {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const { modelId, transport } = getConnectedDeviceTrackingProperties(device);
+  const handleRetry = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      button: DEVICE_ACTION_BUTTON.Retry,
+      modelId,
+      transport,
+      extraProperties: analyticsProperties,
+    });
+    onRetry();
+  };
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      button: DEVICE_ACTION_BUTTON.Close,
+      modelId,
+      transport,
+      extraProperties: analyticsProperties,
+    });
+    onClose();
+  };
 
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={t("deviceIntentExecutor.errors.connectionError.title")}
-      description={t("deviceIntentExecutor.errors.connectionError.description")}
-      primaryCta={{
-        label: t("common.retry"),
-        onPress: onRetry,
-      }}
-      secondaryCta={{
-        label: t("common.close"),
-        onPress: onClose,
-      }}
-      testID="device-intent-executor-device-disconnected"
-    />
+    <>
+      <TrackDIEScreen
+        category={PAGE_DEVICE_ACTION.Disconnected}
+        modelId={modelId}
+        transport={transport}
+        refreshSource
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={t("deviceIntentExecutor.errors.connectionError.title")}
+        description={t("deviceIntentExecutor.errors.connectionError.description")}
+        primaryCta={{
+          label: t("common.retry"),
+          onPress: handleRetry,
+        }}
+        secondaryCta={{
+          label: t("common.close"),
+          onPress: handleClose,
+        }}
+        testID="device-intent-executor-device-disconnected"
+      />
+    </>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/IntentError.tsx
@@ -2,8 +2,16 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import type { ErrorComponent } from "@ledgerhq/device-intent";
 import { isDmkError } from "@ledgerhq/live-dmk-desktop";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "./TrackDIEScreen";
+import {
+  DEVICE_ACTION_BUTTON,
+  getConnectedDeviceTrackingProperties,
+  PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
+} from "../utils/trackDeviceIntent";
 
 const devBanner = __DEV__
   ? ({
@@ -15,39 +23,69 @@ const devBanner = __DEV__
     } as const)
   : undefined;
 
-export const IntentError: ErrorComponent = ({ onRetry, onClose, error }) => {
+export const IntentError: ErrorComponent = ({ device, onRetry, onClose, error }) => {
   const { t } = useTranslation();
   const errorIsTranslatable = error && (isDmkError(error) || error instanceof Error);
   const translatedError = error as Error;
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const { modelId, transport } = getConnectedDeviceTrackingProperties(device);
+  const handleRetry = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      button: DEVICE_ACTION_BUTTON.Retry,
+      modelId,
+      transport,
+      extraProperties: analyticsProperties,
+    });
+    onRetry();
+  };
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      button: DEVICE_ACTION_BUTTON.Close,
+      modelId,
+      transport,
+      extraProperties: analyticsProperties,
+    });
+    onClose();
+  };
 
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={
-        errorIsTranslatable ? (
-          <TranslatedError error={translatedError} field="title" />
-        ) : (
-          t("deviceIntentExecutor.errors.intentError.title")
-        )
-      }
-      description={
-        errorIsTranslatable ? (
-          <TranslatedError error={translatedError} field="description" />
-        ) : (
-          t("deviceIntentExecutor.errors.intentError.description")
-        )
-      }
-      banner={devBanner}
-      primaryCta={{
-        label: t("common.retry"),
-        onPress: onRetry,
-      }}
-      secondaryCta={{
-        label: t("common.close"),
-        onPress: onClose,
-      }}
-      testID="device-intent-executor-intent-error"
-    />
+    <>
+      <TrackDIEScreen
+        category={PAGE_DEVICE_ACTION.UnknownIntentError}
+        modelId={modelId}
+        transport={transport}
+        refreshSource
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={
+          errorIsTranslatable ? (
+            <TranslatedError error={translatedError} field="title" />
+          ) : (
+            t("deviceIntentExecutor.errors.intentError.title")
+          )
+        }
+        description={
+          errorIsTranslatable ? (
+            <TranslatedError error={translatedError} field="description" />
+          ) : (
+            t("deviceIntentExecutor.errors.intentError.description")
+          )
+        }
+        banner={devBanner}
+        primaryCta={{
+          label: t("common.retry"),
+          onPress: handleRetry,
+        }}
+        secondaryCta={{
+          label: t("common.close"),
+          onPress: handleClose,
+        }}
+        testID="device-intent-executor-intent-error"
+      />
+    </>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/InvalidOperation.tsx
@@ -1,7 +1,14 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 import type { InvalidOperationComponent } from "@ledgerhq/device-intent";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "./TrackDIEScreen";
+import {
+  DEVICE_ACTION_BUTTON,
+  PAGE_DEVICE_ACTION,
+  trackDeviceActionButtonClicked,
+} from "../utils/trackDeviceIntent";
 
 const devBanner = __DEV__
   ? ({
@@ -16,19 +23,31 @@ const devBanner = __DEV__
 
 export const InvalidOperation: InvalidOperationComponent = ({ onClose }) => {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const handleClose = () => {
+    trackDeviceActionButtonClicked({
+      sourceFlow,
+      button: DEVICE_ACTION_BUTTON.Close,
+      extraProperties: analyticsProperties,
+    });
+    onClose();
+  };
 
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={t("deviceIntentExecutor.errors.invalidOperation.title")}
-      description={t("deviceIntentExecutor.errors.invalidOperation.description")}
-      banner={devBanner}
-      primaryCta={{
-        label: t("common.close"),
-        onPress: onClose,
-      }}
-      testID="device-intent-executor-invalid-operation"
-    />
+    <>
+      <TrackDIEScreen category={PAGE_DEVICE_ACTION.InvalidState} refreshSource />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={t("deviceIntentExecutor.errors.invalidOperation.title")}
+        description={t("deviceIntentExecutor.errors.invalidOperation.description")}
+        banner={devBanner}
+        primaryCta={{
+          label: t("common.close"),
+          onPress: handleClose,
+        }}
+        testID="device-intent-executor-invalid-operation"
+      />
+    </>
   );
 };

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/TrackDIEScreen.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/TrackDIEScreen.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render } from "tests/testSetup";
+import { DeviceIntentTrackingProvider } from "@ledgerhq/live-dmk-shared";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { TrackDIEScreen } from "./TrackDIEScreen";
+
+jest.mock("~/renderer/analytics/TrackPage", () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+const mockedTrackPage = jest.mocked(TrackPage);
+
+describe("TrackDIEScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GIVEN provider analytics properties WHEN rendering THEN it forwards them with canonical DIE properties", () => {
+    const analyticsProperties = { manifestId: "app-id", manifestName: "My app" };
+
+    render(
+      <DeviceIntentTrackingProvider value={{ sourceFlow: "wallet_api", analyticsProperties }}>
+        <TrackDIEScreen category="Device Action - Disconnected" refreshSource />
+      </DeviceIntentTrackingProvider>,
+    );
+
+    expect(mockedTrackPage).toHaveBeenCalledWith(
+      {
+        category: "Device Action - Disconnected",
+        deviceUxV2: true,
+        manifestId: "app-id",
+        manifestName: "My app",
+        refreshSource: true,
+        sourceFlow: "wallet_api",
+      },
+      undefined,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/TrackDIEScreen.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/components/TrackDIEScreen.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
+import TrackPage from "~/renderer/analytics/TrackPage";
+
+type TrackDIEScreenProps = React.ComponentProps<typeof TrackPage> & {
+  sourceFlow?: never;
+  deviceUxV2?: never;
+};
+
+export function TrackDIEScreen(props: TrackDIEScreenProps): React.ReactNode {
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+
+  return <TrackPage {...analyticsProperties} {...props} sourceFlow={sourceFlow} deviceUxV2 />;
+}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/index.tsx
@@ -61,7 +61,8 @@ const emptyAnalyticsProperties: DeviceIntentTrackingProperties = {};
 export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): React.ReactElement | null {
-  const { wrappedProps, onOpenChange, onClose } = useDeviceIntentExecutorLWDViewModel(props);
+  const { wrappedProps, onOpenChange, onHeaderClosePressed, onOverlayDismiss, onEscapeKeyDown } =
+    useDeviceIntentExecutorLWDViewModel(props);
   const analyticsProperties = props.analyticsProperties ?? emptyAnalyticsProperties;
   const trackingContextValue = React.useMemo(
     () => ({ sourceFlow: props.sourceFlow, analyticsProperties }),
@@ -76,10 +77,12 @@ export function DeviceIntentExecutorLWD<JobState, Input, ExtraProps>(
         aria-describedby={undefined}
         className="max-h-[90vh] w-[400px] bg-base p-0"
         data-testid="device-intent-executor-dialog"
+        onPointerDownOutside={onOverlayDismiss}
+        onEscapeKeyDown={onEscapeKeyDown}
       >
         <DialogBackgroundToneProvider>
           <DeviceIntentTrackingProvider value={trackingContextValue}>
-            <DialogHeader density="compact" onClose={onClose} className="!mb-0" />
+            <DialogHeader density="compact" onClose={onHeaderClosePressed} className="!mb-0" />
             <DialogBody className="!mb-0 flex min-h-0 flex-col px-24 pb-24">
               <DeviceIntentExecutor
                 {...wrappedProps}

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.test.tsx
@@ -1,0 +1,461 @@
+import { act, renderHook } from "@testing-library/react";
+import type {
+  DeviceConnectionResult,
+  DeviceExtractedContext,
+  DeviceIntentExecutorProps,
+  ExecutorState,
+} from "@ledgerhq/device-intent";
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/renderer/analytics/segment";
+import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
+import type { InitializerConfig } from "./DeviceContextInitializerComponentLWD";
+import type { InitializationInput } from "./types";
+import { PAGE_DEVICE_ACTION } from "./utils/trackDeviceIntent";
+import { useDeviceIntentExecutorLWDViewModel } from "./useDeviceIntentExecutorLWDViewModel";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+}));
+
+const mockedTrack = jest.mocked(track);
+
+const layerABaseProperties = {
+  deviceUxV2: true,
+};
+
+type Props = DeviceIntentExecutorProps<unknown, unknown, unknown, InitializationInput> & {
+  initializerConfig?: InitializerConfig;
+  sourceFlow: "swap";
+  analyticsProperties?: Record<string, string | number | boolean | undefined>;
+};
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  return {
+    deviceConnectionParams: {} as Props["deviceConnectionParams"],
+    deviceInitializationInput: {} as InitializationInput,
+    onExecutorStateChanged: jest.fn(),
+    intent: {} as Props["intent"],
+    intentComponentExtraProps: undefined,
+    onIntentJobStateChanged: jest.fn(),
+    onIntentJobComplete: jest.fn(),
+    onIntentJobError: jest.fn(),
+    enabled: true,
+    onUserCancel: jest.fn(),
+    cancelIntentRequestId: undefined,
+    sourceFlow: "swap",
+    ...overrides,
+  };
+}
+
+function renderViewModel(initialProps?: Partial<Props>) {
+  let props = makeProps(initialProps);
+  const { result, rerender, unmount } = renderHook(() =>
+    useDeviceIntentExecutorLWDViewModel(props),
+  );
+  const rerenderWithProps = (overrides: Partial<Props>) => {
+    props = { ...props, ...overrides };
+    rerender(undefined);
+  };
+
+  return { result, rerender, rerenderWithProps, unmount, props };
+}
+
+function makeConnectionResult(
+  overrides: Partial<DeviceConnectionResult["connectedDevice"]> = {},
+): DeviceConnectionResult {
+  return {
+    connectedDevice: {
+      modelId: ledgerToDmkDeviceIdMap[DeviceModelId.stax],
+      type: "BLE",
+      ...overrides,
+    },
+  } as DeviceConnectionResult;
+}
+
+const TEST_EXTRACTED_CONTEXT = {} as DeviceExtractedContext;
+
+function executingIntentState(
+  connectionResult: DeviceConnectionResult = makeConnectionResult(),
+): ExecutorState {
+  return {
+    type: "executingIntent",
+    connectionResult,
+    extractedContext: TEST_EXTRACTED_CONTEXT,
+  };
+}
+
+describe("useDeviceIntentExecutorLWDViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentRouteNameRef.current = "Connect Device - Connecting";
+  });
+
+  describe("GIVEN the ViewModel mounts", () => {
+    it("WHEN the hook renders again THEN it fires deviceflow_started exactly once with the sourceFlow", () => {
+      const { rerender } = renderViewModel();
+      rerender(undefined);
+
+      const startedCalls = mockedTrack.mock.calls.filter(
+        ([eventName]) => eventName === "deviceflow_started",
+      );
+      expect(startedCalls).toHaveLength(1);
+      expect(startedCalls[0]).toEqual([
+        "deviceflow_started",
+        { ...layerABaseProperties, sourceFlow: "swap" },
+      ]);
+    });
+
+    it("WHEN the executor is disabled THEN it does not fire deviceflow_started", () => {
+      renderViewModel({ enabled: false });
+
+      expect(mockedTrack).not.toHaveBeenCalledWith("deviceflow_started", expect.anything());
+    });
+  });
+
+  describe("GIVEN a disabled ViewModel", () => {
+    it("WHEN the executor is enabled THEN it fires deviceflow_started", () => {
+      const { rerenderWithProps } = renderViewModel({ enabled: false });
+      mockedTrack.mockClear();
+
+      rerenderWithProps({ enabled: true });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_started", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+  });
+
+  describe("GIVEN the executor reaches executingIntent for the first time", () => {
+    it("WHEN the connection result is BLE THEN it fires app_ready THEN deviceflow_completed with the data carried by the state", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(
+          executingIntentState(
+            makeConnectionResult({
+              modelId: ledgerToDmkDeviceIdMap[DeviceModelId.stax],
+              type: "BLE",
+            }),
+          ),
+        );
+      });
+
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+    });
+
+    it("WHEN the connection result is USB THEN deviceflow_completed reports transport: usb", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(
+          executingIntentState(
+            makeConnectionResult({
+              modelId: ledgerToDmkDeviceIdMap[DeviceModelId.nanoX],
+              type: "USB",
+            }),
+          ),
+        );
+      });
+
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+      });
+    });
+
+    it("THEN it forwards the executor state to the original onExecutorStateChanged", () => {
+      const onExecutorStateChanged = jest.fn();
+      const { result } = renderViewModel({ onExecutorStateChanged });
+      const state = executingIntentState();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(state);
+      });
+
+      expect(onExecutorStateChanged).toHaveBeenCalledWith(state);
+    });
+  });
+
+  describe("GIVEN the executor enters executingIntent a second time", () => {
+    it("THEN it does not re-fire app_ready / deviceflow_completed", () => {
+      const { result } = renderViewModel();
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+
+      expect(mockedTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GIVEN a completed flow is disabled and reenabled", () => {
+    it("WHEN the executor reaches executingIntent again THEN it tracks the new flow completion", () => {
+      const { result, rerenderWithProps } = renderViewModel();
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      rerenderWithProps({ enabled: false });
+      rerenderWithProps({ enabled: true });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+    });
+
+    it("WHEN the user cancels before executingIntent again THEN it tracks the new flow cancellation", () => {
+      const onUserCancel = jest.fn();
+      const { result, rerenderWithProps } = renderViewModel({ onUserCancel });
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      rerenderWithProps({ enabled: false });
+      rerenderWithProps({ enabled: true });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GIVEN a non-completing executor state", () => {
+    const nonCompleting: ExecutorState[] = [
+      { type: "connectingDevice" },
+      { type: "deviceDisconnected", device: makeConnectionResult().connectedDevice },
+      { type: "initializingDeviceContext", connectionResult: makeConnectionResult() },
+      { type: "idle" },
+    ];
+
+    it.each(nonCompleting)("WHEN state is $type THEN no additional Layer A event fires", state => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(state);
+      });
+
+      expect(mockedTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GIVEN the dialog dismiss interaction is triggered", () => {
+    it("WHEN the header close button is pressed THEN it tracks the Close button click", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.onHeaderClosePressed();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
+    it("WHEN the overlay is pressed THEN it tracks the Close button click", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.onOverlayDismiss();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
+    it("WHEN Escape is pressed THEN it tracks the Close button click", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.onEscapeKeyDown();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+      });
+    });
+
+    it("WHEN the user cancels (onOpenChange) THEN it does NOT track the Close button click", () => {
+      const { result } = renderViewModel();
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.onOpenChange(false);
+      });
+
+      expect(mockedTrack).not.toHaveBeenCalledWith("button_clicked", expect.anything());
+    });
+  });
+
+  describe("GIVEN a ViewModel that has not yet completed", () => {
+    it("WHEN the user cancels from a non-blocking page THEN it fires deviceflow_aborted and forwards to the original onUserCancel", () => {
+      const onUserCancel = jest.fn();
+      const { result } = renderViewModel({ onUserCancel });
+
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("WHEN the user cancels from a shell error page THEN it fires deviceflow_failed and forwards to the original onUserCancel", () => {
+      currentRouteNameRef.current = PAGE_DEVICE_ACTION.Disconnected;
+      const onUserCancel = jest.fn();
+      const { result } = renderViewModel({ onUserCancel });
+
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GIVEN a ViewModel that has already completed (executingIntent observed)", () => {
+    it("WHEN the user cancels THEN it does NOT fire deviceflow_aborted but still forwards to the original onUserCancel", () => {
+      const onUserCancel = jest.fn();
+      const { result } = renderViewModel({ onUserCancel });
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      expect(mockedTrack).not.toHaveBeenCalledWith("deviceflow_aborted", expect.anything());
+      expect(onUserCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GIVEN analyticsProperties (e.g. wallet-api manifest) are provided", () => {
+    const MANIFEST_PROPS = { manifestId: "swap-live-app", manifestName: "Swap" };
+
+    it("WHEN the flow starts THEN deviceflow_started is enriched with the analytics properties", () => {
+      renderViewModel({ analyticsProperties: MANIFEST_PROPS });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_started", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        ...MANIFEST_PROPS,
+      });
+    });
+
+    it("WHEN executingIntent is reached THEN app_ready and deviceflow_completed are enriched", () => {
+      const { result } = renderViewModel({ analyticsProperties: MANIFEST_PROPS });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onExecutorStateChanged(executingIntentState());
+      });
+
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        ...MANIFEST_PROPS,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+        ...MANIFEST_PROPS,
+      });
+    });
+
+    it("WHEN the dialog is closed THEN the Close button_clicked is enriched", () => {
+      const { result } = renderViewModel({ analyticsProperties: MANIFEST_PROPS });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.onHeaderClosePressed();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: "Close",
+        ...MANIFEST_PROPS,
+      });
+    });
+
+    it("WHEN the user cancels before completion THEN deviceflow_aborted is enriched", () => {
+      const { result } = renderViewModel({ analyticsProperties: MANIFEST_PROPS });
+      mockedTrack.mockClear();
+
+      act(() => {
+        result.current.wrappedProps.onUserCancel();
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        ...MANIFEST_PROPS,
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/useDeviceIntentExecutorLWDViewModel.ts
@@ -1,7 +1,24 @@
-import { useCallback } from "react";
-import type { DeviceIntentExecutorProps } from "@ledgerhq/device-intent";
+import { useCallback, useEffect, useRef } from "react";
+import type {
+  DeviceConnectionResult,
+  DeviceIntentExecutorProps,
+  ExecutorState,
+} from "@ledgerhq/device-intent";
+import {
+  dmkToLedgerDeviceIdMap,
+  type DeviceIntentTrackingProperties,
+  type SourceFlow,
+} from "@ledgerhq/live-dmk-shared";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { InitializerConfig } from "./DeviceContextInitializerComponentLWD";
 import type { InitializationInput } from "./types";
+import {
+  trackAppReady,
+  trackDeviceflowCanceled,
+  trackDeviceflowCompleted,
+  trackDeviceflowStarted,
+  trackDrawerCloseButtonClicked,
+} from "./utils/trackDeviceIntent";
 
 type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   JobState,
@@ -10,31 +27,124 @@ type Props<JobState, Input, ExtraProps> = DeviceIntentExecutorProps<
   InitializationInput
 > & {
   initializerConfig?: InitializerConfig;
+  sourceFlow: SourceFlow;
+  analyticsProperties?: DeviceIntentTrackingProperties;
 };
 
 export type DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> = {
   wrappedProps: Props<JobState, Input, ExtraProps>;
   onOpenChange: (open: boolean) => void;
-  onClose: () => void;
+  /**
+   * Tracks the "Close" `button_clicked` event when the dialog header close button is pressed.
+   * Wired to `DialogHeader.onClose` so tracking reflects real user intent, unlike
+   * `onOpenChange` which can fire for any closing reason.
+   */
+  onHeaderClosePressed: () => void;
+  /**
+   * Tracks the "Close" `button_clicked` event when the dialog overlay is pressed.
+   * Wired to `DialogContent.onPointerDownOutside`.
+   */
+  onOverlayDismiss: () => void;
+  /**
+   * Tracks the "Close" `button_clicked` event when Escape is pressed.
+   * Wired to `DialogContent.onEscapeKeyDown`.
+   */
+  onEscapeKeyDown: () => void;
 };
+
+type ConnectionTrackingInfo = {
+  modelId: DeviceModelId;
+  transport: "ble" | "usb";
+};
+
+const emptyAnalyticsProperties: DeviceIntentTrackingProperties = {};
+
+function mapConnectionResult(result: DeviceConnectionResult): ConnectionTrackingInfo {
+  return {
+    modelId: dmkToLedgerDeviceIdMap[result.connectedDevice.modelId],
+    transport: result.connectedDevice.type === "USB" ? "usb" : "ble",
+  };
+}
 
 export function useDeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps>(
   props: Props<JobState, Input, ExtraProps>,
 ): DeviceIntentExecutorLWDViewModel<JobState, Input, ExtraProps> {
-  const { onUserCancel } = props;
+  const {
+    enabled,
+    sourceFlow,
+    analyticsProperties = emptyAnalyticsProperties,
+    onExecutorStateChanged,
+    onUserCancel,
+  } = props;
+
+  const flowStartedRef = useRef(false);
+  const initializationCompletedRef = useRef(false);
+  const cancelTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      flowStartedRef.current = false;
+      initializationCompletedRef.current = false;
+      cancelTrackedRef.current = false;
+      return;
+    }
+
+    if (flowStartedRef.current) return;
+    flowStartedRef.current = true;
+    initializationCompletedRef.current = false;
+    trackDeviceflowStarted({ sourceFlow, extraProperties: analyticsProperties });
+  }, [enabled, sourceFlow, analyticsProperties]);
+
+  const wrappedOnExecutorStateChanged = useCallback(
+    (state: ExecutorState) => {
+      if (enabled && state.type === "executingIntent" && !initializationCompletedRef.current) {
+        initializationCompletedRef.current = true;
+        const { modelId, transport } = mapConnectionResult(state.connectionResult);
+        trackAppReady({ sourceFlow, modelId, extraProperties: analyticsProperties });
+        trackDeviceflowCompleted({
+          sourceFlow,
+          modelId,
+          transport,
+          extraProperties: analyticsProperties,
+        });
+      }
+      onExecutorStateChanged(state);
+    },
+    [enabled, onExecutorStateChanged, sourceFlow, analyticsProperties],
+  );
+
+  const trackClose = useCallback(() => {
+    trackDrawerCloseButtonClicked({ sourceFlow, extraProperties: analyticsProperties });
+  }, [sourceFlow, analyticsProperties]);
+
+  const wrappedOnUserCancel = useCallback(() => {
+    if (!cancelTrackedRef.current) {
+      cancelTrackedRef.current = true;
+      if (!initializationCompletedRef.current) {
+        trackDeviceflowCanceled({ sourceFlow, extraProperties: analyticsProperties });
+      }
+    }
+    onUserCancel();
+  }, [onUserCancel, sourceFlow, analyticsProperties]);
 
   const onOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
-        onUserCancel();
+        wrappedOnUserCancel();
       }
     },
-    [onUserCancel],
+    [wrappedOnUserCancel],
   );
 
   return {
-    wrappedProps: props,
+    wrappedProps: {
+      ...props,
+      onExecutorStateChanged: wrappedOnExecutorStateChanged,
+      onUserCancel: wrappedOnUserCancel,
+    },
     onOpenChange,
-    onClose: onUserCancel,
+    onHeaderClosePressed: trackClose,
+    onOverlayDismiss: trackClose,
+    onEscapeKeyDown: trackClose,
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -1,0 +1,266 @@
+import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { DeviceModelId } from "@ledgerhq/types-devices";
+import { track } from "~/renderer/analytics/segment";
+import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
+import {
+  DEVICE_ACTION_BUTTON,
+  getConnectedDeviceTrackingProperties,
+  PAGE_DEVICE_ACTION,
+  trackAppReady,
+  trackDeviceActionButtonClicked,
+  trackDeviceflowAborted,
+  trackDeviceflowCanceled,
+  trackDeviceflowCompleted,
+  trackDeviceflowFailed,
+  trackDeviceflowStarted,
+  trackDrawerCloseButtonClicked,
+} from "./trackDeviceIntent";
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
+}));
+
+const mockedTrack = jest.mocked(track);
+
+const connectedDevice = {
+  id: "device-id",
+  name: "Ledger Stax",
+  modelId: ledgerToDmkDeviceIdMap[DeviceModelId.stax],
+  sessionId: "session-id",
+  type: "BLE" as const,
+  transport: "ble" as const,
+};
+
+const layerABaseProperties = {
+  deviceUxV2: true,
+};
+
+describe("trackDeviceIntent — Layer A tracking helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentRouteNameRef.current = "Connect Device - Connecting";
+  });
+
+  describe("trackDeviceflowStarted", () => {
+    it("GIVEN a sourceFlow WHEN called THEN tracks deviceflow_started with the Layer A base properties", () => {
+      trackDeviceflowStarted({ sourceFlow: "swap", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_started", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+  });
+
+  describe("trackAppReady", () => {
+    it("GIVEN a sourceFlow and modelId WHEN called THEN tracks app_ready with sourceFlow and modelId", () => {
+      trackAppReady({
+        sourceFlow: "add_account",
+        modelId: DeviceModelId.nanoSP,
+        extraProperties: {},
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("app_ready", {
+        ...layerABaseProperties,
+        sourceFlow: "add_account",
+        modelId: DeviceModelId.nanoSP,
+      });
+    });
+  });
+
+  describe("trackDeviceflowCompleted", () => {
+    it("GIVEN full completion info WHEN called THEN tracks deviceflow_completed with sourceFlow, modelId and transport", () => {
+      trackDeviceflowCompleted({
+        sourceFlow: "onboarding",
+        modelId: DeviceModelId.europa,
+        transport: "usb",
+        extraProperties: {},
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_completed", {
+        ...layerABaseProperties,
+        sourceFlow: "onboarding",
+        modelId: DeviceModelId.europa,
+        transport: "usb",
+      });
+    });
+  });
+
+  describe("trackDeviceflowAborted", () => {
+    it("GIVEN a sourceFlow WHEN called THEN tracks deviceflow_aborted with the Layer A base properties", () => {
+      trackDeviceflowAborted({ sourceFlow: "my_ledger", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "my_ledger",
+      });
+    });
+  });
+
+  describe("trackDeviceflowFailed", () => {
+    it("GIVEN a sourceFlow WHEN called THEN tracks deviceflow_failed with the Layer A base properties", () => {
+      trackDeviceflowFailed({ sourceFlow: "my_ledger", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+        ...layerABaseProperties,
+        sourceFlow: "my_ledger",
+      });
+    });
+  });
+
+  describe("trackDeviceflowCanceled", () => {
+    it("GIVEN the current page is non-blocking WHEN called THEN it tracks deviceflow_aborted", () => {
+      currentRouteNameRef.current = "Connect Device - Connecting";
+
+      trackDeviceflowCanceled({ sourceFlow: "swap", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+
+    it.each([
+      PAGE_DEVICE_ACTION.Disconnected,
+      PAGE_DEVICE_ACTION.UnknownIntentError,
+      PAGE_DEVICE_ACTION.InvalidState,
+    ])(
+      "GIVEN the current page is shell error page %s WHEN called THEN it tracks deviceflow_failed",
+      page => {
+        currentRouteNameRef.current = page;
+
+        trackDeviceflowCanceled({ sourceFlow: "send", extraProperties: {} });
+
+        expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+          ...layerABaseProperties,
+          sourceFlow: "send",
+        });
+      },
+    );
+  });
+
+  describe("getConnectedDeviceTrackingProperties", () => {
+    it("GIVEN a connected device WHEN called THEN it maps DMK model and transport to tracking values", () => {
+      const usbDevice = {
+        ...connectedDevice,
+        modelId: ledgerToDmkDeviceIdMap[DeviceModelId.nanoX],
+        type: "USB" as const,
+      };
+
+      expect(getConnectedDeviceTrackingProperties(connectedDevice)).toEqual({
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+      expect(getConnectedDeviceTrackingProperties(usbDevice)).toEqual({
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+      });
+    });
+  });
+
+  describe("PAGE_DEVICE_ACTION", () => {
+    it("GIVEN generic DIE error pages THEN it exposes the expected page event names", () => {
+      expect(PAGE_DEVICE_ACTION).toEqual({
+        Disconnected: "Device Action - Disconnected",
+        UnknownIntentError: "Device Action - Unknown Intent Error",
+        InvalidState: "Device Action - Invalid State",
+      });
+    });
+  });
+
+  describe("trackDeviceActionButtonClicked", () => {
+    it("GIVEN sourceFlow button and device properties WHEN called THEN it tracks button_clicked without overriding the current page", () => {
+      trackDeviceActionButtonClicked({
+        sourceFlow: "send",
+        button: DEVICE_ACTION_BUTTON.Close,
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+        extraProperties: {},
+      });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+        button: DEVICE_ACTION_BUTTON.Close,
+        modelId: DeviceModelId.stax,
+        transport: "ble",
+      });
+    });
+  });
+
+  describe("trackDrawerCloseButtonClicked", () => {
+    it("GIVEN a sourceFlow WHEN called THEN it tracks Close button_clicked", () => {
+      trackDrawerCloseButtonClicked({ sourceFlow: "swap", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: DEVICE_ACTION_BUTTON.Close,
+      });
+    });
+  });
+
+  describe("contextual analytics properties propagation", () => {
+    const extraProperties = { manifestId: "swap-live-app", manifestName: "Swap" };
+
+    const trackingHelpers = [
+      {
+        name: "trackDeviceflowStarted",
+        track: () => trackDeviceflowStarted({ sourceFlow: "wallet_api", extraProperties }),
+      },
+      {
+        name: "trackAppReady",
+        track: () =>
+          trackAppReady({ sourceFlow: "wallet_api", modelId: DeviceModelId.stax, extraProperties }),
+      },
+      {
+        name: "trackDeviceflowCompleted",
+        track: () =>
+          trackDeviceflowCompleted({
+            sourceFlow: "wallet_api",
+            modelId: DeviceModelId.stax,
+            transport: "ble",
+            extraProperties,
+          }),
+      },
+      {
+        name: "trackDeviceflowAborted",
+        track: () => trackDeviceflowAborted({ sourceFlow: "wallet_api", extraProperties }),
+      },
+      {
+        name: "trackDeviceflowFailed",
+        track: () => trackDeviceflowFailed({ sourceFlow: "wallet_api", extraProperties }),
+      },
+      {
+        name: "trackDeviceflowCanceled",
+        track: () => trackDeviceflowCanceled({ sourceFlow: "wallet_api", extraProperties }),
+      },
+      {
+        name: "trackDeviceActionButtonClicked",
+        track: () =>
+          trackDeviceActionButtonClicked({
+            sourceFlow: "wallet_api",
+            button: DEVICE_ACTION_BUTTON.Retry,
+            modelId: DeviceModelId.stax,
+            transport: "ble",
+            extraProperties,
+          }),
+      },
+      {
+        name: "trackDrawerCloseButtonClicked",
+        track: () => trackDrawerCloseButtonClicked({ sourceFlow: "wallet_api", extraProperties }),
+      },
+    ];
+
+    describe.each(trackingHelpers)("$name", ({ track: trackEvent }) => {
+      it("GIVEN contextual analytics properties WHEN tracking THEN it forwards them to the event", () => {
+        const expectedProperties = expect.objectContaining(extraProperties);
+
+        trackEvent();
+
+        expect(mockedTrack).toHaveBeenCalledWith(expect.any(String), expectedProperties);
+      });
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -1,0 +1,145 @@
+import type { DeviceDisconnectedComponent } from "@ledgerhq/device-intent";
+import {
+  dmkToLedgerDeviceIdMap,
+  type DeviceIntentTrackingProperties,
+  type SourceFlow,
+} from "@ledgerhq/live-dmk-shared";
+import type { DeviceModelId } from "@ledgerhq/types-devices";
+import type { ComponentProps } from "react";
+import { track } from "~/renderer/analytics/segment";
+import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
+
+type ConnectedDevice = ComponentProps<DeviceDisconnectedComponent>["device"];
+
+export const PAGE_DEVICE_ACTION = {
+  Disconnected: "Device Action - Disconnected",
+  UnknownIntentError: "Device Action - Unknown Intent Error",
+  InvalidState: "Device Action - Invalid State",
+} as const;
+
+/**
+ * Canonical, locale-independent `button` values for Device Action `button_clicked`
+ * events. The displayed CTA label stays localized; analytics receives these stable
+ * strings so the property is not fragmented across languages.
+ */
+export const DEVICE_ACTION_BUTTON = {
+  Retry: "Retry",
+  Close: "Close",
+} as const;
+
+const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
+  PAGE_DEVICE_ACTION.Disconnected,
+  PAGE_DEVICE_ACTION.UnknownIntentError,
+  PAGE_DEVICE_ACTION.InvalidState,
+]);
+
+export type TrackingTransport = "ble" | "usb";
+
+export const getDeviceUxV2BaseProperties = (
+  sourceFlow: SourceFlow,
+  extraProperties?: DeviceIntentTrackingProperties,
+) => ({
+  ...extraProperties,
+  sourceFlow,
+  deviceUxV2: true,
+});
+
+export const getConnectedDeviceTrackingProperties = (
+  device: ConnectedDevice,
+): { modelId: DeviceModelId; transport: TrackingTransport } => ({
+  modelId: dmkToLedgerDeviceIdMap[device.modelId],
+  transport: device.type === "USB" ? "usb" : "ble",
+});
+
+export const trackDeviceflowStarted = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track(
+    "deviceflow_started",
+    getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+  );
+};
+
+export const trackAppReady = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("app_ready", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    modelId: params.modelId,
+  });
+};
+
+export const trackDeviceflowCompleted = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+  transport: TrackingTransport;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("deviceflow_completed", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    modelId: params.modelId,
+    transport: params.transport,
+  });
+};
+
+export const trackDeviceflowAborted = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track(
+    "deviceflow_aborted",
+    getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+  );
+};
+
+export const trackDeviceflowFailed = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track(
+    "deviceflow_failed",
+    getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+  );
+};
+
+export const trackDeviceflowCanceled = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  const currentPage = currentRouteNameRef.current;
+
+  if (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage)) {
+    trackDeviceflowFailed(params);
+    return;
+  }
+
+  trackDeviceflowAborted(params);
+};
+
+export const trackDeviceActionButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  button: string;
+  modelId?: DeviceModelId;
+  transport?: TrackingTransport;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    button: params.button,
+    ...(params.modelId ? { modelId: params.modelId } : {}),
+    ...(params.transport ? { transport: params.transport } : {}),
+  });
+};
+
+export const trackDrawerCloseButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    button: DEVICE_ACTION_BUTTON.Close,
+  });
+};


### PR DESCRIPTION
### 📝 Description

Port Device UX v2 DIE **shell** tracking from LWM to LWD: Layer A lifecycle, generic error screens, and dialog close/dismiss.

**Problem**: LWD DIE had the shared tracking context (LIVE-33202) but did not emit Device UX v2 funnel events for the executor shell.

**Solution**:
- Add shell-only `trackDeviceIntent` helpers and `TrackDIEScreen`
- Mirror LWM lifecycle in `useDeviceIntentExecutorLWDViewModel` (`deviceflow_started` / `app_ready` / `deviceflow_completed` / cancel)
- Track Close `button_clicked` on dialog header, overlay, and Escape (not on generic cancel)
- Wire page + CTA tracking on `DeviceDisconnected`, `IntentError`, and `InvalidOperation`

Connect Device / Connect App phase tracking remain out of scope (LIVE-35575 / LIVE-35576).

**Depends on**: [#20503](https://github.com/LedgerHQ/ledger-live/pull/20503) (shared `DeviceIntentTrackingContext`)

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33003](https://ledgerhq.atlassian.net/browse/LIVE-33003)
- **ADR** (if any): [Data tracking plan - Device UX V2 - LWM](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7157121213/Data+tracking+plan+-+Device+UX+V2+-+LWM)

[LIVE-33003]: https://ledgerhq.atlassian.net/browse/LIVE-33003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33202]: https://ledgerhq.atlassian.net/browse/LIVE-33202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ