### PR TITLE
ci(release-final): add jfrog dual-path publish for production releases

### DIFF
--- a/.github/workflows/release-final.yml
+++ b/.github/workflows/release-final.yml
@@ -32,10 +32,9 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on: ledger-live-linux-8CPU-32RAM
     env:
       NODE_OPTIONS: "--max-old-space-size=7168"
-      NPM_REGISTRY: jfrog.ledgerlabs.net/artifactory/api/npm/ledger-live-npm-prod-public
     permissions:
       contents: write
       pull-requests: write
@@ -75,18 +74,37 @@ jobs:
         with:
           ruby-version: 3.3.0
 
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
       - name: install dependencies
         run: pnpm i -F "ledger-live" -F "{libs/**}..." -F "@ledgerhq/live-cli..." -F "@ledgerhq/wallet-cli..." -F "@ledgerhq/wallet-cli-*"
 
       - name: build libs
         run: pnpm exec nx run-many -t build --projects=tag:scope:libs,@ledgerhq/live-e2e-shared
 
+      #JFrog publishing - if statements to be removed when all is migrated
+      - name: JFrog npm auth (publish registry)
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_PUBLISH_URL }}
+
+      - name: publish release (JFrog)
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL != '' }}
+        run: npm_config_registry="https://${{ vars.ARTIFACTORY_PUBLISH_URL }}/" pnpm changeset publish
+
+      #NPM publishing - to be removed when all is migrated
       - name: authenticate with npm
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL == '' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"
 
       - name: publish release
+        if: ${{ vars.ARTIFACTORY_PUBLISH_URL == '' }}
         run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}


### PR DESCRIPTION
Brings release-final.yml to parity with the jFrog migration already completed in release-final-nightly.yml.

**Changes**:
- Add JFrog npm auth step before install dependencies so pnpm i can resolve private packages from Artifactory (vars.ARTIFACTORY_URL)
- Add a jFrog-gated publish path (ARTIFACTORY_PUBLISH_URL != ''): authenticates to the publish registry and runs pnpm changeset publish against it
- Guard the existing npmjs auth and publish steps behind ARTIFACTORY_PUBLISH_URL == '' so only one path runs at a time
- Remove the unused NPM_REGISTRY env var (was set but never referenced by any step)

**Why**

The nightly release workflow was already migrated to publish to Artifactory. This aligns the production release workflow with the same dual-path pattern, keeping both environments consistent and unblocking the production cutover.

**Rollout**

The workflow is fully backward-compatible. Until vars.ARTIFACTORY_PUBLISH_URL is set in the repository variables, the existing npmjs path runs unchanged. Setting the variable is the only action required to activate the jFrog path.

The jFrog publish and npmjs blocks are marked with #to be removed when all is migrated comments — the fallback path and its guards can be cleaned up in a follow-up once the cutover is confirmed.
