### PR TITLE
[LWD] feat(contacts): introduce signer mismatch dialog for address editing

### DIFF
--- a/.changeset/live-33952-desktop-edit-signer-mismatch.md
+++ b/.changeset/live-33952-desktop-edit-signer-mismatch.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@features/flow-contacts": minor
+---
+
+Render Desktop Contacts address edit signer mismatch error from shared flow state.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { mockPopulatedContacts } from "@domain/entity-contact/schema.mock";
+import { render, screen, waitFor, withFlagOverrides } from "tests/testSetup";
+import ContactsScreen from "LLD/features/Contacts";
+
+jest.mock("@features/flow-contacts", () => {
+  const actual =
+    jest.requireActual<typeof import("@features/flow-contacts")>("@features/flow-contacts");
+
+  return {
+    ...actual,
+    useContactsAddressDetailActionsPorts: (
+      signerValidation?: Parameters<typeof actual.useContactsAddressDetailActionsPorts>[0],
+    ) =>
+      actual.useContactsAddressDetailActionsPorts(
+        signerValidation ??
+          actual.createMockContactSignerValidationPort({
+            currentSignerId: "signer-b",
+          }),
+      ),
+  };
+});
+
+function renderContactsScreen(extraInitialState: Record<string, unknown> = {}) {
+  return render(
+    <MemoryRouter initialEntries={["/contacts"]}>
+      <Routes>
+        <Route path="/contacts" element={<ContactsScreen />} />
+      </Routes>
+    </MemoryRouter>,
+    {
+      skipRouter: true,
+      initialState: {
+        ...withFlagOverrides({
+          lwdContacts: { enabled: true, params: { newBadge: false } },
+        }),
+        settings: {
+          hasDismissedContactsFeatureIntroduction: true,
+        },
+        ...extraInitialState,
+      },
+    },
+  );
+}
+
+describe("Contacts signer mismatch integration", () => {
+  it("should show the signer mismatch dialog when validation fails", async () => {
+    const { user } = renderContactsScreen({ contacts: { contacts: mockPopulatedContacts() } });
+
+    await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
+    await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
+    await user.click(screen.getByTestId("contacts-address-detail-edit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    });
+
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("contacts-edit-signer-mismatch-dialog")).toBeVisible();
+      expect(
+        screen.getByText("Use the same Ledger device you used to add this contact"),
+      ).toBeVisible();
+      expect(screen.getByText("The connected device isn't a match.")).toBeVisible();
+    });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/ContactsView.tsx
@@ -5,6 +5,7 @@ import {
   ContactsDeleteAddressDialog,
   ContactsDeleteContactDialog,
   ContactsEditSignerDialog,
+  ContactsEditSignerMismatchDialog,
   ContactsListView,
   ContactsRenameAddressDialog,
   ContactsRenameContactDialog,
@@ -48,6 +49,7 @@ export function ContactsView({
       <ContactsDeleteAddressDialog {...addressDetailActionsDialogs.deleteDialog} />
       <ContactsRenameAddressDialog {...addressDetailActionsDialogs.renameDialog} />
       <ContactsEditSignerDialog {...addressDetailActionsDialogs.signerDialog} />
+      <ContactsEditSignerMismatchDialog {...addressDetailActionsDialogs.signerMismatchDialog} />
     </>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactAddressDetailActionsAdapter.ts
@@ -9,6 +9,7 @@ import {
 import {
   type ContactsDeleteAddressDialogProps,
   type ContactsEditSignerDialogProps,
+  type ContactsEditSignerMismatchDialogProps,
   type ContactsRenameAddressDialogProps,
   type ContactAddressDetailDialogProps,
   type ContactAddressDetailSendIntent,
@@ -27,6 +28,7 @@ export type ContactAddressDetailActionsDialogProps = Readonly<{
   deleteDialog: ContactsDeleteAddressDialogProps;
   renameDialog: ContactsRenameAddressDialogProps;
   signerDialog: ContactsEditSignerDialogProps;
+  signerMismatchDialog: ContactsEditSignerMismatchDialogProps;
 }>;
 
 export function useContactAddressDetailActionsAdapter(
@@ -87,6 +89,16 @@ export function useContactAddressDetailActionsAdapter(
     [t],
   );
 
+  const signerMismatchLabels = useMemo(
+    () => ({
+      title: t("contacts.editSignerMismatch.title"),
+      description: t("contacts.editSignerMismatch.description"),
+      connectDifferentDevice: t("contacts.editSignerMismatch.connectDifferentDevice"),
+      cancel: t("contacts.editSignerMismatch.cancel"),
+    }),
+    [t],
+  );
+
   if (!isSelectionActive) {
     return {
       addressDetailDialog: {
@@ -119,6 +131,12 @@ export function useContactAddressDetailActionsAdapter(
         onConfirm: () => undefined,
         onCancel: () => undefined,
       },
+      signerMismatchDialog: {
+        isOpen: false,
+        labels: signerMismatchLabels,
+        onConnectDifferentDevice: () => undefined,
+        onCancel: () => undefined,
+      },
     };
   }
 
@@ -147,6 +165,12 @@ export function useContactAddressDetailActionsAdapter(
       labels: signerLabels,
       onConfirm: flow.onSignerConfirm,
       onCancel: flow.onSignerCancel,
+    },
+    signerMismatchDialog: {
+      isOpen: flow.editUiState === "signer-mismatch",
+      labels: signerMismatchLabels,
+      onConnectDifferentDevice: flow.onConnectDifferentDevice,
+      onCancel: flow.onSignerMismatchCancel,
     },
   };
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailPaneAdapter.ts
@@ -129,6 +129,7 @@ export function useContactDetailPaneAdapter(
     const isAddressActionDialogOpen =
       addressDetailActionsDialogs.deleteDialog.isOpen ||
       addressDetailActionsDialogs.signerDialog.isOpen ||
+      addressDetailActionsDialogs.signerMismatchDialog.isOpen ||
       addressDetailActionsDialogs.renameDialog.isOpen;
 
     return {
@@ -145,6 +146,7 @@ export function useContactDetailPaneAdapter(
     addressDetailActionsDialogs.deleteDialog.isOpen,
     addressDetailActionsDialogs.renameDialog.isOpen,
     addressDetailActionsDialogs.signerDialog.isOpen,
+    addressDetailActionsDialogs.signerMismatchDialog.isOpen,
     addressDetailDialogLabels,
     emptyContact?.name,
     isOpen,

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -9391,6 +9391,12 @@
       "confirm": "Continue",
       "cancel": "Cancel"
     },
+    "editSignerMismatch": {
+      "title": "Use the same Ledger device you used to add this contact",
+      "description": "The connected device isn't a match.",
+      "connectDifferentDevice": "Connect a different device",
+      "cancel": "Cancel"
+    },
     "ledgerSyncIntroduction": {
       "description": "Your contacts are end-to-end encrypted with your Ledger and synced across your devices, only you can unlock them.",
       "dismiss": "Got it"

--- a/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.web.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { LedgerDevices } from "@ledgerhq/lumen-ui-react/symbols";
+import type { ContactsEditSignerMismatchDialogProps } from "./types";
+
+export function ContactsEditSignerMismatchDialog({
+  isOpen,
+  labels,
+  onConnectDifferentDevice,
+  onCancel,
+}: ContactsEditSignerMismatchDialogProps): React.ReactNode {
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onCancel();
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="w-[400px] bg-canvas-sheet pb-24"
+        data-testid="contacts-edit-signer-mismatch-dialog"
+      >
+        <DialogHeader density="compact" onClose={onCancel} />
+        <DialogBody className="flex flex-col items-center gap-32 px-24 pb-24 text-center">
+          <div className="flex flex-col items-center gap-24">
+            <Spot appearance="icon" icon={LedgerDevices} size={56} />
+            <div className="flex flex-col gap-8">
+              <h2 className="heading-3-semi-bold text-base">{labels.title}</h2>
+              <p className="body-2 text-muted">{labels.description}</p>
+            </div>
+          </div>
+          <div className="flex w-full flex-col gap-16">
+            <Button
+              appearance="base"
+              size="lg"
+              isFull
+              onClick={onConnectDifferentDevice}
+              data-testid="contacts-edit-signer-mismatch-connect"
+            >
+              {labels.connectDifferentDevice}
+            </Button>
+            <Button appearance="gray" size="lg" isFull onClick={onCancel}>
+              {labels.cancel}
+            </Button>
+          </div>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/types.ts
+++ b/features/flow/contacts/src/steps/Detail/components/ContactsEditSignerMismatchDialog/types.ts
@@ -1,0 +1,13 @@
+export type ContactsEditSignerMismatchDialogLabels = Readonly<{
+  title: string;
+  description: string;
+  connectDifferentDevice: string;
+  cancel: string;
+}>;
+
+export type ContactsEditSignerMismatchDialogProps = Readonly<{
+  isOpen: boolean;
+  labels: ContactsEditSignerMismatchDialogLabels;
+  onConnectDifferentDevice: () => void;
+  onCancel: () => void;
+}>;

--- a/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
@@ -1,4 +1,4 @@
-export type SignerEditUiState = "closed" | "signer-open" | "edit-open";
+export type SignerEditUiState = "closed" | "signer-open" | "signer-mismatch" | "edit-open";
 
 export function resolveEditUiStateOnPress(isSignerRequired: boolean): SignerEditUiState {
   return isSignerRequired ? "signer-open" : "edit-open";
@@ -6,4 +6,16 @@ export function resolveEditUiStateOnPress(isSignerRequired: boolean): SignerEdit
 
 export function resolveEditUiStateOnSignerCancel(current: SignerEditUiState): SignerEditUiState {
   return current === "signer-open" ? "closed" : current;
+}
+
+export function resolveEditUiStateOnSignerMismatch(): SignerEditUiState {
+  return "signer-mismatch";
+}
+
+export function resolveEditUiStateOnSignerMismatchCancel(): SignerEditUiState {
+  return "closed";
+}
+
+export function resolveEditUiStateOnConnectDifferentDevice(): SignerEditUiState {
+  return "signer-open";
 }

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
@@ -34,6 +34,8 @@ export type UseContactAddressDetailActionsFlowViewModelResult = Readonly<{
   onDeletePress: () => void;
   onSignerConfirm: () => Promise<void>;
   onSignerCancel: () => void;
+  onSignerMismatchCancel: () => void;
+  onConnectDifferentDevice: () => void;
   onEditClose: () => void;
   confirmDelete: () => Promise<void>;
   cancelDelete: () => void;
@@ -60,8 +62,11 @@ export function useContactAddressDetailActionsFlowViewModel({
   const {
     editUiState,
     openSignerDialog,
+    openSignerMismatchDialog,
     openEditDialog,
     onSignerCancel,
+    onSignerMismatchCancel,
+    onConnectDifferentDevice,
     onEditClose: closeEditUiState,
     resetEditUiState,
   } = useContactEditSignerUiState();
@@ -107,11 +112,12 @@ export function useContactAddressDetailActionsFlowViewModel({
     const status = resolveContactSignerValidationResult(expectedSignerId, currentSignerId);
 
     if (status === CONTACT_SIGNER_MISMATCH_ERROR) {
+      openSignerMismatchDialog();
       return;
     }
 
     openEditDialog();
-  }, [editIntent, openEditDialog, ports.signerValidation]);
+  }, [editIntent, openEditDialog, openSignerMismatchDialog, ports.signerValidation]);
 
   const onEditClose = useCallback(() => {
     closeEditUiState();
@@ -168,6 +174,8 @@ export function useContactAddressDetailActionsFlowViewModel({
     onDeletePress,
     onSignerConfirm,
     onSignerCancel,
+    onSignerMismatchCancel,
+    onConnectDifferentDevice,
     onEditClose,
     confirmDelete,
     cancelDelete,

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -121,7 +121,7 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
     expect(result.current.editUiState).toBe("edit-open");
   });
 
-  it("should keep the signer dialog open when validation fails", async () => {
+  it("should open the signer mismatch dialog when validation fails", async () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
     const mismatchPort: ContactSignerValidationPort = createMockContactSignerValidationPort({
@@ -146,6 +146,39 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     await act(async () => {
       await result.current.onSignerConfirm();
+    });
+
+    expect(result.current.editUiState).toBe("signer-mismatch");
+  });
+
+  it("should return to the signer dialog when connecting a different device", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const mismatchPort: ContactSignerValidationPort = createMockContactSignerValidationPort({
+      currentSignerId: "signer-b",
+    });
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsFlowViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          ports: createPorts({ signerValidation: mismatchPort }),
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.onEditPress();
+    });
+    await act(async () => {
+      await result.current.onSignerConfirm();
+    });
+
+    expect(result.current.editUiState).toBe("signer-mismatch");
+
+    act(() => {
+      result.current.onConnectDifferentDevice();
     });
 
     expect(result.current.editUiState).toBe("signer-open");

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
@@ -1,12 +1,20 @@
 import { useCallback, useState } from "react";
-import type { SignerEditUiState } from "./model/signerEditUiState";
+import {
+  resolveEditUiStateOnConnectDifferentDevice,
+  resolveEditUiStateOnSignerMismatch,
+  resolveEditUiStateOnSignerMismatchCancel,
+  type SignerEditUiState,
+} from "./model/signerEditUiState";
 
 export type UseContactEditSignerUiStateResult = Readonly<{
   editUiState: SignerEditUiState;
   openSignerDialog: () => void;
+  openSignerMismatchDialog: () => void;
   openEditDialog: () => void;
   onSignerConfirm: () => void;
   onSignerCancel: () => void;
+  onSignerMismatchCancel: () => void;
+  onConnectDifferentDevice: () => void;
   onEditClose: () => void;
   resetEditUiState: () => void;
 }>;
@@ -18,12 +26,24 @@ export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult
     setEditUiState("signer-open");
   }, []);
 
+  const openSignerMismatchDialog = useCallback(() => {
+    setEditUiState(resolveEditUiStateOnSignerMismatch());
+  }, []);
+
   const openEditDialog = useCallback(() => {
     setEditUiState("edit-open");
   }, []);
 
   const onSignerConfirm = useCallback(() => {
     setEditUiState("edit-open");
+  }, []);
+
+  const onSignerMismatchCancel = useCallback(() => {
+    setEditUiState(resolveEditUiStateOnSignerMismatchCancel());
+  }, []);
+
+  const onConnectDifferentDevice = useCallback(() => {
+    setEditUiState(resolveEditUiStateOnConnectDifferentDevice());
   }, []);
 
   const onSignerCancel = useCallback(() => {
@@ -43,9 +63,12 @@ export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult
   return {
     editUiState,
     openSignerDialog,
+    openSignerMismatchDialog,
     openEditDialog,
     onSignerConfirm,
     onSignerCancel,
+    onSignerMismatchCancel,
+    onConnectDifferentDevice,
     onEditClose,
     resetEditUiState,
   };

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.web.test.ts
@@ -52,4 +52,31 @@ describe("useContactEditSignerUiState", () => {
 
     expect(result.current.editUiState).toBe("closed");
   });
+
+  it("should open the signer mismatch dialog and close it on cancel", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openSignerMismatchDialog();
+    });
+
+    expect(result.current.editUiState).toBe("signer-mismatch");
+
+    act(() => {
+      result.current.onSignerMismatchCancel();
+    });
+
+    expect(result.current.editUiState).toBe("closed");
+  });
+
+  it("should return to the signer dialog when connecting a different device", () => {
+    const { result } = renderHook(() => useContactEditSignerUiState());
+
+    act(() => {
+      result.current.openSignerMismatchDialog();
+      result.current.onConnectDifferentDevice();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+  });
 });

--- a/features/flow/contacts/src/steps/Detail/web.ts
+++ b/features/flow/contacts/src/steps/Detail/web.ts
@@ -5,6 +5,8 @@ export type { ContactDetailActionsProps } from "./components/ContactDetailAction
 export { ContactsDeleteContactDialog } from "./components/ContactsDeleteContactDialog/ContactsDeleteContactDialog.web";
 export { ContactsDeleteAddressDialog } from "./components/ContactsDeleteAddressDialog/ContactsDeleteAddressDialog.web";
 export { ContactsEditSignerDialog } from "./components/ContactsEditSignerDialog/ContactsEditSignerDialog.web";
+export { ContactsEditSignerMismatchDialog } from "./components/ContactsEditSignerMismatchDialog/ContactsEditSignerMismatchDialog.web";
 export type { ContactsDeleteContactDialogProps } from "./components/ContactsDeleteContactDialog/types";
 export type { ContactsDeleteAddressDialogProps } from "./components/ContactsDeleteAddressDialog/types";
 export type { ContactsEditSignerDialogProps } from "./components/ContactsEditSignerDialog/types";
+export type { ContactsEditSignerMismatchDialogProps } from "./components/ContactsEditSignerMismatchDialog/types";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Extend shared Contacts edit flow with a `signer-mismatch` UI state when address edit signer validation fails (mocked port until US-07).
- Add `ContactsEditSignerMismatchDialog` with copy and actions from design: “Connect a different device” returns to the signer dialog; “Cancel” closes the flow.
- Wire Desktop Contacts MVVM: adapter maps shared state to the mismatch dialog, `ContactsView` renders it, and the address detail pane hides while the error is shown.
- Add i18n keys under `contacts.editSignerMismatch.*` and a Desktop integration test that mocks a mismatched signer port.

## Test plan

- [ ] Run unit tests:
  ```bash
  pnpm --filter @features/flow-contacts test "useContactAddressDetailActionsFlowViewModel.web.test.tsx" "useContactEditSignerUiState.web.test.ts"
  ```
- [ ] Run Desktop integration test:
  ```bash
  pnpm desktop test:jest "apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.signerMismatch.integration.test.tsx"
  ```
- [ ] Manual QA (optional): temporarily pass a mismatched mock port in `useContactAddressDetailActionsAdapter`:
  ```typescript
  useContactsAddressDetailActionsPorts(
    createMockContactSignerValidationPort({ currentSignerId: "signer-b" }),
  )
  ```
  Then: Contacts → open address → Edit → Continue → mismatch dialog appears.
- [ ] Happy path still works with default mock (`signer-a` / `signer-a`): Edit → Continue → rename address dialog opens.
- [ ] “Connect a different device” returns to signer confirmation dialog.
- [ ] “Cancel” closes the flow without opening rename dialog.

---

**Packages bumped:** `ledger-live-desktop`, `@features/flow-contacts` (see `.changeset/live-33952-desktop-edit-signer-mismatch.md`)


https://github.com/user-attachments/assets/24efb584-af5a-4b46-be28-c8231abf281a



### 🔗 Context

[LIVE-33952](https://ledgerhq.atlassian.net/browse/LIVE-33952)

[LIVE-33952]: https://ledgerhq.atlassian.net/browse/LIVE-33952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ