### PR TITLE
docs(ddd): mark delivered platform packages as STABLE

### DIFF
--- a/domain/api/currency-fiat/README.md
+++ b/domain/api/currency-fiat/README.md
@@ -1,7 +1,7 @@
 # @domain/api-currency-fiat
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Domain API client for **fiat currencies**, backed by the Ledger Countervalues Service (CVS). RTK
 Query endpoint and helpers, typed on the Zod-first `@domain/entity-currency-fiat` entity. Owns no

--- a/domain/api/currency-token/README.md
+++ b/domain/api/currency-token/README.md
@@ -1,7 +1,7 @@
 # @domain/api-currency-token
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Domain API client for **token currencies**, backed by the Crypto Asset List (CAL). RTK Query
 endpoints and helpers, typed on the Zod-first `@domain/entity-currency-token` entity. Owns no

--- a/domain/entity/account-name/README.md
+++ b/domain/entity/account-name/README.md
@@ -1,6 +1,7 @@
 # @domain/entity-account-name
 
-> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 RTK slice and WalletSync module for user-defined account names.
 

--- a/domain/entity/recent-addresses/README.md
+++ b/domain/entity/recent-addresses/README.md
@@ -1,6 +1,7 @@
 # @domain/entity-recent-addresses
 
-> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Schemas, RTK slice, in-memory store and WalletSync module for recently used recipient addresses.
 

--- a/domain/entity/wallet-sync/README.md
+++ b/domain/entity/wallet-sync/README.md
@@ -1,6 +1,7 @@
 # @domain/entity-wallet-sync
 
-> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 RTK slice for WalletSync protocol state (distant data + version).
 

--- a/features/platform/currencies/README.md
+++ b/features/platform/currencies/README.md
@@ -1,7 +1,7 @@
 # `@features/platform-currencies`
 
-> [!CAUTION]
-> **Status: UNSTABLE** — Part of the emerging DDD layer; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 App-facing currency **runtime glue**. Mirrors `@features/platform-feature-flags`:
 this package owns hooks + the crypto-assets store builder; currency **state lives in

--- a/features/platform/env/README.md
+++ b/features/platform/env/README.md
@@ -1,5 +1,8 @@
 # @features/platform-env
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 React hook for subscribing to typed env var changes in Ledger Live apps.
 
 ## Usage

--- a/features/platform/wallet-sync/README.md
+++ b/features/platform/wallet-sync/README.md
@@ -1,5 +1,8 @@
 # @features/platform-wallet-sync
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Platform-level orchestration for Ledger Live wallet synchronisation.
 
 Wires together `@shared/cloud-sync` (network), `@shared/cloud-sync-module` (aggregation) and the domain entity modules into a runnable watch loop. Exports:

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -1,7 +1,7 @@
 # @shared/auth
 
-> [!CAUTION]
-> **Status: UNSTABLE** — RTK Query auth adapter; under active development.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 RTK Query helpers for APIs that authenticate through an injected token provider.
 

--- a/shared/cloud-sync-module/README.md
+++ b/shared/cloud-sync-module/README.md
@@ -1,6 +1,7 @@
 # @shared/cloud-sync-module
 
-> **Status: UNSTABLE** — This package is incrementally shipping the validated CloudSync DDD architecture; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Context-free aggregation core for Ledger Live cloud synchronisation.
 

--- a/shared/cloud-sync/README.md
+++ b/shared/cloud-sync/README.md
@@ -1,6 +1,7 @@
 # @shared/cloud-sync
 
-> **Status: UNSTABLE** — This package is incrementally shipping the validated WalletSync DDD architecture; API may change.
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
 
 Generic cloud sync networking layer for Ledger Live wallet synchronisation.
 

--- a/shared/env/README.md
+++ b/shared/env/README.md
@@ -1,5 +1,8 @@
 # @shared/env
 
+> [!NOTE]
+> **Status: STABLE** — Production-ready; API is considered stable.
+
 Workspace-private DDD layer for Ledger Live environment variables.
 
 ## What it is


### PR DESCRIPTION
> [!NOTE]
> Documentation-only change. No code, no build, no runtime impact.

### 📝 Description

Promotes to **STABLE** the `domain/*`, `features/*` and `shared/*` packages that are (a) imported directly by both apps and (b) part of a feature effort that is delivered, with no open PR against them.

Follows the status marker convention in [docs/new-library.md](../blob/develop/docs/new-library.md#readme-status-marker).

**Promoted `UNSTABLE` → `STABLE`** (9)

| Package | LLD / LLM import sites | Effort |
| --- | --- | --- |
| `@shared/cloud-sync` | 2 / 2 | Cloud Sync |
| `@shared/cloud-sync-module` | indirect | Cloud Sync |
| `@shared/auth` | 4 / 5 | Cloud Sync |
| `@domain/entity-wallet-sync` | 3 / 3 | Cloud Sync |
| `@domain/entity-account-name` | 30 / 7 | Cloud Sync |
| `@domain/entity-recent-addresses` | 4 / 5 | Cloud Sync |
| `@domain/api-currency-fiat` | 2 / 2 | Crypto Assets |
| `@domain/api-currency-token` | 9 / 3 | Crypto Assets |
| `@features/platform-currencies` | 12 / 21 | Crypto Assets |

**Marker added (was missing entirely) as `STABLE`** (3)

| Package | LLD / LLM import sites |
| --- | --- |
| `@shared/env` | 89 / 55 |
| `@features/platform-env` | 15 / 35 |
| `@features/platform-wallet-sync` | 2 / 1 |

The marker is a documentation convention only — nothing in the repo consumes it programmatically, so this is purely a signal to readers and agents that these APIs can be relied on.

### Left UNSTABLE on purpose

| Package(s) | Reason |
| --- | --- |
| `entity-contact`, `platform-contacts`, `flow-contacts`, `flow-contacts-add-contact`, `shared/name`, `shared/qr-code` | Contacts is still in flight (#20140, #20272, #20409, #20505, #20510, #20537) |
| `entity-pay-card`, `api-pay-card`, `flow-pay-card-auth` | Pay Card still in flight (#19788, #20096) — `entity-pay-card` / `api-pay-card` still have no marker, left for the owning team |
| `entity-aggregated-asset`, `api-aggregated-assets`, `platform-aggregated-assets`, `entity-interest-rate` | #20540 in flight; `platform-aggregated-assets` is still an empty stub |
| `api-swap-quotes` | #20464 in flight |
| `api-market-sentiment`, `api-altcoins-sentiment`, `flow-fear-and-greed` | Market effort not considered done |
| `entity-analytics-consent`, `flow-analytics-consent` | Still behind the `analyticsOptIn` flag |
| `flow-large-screen-upsell` | Still behind the `largeScreenUpsell` flag, desktop only |
| `entity-starred-account` | Its README already carries a hand-written DEPRECATED note (Wallet V4 dropped starred accounts). Promoting it would contradict that — it needs a proper `Status: DEPRECATED` marker in a separate PR. |
| `flow-market-banner` | Declared in LLM devDependencies but never imported |

### 🔗 Context

- **JIRA / GitHub issue**: N/A — follow-up hygiene on the DDD re-architecture (LIVE-29793)
- **ADR** (if any): [docs/new-library.md — README status marker](../blob/develop/docs/new-library.md#readme-status-marker)
