### PR TITLE
[LWM] fix(pay-card): use unique Pay tab navigator route (LIVE-34743)

### DIFF
--- a/.changeset/calm-tabs-navigate.md
+++ b/.changeset/calm-tabs-navigate.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the Pay tab navigator route name collision

--- a/apps/ledger-live-mobile/src/const/navigation.ts
+++ b/apps/ledger-live-mobile/src/const/navigation.ts
@@ -775,7 +775,7 @@ export enum NavigatorName {
   // Tab
   Main = "Main",
   CardTab = "CardTab",
-  PayTab = "PayTab",
+  PayTab = "PayTabNavigator",
   // Root
   RootNavigator = "RootNavigator",
   Discover = "Discover",


### PR DESCRIPTION
## Summary

- Rename the outer Pay tab navigator route from `PayTab` to `PayTabNavigator`, while keeping the nested screen route as `PayTab`.
- Fix the React Navigation warning reporting nested screens with the same name: `Base > Main > PayTab` and `Base > Main > PayTab > PayTab`.
- Add a `live-mobile` changeset documenting the fix.

## Why

React Navigation requires route names to be unique across nested navigator levels. Both the outer tab route and its inner screen resolved to `PayTab`, which produced a console warning and could make navigation targeting and state resolution ambiguous.

The independent `process.env.EXPO_OS` Babel warning is outside this PR's scope.

## Stack

- Base PR: [#20096](https://github.com/LedgerHQ/ledger-live/pull/20096)

## Test plan

- [x] `pnpm nx run live-mobile:lint`
- [x] `pnpm nx run live-mobile:format:check`
- [x] `pnpm nx run live-mobile:typecheck`
- [x] `pnpm --filter live-mobile test:jest --runInBand --findRelatedTests src/const/navigation.ts --passWithNoTests` (689 suites, 4645 tests passed)

Made with [Cursor](https://cursor.com)