### PR TITLE
feat(devtools/relay): support multiple tools per relay session

### DIFF
--- a/.changeset/golden-dolphin-dance.md
+++ b/.changeset/golden-dolphin-dance.md
@@ -1,0 +1,5 @@
+---
+"@devtools/relay": minor
+---
+
+Multiple tool clients can now connect to the same host session simultaneously. Messages are broadcast to all connected peers instead of being delivered to a single counterpart.

--- a/devtools/relay/src/relay.test.ts
+++ b/devtools/relay/src/relay.test.ts
@@ -139,32 +139,3 @@ describe("relay hub — close", () => {
     await expect(hub.close()).resolves.toBeUndefined();
   });
 });
-
-describe("relay hub — eviction", () => {
-  let hub: Hub;
-  let base: string;
-
-  beforeEach(async () => {
-    hub = createRelayHub({
-      port: 0,
-      host: "127.0.0.1",
-      logger: createMockLogger(),
-      getLanIp: nullLanIp,
-    });
-    await waitForListening(hub);
-    base = `ws://127.0.0.1:${(hub.ws.address() as AddressInfo).port}`;
-  });
-
-  afterEach(async () => {
-    await hub.close();
-  });
-
-  it("closes the previous tool when a new one reconnects targeting the same host", async () => {
-    await open(`${base}/?role=host&id=app`); // uid = "1"
-    const tool1 = await open(`${base}/?role=tool&id=web-tools&target=1`);
-    const closed1 = waitForClose(tool1);
-    await open(`${base}/?role=tool&id=web-tools&target=1`);
-    await closed1;
-    expect(tool1.readyState).toBe(WebSocket.CLOSED);
-  });
-});

--- a/devtools/relay/src/relay.ts
+++ b/devtools/relay/src/relay.ts
@@ -91,18 +91,22 @@ export function createRelayHub(options: RelayHubOptions = {}) {
     if (attached.status === "sessionless") {
       warn(msg.sessionless(me.id));
     } else {
-      if (attached.evicted) log(msg.evicted(attached.role, attached.descriptor?.uid ?? "unknown"));
       log(msg.attached(attached.role, me.id, attached.descriptor?.uid ?? "unknown"));
       if (attached.paired) log(msg.paired(attached.descriptor?.uid ?? "unknown"));
     }
 
     const peerRole = me.role === "tool" ? "host" : "tool";
     socket.on("message", (data, isBinary) => {
-      const peer = registry.peerOf(socket);
+      const peers = registry.peersOf(socket);
       const kind = isBinary ? "binary" : "text";
-      if (peer && peer.readyState === WebSocket.OPEN) {
-        peer.send(data, { binary: isBinary });
-        trace(msg.forwarded(me.id, peerRole, kind));
+      if (peers) {
+        for (const peer of peers)
+          if (peer && peer.readyState === WebSocket.OPEN) {
+            peer.send(data, { binary: isBinary });
+            trace(msg.forwarded(me.id, peerRole, kind));
+          } else {
+            trace(msg.dropped(me.id, kind, peerRole));
+          }
       } else {
         trace(msg.dropped(me.id, kind, peerRole));
       }

--- a/devtools/relay/src/sessionRegistry.test.ts
+++ b/devtools/relay/src/sessionRegistry.test.ts
@@ -42,7 +42,6 @@ describe("sessionRegistry — attach", () => {
       expect.objectContaining({
         status: "filed",
         role: "host",
-        evicted: false,
         paired: false,
         descriptor: expect.objectContaining({ uid: "1" }),
       }),
@@ -59,51 +58,60 @@ describe("sessionRegistry — attach", () => {
     expect(result.paired).toBe(true);
   });
 
-  it("evicts the previous tool when a new one targets the same uid", () => {
+  it("reports paired when a second tool attaches to a session that already has a host", () => {
     const registry = createSessionRegistry();
     const { uid } = attachHost(registry);
-    const first = makeSocket();
-    registry.attach({ role: "tool", id: "web-tools", target: uid }, first);
+    registry.attach({ role: "tool", id: "web-tools", target: uid }, makeSocket());
     const result = registry.attach(
       { role: "tool", id: "web-tools-v2", target: uid },
       makeSocket(),
     ) as Extract<AttachResult, { status: "filed" }>;
-    expect(first.closed).toBe(true);
-    expect(result.evicted).toBe(true);
-  });
-
-  it("unpairs the evicted tool from its peer", () => {
-    const registry = createSessionRegistry();
-    const { socket: host, uid } = attachHost(registry);
-    const tool1 = makeSocket();
-    registry.attach({ role: "tool", id: "web-tools", target: uid }, tool1);
-    registry.attach({ role: "tool", id: "web-tools-v2", target: uid }, makeSocket());
-    expect(registry.peerOf(tool1)).toBeUndefined();
-    host.close();
+    expect(result.paired).toBe(true);
   });
 });
 
-describe("sessionRegistry — peerOf", () => {
+describe("sessionRegistry — peersOf", () => {
   it("returns undefined when only the host is attached", () => {
     const registry = createSessionRegistry();
     const { socket: host } = attachHost(registry);
-    expect(registry.peerOf(host)).toBeUndefined();
+    expect(registry.peersOf(host)).toBeUndefined();
   });
 
-  it("returns the tool from the host's perspective after pairing", () => {
+  it("returns a Set containing the tool from the host's perspective after pairing", () => {
     const registry = createSessionRegistry();
     const { socket: host, uid } = attachHost(registry);
     const tool = makeSocket();
     registry.attach({ role: "tool", id: "web-tools", target: uid }, tool);
-    expect(registry.peerOf(host)).toBe(tool);
+    expect(registry.peersOf(host)).toEqual(new Set([tool]));
   });
 
-  it("returns the host from the tool's perspective after pairing", () => {
+  it("returns a Set containing the host from the tool's perspective after pairing", () => {
     const registry = createSessionRegistry();
     const { socket: host, uid } = attachHost(registry);
     const tool = makeSocket();
     registry.attach({ role: "tool", id: "web-tools", target: uid }, tool);
-    expect(registry.peerOf(tool)).toBe(host);
+    expect(registry.peersOf(tool)).toEqual(new Set([host]));
+  });
+
+  it("host's peers include all connected tools", () => {
+    const registry = createSessionRegistry();
+    const { socket: host, uid } = attachHost(registry);
+    const tool1 = makeSocket();
+    const tool2 = makeSocket();
+    registry.attach({ role: "tool", id: "web-tools", target: uid }, tool1);
+    registry.attach({ role: "tool", id: "web-tools-v2", target: uid }, tool2);
+    expect(registry.peersOf(host)).toEqual(new Set([tool1, tool2]));
+  });
+
+  it("each tool's peers include the host and its sibling tools but not itself", () => {
+    const registry = createSessionRegistry();
+    const { socket: host, uid } = attachHost(registry);
+    const tool1 = makeSocket();
+    const tool2 = makeSocket();
+    registry.attach({ role: "tool", id: "web-tools", target: uid }, tool1);
+    registry.attach({ role: "tool", id: "web-tools-v2", target: uid }, tool2);
+    expect(registry.peersOf(tool1)).toEqual(new Set([host, tool2]));
+    expect(registry.peersOf(tool2)).toEqual(new Set([host, tool1]));
   });
 });
 
@@ -124,13 +132,13 @@ describe("sessionRegistry — detach", () => {
     );
   });
 
-  it("unpairs the peer when a socket detaches", () => {
+  it("unpairs all tools when the host detaches", () => {
     const registry = createSessionRegistry();
     const { socket: host, uid } = attachHost(registry);
     const tool = makeSocket();
     registry.attach({ role: "tool", id: "web-tools", target: uid }, tool);
     registry.detach(host);
-    expect(registry.peerOf(tool)).toBeUndefined();
+    expect(registry.peersOf(tool)).toBeUndefined();
   });
 
   it("removes the uid from the index when a host detaches", () => {
@@ -141,7 +149,20 @@ describe("sessionRegistry — detach", () => {
     expect(result).toEqual({ status: "sessionless" });
   });
 
-  it("drops the session once both slots are detached, allowing re-registration", () => {
+  it("removes only the detached tool and keeps the rest paired", () => {
+    const registry = createSessionRegistry();
+    const { socket: host, uid } = attachHost(registry);
+    const tool1 = makeSocket();
+    const tool2 = makeSocket();
+    registry.attach({ role: "tool", id: "web-tools", target: uid }, tool1);
+    registry.attach({ role: "tool", id: "web-tools-v2", target: uid }, tool2);
+    registry.detach(tool1);
+    expect(registry.peersOf(tool2)).toEqual(new Set([host]));
+    expect(registry.peersOf(host)).toEqual(new Set([tool2]));
+    expect(registry.peersOf(tool1)).toBeUndefined();
+  });
+
+  it("drops the session once both host and all tools have detached", () => {
     const registry = createSessionRegistry();
     const { socket: host, uid } = attachHost(registry);
     const tool = makeSocket();
@@ -153,7 +174,6 @@ describe("sessionRegistry — detach", () => {
       expect.objectContaining({
         status: "filed",
         role: "host",
-        evicted: false,
         paired: false,
       }),
     );

--- a/devtools/relay/src/sessionRegistry.ts
+++ b/devtools/relay/src/sessionRegistry.ts
@@ -12,42 +12,34 @@ export interface RelaySocket {
 /** Outcome of {@link SessionRegistry.attach}, for the caller to log. */
 export type AttachResult =
   | { status: "sessionless" }
-  | {
-      status: "filed";
-      role: Role;
-      evicted: boolean;
-      paired: boolean;
-      descriptor?: DeviceDescriptor;
-    };
+  | { status: "filed"; role: Role; paired: boolean; descriptor?: DeviceDescriptor };
 
 /** Outcome of {@link SessionRegistry.detach}; `undefined` when the socket was never filed. */
 export type DetachResult = { role: Role; descriptor?: DeviceDescriptor } | undefined;
 
 export interface SessionRegistry<S extends RelaySocket> {
-  /** File a socket into its session role slot, evicting the previous occupant and pairing once both roles are filled. */
+  /** File a socket into its session. Tools accumulate in a Set; a host takes a single slot. All participants are paired once a host and at least one tool are present. */
   attach(identity: Identity, socket: S): AttachResult;
-  /** Remove a socket, unpair its peer, and drop the session once empty. */
+  /** Remove a socket, unpair its peers, and drop the session once empty. */
   detach(socket: S): DetachResult;
-  /** The socket currently paired with this one, if any. */
-  peerOf(socket: S): S | undefined;
+  /** The sockets currently paired with this one, if any. */
+  peersOf(socket: S): Set<S> | undefined;
 }
 
 /**
  * Pairing broker, extracted from the relay's socket wiring.
  *
- * Each session owns two roles — one `host`, one `tool`. Filling both roles pairs
- * the sockets (each gets a direct reference to the other). A newcomer evicts the
- * previous occupant of its role slot. A tool without a target has no host to reach,
- * so it is left connected but unfiled (`sessionless`).
- *
- * The relay assigns a monotonic `uid` to each connecting host; this uid becomes the
- * session key and is what tools use as their `target`.
+ * Each connecting host is assigned a monotonic uid as its session key; tools target
+ * by that uid. A session holds one `host` and any number of `tool` sockets. Once both
+ * are present, all participants are paired: each holds a Set of its peers so messages
+ * can be fanned out without role look-ups. A tool without a target, or targeting an
+ * unknown uid, is left connected but unfiled (`sessionless`).
  */
 export function createSessionRegistry<S extends RelaySocket>(): SessionRegistry<S> {
-  type Session = { host?: S; tool?: S };
+  type Session = { host?: S; tool?: Set<S> };
 
-  const sessions = new Map<string, Session>(); // uid -> its two roles
-  const peers = new WeakMap<S, S>(); // socket -> the socket it's paired with
+  const sessions = new Map<string, Session>(); // uid -> session
+  const peers = new WeakMap<S, Set<S>>();
   const filed = new WeakMap<S, { role: Role; uid: string; descriptor?: DeviceDescriptor }>();
   let counter = 0;
 
@@ -61,15 +53,23 @@ export function createSessionRegistry<S extends RelaySocket>(): SessionRegistry<
   }
 
   function pair(session: Session) {
-    if (session.host && session.tool) {
-      peers.set(session.host, session.tool);
-      peers.set(session.tool, session.host);
+    const host = session.host;
+    const tools = session.tool;
+    if (host && tools) {
+      peers.set(host, new Set<S>(tools));
+      tools.forEach((tool: S) => {
+        const peerSet = new Set<S>([...tools, host]);
+        peerSet.delete(tool);
+        peers.set(tool, peerSet);
+      });
     }
   }
 
   function unpair(socket: S) {
     const peer = peers.get(socket);
-    if (peer) peers.delete(peer);
+    if (peer) {
+      for (const s of peer) peers.get(s)?.delete(socket);
+    }
     peers.delete(socket);
   }
 
@@ -91,21 +91,18 @@ export function createSessionRegistry<S extends RelaySocket>(): SessionRegistry<
     const role = identity.role;
     const session = sessionFor(uid);
 
-    const previous = session[role];
-    const evicted = Boolean(previous && previous !== socket);
-    if (previous && previous !== socket) {
-      unpair(previous);
-      previous.close();
+    if (role === "tool") {
+      if (!session.tool) session.tool = new Set();
+      session.tool.add(socket);
+    } else {
+      session.host = socket;
     }
-
-    session[role] = socket;
     filed.set(socket, { role, uid, descriptor });
     pair(session);
 
     return {
       status: "filed",
       role,
-      evicted,
       paired: Boolean(session.host && session.tool),
       descriptor,
     };
@@ -120,15 +117,18 @@ export function createSessionRegistry<S extends RelaySocket>(): SessionRegistry<
 
     const session = sessions.get(entry.uid);
     if (session) {
-      if (session[entry.role] === socket) session[entry.role] = undefined;
-      if (!session.host && !session.tool) sessions.delete(entry.uid);
+      if (entry.role === "tool") session.tool?.delete(socket);
+      else if (entry.role === "host") session.host = undefined;
+      if (!session.host && (!session.tool || session.tool.size === 0))
+        sessions.delete(entry.uid);
     }
     return { role: entry.role, descriptor: entry.descriptor };
   }
 
-  function peerOf(socket: S): S | undefined {
-    return peers.get(socket);
+  function peersOf(socket: S): Set<S> | undefined {
+    const set = peers.get(socket);
+    return set?.size ? set : undefined;
   }
 
-  return { attach, detach, peerOf };
+  return { attach, detach, peersOf };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

Lifts the one-tool-per-session constraint in `@devtools/relay` so any number of tool clients can connect to the same host session simultaneously. Messages sent by a host are now broadcast to every connected tool, and messages sent by any tool are forwarded to the host.

### What changed

**`sessionRegistry.ts`**
- `Session.tool` is now `Set<S>` instead of a single socket; tools accumulate rather than evict one another.
- Pairing builds a `peers` WeakMap of `Set<S>` so each socket holds a direct reference to all its counterparts — no role look-ups at message time.
- `peerOf(socket)` → `peersOf(socket): Set<S> | undefined`.
- Removed the `evicted` field from `AttachResult` and the eviction code path.
- `detach` cleans each peer's set entry individually before dropping the socket.

**`relay.ts`**
- Message forwarding iterates `peersOf(socket)` and sends to every open peer instead of a single one.
### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35500](https://ledgerhq.atlassian.net/browse/LIVE-35500)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35500]: https://ledgerhq.atlassian.net/browse/LIVE-35500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ