### PR TITLE
[LWD] feat(lwd): isolate Segment identity for opted-out users (LIVE-34723)

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identityIsolation.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identityIsolation.test.ts
@@ -1,11 +1,39 @@
+jest.unmock("../segment");
+jest.unmock("~/renderer/analytics/segment");
+jest.unmock("src/renderer/analytics/segment");
+
+const mockIdentify = jest.fn();
+
+jest.mock("@segment/analytics-next", () => ({
+  AnalyticsBrowser: {
+    load: jest.fn(() => ({
+      identify: mockIdentify,
+      track: jest.fn(),
+    })),
+  },
+}));
+
+jest.mock("~/renderer/logger", () => ({
+  __esModule: true,
+  default: {
+    analyticsPage: jest.fn(),
+    analyticsStart: jest.fn(),
+    analyticsTrack: jest.fn(),
+    onReduxAction: jest.fn(),
+  },
+}));
+
 import createStore from "~/state-manager/configureStore";
 import { withFlagOverrides } from "tests/testSetup";
 import type { State } from "~/renderer/reducers";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
 import { shouldIncludeSegmentIdentity } from "../segmentIdentity";
+import { startAnalytics, updateIdentify } from "../segment";
 
 const createTestState = (overrides: Partial<State> = {}): State =>
   ({
     settings: {
+      ...SETTINGS_INITIAL_STATE,
       shareAnalytics: false,
       sharePersonalizedRecommandations: false,
     },
@@ -13,9 +41,15 @@ const createTestState = (overrides: Partial<State> = {}): State =>
   }) as State;
 
 describe("segment identity isolation (LIVE-34723)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("returns true when flag is off regardless of consent", () => {
     const store = createStore({
-      state: createTestState(withFlagOverrides({})),
+      state: createTestState(
+        withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: false } }) as Partial<State>,
+      ),
       fetchRemoteFlags: null,
     });
     expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
@@ -23,7 +57,9 @@ describe("segment identity isolation (LIVE-34723)", () => {
 
   it("returns false when flag is on and tracking is disabled", () => {
     const store = createStore({
-      state: createTestState(withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } })),
+      state: createTestState(
+        withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } }) as Partial<State>,
+      ),
       fetchRemoteFlags: null,
     });
     expect(shouldIncludeSegmentIdentity(store.getState())).toBe(false);
@@ -32,8 +68,9 @@ describe("segment identity isolation (LIVE-34723)", () => {
   it("returns true when flag is on and analytics is enabled", () => {
     const store = createStore({
       state: createTestState({
-        ...withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } }),
+        ...(withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } }) as Partial<State>),
         settings: {
+          ...SETTINGS_INITIAL_STATE,
           shareAnalytics: true,
           sharePersonalizedRecommandations: false,
         },
@@ -41,5 +78,58 @@ describe("segment identity isolation (LIVE-34723)", () => {
       fetchRemoteFlags: null,
     });
     expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
+  });
+
+  describe("updateIdentify({ force: true })", () => {
+    it("omits userId and braze_external_id when flag is on and tracking is off", async () => {
+      const store = createStore({
+        state: createTestState(
+          withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } }) as Partial<State>,
+        ),
+        fetchRemoteFlags: null,
+      });
+
+      await startAnalytics(store);
+      mockIdentify.mockClear();
+
+      await updateIdentify({ force: true });
+
+      expect(mockIdentify).toHaveBeenCalled();
+      const [segmentUserId, traits] = mockIdentify.mock.calls.at(-1)!;
+      expect(segmentUserId).toBeUndefined();
+      expect(traits).not.toHaveProperty("userId");
+      expect(traits).not.toHaveProperty("braze_external_id");
+      expect(traits).toMatchObject({
+        optInAnalytics: false,
+        optInPersonalRecommendations: false,
+      });
+    });
+
+    it("includes identity when flag is on and analytics is enabled", async () => {
+      const store = createStore({
+        state: createTestState({
+          ...(withFlagOverrides({
+            brazeOptOutIdentityCleanup: { enabled: true },
+          }) as Partial<State>),
+          settings: {
+            ...SETTINGS_INITIAL_STATE,
+            shareAnalytics: true,
+            sharePersonalizedRecommandations: false,
+          },
+        }),
+        fetchRemoteFlags: null,
+      });
+
+      await startAnalytics(store);
+      expect(mockIdentify).toHaveBeenCalled();
+      const [segmentUserId, traits] = mockIdentify.mock.calls.at(-1)!;
+      expect(segmentUserId).toEqual(expect.any(String));
+      expect(traits).toEqual(
+        expect.objectContaining({
+          userId: segmentUserId,
+          braze_external_id: segmentUserId,
+        }),
+      );
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identityIsolation.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/__tests__/segment.identityIsolation.test.ts
@@ -1,0 +1,45 @@
+import createStore from "~/state-manager/configureStore";
+import { withFlagOverrides } from "tests/testSetup";
+import type { State } from "~/renderer/reducers";
+import { shouldIncludeSegmentIdentity } from "../segmentIdentity";
+
+const createTestState = (overrides: Partial<State> = {}): State =>
+  ({
+    settings: {
+      shareAnalytics: false,
+      sharePersonalizedRecommandations: false,
+    },
+    ...overrides,
+  }) as State;
+
+describe("segment identity isolation (LIVE-34723)", () => {
+  it("returns true when flag is off regardless of consent", () => {
+    const store = createStore({
+      state: createTestState(withFlagOverrides({})),
+      fetchRemoteFlags: null,
+    });
+    expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
+  });
+
+  it("returns false when flag is on and tracking is disabled", () => {
+    const store = createStore({
+      state: createTestState(withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } })),
+      fetchRemoteFlags: null,
+    });
+    expect(shouldIncludeSegmentIdentity(store.getState())).toBe(false);
+  });
+
+  it("returns true when flag is on and analytics is enabled", () => {
+    const store = createStore({
+      state: createTestState({
+        ...withFlagOverrides({ brazeOptOutIdentityCleanup: { enabled: true } }),
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: false,
+        },
+      }),
+      fetchRemoteFlags: null,
+    });
+    expect(shouldIncludeSegmentIdentity(store.getState())).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segment.ts
@@ -40,6 +40,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { accountsSelector } from "../reducers/accounts";
 import { currentRouteNameRef, previousRouteNameRef } from "./screenRefs";
+import { shouldIncludeSegmentIdentity } from "./segmentIdentity";
 import {
   onboardingIsSyncFlowSelector,
   onboardingReceiveFlowSelector,
@@ -501,7 +502,8 @@ export interface UpdateIdentifyOptions {
 export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force: false }) => {
   if (!storeInstance) return;
 
-  const canTrack = force || trackingEnabledSelector(storeInstance.getState());
+  const state = storeInstance.getState();
+  const canTrack = force || trackingEnabledSelector(state);
   if (!canTrack) return;
 
   let analytics = getAnalytics();
@@ -513,12 +515,12 @@ export const updateIdentify = async ({ force }: UpdateIdentifyOptions = { force:
     if (!analytics) return;
   }
 
-  const id = userIdSelector(storeInstance.getState()).exportUserIdForAnalytics();
+  const includeIdentity = shouldIncludeSegmentIdentity(state);
+  const id = includeIdentity ? userIdSelector(state).exportUserIdForAnalytics() : undefined;
 
   const allProperties = {
     ...extraProperties(storeInstance),
-    userId: id,
-    braze_external_id: id, // Needed for braze with this exact name
+    ...(id ? { userId: id, braze_external_id: id } : {}),
   };
   analytics.identify(id, allProperties, {
     context: getContext(),

--- a/apps/ledger-live-desktop/src/renderer/analytics/segmentIdentity.ts
+++ b/apps/ledger-live-desktop/src/renderer/analytics/segmentIdentity.ts
@@ -1,0 +1,9 @@
+import { selectFeature } from "@shared/feature-flags";
+import { trackingEnabledSelector } from "../reducers/settings";
+import type { State } from "../reducers";
+
+export function shouldIncludeSegmentIdentity(state: State): boolean {
+  const brazeOptOutIdentityCleanup = selectFeature(state, "brazeOptOutIdentityCleanup")?.enabled;
+  if (!brazeOptOutIdentityCleanup) return true;
+  return trackingEnabledSelector(state);
+}


### PR DESCRIPTION
## Summary
Implements [LIVE-34723](https://ledgerhq.atlassian.net/browse/LIVE-34723) (PR-6) — desktop Segment identity isolation.
When `brazeOptOutIdentityCleanup` is enabled and tracking is off, forced `updateIdentify({ force: true })` on consent toggles omits `userId` and `braze_external_id` while still sending consent flags.
**Depends on:** LIVE-34718  
**Epic:** [LIVE-34717](https://ledgerhq.atlassian.net/browse/LIVE-34717)
## Test plan
- [x] `pnpm desktop test:jest "src/renderer/analytics/__tests__/segment.identityIsolation.test.ts"`
- [ ] Forced identify on opt-out omits identity (flag on)
- [ ] Forced identify on opt-in includes identity (flag on)
- [ ] Flag off: legacy behavior unchanged

[LIVE-34723]: https://ledgerhq.atlassian.net/browse/LIVE-34723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34717]: https://ledgerhq.atlassian.net/browse/LIVE-34717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ