### PR TITLE
refactor(architecture): move currency id schemas to domain packages

### DIFF
--- a/.changeset/currency-ids-move-to-domain.md
+++ b/.changeset/currency-ids-move-to-domain.md
@@ -1,0 +1,19 @@
+---
+"@domain/entity-currency-crypto": minor
+"@domain/entity-currency-token": minor
+"@domain/entity-currency-fiat": minor
+"@shared/schema-primitives": minor
+"@domain/entity-contact": minor
+---
+
+Move the currency id schemas to the packages that own them.
+
+`CryptoCurrencyIdSchema`, `TokenCurrencyIdSchema` and `FiatCurrencyIdSchema` (and their inferred
+types) now live in `@domain/entity-currency-crypto`, `@domain/entity-currency-token` and
+`@domain/entity-currency-fiat` respectively, instead of `@shared/schema-primitives`. A primitives
+package has no business knowing about crypto, tokens or fiat.
+
+The crypto and token packages used to re-export these symbols from primitives, which made them
+proxies: two import paths for the same thing, and no obvious original provider. Consumers already
+importing from `@domain/entity-currency-*` are unaffected, since the symbols genuinely moved there.
+Anything importing them from `@shared/schema-primitives` must now import the owning domain package.

--- a/domain/entity/contact/package.json
+++ b/domain/entity/contact/package.json
@@ -19,6 +19,8 @@
     "unimported": "pnpm knip --directory ../../.. -W domain/entity/contact"
   },
   "dependencies": {
+    "@domain/entity-currency-crypto": "workspace:*",
+    "@domain/entity-currency-token": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"

--- a/domain/entity/contact/src/schema.ts
+++ b/domain/entity/contact/src/schema.ts
@@ -1,8 +1,6 @@
-import {
-  CryptoCurrencyIdSchema,
-  NonEmptyStringSchema,
-  TokenCurrencyIdSchema,
-} from "@shared/schema-primitives";
+import { CryptoCurrencyIdSchema } from "@domain/entity-currency-crypto";
+import { TokenCurrencyIdSchema } from "@domain/entity-currency-token";
+import { NonEmptyStringSchema } from "@shared/schema-primitives";
 import { z } from "zod";
 import {
   ContactAddressLabelTooLongError,

--- a/domain/entity/currency-crypto/package.json
+++ b/domain/entity/currency-crypto/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@domain/entity-currency-unit": "workspace:*",
-    "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/domain/entity/currency-crypto/src/index.ts
+++ b/domain/entity/currency-crypto/src/index.ts
@@ -1,5 +1,3 @@
 export * from "./schema";
 export * from "./registry";
 export * from "./legacy/accessors";
-export type { CryptoCurrencyId } from "@shared/schema-primitives";
-export { CryptoCurrencyIdSchema } from "@shared/schema-primitives";

--- a/domain/entity/currency-crypto/src/schema.mock.ts
+++ b/domain/entity/currency-crypto/src/schema.mock.ts
@@ -1,5 +1,4 @@
-import { CryptoCurrencyIdSchema } from "@shared/schema-primitives";
-import type { CryptoCurrency } from "./schema";
+import { CryptoCurrencyIdSchema, type CryptoCurrency } from "./schema";
 
 export function mockCryptoCurrency(overrides?: Partial<CryptoCurrency>): CryptoCurrency {
   return {

--- a/domain/entity/currency-crypto/src/schema.test.ts
+++ b/domain/entity/currency-crypto/src/schema.test.ts
@@ -2,9 +2,19 @@ import {
   ExplorerViewSchema,
   BitcoinLikeInfoSchema,
   EthereumLikeInfoSchema,
+  CryptoCurrencyIdSchema,
   CryptoCurrencySchema,
 } from "./schema";
 import { mockCryptoCurrency } from "./schema.mock";
+
+describe("CryptoCurrencyIdSchema", () => {
+  it("accepts a non-empty string", () => {
+    expect(CryptoCurrencyIdSchema.parse("bitcoin")).toBe("bitcoin");
+  });
+  it("rejects an empty string", () => {
+    expect(() => CryptoCurrencyIdSchema.parse("")).toThrow();
+  });
+});
 
 describe("ExplorerViewSchema", () => {
   it("accepts an empty object", () => {

--- a/domain/entity/currency-crypto/src/schema.ts
+++ b/domain/entity/currency-crypto/src/schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
-import { CryptoCurrencyIdSchema } from "@shared/schema-primitives";
 import { UnitSchema } from "@domain/entity-currency-unit";
+
+/** Opaque identifier for a crypto currency (e.g. `"bitcoin"`, `"ethereum"`). Non-empty string. */
+export const CryptoCurrencyIdSchema = z.string().min(1).brand<"CryptoCurrencyId">();
 
 /**
  * Blockchain explorer URL templates for a crypto currency.
@@ -107,6 +109,8 @@ export const CryptoCurrencySchema = z.object({
   tokenTypes: z.array(z.string()).optional(),
 });
 
+/** A crypto currency id, inferred from {@link CryptoCurrencyIdSchema}. */
+export type CryptoCurrencyId = z.infer<typeof CryptoCurrencyIdSchema>;
 /** A crypto currency entity, inferred from {@link CryptoCurrencySchema}. */
 export type CryptoCurrency = z.infer<typeof CryptoCurrencySchema>;
 /** Explorer view value object, inferred from {@link ExplorerViewSchema}. */

--- a/domain/entity/currency-fiat/src/schema.test.ts
+++ b/domain/entity/currency-fiat/src/schema.test.ts
@@ -1,5 +1,14 @@
-import { FiatCurrencySchema } from "./schema";
+import { FiatCurrencyIdSchema, FiatCurrencySchema } from "./schema";
 import { mockFiatCurrency } from "./schema.mock";
+
+describe("FiatCurrencyIdSchema", () => {
+  it("accepts a non-empty string", () => {
+    expect(FiatCurrencyIdSchema.parse("usd")).toBe("usd");
+  });
+  it("rejects an empty string", () => {
+    expect(() => FiatCurrencyIdSchema.parse("")).toThrow();
+  });
+});
 
 describe("FiatCurrencySchema", () => {
   it("parses a valid fiat currency from mock factory", () => {

--- a/domain/entity/currency-fiat/src/schema.ts
+++ b/domain/entity/currency-fiat/src/schema.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 import { UnitSchema } from "@domain/entity-currency-unit";
 
+/** Opaque identifier for a fiat currency (e.g. `"usd"`, `"eur"`). Non-empty string. */
+export const FiatCurrencyIdSchema = z.string().min(1).brand<"FiatCurrencyId">();
+
 /**
  * Canonical Zod-first schema for a fiat currency entity.
  *
@@ -29,5 +32,7 @@ export const FiatCurrencySchema = z.object({
   keywords: z.array(z.string()).optional(),
 });
 
+/** A fiat currency id, inferred from {@link FiatCurrencyIdSchema}. */
+export type FiatCurrencyId = z.infer<typeof FiatCurrencyIdSchema>;
 /** A fiat currency entity, inferred from {@link FiatCurrencySchema}. */
 export type FiatCurrency = z.infer<typeof FiatCurrencySchema>;

--- a/domain/entity/currency-token/package.json
+++ b/domain/entity/currency-token/package.json
@@ -19,8 +19,8 @@
     "unimported": "pnpm knip --directory ../../.. -W domain/entity/currency-token"
   },
   "dependencies": {
+    "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-unit": "workspace:*",
-    "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/domain/entity/currency-token/src/index.ts
+++ b/domain/entity/currency-token/src/index.ts
@@ -1,4 +1,2 @@
 export * from "./schema";
 export * from "./define";
-export type { TokenCurrencyId } from "@shared/schema-primitives";
-export { TokenCurrencyIdSchema } from "@shared/schema-primitives";

--- a/domain/entity/currency-token/src/schema.mock.ts
+++ b/domain/entity/currency-token/src/schema.mock.ts
@@ -1,5 +1,5 @@
-import { TokenCurrencyIdSchema, CryptoCurrencyIdSchema } from "@shared/schema-primitives";
-import type { TokenCurrency } from "./schema";
+import { CryptoCurrencyIdSchema } from "@domain/entity-currency-crypto";
+import { TokenCurrencyIdSchema, type TokenCurrency } from "./schema";
 
 /**
  * Returns a valid {@link TokenCurrency} fixture (USDT on Ethereum, ERC-20).

--- a/domain/entity/currency-token/src/schema.test.ts
+++ b/domain/entity/currency-token/src/schema.test.ts
@@ -1,5 +1,16 @@
-import { TokenCurrencySchema } from "./schema";
+import { TokenCurrencyIdSchema, TokenCurrencySchema } from "./schema";
 import { mockTokenCurrency } from "./schema.mock";
+
+describe("TokenCurrencyIdSchema", () => {
+  it("accepts a non-empty string", () => {
+    expect(TokenCurrencyIdSchema.parse("ethereum/erc20/usd-tether")).toBe(
+      "ethereum/erc20/usd-tether",
+    );
+  });
+  it("rejects an empty string", () => {
+    expect(() => TokenCurrencyIdSchema.parse("")).toThrow();
+  });
+});
 
 describe("TokenCurrencySchema", () => {
   it("parses a valid token currency from mock factory", () => {

--- a/domain/entity/currency-token/src/schema.ts
+++ b/domain/entity/currency-token/src/schema.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
-import { TokenCurrencyIdSchema, CryptoCurrencyIdSchema } from "@shared/schema-primitives";
+import { CryptoCurrencyIdSchema } from "@domain/entity-currency-crypto";
 import { UnitSchema } from "@domain/entity-currency-unit";
+
+/** Opaque identifier for a token (e.g. `"ethereum/erc20/usd-tether"`). Non-empty string. */
+export const TokenCurrencyIdSchema = z.string().min(1).brand<"TokenCurrencyId">();
 
 /**
  * Canonical Zod-first schema for a token currency entity.
@@ -38,5 +41,7 @@ export const TokenCurrencySchema = z.object({
   ledgerSignature: z.string().optional(),
 });
 
+/** A token currency id, inferred from {@link TokenCurrencyIdSchema}. */
+export type TokenCurrencyId = z.infer<typeof TokenCurrencyIdSchema>;
 /** A token currency entity, inferred from {@link TokenCurrencySchema}. */
 export type TokenCurrency = z.infer<typeof TokenCurrencySchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4223,6 +4223,12 @@ importers:
 
   domain/entity/contact:
     dependencies:
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../currency-crypto
+      '@domain/entity-currency-token':
+        specifier: workspace:*
+        version: link:../currency-token
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
@@ -4285,9 +4291,6 @@ importers:
       '@domain/entity-currency-unit':
         specifier: workspace:*
         version: link:../currency-unit
-      '@shared/schema-primitives':
-        specifier: workspace:*
-        version: link:../../../shared/schema-primitives
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -4344,12 +4347,12 @@ importers:
 
   domain/entity/currency-token:
     dependencies:
+      '@domain/entity-currency-crypto':
+        specifier: workspace:*
+        version: link:../currency-crypto
       '@domain/entity-currency-unit':
         specifier: workspace:*
         version: link:../currency-unit
-      '@shared/schema-primitives':
-        specifier: workspace:*
-        version: link:../../../shared/schema-primitives
       zod:
         specifier: 'catalog:'
         version: 4.3.6

--- a/shared/schema-primitives/src/string.test.ts
+++ b/shared/schema-primitives/src/string.test.ts
@@ -1,43 +1,11 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   BigNumberStrSchema,
-  CryptoCurrencyIdSchema,
   DateTimeIsoSchema,
-  FiatCurrencyIdSchema,
   HttpUrlSchema,
   NonEmptyStringSchema,
   SemVerSchema,
-  TokenCurrencyIdSchema,
 } from "./string";
-
-describe("CryptoCurrencyIdSchema", () => {
-  it("accepts a non-empty string", () => {
-    expect(CryptoCurrencyIdSchema.parse("bitcoin")).toBe("bitcoin");
-  });
-  it("rejects an empty string", () => {
-    expect(() => CryptoCurrencyIdSchema.parse("")).toThrow();
-  });
-});
-
-describe("TokenCurrencyIdSchema", () => {
-  it("accepts a non-empty string", () => {
-    expect(TokenCurrencyIdSchema.parse("ethereum/erc20/usd-tether")).toBe(
-      "ethereum/erc20/usd-tether",
-    );
-  });
-  it("rejects an empty string", () => {
-    expect(() => TokenCurrencyIdSchema.parse("")).toThrow();
-  });
-});
-
-describe("FiatCurrencyIdSchema", () => {
-  it("accepts a non-empty string", () => {
-    expect(FiatCurrencyIdSchema.parse("usd")).toBe("usd");
-  });
-  it("rejects an empty string", () => {
-    expect(() => FiatCurrencyIdSchema.parse("")).toThrow();
-  });
-});
 
 describe("BigNumberStrSchema", () => {
   it("accepts a decimal string", () => {

--- a/shared/schema-primitives/src/string.ts
+++ b/shared/schema-primitives/src/string.ts
@@ -1,14 +1,5 @@
 import { z } from "zod";
 
-/** Opaque identifier for a crypto currency (e.g. `"bitcoin"`, `"ethereum"`). Non-empty string. */
-export const CryptoCurrencyIdSchema = z.string().min(1).brand<"CryptoCurrencyId">();
-
-/** Opaque identifier for a token (e.g. `"ethereum/erc20/usd-tether"`). Non-empty string. */
-export const TokenCurrencyIdSchema = z.string().min(1).brand<"TokenCurrencyId">();
-
-/** Opaque identifier for a fiat currency (e.g. `"usd"`, `"eur"`). Non-empty string. */
-export const FiatCurrencyIdSchema = z.string().min(1).brand<"FiatCurrencyId">();
-
 /**
  * Arbitrary-precision decimal number encoded as a string.
  * Use this for on-chain amounts to avoid IEEE 754 precision loss.
@@ -51,9 +42,6 @@ export const SemVerSchema = z
   .regex(/^\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?$/, "Expected a semver string (e.g. 1.2.3)")
   .brand<"SemVer">();
 
-export type CryptoCurrencyId = z.infer<typeof CryptoCurrencyIdSchema>;
-export type TokenCurrencyId = z.infer<typeof TokenCurrencyIdSchema>;
-export type FiatCurrencyId = z.infer<typeof FiatCurrencyIdSchema>;
 export type BigNumberStr = z.infer<typeof BigNumberStrSchema>;
 export type NonEmptyString = z.infer<typeof NonEmptyStringSchema>;
 export type DateTimeIso = z.infer<typeof DateTimeIsoSchema>;


### PR DESCRIPTION
### 📝 Description

`CryptoCurrencyIdSchema`, `TokenCurrencyIdSchema` and `FiatCurrencyIdSchema` (and their inferred
types) move from `@shared/schema-primitives` to the packages that own them:

| Symbol | From | To |
| --- | --- | --- |
| `CryptoCurrencyIdSchema` / `CryptoCurrencyId` | `@shared/schema-primitives` | `@domain/entity-currency-crypto` |
| `TokenCurrencyIdSchema` / `TokenCurrencyId` | `@shared/schema-primitives` | `@domain/entity-currency-token` |
| `FiatCurrencyIdSchema` / `FiatCurrencyId` | `@shared/schema-primitives` | `@domain/entity-currency-fiat` |

Two reasons:

1. **A primitives package has no business knowing about crypto, tokens or fiat.** After this
   change `shared/schema-primitives` no longer contains the word "currency" — it is back to
   generic string primitives (`NonEmptyString`, `BigNumberStr`, `DateTimeIso`, `HttpUrl`, `SemVer`).
2. **The crypto and token barrels were proxies.** They re-exported these symbols from primitives,
   so the same symbol had two import paths and no obvious original provider.

```ts
// domain/entity/currency-crypto/src/index.ts — before
export * from "./schema";
export type { CryptoCurrencyId } from "@shared/schema-primitives";
export { CryptoCurrencyIdSchema } from "@shared/schema-primitives";

// after
export * from "./schema";
```

#### Blast radius

Small, and measured before starting. Only **5 files** imported these symbols from
`@shared/schema-primitives`, four of them inside the crypto and token packages themselves; the
fifth is `domain/entity/contact/src/schema.ts`.

The **70 files** that consume these symbols today already import them from
`@domain/entity-currency-*` through the proxy, so they are untouched — the symbol genuinely moved
to the package they were already naming.

Dependency changes: `currency-crypto` drops `@shared/schema-primitives`; `currency-token` swaps it
for `@domain/entity-currency-crypto` (no cycle, crypto does not depend on token); `contact` gains
both currency packages and keeps primitives for `NonEmptyStringSchema`.

The three `describe` blocks covering the id schemas moved out of `string.test.ts` into each
package's `schema.test.ts`, unchanged.

#### Checks

- `nx run-many -t typecheck` on the 6 affected projects — green
- `nx run-many -t test` on the same — 216 tests green
- `nx run enforce-boundaries:lint:boundaries` — `✓ module boundaries ok`

### 🔗 Context

- **JIRA / GitHub issue**: _none — groundwork for an upcoming nx plugin that forbids barrels from re-exporting another workspace package_
- **ADR** (if any): n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
