### PR TITLE
docs(die): document LWD compatibility (LIVE-33002)

### DIFF
--- a/libs/device-intent/README.md
+++ b/libs/device-intent/README.md
@@ -83,6 +83,13 @@ connection, context-initialisation, and error screens. The shared core
 (`DeviceIntentExecutor`, state machine, intent definitions, initialization logic
 via `ensureAppReadyUseCase`) remains platform-agnostic.
 
+LWD currently differs from LWM only in two dialog-level capabilities:
+
+- it cannot yet lock the dialog while a device-intent phase is in progress
+  ([LIVE-33204](https://ledgerhq.atlassian.net/browse/LIVE-33204));
+- intent components cannot yet override the dialog header
+  ([LIVE-33203](https://ledgerhq.atlassian.net/browse/LIVE-33203)).
+
 ### CLI
 
 Not supported out of the box. DIE is designed for React apps and assumes a


### PR DESCRIPTION
### 📝 Description

Document Device Intent Executor support on Ledger Wallet Desktop in the canonical integration guide. The desktop wrapper has parity with mobile except for dialog locking and header overrides, so the guide now lists only those two temporary differences and links to their follow-up tickets.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-33002](https://ledgerhq.atlassian.net/browse/LIVE-33002)
- **Related**: [LIVE-33203](https://ledgerhq.atlassian.net/browse/LIVE-33203), [LIVE-33204](https://ledgerhq.atlassian.net/browse/LIVE-33204)

[LIVE-33002]: https://ledgerhq.atlassian.net/browse/LIVE-33002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33203]: https://ledgerhq.atlassian.net/browse/LIVE-33203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33204]: https://ledgerhq.atlassian.net/browse/LIVE-33204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ