### PR TITLE
[LWDM] fix(walletsync): isolate module failures from the whole sync

### DIFF
--- a/.changeset/shaggy-pugs-shake.md
+++ b/.changeset/shaggy-pugs-shake.md
@@ -1,0 +1,13 @@
+---
+"@shared/cloud-sync-module": minor
+"@shared/cloud-sync": minor
+"@ledgerhq/live-wallet": minor
+"@ledgerhq/live-e2e-shared": minor
+"@ledgerhq/web-tools": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Isolate wallet sync module failures instead of failing the whole sync: the aggregator validates each module slice on its own and quarantines a broken one, preserving its raw distant value, while every other module keeps syncing. A quarantine is reported as the module key plus the failure kind only, never the offending data.
+
+A distant document is now typed as what it is — a `DistantDocument` (`Record<string, unknown>`) whose slices are trusted per module — instead of the aggregate of the module schemas that nothing validates. `parseDistantState` is removed: it cast an unvalidated document to a validated type, and the aggregator already narrows the document at runtime. `CloudSyncSDK` drops its `schema` constructor option, which was never applied to anything and only served to infer that same misleading type; the class is now parameterised by its document type directly.

--- a/.changeset/shaggy-pugs-shake.md
+++ b/.changeset/shaggy-pugs-shake.md
@@ -2,6 +2,7 @@
 "@shared/cloud-sync-module": minor
 "@shared/cloud-sync": minor
 "@ledgerhq/live-wallet": minor
+"@domain/entity-recent-addresses": minor
 "@ledgerhq/live-e2e-shared": minor
 "@ledgerhq/web-tools": minor
 "ledger-live-desktop": minor
@@ -11,3 +12,5 @@
 Isolate wallet sync module failures instead of failing the whole sync: the aggregator validates each module slice on its own and quarantines a broken one, preserving its raw distant value, while every other module keeps syncing. A quarantine is reported as the module key plus the failure kind only, never the offending data.
 
 A distant document is now typed as what it is — a `DistantDocument` (`Record<string, unknown>`) whose slices are trusted per module — instead of the aggregate of the module schemas that nothing validates. `parseDistantState` is removed: it cast an unvalidated document to a validated type, and the aggregator already narrows the document at runtime. `CloudSyncSDK` drops its `schema` constructor option, which was never applied to anything and only served to infer that same misleading type; the class is now parameterised by its document type directly.
+
+`recentAddresses` drops its corrupted-address repair path. `CorruptedNestedAddressDistantSchema` and the lenient `z.array(z.unknown())` wrapper that swallowed every bad entry are removed together: a corrupted distant entry now quarantines the module, so the slice is preserved verbatim and reported, instead of being silently rewritten — or, had only the transform been removed, silently dropped. The local-cache repair in `schema.ts`/`store.ts` is untouched; it migrates data on disk, which quarantine does not cover.

--- a/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -13,9 +13,9 @@ import { updateRecentAddresses } from "@domain/entity-recent-addresses";
 import { setNonImportedAccounts } from "@ledgerhq/live-wallet/accounts";
 import {
   createWalletsync,
-  parseDistantState,
+  type CloudSyncModuleQuarantined,
   type Walletsync,
-  type WalletSyncDistantState,
+  type DistantDocument,
   type WalletSyncLocalState,
 } from "@ledgerhq/live-wallet/walletSyncComposition";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -39,26 +39,29 @@ import { useOnTrustchainRefreshNeeded } from "./useOnTrustchainRefreshNeeded";
 import { Dispatch } from "redux";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
+import logger from "~/renderer/logger";
 
-type Schema = Walletsync["schema"];
-type DistantState = WalletSyncDistantState;
+type DistantState = DistantDocument;
 type LocalState = WalletSyncLocalState;
+
+function onModuleError(moduleKey: string, error: CloudSyncModuleQuarantined) {
+  logger.critical(error, `cloud-sync module ${moduleKey} quarantined`);
+}
 
 function useWalletsync(): Walletsync {
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   return useMemo(
-    () => createWalletsync({ getAccountBridge, bridgeCache, blacklistedTokenIds }),
+    () =>
+      createWalletsync({ getAccountBridge, bridgeCache, blacklistedTokenIds }, { onModuleError }),
     [blacklistedTokenIds],
   );
 }
 
-function makeLatestWalletStateSelector(walletsync: Walletsync) {
-  return (s: State): { data: DistantState | null; version: number } => {
-    const ws = walletSelector(s).walletSync.walletSyncState;
-    return {
-      data: parseDistantState(walletsync, ws.data),
-      version: ws.version,
-    };
+function latestWalletStateSelector(s: State): { data: DistantState | null; version: number } {
+  const ws = walletSelector(s).walletSync.walletSyncState;
+  return {
+    data: ws.data,
+    version: ws.version,
   };
 }
 
@@ -88,7 +91,7 @@ async function save(
   }
 }
 
-export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
+export function useCloudSyncSDK(): CloudSyncSDK<DistantState> {
   const featureWalletSync = useFeature("lldWalletSync");
   const { cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(
     featureWalletSync?.params?.environment,
@@ -104,8 +107,7 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
       makeSaveNewUpdate({
         walletsync,
         getState,
-        latestDistantStateSelector: s =>
-          parseDistantState(walletsync, latestDistantStateSelector(s)),
+        latestDistantStateSelector,
         latestDistantVersionSelector,
         localStateSelector,
         saveUpdate,
@@ -118,12 +120,11 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
       new CloudSyncSDK({
         apiBaseUrl: cloudSyncApiBaseUrl,
         slug: liveSlug,
-        schema: walletsync.schema,
         trustchainSdk,
         getCurrentVersion,
         saveNewUpdate,
       }),
-    [cloudSyncApiBaseUrl, walletsync.schema, trustchainSdk, getCurrentVersion, saveNewUpdate],
+    [cloudSyncApiBaseUrl, trustchainSdk, getCurrentVersion, saveNewUpdate],
   );
 
   return cloudSyncSDK;
@@ -184,7 +185,7 @@ export function useWatchWalletSync(): WalletSyncUserState {
     const localIncrementUpdate = makeLocalIncrementalUpdate({
       walletsync,
       getState,
-      latestWalletStateSelector: makeLatestWalletStateSelector(walletsync),
+      latestWalletStateSelector,
       localStateSelector,
       saveUpdate,
     });
@@ -199,7 +200,7 @@ export function useWatchWalletSync(): WalletSyncUserState {
       setVisualPending,
       getState,
       localStateSelector,
-      latestDistantStateSelector: s => parseDistantState(walletsync, latestDistantStateSelector(s)),
+      latestDistantStateSelector,
       onError: e => setWalletSyncError(e && e instanceof Error ? e : new Error(String(e))),
       onStartPolling: () => setWalletSyncError(null),
       onTrustchainRefreshNeeded,

--- a/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/wallet.ts
@@ -11,6 +11,7 @@ import { createSelector } from "reselect";
 import { useSelector } from "LLD/hooks/redux";
 import { shallowEqual } from "react-redux";
 import type { RecentAddressesState } from "@domain/entity-recent-addresses";
+import type { WSState } from "@domain/entity-wallet-sync";
 import type { Account, AccountLike, AccountUserData } from "@ledgerhq/types-live";
 import type { State } from ".";
 import type { WalletState } from "./wallet.core";
@@ -66,7 +67,7 @@ export const accountStarredSelector = createSelector(
   (wallet, accountId) => entityIsStarredAccount(wallet.starredAccountIds, { accountId }),
 );
 
-export function latestDistantStateSelector(state: State): unknown {
+export function latestDistantStateSelector(state: State): WSState["data"] {
   return walletSelector(state).walletSync.walletSyncState.data;
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/WalletSync/hooks/useWatchWalletSync.ts
@@ -13,9 +13,9 @@ import { updateRecentAddresses } from "@domain/entity-recent-addresses";
 import { setNonImportedAccounts } from "@ledgerhq/live-wallet/accounts";
 import {
   createWalletsync,
-  parseDistantState,
+  type CloudSyncModuleQuarantined,
   type Walletsync,
-  type WalletSyncDistantState,
+  type DistantDocument,
   type WalletSyncLocalState,
 } from "@ledgerhq/live-wallet/walletSyncComposition";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
@@ -39,26 +39,29 @@ import { bridgeCache } from "~/bridge/cache";
 import { replaceAccounts } from "~/actions/accounts";
 import { useFeature } from "@features/platform-feature-flags";
 import getWalletSyncEnvironmentParams from "@ledgerhq/live-common/walletSync/getEnvironmentParams";
+import logger from "~/logger";
 
-type Schema = Walletsync["schema"];
-type DistantState = WalletSyncDistantState;
+type DistantState = DistantDocument;
 type LocalState = WalletSyncLocalState;
+
+function onModuleError(_moduleKey: string, error: CloudSyncModuleQuarantined) {
+  logger.critical(error);
+}
 
 function useWalletsync(): Walletsync {
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   return useMemo(
-    () => createWalletsync({ getAccountBridge, bridgeCache, blacklistedTokenIds }),
+    () =>
+      createWalletsync({ getAccountBridge, bridgeCache, blacklistedTokenIds }, { onModuleError }),
     [blacklistedTokenIds],
   );
 }
 
-function makeLatestWalletStateSelector(walletsync: Walletsync) {
-  return (s: State): { data: DistantState | null; version: number } => {
-    const ws = walletSelector(s).walletSync.walletSyncState;
-    return {
-      data: parseDistantState(walletsync, ws.data),
-      version: ws.version,
-    };
+function latestWalletStateSelector(s: State): { data: DistantState | null; version: number } {
+  const ws = walletSelector(s).walletSync.walletSyncState;
+  return {
+    data: ws.data,
+    version: ws.version,
   };
 }
 
@@ -88,7 +91,7 @@ async function save(
   }
 }
 
-export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
+export function useCloudSyncSDK(): CloudSyncSDK<DistantState> {
   const featureWalletSync = useFeature("llmWalletSync");
   const { cloudSyncApiBaseUrl } = getWalletSyncEnvironmentParams(
     featureWalletSync?.params?.environment,
@@ -104,8 +107,7 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
       makeSaveNewUpdate({
         walletsync,
         getState,
-        latestDistantStateSelector: s =>
-          parseDistantState(walletsync, latestDistantStateSelector(s)),
+        latestDistantStateSelector,
         latestDistantVersionSelector,
         localStateSelector,
         saveUpdate,
@@ -118,12 +120,11 @@ export function useCloudSyncSDK(): CloudSyncSDK<Schema> {
       new CloudSyncSDK({
         apiBaseUrl: cloudSyncApiBaseUrl,
         slug: liveSlug,
-        schema: walletsync.schema,
         trustchainSdk,
         getCurrentVersion,
         saveNewUpdate,
       }),
-    [cloudSyncApiBaseUrl, walletsync.schema, trustchainSdk, getCurrentVersion, saveNewUpdate],
+    [cloudSyncApiBaseUrl, trustchainSdk, getCurrentVersion, saveNewUpdate],
   );
 
   return cloudSyncSDK;
@@ -185,7 +186,7 @@ export function useWatchWalletSync(): WalletSyncUserState {
     const localIncrementUpdate = makeLocalIncrementalUpdate({
       walletsync,
       getState,
-      latestWalletStateSelector: makeLatestWalletStateSelector(walletsync),
+      latestWalletStateSelector,
       localStateSelector,
       saveUpdate,
     });
@@ -200,7 +201,7 @@ export function useWatchWalletSync(): WalletSyncUserState {
       setVisualPending,
       getState,
       localStateSelector,
-      latestDistantStateSelector: s => parseDistantState(walletsync, latestDistantStateSelector(s)),
+      latestDistantStateSelector,
       onError: e => setWalletSyncError(e && e instanceof Error ? e : new Error(String(e))),
       onStartPolling: () => setWalletSyncError(null),
       onTrustchainRefreshNeeded,

--- a/apps/ledger-live-mobile/src/reducers/wallet.ts
+++ b/apps/ledger-live-mobile/src/reducers/wallet.ts
@@ -129,7 +129,7 @@ export const accountUserDataExportSelector = (
   };
 };
 
-export function latestDistantStateSelector(state: State): unknown {
+export function latestDistantStateSelector(state: State): WSState["data"] {
   return walletSelector(state).walletSync.walletSyncState.data;
 }
 

--- a/apps/web-tools/src/trustchain/components/App.tsx
+++ b/apps/web-tools/src/trustchain/components/App.tsx
@@ -37,7 +37,8 @@ import { AppRestoreTrustchain } from "./AppRestoreTrustchain";
 import { AppWalletSync } from "./AppCloudSync";
 import { AppSetCloudSyncAPIEnv } from "./AppSetCloudSyncAPIEnv";
 import { DeviceInteractionLayer } from "./DeviceInteractionLayer";
-import { DistantState, trustchainLifecycle } from "./walletSync";
+import { trustchainLifecycle } from "./walletSync";
+import type { DistantDocument } from "@shared/cloud-sync-module";
 import { Loading } from "./Loading";
 import { State } from "./types";
 
@@ -100,7 +101,7 @@ const App = () => {
   }, [setAccountsSync]);
 
   const [wssdkHandledVersion, setWssdkHandledVersion] = useState(0);
-  const [wssdkHandledData, setWssdkHandledData] = useState<DistantState | null>(null);
+  const [wssdkHandledData, setWssdkHandledData] = useState<DistantDocument | null>(null);
 
   const version = state.walletState.walletSyncState.version || wssdkHandledVersion;
   const data = state.walletState.walletSyncState.data || wssdkHandledData;

--- a/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppAccountsSync.tsx
@@ -106,11 +106,16 @@ export default function AppAccountsSync({
 
   const walletsync = useMemo(
     () =>
-      createAggregator({
-        accounts: accountsSyncModule,
-        accountNames: accountNamesSyncModule,
-        recentAddresses: recentAddressesSyncModule,
-      }),
+      createAggregator(
+        {
+          accounts: accountsSyncModule,
+          accountNames: accountNamesSyncModule,
+          recentAddresses: recentAddressesSyncModule,
+        },
+        // warn, not error: a quarantine is recoverable, and this devtool is where a corrupted
+        // slice is most likely to be inspected, so it should stay visible in the console
+        { onModuleError: (_key, error) => console.warn(error.message) },
+      ),
     [accountsSyncModule],
   );
 
@@ -183,12 +188,11 @@ export default function AppAccountsSync({
       new CloudSyncSDK({
         apiBaseUrl: getWalletSyncEnvironmentParams("STAGING").cloudSyncApiBaseUrl,
         slug: liveSlug,
-        schema: walletsync.schema,
         trustchainSdk,
         getCurrentVersion,
         saveNewUpdate,
       }),
-    [walletsync, trustchainSdk, getCurrentVersion, saveNewUpdate],
+    [trustchainSdk, getCurrentVersion, saveNewUpdate],
   );
 
   const [visualPending, setVisualPending] = useState(true);

--- a/apps/web-tools/src/trustchain/components/AppCloudSync.tsx
+++ b/apps/web-tools/src/trustchain/components/AppCloudSync.tsx
@@ -3,7 +3,8 @@ import { Button } from "@ledgerhq/lumen-ui-react";
 import { MemberCredentials, Trustchain } from "@ledgerhq/ledger-key-ring-protocol/types";
 import { useTrustchainSDK } from "../context";
 import { CloudSyncSDK, UpdateEvent } from "@shared/cloud-sync";
-import { liveSchema, DistantState as LiveData, liveSlug } from "./walletSync";
+import { liveSchema, liveSlug } from "./walletSync";
+import type { DistantDocument } from "@shared/cloud-sync-module";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { getDefaultAccountName } from "@domain/entity-account-name";
 import { v4 as uuid } from "uuid";
@@ -25,11 +26,11 @@ export function AppWalletSync({
   trustchain: Trustchain;
   setTrustchain: (t: Trustchain | null) => void;
   memberCredentials: MemberCredentials;
-  data: LiveData | null;
-  setData: (d: LiveData | null) => void;
+  data: DistantDocument | null;
+  setData: (d: DistantDocument | null) => void;
   version: number;
   setVersion: (n: number) => void;
-  forceReadOnlyData?: LiveData | null;
+  forceReadOnlyData?: DistantDocument | null;
   readOnly?: boolean;
   takeControl?: () => void;
 }) {
@@ -74,7 +75,7 @@ export function AppWalletSync({
   const getCurrentVersion = useCallback(() => versionRef.current, []);
 
   const saveNewUpdate = useCallback(
-    async (event: UpdateEvent<LiveData>) => {
+    async (event: UpdateEvent<DistantDocument>) => {
       switch (event.type) {
         case "new-data":
           setVersion(event.version);
@@ -98,7 +99,6 @@ export function AppWalletSync({
     return new CloudSyncSDK({
       apiBaseUrl: cloudSyncApiBaseUrl,
       slug: liveSlug,
-      schema: liveSchema,
       trustchainSdk,
       getCurrentVersion,
       saveNewUpdate,

--- a/domain/entity/recent-addresses/src/cloudSyncModule.test.ts
+++ b/domain/entity/recent-addresses/src/cloudSyncModule.test.ts
@@ -1,6 +1,17 @@
+import { z } from "zod";
+import { createAggregator, type CloudSyncDataManager } from "@shared/cloud-sync-module";
 import { recentAddressesSyncModule, RecentAddressesDistantSchema } from "./cloudSyncModule";
 import type { RecentAddressesState } from "./schema";
 import { describeCloudSyncModuleContract } from "@shared/cloud-sync-module/moduleRequirements";
+
+type Names = Record<string, string>;
+/** a healthy neighbour, to prove a quarantine stays confined to its own module */
+const namesModule: CloudSyncDataManager<Names, Names, z.ZodType<Names>, Names> = {
+  schema: z.record(z.string(), z.string()),
+  diffLocalToDistant: local => ({ hasChanges: false, nextState: local }),
+  resolveIncrementalUpdate: async () => ({ hasChanges: false }),
+  applyUpdate: local => local,
+};
 
 describeCloudSyncModuleContract("recentAddressesSyncModule contract", recentAddressesSyncModule, {
   emptyLocalState: {},
@@ -16,36 +27,42 @@ describe("RecentAddressesDistantSchema", () => {
     expect(RecentAddressesDistantSchema.parse(input)).toEqual(input);
   });
 
-  it("filters out invalid entries, keeps valid ones", () => {
+  it("rejects a slice holding an invalid entry rather than dropping it", () => {
     const input = {
       bitcoin: [{ address: "bc1q", index: 0 }, "invalid", null, { address: "bc1b", index: 1 }],
     };
-    const parsed = RecentAddressesDistantSchema.parse(input);
-    expect(parsed.bitcoin).toHaveLength(2);
-    expect(parsed.bitcoin[0].address).toBe("bc1q");
-    expect(parsed.bitcoin[1].address).toBe("bc1b");
+    expect(RecentAddressesDistantSchema.safeParse(input).success).toBe(false);
   });
 
-  it("handles corrupted nested address format", () => {
+  it("rejects the corrupted nested address format instead of repairing it", () => {
     const input = {
       bitcoin: [{ address: { address: "bc1q", lastUsed: 500 }, index: 0, lastUsed: 600 }],
     };
-    const parsed = RecentAddressesDistantSchema.parse(input);
-    expect(parsed.bitcoin[0].address).toBe("bc1q");
-    expect(parsed.bitcoin[0].lastUsed).toBe(500);
+    expect(RecentAddressesDistantSchema.safeParse(input).success).toBe(false);
   });
+});
 
-  it("handles corrupted nested address format with ensName", () => {
-    const input = {
-      bitcoin: [
-        {
-          address: { address: "bc1q", lastUsed: 500, ensName: "wallet.eth" },
-          index: 0,
-        },
-      ],
+describe("a corrupted distant slice quarantines the module", () => {
+  it("preserves the slice verbatim and reports it, leaving healthy modules alone", () => {
+    const onModuleError = jest.fn();
+    const aggregator = createAggregator(
+      { recentAddresses: recentAddressesSyncModule, names: namesModule },
+      { onModuleError },
+    );
+    const corrupted = {
+      recentAddresses: { bitcoin: [{ address: { address: "bc1q" }, index: 0 }] },
+      names: { "account-1": "from another instance" },
     };
-    const parsed = RecentAddressesDistantSchema.parse(input);
-    expect(parsed.bitcoin[0].address).toBe("bc1q");
+
+    const { nextState } = aggregator.diffLocalToDistant(
+      { recentAddresses: { bitcoin: [addr("bc1local")] }, names: {} },
+      corrupted,
+    );
+
+    expect(nextState.recentAddresses).toEqual(corrupted.recentAddresses);
+    expect(onModuleError).toHaveBeenCalledTimes(1);
+    expect(onModuleError.mock.calls[0][0]).toBe("recentAddresses");
+    expect(nextState.names).toEqual({});
   });
 });
 

--- a/domain/entity/recent-addresses/src/cloudSyncModule.ts
+++ b/domain/entity/recent-addresses/src/cloudSyncModule.ts
@@ -2,43 +2,15 @@ import { z } from "zod";
 import type { CloudSyncDataManager } from "@shared/cloud-sync-module";
 import type { RecentAddressesState } from "./schema";
 
-const CorrectAddressDistantSchema = z.object({
+const RecentAddressDistantSchema = z.object({
   address: z.string(),
   index: z.number(),
   lastUsed: z.number().optional(),
 });
 
-const CorruptedNestedAddressDistantSchema = z
-  .object({
-    address: z.object({
-      address: z.string(),
-      lastUsed: z.number().optional(),
-      ensName: z.string().optional(),
-    }),
-    index: z.number(),
-    lastUsed: z.number().optional(),
-  })
-  .transform(entry => ({
-    address: entry.address.address,
-    index: entry.index,
-    lastUsed: entry.address.lastUsed ?? entry.lastUsed,
-  }));
-
-const RecentAddressDistantSchema = z.union([
-  CorrectAddressDistantSchema,
-  CorruptedNestedAddressDistantSchema,
-]);
-
 export const RecentAddressesDistantSchema = z.record(
   z.string(),
-  z.array(z.unknown()).transform(entries =>
-    entries
-      .map(entry => {
-        const result = RecentAddressDistantSchema.safeParse(entry);
-        return result.success ? result.data : null;
-      })
-      .filter((entry): entry is z.infer<typeof CorrectAddressDistantSchema> => entry !== null),
-  ),
+  z.array(RecentAddressDistantSchema),
 );
 
 type DistantRecentAddressesState = z.infer<typeof RecentAddressesDistantSchema>;

--- a/e2e/mobile/utils/cliUtils.ts
+++ b/e2e/mobile/utils/cliUtils.ts
@@ -2,10 +2,8 @@ import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { CloudSyncSDK, type UpdateEvent } from "@shared/cloud-sync";
 import { liveSlug } from "@features/platform-wallet-sync";
-import {
-  walletSyncSchema,
-  type WalletSyncDistantState as LiveData,
-} from "@ledgerhq/live-wallet/walletSyncComposition";
+import type { DistantDocument } from "@ledgerhq/live-wallet/walletSyncComposition";
+import { parseDocumentArg } from "@ledgerhq/live-e2e-shared/ledgerSync/cli";
 import { getEnv } from "@shared/env";
 import {
   registerTransportModule,
@@ -113,16 +111,15 @@ export const CLI = {
       return;
     }
 
-    let latestUpdateEvent: UpdateEvent<LiveData> | null = null;
+    let latestUpdateEvent: UpdateEvent<DistantDocument> | null = null;
     const ledgerKeyRingProtocolSDK = getSdk(false, context, withDevice);
 
     const cloudSyncSDK = new CloudSyncSDK({
       apiBaseUrl: cloudSyncApiBaseUrl,
       slug: liveSlug,
-      schema: walletSyncSchema,
       trustchainSdk: ledgerKeyRingProtocolSDK,
       getCurrentVersion: () => version ?? 0,
-      saveNewUpdate: async (event: UpdateEvent<LiveData>) => {
+      saveNewUpdate: async (event: UpdateEvent<DistantDocument>) => {
         latestUpdateEvent = event;
       },
     });
@@ -151,7 +148,7 @@ export const CLI = {
         .push(
           { rootId, walletSyncEncryptionKey, applicationPath },
           { pubkey: pubKey, privatekey: privateKey },
-          JSON.parse(data!) as LiveData,
+          parseDocumentArg(data!),
         )
         .then((result: void) => JSON.stringify(result, null, 2));
     }

--- a/libs/live-e2e-shared/package.json
+++ b/libs/live-e2e-shared/package.json
@@ -34,6 +34,7 @@
     "@ledgerhq/types-devices": "workspace:^",
     "@ledgerhq/types-live": "workspace:^",
     "@shared/cloud-sync": "workspace:^",
+    "@shared/cloud-sync-module": "workspace:^",
     "@shared/env": "workspace:*",
     "@shared/feature-flags": "workspace:*",
     "axios": "catalog:",

--- a/libs/live-e2e-shared/src/ledgerSync/cli.ts
+++ b/libs/live-e2e-shared/src/ledgerSync/cli.ts
@@ -2,14 +2,18 @@ import { getSdk } from "@ledgerhq/ledger-key-ring-protocol";
 import { withDevice } from "@ledgerhq/live-common/hw/deviceAccess";
 import { CloudSyncSDK, type UpdateEvent } from "@shared/cloud-sync";
 import { liveSlug } from "@features/platform-wallet-sync";
-import {
-  walletSyncSchema,
-  type WalletSyncDistantState as LiveData,
-} from "@ledgerhq/live-wallet/walletSyncComposition";
+import { isDistantDocument, type DistantDocument } from "@shared/cloud-sync-module";
 import type { LedgerKeyRingProtocolOpts, LedgerSyncOpts } from "../runCli";
 import { trustchainApiBaseUrl } from "./environment";
 
 const CREDENTIALS_REQUIRED = "pubKey and privateKey are required";
+
+/** checked, not cast; not schema-validated so a suite can push a malformed slice on purpose */
+export function parseDocumentArg(data: string): DistantDocument {
+  const document: unknown = JSON.parse(data);
+  if (!isDistantDocument(document)) throw new Error("ledgerSync: --data must be a JSON object");
+  return document;
+}
 
 /**
  * Ledger Sync CLI entry points, shared by the desktop and mobile e2e suites. Unlike the other
@@ -123,16 +127,15 @@ export function ledgerSync(opts: LedgerSyncOpts) {
     return;
   }
 
-  let latestUpdateEvent: UpdateEvent<LiveData> | null = null;
+  let latestUpdateEvent: UpdateEvent<DistantDocument> | null = null;
   const ledgerKeyRingProtocolSDK = getSdk(false, { applicationId, name, apiBaseUrl }, withDevice);
 
   const cloudSyncSDK = new CloudSyncSDK({
     apiBaseUrl: cloudSyncApiBaseUrl,
     slug: liveSlug,
-    schema: walletSyncSchema,
     trustchainSdk: ledgerKeyRingProtocolSDK,
     getCurrentVersion: () => version ?? 0,
-    saveNewUpdate: async (event: UpdateEvent<LiveData>) => {
+    saveNewUpdate: async (event: UpdateEvent<DistantDocument>) => {
       latestUpdateEvent = event;
     },
   });
@@ -159,7 +162,7 @@ export function ledgerSync(opts: LedgerSyncOpts) {
       .push(
         { rootId, walletSyncEncryptionKey, applicationPath },
         { pubkey: pubKey, privatekey: privateKey },
-        JSON.parse(data!) as LiveData,
+        parseDocumentArg(data!),
       )
       .then((result: void) => JSON.stringify(result, null, 2));
   }

--- a/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
+++ b/libs/live-wallet/src/__tests__/walletSyncComposition.test.ts
@@ -1,53 +1,195 @@
 import { of } from "rxjs";
-import type { Account, AccountBridge, TransactionCommon } from "@ledgerhq/types-live";
-import { createWalletsync, parseDistantState } from "../walletSyncComposition";
+import type { Account } from "@ledgerhq/types-live";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import {
+  createWalletsync,
+  type WalletSyncDocument,
+  type WalletSyncLocalState,
+} from "../walletSyncComposition";
+import type { CloudSyncDataManagerResolutionContext } from "../accounts";
 
-const walletsync = createWalletsync({
-  getAccountBridge: <T extends TransactionCommon>() =>
-    ({ sync: () => of((acc: Account) => acc) }) as unknown as AccountBridge<T>,
+const account1 = genAccount("composition-1");
+const account2 = genAccount("composition-2");
+
+const ctx = {
+  getAccountBridge: () => ({ sync: (initial: Account) => of(() => initial) }),
   bridgeCache: {
     hydrateCurrency: () => Promise.resolve(null),
     prepareCurrency: () => Promise.resolve(null),
   },
-});
+} as unknown as CloudSyncDataManagerResolutionContext;
+
+function makeLocalState(overrides: Partial<WalletSyncLocalState> = {}): WalletSyncLocalState {
+  return {
+    accounts: { list: [account1], nonImportedAccountInfos: [] },
+    accountNames: new Map([[account1.id, "Local name"]]),
+    recentAddresses: { bitcoin: [{ address: "bc1local", lastUsed: 1000 }] },
+    ...overrides,
+  } as WalletSyncLocalState;
+}
 
 const emptyLocalState = {
   accounts: { list: [], nonImportedAccountInfos: [] },
   accountNames: new Map<string, string>(),
   recentAddresses: {},
-};
+} as unknown as WalletSyncLocalState;
 
-const distantEmptyState = walletsync.diffLocalToDistant(emptyLocalState, null).nextState;
+const validAccountsSlice = [
+  {
+    id: account2.id,
+    currencyId: account2.currency.id,
+    freshAddress: account2.freshAddress,
+    seedIdentifier: account2.seedIdentifier,
+    derivationMode: account2.derivationMode,
+    index: account2.index,
+  },
+];
 
-describe("parseDistantState", () => {
-  const withUnknownField = { ...distantEmptyState, fooBAR: { nested: [1, 2, 3] } };
+describe("walletsync composition", () => {
+  let onModuleError: jest.Mock;
+  let walletsync: ReturnType<typeof createWalletsync>;
 
-  it("preserves fields written by a newer version that the schema strips", () => {
-    expect(walletsync.schema.parse(withUnknownField)).not.toHaveProperty("fooBAR");
-    expect(parseDistantState(walletsync, withUnknownField)).toEqual(withUnknownField);
+  beforeEach(() => {
+    onModuleError = jest.fn();
+    walletsync = createWalletsync(ctx, { onModuleError });
   });
 
-  it("accepts data missing a module's field", () => {
-    const partial = { accounts: [] };
-    expect(parseDistantState(walletsync, partial)).toEqual(partial);
-  });
+  describe("one module's distant slice is corrupted", () => {
+    // shape recentAddresses cannot parse: entries are not a list
+    const corrupted = {
+      accounts: validAccountsSlice,
+      accountNames: { [account2.id]: "Distant name" },
+      recentAddresses: { bitcoin: "this is not a list of addresses" },
+    };
 
-  it("returns null when the data fails schema validation", () => {
-    expect(parseDistantState(walletsync, { accountNames: { foo: 42 } })).toBe(null);
-    expect(parseDistantState(walletsync, "not an object")).toBe(null);
-  });
+    it("keeps syncing the healthy modules", async () => {
+      const resolved = await walletsync.resolveIncrementalUpdate(makeLocalState(), null, corrupted);
+      expect(resolved.hasChanges).toBe(true);
+      if (!resolved.hasChanges) return;
+      expect(resolved.update.accounts.hasChanges).toBe(true);
+      expect(resolved.update.accountNames.hasChanges).toBe(true);
+      expect(resolved.update.recentAddresses).toEqual({ hasChanges: false });
 
-  it("keeps unknown fields through a parse then re-upload round trip", () => {
-    const latest = parseDistantState(walletsync, {
-      ...withUnknownField,
-      accountNames: { foo: "bar" },
+      const local = walletsync.applyUpdate(makeLocalState(), resolved.update);
+      expect(local.accountNames.get(account2.id)).toBe("Distant name");
+      expect(local.accounts.list.map(a => a.id)).toContain(account2.id);
     });
-    const localData = { ...emptyLocalState, accountNames: new Map([["foo", "baz"]]) };
-    const diff = walletsync.diffLocalToDistant(localData, latest);
-    expect(diff.hasChanges).toBe(true);
-    expect(diff.nextState).toMatchObject({
-      accountNames: { foo: "baz" },
-      fooBAR: { nested: [1, 2, 3] },
+
+    it("leaves the corrupted slice untouched instead of overwriting it with local data", () => {
+      const { nextState } = walletsync.diffLocalToDistant(makeLocalState(), corrupted);
+      expect(nextState.recentAddresses).toEqual({ bitcoin: "this is not a list of addresses" });
+    });
+
+    it("reports the quarantined module", () => {
+      walletsync.diffLocalToDistant(makeLocalState(), corrupted);
+      expect(onModuleError).toHaveBeenCalledWith("recentAddresses", expect.anything());
+      expect(onModuleError.mock.calls.map(c => c[0])).toEqual(["recentAddresses"]);
+    });
+
+    it("still pushes the healthy modules' changes", () => {
+      const { hasChanges, nextState } = walletsync.diffLocalToDistant(makeLocalState(), corrupted);
+      expect(hasChanges).toBe(true);
+      expect(nextState.accountNames).toEqual({ [account1.id]: "Local name" });
+      // account2 is distant-only and was not imported locally, so it is dropped
+      const pushedAccounts = nextState.accounts as { id: string }[];
+      expect(pushedAccounts.map(a => a.id)).toEqual([account1.id]);
+    });
+  });
+
+  it("preserves a slice written by a module this version does not know", () => {
+    const distant = {
+      accounts: validAccountsSlice,
+      futureModule: { some: ["unknown", "data"] },
+    };
+    const { nextState } = walletsync.diffLocalToDistant(makeLocalState(), distant);
+    expect(nextState.futureModule).toEqual({
+      some: ["unknown", "data"],
+    });
+    expect(onModuleError).not.toHaveBeenCalled();
+  });
+
+  it("does not freeze the whole sync when every module's slice is garbage", async () => {
+    const garbage = { accounts: "nope", accountNames: 42, recentAddresses: [] };
+    expect(() => walletsync.diffLocalToDistant(makeLocalState(), garbage)).not.toThrow();
+    await expect(
+      walletsync.resolveIncrementalUpdate(makeLocalState(), null, garbage),
+    ).resolves.toBeDefined();
+  });
+
+  // regression: a rejected slice used to null the whole document and erase the healthy ones
+  describe("data loss regression (one slice rejected by its schema)", () => {
+    const distant = {
+      accountNames: { [account2.id]: "Name from another instance" },
+      recentAddresses: { bitcoin: "corrupted by some other app version" },
+      futureModule: { written: "by a newer app version" },
+    };
+
+    it("does not erase the key of a module this version does not know", () => {
+      const { nextState } = walletsync.diffLocalToDistant(makeLocalState(), distant);
+      expect(nextState.futureModule).toEqual({
+        written: "by a newer app version",
+      });
+    });
+
+    it("does not overwrite another instance's healthy slice with local data", async () => {
+      const resolved = await walletsync.resolveIncrementalUpdate(makeLocalState(), null, distant);
+      expect(resolved.hasChanges).toBe(true);
+      if (!resolved.hasChanges) return;
+      const local = walletsync.applyUpdate(makeLocalState(), resolved.update);
+      expect(local.accountNames.get(account2.id)).toBe("Name from another instance");
+    });
+
+    it("keeps the rejected slice verbatim rather than replacing it with local state", () => {
+      const { nextState } = walletsync.diffLocalToDistant(makeLocalState(), distant);
+      expect(nextState.recentAddresses).toEqual({
+        bitcoin: "corrupted by some other app version",
+      });
+    });
+  });
+
+  // a distant document is read as-is: no aggregate parse ever runs, on any path
+  describe("distant document", () => {
+    const unknownField = { fooBAR: { nested: [1, 2, 3] } };
+    const withUnknownField = () => ({
+      ...walletsync.diffLocalToDistant(emptyLocalState, null).nextState,
+      ...unknownField,
+    });
+
+    it("is read without validating the modules", () => {
+      const raw = { accounts: "garbage", futureModule: true };
+      expect(() => walletsync.diffLocalToDistant(makeLocalState(), raw)).not.toThrow();
+    });
+
+    it("is treated as absent when it is not an object", () => {
+      // the casts are the point: a storage slot violating its declared type is why this narrows
+      for (const raw of [null, undefined, 42, "string", true, []] as WalletSyncDocument[]) {
+        expect(walletsync.diffLocalToDistant(emptyLocalState, raw)).toEqual(
+          walletsync.diffLocalToDistant(emptyLocalState, null),
+        );
+      }
+    });
+
+    it("keeps fields written by a newer version that the aggregate schema strips", () => {
+      const distant = withUnknownField();
+      expect(walletsync.schema.parse(distant)).not.toHaveProperty("fooBAR");
+      expect(walletsync.diffLocalToDistant(emptyLocalState, distant).nextState).toHaveProperty(
+        "fooBAR",
+      );
+    });
+
+    it("is accepted when a module's field is missing", () => {
+      expect(() => walletsync.diffLocalToDistant(makeLocalState(), { accounts: [] })).not.toThrow();
+    });
+
+    it("keeps unknown fields through a read then re-upload round trip", () => {
+      const latest = { ...withUnknownField(), accountNames: { foo: "bar" } };
+      const localData = { ...emptyLocalState, accountNames: new Map([["foo", "baz"]]) };
+      const diff = walletsync.diffLocalToDistant(localData, latest);
+      expect(diff.hasChanges).toBe(true);
+      expect(diff.nextState).toMatchObject({
+        accountNames: { foo: "baz" },
+        fooBAR: { nested: [1, 2, 3] },
+      });
     });
   });
 });

--- a/libs/live-wallet/src/walletSyncComposition.ts
+++ b/libs/live-wallet/src/walletSyncComposition.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
-import { createAggregator } from "@shared/cloud-sync-module";
+import { createAggregator, type AggregatorOptions } from "@shared/cloud-sync-module";
+
+export type {
+  AggregatorOptions,
+  CloudSyncModuleQuarantined,
+  DistantDocument,
+} from "@shared/cloud-sync-module";
 import { accountNamesSyncModule } from "@domain/entity-account-name";
 import { recentAddressesSyncModule } from "@domain/entity-recent-addresses";
 import {
@@ -8,31 +14,28 @@ import {
   type CloudSyncDataManagerResolutionContext,
 } from "./accounts";
 
+/** the shape we author; one we read is a DistantDocument, validated per module by the aggregator */
 export const walletSyncSchema = z.object({
   accounts: z.optional(accountsSyncModule.schema),
   accountNames: z.optional(accountNamesSyncModule.schema),
   recentAddresses: z.optional(recentAddressesSyncModule.schema),
 });
 
-export function createWalletsync(ctx: CloudSyncDataManagerResolutionContext) {
-  return createAggregator({
-    accounts: bindCtx(ctx),
-    accountNames: accountNamesSyncModule,
-    recentAddresses: recentAddressesSyncModule,
-  });
+export function createWalletsync(
+  ctx: CloudSyncDataManagerResolutionContext,
+  options?: AggregatorOptions,
+) {
+  return createAggregator(
+    {
+      accounts: bindCtx(ctx),
+      accountNames: accountNamesSyncModule,
+      recentAddresses: recentAddressesSyncModule,
+    },
+    options,
+  );
 }
 
 export type Walletsync = ReturnType<typeof createWalletsync>;
 export type WalletSyncSchema = Walletsync["schema"];
-export type WalletSyncDistantState = z.infer<typeof walletSyncSchema>;
+export type WalletSyncDocument = z.infer<typeof walletSyncSchema>;
 export type WalletSyncLocalState = ReturnType<Walletsync["applyUpdate"]>;
-
-export function parseDistantState(
-  walletsync: Walletsync,
-  raw: unknown,
-): WalletSyncDistantState | null {
-  const result = walletsync.schema.safeParse(raw);
-  // returns raw, not result.data: zod strips unknown keys and we must preserve fields
-  // written by newer app versions so re-uploading this state does not drop them.
-  return result.success ? (raw as WalletSyncDistantState) : null;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13927,6 +13927,9 @@ importers:
       '@shared/cloud-sync':
         specifier: workspace:^
         version: link:../../shared/cloud-sync
+      '@shared/cloud-sync-module':
+        specifier: workspace:^
+        version: link:../../shared/cloud-sync-module
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env

--- a/shared/cloud-sync-module/src/__tests__/createAggregator.test.ts
+++ b/shared/cloud-sync-module/src/__tests__/createAggregator.test.ts
@@ -1,9 +1,33 @@
 import { z } from "zod";
-import { createAggregator, mapValues } from "../cloudSyncModule";
+import { createAggregator, isDistantDocument, mapValues } from "../cloudSyncModule";
 
 describe(mapValues.name, () => {
   it("maps object values while preserving keys", () => {
     expect(mapValues({ a: 1, b: 2 }, value => value * 2)).toEqual({ a: 2, b: 4 });
+  });
+});
+
+describe(isDistantDocument.name, () => {
+  it.each([
+    ["an empty object", {}],
+    ["a bag of slices", { accounts: [], unknownKey: 1 }],
+    ["an object with a garbage slice", { accounts: "not a list" }],
+    ["a null-prototype object", Object.create(null)],
+  ])("accepts %s", (_label, value) => {
+    expect(isDistantDocument(value)).toBe(true);
+  });
+
+  // an array or a scalar carries no slice to read, so it can only be treated as an absent document
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 42],
+    ["a string", "string"],
+    ["a boolean", true],
+    ["an array", []],
+    ["a function", () => {}],
+  ])("rejects %s", (_label, value) => {
+    expect(isDistantDocument(value)).toBe(false);
   });
 });
 

--- a/shared/cloud-sync-module/src/__tests__/moduleIsolation.test.ts
+++ b/shared/cloud-sync-module/src/__tests__/moduleIsolation.test.ts
@@ -1,0 +1,492 @@
+import { z } from "zod";
+import {
+  createAggregator,
+  type CloudSyncDataManager,
+  type DistantDocument,
+  type OnModuleError,
+} from "../cloudSyncModule";
+
+// a failing module must not cascade: others keep syncing and its distant data is preserved
+
+type HealthyLocal = string[];
+type HealthyDistant = string[];
+
+function makeHealthyModule(): CloudSyncDataManager<
+  HealthyLocal,
+  HealthyDistant,
+  z.ZodType<HealthyDistant>,
+  HealthyDistant
+> {
+  return {
+    schema: z.array(z.string()),
+    diffLocalToDistant: (local, latest) => ({
+      hasChanges: local.join() !== (latest ?? []).join(),
+      nextState: local,
+    }),
+    resolveIncrementalUpdate: async (local, latest, incoming) => {
+      if (!incoming || incoming.join() === (latest ?? []).join()) return { hasChanges: false };
+      if (incoming.join() === local.join()) return { hasChanges: false };
+      return { hasChanges: true, update: incoming };
+    },
+    applyUpdate: (_local, update) => update,
+  };
+}
+
+type PoisonBehaviour = {
+  /** throws synchronously from diffLocalToDistant */
+  diffThrows?: boolean;
+  /** throws synchronously from resolveIncrementalUpdate (before returning a promise) */
+  resolveThrowsSync?: boolean;
+  /** returns a rejected promise from resolveIncrementalUpdate */
+  resolveRejects?: boolean;
+  /** throws synchronously from applyUpdate */
+  applyThrows?: boolean;
+};
+
+/** A module whose schema only accepts `{ ok: true }`, and that can be made to throw on demand. */
+function makePoisonModule(behaviour: PoisonBehaviour = {}) {
+  const schema = z.object({ ok: z.literal(true) });
+  type Distant = z.infer<typeof schema>;
+  const module: CloudSyncDataManager<Distant, Distant, typeof schema, Distant> = {
+    schema,
+    diffLocalToDistant: (local, latest) => {
+      if (behaviour.diffThrows) throw new Error("poison: diffLocalToDistant");
+      return { hasChanges: latest == null, nextState: local };
+    },
+    resolveIncrementalUpdate: (_local, _latest, incoming) => {
+      if (behaviour.resolveThrowsSync) throw new Error("poison: resolveIncrementalUpdate sync");
+      if (behaviour.resolveRejects) {
+        return Promise.reject(new Error("poison: resolveIncrementalUpdate async"));
+      }
+      return Promise.resolve(
+        incoming ? { hasChanges: true, update: incoming } : { hasChanges: false },
+      );
+    },
+    applyUpdate: (local, update) => {
+      if (behaviour.applyThrows) throw new Error("poison: applyUpdate");
+      return update ?? local;
+    },
+  };
+  return module;
+}
+
+function setup(behaviour: PoisonBehaviour = {}) {
+  const onModuleError = jest.fn<ReturnType<OnModuleError>, Parameters<OnModuleError>>();
+  const aggregator = createAggregator(
+    {
+      alpha: makeHealthyModule(),
+      poison: makePoisonModule(behaviour),
+      omega: makeHealthyModule(),
+    },
+    { onModuleError },
+  );
+  const localState = { alpha: ["a"], poison: { ok: true as const }, omega: ["o"] };
+  return { aggregator, onModuleError, localState };
+}
+
+/** a distant state where the poison module's slice does not match its schema */
+const garbageDistant = {
+  alpha: ["a-distant"],
+  poison: { ok: "definitely not a boolean", extra: [1, 2, 3] },
+  omega: ["o-distant"],
+  futureModule: { written: "by a newer app version" },
+};
+
+describe("createAggregator module isolation", () => {
+  describe("a distant slice that fails its module schema", () => {
+    it("does not stop the other modules from diffing", () => {
+      const { aggregator, localState } = setup();
+      const result = aggregator.diffLocalToDistant(localState, garbageDistant);
+      expect(result.hasChanges).toBe(true);
+      expect(result.nextState.alpha).toEqual(["a"]);
+      expect(result.nextState.omega).toEqual(["o"]);
+    });
+
+    it("preserves the unparseable slice verbatim instead of erasing or overwriting it", () => {
+      const { aggregator, localState } = setup();
+      const result = aggregator.diffLocalToDistant(localState, garbageDistant);
+      expect(result.nextState.poison).toEqual({
+        ok: "definitely not a boolean",
+        extra: [1, 2, 3],
+      });
+    });
+
+    it("still preserves keys written by newer app versions", () => {
+      const { aggregator, localState } = setup();
+      const result = aggregator.diffLocalToDistant(localState, garbageDistant);
+      expect(result.nextState.futureModule).toEqual({
+        written: "by a newer app version",
+      });
+    });
+
+    it("reports the failing module", () => {
+      const { aggregator, onModuleError, localState } = setup();
+      aggregator.diffLocalToDistant(localState, garbageDistant);
+      expect(onModuleError).toHaveBeenCalledTimes(1);
+      expect(onModuleError.mock.calls[0][0]).toBe("poison");
+      expect(onModuleError.mock.calls[0][1]).toBeDefined();
+    });
+
+    it("reports a sticky quarantine only once, not on every poll", async () => {
+      const { aggregator, onModuleError, localState } = setup();
+      for (let i = 0; i < 5; i++) {
+        aggregator.diffLocalToDistant(localState, garbageDistant);
+        await aggregator.resolveIncrementalUpdate(localState, garbageDistant, garbageDistant);
+      }
+      expect(onModuleError).toHaveBeenCalledTimes(1);
+    });
+
+    it("still reports a module that later starts failing a different way", () => {
+      const onModuleError = jest.fn<ReturnType<OnModuleError>, Parameters<OnModuleError>>();
+      let mode: "schema" | "throw" = "schema";
+      const flakySchema = z.object({ ok: z.literal(true) });
+      type FlakyState = z.infer<typeof flakySchema>;
+      const flaky: CloudSyncDataManager<FlakyState, FlakyState, typeof flakySchema, FlakyState> = {
+        schema: flakySchema,
+        diffLocalToDistant: local => {
+          if (mode === "throw") throw new Error("a completely different failure");
+          return { hasChanges: false, nextState: local };
+        },
+        resolveIncrementalUpdate: async () => ({ hasChanges: false }),
+        applyUpdate: local => local,
+      };
+      const aggregator = createAggregator({ flaky }, { onModuleError });
+      const local = { flaky: { ok: true as const } };
+
+      aggregator.diffLocalToDistant(local, { flaky: "garbage" });
+      expect(onModuleError).toHaveBeenCalledTimes(1);
+
+      mode = "throw";
+      aggregator.diffLocalToDistant(local, { flaky: { ok: true } });
+      expect(onModuleError).toHaveBeenCalledTimes(2);
+      expect(onModuleError.mock.calls[1][1]).toEqual(expect.any(Error));
+    });
+
+    // guards the seeding spread: Object.assign semantics would drop this key and move the
+    // prototype instead, so a downlevelled build would fail here rather than silently lose data
+    it("preserves a distant key named __proto__ without touching the prototype chain", () => {
+      const { aggregator, localState } = setup();
+      const distant = JSON.parse('{"__proto__": {"polluted": true}}');
+      distant.alpha = ["a-distant"];
+      distant.omega = ["o-distant"];
+
+      const { nextState } = aggregator.diffLocalToDistant(localState, distant);
+
+      expect(Object.prototype.hasOwnProperty.call(nextState, "__proto__")).toBe(true);
+      expect(Object.getPrototypeOf(nextState)).toBe(Object.prototype);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      expect(nextState.alpha).toEqual(["a"]);
+    });
+
+    it("lets the other modules resolve an incoming update", async () => {
+      const { aggregator, localState } = setup();
+      const result = await aggregator.resolveIncrementalUpdate(localState, null, garbageDistant);
+      expect(result.hasChanges).toBe(true);
+      if (!result.hasChanges) return;
+      expect(result.update.alpha).toEqual({ hasChanges: true, update: ["a-distant"] });
+      expect(result.update.omega).toEqual({ hasChanges: true, update: ["o-distant"] });
+      expect(result.update.poison).toEqual({ hasChanges: false });
+    });
+
+    it("does not erase the healthy modules' distant keys (data-loss regression)", () => {
+      const { aggregator, localState } = setup();
+      const { nextState } = aggregator.diffLocalToDistant(localState, garbageDistant);
+      const keys = Object.keys(nextState as Record<string, unknown>).sort();
+      expect(keys).toEqual(["alpha", "futureModule", "omega", "poison"]);
+    });
+
+    it("survives a distant state that is not even shaped like a state object", async () => {
+      const { aggregator, localState } = setup();
+      for (const garbage of [
+        { alpha: 42, poison: "nope", omega: null },
+        { alpha: null, poison: undefined, omega: ["o-distant"] },
+        {},
+      ]) {
+        expect(() => aggregator.diffLocalToDistant(localState, garbage)).not.toThrow();
+        await expect(
+          aggregator.resolveIncrementalUpdate(localState, null, garbage),
+        ).resolves.toBeDefined();
+      }
+    });
+
+    // a document arrives from the network or from storage, so its declared type is not trusted
+    it("treats a document that is not an object as an absent one", async () => {
+      const { aggregator, localState } = setup();
+      const absent = aggregator.diffLocalToDistant(localState, null);
+      for (const notADocument of [undefined, 42, "string", true, [], () => {}]) {
+        const document = notADocument as unknown as DistantDocument;
+        expect(aggregator.diffLocalToDistant(localState, document)).toEqual(absent);
+        await expect(
+          aggregator.resolveIncrementalUpdate(localState, document, document),
+        ).resolves.toBeDefined();
+      }
+    });
+
+    it("never reports a quarantine for a document that carries no slice at all", () => {
+      const { aggregator, localState, onModuleError } = setup();
+      aggregator.diffLocalToDistant(localState, 42 as unknown as DistantDocument);
+      expect(onModuleError).not.toHaveBeenCalled();
+    });
+  });
+
+  // a quarantine must be recoverable: an unreadable *latest* slice is only a missing baseline,
+  // so it must not stop the module adopting a *incoming* slice that parses again
+  describe("recovering from a quarantine", () => {
+    it("applies a readable incoming slice even when the latest slice is unreadable", async () => {
+      const { aggregator, localState } = setup();
+      const resolved = await aggregator.resolveIncrementalUpdate(
+        localState,
+        { poison: "garbage from an older push" },
+        { poison: { ok: true } },
+      );
+
+      expect(resolved.hasChanges).toBe(true);
+      if (!resolved.hasChanges) return;
+      expect(resolved.update.poison).toEqual({ hasChanges: true, update: { ok: true } });
+    });
+
+    it("still skips the module when the incoming slice is the unreadable one", async () => {
+      const { aggregator, localState } = setup();
+      const resolved = await aggregator.resolveIncrementalUpdate(
+        localState,
+        { poison: { ok: true } },
+        { poison: "garbage" },
+      );
+
+      if (resolved.hasChanges) expect(resolved.update.poison).toEqual({ hasChanges: false });
+    });
+
+    it("reports the unreadable latest slice even though it lets the incoming one through", async () => {
+      const { aggregator, localState, onModuleError } = setup();
+      await aggregator.resolveIncrementalUpdate(
+        localState,
+        { poison: "garbage" },
+        { poison: { ok: true } },
+      );
+      expect(onModuleError).toHaveBeenCalledTimes(1);
+      expect(onModuleError.mock.calls[0][0]).toBe("poison");
+    });
+  });
+
+  describe("a module that throws", () => {
+    it("diffLocalToDistant: keeps the other modules and falls back to the latest distant value", () => {
+      const { aggregator, onModuleError, localState } = setup({ diffThrows: true });
+      const latest = { alpha: ["a-distant"], poison: { ok: true as const }, omega: ["o-distant"] };
+      const result = aggregator.diffLocalToDistant(localState, latest);
+      expect(result.nextState.alpha).toEqual(["a"]);
+      expect(result.nextState.omega).toEqual(["o"]);
+      expect(result.nextState.poison).toEqual({ ok: true });
+      expect(onModuleError).toHaveBeenCalledWith("poison", expect.any(Error));
+    });
+
+    it("diffLocalToDistant: throwing on a null latest state leaves no bogus value behind", () => {
+      const { aggregator, localState } = setup({ diffThrows: true });
+      const result = aggregator.diffLocalToDistant(localState, null);
+      expect(result.nextState.alpha).toEqual(["a"]);
+      expect(result.nextState.omega).toEqual(["o"]);
+      expect(result.nextState.poison).toBeUndefined();
+      expect(JSON.parse(JSON.stringify(result.nextState))).not.toHaveProperty("poison");
+    });
+
+    it("resolveIncrementalUpdate: a rejected module degrades to hasChanges=false", async () => {
+      const { aggregator, onModuleError, localState } = setup({ resolveRejects: true });
+      const incoming = {
+        alpha: ["a-distant"],
+        poison: { ok: true as const },
+        omega: ["o-distant"],
+      };
+      const result = await aggregator.resolveIncrementalUpdate(localState, null, incoming);
+      expect(result.hasChanges).toBe(true);
+      if (!result.hasChanges) return;
+      expect(result.update.poison).toEqual({ hasChanges: false });
+      expect(result.update.alpha).toEqual({ hasChanges: true, update: ["a-distant"] });
+      expect(result.update.omega).toEqual({ hasChanges: true, update: ["o-distant"] });
+      expect(onModuleError).toHaveBeenCalledWith("poison", expect.any(Error));
+    });
+
+    it("resolveIncrementalUpdate: a synchronous throw is caught like a rejection", async () => {
+      const { aggregator, onModuleError, localState } = setup({ resolveThrowsSync: true });
+      const incoming = {
+        alpha: ["a-distant"],
+        poison: { ok: true as const },
+        omega: ["o-distant"],
+      };
+      const result = await aggregator.resolveIncrementalUpdate(localState, null, incoming);
+      expect(result.hasChanges).toBe(true);
+      if (!result.hasChanges) return;
+      expect(result.update.poison).toEqual({ hasChanges: false });
+      expect(onModuleError).toHaveBeenCalledWith("poison", expect.any(Error));
+    });
+
+    it("resolveIncrementalUpdate: a rejection alone never rejects the aggregate", async () => {
+      const { aggregator, localState } = setup({ resolveRejects: true });
+      const incoming = { alpha: ["a"], poison: { ok: true as const }, omega: ["o"] };
+      await expect(
+        aggregator.resolveIncrementalUpdate(localState, incoming, incoming),
+      ).resolves.toEqual({ hasChanges: false });
+    });
+
+    it("applyUpdate: keeps the local state of the failing module and applies the others", () => {
+      const { aggregator, onModuleError, localState } = setup({ applyThrows: true });
+      const result = aggregator.applyUpdate(localState, {
+        alpha: { hasChanges: true, update: ["a-new"] },
+        poison: { hasChanges: true, update: { ok: true } },
+        omega: { hasChanges: true, update: ["o-new"] },
+      });
+      expect(result.alpha).toEqual(["a-new"]);
+      expect(result.omega).toEqual(["o-new"]);
+      expect(result.poison).toBe(localState.poison);
+      expect(onModuleError).toHaveBeenCalledWith("poison", expect.any(Error));
+    });
+
+    it("applyUpdate: tolerates an update object missing a module entry", () => {
+      const { aggregator, localState } = setup();
+      const result = aggregator.applyUpdate(localState, {
+        alpha: { hasChanges: true, update: ["a-new"] },
+      } as never);
+      expect(result.alpha).toEqual(["a-new"]);
+      expect(result.poison).toBe(localState.poison);
+      expect(result.omega).toEqual(["o"]);
+    });
+  });
+
+  describe("a full pull/push round trip with a poisoned module", () => {
+    it("converges the healthy modules and round-trips the poisoned slice untouched", async () => {
+      const { aggregator, localState } = setup();
+      const resolved = await aggregator.resolveIncrementalUpdate(localState, null, garbageDistant);
+      expect(resolved.hasChanges).toBe(true);
+      if (!resolved.hasChanges) return;
+
+      const newLocal = aggregator.applyUpdate(localState, resolved.update);
+      expect(newLocal.alpha).toEqual(["a-distant"]);
+      expect(newLocal.omega).toEqual(["o-distant"]);
+
+      // what we would push back must still carry the poisoned and unknown slices as-is
+      const { nextState } = aggregator.diffLocalToDistant(newLocal, garbageDistant);
+      expect(nextState).toEqual(garbageDistant);
+    });
+  });
+
+  it("hands modules their slice by reference, so identity short-circuits still work", async () => {
+    const seen: unknown[] = [];
+    const spyModule = {
+      ...makeHealthyModule(),
+      resolveIncrementalUpdate: async (_l: HealthyLocal, latest: unknown, incoming: unknown) => {
+        seen.push(latest, incoming);
+        return { hasChanges: false as const };
+      },
+    };
+    const aggregator = createAggregator({ alpha: spyModule });
+    const slice = ["a"];
+    const state = { alpha: slice };
+    await aggregator.resolveIncrementalUpdate({ alpha: ["a"] }, state, state);
+    expect(seen[0]).toBe(slice);
+    expect(seen[1]).toBe(slice);
+  });
+
+  // the package is platform-agnostic, so it reports only through onModuleError: touching console
+  // both breaks consumers compiling its source with lib ES2022 and picks their alert severity
+  it("quarantines silently, without touching the console, when no onModuleError is given", () => {
+    const spies = (["error", "warn", "log", "info", "debug"] as const).map(level =>
+      jest.spyOn(console, level).mockImplementation(() => {}),
+    );
+    try {
+      const aggregator = createAggregator({ poison: makePoisonModule() });
+      const { nextState } = aggregator.diffLocalToDistant(
+        { poison: { ok: true } },
+        { poison: "garbage" },
+      );
+      expect(nextState.poison).toBe("garbage");
+      spies.forEach(spy => expect(spy).not.toHaveBeenCalled());
+    } finally {
+      spies.forEach(spy => spy.mockRestore());
+    }
+  });
+
+  // a report reaches Datadog, so it must never carry synced data. A zod message is its issues
+  // serialized, and an issue path is a record key -- for accountNames that key is an account id
+  // carrying the xpub.
+  describe("reported errors carry no synced content", () => {
+    const ACCOUNT_ID = "js:2:bitcoin:xpub6CUGRUonZSQ4TWtTMmzXd7feUVBJvSEyLEAKEDXPUB:native_segwit";
+    const ADDRESS = "bc1qLEAKEDADDRESS0000";
+
+    /** everything a sink could reach: message, stack, own props, cause chain */
+    function fullyExposed(error: unknown): string {
+      const seen = new Set<unknown>();
+      const parts: string[] = [];
+      let current: unknown = error;
+      while (current instanceof Error && !seen.has(current)) {
+        seen.add(current);
+        parts.push(current.name, current.message, current.stack ?? "");
+        parts.push(JSON.stringify(current, Object.getOwnPropertyNames(current)));
+        current = (current as { cause?: unknown }).cause;
+      }
+      parts.push(String(error), JSON.stringify(error));
+      return parts.join("\n");
+    }
+
+    /** mirrors accountNames: a record keyed by account id, so the key lands in the issue path */
+    const namesModule: CloudSyncDataManager<
+      Record<string, string>,
+      Record<string, string>,
+      z.ZodType<Record<string, string>>,
+      Record<string, string>
+    > = {
+      schema: z.record(z.string(), z.string()),
+      diffLocalToDistant: local => ({ hasChanges: false, nextState: local }),
+      resolveIncrementalUpdate: async () => ({ hasChanges: false }),
+      applyUpdate: (_local, update) => update,
+    };
+
+    it("omits the account id and address from a schema rejection", () => {
+      const onModuleError = jest.fn<ReturnType<OnModuleError>, Parameters<OnModuleError>>();
+      const aggregator = createAggregator({ names: namesModule }, { onModuleError });
+
+      // a number value rejects the slice, putting the account id in the issue path
+      const distant = { names: { [ACCOUNT_ID]: 42, other: ADDRESS } };
+      aggregator.diffLocalToDistant({ names: {} }, distant);
+
+      expect(onModuleError).toHaveBeenCalledTimes(1);
+      const [moduleKey, reported] = onModuleError.mock.calls[0];
+      expect(moduleKey).toBe("names");
+
+      const exposed = fullyExposed(reported);
+      expect(exposed).not.toContain("LEAKEDXPUB");
+      expect(exposed).not.toContain(ACCOUNT_ID);
+      expect(exposed).not.toContain(ADDRESS);
+      // the useful part survives: which module, and what kind of failure
+      expect(reported.moduleKey).toBe("names");
+      expect(reported.reason).toBe("ZodError(invalid_type)");
+      expect(reported.cause).toBeUndefined();
+    });
+
+    it("omits the thrown error's message when a module throws", () => {
+      const onModuleError = jest.fn<ReturnType<OnModuleError>, Parameters<OnModuleError>>();
+      const thrower: CloudSyncDataManager<string[], string[], z.ZodType<string[]>, string[]> = {
+        schema: z.array(z.string()),
+        diffLocalToDistant: () => {
+          throw new TypeError(`cannot read ${ACCOUNT_ID}`);
+        },
+        resolveIncrementalUpdate: async () => ({ hasChanges: false }),
+        applyUpdate: (_local, update) => update,
+      };
+      const aggregator = createAggregator({ thrower }, { onModuleError });
+      aggregator.diffLocalToDistant({ thrower: [] }, null);
+
+      const [, reported] = onModuleError.mock.calls[0];
+      expect(fullyExposed(reported)).not.toContain("LEAKEDXPUB");
+      expect(reported.reason).toBe("TypeError");
+    });
+
+    it("keeps the quarantine message itself payload-free", () => {
+      const onModuleError = jest.fn<ReturnType<OnModuleError>, Parameters<OnModuleError>>();
+      const aggregator = createAggregator({ names: namesModule }, { onModuleError });
+      aggregator.diffLocalToDistant({ names: {} }, { names: { [ACCOUNT_ID]: 42 } });
+
+      // the message is what a consumer is most likely to log verbatim
+      const [, reported] = onModuleError.mock.calls[0];
+      expect(reported.message).not.toContain("LEAKEDXPUB");
+      expect(reported.message).not.toContain(ACCOUNT_ID);
+    });
+  });
+});

--- a/shared/cloud-sync-module/src/cloudSyncModule.ts
+++ b/shared/cloud-sync-module/src/cloudSyncModule.ts
@@ -23,61 +23,172 @@ export type UpdateDiff<Update> = { hasChanges: false } | { hasChanges: true; upd
 
 export type DistantDiff<DistantState> = { hasChanges: boolean; nextState: DistantState };
 
+/** a bag of module slices: nothing validates a document as a whole, on read or on write */
+export type DistantDocument = Record<string, unknown>;
+
+/** sound unlike a cast: any non-null non-array object is a bag of unknown values by key */
+export function isDistantDocument(state: unknown): state is DistantDocument {
+  return !!state && typeof state === "object" && !Array.isArray(state);
+}
+
+/** runtime defense: a document reaches us from the network or from rehydrated storage */
+function asDocument(state: unknown): DistantDocument | null {
+  return isDistantDocument(state) ? state : null;
+}
+
 export type ExtractLocalState<T> = T extends CloudSyncDataManager<infer L, any, any> ? L : never;
 export type ExtractUpdateEvent<T> = T extends CloudSyncDataManager<any, infer U, any> ? U : never;
 export type ExtractSchema<T> = T extends CloudSyncDataManager<any, any, infer S> ? S : never;
 export type ExtractDistantState<T> =
   T extends CloudSyncDataManager<any, any, any, infer D> ? D : never;
 
+/**
+ * Everything a quarantine reports, and nothing else: the module and what kind of failure it was.
+ * Never carries the offending value, and never wraps the original error as `cause` — a ZodError
+ * stringifies to its issues, whose `path` is a record key, and an accountNames key is an account
+ * id carrying the xpub. This reaches Datadog, so it stays free of any synced content.
+ */
+export class CloudSyncModuleQuarantined extends Error {
+  override name = "CloudSyncModuleQuarantined";
+  constructor(
+    readonly moduleKey: string,
+    readonly reason: string,
+  ) {
+    super(`cloud-sync module "${moduleKey}" quarantined: ${reason}`);
+  }
+}
+
+/** a quarantined module stays frozen until data or code is fixed, so report this to logs/Sentry */
+export type OnModuleError = (moduleKey: string, error: CloudSyncModuleQuarantined) => void;
+
+/** the failure kind alone: zod codes are a fixed vocabulary, an error name is a class name */
+function describeError(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    const codes = Array.from(new Set(error.issues.map(issue => issue.code))).sort((a, b) =>
+      a.localeCompare(b),
+    );
+    return codes.length ? `ZodError(${codes.join(", ")})` : "ZodError";
+  }
+  if (error instanceof Error) return error.name;
+  return typeof error;
+}
+
+export type AggregatorOptions = {
+  onModuleError?: OnModuleError;
+};
+
+type SliceRead = { ok: true; value: unknown } | { ok: false };
+
 export function createAggregator<Mods extends Record<string, CloudSyncDataManager<any, any, any>>>(
   modules: Mods,
+  options: AggregatorOptions = {},
 ) {
   const schema = z.object(mapValues(modules, m => z.optional(m.schema)));
 
   type Schema = typeof schema;
-  type DistantState = { [K in keyof Mods]?: z.infer<Mods[K]["schema"]> };
+  // not `{ [K in keyof Mods]?: z.infer<Mods[K]["schema"]> }`: see DistantDocument
+  type DistantState = DistantDocument;
   type LocalState = { [K in keyof Mods]: ExtractLocalState<Mods[K]> };
   type UpdateEvent = { [K in keyof Mods]: UpdateDiff<ExtractUpdateEvent<Mods[K]>> };
+
+  const moduleKeys = Object.keys(modules) as (keyof Mods & string)[];
+
+  // a quarantine repeats on every poll, so report each module once per kind of failure.
+  // keyed on the failure kind, not the error message: a zod message is its issues serialized,
+  // so it varies with the data and would grow this set on every poll for as long as the app runs.
+  const reported = new Set<string>();
+
+  const reportModuleError = (moduleKey: string, error: unknown) => {
+    const reason = describeError(error);
+    const key = `${moduleKey} ${reason}`;
+    if (reported.has(key)) return;
+    reported.add(key);
+    // no console fallback: this package is platform-agnostic and consumers compile its source
+    // with lib ES2022 only, and a recoverable quarantine must not pick their monitoring severity
+    options.onModuleError?.(moduleKey, new CloudSyncModuleQuarantined(moduleKey, reason));
+  };
+
+  /** checks a slice against its module schema; a failing one must be skipped, never rewritten */
+  function readSlice(key: keyof Mods & string, state: DistantDocument | null): SliceRead {
+    if (state == null) return { ok: true, value: null };
+    const raw = state[key];
+    if (raw === undefined || raw === null) return { ok: true, value: null };
+    const result = modules[key].schema.safeParse(raw);
+    if (!result.success) {
+      reportModuleError(key, result.error);
+      return { ok: false };
+    }
+    // raw, not result.data: zod strips fields written by newer app versions
+    return { ok: true, value: raw };
+  }
 
   const root: CloudSyncDataManager<LocalState, UpdateEvent, Schema, DistantState> = {
     schema,
 
-    diffLocalToDistant(localData, latestState) {
+    diffLocalToDistant(localData, distantState) {
+      const latestState = asDocument(distantState);
       let hasChanges = false;
-      const unknownRest: Record<string, unknown> = { ...latestState };
-      const nextState = mapValues(modules, (m, k) => {
-        const diff = m.diffLocalToDistant(
-          localData[k],
-          latestState != null ? (latestState[k] ?? null) : null,
-        );
-        delete unknownRest[k as string];
-        if (diff.hasChanges) hasChanges = true;
-        return diff.nextState;
-      });
-      return { hasChanges, nextState: { ...nextState, ...unknownRest } };
+      // seeding from latestState keeps unknown module keys and quarantined slices verbatim
+      const nextState: DistantDocument = { ...latestState };
+      for (const key of moduleKeys) {
+        const slice = readSlice(key, latestState);
+        if (!slice.ok) continue;
+        try {
+          const diff = modules[key].diffLocalToDistant(localData[key], slice.value);
+          if (diff.hasChanges) hasChanges = true;
+          nextState[key] = diff.nextState;
+        } catch (error) {
+          reportModuleError(key, error);
+        }
+      }
+      return { hasChanges, nextState };
     },
 
-    async resolveIncrementalUpdate(localData, latestState, incomingState) {
-      const resolved = mapValues(modules, (m, k) =>
-        m.resolveIncrementalUpdate(
-          localData[k],
-          latestState != null ? (latestState[k] ?? null) : null,
-          incomingState != null ? (incomingState[k] ?? null) : null,
-        ),
+    async resolveIncrementalUpdate(localData, distantLatestState, distantIncomingState) {
+      const latestState = asDocument(distantLatestState);
+      const incomingState = asDocument(distantIncomingState);
+      const results = await Promise.allSettled(
+        moduleKeys.map(async key => {
+          const latest = readSlice(key, latestState);
+          const incoming = readSlice(key, incomingState);
+          // an unreadable incoming slice is the one with nothing to apply. an unreadable latest is
+          // only a missing baseline, so treat it as absent: skipping on it would strand the module
+          // once its stored slice was corrupt, since a later fixed document short-circuits on
+          // latest === incoming and the data it skipped would never be applied
+          if (!incoming.ok) return { hasChanges: false as const };
+          return modules[key].resolveIncrementalUpdate(
+            localData[key],
+            latest.ok ? latest.value : null,
+            incoming.value,
+          );
+        }),
       );
-      const results = await Promise.all(Object.values(resolved));
-      const hasChanges = results.some(r => r.hasChanges);
-      let index = 0;
-      const update = mapValues(modules, () => results[index++]) as UpdateEvent;
+      let hasChanges = false;
+      const update = {} as UpdateEvent;
+      moduleKeys.forEach((key, i) => {
+        const result = results[i];
+        if (result.status === "rejected") {
+          reportModuleError(key, result.reason);
+          update[key] = { hasChanges: false };
+          return;
+        }
+        update[key] = result.value;
+        if (result.value.hasChanges) hasChanges = true;
+      });
       return !hasChanges ? { hasChanges: false } : { hasChanges: true, update };
     },
 
     applyUpdate(localData, update) {
-      const result = mapValues(modules, (m, k) => {
-        const up = update[k];
-        return up.hasChanges ? m.applyUpdate(localData[k], up.update) : localData[k];
-      });
-      return result;
+      return mapValues(modules, (m, key) => {
+        const up = update[key];
+        if (!up?.hasChanges) return localData[key];
+        try {
+          return m.applyUpdate(localData[key], up.update);
+        } catch (error) {
+          reportModuleError(key as string, error);
+          return localData[key];
+        }
+      }) as LocalState;
     },
   };
   return root;

--- a/shared/cloud-sync-module/src/moduleRequirements.ts
+++ b/shared/cloud-sync-module/src/moduleRequirements.ts
@@ -1,5 +1,5 @@
-import type { ZodType } from "zod";
-import type { CloudSyncDataManager } from "./cloudSyncModule";
+import { z, type ZodType } from "zod";
+import { createAggregator, type CloudSyncDataManager } from "./cloudSyncModule";
 
 type Fixtures<LocalState, DistantState> = {
   /** A local state with no meaningful data (e.g. empty map/array/object) */
@@ -13,20 +13,41 @@ type Fixtures<LocalState, DistantState> = {
 /** UTF-8 byte length, without Buffer or TextEncoder so consumers need no node/dom types */
 function utf8ByteLength(value: string): number {
   let bytes = 0;
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
+  // iterating the string yields whole code points, so a surrogate pair counts once
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
     if (code < 0x80) {
       bytes += 1;
     } else if (code < 0x800) {
       bytes += 2;
-    } else if (code >= 0xd800 && code <= 0xdbff) {
-      bytes += 4;
-      i++; // surrogate pair encodes as a single 4-byte sequence
-    } else {
+    } else if (code < 0x10000) {
       bytes += 3;
+    } else {
+      bytes += 4;
     }
   }
   return bytes;
+}
+
+/** the module under test plus a healthy neighbour, to prove failures do not cascade */
+function composeWithNeighbour<
+  LocalState,
+  Update,
+  DistantState,
+  Schema extends ZodType<DistantState>,
+>(module: CloudSyncDataManager<LocalState, Update, Schema, DistantState>) {
+  const quarantined: string[] = [];
+  const neighbour: CloudSyncDataManager<string[], string[], ZodType<string[]>, string[]> = {
+    schema: z.array(z.string()),
+    diffLocalToDistant: local => ({ hasChanges: local.length > 0, nextState: local }),
+    resolveIncrementalUpdate: async () => ({ hasChanges: false }),
+    applyUpdate: (_local, update) => update,
+  };
+  const aggregator = createAggregator(
+    { subject: module, neighbour },
+    { onModuleError: key => quarantined.push(key) },
+  );
+  return { aggregator, quarantined };
 }
 
 /**
@@ -43,12 +64,13 @@ function utf8ByteLength(value: string): number {
  * - convergence: applying an incoming update makes the local state in sync with that distant state
  * - nextState is JSON-serializable and under 1MB
  * - diffLocalToDistant and applyUpdate complete within 5ms each (pure in-memory ops)
+ * - composed in an aggregator, arbitrary garbage as incomingState never breaks the sync
  */
 export function describeCloudSyncModuleContract<
   LocalState,
   Update,
-  Schema extends ZodType<DistantState>,
   DistantState,
+  Schema extends ZodType<DistantState>,
 >(
   label: string,
   module: CloudSyncDataManager<LocalState, Update, Schema, DistantState>,
@@ -152,6 +174,69 @@ export function describeCloudSyncModuleContract<
         }
         expect((Date.now() - t0) / 100).toBeLessThan(5);
       }
+    });
+
+    describe("composed in an aggregator, tolerates arbitrary garbage as incomingState", () => {
+      // isolation is the aggregator's job, so this checks the module composes safely in one
+      const garbageValues: [label: string, value: unknown][] = [
+        ["null", null],
+        ["undefined", undefined],
+        ["0", 0],
+        ["-1", -1],
+        ["NaN", Number.NaN],
+        ["Infinity", Number.POSITIVE_INFINITY],
+        ["empty string", ""],
+        ["string", "garbage"],
+        ["true", true],
+        ["false", false],
+        ["empty array", []],
+        ["empty object", {}],
+        ["array of null", [null]],
+        ["array of foreign objects", [{ nope: true }]],
+        ["object with unexpected key", { unexpected: "key" }],
+        ["deeply nested object", { nested: { deep: [1, "2", null, { deeper: true }] } }],
+        ["__proto__ payload", JSON.parse('{"__proto__": {"polluted": true}}')],
+      ];
+
+      it.each(garbageValues)(
+        "resolveIncrementalUpdate(%s) resolves without breaking the sync",
+        async (_label, garbage) => {
+          for (const localState of [fixtures.emptyLocalState, fixtures.nonEmptyLocalState]) {
+            const { aggregator } = composeWithNeighbour(module);
+            const local = { subject: localState, neighbour: ["n"] };
+            const result = await aggregator.resolveIncrementalUpdate(local, null, {
+              subject: garbage,
+              neighbour: ["n"],
+            });
+            expect(typeof result.hasChanges).toBe("boolean");
+            if (result.hasChanges) {
+              expect(() => aggregator.applyUpdate(local, result.update)).not.toThrow();
+            }
+          }
+        },
+      );
+
+      it.each(garbageValues)(
+        "diffLocalToDistant(%s) keeps a serializable nextState and never deletes the slice",
+        (_label, garbage) => {
+          for (const localState of [fixtures.emptyLocalState, fixtures.nonEmptyLocalState]) {
+            const { aggregator, quarantined } = composeWithNeighbour(module);
+            const distant = { subject: garbage, neighbour: ["n"] };
+            const result = aggregator.diffLocalToDistant(
+              { subject: localState, neighbour: ["n"] },
+              distant,
+            );
+            expect(typeof result.hasChanges).toBe("boolean");
+            expect(() => JSON.stringify(result.nextState)).not.toThrow();
+            // a healthy neighbour must keep syncing whatever the subject did
+            expect(result.nextState.neighbour).toEqual(["n"]);
+            // quarantine must never become deletion
+            if (quarantined.includes("subject")) {
+              expect((result.nextState as Record<string, unknown>).subject).toEqual(garbage);
+            }
+          }
+        },
+      );
     });
 
     if (fixtures.matchingDistantState !== undefined) {

--- a/shared/cloud-sync/src/cloudsync/__tests__/sdk.test.ts
+++ b/shared/cloud-sync/src/cloudsync/__tests__/sdk.test.ts
@@ -1,16 +1,14 @@
-import { z } from "zod";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import WebSocket from "ws";
-import { CloudSyncSDK, UpdateEvent } from "../sdk";
+import { CloudSyncInvalidPayload, CloudSyncSDK, UpdateEvent } from "../sdk";
 import { TrustchainOutdated } from "../../trustchain-types";
 import type { MemberCredentials, Trustchain, TrustchainSDK } from "../../trustchain-types";
 
 describe("CloudSyncSDK", () => {
   const port = 54036;
   const base = `http://localhost:${port}`;
-  const schema = z.object({ value: z.string() });
-  type Data = z.infer<typeof schema>;
+  type Data = { value: string };
 
   let storedData: string | null = null;
   let storedVersion = 0;
@@ -68,7 +66,7 @@ describe("CloudSyncSDK", () => {
   let version = 0;
   let data: Data | null = null;
   let trustchainSdk: TrustchainSDK;
-  let sdk: CloudSyncSDK<typeof schema>;
+  let sdk: CloudSyncSDK<Data>;
 
   beforeAll(() => server.listen());
   afterAll(() => server.close());
@@ -83,7 +81,6 @@ describe("CloudSyncSDK", () => {
     sdk = new CloudSyncSDK({
       apiBaseUrl: base,
       slug: "test",
-      schema,
       trustchainSdk,
       getCurrentVersion: () => version,
       saveNewUpdate: (update: UpdateEvent<Data>) => {
@@ -125,8 +122,30 @@ describe("CloudSyncSDK", () => {
     expect(storedData).toBeNull();
   });
 
-  it("rejects invalid payloads on push", async () => {
-    await expect(sdk.push(trustchain, creds, { invalid: 42 } as unknown as Data)).rejects.toThrow();
+  it("rejects non-object payloads on push", async () => {
+    for (const invalid of [null, undefined, 42, "string", true, []]) {
+      await expect(sdk.push(trustchain, creds, invalid as unknown as Data)).rejects.toThrow(
+        CloudSyncInvalidPayload,
+      );
+    }
+  });
+
+  it("accepts a payload it cannot validate, leaving per-module validation to the aggregator", async () => {
+    // a shape this app version does not know must not block the push for every other module
+    const unknownShape = { value: "hello", futureModule: { nested: [1, 2] } };
+    await sdk.push(trustchain, creds, unknownShape as unknown as Data);
+    expect(data).toEqual(unknownShape);
+    expect(version).toBe(1);
+  });
+
+  it("passes an unvalidated document through on pull", async () => {
+    await sdk.push(trustchain, creds, { unexpected: true } as unknown as Data);
+    version = 0;
+    data = null;
+
+    await sdk.pull(trustchain, creds);
+    expect(data).toEqual({ unexpected: true });
+    expect(version).toBe(1);
   });
 
   it("throws TrustchainOutdated when local version exists but remote has no data", async () => {
@@ -176,7 +195,6 @@ describe("CloudSyncSDK", () => {
     const sdkWithWs = new CloudSyncSDK({
       apiBaseUrl: `http://localhost:${wsPort}`,
       slug: "test",
-      schema,
       trustchainSdk,
       getCurrentVersion: () => version,
       saveNewUpdate: async () => {},

--- a/shared/cloud-sync/src/cloudsync/sdk.ts
+++ b/shared/cloud-sync/src/cloudsync/sdk.ts
@@ -7,8 +7,14 @@ import {
 } from "../trustchain-types";
 import { getCloudSyncApi } from "./api";
 import { Observable } from "rxjs";
-import { z, ZodType } from "zod";
 import { Cipher, makeCipher } from "./cipher";
+
+export class CloudSyncInvalidPayload extends Error {
+  override name = "CloudSyncInvalidPayload";
+  constructor(context: string) {
+    super(`CloudSyncSDK ${context}: payload must be an object`);
+  }
+}
 
 export type UpdateEvent<Data> =
   | { type: "new-data"; data: Data; version: number }
@@ -25,12 +31,17 @@ export interface CloudSyncSDKInterface<Data> {
   ): Observable<number>;
 }
 
+/** only the envelope: validating the whole document here would let one bad slice break every module */
+function assertPayloadObject(data: unknown, context: string): void {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new CloudSyncInvalidPayload(context);
+  }
+}
+
 export class CloudSyncSDK<
-  Schema extends ZodType,
-  Data = z.infer<Schema>,
+  Data extends Record<string, unknown> = Record<string, unknown>,
 > implements CloudSyncSDKInterface<Data> {
   private readonly slug: string;
-  private readonly schema: Schema;
   private readonly trustchainSdk: TrustchainSDK;
   private readonly getCurrentVersion: () => number | undefined;
   private readonly saveNewUpdate: (updateEvent: UpdateEvent<Data>) => Promise<void>;
@@ -40,20 +51,17 @@ export class CloudSyncSDK<
   constructor({
     apiBaseUrl,
     slug,
-    schema,
     trustchainSdk,
     getCurrentVersion,
     saveNewUpdate,
   }: {
     apiBaseUrl: string;
     slug: string;
-    schema: Schema;
     trustchainSdk: TrustchainSDK;
     getCurrentVersion: () => number | undefined;
     saveNewUpdate: (event: UpdateEvent<Data>) => Promise<void>;
   }) {
     this.slug = slug;
-    this.schema = schema;
     this.trustchainSdk = trustchainSdk;
     this.getCurrentVersion = getCurrentVersion;
     this.saveNewUpdate = saveNewUpdate;
@@ -69,9 +77,8 @@ export class CloudSyncSDK<
     memberCredentials: MemberCredentials,
     data: Data,
   ): Promise<void> {
-    this.schema.parse(data);
-    const validated = data;
-    const base64 = await this.cipher.encrypt(trustchain, validated);
+    assertPayloadObject(data, "push");
+    const base64 = await this.cipher.encrypt(trustchain, data);
     const version = (this.getCurrentVersion() || 0) + 1;
     const response = await this.trustchainSdk.withAuth(trustchain, memberCredentials, jwt =>
       this.api.uploadData(jwt, this.slug, version, base64, trustchain),
@@ -102,10 +109,9 @@ export class CloudSyncSDK<
         break;
       case "out-of-sync": {
         const json = await this.cipher.decrypt(trustchain, response.payload);
-        this.schema.parse(json);
-        const validated = json;
+        assertPayloadObject(json, "pull");
         const version = response.version;
-        await this.saveNewUpdate({ type: "new-data", data: validated, version });
+        await this.saveNewUpdate({ type: "new-data", data: json, version });
         break;
       }
     }


### PR DESCRIPTION
### 📝 Description

Wallet sync validated the whole distant document against a single aggregated Zod schema, so one module's bad data broke every module. Both failure regimes were reproduced against `develop` before fixing, with a document holding one rejected slice plus a healthy `accountNames` from another instance and a key from a newer app version:

| Regime | Observed on develop |
| --- | --- |
| **Freeze** | `walletSyncSchema.parse(doc)` throws. `CloudSyncSDK.pull()` runs exactly that, untried, *before* `saveNewUpdate` — so the version never advances and every later poll repeats identically. Ledger Sync stays dead until the user updates the app. |
| **Data loss** | `parseDistantState` returns `null`, and diffing against that null erased the unknown `futureModule` key, overwrote the other instance's account name with local data, and reported `hasChanges: false` so their update was never applied locally. |

**The fix lives in `createAggregator`.** Each module's slice is validated on its own. A module that cannot parse its slice is quarantined: skipped for read, its raw value preserved verbatim in `nextState`, and reported through `onModuleError`. `diffLocalToDistant` and `applyUpdate` are guarded per module, `resolveIncrementalUpdate` uses `Promise.allSettled` — so a failing module degrades to `hasChanges: false` instead of taking the sync down with it.

**A quarantine is recoverable.** An unreadable *latest* slice is only a missing baseline, so it degrades to `null` rather than skipping the module — otherwise a module whose stored slice was corrupt could never adopt a fixed remote one, because the repaired document is saved to the store and every later comparison short-circuits on `latest === incoming`. An unreadable *incoming* slice still skips, having nothing to apply.

**Consumer side** — a module opts into isolation for free; only report the errors:

```ts
createWalletsync(ctx, {
  onModuleError: (moduleKey, error) => logger.critical(error, `cloud-sync ${moduleKey}`),
});
```

The aggregator has no console fallback: it is platform-agnostic and consumers compile its source with `lib: ES2022`, so touching `console` breaks their typecheck — and a recoverable quarantine should not pick a consumer's monitoring severity.

> [!IMPORTANT]
> **A quarantine report carries no synced data.** `error` here is a `CloudSyncModuleQuarantined` holding the module key and the failure kind only — zod issue codes (a fixed vocabulary) or the error class name. The aggregator never hands out the original error, so there is no message, no path and no `cause` to leak through.
>
> This matters more than it looks. A `ZodError` message is `JSON.stringify(issues)`, and an issue `path` is a **record key** — `accountNames` is `z.record(z.string(), z.string())` keyed by account id, and an account id carries the xpub. Every sink was reachable before this: desktop passed the raw error to `logger.critical`, mobile attached it as `cause`, and the aggregator's console fallback logged it. `moduleIsolation.test.ts` pins all three against an xpub-bearing account id, walking the whole cause chain and own properties.

### A distant document is now typed as what it is

Removing the aggregate parse fixed the behaviour but left the *type* lying, in three places at once. `parseDistantState` cast an unvalidated document up to the validated aggregate; `asDistantObject` immediately cast it back down to `Record<string, unknown>`, re-running the identical check; and `diffLocalToDistant` returned `nextState as DistantState` — **provably false**, since a quarantined slice is preserved verbatim precisely because it failed `safeParse`.

There is no direction in which the aggregate type is true. On read the document comes from another app version; on write it carries quarantined slices and unknown keys straight through. So the document is a `DistantDocument` (`Record<string, unknown>`) — a bag of module slices whose trust is established per module by `readSlice`, which is where validation already happens. `isDistantDocument` replaces the casts with a type predicate that is sound rather than asserted: any non-null non-array object really *is* a bag of `unknown` by key.

The clearest evidence this was the right shape: **20 `as never` casts disappeared from the tests.** Every one existed only to smuggle a garbage document past a type that refused it — the suite was fighting the type to express the exact scenario this PR handles.

```diff
- parseDistantState(walletsync, raw)   // removed: cast unvalidated data to a validated type
+ // nothing. the selectors return the type the wallet-sync entity already declares,
+ // and the aggregator narrows a document at runtime via isDistantDocument
```

```diff
  new CloudSyncSDK({
-   schema: walletsync.schema,   // never applied to anything once the aggregate parse was gone
    trustchainSdk, getCurrentVersion, saveNewUpdate,
  })
- CloudSyncSDK<Schema, Data = z.infer<Schema>>
+ CloudSyncSDK<Data extends Record<string, unknown>>
```

`CloudSyncSDK.schema` was write-only — assigned in the constructor and never read. Keeping it would have forced every caller to override `Data`, making the option purely decorative. `WalletSyncDistantState` is renamed `WalletSyncDocument` and documented as *the shape we author* (fixtures, CLI input), never the shape we read; the rename forced every call site to be revisited rather than silently inherit a new meaning.

Two judgement calls worth a look:

- The redux selectors were the root cause. `latestDistantStateSelector` widened to `unknown` a slot the wallet-sync entity **already declares** as `Record<string, unknown> | null` (`WSStateSchema`). They now return `WSState["data"]`, so no narrowing is needed at the boundary at all and `parseDistantState` had nothing left to do.
- The e2e CLIs check `--data` with `isDistantDocument` instead of parsing it against `walletSyncSchema`. `z.object` strips unknown keys silently, so parsing would have rejected — or quietly gutted — a fixture that pushes a malformed slice on purpose to exercise quarantine.

### `recentAddresses` drops its corrupted-address repair path

Second commit, and the reason it belongs here rather than in a follow-up: quarantine now covers this data strictly better than the repair did.

`CorruptedNestedAddressDistantSchema` rewrote the old `{ address: { address, lastUsed, ensName } }` shape back to a flat entry. It went **together** with the lenient `z.array(z.unknown()).transform(entries => …filter(…))` wrapper, because that wrapper is what made the slice unrejectable — removing only the transform would have silently *dropped* corrupted entries instead of surfacing them. Both, or neither.

| | corrupted nested entry arrives |
| --- | --- |
| **Before** | slice parses (`safeParse` succeeds), **no** quarantine, and — since `readSlice` hands the module its *raw* slice, not the parsed one — the raw `{ address: { address: … } }` object lands in local state through `toState` |
| **Now** | `ZodError(invalid_type)` → module quarantined, slice preserved verbatim and reported, healthy modules keep syncing, healthy slices still accepted |

> [!NOTE]
> The local-cache repair in `schema.ts` / `store.ts` is deliberately untouched. It migrates entries already written to disk by a past version, which quarantine says nothing about — only the *distant* path is affected.

**Regression coverage**

- `moduleIsolation.test.ts` — a poisoned module against two healthy ones: schema-rejected slice, sync/async throws in each of the three methods, quarantine-is-not-deletion, unknown-key preservation, slice passed by reference so identity short-circuits still work, and one report per distinct failure. Plus: quarantine recovery (unreadable latest + readable incoming), a non-object document treated as absent, and the aggregator touching no console method.
- `createAggregator.test.ts` — `isDistantDocument` over 11 cases, including a null-prototype object (accepted) and a function (rejected).
- `walletSyncComposition.test.ts` — the two regimes above, pinned with the real modules, plus the read-then-re-upload round trip that keeps keys the aggregate schema strips.
- `recent-addresses/cloudSyncModule.test.ts` — a corrupted slice is now rejected rather than repaired or dropped, and quarantines the module through a real aggregator while a healthy neighbour keeps syncing.
- `describeCloudSyncModuleContract` gains a garbage-tolerance invariant exercised **through** an aggregator (module + healthy neighbour), so it asserts what the architecture actually guarantees rather than requiring every module to be garbage-proof on its own.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-13467](https://ledgerhq.atlassian.net/browse/LIVE-13467)
- **ADR** (if any): n/a


[LIVE-13467]: https://ledgerhq.atlassian.net/browse/LIVE-13467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
