### PR TITLE
[LWM] feat(mobile): wire pay-card debug tool into DevTools host (LIVE-35498)

### DIFF
--- a/.changeset/pay-card-devtool-mobile-wiring.md
+++ b/.changeset/pay-card-devtool-mobile-wiring.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire the Card / Pay debug tool (`@devtools/pay-card`) into the mobile DevTools host, surfacing it alongside feature flags with native-platform overrides (LIVE-35498).

--- a/apps/ledger-live-mobile/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/DevTools/__integrations__/DevToolsScreen.integration.test.tsx
@@ -16,7 +16,10 @@ jest.mock(
 );
 jest.mock(
   "@devtools/bindings",
-  () => ({ useFeatureFlagsToolProps: () => ({ marker: "ff-props" }) }),
+  () => ({
+    useFeatureFlagsToolProps: () => ({ marker: "ff-props" }),
+    usePayCardToolProps: () => ({ marker: "pay-card-props" }),
+  }),
   { virtual: true },
 );
 jest.mock("@devtools/transport-panel", () => ({ TransportPanel: () => null }), { virtual: true });
@@ -52,13 +55,16 @@ function withBottomInset(children: React.ReactNode) {
 }
 
 describe("DevToolsScreen", () => {
-  it("mounts DevTools with the feature-flags tool and stack screen options padded by the bottom inset", () => {
+  it("mounts DevTools with the configured tools and stack screen options padded by the bottom inset", () => {
     render(withBottomInset(<DevToolsScreen />));
 
     expect(devToolsSpy).toHaveBeenCalledTimes(1);
     const props = devToolsSpy.mock.calls[0][0];
 
-    expect(props.config).toEqual([{ id: "feature-flags", config: { marker: "ff-props" } }]);
+    expect(props.config).toEqual([
+      { id: "feature-flags", config: { marker: "ff-props" } },
+      { id: "pay-card", config: { marker: "pay-card-props" } },
+    ]);
     expect(props.screenOptions.contentStyle).toEqual([expect.anything(), { paddingBottom: 34 }]);
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts
@@ -3,19 +3,23 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 import { useTheme } from "@ledgerhq/lumen-ui-rnative/styles";
 import { getStackNavigationConfigV4 } from "LLM/components/Navigation";
-import { useFeatureFlagsToolProps } from "@devtools/bindings";
+import { useFeatureFlagsToolProps, usePayCardToolProps } from "@devtools/bindings";
 import type { DevToolsConfig } from "@devtools/shell";
 import { useDevToolsRelay } from "./useDevToolsRelay";
 
 export function useDevToolsScreenViewModel() {
   const featureFlagsProps = useFeatureFlagsToolProps();
+  const payCardToolProps = usePayCardToolProps({ platform: "native" });
   const { theme } = useTheme();
   const { bottom } = useSafeAreaInsets();
   const { wire, wireState } = useDevToolsRelay();
 
   const config: DevToolsConfig = useMemo(
-    () => [{ id: "feature-flags", config: featureFlagsProps }],
-    [featureFlagsProps],
+    () => [
+      { id: "feature-flags", config: featureFlagsProps },
+      { id: "pay-card", config: payCardToolProps },
+    ],
+    [featureFlagsProps, payCardToolProps],
   );
 
   const screenOptions: NativeStackNavigationOptions = useMemo(() => {


### PR DESCRIPTION
### 📝 Description

Surfaces the `@devtools/pay-card` debug tool in the Ledger Wallet Mobile DevTools shell. This is host-wiring only: the tool package, bindings, and native UI already exist on the branch lineage.

Changes in [`useDevToolsScreenViewModel.ts`](apps/ledger-live-mobile/src/mvvm/features/DevTools/screens/DevToolsScreen/useDevToolsScreenViewModel.ts):

- Call `usePayCardToolProps({ platform: "native" })` so the hook targets `lwmPayTab` and includes the `walletPay` onboarding step.
- Register `{ id: "pay-card", config }` in the memoized `config` array alongside `feature-flags`.

No new app dependency is needed: `@devtools/registry` already depends on `@devtools/pay-card` and lazy-loads its UI, mirroring the desktop wiring.

The DevTools integration test now asserts both tool configs are passed to the shell.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35498](https://ledgerhq.atlassian.net/browse/LIVE-35498)

[LIVE-35498]: https://ledgerhq.atlassian.net/browse/LIVE-35498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ