### PR TITLE
[LWD] feat(die): add lwd connect device tracking (LIVE-35575)

### DIFF
--- a/.changeset/track-lwd-connect-device.md
+++ b/.changeset/track-lwd-connect-device.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add Device Intent Executor Connect Device tracking.

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/DeviceConnectionComponentLWDView.test.tsx
@@ -9,7 +9,7 @@ import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
 import { DeviceConnectionComponentLWDView } from "./DeviceConnectionComponentLWDView";
-import { makeKnownDevice } from "./testUtils";
+import { DeviceIntentTrackingTestWrapper, makeKnownDevice } from "./testUtils";
 import type { DeviceConnectionComponentLWDViewModel } from "./useDeviceConnectionComponentLWDViewModel";
 
 jest.mock("~/renderer/components/DeviceAction/animations", () => ({
@@ -28,6 +28,7 @@ function renderView(
       onConnectLedgerDevice={callbacks.onConnectLedgerDevice ?? jest.fn()}
       onBuyLedgerDevice={callbacks.onBuyLedgerDevice ?? jest.fn()}
     />,
+    { wrapper: DeviceIntentTrackingTestWrapper },
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.test.tsx
@@ -3,7 +3,7 @@ import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
-import { makeKnownDevice } from "../testUtils";
+import { DeviceIntentTrackingTestWrapper, makeKnownDevice } from "../testUtils";
 import { ConnectingState } from "./ConnectingState";
 
 type ConnectingUIState = Extract<
@@ -20,7 +20,7 @@ describe("ConnectingState", () => {
     };
 
     // WHEN
-    render(<ConnectingState state={state} />);
+    render(<ConnectingState state={state} />, { wrapper: DeviceIntentTrackingTestWrapper });
 
     // THEN
     expect(screen.getByText("Loading")).toBeVisible();

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectingState.tsx
@@ -1,14 +1,31 @@
 import React from "react";
-import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/live-dmk-desktop";
+import {
+  ConnectDeviceUIStateTypes,
+  type ConnectDeviceUIState,
+  webHidTransportIdentifier,
+} from "@ledgerhq/live-dmk-desktop";
 import { useTranslation } from "react-i18next";
 import { LoadingContent } from "../../components/DeviceGenericStates/LoadingContent";
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 
 type ConnectingStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.Connecting }>;
 };
 
-export function ConnectingState(_props: Readonly<ConnectingStateProps>): React.ReactNode {
+export function ConnectingState({ state }: Readonly<ConnectingStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const transport = state.device.transport === webHidTransportIdentifier ? "usb" : "ble";
 
-  return <LoadingContent title={t("deviceIntentExecutor.connectDevice.states.connecting.title")} />;
+  return (
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_DEVICE.Connecting}
+        modelId={state.device.deviceModelId}
+        transport={transport}
+        refreshSource
+      />
+      <LoadingContent title={t("deviceIntentExecutor.connectDevice.states.connecting.title")} />
+    </>
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.test.tsx
@@ -7,7 +7,7 @@ import {
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
-import { makeKnownDevice } from "../testUtils";
+import { DeviceIntentTrackingTestWrapper, makeKnownDevice } from "../testUtils";
 import { ConnectionErrorState } from "./ConnectionErrorState";
 
 type ConnectionErrorUIState = Extract<
@@ -29,6 +29,7 @@ function renderState(state: Partial<ConnectionErrorUIState> = {}) {
         } as ConnectionErrorUIState
       }
     />,
+    { wrapper: DeviceIntentTrackingTestWrapper },
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/ConnectionErrorState.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import {
   BaseConnectionErrorTypes,
   ConnectDeviceUIStateTypes,
@@ -7,6 +8,15 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import {
+  CONNECT_DEVICE_BUTTON,
+  getTrackingSubError,
+  getTrackingTransport,
+  PAGE_CONNECT_DEVICE,
+  setIsInTerminalConnectDeviceError,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 
 type ConnectionErrorStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.ConnectionError }>;
@@ -16,29 +26,51 @@ export function ConnectionErrorState({
   state,
 }: Readonly<ConnectionErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+
+  useEffect(() => {
+    setIsInTerminalConnectDeviceError(true);
+    return () => setIsInTerminalConnectDeviceError(false);
+  }, []);
 
   if (state.error.type !== BaseConnectionErrorTypes.Unknown) {
     return null;
   }
 
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title")}
-      description={t(
-        "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description",
-      )}
-      banner={{
-        title: t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.tip"),
-      }}
-      primaryCta={{
-        label: t(
-          "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.cta.retry",
-        ),
-        onPress: state.retry,
-      }}
-      testID="device-intent-executor-connect-device-connection-error"
-    />
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_DEVICE.ConnectionError}
+        modelId={state.device.deviceModelId}
+        transport={getTrackingTransport(state.device.transport)}
+        subError={getTrackingSubError(state.error.type)}
+        refreshSource
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.title")}
+        description={t(
+          "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.description",
+        )}
+        banner={{
+          title: t("deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.tip"),
+        }}
+        primaryCta={{
+          label: t(
+            "deviceIntentExecutor.connectDevice.states.connectionError.errors.unknown.cta.retry",
+          ),
+          onPress: () => {
+            trackConnectDeviceButtonClicked({
+              sourceFlow,
+              button: CONNECT_DEVICE_BUTTON.Retry,
+              extraProperties: analyticsProperties,
+            });
+            state.retry();
+          },
+        }}
+        testID="device-intent-executor-connect-device-connection-error"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.test.tsx
@@ -4,7 +4,11 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
-import { makeDisplayedDevice, makeKnownDevice } from "../testUtils";
+import {
+  DeviceIntentTrackingTestWrapper,
+  makeDisplayedDevice,
+  makeKnownDevice,
+} from "../testUtils";
 import { DeviceListItem } from "./DeviceListItem";
 
 describe("DeviceListItem", () => {
@@ -16,7 +20,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    render(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />, { wrapper: DeviceIntentTrackingTestWrapper });
 
     // THEN
     expect(screen.getByText("Available Ledger")).toBeVisible();
@@ -31,7 +35,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    render(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />, { wrapper: DeviceIntentTrackingTestWrapper });
 
     // THEN
     expect(screen.getByText("Unavailable Ledger")).toBeVisible();
@@ -45,7 +49,7 @@ describe("DeviceListItem", () => {
     });
 
     // WHEN
-    render(<DeviceListItem device={device} />);
+    render(<DeviceListItem device={device} />, { wrapper: DeviceIntentTrackingTestWrapper });
 
     // THEN
     expect(
@@ -63,7 +67,9 @@ describe("DeviceListItem", () => {
       }),
       onSelect,
     });
-    const { user } = render(<DeviceListItem device={device} />);
+    const { user } = render(<DeviceListItem device={device} />, {
+      wrapper: DeviceIntentTrackingTestWrapper,
+    });
 
     // WHEN
     await user.click(screen.getByText("Ledger Stax"));

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DeviceListItem.tsx
@@ -9,9 +9,11 @@ import {
   Tag,
 } from "@ledgerhq/lumen-ui-react";
 import type { DisplayedDevice } from "@ledgerhq/live-dmk-desktop";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import { getProductName } from "@ledgerhq/devices";
 import { getDeviceIcon } from "LLD/utils/getDeviceIcon";
 import { useTranslation } from "react-i18next";
+import { trackDeviceSelected } from "../../utils/trackDeviceIntent";
 
 type DeviceListItemProps = {
   device: DisplayedDevice;
@@ -23,11 +25,20 @@ function getDeviceName(device: DisplayedDevice["knownDevice"], fallbackName: str
 
 export function DeviceListItem({ device }: Readonly<DeviceListItemProps>): React.ReactNode {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
   const DeviceIcon = getDeviceIcon(device.knownDevice.deviceModelId);
   const isAvailable = device.type === "available";
+  const handleSelect = () => {
+    trackDeviceSelected({
+      sourceFlow,
+      device: device.knownDevice,
+      extraProperties: analyticsProperties,
+    });
+    device.onSelect();
+  };
 
   return (
-    <ListItem onClick={device.onSelect}>
+    <ListItem onClick={handleSelect}>
       <ListItemLeading>
         <Spot size={48} appearance="icon" icon={DeviceIcon} />
         <ListItemContent>

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.test.tsx
@@ -3,7 +3,11 @@ import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
-import { makeDisplayedDevice, makeKnownDevice } from "../testUtils";
+import {
+  DeviceIntentTrackingTestWrapper,
+  makeDisplayedDevice,
+  makeKnownDevice,
+} from "../testUtils";
 import { DiscoveringState } from "./DiscoveringState";
 
 type DiscoveringUIState = Extract<
@@ -29,6 +33,7 @@ function renderState(state: Partial<DiscoveringUIState> = {}) {
         ...state,
       }}
     />,
+    { wrapper: DeviceIntentTrackingTestWrapper },
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveringState.tsx
@@ -6,6 +6,8 @@ import {
 } from "@ledgerhq/live-dmk-desktop";
 import { useTranslation } from "react-i18next";
 
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 import { DeviceListItem } from "./DeviceListItem";
 
 type DiscoveringStateProps = {
@@ -24,6 +26,7 @@ export function DiscoveringState({ state }: Readonly<DiscoveringStateProps>): Re
 
   return (
     <div className="flex w-full flex-col gap-16">
+      <TrackDIEScreen category={PAGE_CONNECT_DEVICE.Discovering} refreshSource />
       <h3 className="heading-4-semi-bold text-left text-base">
         {t(
           hasAvailableDevice

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.test.tsx
@@ -7,6 +7,7 @@ import {
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
+import { DeviceIntentTrackingTestWrapper } from "../testUtils";
 import { DiscoveryErrorState } from "./DiscoveryErrorState";
 
 type DiscoveryErrorUIState = Extract<
@@ -27,6 +28,7 @@ function renderState(state: Partial<DiscoveryErrorUIState> = {}) {
         } as DiscoveryErrorUIState
       }
     />,
+    { wrapper: DeviceIntentTrackingTestWrapper },
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
@@ -27,6 +27,7 @@ export function DiscoveryErrorState({
 }: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
   const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const trackingTransport = getTrackingTransport(state.error.transportId);
 
   useEffect(() => {
     setIsInTerminalConnectDeviceError(!state.retry);
@@ -41,9 +42,7 @@ export function DiscoveryErrorState({
     <>
       <TrackDIEScreen
         category={PAGE_CONNECT_DEVICE.DiscoveryError}
-        {...(getTrackingTransport(state.error.transportId)
-          ? { transport: getTrackingTransport(state.error.transportId) }
-          : {})}
+        {...(trackingTransport ? { transport: trackingTransport } : {})}
         subError={getTrackingSubError(state.error.type)}
         refreshSource
       />

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/DiscoveryErrorState.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import {
   BaseDiscoveryErrorTypes,
   ConnectDeviceUIStateTypes,
@@ -7,6 +8,15 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import {
+  CONNECT_DEVICE_BUTTON,
+  getTrackingSubError,
+  getTrackingTransport,
+  PAGE_CONNECT_DEVICE,
+  setIsInTerminalConnectDeviceError,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 
 type DiscoveryErrorStateProps = {
   state: Extract<ConnectDeviceUIState, { type: ConnectDeviceUIStateTypes.DiscoveryError }>;
@@ -16,30 +26,53 @@ export function DiscoveryErrorState({
   state,
 }: Readonly<DiscoveryErrorStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+
+  useEffect(() => {
+    setIsInTerminalConnectDeviceError(!state.retry);
+    return () => setIsInTerminalConnectDeviceError(false);
+  }, [state.retry]);
 
   if (state.error.type !== BaseDiscoveryErrorTypes.Unknown) {
     return null;
   }
 
   return (
-    <InfoState
-      preset="error"
-      size="hug"
-      title={t("deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.title")}
-      description={t(
-        "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.description",
-      )}
-      primaryCta={
-        state.retry
-          ? {
-              label: t(
-                "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.cta.retry",
-              ),
-              onPress: state.retry,
-            }
-          : undefined
-      }
-      testID="device-intent-executor-connect-device-discovery-error"
-    />
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_DEVICE.DiscoveryError}
+        {...(getTrackingTransport(state.error.transportId)
+          ? { transport: getTrackingTransport(state.error.transportId) }
+          : {})}
+        subError={getTrackingSubError(state.error.type)}
+        refreshSource
+      />
+      <InfoState
+        preset="error"
+        size="hug"
+        title={t("deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.title")}
+        description={t(
+          "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.description",
+        )}
+        primaryCta={
+          state.retry
+            ? {
+                label: t(
+                  "deviceIntentExecutor.connectDevice.states.discoveryError.errors.unknown.cta.retry",
+                ),
+                onPress: () => {
+                  trackConnectDeviceButtonClicked({
+                    sourceFlow,
+                    button: CONNECT_DEVICE_BUTTON.Retry,
+                    extraProperties: analyticsProperties,
+                  });
+                  state.retry?.();
+                },
+              }
+            : undefined
+        }
+        testID="device-intent-executor-connect-device-discovery-error"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.test.tsx
@@ -2,12 +2,15 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
+import { DeviceIntentTrackingTestWrapper } from "../testUtils";
 import { NoKnownDeviceState } from "./NoKnownDeviceState";
 
 describe("NoKnownDeviceState", () => {
   it("GIVEN there is no known device WHEN rendering THEN it shows the no known device copy", () => {
     // WHEN
-    render(<NoKnownDeviceState onConnectLedgerDevice={jest.fn()} onBuyLedgerDevice={jest.fn()} />);
+    render(<NoKnownDeviceState onConnectLedgerDevice={jest.fn()} onBuyLedgerDevice={jest.fn()} />, {
+      wrapper: DeviceIntentTrackingTestWrapper,
+    });
 
     // THEN
     expect(screen.getByText("Ledger device required")).toBeVisible();
@@ -22,6 +25,7 @@ describe("NoKnownDeviceState", () => {
         onConnectLedgerDevice={onConnectLedgerDevice}
         onBuyLedgerDevice={jest.fn()}
       />,
+      { wrapper: DeviceIntentTrackingTestWrapper },
     );
 
     // WHEN
@@ -39,6 +43,7 @@ describe("NoKnownDeviceState", () => {
         onConnectLedgerDevice={jest.fn()}
         onBuyLedgerDevice={onBuyLedgerDevice}
       />,
+      { wrapper: DeviceIntentTrackingTestWrapper },
     );
 
     // WHEN

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/NoKnownDeviceState.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import { LedgerDevices } from "@ledgerhq/lumen-ui-react/symbols";
+import { useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import { useTranslation } from "react-i18next";
 
 import { InfoState } from "LLD/components/InfoState";
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import {
+  CONNECT_DEVICE_BUTTON,
+  PAGE_CONNECT_DEVICE,
+  trackConnectDeviceButtonClicked,
+} from "../../utils/trackDeviceIntent";
 
 type NoKnownDeviceStateProps = {
   onConnectLedgerDevice: () => void;
@@ -14,23 +21,43 @@ export function NoKnownDeviceState({
   onBuyLedgerDevice,
 }: Readonly<NoKnownDeviceStateProps>): React.ReactNode {
   const { t } = useTranslation();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
+  const handleConnectLedgerDevice = () => {
+    trackConnectDeviceButtonClicked({
+      sourceFlow,
+      button: CONNECT_DEVICE_BUTTON.ConnectDevice,
+      extraProperties: analyticsProperties,
+    });
+    onConnectLedgerDevice();
+  };
+  const handleBuyLedgerDevice = () => {
+    trackConnectDeviceButtonClicked({
+      sourceFlow,
+      button: CONNECT_DEVICE_BUTTON.BuyDevice,
+      extraProperties: analyticsProperties,
+    });
+    onBuyLedgerDevice();
+  };
 
   return (
-    <InfoState
-      preset="spot"
-      spotProps={{ icon: LedgerDevices }}
-      size="hug"
-      title={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.title")}
-      description={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.description")}
-      primaryCta={{
-        label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice"),
-        onPress: onConnectLedgerDevice,
-      }}
-      secondaryCta={{
-        label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice"),
-        onPress: onBuyLedgerDevice,
-      }}
-      testID="device-intent-executor-connect-device-no-known-device"
-    />
+    <>
+      <TrackDIEScreen category={PAGE_CONNECT_DEVICE.NoKnownDevice} refreshSource />
+      <InfoState
+        preset="spot"
+        spotProps={{ icon: LedgerDevices }}
+        size="hug"
+        title={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.title")}
+        description={t("deviceIntentExecutor.connectDevice.states.noKnownDevice.description")}
+        primaryCta={{
+          label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.connectLedgerDevice"),
+          onPress: handleConnectLedgerDevice,
+        }}
+        secondaryCta={{
+          label: t("deviceIntentExecutor.connectDevice.states.noKnownDevice.noLedgerDevice"),
+          onPress: handleBuyLedgerDevice,
+        }}
+        testID="device-intent-executor-connect-device-no-known-device"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.test.tsx
@@ -5,7 +5,7 @@ import { DeviceModelId } from "@ledgerhq/types-devices";
 import { screen } from "@testing-library/react";
 import { render } from "tests/testSetup";
 
-import { makeKnownDevice } from "../testUtils";
+import { DeviceIntentTrackingTestWrapper, makeKnownDevice } from "../testUtils";
 import { WaitingForSelectedDeviceState } from "./WaitingForSelectedDeviceState";
 
 jest.mock("~/renderer/components/DeviceAction/animations", () => ({
@@ -27,6 +27,7 @@ function renderState(device: WaitingForSelectedDeviceUIState["device"]) {
         device,
       }}
     />,
+    { wrapper: DeviceIntentTrackingTestWrapper },
   );
 }
 

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/components/WaitingForSelectedDeviceState.tsx
@@ -4,6 +4,8 @@ import { ConnectDeviceUIStateTypes, type ConnectDeviceUIState } from "@ledgerhq/
 import { useTranslation } from "react-i18next";
 
 import { DeviceActionContent } from "LLD/components/DeviceActionContent";
+import { TrackDIEScreen } from "../../components/TrackDIEScreen";
+import { PAGE_CONNECT_DEVICE } from "../../utils/trackDeviceIntent";
 
 type WaitingForSelectedDeviceStateProps = {
   state: Extract<
@@ -26,14 +28,21 @@ export function WaitingForSelectedDeviceState({
   const productName = getProductName(state.device.deviceModelId);
 
   return (
-    <DeviceActionContent
-      action="power-and-unlock"
-      deviceModelId={state.device.deviceModelId}
-      deviceName={getDeviceName(state.device, productName)}
-      title={t("deviceIntentExecutor.connectDevice.states.waitingForSelectedDevice.title", {
-        productName,
-      })}
-      testID="device-intent-executor-connect-device-waiting-for-selected-device"
-    />
+    <>
+      <TrackDIEScreen
+        category={PAGE_CONNECT_DEVICE.WaitingForSelectedDevice}
+        modelId={state.device.deviceModelId}
+        refreshSource
+      />
+      <DeviceActionContent
+        action="power-and-unlock"
+        deviceModelId={state.device.deviceModelId}
+        deviceName={getDeviceName(state.device, productName)}
+        title={t("deviceIntentExecutor.connectDevice.states.waitingForSelectedDevice.title", {
+          productName,
+        })}
+        testID="device-intent-executor-connect-device-waiting-for-selected-device"
+      />
+    </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/testUtils.tsx
@@ -1,6 +1,7 @@
 import { webHidTransportIdentifier, type DisplayedDevice } from "@ledgerhq/live-dmk-desktop";
-import type { KnownDevice } from "@ledgerhq/live-dmk-shared";
+import { DeviceIntentTrackingProvider, type KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { DeviceModelId } from "@ledgerhq/types-devices";
+import React, { type ReactNode } from "react";
 
 export function makeKnownDevice(overrides: Partial<KnownDevice> = {}): KnownDevice {
   return {
@@ -19,4 +20,16 @@ export function makeDisplayedDevice(overrides: Partial<DisplayedDevice> = {}): D
     onSelect: () => undefined,
     ...overrides,
   } as DisplayedDevice;
+}
+
+export function DeviceIntentTrackingTestWrapper({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>): ReactNode {
+  return (
+    <DeviceIntentTrackingProvider value={{ sourceFlow: "swap" }}>
+      {children}
+    </DeviceIntentTrackingProvider>
+  );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
@@ -6,7 +6,11 @@ import {
   type ConnectDeviceUIState,
   useDeviceManagementKit,
 } from "@ledgerhq/live-dmk-desktop";
-import { ledgerToDmkDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
+import {
+  DeviceIntentTrackingProvider,
+  ledgerToDmkDeviceIdMap,
+  type KnownDevice,
+} from "@ledgerhq/live-dmk-shared";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
@@ -96,7 +100,11 @@ function renderViewModel({
 function TestWrapper({ children, store }: { children: React.ReactNode; store: ReduxStore }) {
   return (
     <Provider store={store}>
-      <MemoryRouter>{children}</MemoryRouter>
+      <MemoryRouter>
+        <DeviceIntentTrackingProvider value={{ sourceFlow: "swap" }}>
+          {children}
+        </DeviceIntentTrackingProvider>
+      </MemoryRouter>
     </Provider>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.test.tsx
@@ -16,6 +16,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
+import { track } from "~/renderer/analytics/segment";
 import type { State } from "~/renderer/reducers";
 import createStore, { type ReduxStore } from "~/state-manager/configureStore";
 
@@ -29,6 +30,10 @@ jest.mock("LLD/hooks/useLazyOnboardingActions", () => ({
     handleConnect: mockHandleConnect,
     handleBuyDevice: mockHandleBuyDevice,
   }),
+}));
+
+jest.mock("~/renderer/analytics/segment", () => ({
+  track: jest.fn(),
 }));
 
 jest.mock("@ledgerhq/live-dmk-desktop", () => {
@@ -47,6 +52,7 @@ type ConnectDeviceObserver = {
 
 const mockedUseDeviceManagementKit = jest.mocked(useDeviceManagementKit);
 const mockedConnectDevice = jest.mocked(connectDevice);
+const mockedTrack = jest.mocked(track);
 const mockDmk = { id: "dmk" } as unknown as NonNullable<ReturnType<typeof useDeviceManagementKit>>;
 
 let connectDeviceObserver: ConnectDeviceObserver | undefined;
@@ -54,6 +60,11 @@ let mockUnsubscribe: jest.Mock;
 
 const defaultDeviceConnectionParams: DeviceConnectionParams = {
   acceptedDeviceModelIds: [],
+};
+
+const layerABaseProperties = {
+  deviceUxV2: true,
+  sourceFlow: "swap",
 };
 
 function mockConnectDeviceSubscription() {
@@ -200,6 +211,71 @@ describe("useDeviceConnectionComponentLWDViewModel", () => {
 
     // THEN
     expect(result.current.state).toBe(discoveringState);
+  });
+
+  describe("GIVEN the Connect Device flow emits tracking states", () => {
+    it("WHEN Discovering and WaitingForSelectedDevice are observed THEN device_prompted fires once", () => {
+      // GIVEN
+      renderViewModel();
+
+      // WHEN
+      act(() =>
+        connectDeviceObserver?.next({
+          type: ConnectDeviceUIStateTypes.Discovering,
+          devices: [],
+        }),
+      );
+      act(() =>
+        connectDeviceObserver?.next({
+          type: ConnectDeviceUIStateTypes.WaitingForSelectedDevice,
+          device: makeKnownDevice(),
+        }),
+      );
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("device_prompted", layerABaseProperties);
+    });
+
+    it("WHEN Connecting is observed repeatedly THEN device_connecting fires once with USB properties", () => {
+      // GIVEN
+      renderViewModel();
+      const connectingState: ConnectDeviceUIState = {
+        type: ConnectDeviceUIStateTypes.Connecting,
+        device: makeKnownDevice({ deviceModelId: DeviceModelId.stax }),
+      };
+
+      // WHEN
+      act(() => connectDeviceObserver?.next(connectingState));
+      act(() => connectDeviceObserver?.next(connectingState));
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("device_connecting", {
+        ...layerABaseProperties,
+        modelId: DeviceModelId.stax,
+        transport: "usb",
+        matchedDevice: DeviceModelId.stax,
+      });
+    });
+
+    it("WHEN a device connection succeeds THEN device_connected carries the model and USB transport", () => {
+      // GIVEN
+      renderViewModel();
+      const connectionResult = makeConnectionResult();
+      const wrappedOnConnected = mockedConnectDevice.mock.calls[0][0].onConnected;
+
+      // WHEN
+      act(() => wrappedOnConnected(connectionResult));
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledWith("device_connected", {
+        ...layerABaseProperties,
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        matchedDevice: DeviceModelId.nanoX,
+      });
+    });
   });
 
   it("GIVEN the view model is subscribed WHEN unmounting THEN it unsubscribes from connect device", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/DeviceConnectionComponentLWD/useDeviceConnectionComponentLWDViewModel.ts
@@ -1,16 +1,22 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { DeviceConnectionParams, DeviceConnectionResult } from "@ledgerhq/device-intent";
-import { dmkToLedgerDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { dmkToLedgerDeviceIdMap, useDeviceIntentTracking } from "@ledgerhq/live-dmk-shared";
 import {
   connectDevice,
   ConnectDeviceUIStateTypes,
   type ConnectDeviceUIState,
+  webHidTransportIdentifier,
   useDeviceManagementKit,
 } from "@ledgerhq/live-dmk-desktop";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useLazyOnboardingActions } from "LLD/hooks/useLazyOnboardingActions";
 import { addNewDeviceModel } from "~/renderer/actions/settings";
 import { knownDevicesSelector } from "~/renderer/reducers/knownDevices";
+import {
+  trackDeviceConnected,
+  trackDeviceConnecting,
+  trackDevicePrompted,
+} from "../utils/trackDeviceIntent";
 
 const missingDeviceManagementKitError = new Error("Device Management Kit is not available");
 
@@ -33,18 +39,52 @@ export function useDeviceConnectionComponentLWDViewModel({
   const dmk = useDeviceManagementKit();
   const knownDevices = useSelector(knownDevicesSelector);
   const { handleConnect, handleBuyDevice } = useLazyOnboardingActions();
+  const { sourceFlow, analyticsProperties } = useDeviceIntentTracking();
   const [state, setState] = useState<ConnectDeviceUIState>({
     type: ConnectDeviceUIStateTypes.Loading,
   });
+  const firedRef = useRef({
+    prompted: false,
+    connecting: false,
+  });
+
+  useEffect(() => {
+    switch (state.type) {
+      case ConnectDeviceUIStateTypes.Discovering:
+      case ConnectDeviceUIStateTypes.WaitingForSelectedDevice:
+        if (firedRef.current.prompted) return;
+        firedRef.current.prompted = true;
+        trackDevicePrompted({ sourceFlow, extraProperties: analyticsProperties });
+        return;
+      case ConnectDeviceUIStateTypes.Connecting:
+        if (firedRef.current.connecting) return;
+        firedRef.current.connecting = true;
+        trackDeviceConnecting({
+          sourceFlow,
+          modelId: state.device.deviceModelId,
+          transport: state.device.transport === webHidTransportIdentifier ? "usb" : "ble",
+          extraProperties: analyticsProperties,
+        });
+    }
+  }, [analyticsProperties, sourceFlow, state]);
 
   const wrappedOnConnected = useCallback(
     (result: DeviceConnectionResult) => {
       const modelId = dmkToLedgerDeviceIdMap[result.connectedDevice.modelId];
+      const transport = result.connectedDevice.type === "USB" ? "usb" : "ble";
+
+      trackDeviceConnected({
+        sourceFlow,
+        modelId,
+        transport,
+        extraProperties: analyticsProperties,
+      });
+
       dispatch(addNewDeviceModel({ deviceModelId: modelId }));
 
       onConnected(result);
     },
-    [dispatch, onConnected],
+    [analyticsProperties, dispatch, onConnected, sourceFlow],
   );
 
   useEffect(() => {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -1,18 +1,29 @@
-import { ledgerToDmkDeviceIdMap } from "@ledgerhq/live-dmk-shared";
+import { webHidTransportIdentifier } from "@ledgerhq/live-dmk-desktop";
+import { ledgerToDmkDeviceIdMap, type KnownDevice } from "@ledgerhq/live-dmk-shared";
 import { DeviceModelId } from "@ledgerhq/types-devices";
 import { track } from "~/renderer/analytics/segment";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 import {
+  CONNECT_DEVICE_BUTTON,
   DEVICE_ACTION_BUTTON,
   getConnectedDeviceTrackingProperties,
+  getTrackingSubError,
+  getTrackingTransport,
+  PAGE_CONNECT_DEVICE,
   PAGE_DEVICE_ACTION,
+  setIsInTerminalConnectDeviceError,
   trackAppReady,
+  trackConnectDeviceButtonClicked,
   trackDeviceActionButtonClicked,
+  trackDeviceConnected,
+  trackDeviceConnecting,
   trackDeviceflowAborted,
   trackDeviceflowCanceled,
   trackDeviceflowCompleted,
   trackDeviceflowFailed,
   trackDeviceflowStarted,
+  trackDevicePrompted,
+  trackDeviceSelected,
   trackDrawerCloseButtonClicked,
 } from "./trackDeviceIntent";
 
@@ -39,6 +50,7 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     currentRouteNameRef.current = "Connect Device - Connecting";
+    setIsInTerminalConnectDeviceError(false);
   });
 
   describe("trackDeviceflowStarted", () => {
@@ -138,6 +150,110 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         });
       },
     );
+
+    it("GIVEN a terminal Connect Device error WHEN called THEN it tracks deviceflow_failed", () => {
+      currentRouteNameRef.current = PAGE_CONNECT_DEVICE.ConnectionError;
+      setIsInTerminalConnectDeviceError(true);
+
+      trackDeviceflowCanceled({ sourceFlow: "send", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_failed", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+      });
+    });
+
+    it("GIVEN a retryable Connect Device discovery error WHEN called THEN it tracks deviceflow_aborted", () => {
+      currentRouteNameRef.current = PAGE_CONNECT_DEVICE.DiscoveryError;
+
+      trackDeviceflowCanceled({ sourceFlow: "send", extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("deviceflow_aborted", {
+        ...layerABaseProperties,
+        sourceFlow: "send",
+      });
+    });
+  });
+
+  describe("Connect Device tracking helpers", () => {
+    it("GIVEN a Connect Device page WHEN inspecting constants THEN it exposes stable page names", () => {
+      expect(PAGE_CONNECT_DEVICE).toEqual({
+        NoKnownDevice: "Connect Device - No Known Device",
+        Discovering: "Connect Device - Discovering",
+        WaitingForSelectedDevice: "Connect Device - Waiting For Device",
+        Connecting: "Connect Device - Connecting",
+        DiscoveryError: "Connect Device - Discovery Error",
+        ConnectionError: "Connect Device - Connection Error",
+      });
+    });
+
+    it("GIVEN a selected USB device WHEN tracking THEN it sends the selected model and USB transport", () => {
+      const device: KnownDevice = {
+        id: "device-id",
+        name: "Ledger Stax",
+        deviceModelId: DeviceModelId.stax,
+        transport: webHidTransportIdentifier,
+      };
+
+      trackDeviceSelected({ sourceFlow: "swap", device, extraProperties: {} });
+
+      expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.stax,
+        transport: "usb",
+      });
+    });
+
+    it("GIVEN Connect Device funnel data WHEN tracking THEN it sends the expected events and properties", () => {
+      trackDevicePrompted({ sourceFlow: "swap", extraProperties: {} });
+      trackDeviceConnecting({
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        extraProperties: {},
+      });
+      trackDeviceConnected({
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        extraProperties: {},
+      });
+      trackConnectDeviceButtonClicked({
+        sourceFlow: "swap",
+        button: CONNECT_DEVICE_BUTTON.Retry,
+        extraProperties: {},
+      });
+
+      expect(mockedTrack).toHaveBeenNthCalledWith(1, "device_prompted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(2, "device_connecting", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        matchedDevice: DeviceModelId.nanoX,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(3, "device_connected", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        matchedDevice: DeviceModelId.nanoX,
+      });
+      expect(mockedTrack).toHaveBeenNthCalledWith(4, "button_clicked", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        button: CONNECT_DEVICE_BUTTON.Retry,
+      });
+    });
+
+    it("GIVEN an unknown error and no transport WHEN mapping them THEN it preserves the expected values", () => {
+      expect(getTrackingTransport(undefined)).toBeUndefined();
+      expect(getTrackingSubError("unknown" as never)).toBe("Unknown");
+    });
   });
 
   describe("getConnectedDeviceTrackingProperties", () => {

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.test.ts
@@ -175,8 +175,9 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
     });
   });
 
-  describe("Connect Device tracking helpers", () => {
-    it("GIVEN a Connect Device page WHEN inspecting constants THEN it exposes stable page names", () => {
+  describe("PAGE_CONNECT_DEVICE", () => {
+    it("GIVEN Connect Device pages WHEN inspecting constants THEN it exposes stable page names", () => {
+      // THEN
       expect(PAGE_CONNECT_DEVICE).toEqual({
         NoKnownDevice: "Connect Device - No Known Device",
         Discovering: "Connect Device - Discovering",
@@ -186,8 +187,11 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         ConnectionError: "Connect Device - Connection Error",
       });
     });
+  });
 
-    it("GIVEN a selected USB device WHEN tracking THEN it sends the selected model and USB transport", () => {
+  describe("trackDeviceSelected", () => {
+    it("GIVEN a selected USB device WHEN called THEN it tracks device_selected with the selected model and USB transport", () => {
+      // GIVEN
       const device: KnownDevice = {
         id: "device-id",
         name: "Ledger Stax",
@@ -195,8 +199,11 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         transport: webHidTransportIdentifier,
       };
 
+      // WHEN
       trackDeviceSelected({ sourceFlow: "swap", device, extraProperties: {} });
 
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
       expect(mockedTrack).toHaveBeenCalledWith("device_selected", {
         ...layerABaseProperties,
         sourceFlow: "swap",
@@ -204,54 +211,95 @@ describe("trackDeviceIntent — Layer A tracking helpers", () => {
         transport: "usb",
       });
     });
+  });
 
-    it("GIVEN Connect Device funnel data WHEN tracking THEN it sends the expected events and properties", () => {
+  describe("trackDevicePrompted", () => {
+    it("GIVEN a sourceFlow WHEN called THEN it tracks device_prompted with the Layer A base properties", () => {
+      // WHEN
       trackDevicePrompted({ sourceFlow: "swap", extraProperties: {} });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("device_prompted", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+      });
+    });
+  });
+
+  describe("trackDeviceConnecting", () => {
+    it("GIVEN a sourceFlow modelId and transport WHEN called THEN it tracks device_connecting with matchedDevice", () => {
+      // WHEN
       trackDeviceConnecting({
         sourceFlow: "swap",
         modelId: DeviceModelId.nanoX,
         transport: "usb",
         extraProperties: {},
       });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("device_connecting", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        matchedDevice: DeviceModelId.nanoX,
+      });
+    });
+  });
+
+  describe("trackDeviceConnected", () => {
+    it("GIVEN a sourceFlow modelId and transport WHEN called THEN it tracks device_connected with matchedDevice", () => {
+      // WHEN
       trackDeviceConnected({
         sourceFlow: "swap",
         modelId: DeviceModelId.nanoX,
         transport: "usb",
         extraProperties: {},
       });
+
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("device_connected", {
+        ...layerABaseProperties,
+        sourceFlow: "swap",
+        modelId: DeviceModelId.nanoX,
+        transport: "usb",
+        matchedDevice: DeviceModelId.nanoX,
+      });
+    });
+  });
+
+  describe("trackConnectDeviceButtonClicked", () => {
+    it("GIVEN a sourceFlow and button WHEN called THEN it tracks button_clicked", () => {
+      // WHEN
       trackConnectDeviceButtonClicked({
         sourceFlow: "swap",
         button: CONNECT_DEVICE_BUTTON.Retry,
         extraProperties: {},
       });
 
-      expect(mockedTrack).toHaveBeenNthCalledWith(1, "device_prompted", {
-        ...layerABaseProperties,
-        sourceFlow: "swap",
-      });
-      expect(mockedTrack).toHaveBeenNthCalledWith(2, "device_connecting", {
-        ...layerABaseProperties,
-        sourceFlow: "swap",
-        modelId: DeviceModelId.nanoX,
-        transport: "usb",
-        matchedDevice: DeviceModelId.nanoX,
-      });
-      expect(mockedTrack).toHaveBeenNthCalledWith(3, "device_connected", {
-        ...layerABaseProperties,
-        sourceFlow: "swap",
-        modelId: DeviceModelId.nanoX,
-        transport: "usb",
-        matchedDevice: DeviceModelId.nanoX,
-      });
-      expect(mockedTrack).toHaveBeenNthCalledWith(4, "button_clicked", {
+      // THEN
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
         ...layerABaseProperties,
         sourceFlow: "swap",
         button: CONNECT_DEVICE_BUTTON.Retry,
       });
     });
+  });
 
-    it("GIVEN an unknown error and no transport WHEN mapping them THEN it preserves the expected values", () => {
+  describe("getTrackingTransport", () => {
+    it("GIVEN no transport WHEN mapping THEN it returns undefined", () => {
+      // THEN
       expect(getTrackingTransport(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("getTrackingSubError", () => {
+    it("GIVEN an unknown error WHEN mapping THEN it returns Unknown", () => {
+      // THEN
       expect(getTrackingSubError("unknown" as never)).toBe("Unknown");
     });
   });

--- a/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
+++ b/apps/ledger-live-desktop/src/mvvm/components/DeviceIntentExecutor/utils/trackDeviceIntent.ts
@@ -2,14 +2,29 @@ import type { DeviceDisconnectedComponent } from "@ledgerhq/device-intent";
 import {
   dmkToLedgerDeviceIdMap,
   type DeviceIntentTrackingProperties,
+  type KnownDevice,
   type SourceFlow,
 } from "@ledgerhq/live-dmk-shared";
+import {
+  BaseConnectionErrorTypes,
+  BaseDiscoveryErrorTypes,
+  webHidTransportIdentifier,
+} from "@ledgerhq/live-dmk-desktop";
 import type { DeviceModelId } from "@ledgerhq/types-devices";
 import type { ComponentProps } from "react";
 import { track } from "~/renderer/analytics/segment";
 import { currentRouteNameRef } from "~/renderer/analytics/screenRefs";
 
 type ConnectedDevice = ComponentProps<DeviceDisconnectedComponent>["device"];
+
+export const PAGE_CONNECT_DEVICE = {
+  NoKnownDevice: "Connect Device - No Known Device",
+  Discovering: "Connect Device - Discovering",
+  WaitingForSelectedDevice: "Connect Device - Waiting For Device",
+  Connecting: "Connect Device - Connecting",
+  DiscoveryError: "Connect Device - Discovery Error",
+  ConnectionError: "Connect Device - Connection Error",
+} as const;
 
 export const PAGE_DEVICE_ACTION = {
   Disconnected: "Device Action - Disconnected",
@@ -27,6 +42,14 @@ export const DEVICE_ACTION_BUTTON = {
   Close: "Close",
 } as const;
 
+export const CONNECT_DEVICE_BUTTON = {
+  ConnectDevice: "Connect Device",
+  BuyDevice: "Buy Device",
+  Retry: "Retry",
+} as const;
+
+let isInTerminalConnectDeviceError = false;
+
 const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
   PAGE_DEVICE_ACTION.Disconnected,
   PAGE_DEVICE_ACTION.UnknownIntentError,
@@ -34,6 +57,18 @@ const DEVICEFLOW_FAILED_CLOSE_PAGES = new Set<string>([
 ]);
 
 export type TrackingTransport = "ble" | "usb";
+
+export const getTrackingTransport = (
+  transportId: KnownDevice["transport"] | undefined,
+): TrackingTransport | undefined => {
+  if (!transportId) return undefined;
+
+  return transportId === webHidTransportIdentifier ? "usb" : "ble";
+};
+
+export const getTrackingSubError = (
+  _errorType: BaseDiscoveryErrorTypes | BaseConnectionErrorTypes,
+): string => "Unknown";
 
 export const getDeviceUxV2BaseProperties = (
   sourceFlow: SourceFlow,
@@ -51,6 +86,10 @@ export const getConnectedDeviceTrackingProperties = (
   transport: device.type === "USB" ? "usb" : "ble",
 });
 
+export const setIsInTerminalConnectDeviceError = (value: boolean): void => {
+  isInTerminalConnectDeviceError = value;
+};
+
 export const trackDeviceflowStarted = (params: {
   sourceFlow: SourceFlow;
   extraProperties: DeviceIntentTrackingProperties;
@@ -59,6 +98,41 @@ export const trackDeviceflowStarted = (params: {
     "deviceflow_started",
     getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
   );
+};
+
+export const trackDevicePrompted = (params: {
+  sourceFlow: SourceFlow;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("device_prompted", getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties));
+};
+
+export const trackDeviceConnecting = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+  transport: TrackingTransport;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("device_connecting", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    modelId: params.modelId,
+    transport: params.transport,
+    matchedDevice: params.modelId,
+  });
+};
+
+export const trackDeviceConnected = (params: {
+  sourceFlow: SourceFlow;
+  modelId: DeviceModelId;
+  transport: TrackingTransport;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("device_connected", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    modelId: params.modelId,
+    transport: params.transport,
+    matchedDevice: params.modelId,
+  });
 };
 
 export const trackAppReady = (params: {
@@ -110,8 +184,14 @@ export const trackDeviceflowCanceled = (params: {
   extraProperties: DeviceIntentTrackingProperties;
 }): void => {
   const currentPage = currentRouteNameRef.current;
+  const isTerminalConnectDeviceErrorPage =
+    currentPage === PAGE_CONNECT_DEVICE.DiscoveryError ||
+    currentPage === PAGE_CONNECT_DEVICE.ConnectionError;
 
-  if (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage)) {
+  if (
+    (isTerminalConnectDeviceErrorPage && isInTerminalConnectDeviceError) ||
+    (currentPage && DEVICEFLOW_FAILED_CLOSE_PAGES.has(currentPage))
+  ) {
     trackDeviceflowFailed(params);
     return;
   }
@@ -131,6 +211,29 @@ export const trackDeviceActionButtonClicked = (params: {
     button: params.button,
     ...(params.modelId ? { modelId: params.modelId } : {}),
     ...(params.transport ? { transport: params.transport } : {}),
+  });
+};
+
+export const trackDeviceSelected = (params: {
+  sourceFlow: SourceFlow;
+  device: KnownDevice;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("device_selected", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    modelId: params.device.deviceModelId,
+    transport: params.device.transport === webHidTransportIdentifier ? "usb" : "ble",
+  });
+};
+
+export const trackConnectDeviceButtonClicked = (params: {
+  sourceFlow: SourceFlow;
+  button: string;
+  extraProperties: DeviceIntentTrackingProperties;
+}): void => {
+  track("button_clicked", {
+    ...getDeviceUxV2BaseProperties(params.sourceFlow, params.extraProperties),
+    button: params.button,
   });
 };
 


### PR DESCRIPTION
### 📝 Description

Adds DIE Connect Device tracking to Ledger Wallet Desktop.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35575](https://ledgerhq.atlassian.net/browse/LIVE-35575)
- **Depends on**: [LIVE-33003](https://ledgerhq.atlassian.net/browse/LIVE-33003)

[LIVE-35575]: https://ledgerhq.atlassian.net/browse/LIVE-35575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33003]: https://ledgerhq.atlassian.net/browse/LIVE-33003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ