### PR TITLE
fix(changeset): drop @ledgerhq/coin-tezos from LIVE-32915 changeset

### DIFF
--- a/.changeset/LIVE-32915-remove-errors-package.md
+++ b/.changeset/LIVE-32915-remove-errors-package.md
@@ -25,7 +25,6 @@
 "@ledgerhq/coin-sui": patch
 "@ledgerhq/coin-tester-stellar": patch
 "@ledgerhq/coin-tester-xrp": patch
-"@ledgerhq/coin-tezos": patch
 "@ledgerhq/coin-ton": patch
 "@ledgerhq/coin-tron": patch
 "@ledgerhq/coin-vechain": patch


### PR DESCRIPTION
### 📝 Description

`changeset status` (and therefore the release tooling) fails on `develop`:

```
❌ .changeset/LIVE-32915-remove-errors-package.md: Package '@ledgerhq/coin-tezos' not found in workspace
```

The Tezos coin module was extracted out of the monorepo (`feat(tezos): extract Tezos and remove types-live dependency`, 6be80d873a9), but the LIVE-32915 changeset landed with `@ledgerhq/coin-tezos` still listed. Only stale `lib/` build artifacts remain in `libs/coin-modules/coin-tezos/`, so the package no longer resolves.

This removes that single line. All other entries in the changeset were checked against the workspace and are valid; `npx changeset status` now passes.

### 🔗 Context

- **JIRA / GitHub issue**: LIVE-32915
- **ADR** (if any): n/a