### PR TITLE
[LWDM] feat(internet_computer): add live-common staking hooks

### DIFF
--- a/.changeset/lucky-otter-wanders.md
+++ b/.changeset/lucky-otter-wanders.md
@@ -1,0 +1,6 @@
+---
+"@ledgerhq/coin-internet_computer": minor
+"@ledgerhq/live-common": minor
+---
+
+Add Internet Computer neuron staking hooks and narrow the ICP bridge account types

--- a/libs/coin-modules/coin-internet_computer/src/bridge/bridgeHelpers/account.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/bridgeHelpers/account.ts
@@ -19,7 +19,7 @@ import {
 } from "../../types";
 import { NeuronsData } from "../../types/neuron";
 
-export const getAccountShape: GetAccountShape = async info => {
+export const getAccountShape: GetAccountShape<ICPAccount> = async info => {
   const { currency, derivationMode, rest = {}, initialAccount } = info;
   const publicKey = reconciliatePublicKey(rest.publicKey, initialAccount);
   invariant(publicKey, "publicKey is required");
@@ -60,7 +60,7 @@ export const getAccountShape: GetAccountShape = async info => {
   }, undefined);
   const neurons = latestSnapshot
     ? new NeuronsData(latestSnapshot.neurons, latestSnapshot.date.getTime())
-    : ((initialAccount as ICPAccount | undefined)?.neurons ?? NeuronsData.empty());
+    : (initialAccount?.neurons ?? NeuronsData.empty());
 
   const neuronAddresses = neurons.fullNeurons.map(n => n.accountIdentifier);
 

--- a/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
+++ b/libs/coin-modules/coin-internet_computer/src/bridge/index.ts
@@ -7,10 +7,17 @@ import {
   updateTransaction,
 } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
 import { SignerContext } from "@ledgerhq/ledger-wallet-framework/signer";
-import type { Account, AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
+import type { AccountBridge, CurrencyBridge } from "@ledgerhq/types-live";
 import { ICP_DUMMY_ADDRESS } from "../constants";
 import resolver from "../signer";
-import type { Transaction, TransactionStatus, ICPSigner } from "../types";
+import type {
+  ICPAccount,
+  ICPAccountRaw,
+  InternetComputerOperation,
+  Transaction,
+  TransactionStatus,
+  ICPSigner,
+} from "../types";
 import { getAccountShape } from "./bridgeHelpers/account";
 import { broadcast } from "./broadcast";
 import { createTransaction } from "./createTransaction";
@@ -38,7 +45,13 @@ const sync = makeSync({ getAccountShape });
 
 function buildAccountBridge(
   signerContext: SignerContext<ICPSigner>,
-): AccountBridge<Transaction, Account, TransactionStatus> {
+): AccountBridge<
+  Transaction,
+  ICPAccount,
+  TransactionStatus,
+  InternetComputerOperation,
+  ICPAccountRaw
+> {
   const getAddress = resolver(signerContext);
 
   const receive = makeAccountBridgeReceive(getAddressWrapper(getAddress));

--- a/libs/coin-modules/coin-internet_computer/src/types/common.ts
+++ b/libs/coin-modules/coin-internet_computer/src/types/common.ts
@@ -84,6 +84,12 @@ export interface ICPAccountRaw extends AccountRaw {
   neuronsData?: NeuronsDataRaw;
 }
 
+// `neurons` is only populated once an account has been synced or deserialized, so classify by
+// family rather than by the presence of the field.
+export function isICPAccount(account: Account): account is ICPAccount {
+  return account.currency.family === "internet_computer";
+}
+
 export type TransactionStatus = TransactionStatusCommon;
 
 export type TransactionStatusRaw = TransactionStatusCommonRaw;

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -127,6 +127,7 @@
     "src/families/filecoin/deviceTransactionConfig.ts",
     "src/families/filecoin/types.ts",
     "src/families/hedera/types.ts",
+    "src/families/internet_computer/react.ts",
     "src/families/internet_computer/types.ts",
     "src/families/mina/types.ts",
     "src/families/multiversx/banner.ts",

--- a/libs/ledger-live-common/src/families/internet_computer/react.test.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/react.test.ts
@@ -1,0 +1,317 @@
+/**
+ * @jest-environment jsdom
+ */
+import BigNumber from "bignumber.js";
+import { renderHook } from "@testing-library/react";
+import { ICP_FEES, MIN_NEURON_STAKE } from "./consts";
+import { NeuronsData, NeuronState } from "./types";
+import type { ICPAccount, ICPNeuron } from "./types";
+import {
+  canStakeICP,
+  getNeuronState,
+  useICPNeuronById,
+  useICPNeurons,
+  useTotalMaturity,
+  useTotalStaked,
+  useTotalStakedMaturity,
+} from "./react";
+import type { ICPNeuronStateLabel } from "./react";
+
+const MIN_STAKE_WITH_FEE = MIN_NEURON_STAKE + ICP_FEES;
+
+const makeNeuron = (overrides: Partial<ICPNeuron> = {}): ICPNeuron => ({
+  accountIdentifier: "ab".repeat(32),
+  state: NeuronState.Locked,
+  dissolveDelaySeconds: 0n,
+  ageSeconds: 0n,
+  cachedNeuronStakeE8s: 0n,
+  neuronFeesE8s: 0n,
+  maturityE8sEquivalent: 0n,
+  stakedMaturityE8sEquivalent: 0n,
+  createdTimestampSeconds: 0n,
+  hotKeys: [],
+  followees: [],
+  autoStakeMaturity: false,
+  ...overrides,
+});
+
+const makeICPAccount = (neurons: NeuronsData, spendableBalance: number | string = 0): ICPAccount =>
+  ({
+    type: "Account",
+    currency: { family: "internet_computer" },
+    balance: new BigNumber(spendableBalance),
+    spendableBalance: new BigNumber(spendableBalance),
+    neurons,
+  }) as unknown as ICPAccount;
+
+describe("useICPNeurons", () => {
+  it("returns the neurons stored on the account", () => {
+    const neurons = [makeNeuron({ id: 1n }), makeNeuron({ id: 2n })];
+    const account = makeICPAccount(new NeuronsData(neurons, 1));
+    const { result } = renderHook(() => useICPNeurons(account));
+    expect(result.current).toBe(neurons);
+  });
+
+  it("returns an empty list when the account carries no neurons snapshot", () => {
+    const account = makeICPAccount(NeuronsData.empty());
+    const { result } = renderHook(() => useICPNeurons(account));
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns an empty list when neurons is absent from the account", () => {
+    const account = { spendableBalance: new BigNumber(0) } as unknown as ICPAccount;
+    const { result } = renderHook(() => useICPNeurons(account));
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns the same reference for two accounts that both carry no neurons", () => {
+    const { result: a } = renderHook(() => useICPNeurons(makeICPAccount(NeuronsData.empty())));
+    const { result: b } = renderHook(() => useICPNeurons(makeICPAccount(NeuronsData.empty())));
+    expect(a.current).toBe(b.current);
+  });
+
+  it("keeps the same reference when the account object changes but the snapshot does not", () => {
+    const snapshot = new NeuronsData([makeNeuron({ id: 1n })], 1);
+    const { result, rerender } = renderHook(
+      ({ account }: { account: ICPAccount }) => useICPNeurons(account),
+      { initialProps: { account: makeICPAccount(snapshot) } },
+    );
+    const first = result.current;
+    rerender({ account: makeICPAccount(snapshot, 42) });
+    expect(result.current).toBe(first);
+  });
+});
+
+describe("useICPNeuronById", () => {
+  const neurons = new NeuronsData([makeNeuron({ id: 7n }), makeNeuron({ id: 8n })], 1);
+
+  it("returns the neuron whose id matches", () => {
+    const account = makeICPAccount(neurons);
+    const { result } = renderHook(() => useICPNeuronById(account, "8"));
+    expect(result.current?.id).toBe(8n);
+  });
+
+  it("returns undefined when no neuron matches", () => {
+    const account = makeICPAccount(neurons);
+    const { result } = renderHook(() => useICPNeuronById(account, "99"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined when the account carries no neurons", () => {
+    const account = makeICPAccount(NeuronsData.empty());
+    const { result } = renderHook(() => useICPNeuronById(account, "7"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("ignores neurons whose id was not returned by the canister", () => {
+    const account = makeICPAccount(new NeuronsData([makeNeuron()], 1));
+    const { result } = renderHook(() => useICPNeuronById(account, "undefined"));
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe("canStakeICP", () => {
+  it("allows staking when the spendable balance covers the minimum stake plus the fee", () => {
+    expect(canStakeICP(makeICPAccount(NeuronsData.empty(), MIN_STAKE_WITH_FEE))).toBe(true);
+  });
+
+  it("rejects staking one unit below the minimum stake plus the fee", () => {
+    expect(canStakeICP(makeICPAccount(NeuronsData.empty(), MIN_STAKE_WITH_FEE - 1))).toBe(false);
+  });
+
+  it("allows staking above the minimum stake plus the fee", () => {
+    expect(canStakeICP(makeICPAccount(NeuronsData.empty(), MIN_STAKE_WITH_FEE + 1))).toBe(true);
+  });
+
+  it("rejects staking when the minimum stake is covered but the fee is not", () => {
+    expect(canStakeICP(makeICPAccount(NeuronsData.empty(), MIN_NEURON_STAKE))).toBe(false);
+  });
+
+  it("rejects staking on an empty account", () => {
+    expect(canStakeICP(makeICPAccount(NeuronsData.empty()))).toBe(false);
+  });
+});
+
+describe("getNeuronState", () => {
+  it.each<[NeuronState, ICPNeuronStateLabel]>([
+    [NeuronState.Locked, "Locked"],
+    [NeuronState.Dissolving, "Dissolving"],
+    [NeuronState.Dissolved, "Dissolved"],
+    [NeuronState.Spawning, "Spawning"],
+    [NeuronState.Unspecified, "Unknown"],
+  ])("maps state %s to %s", (state, expected) => {
+    expect(getNeuronState(makeNeuron({ state }))).toBe(expected);
+  });
+
+  it("falls back to Unknown for a state outside the known enum", () => {
+    expect(getNeuronState(makeNeuron({ state: 99 as NeuronState }))).toBe("Unknown");
+  });
+});
+
+describe("useTotalStaked", () => {
+  it("sums the stake of every neuron", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({ id: 1n, cachedNeuronStakeE8s: 300_000_000n }),
+          makeNeuron({ id: 2n, cachedNeuronStakeE8s: 150_000_000n }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalStaked(account));
+    expect(result.current).toEqual(new BigNumber(450_000_000));
+  });
+
+  it("subtracts accrued neuron fees from the stake", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({ id: 1n, cachedNeuronStakeE8s: 300_000_000n, neuronFeesE8s: 20_000_000n }),
+          makeNeuron({ id: 2n, cachedNeuronStakeE8s: 100_000_000n }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalStaked(account));
+    expect(result.current).toEqual(new BigNumber(380_000_000));
+  });
+
+  it("clamps a neuron whose fees exceed its stake to zero", () => {
+    const account = makeICPAccount(
+      new NeuronsData([makeNeuron({ id: 1n, cachedNeuronStakeE8s: 10n, neuronFeesE8s: 500n })], 1),
+    );
+    const { result } = renderHook(() => useTotalStaked(account));
+    expect(result.current).toEqual(new BigNumber(0));
+  });
+
+  it("excludes maturity that has already been staked into the neuron", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({
+            id: 1n,
+            cachedNeuronStakeE8s: 100_000_000n,
+            stakedMaturityE8sEquivalent: 90_000_000n,
+          }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalStaked(account));
+    expect(result.current).toEqual(new BigNumber(100_000_000));
+  });
+
+  it("returns zero when the account has no neurons", () => {
+    const { result } = renderHook(() => useTotalStaked(makeICPAccount(NeuronsData.empty())));
+    expect(result.current).toEqual(new BigNumber(0));
+  });
+
+  it("keeps full precision above Number.MAX_SAFE_INTEGER", () => {
+    const account = makeICPAccount(
+      new NeuronsData([makeNeuron({ id: 1n, cachedNeuronStakeE8s: 9_007_199_254_740_993n })], 1),
+    );
+    const { result } = renderHook(() => useTotalStaked(account));
+    expect(result.current.toFixed()).toBe("9007199254740993");
+  });
+
+  it("returns the same instance while the neurons snapshot is unchanged", () => {
+    const snapshot = new NeuronsData([makeNeuron({ id: 1n, cachedNeuronStakeE8s: 5n })], 1);
+    const { result, rerender } = renderHook(
+      ({ account }: { account: ICPAccount }) => useTotalStaked(account),
+      { initialProps: { account: makeICPAccount(snapshot) } },
+    );
+    const first = result.current;
+    rerender({ account: makeICPAccount(snapshot, 42) });
+    expect(result.current).toBe(first);
+  });
+});
+
+describe("useTotalMaturity", () => {
+  it("sums the maturity of every neuron", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({ id: 1n, maturityE8sEquivalent: 40_000_000n }),
+          makeNeuron({ id: 2n, maturityE8sEquivalent: 2_500_000n }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalMaturity(account));
+    expect(result.current).toEqual(new BigNumber(42_500_000));
+  });
+
+  it("excludes maturity that has already been staked into the neuron", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({
+            id: 1n,
+            maturityE8sEquivalent: 10_000_000n,
+            stakedMaturityE8sEquivalent: 90_000_000n,
+          }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalMaturity(account));
+    expect(result.current).toEqual(new BigNumber(10_000_000));
+  });
+
+  it("is unaffected by accrued neuron fees", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [makeNeuron({ id: 1n, maturityE8sEquivalent: 7n, neuronFeesE8s: 500_000n })],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalMaturity(account));
+    expect(result.current).toEqual(new BigNumber(7));
+  });
+
+  it("returns zero when the account has no neurons", () => {
+    const { result } = renderHook(() => useTotalMaturity(makeICPAccount(NeuronsData.empty())));
+    expect(result.current).toEqual(new BigNumber(0));
+  });
+});
+
+describe("useTotalStakedMaturity", () => {
+  it("sums the staked maturity of every neuron", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({ id: 1n, stakedMaturityE8sEquivalent: 60_000_000n }),
+          makeNeuron({ id: 2n, stakedMaturityE8sEquivalent: 5_000_000n }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalStakedMaturity(account));
+    expect(result.current).toEqual(new BigNumber(65_000_000));
+  });
+
+  it("excludes maturity that has not been staked", () => {
+    const account = makeICPAccount(
+      new NeuronsData(
+        [
+          makeNeuron({
+            id: 1n,
+            maturityE8sEquivalent: 70_000_000n,
+            stakedMaturityE8sEquivalent: 3_000_000n,
+          }),
+        ],
+        1,
+      ),
+    );
+    const { result } = renderHook(() => useTotalStakedMaturity(account));
+    expect(result.current).toEqual(new BigNumber(3_000_000));
+  });
+
+  it("returns zero when the account has no neurons", () => {
+    const { result } = renderHook(() =>
+      useTotalStakedMaturity(makeICPAccount(NeuronsData.empty())),
+    );
+    expect(result.current).toEqual(new BigNumber(0));
+  });
+});

--- a/libs/ledger-live-common/src/families/internet_computer/react.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/react.ts
@@ -1,0 +1,61 @@
+import BigNumber from "bignumber.js";
+import { useMemo } from "react";
+import { neuronStake } from "@ledgerhq/coin-internet_computer/logic";
+import { ICP_FEES, MIN_NEURON_STAKE } from "./consts";
+import { NeuronState } from "./types";
+import type { ICPAccount, ICPNeuron } from "./types";
+
+export type ICPNeuronStateLabel = "Locked" | "Dissolving" | "Dissolved" | "Spawning" | "Unknown";
+
+const NO_NEURONS: readonly ICPNeuron[] = Object.freeze([]);
+
+const NEURON_STATE_LABELS: Record<NeuronState, ICPNeuronStateLabel> = {
+  [NeuronState.Unspecified]: "Unknown",
+  [NeuronState.Locked]: "Locked",
+  [NeuronState.Dissolving]: "Dissolving",
+  [NeuronState.Dissolved]: "Dissolved",
+  [NeuronState.Spawning]: "Spawning",
+};
+
+const sumE8s = (
+  neurons: readonly ICPNeuron[],
+  amountOf: (neuron: ICPNeuron) => bigint,
+): BigNumber => new BigNumber(neurons.reduce((total, n) => total + amountOf(n), 0n).toString());
+
+export function useICPNeurons(account: ICPAccount): readonly ICPNeuron[] {
+  // Collapse every empty case onto one reference: each NeuronsData.empty() carries its own `[]`, and
+  // the bridge mints a fresh one per sync/deserialize, which would churn the memos below.
+  const fullNeurons = account.neurons?.fullNeurons;
+  return fullNeurons?.length ? fullNeurons : NO_NEURONS;
+}
+
+export function useICPNeuronById(account: ICPAccount, neuronId: string): ICPNeuron | undefined {
+  const neurons = useICPNeurons(account);
+  return useMemo(() => neurons.find(n => n.id?.toString() === neuronId), [neurons, neuronId]);
+}
+
+export function useTotalStaked(account: ICPAccount): BigNumber {
+  const neurons = useICPNeurons(account);
+  return useMemo(() => sumE8s(neurons, neuronStake), [neurons]);
+}
+
+export function useTotalMaturity(account: ICPAccount): BigNumber {
+  const neurons = useICPNeurons(account);
+  return useMemo(() => sumE8s(neurons, n => n.maturityE8sEquivalent), [neurons]);
+}
+
+// Maturity already staked into a neuron. Disjoint from both useTotalStaked and useTotalMaturity:
+// it is excluded from neuronStake but counts toward voting power and is disbursed as stake.
+export function useTotalStakedMaturity(account: ICPAccount): BigNumber {
+  const neurons = useICPNeurons(account);
+  return useMemo(() => sumE8s(neurons, n => n.stakedMaturityE8sEquivalent), [neurons]);
+}
+
+export function canStakeICP(account: ICPAccount): boolean {
+  return account.spendableBalance.gte(MIN_NEURON_STAKE + ICP_FEES);
+}
+
+export function getNeuronState(neuron: ICPNeuron): ICPNeuronStateLabel {
+  // `state` is decoded with `as NeuronState` from a raw canister number, so it can be out of range.
+  return NEURON_STATE_LABELS[neuron.state] ?? "Unknown";
+}

--- a/libs/ledger-live-common/src/families/internet_computer/setup.ts
+++ b/libs/ledger-live-common/src/families/internet_computer/setup.ts
@@ -4,7 +4,7 @@ import { createBridges } from "@ledgerhq/coin-internet_computer/bridge/index";
 import Transport from "@ledgerhq/hw-transport";
 import icpResolver from "@ledgerhq/coin-internet_computer/signer/index";
 import { signMessage } from "@ledgerhq/coin-internet_computer/hw-signMessage";
-import type { Account, Bridge } from "@ledgerhq/types-live";
+import type { Bridge } from "@ledgerhq/types-live";
 import {
   CreateSigner,
   createMessageSigner,
@@ -12,7 +12,13 @@ import {
   executeWithSigner,
 } from "../../bridge/setup";
 import { Resolver } from "../../hw/getAddress/types";
-import { TransactionStatus, Transaction } from "@ledgerhq/coin-internet_computer/types/index";
+import {
+  ICPAccount,
+  ICPAccountRaw,
+  InternetComputerOperation,
+  TransactionStatus,
+  Transaction,
+} from "@ledgerhq/coin-internet_computer/types/index";
 import { DmkSignerICP } from "@ledgerhq/live-signer-icp";
 import { isDmkTransport } from "../../hw/dmkUtils";
 import { ICPSigner } from "./types";
@@ -24,9 +30,13 @@ const createSigner: CreateSigner<ICPSigner> = (transport: Transport): ICPSigner 
   return new DmkSignerICP(transport.dmk, transport.sessionId);
 };
 
-const bridge: Bridge<Transaction, Account, TransactionStatus> = createBridges(
-  executeWithSigner(createSigner),
-);
+const bridge: Bridge<
+  Transaction,
+  ICPAccount,
+  TransactionStatus,
+  InternetComputerOperation,
+  ICPAccountRaw
+> = createBridges(executeWithSigner(createSigner));
 
 const messageSigner = {
   signMessage: createMessageSigner(createSigner, signMessage),


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds `families/internet_computer/react.ts` — hooks exposing an ICP account's neurons to Desktop and Mobile (list, lookup by id, staked / maturity / staked-maturity totals, staking eligibility, state label) plus an `isICPAccount` guard. Also narrows the ICP bridge generics to `ICPAccount`.

Runtime-neutral: nothing consumes the hooks yet and no ICP staking UI exists. That arrives in LIVE-29095–29098.

- The three totals are disjoint. Staked maturity is excluded from `neuronStake` but counts toward voting power and disburses as stake, so it gets its own hook; showing only staked + maturity under-reports.
- **Kept `messageSigner`, contrary to the AC.** `signUpdateCall` signs governance calls, not arbitrary user messages, so removing it would drop ICP message signing outright. LIVE-34593, which would have covered that, is abandoned — needs a decision.
- Four other AC items are stale against `develop`: `ICP_MIN_STAKING_AMOUNT` and `cliTools` don't exist, `NeuronState` has no `Unlocked`, and `signUpdateCall` is already wired via `DmkSignerICP`.

```ts
const neurons = useICPNeurons(account); // account: ICPAccount
const staked = useTotalStaked(account); // e8s, BigNumber
```

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-29094](https://ledgerhq.atlassian.net/browse/LIVE-29094?atlOrigin=eyJpIjoiMGJkY2Y4NWNkMTMwNDA3NmIxNTBkMzg5M2E4Nzk4YjgiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-29094]: https://ledgerhq.atlassian.net/browse/LIVE-29094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ