### PR TITLE
[LWD] fix(test): no patching window fetch via page evaluate

### DIFF
--- a/apps/ledger-live-desktop/tests/specs/accounts/delegate.evmNativeStaking.smoke.spec.ts
+++ b/apps/ledger-live-desktop/tests/specs/accounts/delegate.evmNativeStaking.smoke.spec.ts
@@ -190,44 +190,25 @@ function stringifySeiEvmRpcResponse(rawPostData: string): string {
 }
 
 async function mockSeiEvmRpc(page: Page) {
-  await page.exposeFunction("mockSeiEvmRpcResponse", stringifySeiEvmRpcResponse);
-  await page.evaluate(
-    ({ rpcOrigin, headers }) => {
-      const originalFetch = window.fetch.bind(window);
+  await page.route(
+    url => url.origin === SEI_EVM_RPC_ORIGIN,
+    async route => {
+      const request = route.request();
 
-      window.fetch = async (input, init) => {
-        const url =
-          typeof input === "string"
-            ? input
-            : input instanceof Request
-              ? input.url
-              : input.toString();
+      // Cross-origin JSON-RPC POSTs trigger a CORS preflight; answer it so the
+      // actual RPC request can proceed to the mock below.
+      if (request.method() === "OPTIONS") {
+        await route.fulfill({ status: 204, headers: CORS_HEADERS });
+        return;
+      }
 
-        if (url === rpcOrigin || url.startsWith(`${rpcOrigin}/`)) {
-          let body = init?.body;
-          if (!body && input instanceof Request) {
-            body = await input.clone().text();
-          }
-
-          const requestBody =
-            typeof body === "string" ? body : body ? await new Response(body).text() : "{}";
-          const responseBody = await (
-            window as typeof window & {
-              mockSeiEvmRpcResponse: (body: string) => Promise<string>;
-            }
-          ).mockSeiEvmRpcResponse(requestBody);
-
-          return new Response(responseBody, {
-            status: 200,
-            statusText: "OK",
-            headers: { ...headers, "content-type": "application/json", teststatus: "mocked" },
-          });
-        }
-
-        return originalFetch(input, init);
-      };
+      const responseBody = stringifySeiEvmRpcResponse(request.postData() ?? "{}");
+      await route.fulfill({
+        status: 200,
+        headers: { ...CORS_HEADERS, "content-type": "application/json", teststatus: "mocked" },
+        body: responseBody,
+      });
     },
-    { rpcOrigin: SEI_EVM_RPC_ORIGIN, headers: CORS_HEADERS },
   );
 }
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Intercept at the network layer (like the REST mocks above) rather than patching window.fetch via page.evaluate: a one-shot fetch override does not survive renderer document reloads, so on slower CI the sei_evm sync could fire before/after the patch and escape to the real RPC, hanging the flow.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35621](https://ledgerhq.atlassian.net/browse/LIVE-35621)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35621]: https://ledgerhq.atlassian.net/browse/LIVE-35621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ