### PR TITLE
feat(pay-card): add hasSeenFeatureTour to entity slice (LIVE-34860)

### DIFF
--- a/.changeset/pay-card-has-seen-feature-tour.md
+++ b/.changeset/pay-card-has-seen-feature-tour.md
@@ -1,0 +1,5 @@
+---
+"@domain/entity-pay-card": minor
+---
+
+Add persistable hasSeenFeatureTour flag to the payCard entity slice (markPayCardFeatureTourSeen, restorePayCardPersistedState, selectPayCardHasSeenFeatureTour, payCardPersistedSelector)

--- a/domain/entity/pay-card/src/selectors.ts
+++ b/domain/entity/pay-card/src/selectors.ts
@@ -1,4 +1,4 @@
-import type { PayCardParams, PayCardState } from "./types";
+import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
 
 type PayCardStateRoot = {
   payCard: PayCardState;
@@ -14,4 +14,15 @@ export function selectPayCardIsOpen(state: PayCardStateRoot): boolean {
 
 export function selectPayCardParams(state: PayCardStateRoot): PayCardParams | null {
   return state.payCard.params;
+}
+
+export function selectPayCardHasSeenFeatureTour(state: PayCardStateRoot): boolean {
+  return state.payCard.hasSeenFeatureTour;
+}
+
+/** Returns only the persisted subset of the pay card state. */
+export function payCardPersistedSelector(state: PayCardStateRoot): PayCardPersistedState {
+  return {
+    hasSeenFeatureTour: state.payCard.hasSeenFeatureTour,
+  };
 }

--- a/domain/entity/pay-card/src/slice.test.ts
+++ b/domain/entity/pay-card/src/slice.test.ts
@@ -49,6 +49,15 @@ describe("restorePayCardPersistedState", () => {
     expect(state.hasSeenFeatureTour).toBe(true);
   });
 
+  it("is a no-op when dispatched with an undefined payload (nothing persisted yet)", () => {
+    const state = reducer(
+      undefined,
+      // @ts-expect-error - simulating a restore with no persisted data
+      restorePayCardPersistedState(undefined),
+    );
+    expect(state).toEqual(payCardInitialState);
+  });
+
   it("ignores non-boolean values", () => {
     const state = reducer(
       undefined,

--- a/domain/entity/pay-card/src/slice.test.ts
+++ b/domain/entity/pay-card/src/slice.test.ts
@@ -1,23 +1,69 @@
-import { payCardSlice, payCardInitialState, openPayCard, closePayCard } from "./slice";
-import { selectPayCard, selectPayCardIsOpen, selectPayCardParams } from "./selectors";
+import {
+  payCardSlice,
+  payCardInitialState,
+  openPayCard,
+  closePayCard,
+  markPayCardFeatureTourSeen,
+  restorePayCardPersistedState,
+} from "./slice";
+import {
+  selectPayCard,
+  selectPayCardIsOpen,
+  selectPayCardParams,
+  selectPayCardHasSeenFeatureTour,
+  payCardPersistedSelector,
+} from "./selectors";
 
 const reducer = payCardSlice.reducer;
 const params = { platform: "cl-card", name: "CL Card" };
 const root = (state = payCardInitialState) => ({ payCard: state });
 
 describe("payCard slice", () => {
-  it("initializes closed with no params", () => {
+  it("initializes closed with no params and tour unseen", () => {
     expect(reducer(undefined, { type: "unknown" })).toEqual(payCardInitialState);
   });
 
   it("opens with the given params", () => {
     const state = reducer(undefined, openPayCard(params));
-    expect(state).toEqual({ isOpen: true, params });
+    expect(state).toEqual({ ...payCardInitialState, isOpen: true, params });
   });
 
-  it("closes and clears params", () => {
+  it("closes and clears params without touching hasSeenFeatureTour", () => {
+    const seen = reducer(undefined, markPayCardFeatureTourSeen());
+    const opened = reducer(seen, openPayCard(params));
+    expect(reducer(opened, closePayCard())).toEqual({
+      ...payCardInitialState,
+      hasSeenFeatureTour: true,
+    });
+  });
+
+  it("marks the feature tour as seen", () => {
+    const state = reducer(undefined, markPayCardFeatureTourSeen());
+    expect(state.hasSeenFeatureTour).toBe(true);
+  });
+});
+
+describe("restorePayCardPersistedState", () => {
+  it("restores hasSeenFeatureTour from a valid payload", () => {
+    const state = reducer(undefined, restorePayCardPersistedState({ hasSeenFeatureTour: true }));
+    expect(state.hasSeenFeatureTour).toBe(true);
+  });
+
+  it("ignores non-boolean values", () => {
+    const state = reducer(
+      undefined,
+      // @ts-expect-error - guarding against malformed persisted data
+      restorePayCardPersistedState({ hasSeenFeatureTour: "yes" }),
+    );
+    expect(state.hasSeenFeatureTour).toBe(false);
+  });
+
+  it("leaves ephemeral fields untouched", () => {
     const opened = reducer(undefined, openPayCard(params));
-    expect(reducer(opened, closePayCard())).toEqual(payCardInitialState);
+    const state = reducer(opened, restorePayCardPersistedState({ hasSeenFeatureTour: true }));
+    expect(state.isOpen).toBe(true);
+    expect(state.params).toEqual(params);
+    expect(state.hasSeenFeatureTour).toBe(true);
   });
 });
 
@@ -35,5 +81,17 @@ describe("payCard selectors", () => {
   it("selectPayCardParams returns params when open, null when closed", () => {
     expect(selectPayCardParams(root())).toBeNull();
     expect(selectPayCardParams(root(reducer(undefined, openPayCard(params))))).toEqual(params);
+  });
+
+  it("selectPayCardHasSeenFeatureTour reflects mark/reset", () => {
+    expect(selectPayCardHasSeenFeatureTour(root())).toBe(false);
+    expect(
+      selectPayCardHasSeenFeatureTour(root(reducer(undefined, markPayCardFeatureTourSeen()))),
+    ).toBe(true);
+  });
+
+  it("payCardPersistedSelector returns only the persisted subset", () => {
+    const state = reducer(undefined, openPayCard(params));
+    expect(payCardPersistedSelector(root(state))).toEqual({ hasSeenFeatureTour: false });
   });
 });

--- a/domain/entity/pay-card/src/slice.ts
+++ b/domain/entity/pay-card/src/slice.ts
@@ -1,9 +1,10 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { PayCardParams, PayCardState } from "./types";
+import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
 
 export const payCardInitialState: PayCardState = {
   isOpen: false,
   params: null,
+  hasSeenFeatureTour: false,
 };
 
 export const payCardSlice = createSlice({
@@ -18,7 +19,24 @@ export const payCardSlice = createSlice({
       state.isOpen = false;
       state.params = null;
     },
+    markPayCardFeatureTourSeen: state => {
+      state.hasSeenFeatureTour = true;
+    },
+    restorePayCardPersistedState: (
+      state,
+      action: PayloadAction<Partial<PayCardPersistedState>>,
+    ) => {
+      const { hasSeenFeatureTour } = action.payload;
+      if (typeof hasSeenFeatureTour === "boolean") {
+        state.hasSeenFeatureTour = hasSeenFeatureTour;
+      }
+    },
   },
 });
 
-export const { openPayCard, closePayCard } = payCardSlice.actions;
+export const {
+  openPayCard,
+  closePayCard,
+  markPayCardFeatureTourSeen,
+  restorePayCardPersistedState,
+} = payCardSlice.actions;

--- a/domain/entity/pay-card/src/slice.ts
+++ b/domain/entity/pay-card/src/slice.ts
@@ -26,7 +26,7 @@ export const payCardSlice = createSlice({
       state,
       action: PayloadAction<Partial<PayCardPersistedState>>,
     ) => {
-      const { hasSeenFeatureTour } = action.payload;
+      const { hasSeenFeatureTour } = action.payload ?? {};
       if (typeof hasSeenFeatureTour === "boolean") {
         state.hasSeenFeatureTour = hasSeenFeatureTour;
       }

--- a/domain/entity/pay-card/src/types.ts
+++ b/domain/entity/pay-card/src/types.ts
@@ -29,4 +29,10 @@ export type PayCardParams = z.infer<typeof PayCardParamsSchema>;
 export type PayCardState = Readonly<{
   isOpen: boolean;
   params: PayCardParams | null;
+  hasSeenFeatureTour: boolean;
+}>;
+
+/** Subset of {@link PayCardState} that is persisted across app restarts. */
+export type PayCardPersistedState = Readonly<{
+  hasSeenFeatureTour: boolean;
 }>;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Foundation for the Pay feature tour: add a persistable `hasSeenFeatureTour` flag to the `@domain/entity-pay-card` slice (default `false`).

- Reducers: `markPayCardFeatureTourSeen` (→ true) and `restorePayCardPersistedState` (merges only the persisted subset on launch, never touching the ephemeral `isOpen` / `params`).
- Selectors: `selectPayCardHasSeenFeatureTour` and `payCardPersistedSelector` (returns only `{ hasSeenFeatureTour }`).
- Exports `PayCardPersistedState` so future persisted fields (e.g. `balanceFilter`, LIVE-34894) extend the same shape without a rename.

Usage:

```ts
import {
  markPayCardFeatureTourSeen,
  restorePayCardPersistedState,
  selectPayCardHasSeenFeatureTour,
  payCardPersistedSelector,
} from "@domain/entity-pay-card";

// on launch
dispatch(restorePayCardPersistedState(loadedPersistedState));
// when the tour has been shown
dispatch(markPayCardFeatureTourSeen());
// persist only the safe subset
const toPersist = payCardPersistedSelector(state);
```

The DevTools reset + `resetPayCardFeatureTourSeen` (LIVE-34881) is stacked on top of this branch (#20548). App persistence wiring (LIVE-34861 / LIVE-34862) is out of scope.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34860](https://ledgerhq.atlassian.net/browse/LIVE-34860)
- **ADR** (if any): n/a

[LIVE-34860]: https://ledgerhq.atlassian.net/browse/LIVE-34860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ