### PR TITLE
[LWD] feat(lwd): align desktop Braze identity for opt-out (LIVE-34722)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/actions/settings.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/settings.ts
@@ -330,6 +330,7 @@ export const clearDismissedContentCards = (payload: { now: Date }) => ({
   payload,
 });
 
+/** @deprecated Only used for legacy anonymous Braze identity when brazeOptOutIdentityCleanup is off. */
 export const setAnonymousBrazeId = (payload: string) => ({
   type: "SET_ANONYMOUS_BRAZE_ID",
   payload,

--- a/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
@@ -1,0 +1,100 @@
+import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
+import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
+import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "./brazeIdentity";
+
+jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
+  generateAnonymousId: jest.fn(() => "anonymous_id_1"),
+}));
+
+const mockedGenerateAnonymousId = jest.mocked(generateAnonymousId);
+const REAL_USER_ID = UserId.fromString("11111111-1111-1111-1111-111111111111");
+
+describe("brazeIdentity", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("resolveDesktopBrazeUserId", () => {
+    it("returns null for dummy user id", () => {
+      expect(
+        resolveDesktopBrazeUserId({
+          isTrackedUser: true,
+          userId: DUMMY_USER_ID,
+          anonymousBrazeId: null,
+          brazeOptOutIdentityCleanup: true,
+        }),
+      ).toBeNull();
+    });
+
+    describe("when brazeOptOutIdentityCleanup is off (legacy)", () => {
+      it("returns real id when tracked", () => {
+        expect(
+          resolveDesktopBrazeUserId({
+            isTrackedUser: true,
+            userId: REAL_USER_ID,
+            anonymousBrazeId: "stored_anonymous",
+            brazeOptOutIdentityCleanup: false,
+          }),
+        ).toBe(REAL_USER_ID.exportUserIdForBraze());
+      });
+
+      it("returns persisted anonymous id when opted out", () => {
+        expect(
+          resolveDesktopBrazeUserId({
+            isTrackedUser: false,
+            userId: REAL_USER_ID,
+            anonymousBrazeId: "stored_anonymous",
+            brazeOptOutIdentityCleanup: false,
+          }),
+        ).toBe("stored_anonymous");
+        expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+      });
+
+      it("generates anonymous id when opted out and none persisted", () => {
+        expect(
+          resolveDesktopBrazeUserId({
+            isTrackedUser: false,
+            userId: REAL_USER_ID,
+            anonymousBrazeId: null,
+            brazeOptOutIdentityCleanup: false,
+          }),
+        ).toBe("anonymous_id_1");
+      });
+    });
+
+    describe("when brazeOptOutIdentityCleanup is on", () => {
+      it("returns real id when tracked", () => {
+        expect(
+          resolveDesktopBrazeUserId({
+            isTrackedUser: true,
+            userId: REAL_USER_ID,
+            anonymousBrazeId: "stored_anonymous",
+            brazeOptOutIdentityCleanup: true,
+          }),
+        ).toBe(REAL_USER_ID.exportUserIdForBraze());
+      });
+
+      it("returns null when opted out", () => {
+        expect(
+          resolveDesktopBrazeUserId({
+            isTrackedUser: false,
+            userId: REAL_USER_ID,
+            anonymousBrazeId: "stored_anonymous",
+            brazeOptOutIdentityCleanup: true,
+          }),
+        ).toBeNull();
+        expect(mockedGenerateAnonymousId).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("shouldPersistAnonymousBrazeId", () => {
+    it("returns true when flag is off", () => {
+      expect(shouldPersistAnonymousBrazeId(false)).toBe(true);
+    });
+
+    it("returns false when flag is on", () => {
+      expect(shouldPersistAnonymousBrazeId(true)).toBe(false);
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/__tests__/brazeIdentity.test.ts
@@ -1,6 +1,6 @@
 import { UserId, DUMMY_USER_ID } from "@domain/entity-client-identity";
 import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
-import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "./brazeIdentity";
+import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "../brazeIdentity";
 
 jest.mock("@ledgerhq/live-common/braze/anonymousUsers", () => ({
   generateAnonymousId: jest.fn(() => "anonymous_id_1"),

--- a/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
+++ b/apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts
@@ -1,0 +1,30 @@
+import { type UserId, isDummyUserId } from "@domain/entity-client-identity";
+import { generateAnonymousId } from "@ledgerhq/live-common/braze/anonymousUsers";
+
+type ResolveDesktopBrazeUserIdArgs = {
+  isTrackedUser: boolean;
+  userId: UserId;
+  anonymousBrazeId: string | null;
+  brazeOptOutIdentityCleanup: boolean;
+};
+
+export function resolveDesktopBrazeUserId({
+  isTrackedUser,
+  userId,
+  anonymousBrazeId,
+  brazeOptOutIdentityCleanup,
+}: ResolveDesktopBrazeUserIdArgs): string | null {
+  if (isDummyUserId(userId)) return null;
+
+  if (brazeOptOutIdentityCleanup) {
+    return isTrackedUser ? userId.exportUserIdForBraze() : null;
+  }
+
+  return isTrackedUser
+    ? userId.exportUserIdForBraze()
+    : (anonymousBrazeId ?? generateAnonymousId());
+}
+
+export function shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanup: boolean): boolean {
+  return !brazeOptOutIdentityCleanup;
+}

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -278,11 +278,18 @@ export function useBraze() {
       dispatch(setGenericAwarenessModalContentCards(genericAwarenessModalContentCards));
     });
 
-        braze.automaticallyShowInAppMessages();
+    braze.automaticallyShowInAppMessages();
     braze.openSession();
 
     return subscriptionId;
-  }, [dispatch, devMode, isTrackedUser, brazeOptOutIdentityCleanupEnabled, anonymousBrazeId, userId]);
+  }, [
+    dispatch,
+    devMode,
+    isTrackedUser,
+    brazeOptOutIdentityCleanupEnabled,
+    anonymousBrazeId,
+    userId,
+  ]);
 
   useEffect(() => {
     let subscriptionId: string | undefined;

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -9,7 +9,9 @@ import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { ALWAYS_ON_CATEGORY_ID } from "LLD/features/DynamicContent/utils/constants";
 
 import { userIdSelector } from "@domain/entity-client-identity";
+import { useFeature } from "@features/platform-feature-flags";
 import { getBrazeConfig } from "~/braze-setup";
+import { resolveDesktopBrazeUserId, shouldPersistAnonymousBrazeId } from "../braze/brazeIdentity";
 import {
   ActionContentCard,
   CategoryContentCard,
@@ -162,8 +164,10 @@ export function useBraze() {
   const devMode = useSelector(developerModeSelector);
   const contentCardsDismissed = useSelector(dismissedContentCardsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
+  const brazeOptOutIdentityCleanup = useFeature("brazeOptOutIdentityCleanup");
   const anonymousBrazeId = useRef(useSelector(anonymousBrazeIdSelector));
   const userId = useSelector(userIdSelector);
+  const brazeOptOutIdentityCleanupEnabled = brazeOptOutIdentityCleanup?.enabled ?? false;
 
   // Read through a ref so that dismissing a card does not re-run the whole Braze
   // init, which would open a new session and stack another card subscription.
@@ -174,7 +178,10 @@ export function useBraze() {
     const brazeConfig = getBrazeConfig();
     const isPlaywright = !!getEnv("PLAYWRIGHT_RUN");
 
-    if (!anonymousBrazeId.current) {
+    if (
+      shouldPersistAnonymousBrazeId(brazeOptOutIdentityCleanupEnabled) &&
+      !anonymousBrazeId.current
+    ) {
       anonymousBrazeId.current = generateAnonymousId();
       dispatch(setAnonymousBrazeId(anonymousBrazeId.current));
     }
@@ -197,7 +204,15 @@ export function useBraze() {
       return;
     }
 
-    braze.changeUser(isTrackedUser ? userId.exportUserIdForBraze() : anonymousBrazeId.current);
+    const changeUserId = resolveDesktopBrazeUserId({
+      isTrackedUser,
+      userId,
+      anonymousBrazeId: anonymousBrazeId.current,
+      brazeOptOutIdentityCleanup: brazeOptOutIdentityCleanupEnabled,
+    });
+    if (changeUserId) {
+      braze.changeUser(changeUserId);
+    }
 
     braze.requestContentCardsRefresh();
 
@@ -263,11 +278,11 @@ export function useBraze() {
       dispatch(setGenericAwarenessModalContentCards(genericAwarenessModalContentCards));
     });
 
-    braze.automaticallyShowInAppMessages();
+        braze.automaticallyShowInAppMessages();
     braze.openSession();
 
     return subscriptionId;
-  }, [dispatch, devMode, isTrackedUser, anonymousBrazeId, userId]);
+  }, [dispatch, devMode, isTrackedUser, brazeOptOutIdentityCleanupEnabled, anonymousBrazeId, userId]);
 
   useEffect(() => {
     let subscriptionId: string | undefined;

--- a/domain/entity/client-identity/export-rules.json
+++ b/domain/entity/client-identity/export-rules.json
@@ -14,7 +14,7 @@
       "apps/ledger-live-mobile/src/analytics/UserIdPlugin.tsx"
     ],
     "exportUserIdForBraze": [
-      "apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts",
+      "apps/ledger-live-desktop/src/renderer/braze/brazeIdentity.ts",
       "apps/ledger-live-mobile/src/notifications/braze.ts"
     ],
     "exportUserIdForRecover": [


### PR DESCRIPTION
## Summary
Implements [LIVE-34722](https://ledgerhq.atlassian.net/browse/LIVE-34722) (PR-5) — desktop Braze identity alignment.
When `brazeOptOutIdentityCleanup` is enabled, desktop skips `changeUser` for opted-out users, adds dummy UserId guard, and stops persisting new `anonymousBrazeId`. Legacy path preserved when flag is off.
**Depends on:** LIVE-34718  
**Epic:** [LIVE-34717](https://ledgerhq.atlassian.net/browse/LIVE-34717)
## Test plan
- [x] `pnpm desktop test:jest "src/renderer/braze/__tests__/brazeIdentity.test.ts"`
- [ ] Flag **on** + opted out: no `changeUser`
- [ ] Flag **on** + opted in: `changeUser(exportUserIdForBraze())`
- [ ] Flag **off**: legacy `anonymousBrazeId` behavior preserved

[LIVE-34722]: https://ledgerhq.atlassian.net/browse/LIVE-34722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34717]: https://ledgerhq.atlassian.net/browse/LIVE-34717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ