### PR TITLE
[LWDM] feat(coin-tron): block underfunded sponsored USDT send (LIVE-32777)

### DIFF
--- a/.changeset/tron-sponsored-send-usdt-fee-guard.md
+++ b/.changeset/tron-sponsored-send-usdt-fee-guard.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-tron": patch
+---
+
+Guard sponsored (Tronify) USDT sends against the "fee consumed, transfer fails" loss (LIVE-32777). When a send carries `energyProviderInfo`, `getTransactionStatus` now reserves the USDT rental fee — a live Tronify quote priced from the transfer's energy requirement — out of the token balance: it blocks with `NotEnoughBalance` when the USDT balance can't cover fee + amount, and a max send leaves the fee behind (`amount = balance − fee`, `totalSpent = balance`). `estimateMaxSpendable` mirrors the reservation so "Max" doesn't overshoot. The guard is inert for non-sponsored sends and degrades to no reservation when the quote is unavailable or the rent is priced in a different asset (the TRX-paid flow).

--- a/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.test.ts
@@ -1,0 +1,98 @@
+import type { TokenAccount } from "@ledgerhq/types-live";
+import BigNumber from "bignumber.js";
+import type { Transaction, TronAccount } from "../types";
+import estimateMaxSpendable from "./estimateMaxSpendable";
+import getEstimatedFees, {
+  computeSponsoredUsdtFee,
+  getFeeResourceBreakdown,
+  type FeeResourceBreakdown,
+} from "./getEstimateFees";
+
+jest.mock("./getEstimateFees");
+
+const mockGetEstimatedFees = jest.mocked(getEstimatedFees);
+const mockGetFeeResourceBreakdown = jest.mocked(getFeeResourceBreakdown);
+const mockComputeSponsoredUsdtFee = jest.mocked(computeSponsoredUsdtFee);
+
+const SENDER_ADDRESS = "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3";
+
+const parentAccount = {
+  type: "Account",
+  freshAddress: SENDER_ADDRESS,
+  balance: new BigNumber(50_000_000),
+  spendableBalance: new BigNumber(50_000_000),
+} as unknown as TronAccount;
+
+const tokenAccount = {
+  type: "TokenAccount",
+  id: "js:2:tron:sender:+trc20",
+  balance: new BigNumber(1_000_000),
+} as unknown as TokenAccount;
+
+const energyProviderInfo = { providerId: "tronify", orderId: "order-1" };
+
+const breakdown = {
+  energyRequired: new BigNumber(65_000),
+  energyEstimated: true,
+} as unknown as FeeResourceBreakdown;
+
+describe("estimateMaxSpendable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFeeResourceBreakdown.mockResolvedValue(breakdown);
+    mockComputeSponsoredUsdtFee.mockResolvedValue(new BigNumber(0));
+  });
+
+  it("parent (TRX) account: spendable balance minus network fees", async () => {
+    mockGetEstimatedFees.mockResolvedValue(new BigNumber(1_000_000));
+
+    const max = await estimateMaxSpendable({ account: parentAccount, parentAccount: undefined });
+
+    expect(max).toEqual(new BigNumber(49_000_000));
+    // Token-only helpers are not touched for a native account.
+    expect(mockComputeSponsoredUsdtFee).not.toHaveBeenCalled();
+  });
+
+  it("non-sponsored token account: full token balance, no fee estimation", async () => {
+    const max = await estimateMaxSpendable({
+      account: tokenAccount,
+      parentAccount,
+      transaction: { recipient: SENDER_ADDRESS } as Transaction,
+    });
+
+    expect(max).toEqual(new BigNumber(1_000_000));
+    // No sponsored context → no rental quote and no (unused) fee estimation for the token account.
+    expect(mockComputeSponsoredUsdtFee).not.toHaveBeenCalled();
+    expect(mockGetEstimatedFees).not.toHaveBeenCalled();
+  });
+
+  it("sponsored token account: balance minus the reserved USDT rental fee", async () => {
+    mockComputeSponsoredUsdtFee.mockResolvedValue(new BigNumber(300_000));
+
+    const max = await estimateMaxSpendable({
+      account: tokenAccount,
+      parentAccount,
+      transaction: { recipient: SENDER_ADDRESS, energyProviderInfo } as Transaction,
+    });
+
+    expect(max).toEqual(new BigNumber(700_000)); // 1_000_000 − 300_000
+    // The rental breakdown is computed with useAllAmount so the energy sim uses the token balance.
+    expect(mockGetFeeResourceBreakdown).toHaveBeenCalledWith(
+      parentAccount,
+      expect.objectContaining({ useAllAmount: true }),
+      tokenAccount,
+    );
+  });
+
+  it("clamps to 0 when the reserved fee exceeds the token balance", async () => {
+    mockComputeSponsoredUsdtFee.mockResolvedValue(new BigNumber(2_000_000));
+
+    const max = await estimateMaxSpendable({
+      account: tokenAccount,
+      parentAccount,
+      transaction: { recipient: SENDER_ADDRESS, energyProviderInfo } as Transaction,
+    });
+
+    expect(max).toEqual(new BigNumber(0));
+  });
+});

--- a/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.ts
@@ -17,7 +17,9 @@ const estimateMaxSpendable: AccountBridge<
     ...createTransaction(),
     subAccountId: account.type === "Account" ? null : account.id,
     ...transaction,
-    recipient: transaction?.recipient || "0x0000000000000000000000000000000000000000",
+    // Placeholder when no recipient is set yet; a valid Tron address (self) keeps the TRC20 energy
+    // simulation in the sponsored-fee path from failing to decode an Ethereum-style address.
+    recipient: transaction?.recipient || mainAccount.freshAddress,
     amount: new BigNumber(0),
   };
   // The parent (TRX) account's max is its spendable balance minus the network fees; the token

--- a/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/estimateMaxSpendable.ts
@@ -3,27 +3,41 @@ import { AccountBridge } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { Transaction, TronAccount } from "../types";
 import createTransaction from "./createTransaction";
-import getEstimatedFees from "./getEstimateFees";
+import getEstimatedFees, {
+  computeSponsoredUsdtFee,
+  getFeeResourceBreakdown,
+} from "./getEstimateFees";
 
 const estimateMaxSpendable: AccountBridge<
   Transaction,
   TronAccount
 >["estimateMaxSpendable"] = async ({ account, parentAccount, transaction }): Promise<BigNumber> => {
   const mainAccount = getMainAccount(account, parentAccount);
-  const fees = await getEstimatedFees(
-    mainAccount,
-    {
-      ...createTransaction(),
-      subAccountId: account.type === "Account" ? null : account.id,
-      ...transaction,
-      recipient: transaction?.recipient || "0x0000000000000000000000000000000000000000",
-      amount: new BigNumber(0),
-    },
-    account.type === "TokenAccount" ? account : undefined,
-  );
-  return account.type === "Account"
-    ? BigNumber.max(0, account.spendableBalance.minus(fees))
-    : account.balance;
+  const txForFees: Transaction = {
+    ...createTransaction(),
+    subAccountId: account.type === "Account" ? null : account.id,
+    ...transaction,
+    recipient: transaction?.recipient || "0x0000000000000000000000000000000000000000",
+    amount: new BigNumber(0),
+  };
+  // The parent (TRX) account's max is its spendable balance minus the network fees; the token
+  // account's max is its balance minus only the sponsored USDT rental fee (TRX fees are charged to
+  // the parent, not the token), so skip the unused fee estimation for token accounts.
+  if (account.type !== "TokenAccount") {
+    const fees = await getEstimatedFees(mainAccount, txForFees, undefined);
+    return BigNumber.max(0, account.spendableBalance.minus(fees));
+  }
+
+  // Reserve the sponsored USDT rental fee so "Max" doesn't overshoot what getTransactionStatus will
+  // accept (LIVE-32777). Only quote for a sponsored send; useAllAmount makes the energy simulation
+  // use the token balance rather than a 0-amount transfer.
+  let rentalFee = new BigNumber(0);
+  if (transaction?.energyProviderInfo) {
+    const txForRent: Transaction = { ...txForFees, useAllAmount: true };
+    const breakdown = await getFeeResourceBreakdown(mainAccount, txForRent, account);
+    rentalFee = await computeSponsoredUsdtFee(mainAccount, txForRent, account, breakdown);
+  }
+  return BigNumber.max(0, account.balance.minus(rentalFee));
 };
 
 export default estimateMaxSpendable;

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -564,6 +564,16 @@ describe("getEstimatedFees", () => {
       expect(fee).toEqual(new BigNumber(500_000)); // 0.5 USDT × 10^6
     });
 
+    it("returns 0 (and skips the quote) for an unknown provider id", async () => {
+      const tx: Transaction = {
+        ...mockTransaction,
+        energyProviderInfo: { providerId: "not-a-provider", orderId: "order-1" },
+      };
+      const fee = await computeSponsoredUsdtFee(mockAccount, tx, usdtTokenAccount, breakdown);
+      expect(fee).toEqual(new BigNumber(0));
+      expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+    });
+
     it("returns 0 (and skips the quote) for a non-sponsored send", async () => {
       const fee = await computeSponsoredUsdtFee(
         mockAccount,

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.test.ts
@@ -2,12 +2,14 @@ import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { estimateFees, getAccount } from "../logic";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { getEnergyRentQuote } from "../logic/energyRent";
 import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/estimateFees";
 import { getChainParameters, getTronAccountNetwork } from "../network";
 import type { ChainParameters } from "../network/types";
 import type { Transaction } from "../types";
 import getEstimatedFees, {
   computeSponsoredEnergyEstimate,
+  computeSponsoredUsdtFee,
   getFeeResourceBreakdown,
   type FeeResourceBreakdown,
 } from "./getEstimateFees";
@@ -30,7 +32,10 @@ jest.mock("./utils", () => ({
 
 jest.mock("../logic/estimateFees");
 jest.mock("../logic/getAccount");
+jest.mock("../logic/energyRent");
 jest.mock("../network");
+
+const mockGetEnergyRentQuote = jest.mocked(getEnergyRentQuote);
 
 const chainParams: ChainParameters = {
   energyFee: 210,
@@ -514,6 +519,104 @@ describe("getEstimatedFees", () => {
         energyRequired: new BigNumber(0),
       };
       expect(await computeSponsoredEnergyEstimate(sponsoredTx, breakdown)).toBeNull();
+    });
+  });
+
+  // LIVE-32777: USDT rental fee (token base units) a sponsored TRC20 send must reserve; 0 otherwise.
+  describe("computeSponsoredUsdtFee", () => {
+    const breakdown: FeeResourceBreakdown = {
+      energyRequired: new BigNumber(65_000),
+      energyAvailable: new BigNumber(100_000),
+      bandwidthRequired: new BigNumber(345),
+      bandwidthAvailable: new BigNumber(5000),
+      energyEstimated: true,
+      networkInfo: mockTransaction.networkInfo!,
+    };
+    const usdtTokenAccount = {
+      ...mockTokenAccount,
+      token: {
+        ...mockTokenAccount.token,
+        tokenType: "trc20",
+        ticker: "USDT",
+        units: [{ name: "USDT", code: "USDT", magnitude: 6 }],
+      },
+    } as TokenAccount;
+    const sponsoredTx: Transaction = {
+      ...mockTransaction,
+      energyProviderInfo: { providerId: "tronify", orderId: "order-1" },
+    };
+    const quote = (payCoinCode: string, payCoinAmt: string) => ({
+      energy: 65_000n,
+      durationSeconds: 600,
+      payCoinCode,
+      payCoinAmt,
+      fees: { energy: "0", trx: "0", bandwidth: "0", activateAccount: "0" },
+    });
+
+    it("returns the quoted USDT fee in token base units for a sponsored TRC20 send", async () => {
+      mockGetEnergyRentQuote.mockResolvedValue(quote("USDT", "0.5"));
+      const fee = await computeSponsoredUsdtFee(
+        mockAccount,
+        sponsoredTx,
+        usdtTokenAccount,
+        breakdown,
+      );
+      expect(fee).toEqual(new BigNumber(500_000)); // 0.5 USDT × 10^6
+    });
+
+    it("returns 0 (and skips the quote) for a non-sponsored send", async () => {
+      const fee = await computeSponsoredUsdtFee(
+        mockAccount,
+        mockTransaction,
+        usdtTokenAccount,
+        breakdown,
+      );
+      expect(fee).toEqual(new BigNumber(0));
+      expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 when there is no TRC20 token account", async () => {
+      expect(await computeSponsoredUsdtFee(mockAccount, sponsoredTx, null, breakdown)).toEqual(
+        new BigNumber(0),
+      );
+    });
+
+    it("returns 0 when energy could not be estimated", async () => {
+      const fee = await computeSponsoredUsdtFee(mockAccount, sponsoredTx, usdtTokenAccount, {
+        ...breakdown,
+        energyEstimated: false,
+      });
+      expect(fee).toEqual(new BigNumber(0));
+    });
+
+    it("returns 0 for a 0-energy transfer", async () => {
+      const fee = await computeSponsoredUsdtFee(mockAccount, sponsoredTx, usdtTokenAccount, {
+        ...breakdown,
+        energyRequired: new BigNumber(0),
+      });
+      expect(fee).toEqual(new BigNumber(0));
+    });
+
+    it("returns 0 when the rent is priced in a different asset than the token being sent", async () => {
+      mockGetEnergyRentQuote.mockResolvedValue(quote("TRX", "3.4"));
+      const fee = await computeSponsoredUsdtFee(
+        mockAccount,
+        sponsoredTx,
+        usdtTokenAccount,
+        breakdown,
+      );
+      expect(fee).toEqual(new BigNumber(0));
+    });
+
+    it("returns 0 when the quote is unavailable", async () => {
+      mockGetEnergyRentQuote.mockRejectedValue(new Error("tronify down"));
+      const fee = await computeSponsoredUsdtFee(
+        mockAccount,
+        sponsoredTx,
+        usdtTokenAccount,
+        breakdown,
+      );
+      expect(fee).toEqual(new BigNumber(0));
     });
   });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -209,7 +209,11 @@ export const computeSponsoredUsdtFee = async (
   tokenAccount: TokenAccount | null | undefined,
   breakdown: FeeResourceBreakdown,
 ): Promise<BigNumber> => {
-  if (!transaction.energyProviderInfo) return new BigNumber(0);
+  const info = transaction.energyProviderInfo;
+  if (!info) return new BigNumber(0);
+  // Consistent with computeSponsoredEnergyEstimate: an unknown provider id reserves nothing (and
+  // must not block the send), rather than silently pricing via the config-selected provider.
+  if (!getEnergyProvider(info.providerId)) return new BigNumber(0);
   if (tokenAccount?.token.tokenType !== "trc20") return new BigNumber(0);
   if (!breakdown.energyEstimated || breakdown.energyRequired.lte(0)) return new BigNumber(0);
 

--- a/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getEstimateFees.ts
@@ -1,10 +1,12 @@
 import type { TransactionIntent } from "@ledgerhq/coin-module-framework/api/index";
+import { parseCurrencyUnit } from "@ledgerhq/coin-module-framework/currencies";
 import { log } from "@ledgerhq/logs";
 import type { Account, TokenAccount } from "@ledgerhq/types-live";
 import BigNumber from "bignumber.js";
 import { estimateFees, getAccount } from "../logic";
 import { ACTIVATION_FEES, STANDARD_FEES_NATIVE, STANDARD_FEES_TRC_20 } from "../logic/constants";
 import { getEnergyProvider } from "../logic/energyProviders";
+import { getEnergyRentQuote } from "../logic/energyRent";
 import { computeBandwidthFee, computeEnergyFee, estimateEnergy } from "../logic/estimateFees";
 import { getChainParameters, getTronAccountNetwork } from "../network";
 import type { AccountTronAPI, ChainParameters } from "../network/types";
@@ -187,6 +189,49 @@ export const computeSponsoredEnergyEstimate = async (
       err,
     });
     return null;
+  }
+};
+
+// Rental-quote params for the sponsored-fee guard.
+// TODO(LIVE-32892): align these with the params the real energy-rent order uses at signing time.
+const SPONSORED_RENTAL_DURATION_SECONDS = 600; // 10-min fastTrade window (~200-block lock, per PRD)
+const SPONSORED_RENTAL_EXTRA_TRX = 0.8; // bandwidth top-up Tronify bundles in the USDT-paid flow
+
+// LIVE-32777: the USDT rental fee (in the token's base units) that a sponsored TRC20 send must
+// reserve on top of the transfer amount, so the send can't be confirmed when the USDT balance can't
+// cover fee + amount (the Trust Wallet "Case 2" loss). Live Tronify quote using the breakdown's
+// energyRequired. Returns 0 when not applicable — not sponsored, not a TRC20 send, no reliable
+// energy figure, or the rent is priced in a currency other than the token being sent (Flow 1 / TRX).
+// Never throws: a quote failure degrades to no reservation (mirrors getFeeResourceBreakdown), logged.
+export const computeSponsoredUsdtFee = async (
+  account: Account,
+  transaction: Transaction,
+  tokenAccount: TokenAccount | null | undefined,
+  breakdown: FeeResourceBreakdown,
+): Promise<BigNumber> => {
+  if (!transaction.energyProviderInfo) return new BigNumber(0);
+  if (tokenAccount?.token.tokenType !== "trc20") return new BigNumber(0);
+  if (!breakdown.energyEstimated || breakdown.energyRequired.lte(0)) return new BigNumber(0);
+
+  try {
+    const quote = await getEnergyRentQuote({
+      payerAddress: account.freshAddress,
+      receiverAddress: account.freshAddress,
+      energy: BigInt(breakdown.energyRequired.integerValue(BigNumber.ROUND_CEIL).toFixed()),
+      durationSeconds: SPONSORED_RENTAL_DURATION_SECONDS,
+      extraTrx: SPONSORED_RENTAL_EXTRA_TRX,
+    });
+    // Only reserve when the rent is paid in the SAME asset being sent (Flow 2 / USDT); a TRX-paid
+    // rent (Flow 1) is charged to the parent account, not this token balance.
+    if (quote.payCoinCode.toUpperCase() !== tokenAccount.token.ticker.toUpperCase()) {
+      return new BigNumber(0);
+    }
+    return parseCurrencyUnit(tokenAccount.token.units[0], quote.payCoinAmt);
+  } catch (err) {
+    log("tron/computeSponsoredUsdtFee", "rent quote unavailable, skipping fee reservation", {
+      err,
+    });
+    return new BigNumber(0);
   }
 };
 

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.test.ts
@@ -16,6 +16,7 @@ import {
   triggerConstantContract,
 } from "../network";
 import { STANDARD_FEES_TRC_20 } from "../logic/constants";
+import { getEnergyRentQuote } from "../logic/energyRent";
 import type { NetworkInfo, Transaction, TronAccount } from "../types";
 import {
   NotEnoughGas,
@@ -33,6 +34,7 @@ import {
 import getTransactionStatus from "./getTransactionStatus";
 
 jest.mock("../network");
+jest.mock("../logic/energyRent");
 
 const mockFetchTronAccount = jest.mocked(fetchTronAccount);
 const mockFetchTronContract = jest.mocked(fetchTronContract);
@@ -41,6 +43,7 @@ const mockGetTronSuperRepresentatives = jest.mocked(getTronSuperRepresentatives)
 const mockTriggerConstantContract = jest.mocked(triggerConstantContract);
 const mockGetChainParameters = jest.mocked(getChainParameters);
 const mockGetTronAccountNetwork = jest.mocked(getTronAccountNetwork);
+const mockGetEnergyRentQuote = jest.mocked(getEnergyRentQuote);
 
 const SENDER_ADDRESS = "TF17BgPaZYbz8oxbjhriubPDsA7ArKoLX3";
 const RECIPIENT_ADDRESS = "TJRabPrwbZy45sbavfcjinPJC18kjpRTv8";
@@ -76,6 +79,8 @@ const createTrc20TokenAccount = (overrides: Partial<TokenAccount> = {}): TokenAc
       id: "tron/trc20/mock",
       contractAddress: TRC20_CONTRACT,
       tokenType: "trc20",
+      ticker: "USDT",
+      units: [{ name: "USDT", code: "USDT", magnitude: 6 }],
     },
     ...overrides,
   }) as TokenAccount;
@@ -137,6 +142,8 @@ describe("getTransactionStatus", () => {
     mockGetChainParameters.mockResolvedValue(chainParams);
     mockTriggerConstantContract.mockResolvedValue({ energy_used: 0 });
     mockGetTronAccountNetwork.mockResolvedValue(buildNetworkInfo());
+    // Default: no sponsored fee reserved unless a test opts in (mirrors "provider not configured").
+    mockGetEnergyRentQuote.mockRejectedValue(new Error("no energy-rent provider configured"));
   });
 
   it("sufficient TRC20 fixture: no TronNotEnoughEnergy, fee 0, no fee warning (State A)", async () => {
@@ -500,6 +507,129 @@ describe("getTransactionStatus", () => {
         createTransaction({ mode: "withdrawExpireUnfreeze" }),
       );
       expect(status.errors.resource).toBeInstanceOf(TronNoUnfrozenResource);
+    });
+  });
+
+  // LIVE-32777: on a sponsored USDT send the rental fee is paid in USDT, so getTransactionStatus
+  // must reserve it out of the token balance — blocking the send when USDT can't cover fee + amount
+  // (the Trust Wallet "Case 2" loss), and leaving the fee behind on a max send.
+  describe("sponsored USDT fee guard (LIVE-32777)", () => {
+    const energyProviderInfo = { providerId: "tronify", orderId: "order-123" };
+
+    // A rent quote paying `payCoinAmt` in `payCoinCode`; the token here has magnitude 6.
+    const quote = (payCoinCode: string, payCoinAmt: string) => ({
+      energy: 65_000n,
+      durationSeconds: 600,
+      payCoinCode,
+      payCoinAmt,
+      fees: { energy: "0", trx: "0", bandwidth: "0", activateAccount: "0" },
+    });
+
+    const sponsoredAccount = () => {
+      const tokenAccount = createTrc20TokenAccount({
+        balance: new BigNumber(1_000_000), // 1 USDT
+        spendableBalance: new BigNumber(1_000_000),
+      });
+      return { tokenAccount, account: createAccount({ subAccounts: [tokenAccount] }) };
+    };
+
+    beforeEach(() => {
+      // A real energy figure so the fee helper reaches the quote (0 energy → no reservation).
+      mockTriggerConstantContract.mockResolvedValue({ energy_used: 65_000 });
+    });
+
+    it("blocks with NotEnoughBalance when USDT can't cover fee + amount", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+      mockGetEnergyRentQuote.mockResolvedValue(quote("USDT", "0.5")); // fee = 500_000
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          amount: new BigNumber(600_000), // 600_000 + 500_000 > 1_000_000
+          energyProviderInfo,
+        }),
+      );
+
+      expect(status.errors.amount).toBeInstanceOf(NotEnoughBalance);
+    });
+
+    it("allows the send when USDT covers fee + amount", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+      mockGetEnergyRentQuote.mockResolvedValue(quote("USDT", "0.5")); // fee = 500_000
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          amount: new BigNumber(400_000), // 400_000 + 500_000 <= 1_000_000
+          energyProviderInfo,
+        }),
+      );
+
+      expect(status.errors.amount).toBeUndefined();
+    });
+
+    it("reserves the fee on a max send: amount = balance − fee, totalSpent = balance", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+      mockGetEnergyRentQuote.mockResolvedValue(quote("USDT", "0.5")); // fee = 500_000
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          useAllAmount: true,
+          energyProviderInfo,
+        }),
+      );
+
+      expect(status.amount).toEqual(new BigNumber(500_000));
+      expect(status.totalSpent).toEqual(new BigNumber(1_000_000));
+      expect(status.errors.amount).toBeUndefined();
+    });
+
+    it("does not reserve a fee for a non-sponsored send", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({ subAccountId: tokenAccount.id, amount: new BigNumber(600_000) }),
+      );
+
+      expect(status.errors.amount).toBeUndefined();
+      expect(mockGetEnergyRentQuote).not.toHaveBeenCalled();
+    });
+
+    it("degrades to no reservation when the quote is unavailable", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+      mockGetEnergyRentQuote.mockRejectedValue(new Error("tronify unreachable"));
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          amount: new BigNumber(600_000),
+          energyProviderInfo,
+        }),
+      );
+
+      expect(status.errors.amount).toBeUndefined();
+    });
+
+    it("does not reserve when the rent is priced in a different asset (TRX-paid flow)", async () => {
+      const { tokenAccount, account } = sponsoredAccount();
+      mockGetEnergyRentQuote.mockResolvedValue(quote("TRX", "3.4"));
+
+      const status = await getTransactionStatus(
+        account,
+        createTransaction({
+          subAccountId: tokenAccount.id,
+          amount: new BigNumber(600_000),
+          energyProviderInfo,
+        }),
+      );
+
+      expect(status.errors.amount).toBeUndefined();
     });
   });
 });

--- a/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
+++ b/libs/coin-modules/coin-tron/src/bridge/getTransactionStatus.ts
@@ -43,6 +43,7 @@ import {
 } from "../types/errors";
 import getEstimatedFees, {
   computeSponsoredEnergyEstimate,
+  computeSponsoredUsdtFee,
   getFeeResourceBreakdown,
 } from "./getEstimateFees";
 
@@ -207,6 +208,8 @@ const getTransactionStatus = async (
   let estimatedFees = new BigNumber(0);
   // Informational savings estimate for a sponsored (Tronify) send (LIVE-32776); null otherwise.
   let sponsoredEnergy: SponsoredEnergyEstimate | null = null;
+  // USDT rental fee to reserve from the token balance for a sponsored send (LIVE-32777); 0 otherwise.
+  let rentalFee = new BigNumber(0);
 
   if (!hasErrors) {
     const resourceBreakdown = await getFeeResourceBreakdown(acc, transaction, tokenAccount);
@@ -216,12 +219,17 @@ const getTransactionStatus = async (
     bandwidthAvailable = resourceBreakdown.bandwidthAvailable;
     estimatedFees = await getEstimatedFees(acc, transaction, tokenAccount, resourceBreakdown);
     sponsoredEnergy = await computeSponsoredEnergyEstimate(transaction, resourceBreakdown);
+    rentalFee = await computeSponsoredUsdtFee(acc, transaction, tokenAccount, resourceBreakdown);
   }
 
+  // Reserve the USDT rental fee out of the token balance so a sponsored send can't be confirmed
+  // when the balance can't cover fee + amount (LIVE-32777). rentalFee is 0 for non-sponsored sends,
+  // so this is a no-op there. For useAllAmount the max amount below becomes balance − fee (the fee
+  // stays reserved); for an explicit amount, amount > balance below means amount + fee > tokenBalance.
   const balance =
     account.type === "Account"
       ? BigNumber.max(0, account.spendableBalance.minus(estimatedFees))
-      : account.balance;
+      : BigNumber.max(0, account.balance.minus(rentalFee));
   const amount = useAllAmount ? balance : transaction.amount;
   const amountSpent = ["send", "freeze", "undelegateResource"].includes(mode)
     ? amount
@@ -231,8 +239,10 @@ const getTransactionStatus = async (
     errors.amount = new TronInvalidFreezeAmount();
   }
 
-  // fees are applied in the parent only (TRX)
-  const totalSpent = account.type === "Account" ? amountSpent.plus(estimatedFees) : amountSpent;
+  // TRX network fees are applied in the parent only; a sponsored token send also spends the USDT
+  // rental fee out of the token account (LIVE-32777), so include it in the token-account total.
+  const totalSpent =
+    account.type === "Account" ? amountSpent.plus(estimatedFees) : amountSpent.plus(rentalFee);
 
   if (["send", "freeze"].includes(mode)) {
     if (amount.eq(0)) {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
Prevents the Trust Wallet "Case 2" loss on a sponsored (Tronify) USDT send: when
the rental fee is paid in USDT (Flow 2) and the user's USDT can't cover **fee +
amount**, today the fee gets consumed but the transfer fails — the user pays for
nothing.

`getTransactionStatus` now reserves the USDT rental fee out of the token balance:

- **Explicit amount** → `NotEnoughBalance` when `amount + fee > USDT balance`.
- **Max send** → the amount becomes `balance − fee` (the fee stays reserved), and
  `totalSpent` reflects `amount + fee`.

The fee comes from a **live Tronify quote** (`getEnergyRentQuote`, priced from the
transfer's `energyRequired`); `payCoinAmt` is converted to the token's base units.
`estimateMaxSpendable` mirrors the reservation so "Max" doesn't overshoot.

The guard is **inert for non-sponsored sends** and **degrades to no reservation**
when the quote is unavailable or the rent is priced in a different asset (the
TRX-paid Flow 1), so a Tronify hiccup can't block every send.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-32777](https://ledgerhq.atlassian.net/browse/LIVE-32777)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

## 🔀 Changes

- `bridge/getEstimateFees.ts` — new `computeSponsoredUsdtFee()` helper: quotes the
  USDT rental fee, returns `0` when not sponsored / not TRC20 / no reliable energy
  figure / rent priced in another asset; never throws (quote failure → `0`, logged).
- `bridge/getTransactionStatus.ts` — reserves the fee in the token-account `balance`
  and adds it to `totalSpent`; the existing amount/balance check does the blocking.
- `bridge/estimateMaxSpendable.ts` — reserves the same fee for a sponsored token
  account (and drops an unused fee estimation for token accounts).