### PR TITLE
feat(contacts): add typed device intent data

### DIFF
--- a/.changeset/bright-contacts-sync.md
+++ b/.changeset/bright-contacts-sync.md
@@ -1,0 +1,7 @@
+---
+"@domain/entity-contact": patch
+"@features/platform-contacts": patch
+"@features/flow-contacts": patch
+---
+
+Add typed Device Intent data and a Cloud Sync document for Contacts.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactsViewModel.ts
@@ -31,7 +31,7 @@ import {
   type ContactsListViewLabels,
   type ContactsViewProps,
 } from "@features/flow-contacts";
-import { useContacts } from "@features/platform-contacts";
+import { createMockContactDeviceIntentsPort, useContacts } from "@features/platform-contacts";
 import { MY_WALLET_AVATAR_USER_URL } from "LLD/features/MyWallet/components/UserAvatar/constants";
 import { useContactsFeatureIntroductionPreference } from "../../hooks/useContactsFeatureIntroductionPreference";
 import { useContactsCurrencySelectionAdapter } from "../../hooks/useContactsCurrencySelectionAdapter";
@@ -66,6 +66,7 @@ export function useContactsViewModel(): ContactsPageViewModel {
   const [searchQuery, setSearchQuery] = useState("");
   const meContact = useContactsMeContact();
   const contacts = useContacts();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
   const currencySelection = useContactsCurrencySelectionAdapter();
   const { cancelCurrencySelection } = currencySelection;
   const addressValidation = useContactsAddressValidationAdapter();
@@ -86,21 +87,41 @@ export function useContactsViewModel(): ContactsPageViewModel {
     completeMockConfirmation,
     close: closeAddAddress,
   } = useAddAddressFlowViewModel({ addressValidation });
-  const saveAddressFromReview = useCallback(() => {
+  const saveAddressFromReview = useCallback(async () => {
     if (addAddressFlowState.status !== "reviewingAddress") {
       return;
     }
+
+    const selectedContact = contacts.find(
+      contact => contact.id === addAddressFlowState.selectedContactId,
+    );
+    if (selectedContact === undefined) {
+      return;
+    }
+    const signedAddress = await deviceIntents.registerExternalAddress({
+      contact: selectedContact,
+      currencyId: addAddressFlowState.selectedCurrencyId,
+      label: addAddressFlowState.addressLabel.label,
+      address: addAddressFlowState.addressEntry.resolvedAddress,
+    });
 
     const address = contactAddress({
       id: `address-${uuid()}`,
       currencyId: addAddressFlowState.selectedCurrencyId,
       label: addAddressFlowState.addressLabel.label,
       address: addAddressFlowState.addressEntry.resolvedAddress,
+      device: signedAddress.addressDeviceContext,
     });
 
-    dispatch(addAddress({ contactId: addAddressFlowState.selectedContactId, address }));
+    dispatch(
+      addAddress({
+        contactId: addAddressFlowState.selectedContactId,
+        address,
+        deviceCredentials: signedAddress.deviceCredentials,
+      }),
+    );
     continueFromReview();
-  }, [addAddressFlowState, continueFromReview, dispatch]);
+  }, [addAddressFlowState, contacts, continueFromReview, deviceIntents, dispatch]);
   const selectCurrencyForContact = useCallback(
     (contactId: ContactId) => {
       void selectCurrency()

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -114,6 +114,7 @@
     "@domain/entity-wallet-sync": "workspace:^",
     "@features/flow-analytics-consent": "workspace:*",
     "@features/flow-contacts": "workspace:^",
+    "@features/platform-contacts": "workspace:^",
     "@features/flow-contacts-add-contact": "workspace:^",
     "@features/flow-fear-and-greed": "workspace:^",
     "@features/flow-lazy-onboarding-banner": "workspace:^",

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -19,6 +19,7 @@ import {
   useEmptyContactDetail,
   usePopulatedContactDetail,
 } from "@features/flow-contacts";
+import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { useDispatch } from "~/context/hooks";
@@ -59,6 +60,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const { isEnabled, eligibleAddressFamilies } = useContactsFeature("mobile");
   const { t } = useTranslation();
   const currencyPort = useContactsAddressCurrencyAdapter();
+  const deviceIntents = useMemo(() => createMockContactDeviceIntentsPort(), []);
   const emptyContact = useEmptyContactDetail(route.params.contactId);
   const populatedContactDetail = usePopulatedContactDetail(route.params.contactId, currencyPort);
   const {
@@ -88,7 +90,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     addressValidation,
     manualValidationDebounceMs: MANUAL_ADDRESS_VALIDATION_DEBOUNCE_MS,
   });
-  const completeMockAddressConfirmation = useCallback(() => {
+  const completeMockAddressConfirmation = useCallback(async () => {
     if (addAddressFlowState.status !== "confirmationRequired") {
       hasCompletedMockConfirmation.current = false;
       return;
@@ -98,21 +100,45 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       return;
     }
 
+    if (contact === undefined) {
+      return;
+    }
+
     hasCompletedMockConfirmation.current = true;
 
+    const signedAddress = await deviceIntents.registerExternalAddress({
+      contact,
+      currencyId: addAddressFlowState.selectedCurrencyId,
+      label: addAddressFlowState.addressLabel.label,
+      address: addAddressFlowState.addressEntry.resolvedAddress,
+    });
     const address = contactAddress({
       id: `address-${uuid()}`,
       currencyId: addAddressFlowState.selectedCurrencyId,
       label: addAddressFlowState.addressLabel.label,
       address: addAddressFlowState.addressEntry.resolvedAddress,
+      device: signedAddress.addressDeviceContext,
     });
 
-    dispatch(addAddress({ contactId: addAddressFlowState.selectedContactId, address }));
+    dispatch(
+      addAddress({
+        contactId: addAddressFlowState.selectedContactId,
+        address,
+        deviceCredentials: signedAddress.deviceCredentials,
+      }),
+    );
     completeMockConfirmation();
     closeAddAddress();
-  }, [addAddressFlowState, closeAddAddress, completeMockConfirmation, dispatch]);
+  }, [
+    addAddressFlowState,
+    closeAddAddress,
+    completeMockConfirmation,
+    contact,
+    deviceIntents,
+    dispatch,
+  ]);
   useEffect(() => {
-    completeMockAddressConfirmation();
+    void completeMockAddressConfirmation();
   }, [completeMockAddressConfirmation]);
   const onAddAddress = useCallback(() => {
     if (!contact || eligibleNetworkIds.length === 0) return;

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/__tests__/mockContacts.test.ts
@@ -8,5 +8,13 @@ describe("createContactsDebugSamples", () => {
     expect(contacts.every(contact => !contact.isMe)).toBe(true);
     expect(contacts.map(contact => contact.name)).toContain("\u042f\u043d\u0430");
     expect(contacts.find(contact => contact.name === "David")?.addresses).toHaveLength(3);
+    expect(
+      contacts
+        .filter(contact => contact.addresses.length > 0)
+        .every(contact => contact.deviceCredentials !== undefined),
+    ).toBe(true);
+    expect(contacts.flatMap(contact => contact.addresses).every(address => address.device)).toBe(
+      true,
+    );
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
+++ b/apps/ledger-live-mobile/src/screens/Settings/Debug/Debugging/Contacts/mockContacts.ts
@@ -1,4 +1,8 @@
 import { contact, contactAddress, type Contact } from "@domain/entity-contact";
+import {
+  mockDeviceContactGroupCredentials,
+  mockExternalAddressDeviceContext,
+} from "@domain/entity-contact/schema.mock";
 
 const SAMPLE_CONTACT_NAMES = [
   "Ada",
@@ -35,6 +39,7 @@ function createSampleAddresses(contactId: string, count: number) {
       currencyId: "ethereum",
       label: "Ethereum",
       address: `0x${String(index + 1).padStart(40, "0")}`,
+      device: mockExternalAddressDeviceContext(),
     }),
   );
 }
@@ -43,11 +48,14 @@ export function createContactsDebugSamples(): Contact[] {
   return SAMPLE_CONTACT_NAMES.map((name, index) => {
     const id = `contact-sample-${index + 1}`;
 
+    const addresses = createSampleAddresses(id, index % 4);
+
     return contact({
       id,
       isMe: false,
       name,
-      addresses: createSampleAddresses(id, index % 4),
+      addresses,
+      ...(addresses.length > 0 ? { deviceCredentials: mockDeviceContactGroupCredentials() } : {}),
     });
   });
 }

--- a/domain/entity/contact/README.md
+++ b/domain/entity/contact/README.md
@@ -9,9 +9,9 @@ Domain entity for Contacts. It contains the Zod-first model, Redux slice, select
 
 This package describes what Contacts flows manipulate:
 
-- the default `Me` contact used by the `Me` screens;
-- saved contacts;
-- contact addresses with `currencyId`, `label`, and `address`.
+- the structural `Me` contact used by the `Me` screens;
+- saved `ContactGroup` contacts with synchronized identifiers;
+- `ExternalAddress` records with `currencyId`, `label`, `address`, and device context.
 - local Contacts state and direct contact/address mutations.
 
 `currencyId` is the id of the `CryptoOrTokenCurrency` selected by MAD. `address` is intentionally stored as a generic non-empty string because address parsing and currency-specific validation belong to later flow or integration adapters. Asset names, tickers, icons, and network display data are also resolved later by those adapters.
@@ -22,7 +22,19 @@ without surfacing an error and can reject labels already used by the same contac
 trim surrounding whitespace and normalize Unicode NFC before validation. Duplicate comparison
 ignores casing.
 
-It does not implement persistence, WalletSync, Ledger Sync, device actions, signer payloads, routing, or UI.
+Each contact with one or more addresses carries `deviceCredentials` returned by Device Intents.
+Each address carries its own device context: `blockchainFamily`, `chainId`, and `hmacRest`.
+Empty contacts can be renamed or removed locally. Device Intents are required to add an address,
+rename a contact with an address, or modify an address label or value.
+
+It exposes a Cloud Sync module with a stable Contacts document: `{ me, contactGroups }`. `Me` has
+no remote identifier; the local-only `Me` identifier and `isMe` flags are reconstructed when
+incoming data is applied. Contact group and address identifiers, device credentials, and device
+context are synchronized. The module preserves unknown future fields when a client changes known
+Contacts data. Registering the module in Wallet Sync and persisting Contacts alongside its sync
+metadata are app-integration responsibilities and remain separate from this entity package.
+Registration requires Wallet Sync module isolation so an invalid Contacts payload is quarantined
+without stopping the other modules.
 
 ## Usage
 

--- a/domain/entity/contact/package.json
+++ b/domain/entity/contact/package.json
@@ -24,6 +24,7 @@
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
+    "@shared/cloud-sync-module": "workspace:^",
     "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"
   },

--- a/domain/entity/contact/src/cloudSync/distantSchema.ts
+++ b/domain/entity/contact/src/cloudSync/distantSchema.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+import { DEFAULT_ME_CONTACT_ID } from "../constants";
+
+const DistantStringSchema = z.string().min(1);
+const DistantChainIdSchema = z.union([z.string().min(1), z.number().finite()]);
+
+const DistantDeviceContactGroupCredentialsSchema = z
+  .object({
+    groupHandle: DistantStringSchema,
+    hmacProof: DistantStringSchema,
+  })
+  .passthrough();
+
+const DistantExternalAddressSchema = z
+  .object({
+    id: DistantStringSchema,
+    currencyId: DistantStringSchema,
+    label: DistantStringSchema,
+    address: DistantStringSchema,
+    device: z
+      .object({
+        blockchainFamily: DistantStringSchema,
+        chainId: DistantChainIdSchema,
+        hmacRest: DistantStringSchema,
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const DistantContactSchema = z
+  .object({
+    name: DistantStringSchema,
+    deviceCredentials: DistantDeviceContactGroupCredentialsSchema.optional(),
+    addresses: z.array(DistantExternalAddressSchema),
+  })
+  .passthrough();
+
+const DistantContactGroupSchema = DistantContactSchema.extend({
+  id: DistantStringSchema,
+});
+
+export const ContactsDistantSchema = z
+  .object({
+    me: DistantContactSchema,
+    contactGroups: z.array(DistantContactGroupSchema),
+  })
+  .passthrough();
+
+export type ContactsWire = z.infer<typeof ContactsDistantSchema>;
+export type DistantRecord = Readonly<Record<string, unknown>>;
+export type DistantAddress = ContactsWire["me"]["addresses"][number];
+export type DistantContact = ContactsWire["me"];
+export type DistantContactGroup = ContactsWire["contactGroups"][number];
+
+export function asDistantRecord(value: unknown): DistantRecord | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as DistantRecord)
+    : null;
+}
+
+function hasUniqueIds(values: readonly { id: string }[]): boolean {
+  return new Set(values.map(value => value.id)).size === values.length;
+}
+
+function hasUniqueAddressIds(
+  contacts: readonly { addresses: readonly { id: string }[] }[],
+): boolean {
+  return contacts.every(contact => hasUniqueIds(contact.addresses));
+}
+
+function hasRequiredCredentials(contact: {
+  readonly addresses: readonly unknown[];
+  readonly deviceCredentials?: unknown;
+}): boolean {
+  return contact.addresses.length === 0 || contact.deviceCredentials !== undefined;
+}
+
+export function isValidContactsWire(value: ContactsWire): boolean {
+  return (
+    value.contactGroups.every(contactGroup => contactGroup.id !== DEFAULT_ME_CONTACT_ID) &&
+    hasUniqueIds(value.contactGroups) &&
+    hasUniqueAddressIds([value.me, ...value.contactGroups]) &&
+    hasRequiredCredentials(value.me) &&
+    value.contactGroups.every(hasRequiredCredentials)
+  );
+}
+
+export function parseContactsWire(value: unknown): ContactsWire | null {
+  const result = ContactsDistantSchema.safeParse(value);
+  const raw = asDistantRecord(value);
+  const rawMe = asDistantRecord(raw?.me);
+  const rawContactGroups = Array.isArray(raw?.contactGroups) ? raw.contactGroups : [];
+  const hasReservedRoleFields =
+    (rawMe !== null && ("id" in rawMe || "isMe" in rawMe)) ||
+    rawContactGroups.some(contactGroup => {
+      const record = asDistantRecord(contactGroup);
+      return record !== null && "isMe" in record;
+    });
+
+  return result.success && isValidContactsWire(result.data) && !hasReservedRoleFields
+    ? result.data
+    : null;
+}

--- a/domain/entity/contact/src/cloudSync/extensions.ts
+++ b/domain/entity/contact/src/cloudSync/extensions.ts
@@ -1,0 +1,103 @@
+import {
+  asDistantRecord,
+  ContactsDistantSchema,
+  type ContactsWire,
+  type DistantAddress,
+  type DistantContact,
+  type DistantContactGroup,
+  type DistantRecord,
+} from "./distantSchema";
+
+function rawValuesById(value: unknown): ReadonlyMap<string, DistantRecord> {
+  if (!Array.isArray(value)) {
+    return new Map();
+  }
+
+  return new Map(
+    value.flatMap(item => {
+      const record = asDistantRecord(item);
+      return record !== null && typeof record.id === "string" ? [[record.id, record] as const] : [];
+    }),
+  );
+}
+
+function mergeDistantRecord(rawValue: unknown, ownedValues: object): DistantRecord {
+  const rawRecord = asDistantRecord(rawValue);
+  return rawRecord === null ? { ...ownedValues } : { ...rawRecord, ...ownedValues };
+}
+
+function mergeDeviceCredentialsExtensions(
+  credentials: ContactsWire["me"]["deviceCredentials"],
+  rawCredentials: unknown,
+): DistantRecord | undefined {
+  return credentials === undefined ? undefined : mergeDistantRecord(rawCredentials, credentials);
+}
+
+function mergeAddressExtensions(
+  address: DistantAddress,
+  rawAddress: DistantRecord | undefined,
+): DistantRecord {
+  const { device: _rawDevice, ...rawAddressExtensions } = rawAddress ?? {};
+
+  return {
+    ...rawAddressExtensions,
+    id: address.id,
+    currencyId: address.currencyId,
+    label: address.label,
+    address: address.address,
+    device: mergeDistantRecord(rawAddress?.device, address.device),
+  };
+}
+
+function mergeAddressListExtensions(
+  addresses: readonly DistantAddress[],
+  rawAddresses: unknown,
+): DistantRecord[] {
+  const rawAddressesById = rawValuesById(rawAddresses);
+  return addresses.map(address =>
+    mergeAddressExtensions(address, rawAddressesById.get(address.id)),
+  );
+}
+
+function mergeContactExtensions(
+  contact: DistantContact | DistantContactGroup,
+  rawContact: DistantRecord | undefined,
+  includeId: boolean,
+): DistantRecord {
+  const {
+    id: _rawId,
+    isMe: _rawIsMe,
+    deviceCredentials: _rawCredentials,
+    ...rawExtensions
+  } = rawContact ?? {};
+  const credentials = mergeDeviceCredentialsExtensions(
+    contact.deviceCredentials,
+    rawContact?.deviceCredentials,
+  );
+
+  return {
+    ...rawExtensions,
+    ...(includeId && "id" in contact ? { id: contact.id } : {}),
+    name: contact.name,
+    ...(credentials === undefined ? {} : { deviceCredentials: credentials }),
+    addresses: mergeAddressListExtensions(contact.addresses, rawContact?.addresses),
+  };
+}
+
+export function mergeContactsDistantExtensions(
+  latestState: unknown,
+  localWire: ContactsWire,
+): ContactsWire {
+  const latest = asDistantRecord(latestState);
+  const latestMe = asDistantRecord(latest?.me);
+  const latestContactGroupsById = rawValuesById(latest?.contactGroups);
+  const { me: _rawMe, contactGroups: _rawContactGroups, ...rootExtensions } = latest ?? {};
+
+  return ContactsDistantSchema.parse({
+    ...rootExtensions,
+    me: mergeContactExtensions(localWire.me, latestMe ?? undefined, false),
+    contactGroups: localWire.contactGroups.map(contactGroup =>
+      mergeContactExtensions(contactGroup, latestContactGroupsById.get(contactGroup.id), true),
+    ),
+  });
+}

--- a/domain/entity/contact/src/cloudSync/module.test.ts
+++ b/domain/entity/contact/src/cloudSync/module.test.ts
@@ -1,0 +1,253 @@
+import { describeCloudSyncModuleContract } from "@shared/cloud-sync-module/moduleRequirements";
+import { ContactsDistantSchema, contactsSyncModule } from "./module";
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithMultipleAddresses,
+  mockEmptyContacts,
+  mockMeContact,
+  mockMeContactWithAddresses,
+  mockPopulatedContacts,
+} from "../schema.mock";
+import type { Contact } from "../types";
+
+function toWire(contacts: Contact[]) {
+  return ContactsDistantSchema.parse(
+    contactsSyncModule.diffLocalToDistant(contacts, null).nextState,
+  );
+}
+
+const populatedContacts = mockPopulatedContacts();
+
+describeCloudSyncModuleContract("contactsSyncModule contract", contactsSyncModule, {
+  emptyLocalState: mockEmptyContacts(),
+  nonEmptyLocalState: populatedContacts,
+  matchingDistantState: toWire(populatedContacts),
+});
+
+describe("ContactsDistantSchema", () => {
+  it("should accept additive fields while requiring the permanent document shape", () => {
+    const input = { ...toWire(mockEmptyContacts()), futureField: true };
+
+    expect(ContactsDistantSchema.safeParse(input).success).toBe(true);
+    expect(ContactsDistantSchema.safeParse({ me: { name: "Me", addresses: [] } }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("contactsSyncModule.diffLocalToDistant", () => {
+  it("should not create a distant state for the untouched default Me contact", () => {
+    expect(contactsSyncModule.diffLocalToDistant(mockEmptyContacts(), null)).toEqual({
+      hasChanges: false,
+      nextState: { me: { name: "Me", addresses: [] }, contactGroups: [] },
+    });
+  });
+
+  it("should publish signed data without Me local identifiers", () => {
+    const local = [
+      mockMeContactWithAddresses({ name: "Raphael" }),
+      mockContactWithMultipleAddresses(),
+    ];
+    const wire = toWire(local);
+
+    expect(wire.me).toMatchObject({ name: "Raphael" });
+    expect(wire.me).not.toHaveProperty("id");
+    expect(wire.me).not.toHaveProperty("isMe");
+    expect(wire.me.deviceCredentials).toBeDefined();
+    expect(wire.contactGroups[0]).toMatchObject({ id: local[1]?.id, name: local[1]?.name });
+    expect(wire.contactGroups[0]?.addresses).toEqual(local[1]?.addresses);
+  });
+
+  it("should preserve the insertion order of contact groups and addresses", () => {
+    const local = [
+      mockMeContactWithAddresses(),
+      mockContact({ id: "contact-zed", name: "Zed" }),
+      mockContactWithMultipleAddresses({ id: "contact-ada", name: "Ada" }),
+    ];
+    const wire = toWire(local);
+
+    expect(wire.contactGroups.map(contact => contact.id)).toEqual(["contact-zed", "contact-ada"]);
+    expect(wire.contactGroups[1]?.addresses.map(address => address.id)).toEqual([
+      "address-polygon",
+      "address-ethereum",
+    ]);
+  });
+
+  it("should publish a non-empty local state when the distant slot is absent", () => {
+    const result = contactsSyncModule.diffLocalToDistant(populatedContacts, null);
+
+    expect(result.hasChanges).toBe(true);
+    expect(result.nextState).toEqual(toWire(populatedContacts));
+  });
+
+  it("should preserve future fields when a local change is published", () => {
+    const latest = toWire(populatedContacts);
+    const distantWithFutureFields = {
+      ...latest,
+      rootFutureField: "preserved",
+      me: {
+        ...latest.me,
+        meFutureField: "preserved",
+        addresses: latest.me.addresses.map((address, index) =>
+          index === 0 ? { ...address, addressFutureField: "preserved" } : address,
+        ),
+      },
+      contactGroups: latest.contactGroups.map((contactGroup, index) =>
+        index === 0 ? { ...contactGroup, contactFutureField: "preserved" } : contactGroup,
+      ),
+    };
+    const local = [
+      mockMeContactWithAddresses({ name: "Raphael" }),
+      mockContact({ id: "contact-ada", name: "Ada" }),
+    ];
+
+    const result = contactsSyncModule.diffLocalToDistant(local, distantWithFutureFields);
+
+    expect(result).toMatchObject({
+      hasChanges: true,
+      nextState: {
+        rootFutureField: "preserved",
+        me: { meFutureField: "preserved", name: "Raphael" },
+      },
+    });
+    const nextState = ContactsDistantSchema.parse(result.nextState);
+    expect((nextState.me.addresses[0] as Record<string, unknown>).addressFutureField).toBe(
+      "preserved",
+    );
+    expect((nextState.contactGroups[0] as Record<string, unknown>).contactFutureField).toBe(
+      "preserved",
+    );
+  });
+
+  it("should preserve the raw distant state when known Contacts data is equal", () => {
+    const distantWithFutureField = { ...toWire(populatedContacts), futureField: "preserved" };
+
+    expect(
+      contactsSyncModule.diffLocalToDistant(populatedContacts, distantWithFutureField),
+    ).toEqual({
+      hasChanges: false,
+      nextState: distantWithFutureField,
+    });
+  });
+
+  it("should publish an insertion-order change", () => {
+    const local = [
+      mockMeContact(),
+      mockContact({ id: "contact-zed", name: "Zed" }),
+      mockContact({ id: "contact-ada", name: "Ada" }),
+    ];
+    const distant = toWire(local);
+    const reordered = [local[0]!, local[2]!, local[1]!];
+
+    expect(contactsSyncModule.diffLocalToDistant(reordered, distant).hasChanges).toBe(true);
+  });
+
+  it("should keep an invalid distant payload untouched", () => {
+    const invalid = {
+      me: { name: "Me", addresses: [] },
+      contactGroups: [{ id: "contact-me", name: "Ada", addresses: [] }],
+    };
+
+    expect(contactsSyncModule.diffLocalToDistant(populatedContacts, invalid)).toEqual({
+      hasChanges: false,
+      nextState: invalid,
+    });
+  });
+});
+
+describe("contactsSyncModule.resolveIncrementalUpdate", () => {
+  it("should replace every local contact from a valid distant document", async () => {
+    const incomingContacts = [
+      mockMeContactWithAddresses({ name: "Raphael" }),
+      mockContactWithMultipleAddresses({ id: "contact-ada", name: "Ada" }),
+    ];
+
+    await expect(
+      contactsSyncModule.resolveIncrementalUpdate(
+        mockEmptyContacts(),
+        null,
+        toWire(incomingContacts),
+      ),
+    ).resolves.toEqual({ hasChanges: true, update: incomingContacts });
+  });
+
+  it("should not apply a different reference with equivalent known data", async () => {
+    const distantCopy = JSON.parse(JSON.stringify(toWire(populatedContacts))) as unknown;
+
+    await expect(
+      contactsSyncModule.resolveIncrementalUpdate(populatedContacts, null, distantCopy),
+    ).resolves.toEqual({ hasChanges: false });
+  });
+
+  it("should ignore invalid or unsigned distant data atomically", async () => {
+    const address = mockContactAddress();
+    const invalidDistantStates: unknown[] = [
+      [],
+      {
+        me: { name: "Me", addresses: [address] },
+        contactGroups: [],
+      },
+      {
+        me: { name: "Me", addresses: [] },
+        contactGroups: [
+          { id: "contact-ada", name: "Ada", addresses: [] },
+          { id: "contact-ada", name: "Ada", addresses: [] },
+        ],
+      },
+    ];
+
+    for (const incoming of invalidDistantStates) {
+      await expect(
+        contactsSyncModule.resolveIncrementalUpdate(populatedContacts, null, incoming),
+      ).resolves.toEqual({ hasChanges: false });
+    }
+  });
+
+  it("should reject reserved local role fields in the distant document", async () => {
+    const rawMeId = {
+      me: { id: "contact-me", name: "Me", addresses: [] },
+      contactGroups: [],
+    };
+    const rawContactGroupRole = {
+      me: { name: "Me", addresses: [] },
+      contactGroups: [{ id: "contact-ada", isMe: false, name: "Ada", addresses: [] }],
+    };
+
+    await expect(
+      contactsSyncModule.resolveIncrementalUpdate(populatedContacts, null, rawMeId),
+    ).resolves.toEqual({ hasChanges: false });
+    await expect(
+      contactsSyncModule.resolveIncrementalUpdate(populatedContacts, null, rawContactGroupRole),
+    ).resolves.toEqual({ hasChanges: false });
+  });
+
+  it("should not apply the same distant state reference", async () => {
+    const distant = toWire(populatedContacts);
+
+    await expect(
+      contactsSyncModule.resolveIncrementalUpdate(mockEmptyContacts(), distant, distant),
+    ).resolves.toEqual({ hasChanges: false });
+  });
+});
+
+describe("contactsSyncModule.applyUpdate", () => {
+  it("should replace Contacts without mutating frozen local data", async () => {
+    const local = Object.freeze(mockEmptyContacts()) as Contact[];
+    const incoming = [
+      mockMeContactWithAddresses(),
+      mockContact({ id: "contact-ada", name: "Ada" }),
+    ];
+    const resolution = await contactsSyncModule.resolveIncrementalUpdate(
+      local,
+      null,
+      toWire(incoming),
+    );
+
+    expect(resolution.hasChanges).toBe(true);
+    if (resolution.hasChanges) {
+      expect(contactsSyncModule.applyUpdate(local, resolution.update)).toEqual(incoming);
+    }
+    expect(local).toEqual(mockEmptyContacts());
+  });
+});

--- a/domain/entity/contact/src/cloudSync/module.ts
+++ b/domain/entity/contact/src/cloudSync/module.ts
@@ -1,0 +1,69 @@
+import type { CloudSyncDataManager } from "@shared/cloud-sync-module";
+import { ContactsDistantSchema, parseContactsWire } from "./distantSchema";
+import { mergeContactsDistantExtensions } from "./extensions";
+import {
+  emptyDistantContactsState,
+  hasSameContactsWire,
+  isUntouchedContactsWire,
+  toContactsWire,
+  toLocalContacts,
+} from "./state";
+import type { Contact } from "../types";
+
+export { ContactsDistantSchema } from "./distantSchema";
+
+export const contactsSyncModule: CloudSyncDataManager<
+  Contact[],
+  Contact[],
+  typeof ContactsDistantSchema,
+  unknown
+> = {
+  schema: ContactsDistantSchema,
+
+  diffLocalToDistant(localData, latestState) {
+    const localWire = toContactsWire(localData);
+    if (localWire === null) {
+      return { hasChanges: false as const, nextState: latestState ?? emptyDistantContactsState };
+    }
+
+    if (latestState === null) {
+      return {
+        hasChanges: !isUntouchedContactsWire(localWire),
+        nextState: localWire,
+      };
+    }
+
+    const latestWire = parseContactsWire(latestState);
+    if (latestWire === null || hasSameContactsWire(localWire, latestWire)) {
+      return { hasChanges: false as const, nextState: latestState };
+    }
+
+    return {
+      hasChanges: true as const,
+      nextState: mergeContactsDistantExtensions(latestState, localWire),
+    };
+  },
+
+  async resolveIncrementalUpdate(localData, latestState, incomingState) {
+    if (incomingState === null || incomingState === latestState) {
+      return { hasChanges: false as const };
+    }
+
+    const incomingWire = parseContactsWire(incomingState);
+    const incomingContacts = incomingWire === null ? null : toLocalContacts(incomingWire);
+    if (incomingWire === null || incomingContacts === null) {
+      return { hasChanges: false as const };
+    }
+
+    const localWire = toContactsWire(localData);
+    if (localWire !== null && hasSameContactsWire(localWire, incomingWire)) {
+      return { hasChanges: false as const };
+    }
+
+    return { hasChanges: true as const, update: incomingContacts };
+  },
+
+  applyUpdate(_localData, update) {
+    return update;
+  },
+};

--- a/domain/entity/contact/src/cloudSync/state.ts
+++ b/domain/entity/contact/src/cloudSync/state.ts
@@ -1,0 +1,132 @@
+import { z } from "zod";
+import { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "../constants";
+import { ContactSchema } from "../schema";
+import type { Contact } from "../types";
+import { isValidContactsWire, type ContactsWire, type DistantAddress } from "./distantSchema";
+
+export const emptyDistantContactsState: ContactsWire = {
+  me: { name: DEFAULT_ME_CONTACT_NAME, addresses: [] },
+  contactGroups: [],
+};
+
+export function toContactsWire(localData: readonly Contact[]): ContactsWire | null {
+  const result = z.array(ContactSchema).safeParse(localData);
+  if (!result.success) {
+    return null;
+  }
+
+  const meContacts = result.data.filter(contact => contact.isMe);
+  if (meContacts.length !== 1 || meContacts[0]?.id !== DEFAULT_ME_CONTACT_ID) {
+    return null;
+  }
+
+  const me = meContacts[0];
+  const wire = {
+    me: {
+      name: me.name,
+      ...(me.deviceCredentials === undefined ? {} : { deviceCredentials: me.deviceCredentials }),
+      addresses: me.addresses,
+    },
+    contactGroups: result.data
+      .filter(contact => !contact.isMe)
+      .map(({ id, name, deviceCredentials, addresses }) => ({
+        id,
+        name,
+        ...(deviceCredentials === undefined ? {} : { deviceCredentials }),
+        addresses,
+      })),
+  };
+
+  return isValidContactsWire(wire) ? wire : null;
+}
+
+export function toLocalContacts(wire: ContactsWire): Contact[] | null {
+  const input = [
+    {
+      id: DEFAULT_ME_CONTACT_ID,
+      isMe: true,
+      name: wire.me.name,
+      deviceCredentials: wire.me.deviceCredentials,
+      addresses: wire.me.addresses,
+    },
+    ...wire.contactGroups.map(contactGroup => ({
+      id: contactGroup.id,
+      isMe: false,
+      name: contactGroup.name,
+      deviceCredentials: contactGroup.deviceCredentials,
+      addresses: contactGroup.addresses,
+    })),
+  ];
+  const result = z.array(ContactSchema).safeParse(input);
+
+  return result.success ? result.data : null;
+}
+
+function sameDeviceCredentials(
+  left: ContactsWire["me"]["deviceCredentials"],
+  right: ContactsWire["me"]["deviceCredentials"],
+): boolean {
+  return (
+    left === right ||
+    (left !== undefined &&
+      right !== undefined &&
+      left.groupHandle === right.groupHandle &&
+      left.hmacProof === right.hmacProof)
+  );
+}
+
+function sameAddress(left: DistantAddress, right: DistantAddress): boolean {
+  return (
+    left.id === right.id &&
+    left.currencyId === right.currencyId &&
+    left.label === right.label &&
+    left.address === right.address &&
+    left.device.blockchainFamily === right.device.blockchainFamily &&
+    left.device.chainId === right.device.chainId &&
+    left.device.hmacRest === right.device.hmacRest
+  );
+}
+
+function sameAddressList(
+  left: readonly DistantAddress[],
+  right: readonly DistantAddress[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((address, index) => {
+      const otherAddress = right[index];
+      return otherAddress !== undefined && sameAddress(address, otherAddress);
+    })
+  );
+}
+
+export function hasSameContactsWire(left: ContactsWire, right: ContactsWire): boolean {
+  return (
+    left.me.name === right.me.name &&
+    sameDeviceCredentials(left.me.deviceCredentials, right.me.deviceCredentials) &&
+    sameAddressList(left.me.addresses, right.me.addresses) &&
+    left.contactGroups.length === right.contactGroups.length &&
+    left.contactGroups.every((contactGroup, index) => {
+      const otherContactGroup = right.contactGroups[index];
+      return (
+        otherContactGroup !== undefined &&
+        contactGroup.id === otherContactGroup.id &&
+        contactGroup.name === otherContactGroup.name &&
+        sameDeviceCredentials(
+          contactGroup.deviceCredentials,
+          otherContactGroup.deviceCredentials,
+        ) &&
+        sameAddressList(contactGroup.addresses, otherContactGroup.addresses)
+      );
+    })
+  );
+}
+
+export function isUntouchedContactsWire(wire: ContactsWire): boolean {
+  return (
+    wire.me.name === DEFAULT_ME_CONTACT_NAME &&
+    wire.me.deviceCredentials === undefined &&
+    wire.me.addresses.length === 0 &&
+    wire.contactGroups.length === 0
+  );
+}

--- a/domain/entity/contact/src/cloudSyncModule.ts
+++ b/domain/entity/contact/src/cloudSyncModule.ts
@@ -1,0 +1,1 @@
+export * from "./cloudSync/module";

--- a/domain/entity/contact/src/device/types.test.ts
+++ b/domain/entity/contact/src/device/types.test.ts
@@ -1,0 +1,39 @@
+import {
+  DeviceContactGroupCredentialsSchema,
+  ExternalAddressDeviceContextSchema,
+  LedgerAccountNameProofSchema,
+} from "./types";
+
+describe("Contacts Device Intent types", () => {
+  it("should parse reusable opaque device credentials", () => {
+    expect(
+      DeviceContactGroupCredentialsSchema.parse({
+        groupHandle: "device-group-handle",
+        hmacProof: "external-contact-name-proof",
+      }),
+    ).toEqual({
+      groupHandle: "device-group-handle",
+      hmacProof: "external-contact-name-proof",
+    });
+  });
+
+  it("should parse an external address device context", () => {
+    expect(
+      ExternalAddressDeviceContextSchema.parse({
+        blockchainFamily: "ethereum",
+        chainId: 1,
+        hmacRest: "external-address-proof",
+      }),
+    ).toEqual({
+      blockchainFamily: "ethereum",
+      chainId: 1,
+      hmacRest: "external-address-proof",
+    });
+  });
+
+  it("should keep Ledger account proofs in a separate proof domain", () => {
+    expect(LedgerAccountNameProofSchema.parse("ledger-account-name-proof")).toBe(
+      "ledger-account-name-proof",
+    );
+  });
+});

--- a/domain/entity/contact/src/device/types.ts
+++ b/domain/entity/contact/src/device/types.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+declare const opaqueStringBrand: unique symbol;
+
+export type OpaqueString<Kind extends string> = string & {
+  readonly [opaqueStringBrand]: Kind;
+};
+
+function createOpaqueStringSchema<Kind extends string>() {
+  return z
+    .string()
+    .min(1)
+    .transform(value => value as OpaqueString<Kind>);
+}
+
+export const ContactGroupHandleSchema = createOpaqueStringSchema<"ContactGroupHandle">();
+export const ExternalContactNameProofSchema =
+  createOpaqueStringSchema<"ExternalContactNameProof">();
+export const ExternalAddressProofSchema = createOpaqueStringSchema<"ExternalAddressProof">();
+export const LedgerAccountNameProofSchema = createOpaqueStringSchema<"LedgerAccountNameProof">();
+export const BlockchainFamilySchema = createOpaqueStringSchema<"BlockchainFamily">();
+export const DeviceChainIdSchema = z.union([z.string().min(1), z.number().finite()]);
+
+export const DeviceContactGroupCredentialsSchema = z.object({
+  groupHandle: ContactGroupHandleSchema,
+  hmacProof: ExternalContactNameProofSchema,
+});
+
+export const ExternalAddressDeviceContextSchema = z.object({
+  blockchainFamily: BlockchainFamilySchema,
+  chainId: DeviceChainIdSchema,
+  hmacRest: ExternalAddressProofSchema,
+});
+
+export type ContactGroupHandle = z.infer<typeof ContactGroupHandleSchema>;
+export type ExternalContactNameProof = z.infer<typeof ExternalContactNameProofSchema>;
+export type ExternalAddressProof = z.infer<typeof ExternalAddressProofSchema>;
+export type LedgerAccountNameProof = z.infer<typeof LedgerAccountNameProofSchema>;
+export type BlockchainFamily = z.infer<typeof BlockchainFamilySchema>;
+export type DeviceChainId = z.infer<typeof DeviceChainIdSchema>;
+export type DeviceContactGroupCredentials = z.infer<typeof DeviceContactGroupCredentialsSchema>;
+export type ExternalAddressDeviceContext = z.infer<typeof ExternalAddressDeviceContextSchema>;

--- a/domain/entity/contact/src/index.ts
+++ b/domain/entity/contact/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./constants";
 export * from "./schema";
+export * from "./device/types";
 export * from "./types";
 export * from "./define";
 export * from "./slice";
@@ -7,3 +8,4 @@ export * from "./selectors";
 export * from "./errors";
 export * from "./validation";
 export * from "./signerValidation";
+export * from "./cloudSyncModule";

--- a/domain/entity/contact/src/schema.mock.ts
+++ b/domain/entity/contact/src/schema.mock.ts
@@ -1,6 +1,32 @@
 import { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "./constants";
 import { contact, contactAddress } from "./define";
+import {
+  DeviceContactGroupCredentialsSchema,
+  ExternalAddressDeviceContextSchema,
+} from "./device/types";
 import type { Contact, ContactAddress, ContactAddressInput, ContactInput } from "./types";
+import type { DeviceContactGroupCredentials, ExternalAddressDeviceContext } from "./device/types";
+
+export function mockDeviceContactGroupCredentials(
+  overrides?: Partial<DeviceContactGroupCredentials>,
+): DeviceContactGroupCredentials {
+  return DeviceContactGroupCredentialsSchema.parse({
+    groupHandle: "mock-contact-group-handle",
+    hmacProof: "mock-external-contact-name-proof",
+    ...overrides,
+  });
+}
+
+export function mockExternalAddressDeviceContext(
+  overrides?: Partial<ExternalAddressDeviceContext>,
+): ExternalAddressDeviceContext {
+  return ExternalAddressDeviceContextSchema.parse({
+    blockchainFamily: "mock-blockchain-family",
+    chainId: "mock-chain-id",
+    hmacRest: "mock-external-address-proof",
+    ...overrides,
+  });
+}
 
 export function mockContactAddress(overrides?: Partial<ContactAddressInput>): ContactAddress {
   return contactAddress({
@@ -8,17 +34,26 @@ export function mockContactAddress(overrides?: Partial<ContactAddressInput>): Co
     currencyId: "ethereum",
     label: "Ethereum",
     address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
+    device: mockExternalAddressDeviceContext(),
     ...overrides,
   });
 }
 
 export function mockMeContact(overrides?: Partial<ContactInput>): Contact {
-  return contact({
+  const input = {
     id: DEFAULT_ME_CONTACT_ID,
     isMe: true,
     name: DEFAULT_ME_CONTACT_NAME,
     addresses: [],
     ...overrides,
+  };
+  const deviceCredentials = "deviceCredentials" in input ? input.deviceCredentials : undefined;
+
+  return contact({
+    ...input,
+    ...(input.addresses.length > 0 && deviceCredentials === undefined
+      ? { deviceCredentials: mockDeviceContactGroupCredentials() }
+      : {}),
   });
 }
 
@@ -44,23 +79,33 @@ export function mockMeContactWithAddresses(overrides?: Partial<ContactInput>): C
         address: "0xdD3F8f1234567890123456789012345678901234",
       }),
     ],
+    deviceCredentials: mockDeviceContactGroupCredentials(),
     ...overrides,
   });
 }
 
 export function mockContact(overrides?: Partial<ContactInput>): Contact {
-  return contact({
+  const input = {
     id: "contact-ben",
     isMe: false,
     name: "Ben",
     addresses: [],
     ...overrides,
+  };
+  const deviceCredentials = "deviceCredentials" in input ? input.deviceCredentials : undefined;
+
+  return contact({
+    ...input,
+    ...(input.addresses.length > 0 && deviceCredentials === undefined
+      ? { deviceCredentials: mockDeviceContactGroupCredentials() }
+      : {}),
   });
 }
 
 export function mockContactWithAddress(overrides?: Partial<ContactInput>): Contact {
   return mockContact({
     addresses: [mockContactAddress()],
+    deviceCredentials: mockDeviceContactGroupCredentials(),
     ...overrides,
   });
 }
@@ -76,6 +121,7 @@ export function mockContactWithMultipleAddresses(overrides?: Partial<ContactInpu
       }),
       mockContactAddress(),
     ],
+    deviceCredentials: mockDeviceContactGroupCredentials(),
     ...overrides,
   });
 }

--- a/domain/entity/contact/src/schema.test.ts
+++ b/domain/entity/contact/src/schema.test.ts
@@ -35,6 +35,13 @@ describe("ContactSchema", () => {
     expect(contact.isMe).toBe(false);
   });
 
+  it("rejects a contact address collection without group credentials", () => {
+    const contact = mockContactWithAddress();
+    const { deviceCredentials: _deviceCredentials, ...unsignedContact } = contact;
+
+    expect(ContactSchema.safeParse(unsignedContact).success).toBe(false);
+  });
+
   it("rejects a contact without a name", () => {
     expect(() => ContactSchema.parse(mockContact({ name: "   " }))).toThrow();
   });
@@ -60,6 +67,12 @@ describe("ContactAddressSchema", () => {
 
     expect(ContactAddressSchema.parse(address)).toEqual(address);
     expect(address.currencyId).toBe("ethereum");
+  });
+
+  it("rejects an address without its Device Intent context", () => {
+    const { device: _device, ...unsignedAddress } = mockContactAddress();
+
+    expect(ContactAddressSchema.safeParse(unsignedAddress).success).toBe(false);
   });
 
   it("keeps address format generic for the selected currency", () => {

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -7,6 +7,10 @@ import {
   InvalidContactAddressLabelError,
   InvalidContactNameError,
 } from "./errors";
+import {
+  DeviceContactGroupCredentialsSchema,
+  ExternalAddressDeviceContextSchema,
+} from "./device/types";
 
 export const ContactIdSchema = NonEmptyStringSchema;
 export const ContactAddressIdSchema = NonEmptyStringSchema;
@@ -56,11 +60,32 @@ export const ContactAddressSchema = z.object({
   currencyId: ContactCurrencyIdSchema,
   label: ContactAddressLabelSchema,
   address: ContactAddressValueSchema,
+  device: ExternalAddressDeviceContextSchema,
 });
 
-export const ContactSchema = z.object({
+const ContactBaseSchema = z.object({
   id: ContactIdSchema,
-  isMe: z.boolean(),
   name: ContactNameSchema,
   addresses: z.array(ContactAddressSchema),
+  deviceCredentials: DeviceContactGroupCredentialsSchema.optional(),
 });
+
+export const MeContactSchema = ContactBaseSchema.extend({
+  isMe: z.literal(true),
+});
+
+export const ContactGroupSchema = ContactBaseSchema.extend({
+  isMe: z.literal(false),
+});
+
+export const ContactSchema = z
+  .discriminatedUnion("isMe", [MeContactSchema, ContactGroupSchema])
+  .superRefine((contact, context) => {
+    if (contact.addresses.length > 0 && contact.deviceCredentials === undefined) {
+      context.addIssue({
+        code: "custom",
+        message: "Contact addresses require device credentials",
+        path: ["deviceCredentials"],
+      });
+    }
+  });

--- a/domain/entity/contact/src/slice.test.ts
+++ b/domain/entity/contact/src/slice.test.ts
@@ -10,7 +10,13 @@ import {
   setContacts,
   updateAddress,
 } from "./slice";
-import { mockContact, mockContactAddress, mockMeContact } from "./schema.mock";
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+  mockDeviceContactGroupCredentials,
+  mockMeContact,
+} from "./schema.mock";
 import { ContactNameSchema } from "./schema";
 
 function makeStore() {
@@ -92,6 +98,16 @@ describe("contactsSlice", () => {
     expect(store.getState().contacts.contacts).toEqual([mockMeContact({ name: "Raphael" })]);
   });
 
+  it("does not rename a contact with an address without renewed device credentials", () => {
+    const store = makeStore();
+    const ben = mockContactWithAddress();
+
+    store.dispatch(addContact(ben));
+    store.dispatch(renameContact({ contactId: ben.id, name: ContactNameSchema.parse("Raphael") }));
+
+    expect(store.getState().contacts.contacts[1]).toEqual(ben);
+  });
+
   it("deletes a saved contact", () => {
     const store = makeStore();
     const ben = mockContact();
@@ -112,9 +128,11 @@ describe("contactsSlice", () => {
     });
 
     store.dispatch(addContact(ben));
-    store.dispatch(addAddress({ contactId: ben.id, address }));
+    const deviceCredentials = mockDeviceContactGroupCredentials();
+    store.dispatch(addAddress({ contactId: ben.id, address, deviceCredentials }));
 
     expect(store.getState().contacts.contacts[1]?.addresses).toEqual([address]);
+    expect(store.getState().contacts.contacts[1]?.deviceCredentials).toEqual(deviceCredentials);
   });
 
   it("updates an address on the intended contact", () => {
@@ -124,7 +142,13 @@ describe("contactsSlice", () => {
     const updatedAddress = mockContactAddress({ ...address, label: "Treasury" });
 
     store.dispatch(addContact(ben));
-    store.dispatch(addAddress({ contactId: ben.id, address }));
+    store.dispatch(
+      addAddress({
+        contactId: ben.id,
+        address,
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      }),
+    );
     store.dispatch(updateAddress({ contactId: ben.id, address: updatedAddress }));
 
     expect(store.getState().contacts.contacts[1]?.addresses).toEqual([updatedAddress]);
@@ -136,11 +160,18 @@ describe("contactsSlice", () => {
     const address = mockContactAddress();
 
     store.dispatch(addContact(ben));
-    store.dispatch(addAddress({ contactId: ben.id, address }));
+    store.dispatch(
+      addAddress({
+        contactId: ben.id,
+        address,
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      }),
+    );
 
     store.dispatch(deleteAddress({ contactId: ben.id, addressId: address.id }));
 
     expect(store.getState().contacts.contacts[1]?.addresses).toEqual([]);
+    expect(store.getState().contacts.contacts[1]?.deviceCredentials).toBeUndefined();
   });
 
   it("does not duplicate an address with the same id", () => {
@@ -149,8 +180,20 @@ describe("contactsSlice", () => {
     const address = mockContactAddress();
 
     store.dispatch(addContact(ben));
-    store.dispatch(addAddress({ contactId: ben.id, address }));
-    store.dispatch(addAddress({ contactId: ben.id, address }));
+    store.dispatch(
+      addAddress({
+        contactId: ben.id,
+        address,
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      }),
+    );
+    store.dispatch(
+      addAddress({
+        contactId: ben.id,
+        address,
+        deviceCredentials: mockDeviceContactGroupCredentials(),
+      }),
+    );
 
     expect(store.getState().contacts.contacts[1]?.addresses).toEqual([address]);
   });

--- a/domain/entity/contact/src/slice.ts
+++ b/domain/entity/contact/src/slice.ts
@@ -3,6 +3,7 @@ import { DEFAULT_ME_CONTACT_ID, DEFAULT_ME_CONTACT_NAME } from "./constants";
 import { contact } from "./define";
 import { normalizeContacts } from "./internals";
 import type { Contact, ContactAddress, ContactId, ContactName, ContactsState } from "./types";
+import type { DeviceContactGroupCredentials } from "./device/types";
 
 const defaultMeContact = contact({
   id: DEFAULT_ME_CONTACT_ID,
@@ -31,14 +32,29 @@ export const contactsSlice = createSlice({
     },
     renameContact: (
       state,
-      action: PayloadAction<Readonly<{ contactId: ContactId; name: ContactName }>>,
+      action: PayloadAction<
+        Readonly<{
+          contactId: ContactId;
+          name: ContactName;
+          deviceCredentials?: DeviceContactGroupCredentials;
+        }>
+      >,
     ) => {
       const selectedContact = state.contacts.find(
         contact => contact.id === action.payload.contactId,
       );
 
-      if (selectedContact) {
-        selectedContact.name = action.payload.name;
+      if (!selectedContact) {
+        return;
+      }
+
+      if (selectedContact.addresses.length > 0 && action.payload.deviceCredentials === undefined) {
+        return;
+      }
+
+      selectedContact.name = action.payload.name;
+      if (selectedContact.addresses.length > 0) {
+        selectedContact.deviceCredentials = action.payload.deviceCredentials;
       }
     },
     deleteContact: (state, action: PayloadAction<ContactId>) => {
@@ -51,7 +67,13 @@ export const contactsSlice = createSlice({
     },
     addAddress: (
       state,
-      action: PayloadAction<Readonly<{ contactId: ContactId; address: ContactAddress }>>,
+      action: PayloadAction<
+        Readonly<{
+          contactId: ContactId;
+          address: ContactAddress;
+          deviceCredentials: DeviceContactGroupCredentials;
+        }>
+      >,
     ) => {
       const selectedContact = state.contacts.find(
         contact => contact.id === action.payload.contactId,
@@ -62,6 +84,7 @@ export const contactsSlice = createSlice({
         !selectedContact.addresses.some(address => address.id === action.payload.address.id)
       ) {
         selectedContact.addresses.push(action.payload.address);
+        selectedContact.deviceCredentials = action.payload.deviceCredentials;
       }
     },
     updateAddress: (
@@ -91,6 +114,9 @@ export const contactsSlice = createSlice({
         selectedContact.addresses = selectedContact.addresses.filter(
           address => address.id !== action.payload.addressId,
         );
+        if (selectedContact.addresses.length === 0) {
+          selectedContact.deviceCredentials = undefined;
+        }
       }
     },
   },

--- a/domain/entity/contact/src/types.ts
+++ b/domain/entity/contact/src/types.ts
@@ -4,10 +4,12 @@ import {
   ContactAddressLabelSchema,
   ContactAddressSchema,
   ContactAddressValueSchema,
+  ContactGroupSchema,
   ContactCurrencyIdSchema,
   ContactIdSchema,
   ContactNameSchema,
   ContactSchema,
+  MeContactSchema,
 } from "./schema";
 
 export type ContactId = z.infer<typeof ContactIdSchema>;
@@ -17,7 +19,10 @@ export type ContactName = z.infer<typeof ContactNameSchema>;
 export type ContactAddressLabel = z.infer<typeof ContactAddressLabelSchema>;
 export type ContactAddressValue = z.infer<typeof ContactAddressValueSchema>;
 export type ContactAddress = z.infer<typeof ContactAddressSchema>;
+export type ExternalAddress = ContactAddress;
 export type Contact = z.infer<typeof ContactSchema>;
+export type MeContact = z.infer<typeof MeContactSchema>;
+export type ContactGroup = z.infer<typeof ContactGroupSchema>;
 
 export type ContactsState = {
   contacts: Contact[];

--- a/features/flow/contacts/src/steps/Detail/createContactAddressDetailActionsPorts.ts
+++ b/features/flow/contacts/src/steps/Detail/createContactAddressDetailActionsPorts.ts
@@ -3,18 +3,25 @@ import {
   deleteAddress as deleteAddressAction,
   parseContactAddressLabel,
   selectContactAddressById,
+  selectContactById,
   updateAddress as updateAddressAction,
 } from "@domain/entity-contact";
+import {
+  createMockContactDeviceIntentsPort,
+  type ContactDeviceIntentsPort,
+} from "@features/platform-contacts";
 import type { ContactAddressDetailActionsDataPorts } from "./model/ports";
 
 type ContactAddressDetailActionsPortsDeps = Readonly<{
   dispatch: (action: { type: string }) => void;
   getState: () => Parameters<typeof selectContactAddressById>[0];
+  deviceIntents?: ContactDeviceIntentsPort;
 }>;
 
 export function createContactAddressDetailActionsPorts({
   dispatch,
   getState,
+  deviceIntents = createMockContactDeviceIntentsPort(),
 }: ContactAddressDetailActionsPortsDeps): ContactAddressDetailActionsDataPorts {
   return {
     edit: {
@@ -24,13 +31,24 @@ export function createContactAddressDetailActionsPorts({
         if (currentAddress === undefined) {
           throw new ContactError(`Address not found: ${addressId}`);
         }
+        const currentContact = selectContactById(getState(), contactId);
+        if (currentContact === undefined) {
+          throw new ContactError(`Contact not found: ${contactId}`);
+        }
+        const parsedLabel = parseContactAddressLabel(label);
+        const device = await deviceIntents.editExternalAddressScope({
+          contact: currentContact,
+          address: currentAddress,
+          label: parsedLabel,
+        });
 
         dispatch(
           updateAddressAction({
             contactId,
             address: {
               ...currentAddress,
-              label: parseContactAddressLabel(label),
+              label: parsedLabel,
+              device,
             },
           }),
         );

--- a/features/flow/contacts/src/steps/Detail/createContactDetailActionsPorts.ts
+++ b/features/flow/contacts/src/steps/Detail/createContactDetailActionsPorts.ts
@@ -5,21 +5,41 @@ import {
   renameContact as renameContactAction,
   selectContactById,
 } from "@domain/entity-contact";
+import {
+  createMockContactDeviceIntentsPort,
+  type ContactDeviceIntentsPort,
+} from "@features/platform-contacts";
 import type { ContactDetailActionsPorts } from "./model/ports";
 
 type ContactDetailActionsPortsDeps = Readonly<{
   dispatch: (action: { type: string }) => void;
   getState: () => Parameters<typeof selectContactById>[0];
+  deviceIntents?: ContactDeviceIntentsPort;
 }>;
 
 export function createContactDetailActionsPorts({
   dispatch,
   getState,
+  deviceIntents = createMockContactDeviceIntentsPort(),
 }: ContactDetailActionsPortsDeps): ContactDetailActionsPorts {
   return {
     edit: {
       renameContact: async ({ contactId, name }) => {
-        dispatch(renameContactAction({ contactId, name: parseContactName(name) }));
+        const currentContact = selectContactById(getState(), contactId);
+        if (currentContact === undefined) {
+          throw new ContactError(`Contact not found: ${contactId}`);
+        }
+
+        const parsedName = parseContactName(name);
+        const deviceCredentials =
+          currentContact.addresses.length === 0
+            ? undefined
+            : await deviceIntents.renameExternalContact({
+                contact: currentContact,
+                name: parsedName,
+              });
+
+        dispatch(renameContactAction({ contactId, name: parsedName, deviceCredentials }));
         const updatedContact = selectContactById(getState(), contactId);
 
         if (updatedContact === undefined) {

--- a/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/contactDetailSharedState.web.test.ts
@@ -1,4 +1,4 @@
-import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { mockContact, mockContactAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
 import {
   createContactDetailLedgerWalletAccountsIntent,
   createContactDetailSharedState,
@@ -40,14 +40,7 @@ describe("createContactDetailSharedState", () => {
 
   it("counts only external addresses saved on Me", () => {
     const me = mockMeContact({
-      addresses: [
-        {
-          id: "address-ethereum",
-          currencyId: "ethereum",
-          label: "Ethereum",
-          address: "0x1ad23b2cf8d2e0591ea417eb82f7cd9746c53034",
-        },
-      ],
+      addresses: [mockContactAddress()],
     });
 
     expect(createContactDetailSharedState(me, formatMeDisplayName).addressCount).toBe(1);

--- a/features/platform/contacts/README.md
+++ b/features/platform/contacts/README.md
@@ -3,7 +3,8 @@
 > [!CAUTION]
 > **Status: UNSTABLE** — In active development as part of the DDD migration.
 
-Contacts domain selectors, display helpers, and React hooks shared by flow packages.
+Contacts domain selectors, display helpers, React hooks, and Device Intent ports shared by flow
+packages.
 
 ## Exports
 
@@ -12,3 +13,5 @@ Contacts domain selectors, display helpers, and React hooks shared by flow packa
 - `useContactsMeContact()`: selects the self Contact from the Redux store.
 - `identityFormatMeDisplayName()` and `resolveMeContactDisplayName()`: resolve the shared display
   name rules used by Contacts List and Detail.
+- `ContactDeviceIntentsPort`: defines the typed boundary for Contacts device interactions.
+- `createMockContactDeviceIntentsPort()`: returns temporary typed device results for Contacts flows.

--- a/features/platform/contacts/src/contactDeviceIntentsPort.test.ts
+++ b/features/platform/contacts/src/contactDeviceIntentsPort.test.ts
@@ -1,0 +1,62 @@
+import {
+  mockContact,
+  mockContactAddress,
+  mockContactWithAddress,
+} from "@domain/entity-contact/schema.mock";
+import { ContactAddressLabelSchema, ContactNameSchema } from "@domain/entity-contact";
+import {
+  createMockContactDeviceIntentsPort,
+  type ContactDeviceIntentsPort,
+} from "./contactDeviceIntentsPort";
+
+describe("createMockContactDeviceIntentsPort", () => {
+  let port: ContactDeviceIntentsPort;
+
+  beforeEach(() => {
+    port = createMockContactDeviceIntentsPort();
+  });
+
+  it("should return group credentials and an address context when registering an address", async () => {
+    const contact = mockContact();
+    const address = mockContactAddress();
+
+    await expect(
+      port.registerExternalAddress({
+        contact,
+        currencyId: address.currencyId,
+        label: address.label,
+        address: address.address,
+      }),
+    ).resolves.toEqual({
+      deviceCredentials: {
+        groupHandle: "mock-contact-group-handle",
+        hmacProof: "mock-external-contact-name-proof",
+      },
+      addressDeviceContext: {
+        blockchainFamily: "mock-blockchain-family",
+        chainId: "mock-chain-id",
+        hmacRest: "mock-external-address-proof",
+      },
+    });
+  });
+
+  it("should replace only the proof returned by a signed rename or scope edit", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+
+    await expect(
+      port.renameExternalContact({ contact, name: ContactNameSchema.parse("Raphael") }),
+    ).resolves.toMatchObject({ hmacProof: "mock-external-contact-name-proof-after-rename" });
+    await expect(
+      port.editExternalAddressScope({
+        contact,
+        address,
+        label: ContactAddressLabelSchema.parse("Treasury"),
+      }),
+    ).resolves.toMatchObject({
+      blockchainFamily: address.device.blockchainFamily,
+      chainId: address.device.chainId,
+      hmacRest: "mock-external-address-proof-after-scope-edit",
+    });
+  });
+});

--- a/features/platform/contacts/src/contactDeviceIntentsPort.ts
+++ b/features/platform/contacts/src/contactDeviceIntentsPort.ts
@@ -1,0 +1,71 @@
+import {
+  ExternalAddressProofSchema,
+  ExternalContactNameProofSchema,
+  type Contact,
+  type ContactAddress,
+  type ContactAddressLabel,
+  type ContactAddressValue,
+  type ContactName,
+} from "@domain/entity-contact";
+import {
+  mockDeviceContactGroupCredentials,
+  mockExternalAddressDeviceContext,
+} from "@domain/entity-contact/schema.mock";
+
+export type RegisterExternalAddressIntentInput = Readonly<{
+  contact: Pick<Contact, "id" | "name" | "deviceCredentials">;
+  currencyId: ContactAddress["currencyId"];
+  label: ContactAddressLabel;
+  address: ContactAddressValue;
+}>;
+
+export type RegisterExternalAddressIntentResult = Readonly<{
+  deviceCredentials: NonNullable<Contact["deviceCredentials"]>;
+  addressDeviceContext: ContactAddress["device"];
+}>;
+
+export type RenameExternalContactIntentInput = Readonly<{
+  contact: Contact;
+  name: ContactName;
+}>;
+
+export type EditExternalAddressScopeIntentInput = Readonly<{
+  contact: Contact;
+  address: ContactAddress;
+  label: ContactAddressLabel;
+}>;
+
+export type ContactDeviceIntentsPort = Readonly<{
+  registerExternalAddress(
+    input: RegisterExternalAddressIntentInput,
+  ): Promise<RegisterExternalAddressIntentResult>;
+  renameExternalContact(
+    input: RenameExternalContactIntentInput,
+  ): Promise<NonNullable<Contact["deviceCredentials"]>>;
+  editExternalAddressScope(
+    input: EditExternalAddressScopeIntentInput,
+  ): Promise<ContactAddress["device"]>;
+}>;
+
+export function createMockContactDeviceIntentsPort(): ContactDeviceIntentsPort {
+  return {
+    registerExternalAddress: async input => ({
+      deviceCredentials: input.contact.deviceCredentials ?? mockDeviceContactGroupCredentials(),
+      addressDeviceContext: mockExternalAddressDeviceContext(),
+    }),
+    renameExternalContact: async input =>
+      mockDeviceContactGroupCredentials({
+        ...(input.contact.deviceCredentials === undefined
+          ? {}
+          : { groupHandle: input.contact.deviceCredentials.groupHandle }),
+        hmacProof: ExternalContactNameProofSchema.parse(
+          "mock-external-contact-name-proof-after-rename",
+        ),
+      }),
+    editExternalAddressScope: async input =>
+      mockExternalAddressDeviceContext({
+        ...input.address.device,
+        hmacRest: ExternalAddressProofSchema.parse("mock-external-address-proof-after-scope-edit"),
+      }),
+  };
+}

--- a/features/platform/contacts/src/index.native.ts
+++ b/features/platform/contacts/src/index.native.ts
@@ -5,3 +5,4 @@ export * from "./utils/getContactAvatarColorClass";
 export * from "./utils/formatMeDisplayName";
 export * from "./utils/resolveMeContactDisplayName";
 export * from "./components/ContactAvatar/index.native";
+export * from "./contactDeviceIntentsPort";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -4,3 +4,4 @@ export * from "./hooks/useContactsMeContact";
 export * from "./utils/getContactAvatarColorClass";
 export * from "./utils/formatMeDisplayName";
 export * from "./utils/resolveMeContactDisplayName";
+export * from "./contactDeviceIntentsPort";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1713,6 +1713,9 @@ importers:
       '@features/platform-aggregated-assets':
         specifier: workspace:*
         version: link:../../features/platform/aggregated-assets
+      '@features/platform-contacts':
+        specifier: workspace:^
+        version: link:../../features/platform/contacts
       '@features/platform-currencies':
         specifier: workspace:^
         version: link:../../features/platform/currencies
@@ -4268,6 +4271,9 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
+      '@shared/cloud-sync-module':
+        specifier: workspace:^
+        version: link:../../../shared/cloud-sync-module
       '@shared/schema-primitives':
         specifier: workspace:*
         version: link:../../../shared/schema-primitives


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Domain and Flow suites cover the persistent wire document, opaque Device Intent data, mutation invariants, and the typed mock port.
- [x] **Impact of the changes:**
      Validate Contacts creation, address addition, contact rename, address-label update, and the device data persisted by each signed mutation.

### 📝 Description

This PR makes the Contacts data model safe to persist through Ledger Sync before the Wallet Sync registration work begins.

It introduces a stable `{ me, contactGroups }` document, typed opaque Device Intent values, and complete remote replacement while preserving unknown future fields. `Me` remains structural in the remote document; `ContactGroup` and `ExternalAddress` identifiers are synchronized. Contacts with addresses require device credentials, and each address persists its device context.

The Cloud Sync implementation is grouped under `src/cloudSync/` and separated into focused wire-schema, state-conversion, and extension-preservation modules. The root `cloudSyncModule.ts` remains a compatibility façade, while the nested module only orchestrates the Cloud Sync contract hooks.

The Contacts entity owns the Device Intent result types because it persists and synchronizes them. A temporary typed mock port is wired into Desktop, Mobile, and shared edit flows so every address addition, signed contact rename, and address-label update stores the same shape returned by the future device boundary. The mock will be replaced by the real DIE implementation before Wallet Sync registration; no Wallet Sync registration is included in this PR.

### ❓ Context

- **JIRA issue**: [LIVE-33959](https://ledgerhq.atlassian.net/browse/LIVE-33959)
- **ADR**: [Contacts Device Intents](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7299039425/ADR+Contacts+Device+Intents#External-Contact-Group-And-Address-Record)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked Jira issue.
- **The PR description clearly documents the changes** made and explains the temporary mock Device Intent port.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-33959]: https://ledgerhq.atlassian.net/browse/LIVE-33959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ