### PR TITLE
[LWDM] test(live-wallet): cover walletsync forward-compat guarantee

### DIFF
--- a/docs/ledger-sync/scenarios.md
+++ b/docs/ledger-sync/scenarios.md
@@ -56,7 +56,7 @@ so they stay **linked** (📹) to their Confluence page — the behaviour and it
 | Wallet Sync works even when Ledger Wallet doesn't support a received account (unsupported currency, sync issues): the account is queued, not lost. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896161894) | `accounts.test.ts` (nonImportedAccountInfos) |
 | Wallet Sync preserves non-imported accounts and restores them when available (backoff retry). | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896620635) | `accounts.test.ts`; see [accounts module](./05-wallet-sync-data-manager.md#the-accounts-module) |
 | Wallet Sync supports account-**id migration**. | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896129100) | `accounts.test.ts` |
-| Wallet Sync preserves **unknown fields** in Cloud Sync's DistantState (forward compat). | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896849983) | `__tests__/compatibility.test.ts` |
+| Wallet Sync preserves **unknown fields** in Cloud Sync's DistantState (forward compat). | [📹](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/4896849983) | `walletSyncComposition.test.ts` (`parseDistantState`), `createAggregator.test.ts` |
 
 > [!TIP]
 > Most data scenarios are easiest to reproduce in the

--- a/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
+++ b/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
@@ -1,0 +1,53 @@
+import { of } from "rxjs";
+import type { Account, AccountBridge, TransactionCommon } from "@ledgerhq/types-live";
+import { createWalletsync, parseDistantState } from "../walletSyncComposition";
+
+const walletsync = createWalletsync({
+  getAccountBridge: <T extends TransactionCommon>() =>
+    ({ sync: () => of((acc: Account) => acc) }) as unknown as AccountBridge<T>,
+  bridgeCache: {
+    hydrateCurrency: () => Promise.resolve(null),
+    prepareCurrency: () => Promise.resolve(null),
+  },
+});
+
+const emptyLocalState = {
+  accounts: { list: [], nonImportedAccountInfos: [] },
+  accountNames: new Map<string, string>(),
+  recentAddresses: {},
+};
+
+const distantEmptyState = walletsync.diffLocalToDistant(emptyLocalState, null).nextState;
+
+describe("parseDistantState", () => {
+  const withUnknownField = { ...distantEmptyState, fooBAR: { nested: [1, 2, 3] } };
+
+  it("preserves fields written by a newer version that the schema strips", () => {
+    expect(walletsync.schema.parse(withUnknownField)).not.toHaveProperty("fooBAR");
+    expect(parseDistantState(walletsync, withUnknownField)).toEqual(withUnknownField);
+  });
+
+  it("accepts data missing a module's field", () => {
+    const partial = { accounts: [] };
+    expect(parseDistantState(walletsync, partial)).toEqual(partial);
+  });
+
+  it("returns null when the data fails schema validation", () => {
+    expect(parseDistantState(walletsync, { accountNames: { foo: 42 } })).toBe(null);
+    expect(parseDistantState(walletsync, "not an object")).toBe(null);
+  });
+
+  it("keeps unknown fields through a parse then re-upload round trip", () => {
+    const latest = parseDistantState(walletsync, {
+      ...withUnknownField,
+      accountNames: { foo: "bar" },
+    });
+    const localData = { ...emptyLocalState, accountNames: new Map([["foo", "baz"]]) };
+    const diff = walletsync.diffLocalToDistant(localData, latest);
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.nextState).toMatchObject({
+      accountNames: { foo: "baz" },
+      fooBAR: { nested: [1, 2, 3] },
+    });
+  });
+});


### PR DESCRIPTION
### 📝 Description

`docs/ledger-sync/scenarios.md` lists "Wallet Sync preserves **unknown fields** in Cloud Sync's DistantState (forward compat)" as verified by `walletsync/__tests__/compatibility.test.ts`. That file was deleted in 44694e54fa5 (DDD migration) and never re-added, so the guarantee has been untested since — and `libs/live-wallet/src/walletSyncComposition.ts`, where it now lives, had no test at all.

The guarantee moved into `parseDistantState`: it validates with the composed zod schema but returns the **raw** object, because `z.object` strips unknown keys and re-uploading the stripped result would silently drop fields written by newer app versions. This PR covers exactly that, plus the schema tolerating distant data that misses a module's field.

Scoped to what was actually uncovered — `createAggregator.test.ts` already covers unknown-key propagation through `diffLocalToDistant` on synthetic modules, and `accounts/__tests__/cloudSyncModule.test.ts` covers the accounts module.

Also repoints the doc row at the tests that verify it today.

> [!NOTE]
> While digging, I found a related gap that this PR does **not** fix, since it needs a product decision.
>
> `parseDistantState` returning raw also bypasses the schema's `.transform()` steps, not just its key stripping. `RecentAddressesDistantSchema` has a `CorruptedNestedAddressDistantSchema` branch that recovers entries corrupted by a past migration — that recovery never runs in the app, because neither `parseDistantState` nor `CloudSyncSDK.pull` (`schema.parse(json)` then uses `json`) passes the parsed output downstream. A distant blob containing a corrupted entry resolves to:
>
> ```diff
> - { address: "0xAAA", lastUsed: 111 }            // via schema.parse
> + { address: { address: "0xAAA" }, lastUsed: … } // what actually lands in Redux
> ```
>
> i.e. an object where `RecentAddress.address` is typed `string`, dispatched straight into app state by `updateRecentAddresses`. Preserving unknown keys and applying transforms are in tension here; fixing it properly means merging parsed module output over the raw envelope rather than choosing one. Happy to open a ticket if we want it addressed.

### 🔗 Context

- **JIRA / GitHub issue**: n/a — follow-up on 44694e54fa5
- **ADR** (if any): n/a
