### PR TITLE
feat(pay-card): persist payCard slice on desktop (LIVE-34862)

### DIFF
--- a/.changeset/persist-paycard-slice-desktop.md
+++ b/.changeset/persist-paycard-slice-desktop.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Persist the payCard slice on desktop: save and restore only { hasSeenFeatureTour } so the Pay feature tour does not reappear after restarting the app

--- a/apps/ledger-live-desktop/src/main/db/index.ts
+++ b/apps/ledger-live-desktop/src/main/db/index.ts
@@ -63,6 +63,7 @@ const APP_NAMESPACE_ALLOWED_KEY_PATHS: ReadonlySet<string> = new Set([
   "market",
   "marketBanner",
   LARGE_SCREEN_UPSELL_MODAL,
+  "payCard",
   "knownDevices",
   "cryptoAssets",
   "identities",

--- a/apps/ledger-live-desktop/src/renderer/init.tsx
+++ b/apps/ledger-live-desktop/src/renderer/init.tsx
@@ -11,6 +11,7 @@ import {
   LARGE_SCREEN_UPSELL_MODAL,
   restoreLargeScreenUpsellModalState,
 } from "@features/flow-large-screen-upsell";
+import { restorePayCardPersistedState } from "@domain/entity-pay-card";
 import i18n from "i18next";
 import { webFrame, ipcRenderer } from "electron";
 import each from "lodash/each";
@@ -332,6 +333,11 @@ async function init() {
   const largeScreenUpsellModalState = await getKey("app", LARGE_SCREEN_UPSELL_MODAL);
   if (largeScreenUpsellModalState !== undefined) {
     store.dispatch(restoreLargeScreenUpsellModalState(largeScreenUpsellModalState));
+  }
+
+  const payCardState = await getKey("app", "payCard");
+  if (payCardState !== undefined) {
+    store.dispatch(restorePayCardPersistedState(payCardState));
   }
 
   r(<ReactRoot store={store} language={language} initialCountervalues={initialCountervalues} />);

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -45,6 +45,12 @@ jest.mock("@domain/entity-client-identity", () => ({
   exportIdentitiesForPersistence: jest.fn(s => s),
 }));
 
+jest.mock("@domain/entity-pay-card", () => ({
+  payCardPersistedSelector: (state: FakeState) => ({
+    hasSeenFeatureTour: state.payCard.hasSeenFeatureTour,
+  }),
+}));
+
 jest.mock("@ledgerhq/live-common/account/index", () => ({
   accountsPersistedStateChanged: jest.fn(() => false),
 }));
@@ -62,6 +68,7 @@ type FakeState = {
   featureFlags: { overrides: unknown; bannerVisible: unknown; remoteFlagsReady?: unknown };
   coinConfigOverrides: { overrides: Record<string, unknown> };
   largeScreenUpsellModal: { retries: number; lastSeenAt: number | null };
+  payCard: { isOpen: boolean; params: unknown; hasSeenFeatureTour: boolean };
   trustchain?: unknown;
 };
 
@@ -76,6 +83,7 @@ const baseState = (): FakeState => ({
   featureFlags: { overrides: {}, bannerVisible: false },
   coinConfigOverrides: { overrides: {} },
   largeScreenUpsellModal: { retries: 0, lastSeenAt: null },
+  payCard: { isOpen: false, params: null, hasSeenFeatureTour: false },
 });
 
 function runMiddleware(states: FakeState[], action: { type: string; payload?: unknown }) {
@@ -211,6 +219,28 @@ describe("DBMiddleware - largeScreenUpsellModal branch", () => {
       retries: 2,
       lastSeenAt: 1_720_000_000_000,
     });
+  });
+});
+
+describe("DBMiddleware - payCard branch", () => {
+  beforeEach(() => {
+    mockedSetKey.mockReset();
+  });
+
+  it("persists only { hasSeenFeatureTour } under app/payCard on payCard/* actions", () => {
+    const state: FakeState = {
+      ...baseState(),
+      payCard: { isOpen: true, params: { platform: "cl-card" }, hasSeenFeatureTour: true },
+    };
+
+    runMiddleware([state, state], { type: "payCard/markPayCardFeatureTourSeen" });
+
+    expect(mockedSetKey).toHaveBeenCalledTimes(1);
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", { hasSeenFeatureTour: true });
+
+    const persisted = mockedSetKey.mock.calls[0][2] as Record<string, unknown>;
+    expect(persisted).not.toHaveProperty("isOpen");
+    expect(persisted).not.toHaveProperty("params");
   });
 });
 

--- a/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/db.ts
@@ -32,6 +32,7 @@ import {
 } from "@features/flow-large-screen-upsell";
 import { knownDevicesStoreSelector } from "../reducers/knownDevices";
 import { exportIdentitiesForPersistence } from "@domain/entity-client-identity";
+import { payCardPersistedSelector } from "@domain/entity-pay-card";
 import { accountsPersistedStateChanged } from "@ledgerhq/live-common/account/index";
 
 let DB_MIDDLEWARE_ENABLED = true;
@@ -127,6 +128,13 @@ const DBMiddleware: Middleware<object, State> = store => next => action => {
     const res = next(action);
     const state = store.getState();
     setKey("app", LARGE_SCREEN_UPSELL_MODAL, persistedLargeScreenUpsellModalSelector(state));
+    return res;
+  }
+
+  if (action.type.startsWith("payCard/")) {
+    const res = next(action);
+    const state = store.getState();
+    setKey("app", "payCard", payCardPersistedSelector(state));
     return res;
   }
 

--- a/apps/ledger-live-desktop/src/renderer/storage.ts
+++ b/apps/ledger-live-desktop/src/renderer/storage.ts
@@ -22,6 +22,7 @@ import type { PersistedCAL } from "@domain/api-currency-token";
 import type { PersistedIdentities } from "@domain/entity-client-identity";
 import type { FeatureFlagsState } from "@shared/feature-flags";
 import type { RestorableLargeScreenUpsellModalState } from "@features/flow-large-screen-upsell";
+import type { PayCardPersistedState } from "@domain/entity-pay-card";
 
 /*
   This file serve as an interface for the RPC binding to the main thread that now manage the config file.
@@ -42,6 +43,7 @@ export type Settings = ReturnType<typeof settingsStoreSelector>;
 export type Market = ReturnType<typeof marketStoreSelector>;
 export type MarketBanner = ReturnType<typeof marketBannerStoreSelector>;
 export type KnownDevices = ReturnType<typeof knownDevicesStoreSelector>;
+export type PayCard = PayCardPersistedState;
 
 export type TrustchainStore = ReturnType<typeof trustchainStoreSelector>;
 
@@ -70,6 +72,7 @@ type DatabaseValues = {
     lastScreen: string;
   };
   largeScreenUpsellModal: RestorableLargeScreenUpsellModalState;
+  payCard: PayCard;
 };
 
 // Infers the type seen from the user side (non-raw).


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Persist the `payCard` slice on desktop, following the `largeScreenUpsellModal` / `marketBanner` precedent. Only the persisted subset `payCardPersistedSelector` (`{ hasSeenFeatureTour }`) is saved; the transient `isOpen` / `params` are never written to `app.json`.

- `renderer/middlewares/db.ts`: on `payCard/*` actions, `setKey("app", "payCard", payCardPersistedSelector(state))`.
- `renderer/storage.ts`: add `payCard` to `DatabaseValues` (`PayCardPersistedState`).
- `main/db/index.ts`: allow `payCard` in `APP_NAMESPACE_ALLOWED_KEY_PATHS`.
- `renderer/init.tsx`: read `getKey("app", "payCard")` at startup and dispatch `restorePayCardPersistedState`.

Acceptance: after "Got it", restart the app -> the feature tour does not reappear; `isOpen` / `params` never hit `app.json`.

> Stacked on #20546 (LIVE-34860) - this PR targets its branch. Review/merge #20546 first. Retarget to `develop` once it merges.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34862](https://ledgerhq.atlassian.net/browse/LIVE-34862)
- **ADR** (if any): n/a

[LIVE-34862]: https://ledgerhq.atlassian.net/browse/LIVE-34862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ