### PR TITLE
[LWM] feat(lwm): isolate Segment identity for opted-out users (LIVE-34720)

### DIFF
--- a/apps/ledger-live-mobile/src/analytics/BrazePlugin.tsx
+++ b/apps/ledger-live-mobile/src/analytics/BrazePlugin.tsx
@@ -14,16 +14,19 @@ export class BrazePlugin extends Plugin {
 
   execute(event: SegmentEvent): SegmentEvent | undefined {
     if (event.type === EventType.IdentifyEvent) {
+      const traits = event.traits ?? {};
+      const shouldSkipBrazeDestination = !("braze_external_id" in traits);
+
       // We don't check for some traits as they are sure to be different every time
-      const traits = {
-        ...event.traits,
+      const debouncedTraits = {
+        ...traits,
         appTimeToInteractiveMilliseconds: undefined,
         stakingProvidersEnabled: undefined,
       };
       if (
         this.lastSeenTraits?.userId === event.userId &&
         this.lastSeenTraits?.anonymousId === event.anonymousId &&
-        isEqual(this.lastSeenTraits?.traits, traits)
+        isEqual(this.lastSeenTraits?.traits, debouncedTraits)
       ) {
         const integrations = event.integrations;
 
@@ -35,8 +38,14 @@ export class BrazePlugin extends Plugin {
         this.lastSeenTraits = {
           anonymousId: event.anonymousId ?? "",
           userId: event.userId,
-          traits: traits,
+          traits: debouncedTraits,
         };
+      }
+
+      if (shouldSkipBrazeDestination) {
+        const integrations = event.integrations ?? {};
+        integrations[this.key] = false;
+        event.integrations = integrations;
       }
     }
     return event;

--- a/apps/ledger-live-mobile/src/analytics/BrazePlugin.tsx
+++ b/apps/ledger-live-mobile/src/analytics/BrazePlugin.tsx
@@ -28,12 +28,10 @@ export class BrazePlugin extends Plugin {
         this.lastSeenTraits?.anonymousId === event.anonymousId &&
         isEqual(this.lastSeenTraits?.traits, debouncedTraits)
       ) {
-        const integrations = event.integrations;
-
-        // If the traits didn't changed, disable braze integration
-        if (integrations !== undefined) {
-          integrations[this.key] = false;
-        }
+        // If the traits didn't change, disable braze integration
+        const integrations = event.integrations ?? {};
+        integrations[this.key] = false;
+        event.integrations = integrations;
       } else {
         this.lastSeenTraits = {
           anonymousId: event.anonymousId ?? "",

--- a/apps/ledger-live-mobile/src/analytics/UserIdPlugin.tsx
+++ b/apps/ledger-live-mobile/src/analytics/UserIdPlugin.tsx
@@ -1,17 +1,13 @@
-import type { Store } from "@reduxjs/toolkit";
 import { Plugin, PluginType, SegmentEvent } from "@segment/analytics-react-native";
-import {
-  userIdSelector,
-  isDummyUserId,
-  type IdentitiesState,
-} from "@domain/entity-client-identity";
+import { userIdSelector, isDummyUserId } from "@domain/entity-client-identity";
+import type { AppStore } from "~/reducers";
 import { shouldIncludeSegmentIdentity } from "./segmentIdentity";
 
 export class UserIdPlugin extends Plugin {
   type = PluginType.enrichment;
-  store;
+  store: AppStore;
 
-  constructor(store: Store<{ identities: IdentitiesState }>) {
+  constructor(store: AppStore) {
     super();
     this.store = store;
   }

--- a/apps/ledger-live-mobile/src/analytics/UserIdPlugin.tsx
+++ b/apps/ledger-live-mobile/src/analytics/UserIdPlugin.tsx
@@ -5,6 +5,7 @@ import {
   isDummyUserId,
   type IdentitiesState,
 } from "@domain/entity-client-identity";
+import { shouldIncludeSegmentIdentity } from "./segmentIdentity";
 
 export class UserIdPlugin extends Plugin {
   type = PluginType.enrichment;
@@ -17,6 +18,10 @@ export class UserIdPlugin extends Plugin {
 
   execute(event: SegmentEvent) {
     const state = this.store.getState();
+    if (!shouldIncludeSegmentIdentity(state)) {
+      return event;
+    }
+
     const userId = userIdSelector(state);
     if (!isDummyUserId(userId) && event) {
       // eslint-disable-next-line no-param-reassign

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.identityIsolation.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.identityIsolation.test.ts
@@ -1,0 +1,196 @@
+import { waitFor } from "@testing-library/react-native";
+import { EventType, type SegmentEvent } from "@segment/analytics-react-native";
+import { UserId } from "@domain/entity-client-identity";
+import { setAnalytics, setAnalyticsConsentInfo } from "~/actions/settings";
+import { createStore, withFlagOverrides } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import * as segment from "../segment";
+import { BrazePlugin } from "../BrazePlugin";
+import { UserIdPlugin } from "../UserIdPlugin";
+import { shouldIncludeSegmentIdentity } from "../segmentIdentity";
+
+jest.unmock("../segment");
+
+const { _identifyMock: mockIdentify, _trackMock: mockTrack } =
+  require("@segment/analytics-react-native") as {
+    _identifyMock: jest.Mock;
+    _trackMock: jest.Mock;
+  };
+
+const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
+const ANALYTICS_USER_ID = REAL_USER_ID.exportUserIdForAnalytics();
+
+const analyticsConsentInfo = {
+  consentDate: "2026-04-29T00:00:00.000Z",
+  privacyPolicyVersion: 1,
+};
+
+const withRealUserId =
+  (analyticsEnabled: boolean) =>
+  (state: State): State => ({
+    ...state,
+    identities: { ...state.identities, userId: REAL_USER_ID },
+    settings: {
+      ...state.settings,
+      analyticsEnabled,
+      personalizedRecommendationsEnabled: false,
+    },
+  });
+
+const makeStore = (analyticsEnabled: boolean, brazeOptOutIdentityCleanup: boolean) =>
+  createStore({
+    overrideInitialState: withFlagOverrides(
+      brazeOptOutIdentityCleanup ? { brazeOptOutIdentityCleanup: { enabled: true } } : {},
+      withRealUserId(analyticsEnabled),
+    ),
+  });
+
+describe("segment identity isolation (LIVE-34720)", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useFakeTimers();
+  });
+
+  describe("shouldIncludeSegmentIdentity", () => {
+    it("returns true when flag is off regardless of consent", () => {
+      const store = makeStore(false, false);
+      expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
+    });
+
+    it("returns false when flag is on and tracking is disabled", () => {
+      const store = makeStore(false, true);
+      expect(shouldIncludeSegmentIdentity(store.getState())).toBe(false);
+    });
+
+    it("returns true when flag is on and analytics is enabled", () => {
+      const store = makeStore(true, true);
+      expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
+    });
+  });
+
+  describe("when brazeOptOutIdentityCleanup is on", () => {
+    let store: ReturnType<typeof makeStore>;
+
+    beforeEach(() => {
+      store = makeStore(false, true);
+      store.dispatch(setAnalyticsConsentInfo(analyticsConsentInfo));
+    });
+
+    it("updateIdentify(mandatory) omits identity traits when opted out", async () => {
+      await segment.start(store);
+      mockIdentify.mockClear();
+
+      await segment.updateIdentify(undefined, true);
+
+      await waitFor(() => expect(mockIdentify).toHaveBeenCalled());
+      const [segmentUserId, traits] = mockIdentify.mock.calls.at(-1)!;
+      expect(segmentUserId).toBeUndefined();
+      expect(traits).not.toHaveProperty("userId");
+      expect(traits).not.toHaveProperty("braze_external_id");
+      expect(traits).toMatchObject({
+        optInAnalytics: false,
+        optInPersonalRecommendations: false,
+      });
+    });
+
+    it("track(mandatory) omits identity traits when opted out", async () => {
+      await segment.start(store);
+      mockTrack.mockClear();
+
+      segment.track("ConsentToggle", {}, true);
+
+      await waitFor(() => expect(mockTrack).toHaveBeenCalled());
+      const [, properties] = mockTrack.mock.calls.at(-1)!;
+      expect(properties).not.toHaveProperty("userId");
+      expect(properties).not.toHaveProperty("braze_external_id");
+      expect(properties).toMatchObject({ optInAnalytics: false });
+    });
+
+    it("updateIdentify includes identity when analytics is enabled", async () => {
+      store.dispatch(setAnalytics(true));
+      await segment.start(store);
+      mockIdentify.mockClear();
+
+      await segment.updateIdentify(undefined, true);
+
+      await waitFor(() => expect(mockIdentify).toHaveBeenCalled());
+      const [segmentUserId, traits] = mockIdentify.mock.calls.at(-1)!;
+      expect(segmentUserId).toBe(ANALYTICS_USER_ID);
+      expect(traits).toMatchObject({
+        userId: ANALYTICS_USER_ID,
+        braze_external_id: ANALYTICS_USER_ID,
+      });
+    });
+  });
+
+  describe("when brazeOptOutIdentityCleanup is off (legacy)", () => {
+    it("updateIdentify(mandatory) still includes identity when opted out", async () => {
+      const store = makeStore(false, false);
+      store.dispatch(setAnalyticsConsentInfo(analyticsConsentInfo));
+      await segment.start(store);
+      mockIdentify.mockClear();
+
+      await segment.updateIdentify(undefined, true);
+
+      await waitFor(() => expect(mockIdentify).toHaveBeenCalled());
+      const [segmentUserId, traits] = mockIdentify.mock.calls.at(-1)!;
+      expect(segmentUserId).toBe(ANALYTICS_USER_ID);
+      expect(traits).toMatchObject({
+        userId: ANALYTICS_USER_ID,
+        braze_external_id: ANALYTICS_USER_ID,
+      });
+    });
+  });
+
+  describe("UserIdPlugin", () => {
+    it("does not inject userId on events when identity is isolated", () => {
+      const store = makeStore(false, true);
+      const plugin = new UserIdPlugin(store);
+      const event = { type: EventType.TrackEvent, event: "Test" } as SegmentEvent;
+
+      const result = plugin.execute(event);
+
+      expect(result?.userId).toBeUndefined();
+    });
+
+    it("injects userId on events when analytics is enabled", () => {
+      const store = makeStore(true, true);
+      const plugin = new UserIdPlugin(store);
+      const event = { type: EventType.TrackEvent, event: "Test" } as SegmentEvent;
+
+      const result = plugin.execute(event);
+
+      expect(result?.userId).toBe(ANALYTICS_USER_ID);
+    });
+  });
+
+  describe("BrazePlugin", () => {
+    it("disables Braze integration when braze_external_id is absent from traits", () => {
+      const plugin = new BrazePlugin();
+      const event = {
+        type: EventType.IdentifyEvent,
+        traits: { optInAnalytics: false },
+      } as SegmentEvent;
+
+      const result = plugin.execute(event);
+
+      expect(result?.integrations?.Appboy).toBe(false);
+    });
+
+    it("does not disable Braze integration when braze_external_id is present", () => {
+      const plugin = new BrazePlugin();
+      const event = {
+        type: EventType.IdentifyEvent,
+        traits: { braze_external_id: ANALYTICS_USER_ID, optInAnalytics: true },
+      } as SegmentEvent;
+
+      const result = plugin.execute(event);
+
+      expect(result?.integrations?.Appboy).not.toBe(false);
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -72,6 +72,7 @@ import { AuthorizationStatus, type FirebaseMessagingTypes } from "@react-native-
 import { getNotificationPermissionStatus } from "~/logic/getNotificationPermissionStatus";
 import { isDatadogEnabled } from "~/datadog";
 import { DdLogs } from "@datadog/mobile-react-native";
+import { shouldIncludeSegmentIdentity } from "./segmentIdentity";
 
 const sessionId = uuid();
 const appVersion = `${VersionNumber.appVersion || ""} (${VersionNumber.buildVersion || ""})`;
@@ -228,7 +229,9 @@ const getMEVAttributes = (state: State) => {
 const getMandatoryProperties = (store: AppStore) => {
   const state: State = store.getState();
   const userId = userIdSelector(state);
-  const userIdStr = isDummyUserId(userId) ? undefined : userId.exportUserIdForAnalytics();
+  const includeIdentity = shouldIncludeSegmentIdentity(state);
+  const userIdStr =
+    includeIdentity && !isDummyUserId(userId) ? userId.exportUserIdForAnalytics() : undefined;
   const analyticsEnabled = analyticsEnabledSelector(state);
   const personalizedRecommendationsEnabled = personalizedRecommendationsEnabledSelector(state);
   const hasSeenAnalyticsOptInPrompt = hasSeenAnalyticsOptInPromptSelector(state);
@@ -239,8 +242,7 @@ const getMandatoryProperties = (store: AppStore) => {
   const notificationsOptInAttributes = getNotificationsOptInAttributes();
 
   return {
-    userId: userIdStr,
-    braze_external_id: userIdStr, // Needed for braze with this exact name
+    ...(userIdStr ? { userId: userIdStr, braze_external_id: userIdStr } : {}),
     devModeEnabled,
     optInAnalytics: analyticsEnabled,
     optInPersonalRecommendations: personalizedRecommendationsEnabled,
@@ -592,7 +594,10 @@ export const updateIdentify = async (additionalProperties?: UserTraits, mandator
     : baseProperties;
   if (ANALYTICS_LOGS) console.log("analytics:identify", allProperties);
   if (!token) return;
-  await segmentClient?.identify(userExtraProperties.userId, allProperties);
+  const segmentUserId = shouldIncludeSegmentIdentity(state)
+    ? userExtraProperties.userId
+    : undefined;
+  await segmentClient?.identify(segmentUserId, allProperties);
 };
 
 type Properties = Error | Record<string, unknown> | null;

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -580,9 +580,13 @@ export const start = async (store: AppStore): Promise<SegmentClient | undefined>
 };
 
 export const updateIdentify = async (additionalProperties?: UserTraits, mandatory?: boolean) => {
-  const state = storeInstance?.getState();
+  if (!storeInstance) {
+    return;
+  }
+
+  const state = storeInstance.getState();
   const isTracking = getIsTracking(state, mandatory);
-  if (!storeInstance || !isTracking.enabled) {
+  if (!isTracking.enabled) {
     return;
   }
 

--- a/apps/ledger-live-mobile/src/analytics/segmentIdentity.ts
+++ b/apps/ledger-live-mobile/src/analytics/segmentIdentity.ts
@@ -1,0 +1,9 @@
+import { selectFeature } from "@shared/feature-flags";
+import { trackingEnabledSelector } from "../reducers/settings";
+import type { State } from "../reducers/types";
+
+export function shouldIncludeSegmentIdentity(state: State): boolean {
+  const brazeOptOutIdentityCleanup = selectFeature(state, "brazeOptOutIdentityCleanup")?.enabled;
+  if (!brazeOptOutIdentityCleanup) return true;
+  return trackingEnabledSelector(state);
+}


### PR DESCRIPTION
## Summary

Implements [LIVE-34720](https://ledgerhq.atlassian.net/browse/LIVE-34720) — Segment identity isolation for opted-out users (PR-3).

When `brazeOptOutIdentityCleanup` is enabled and the user has not consented to analytics, Segment identify/track calls no longer carry `userId` or `braze_external_id`, preventing identity from leaking to Braze via the Segment destination. Consent-related traits (`optInAnalytics`, etc.) are still sent on mandatory identify/track calls.

**Changes:**
- Add `shouldIncludeSegmentIdentity()` gated by `brazeOptOutIdentityCleanup` + `trackingEnabledSelector`
- `getMandatoryProperties()` — omit identity fields when opted out; keep consent flags
- `updateIdentify()` — call `identify(undefined, props)` when identity is omitted
- `UserIdPlugin` — skip injecting `event.userId` when identity is isolated
- `BrazePlugin` — disable Braze integration on identify when `braze_external_id` is absent from traits
- Add `segment.identityIsolation.test.ts`

**Base:** `feat/LIVE-34718` (LIVE-34718 — skip Braze `changeUser` for opted-out users)

## Test plan

- [ ] `pnpm mobile test:jest "src/analytics/__tests__/segment.identityIsolation.test.ts"`
- [ ] With `brazeOptOutIdentityCleanup` **off**: opted-out mandatory identify still includes identity (legacy)
- [ ] With flag **on** + analytics **off**: mandatory identify/track omit `userId` and `braze_external_id`; consent flags still present
- [ ] With flag **on** + analytics **on**: identify includes identity as before
- [ ] Toggle analytics consent in Settings → no identity in Segment payloads while opted out

[LIVE-34720]: https://ledgerhq.atlassian.net/browse/LIVE-34720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ