### PR TITLE
[LWM] feat(lwm): reactive Braze identity sync on consent change (LIVE-34719)

### DIFF
--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -112,6 +112,24 @@ describe("HookNotifications", () => {
     });
   });
 
+  it("should re-sync Braze identity when the cleanup feature flag changes", () => {
+    mockedUseFeature.mockReturnValue({ enabled: false } as ReturnType<typeof useFeature>);
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+    expect(mockedStart).toHaveBeenCalledTimes(1);
+    expect(mockedStart).toHaveBeenLastCalledWith(false, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: false,
+    });
+
+    mockedUseFeature.mockReturnValue({ enabled: true } as ReturnType<typeof useFeature>);
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(2);
+    expect(mockedStart).toHaveBeenLastCalledWith(false, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
   it("should update notification preferences when settings change", () => {
     mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
     const updatedNotifications = {

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { UserId, DUMMY_USER_ID, userIdSelector } from "@domain/entity-client-identity";
+import { useFeature } from "@features/platform-feature-flags";
+import { useSelector } from "~/context/hooks";
+import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
+import HookNotifications from "./HookNotifications";
+import { start, updateUserPreferences } from "./braze";
+import type { NotificationsSettings } from "../reducers/types";
+
+jest.mock("./braze", () => ({
+  start: jest.fn(),
+  updateUserPreferences: jest.fn(),
+}));
+
+jest.mock("@features/platform-feature-flags", () => ({
+  useFeature: jest.fn(),
+}));
+
+jest.mock("~/context/hooks", () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockedStart = jest.mocked(start);
+const mockedUpdateUserPreferences = jest.mocked(updateUserPreferences);
+const mockedUseFeature = jest.mocked(useFeature);
+const mockedUseSelector = jest.mocked(useSelector);
+
+const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
+
+const defaultNotifications = {
+  areNotificationsAllowed: true,
+  announcementsCategory: true,
+  largeMoverCategory: true,
+  transactionsAlertsCategory: true,
+  totalMarketCap: true,
+  topGainersLosers: true,
+} satisfies NotificationsSettings;
+
+const mockSelectors = ({
+  isTrackedUser,
+  userId,
+  notifications = defaultNotifications,
+}: {
+  isTrackedUser: boolean;
+  userId: UserId;
+  notifications?: NotificationsSettings;
+}) => {
+  mockedUseSelector.mockImplementation(selector => {
+    if (selector === trackingEnabledSelector) return isTrackedUser;
+    if (selector === userIdSelector) return userId;
+    if (selector === notificationsSelector) return notifications;
+    throw new Error("Unexpected selector");
+  });
+};
+
+describe("HookNotifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseFeature.mockReturnValue({ enabled: true } as ReturnType<typeof useFeature>);
+  });
+
+  it("should sync Braze identity once for unchanged consent and user id", () => {
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+
+    const { rerender } = render(<HookNotifications />);
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(1);
+    expect(mockedStart).toHaveBeenCalledWith(true, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should re-sync Braze identity when consent changes from opt-in to opt-out", () => {
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(2);
+    expect(mockedStart).toHaveBeenLastCalledWith(false, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should re-sync Braze identity when consent changes from opt-out to opt-in", () => {
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(2);
+    expect(mockedStart).toHaveBeenLastCalledWith(true, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should retry Braze identity sync when dummy user id becomes real", () => {
+    mockSelectors({ isTrackedUser: true, userId: DUMMY_USER_ID });
+    const { rerender } = render(<HookNotifications />);
+    expect(mockedStart).not.toHaveBeenCalled();
+
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    rerender(<HookNotifications />);
+
+    expect(mockedStart).toHaveBeenCalledTimes(1);
+    expect(mockedStart).toHaveBeenCalledWith(true, REAL_USER_ID, {
+      brazeOptOutIdentityCleanup: true,
+    });
+  });
+
+  it("should update notification preferences when settings change", () => {
+    mockSelectors({ isTrackedUser: true, userId: REAL_USER_ID });
+    const updatedNotifications = {
+      ...defaultNotifications,
+      announcementsCategory: false,
+    };
+
+    const { rerender } = render(<HookNotifications />);
+    mockSelectors({
+      isTrackedUser: true,
+      userId: REAL_USER_ID,
+      notifications: updatedNotifications,
+    });
+    rerender(<HookNotifications />);
+
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(2);
+    expect(mockedUpdateUserPreferences).toHaveBeenLastCalledWith(updatedNotifications);
+  });
+});

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -1,13 +1,14 @@
 import { useEffect, useRef, useCallback } from "react";
-import { userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
+import { type UserId, userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
 import { start, updateUserPreferences } from "./braze";
 
 type SyncedBrazeIdentity = {
-  userId: string;
+  userId: UserId;
   isTrackedUser: boolean;
+  brazeOptOutIdentityCleanup: boolean;
 };
 
 const HookNotifications = () => {
@@ -23,21 +24,25 @@ const HookNotifications = () => {
       return;
     }
 
+    const brazeOptOutIdentityCleanupEnabled = brazeOptOutIdentityCleanup?.enabled ?? false;
     const currentIdentity: SyncedBrazeIdentity = {
-      userId: userId.exportUserIdForPersistence(),
+      userId,
       isTrackedUser,
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
     };
     const lastSyncedIdentity = lastSyncedIdentityRef.current;
     if (
-      lastSyncedIdentity?.userId === currentIdentity.userId &&
-      lastSyncedIdentity.isTrackedUser === currentIdentity.isTrackedUser
+      lastSyncedIdentity &&
+      lastSyncedIdentity.userId.equals(currentIdentity.userId) &&
+      lastSyncedIdentity.isTrackedUser === currentIdentity.isTrackedUser &&
+      lastSyncedIdentity.brazeOptOutIdentityCleanup === currentIdentity.brazeOptOutIdentityCleanup
     ) {
       return;
     }
 
     lastSyncedIdentityRef.current = currentIdentity;
     start(isTrackedUser, userId, {
-      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
     });
   }, [brazeOptOutIdentityCleanup?.enabled, isTrackedUser, userId]);
 

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -1,33 +1,53 @@
-import { useEffect, useState, useCallback } from "react";
-import { userIdSelector } from "@domain/entity-client-identity";
+import { useEffect, useRef, useCallback } from "react";
+import { userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { notificationsSelector, trackingEnabledSelector } from "../reducers/settings";
 import { start, updateUserPreferences } from "./braze";
 
+type SyncedBrazeIdentity = {
+  userId: string;
+  isTrackedUser: boolean;
+};
+
 const HookNotifications = () => {
-  const [notificationsStarted, setNotificationsStarted] = useState(false);
   const notifications = useSelector(notificationsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const userId = useSelector(userIdSelector);
   const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
+  const lastSyncedIdentityRef = useRef<SyncedBrazeIdentity | null>(null);
 
-  const sync = useCallback(() => {
-    if (notificationsStarted) return;
-    setNotificationsStarted(true);
+  const syncBrazeIdentity = useCallback(() => {
+    if (isDummyUserId(userId)) {
+      lastSyncedIdentityRef.current = null;
+      return;
+    }
+
+    const currentIdentity: SyncedBrazeIdentity = {
+      userId: userId.exportUserIdForPersistence(),
+      isTrackedUser,
+    };
+    const lastSyncedIdentity = lastSyncedIdentityRef.current;
+    if (
+      lastSyncedIdentity?.userId === currentIdentity.userId &&
+      lastSyncedIdentity.isTrackedUser === currentIdentity.isTrackedUser
+    ) {
+      return;
+    }
+
+    lastSyncedIdentityRef.current = currentIdentity;
     start(isTrackedUser, userId, {
       brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
     });
-    updateUserPreferences(notifications);
-  }, [
-    notificationsStarted,
-    notifications,
-    isTrackedUser,
-    userId,
-    brazeOptOutIdentityCleanup?.enabled,
-  ]);
+  }, [brazeOptOutIdentityCleanup?.enabled, isTrackedUser, userId]);
 
-  useEffect(sync, [sync]);
+  useEffect(() => {
+    syncBrazeIdentity();
+  }, [syncBrazeIdentity]);
+
+  useEffect(() => {
+    updateUserPreferences(notifications);
+  }, [notifications]);
 
   return null;
 };


### PR DESCRIPTION
## Summary

- Replace the one-shot `notificationsStarted` flag in `HookNotifications` with reactive Braze identity sync.
- Track the last synced `(userId, isTrackedUser)` pair and re-run `start()` when either value changes.
- Clear sync state on dummy `UserId` and retry when a real `UserId` becomes available.
- Split notification preference updates into a separate effect so unrelated re-renders do not block or duplicate identity sync.

## Context

Part of [LIVE-34717](https://ledgerhq.atlassian.net/browse/LIVE-34717) — Braze opt-out identity cleanup (Release 1).  
Builds on [LIVE-34718](https://ledgerhq.atlassian.net/browse/LIVE-34718) (`brazeOptOutIdentityCleanup` flag + skip `changeUser` for opted-out users).

**Files changed:**
- `apps/ledger-live-mobile/src/notifications/HookNotifications.ts`
- `apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx`

## Test plan

- [ ] Opted-in user at launch → Braze identity sync runs once
- [ ] Toggle analytics consent opt-in → opt-out → identity re-syncs (no duplicate sync on re-render)
- [ ] Toggle analytics consent opt-out → opt-in → `changeUser(realId)` runs again
- [ ] App launch with dummy `UserId`, then real `UserId` resolves → sync runs on transition
- [ ] Unrelated re-renders do not trigger duplicate identity sync
- [ ] Notification preference changes still update Braze custom attributes
- [ ] `pnpm mobile test:jest "HookNotifications.test"`

[LIVE-34717]: https://ledgerhq.atlassian.net/browse/LIVE-34717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34718]: https://ledgerhq.atlassian.net/browse/LIVE-34718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ