### PR TITLE
fix(e2e): make wallet assets checks reliable on Android

### DIFF
--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -511,7 +511,9 @@ export default class PortfolioPage {
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
     const currencyName = testId.replace("assetItem-", "");
-    await scrollToId(testId, this.emptyPortfolioListId);
+    // The transparent nav header floats over the list, and Android reports the row underneath it as
+    // visible, so without this the tap is swallowed by the header.
+    await scrollByPixels(this.emptyPortfolioListId, 200, "up");
     await tapById(testId);
     return currencyName;
   }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -67,6 +67,7 @@ export default class PortfolioPage {
   stocksDiscoveryId = "portfolio-stocks-discovery";
   stocksDiscoveryHeaderId = "portfolio-stocks-discovery-header";
   sectionAssetItemRegExp = (sectionId: string) => new RegExp(String.raw`^${sectionId}-item-\d+$`);
+  sectionAssetItemId = (sectionId: string, index: number) => `${sectionId}-item-${index}`;
 
   portfolioSettingsButton = async () => getElementById(this.portfolioSettingsId);
   assetItemId = (currencyName: string) => `${this.baseAssetItem}${currencyName}`;
@@ -458,20 +459,25 @@ export default class PortfolioPage {
     await tapById(this.transferBottomSheetBankTransferButton);
   }
 
-  private async checkSectionVisible(sectionId: string, isEmptyPortfolio: boolean) {
+  private async checkSectionVisible(
+    sectionId: string,
+    itemCount: number,
+    isEmptyPortfolio: boolean,
+  ) {
     const scrollViewId = isEmptyPortfolio ? this.emptyPortfolioListId : this.accountsListView;
-    await scrollToId(sectionId, scrollViewId);
-    await detoxExpect(getElementById(sectionId)).toBeVisible();
+    const lastItemId = this.sectionAssetItemId(sectionId, itemCount - 1);
+    await scrollToId(lastItemId, scrollViewId);
+    await detoxExpect(getElementById(lastItemId)).toBeVisible();
   }
 
   @Step("Check cryptos list section is visible")
-  async checkCryptosListSectionVisible(isEmptyPortfolio = false) {
-    await this.checkSectionVisible(this.portfolioCryptosListId, isEmptyPortfolio);
+  async checkCryptosListSectionVisible(itemCount: number, isEmptyPortfolio = false) {
+    await this.checkSectionVisible(this.portfolioCryptosListId, itemCount, isEmptyPortfolio);
   }
 
   @Step("Check stablecoins list section is visible")
-  async checkStablecoinsListSectionVisible(isEmptyPortfolio = false) {
-    await this.checkSectionVisible(this.portfolioStablecoinsListId, isEmptyPortfolio);
+  async checkStablecoinsListSectionVisible(itemCount: number, isEmptyPortfolio = false) {
+    await this.checkSectionVisible(this.portfolioStablecoinsListId, itemCount, isEmptyPortfolio);
   }
 
   @Step("Check add account CTA is visible")
@@ -487,13 +493,18 @@ export default class PortfolioPage {
   }
 
   private async checkSectionAssetItemCount(sectionId: string, expected: number) {
-    const count = await countElementsById(this.sectionAssetItemRegExp(sectionId));
+    const count = await countElements(getElementsById(this.sectionAssetItemRegExp(sectionId)));
     jestExpect(count).toBe(expected);
   }
 
   @Step("Check cryptos section asset item count")
   async checkCryptosSectionAssetItemCount(expected: number) {
     await this.checkSectionAssetItemCount(this.portfolioCryptosListId, expected);
+  }
+
+  @Step("Check stablecoins section asset item count")
+  async checkStablecoinsSectionAssetItemCount(expected: number) {
+    await this.checkSectionAssetItemCount(this.portfolioStablecoinsListId, expected);
   }
 
   @Step("Tap first asset item (wallet 4.0) and return its currency name")
@@ -581,11 +592,6 @@ export default class PortfolioPage {
   @Step("Check full stablecoin list page is visible")
   async checkStablecoinListPageVisible() {
     await this.checkListPageVisible(this.stablecoinListId);
-  }
-
-  @Step("Scroll to the top of the portfolio page")
-  async scrollToTopOfPortfolioPage() {
-    await scrollToId(this.portfolioBalanceNormal, this.accountsListView, 1000, "up");
   }
 
   private async scrollToStocksHeader(headerId: string) {

--- a/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
+++ b/e2e/mobile/specs/wallet40Q2/walletAssets.spec.ts
@@ -35,8 +35,8 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${currency.testLabel}] - Wallet assets empty state shows placeholders and add account CTA`, async () => {
-    await app.portfolio.checkCryptosListSectionVisible(true);
-    await app.portfolio.checkStablecoinsListSectionVisible(true);
+    await app.portfolio.checkCryptosListSectionVisible(4, true);
+    await app.portfolio.checkStablecoinsListSectionVisible(2, true);
     await app.portfolio.checkTotalAssetItemCount(6);
     await app.portfolio.checkAddAccountCtaVisible();
   });
@@ -67,8 +67,8 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it(`[${Currency.BTC.testLabel}] - Wallet assets section with fewer than 6 cryptos and stablecoins`, async () => {
-    await app.portfolio.checkCryptosListSectionVisible();
-    await app.portfolio.checkStablecoinsListSectionVisible();
+    await app.portfolio.checkCryptosListSectionVisible(4);
+    await app.portfolio.checkStablecoinsListSectionVisible(2);
     await app.portfolio.checkTotalAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Bitcoin");
   });
@@ -92,8 +92,7 @@ describe("Wallet assets", () => {
   TAGS.forEach(tag => $Tag(tag));
 
   it("Wallet assets section caps cryptos at 6", async () => {
-    await app.portfolio.scrollToTopOfPortfolioPage();
-    await app.portfolio.checkCryptosListSectionVisible();
+    await app.portfolio.checkCryptosListSectionVisible(6);
     await app.portfolio.checkCryptosSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Ethereum");
     await app.portfolio.checkAssetVisible("Bitcoin");
@@ -104,8 +103,8 @@ describe("Wallet assets", () => {
   });
 
   it("Wallet assets section caps stablecoins at 6", async () => {
-    await app.portfolio.scrollToTopOfPortfolioPage();
-    await app.portfolio.checkStablecoinsListSectionVisible();
+    await app.portfolio.checkStablecoinsListSectionVisible(6);
+    await app.portfolio.checkStablecoinsSectionAssetItemCount(6);
     await app.portfolio.checkAssetVisible("Tether USD");
     await app.portfolio.checkAssetVisible("USD Coin");
     await app.portfolio.tapStablecoinsSectionTitle();


### PR DESCRIPTION
### 📝 Description

Two Android-only failures in `specs/wallet40Q2/walletAssets.spec.ts` had the same root cause: **a visibility predicate used where existence is meant.**

Detox's `toBeVisible()` is a viewport-geometry test — ≥75% of the element's *own* area on screen. That is unsatisfiable for a container taller than the viewport, or for more rows than fit on screen. Scrolling was the only lever those assertions had to chase an impossible predicate, which is why this presented as a scroll problem.

**Previous behaviour**

- `Wallet assets section caps cryptos at 6` failed on Android with `Expected: 6, Received: 4`. `countElementsById` asserts `toBeVisible()` per index, so it counted rows **≥75% visible on screen**, not rows that exist — and only 4 of the 6 rows fit an emulator viewport. It also cost 7 sequential device round trips.
- `checkSectionVisible` asserted `toBeVisible()` on `PortfolioCryptosList`, a wrapper around up to 6 rows, so its ceiling is ~70-74% and it could only pass by luck.
- `Selecting an asset redirects to its market page` failed on Android because the topmost asset row sits **underneath the transparent nav header**. Measured with `uiautomator dump`: `assetItem-Bitcoin` spans y `119→287` while the `topbar-*` band is y `163→289`, so the tap landed on the header and never navigated. Android's `visibility` is `View.getLocalVisibleRect()`, which ignores occlusion by sibling views, so Detox believed the row was visible and tapped anyway. iOS uses hittability, hence green there.

**Fix**

- Count by **existence** using `countElements(getElementsById(...))` — the primitive `checkTotalAssetItemCount` already uses. Deterministic regardless of scroll position, and **1 device round trip instead of 7**. The section rows are a plain `.map()` (`WalletAssets/components/SectionListContent`), not a virtualised list, so all rows exist once the section is mounted.
- Anchor `checkSectionVisible` on the section's **last row** rather than the viewport-tall wrapper — a row is a leaf that can genuinely reach 75%. The expected item count is now passed in explicitly (4/2 for the padded states, 6/6 for the capped state, derived from `MAX_ASSETS_TO_DISPLAY` and `padAssetsWithDefaults`).
- Add a slack `scrollByPixels(..., 200, "up")` before tapping the first asset, so the row clears the floating header. This reuses the existing idiom in `assetDetail.page.ts:238-240`, which does the same for the sticky Buy/Swap footer.
- Assert the stablecoins cap too — that test's name claimed it but never checked it.
- Delete `scrollToTopOfPortfolioPage()`, now unused.

`countElementsById` is intentionally left untouched: it has 14 call sites and some genuinely want the visible count.

### ✅ CI results

Full mobile suite (both platforms, no filter) — chosen over a filtered run because the branch was rebased onto current develop and the change touches a shared page object:

**[Run 31163610002](https://github.com/LedgerHQ/ledger-live/actions/runs/31163610002)** (this branch) vs **[run 31137509894](https://github.com/LedgerHQ/ledger-live/actions/runs/31137509894)** (develop nightly, same day)

| Android | develop baseline | this branch |
|---|---|---|
| Passed | 274 | **276** |
| Failed | 13 | **9** |
| `Wallet assets section caps cryptos at 6` | ❌ failed | ✅ **passed** |
| All 5 `walletAssets` tests | 4/5 | **5/5** |

The 9 remaining Android failures are pre-existing and unrelated — Earn v2 webview timeouts, market banner, swap deeplinks, deposit Espresso-constraint failures. Every method touched by this PR is called **only** from `walletAssets.spec.ts` (`scrollToTopOfPortfolioPage` has zero callers), so the blast radius cannot extend to those specs.

### 🔗 Context

- **JIRA issue**: [QAA-1457](https://ledgerhq.atlassian.net/browse/QAA-1457) (part of [QAA-1442](https://ledgerhq.atlassian.net/browse/QAA-1442))

### 🧭 Follow-ups (not in this PR)

- **A real product bug sits behind the header fix.** The portfolio list's `contentContainerStyle.paddingTop` is a hardcoded `48` (`components/WalletTab/WalletTabNavigatorScrollManager.tsx:5`) while the actual floating bar is `insets.top + 68dp` on Android / `+80dp` on iOS (`mvvm/hooks/useNavigationBarHeights.ts`). Content therefore comes to rest underneath the header — a real user at that scroll position also cannot cleanly tap the first asset row. The slack scroll is a test-side workaround. Worth raising with Wallet XP alongside [QAA-1460](https://ledgerhq.atlassian.net/browse/QAA-1460), which should also add a container testID to the top-bar wrapper (there is none today, only the individual icon buttons).
- **The same visibility-vs-existence class exists elsewhere** — 187 `toBeVisible` occurrences across 32 files and 13-17 `checkVisibility: false` escape hatches. One live instance remains at `portfolio.page.ts` `goToSpecificAsset` → `scrollToId(this.assetsListId)`, where `AssetsList` resolves to a plain `<Flex>` wrapping a `.map()` (`AssetsShortListView/index.tsx:13`) — structurally identical to the wrapper fixed here. For [QAA-1458](https://ledgerhq.atlassian.net/browse/QAA-1458).
- **A distinct fourth class: assert-without-wait.** `checkQuickActionButtonsVisibility` uses bare synchronous `detoxExpect(...).toBeVisible()` with no polling, so a not-yet-mounted button fails on the first frame (`Got: was null`). This is what flakes `Charts and assets section are displayed after adding accounts` and `[BTC] - Buy from portfolio page`. Fix is to use `waitForElementById`; worth sweeping the class rather than patching one call site.


[QAA-1457]: https://ledgerhq.atlassian.net/browse/QAA-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ