### PR TITLE
[LWM] feat(lwm): gate Braze notification pref writes (LIVE-34721)

### DIFF
--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
@@ -2,7 +2,11 @@ import { useCallback } from "react";
 import isEqual from "lodash/isEqual";
 import { useSelector, useDispatch } from "~/context/hooks";
 import { AuthorizationStatus } from "@react-native-firebase/messaging";
-import { notificationsSelector, INITIAL_STATE as settingsInitialState } from "~/reducers/settings";
+import {
+  notificationsSelector,
+  trackingEnabledSelector,
+  INITIAL_STATE as settingsInitialState,
+} from "~/reducers/settings";
 import { setNotifications } from "~/actions/settings";
 import { setNotificationsDataOfUser } from "~/actions/notifications";
 import { notificationsDataOfUserSelector } from "~/reducers/notifications";
@@ -24,6 +28,7 @@ const notificationSettingsKeys: Array<keyof NotificationsSettings> = [
 
 export const useNotificationsData = () => {
   const notifications = useSelector(notificationsSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
   const pushNotificationsDataOfUser = useSelector(notificationsDataOfUserSelector);
   const dispatch = useDispatch();
 
@@ -56,8 +61,8 @@ export const useNotificationsData = () => {
     };
 
     dispatch(setNotifications(updatedNotifications));
-    updateUserPreferences(updatedNotifications);
-  }, [dispatch, notifications]);
+    updateUserPreferences(updatedNotifications, isTrackedUser);
+  }, [dispatch, isTrackedUser, notifications]);
 
   const markUserAsOptOut = useCallback(
     (promptTarget?: NotificationPromptTarget) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsData.ts
@@ -16,6 +16,7 @@ import { buildOptOutUserData } from "../utils/buildOptOutUserData";
 import { type DataOfUser, type NotificationPromptTarget } from "../types";
 import { updateIdentify } from "~/analytics";
 import { updateUserPreferences } from "~/notifications/braze";
+import { useFeature } from "@features/platform-feature-flags";
 
 const notificationSettingsKeys: Array<keyof NotificationsSettings> = [
   "areNotificationsAllowed",
@@ -29,6 +30,7 @@ const notificationSettingsKeys: Array<keyof NotificationsSettings> = [
 export const useNotificationsData = () => {
   const notifications = useSelector(notificationsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
+  const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
   const pushNotificationsDataOfUser = useSelector(notificationsDataOfUserSelector);
   const dispatch = useDispatch();
 
@@ -61,8 +63,10 @@ export const useNotificationsData = () => {
     };
 
     dispatch(setNotifications(updatedNotifications));
-    updateUserPreferences(updatedNotifications, isTrackedUser);
-  }, [dispatch, isTrackedUser, notifications]);
+    updateUserPreferences(updatedNotifications, isTrackedUser, {
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+    });
+  }, [brazeOptOutIdentityCleanup?.enabled, dispatch, isTrackedUser, notifications]);
 
   const markUserAsOptOut = useCallback(
     (promptTarget?: NotificationPromptTarget) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -54,6 +54,7 @@ export const useNotificationsDrawer = ({
   updateUserLastInactiveTime,
 }: UseNotificationsDrawerParams) => {
   const featureBrazePushNotifications = useFeature("brazePushNotifications");
+  const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
   const actionEvents = featureBrazePushNotifications?.params?.action_events;
 
   const isPushNotificationsModalOpen = useSelector(notificationsModalOpenSelector);
@@ -301,6 +302,9 @@ export const useNotificationsDrawer = ({
           transactionsAlertsCategory: true,
         },
         isTrackedUser,
+        {
+          brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+        },
       );
       markUserAsOptIn();
       return;
@@ -332,6 +336,7 @@ export const useNotificationsDrawer = ({
     dispatch,
     notifications,
     isTrackedUser,
+    brazeOptOutIdentityCleanup?.enabled,
     permissionStatus,
     requestPushNotificationsPermission,
     drawerSource,

--- a/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/NotificationsPrompt/hooks/useNotificationsDrawer.ts
@@ -17,7 +17,7 @@ import {
   notificationsModalOpenSelector,
 } from "~/reducers/notifications";
 import { ratingsModalOpenSelector } from "~/reducers/ratings";
-import { notificationsSelector } from "~/reducers/settings";
+import { notificationsSelector, trackingEnabledSelector } from "~/reducers/settings";
 import { type NotificationsState } from "~/reducers/types";
 import { type DataOfUser, type NotificationPromptTarget } from "../types";
 import { resolveDrawerPromptTargetForAnalytics } from "../new/notificationsPromptAnalytics";
@@ -61,6 +61,7 @@ export const useNotificationsDrawer = ({
   const drawerSource = useSelector(notificationsDrawerSource);
   const drawerPromptTarget = useSelector(notificationsDrawerPromptTarget);
   const notifications = useSelector(notificationsSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
 
   const dispatch = useDispatch();
   const eventTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -294,10 +295,13 @@ export const useNotificationsDrawer = ({
           transactionsAlertsCategory: true,
         }),
       );
-      updateUserPreferences({
-        ...notifications,
-        transactionsAlertsCategory: true,
-      });
+      updateUserPreferences(
+        {
+          ...notifications,
+          transactionsAlertsCategory: true,
+        },
+        isTrackedUser,
+      );
       markUserAsOptIn();
       return;
     }
@@ -327,6 +331,7 @@ export const useNotificationsDrawer = ({
     drawerPromptTarget,
     dispatch,
     notifications,
+    isTrackedUser,
     permissionStatus,
     requestPushNotificationsPermission,
     drawerSource,

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -146,13 +146,17 @@ describe("HookNotifications", () => {
     rerender(<HookNotifications />);
 
     expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(2);
-    expect(mockedUpdateUserPreferences).toHaveBeenLastCalledWith(updatedNotifications, true);
+    expect(mockedUpdateUserPreferences).toHaveBeenLastCalledWith(updatedNotifications, true, {
+      brazeOptOutIdentityCleanup: true,
+    });
   });
 
   it("should pass tracking consent into notification preference updates", () => {
     mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
     render(<HookNotifications />);
 
-    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, false);
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, false, {
+      brazeOptOutIdentityCleanup: true,
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.test.tsx
@@ -146,6 +146,13 @@ describe("HookNotifications", () => {
     rerender(<HookNotifications />);
 
     expect(mockedUpdateUserPreferences).toHaveBeenCalledTimes(2);
-    expect(mockedUpdateUserPreferences).toHaveBeenLastCalledWith(updatedNotifications);
+    expect(mockedUpdateUserPreferences).toHaveBeenLastCalledWith(updatedNotifications, true);
+  });
+
+  it("should pass tracking consent into notification preference updates", () => {
+    mockSelectors({ isTrackedUser: false, userId: REAL_USER_ID });
+    render(<HookNotifications />);
+
+    expect(mockedUpdateUserPreferences).toHaveBeenCalledWith(defaultNotifications, false);
   });
 });

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -51,8 +51,10 @@ const HookNotifications = () => {
   }, [syncBrazeIdentity]);
 
   useEffect(() => {
-    updateUserPreferences(notifications, isTrackedUser);
-  }, [notifications, isTrackedUser]);
+    updateUserPreferences(notifications, isTrackedUser, {
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+    });
+  }, [notifications, isTrackedUser, brazeOptOutIdentityCleanup?.enabled]);
 
   return null;
 };

--- a/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
+++ b/apps/ledger-live-mobile/src/notifications/HookNotifications.ts
@@ -51,8 +51,8 @@ const HookNotifications = () => {
   }, [syncBrazeIdentity]);
 
   useEffect(() => {
-    updateUserPreferences(notifications);
-  }, [notifications]);
+    updateUserPreferences(notifications, isTrackedUser);
+  }, [notifications, isTrackedUser]);
 
   return null;
 };

--- a/apps/ledger-live-mobile/src/notifications/braze.test.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.test.ts
@@ -84,14 +84,26 @@ describe("updateUserPreferences", () => {
     jest.clearAllMocks();
   });
 
-  it("should skip Braze writes when user is not tracked", () => {
-    updateUserPreferences(defaultNotifications, false);
+  it("should write Braze attributes when flag is off even if user is not tracked", () => {
+    updateUserPreferences(defaultNotifications, false, {
+      brazeOptOutIdentityCleanup: false,
+    });
+
+    expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("notificationsAllowed", true);
+  });
+
+  it("should skip Braze writes when flag is on and user is not tracked", () => {
+    updateUserPreferences(defaultNotifications, false, {
+      brazeOptOutIdentityCleanup: true,
+    });
 
     expect(mockedSetCustomUserAttribute).not.toHaveBeenCalled();
   });
 
   it("should write Braze attributes when user is tracked", () => {
-    updateUserPreferences(defaultNotifications, true);
+    updateUserPreferences(defaultNotifications, true, {
+      brazeOptOutIdentityCleanup: true,
+    });
 
     expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("notificationsAllowed", true);
     expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("optInAnnouncements", true);

--- a/apps/ledger-live-mobile/src/notifications/braze.test.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.test.ts
@@ -1,12 +1,14 @@
 import Braze from "@braze/react-native-sdk";
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
 import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
-import { start } from "./braze";
+import { start, updateUserPreferences } from "./braze";
+import type { NotificationsSettings } from "../reducers/types";
 
 jest.mock("@braze/react-native-sdk", () => ({
   __esModule: true,
   default: {
     changeUser: jest.fn(),
+    setCustomUserAttribute: jest.fn(),
   },
 }));
 
@@ -15,7 +17,17 @@ jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
 }));
 
 const mockedChangeUser = jest.mocked(Braze.changeUser);
+const mockedSetCustomUserAttribute = jest.mocked(Braze.setCustomUserAttribute);
 const mockedGenerateAnonymousId = jest.mocked(generateAnonymousId);
+
+const defaultNotifications = {
+  areNotificationsAllowed: true,
+  announcementsCategory: true,
+  largeMoverCategory: false,
+  transactionsAlertsCategory: true,
+  totalMarketCap: false,
+  topGainersLosers: false,
+} satisfies NotificationsSettings;
 
 const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
 
@@ -64,5 +76,25 @@ describe("start", () => {
       expect(mockedChangeUser).not.toHaveBeenCalled();
       expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("updateUserPreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should skip Braze writes when user is not tracked", () => {
+    updateUserPreferences(defaultNotifications, false);
+
+    expect(mockedSetCustomUserAttribute).not.toHaveBeenCalled();
+  });
+
+  it("should write Braze attributes when user is tracked", () => {
+    updateUserPreferences(defaultNotifications, true);
+
+    expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("notificationsAllowed", true);
+    expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("optInAnnouncements", true);
+    expect(mockedSetCustomUserAttribute).toHaveBeenCalledWith("optInLargeMovers", false);
   });
 });

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -26,7 +26,12 @@ export const start = (
   Braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : generateAnonymousId());
 };
 
-export const updateUserPreferences = (notificationsPreferences: NotificationsSettings) => {
+export const updateUserPreferences = (
+  notificationsPreferences: NotificationsSettings,
+  isTrackedUser: boolean,
+) => {
+  if (!isTrackedUser) return;
+
   const notificationsOptedIn = {
     optInAnnouncements: notificationsPreferences.announcementsCategory,
     optInLargeMovers: notificationsPreferences.largeMoverCategory,

--- a/apps/ledger-live-mobile/src/notifications/braze.ts
+++ b/apps/ledger-live-mobile/src/notifications/braze.ts
@@ -26,11 +26,18 @@ export const start = (
   Braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : generateAnonymousId());
 };
 
+export type UpdateUserPreferencesOptions = {
+  brazeOptOutIdentityCleanup?: boolean;
+};
+
 export const updateUserPreferences = (
   notificationsPreferences: NotificationsSettings,
   isTrackedUser: boolean,
+  { brazeOptOutIdentityCleanup = false }: UpdateUserPreferencesOptions = {},
 ) => {
-  if (!isTrackedUser) return;
+  // Legacy (flag off): still write prefs for opted-out users (anonymous Braze profile).
+  // Flag on: never write Braze custom attributes without tracking consent.
+  if (brazeOptOutIdentityCleanup && !isTrackedUser) return;
 
   const notificationsOptedIn = {
     optInAnnouncements: notificationsPreferences.announcementsCategory,

--- a/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
@@ -35,6 +35,7 @@ function NotificationSettingsRow({ disabled, notificationKey, label }: Notificat
   const dispatch = useDispatch();
   const notifications = useSelector(notificationsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
+  const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
   const { markUserAsOptIn, permissionStatus, markUserAsOptOut } = useNotifications();
 
   const { t } = useTranslation();
@@ -72,6 +73,9 @@ function NotificationSettingsRow({ disabled, notificationKey, label }: Notificat
           [notificationKey]: value,
         },
         isTrackedUser,
+        {
+          brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanup?.enabled ?? false,
+        },
       );
     },
     [
@@ -80,6 +84,7 @@ function NotificationSettingsRow({ disabled, notificationKey, label }: Notificat
       capitalizedKey,
       notifications,
       isTrackedUser,
+      brazeOptOutIdentityCleanup?.enabled,
       markUserAsOptOut,
       permissionStatus,
       markUserAsOptIn,

--- a/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/Settings/Notifications/index.tsx
@@ -7,7 +7,7 @@ import { Box, Switch, Text, Button, IconsLegacy } from "@ledgerhq/native-ui";
 import SettingsNavigationScrollView from "../SettingsNavigationScrollView";
 import SettingsRow from "~/components/SettingsRow";
 import { track, TrackScreen, trackWithRoute, updateIdentify } from "~/analytics";
-import { notificationsSelector } from "~/reducers/settings";
+import { notificationsSelector, trackingEnabledSelector } from "~/reducers/settings";
 import { setNotifications } from "~/actions/settings";
 import type { State } from "~/reducers/types";
 import { useNotifications } from "LLM/features/NotificationsPrompt";
@@ -34,6 +34,7 @@ type NotificationRowProps = {
 function NotificationSettingsRow({ disabled, notificationKey, label }: NotificationRowProps) {
   const dispatch = useDispatch();
   const notifications = useSelector(notificationsSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
   const { markUserAsOptIn, permissionStatus, markUserAsOptOut } = useNotifications();
 
   const { t } = useTranslation();
@@ -65,16 +66,20 @@ function NotificationSettingsRow({ disabled, notificationKey, label }: Notificat
       });
 
       updateIdentify();
-      updateUserPreferences({
-        ...notifications,
-        [notificationKey]: value,
-      });
+      updateUserPreferences(
+        {
+          ...notifications,
+          [notificationKey]: value,
+        },
+        isTrackedUser,
+      );
     },
     [
       dispatch,
       notificationKey,
       capitalizedKey,
       notifications,
+      isTrackedUser,
       markUserAsOptOut,
       permissionStatus,
       markUserAsOptIn,


### PR DESCRIPTION
## Summary
- Gates Braze custom-attribute writes for notification preferences behind tracking consent when `brazeOptOutIdentityCleanup` is on. Opted-out users no longer get `setCustomUserAttribute` for notification prefs; opted-in behaviour is unchanged.
- Passes `isTrackedUser` and the cleanup flag into `updateUserPreferences` from `HookNotifications`, `useNotificationsData`, `useNotificationsDrawer`, and Settings → Notifications. Local Redux notification prefs still update regardless of tracking.
- With the flag off, opted-out users still write prefs to the anonymous Braze profile (legacy).
- Adds unit coverage for skipped vs allowed Braze writes, including the attribute args sent for tracked users.

## Test plan
- [x] `pnpm mobile test:jest --watchman=false "src/notifications/braze.test.ts" "src/notifications/HookNotifications.test.tsx"`
- [x] Opt out of analytics, toggle notification categories: Redux updates, no Braze custom attributes
- [x] Opt in, toggle the same categories: Braze attributes still written
- [x] Disable `brazeOptOutIdentityCleanup`: opted-out users still get the legacy anonymous-profile writes

## Jira
[LIVE-34721](https://ledgerhq.atlassian.net/browse/LIVE-34721)

[LIVE-34721]: https://ledgerhq.atlassian.net/browse/LIVE-34721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ