### PR TITLE
[LWM] feat(pay-card): persist payCard slice on mobile (LIVE-34861)

### DIFF
--- a/.changeset/persist-paycard-slice-mobile.md
+++ b/.changeset/persist-paycard-slice-mobile.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Persist the payCard slice on mobile: save and restore only { hasSeenFeatureTour } so the Pay feature tour does not reappear after killing and reopening the app

--- a/apps/ledger-live-mobile/src/components/DBSave.test.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.test.ts
@@ -1,4 +1,5 @@
 import { featureFlagsLense } from "./DBSave";
+import { payCardPersistedSelector } from "@domain/entity-pay-card";
 import type { State } from "~/reducers/types";
 
 describe("featureFlagsLense", () => {
@@ -16,5 +17,38 @@ describe("featureFlagsLense", () => {
 
     expect(projected).toEqual({ overrides, bannerVisible: false });
     expect(projected).not.toHaveProperty("remoteFlagsReady");
+  });
+});
+
+describe("payCardPersistedSelector (mobile persistence lens)", () => {
+  it("projects only { hasSeenFeatureTour } — never the transient isOpen/params", () => {
+    const state = {
+      payCard: {
+        isOpen: true,
+        params: { platform: "cl-card", name: "CL Card" },
+        hasSeenFeatureTour: true,
+      },
+    } as unknown as State;
+
+    const projected = payCardPersistedSelector(state);
+
+    expect(projected).toEqual({ hasSeenFeatureTour: true });
+    expect(projected).not.toHaveProperty("isOpen");
+    expect(projected).not.toHaveProperty("params");
+  });
+
+  it("does not change when only transient fields change", () => {
+    const base = {
+      payCard: { isOpen: false, params: null, hasSeenFeatureTour: false },
+    } as unknown as State;
+    const opened = {
+      payCard: {
+        isOpen: true,
+        params: { platform: "cl-card", name: "CL Card" },
+        hasSeenFeatureTour: false,
+      },
+    } as unknown as State;
+
+    expect(payCardPersistedSelector(base)).toEqual(payCardPersistedSelector(opened));
   });
 });

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -26,6 +26,7 @@ import {
   saveMarketState,
   saveMarketListConfig,
   saveMarketBannerState,
+  savePayCardState,
   savePostOnboardingState,
   saveSettings,
   saveTrustchainState,
@@ -38,6 +39,7 @@ import { exportSelector as knownDevicesExportSelector } from "~/reducers/knownDe
 import { exportLargeMoverSelector } from "~/reducers/largeMover";
 import { exportMarketSelector, exportMarketListConfigSelector } from "~/reducers/market";
 import { marketBannerStoreSelector } from "~/reducers/marketBanner";
+import { payCardPersistedSelector } from "@domain/entity-pay-card";
 import { settingsStoreSelector } from "~/reducers/settings";
 import type { State } from "~/reducers/types";
 import { Maybe } from "../types/helpers";
@@ -184,6 +186,8 @@ const getLargeScreenUpsellModalStateChanged = (a: State, b: State) =>
 const marketNotEquals = (a: State, b: State) => a.market !== b.market;
 const marketListConfigNotEquals = (a: State, b: State) => a.marketListConfig !== b.marketListConfig;
 const marketBannerNotEquals = (a: State, b: State) => a.marketBanner !== b.marketBanner;
+const payCardPersistedNotEquals = (a: State, b: State) =>
+  !isEqual(payCardPersistedSelector(a), payCardPersistedSelector(b));
 const trustchainNotEquals = (a: State, b: State) => a.trustchain !== b.trustchain;
 const compareWalletState = (a: State, b: State) =>
   walletStateExportShouldDiffer(a.wallet, b.wallet);
@@ -290,6 +294,14 @@ export const ConfigureDBSaveEffects = () => {
     throttle: 500,
     getChangesStats: marketBannerNotEquals,
     lense: marketBannerStoreSelector,
+  });
+
+  useDBSaveEffect({
+    stateSelector: (state: State) => state.payCard.hasSeenFeatureTour,
+    save: savePayCardState,
+    throttle: 500,
+    getChangesStats: payCardPersistedNotEquals,
+    lense: payCardPersistedSelector,
   });
 
   useDBSaveEffect({

--- a/apps/ledger-live-mobile/src/context/LedgerStore.tsx
+++ b/apps/ledger-live-mobile/src/context/LedgerStore.tsx
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { Store } from "redux";
 import { importPostOnboardingState } from "@ledgerhq/live-common/postOnboarding/actions";
 import { restoreLargeScreenUpsellModalState } from "@ledgerhq/live-engagement/largeScreenUpsellModal";
+import { restorePayCardPersistedState } from "@domain/entity-pay-card";
 import { backfillOnboardingDate } from "~/logic/postOnboarding/backfillOnboardingDate";
 import { CounterValuesStateRaw } from "@ledgerhq/live-countervalues/types";
 import { findCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -26,6 +27,7 @@ import {
   getMarketState,
   getMarketListConfig,
   getMarketBannerState,
+  getPayCardState,
   getTrustchainState,
   getWalletExportState,
   getLargeMoverState,
@@ -100,6 +102,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         marketState,
         marketListConfigState,
         marketBannerState,
+        payCardState,
         trustchainStore,
         walletStore,
         protect,
@@ -120,6 +123,7 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
         retry(getMarketState, MAX_RETRIES, RETRY_DELAY),
         retry(getMarketListConfig, MAX_RETRIES, RETRY_DELAY),
         retry(getMarketBannerState, MAX_RETRIES, RETRY_DELAY),
+        retry(getPayCardState, MAX_RETRIES, RETRY_DELAY),
         retry(getTrustchainState, MAX_RETRIES, RETRY_DELAY),
         retry(getWalletExportState, MAX_RETRIES, RETRY_DELAY),
         retry(getProtect, MAX_RETRIES, RETRY_DELAY),
@@ -194,6 +198,10 @@ const LedgerStoreProvider: React.FC<Props> = ({ onInitFinished, children, store 
 
       if (marketBannerState) {
         store.dispatch(importMarketBannerState(marketBannerState));
+      }
+
+      if (payCardState) {
+        store.dispatch(restorePayCardPersistedState(payCardState));
       }
 
       store.dispatch(importTrustchainStoreState(trustchainStore));

--- a/apps/ledger-live-mobile/src/db.ts
+++ b/apps/ledger-live-mobile/src/db.ts
@@ -31,6 +31,7 @@ import { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { ExportedWalletState } from "~/reducers/wallet";
 import { type PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
+import type { PayCardPersistedState } from "@domain/entity-pay-card";
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";
@@ -307,6 +308,14 @@ export function getMarketBannerState(): Promise<MarketBannerState | null> {
 
 export async function saveMarketBannerState(obj: MarketBannerState): Promise<void> {
   await storage.save("marketBanner", obj);
+}
+
+export function getPayCardState(): Promise<PayCardPersistedState | null> {
+  return storage.get("payCard") as Promise<PayCardPersistedState | null>;
+}
+
+export async function savePayCardState(obj: PayCardPersistedState): Promise<void> {
+  await storage.save("payCard", obj);
 }
 
 export function getTrustchainState(): Promise<TrustchainStore> {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Persist the `payCard` slice on mobile, following the `largeScreenUpsellModal` / `marketBanner` precedent. Only the persisted subset `payCardPersistedSelector` (`{ hasSeenFeatureTour }`) is saved; the transient `isOpen` / `params` are never written to storage.

- `src/db.ts`: `getPayCardState()` / `savePayCardState()` via `storage.get/save("payCard", ...)`.
- `src/components/DBSave.ts`: `useDBSaveEffect` for `payCard` with a subset change detector (`payCardPersistedSelector`), so open/close does not trigger a save.
- `src/context/LedgerStore.tsx`: load `getPayCardState()` at startup and dispatch `restorePayCardPersistedState`.

Acceptance: after "Got it", kill + reopen the app -> the feature tour does not reappear; `isOpen` / `params` never hit storage.

> Stacked on #20546 (LIVE-34860) - this PR targets its branch. Review/merge #20546 first. Retarget to `develop` once it merges.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34861](https://ledgerhq.atlassian.net/browse/LIVE-34861)
- **ADR** (if any): n/a

[LIVE-34861]: https://ledgerhq.atlassian.net/browse/LIVE-34861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ