### PR TITLE
[LWDM] feat(contacts): signer-required address delete actions (LIVE-33954)

### DIFF
--- a/.changeset/contacts-address-delete-signer.md
+++ b/.changeset/contacts-address-delete-signer.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-contacts": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Require signer confirmation before opening address delete confirmation in Contacts.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -917,7 +917,7 @@ describe("Contacts integration", () => {
     expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
   });
 
-  it("should open the delete address dialog from the address detail dialog", async () => {
+  it("should open the signer dialog before deleting an address", async () => {
     const { user } = renderContactsScreen(populatedContactsPageState);
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
@@ -925,7 +925,15 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-address-detail-delete"));
 
     expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
-    expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    expect(screen.queryByTestId("contacts-delete-address-dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    });
   });
 
   it("should delete an address and close the address detail dialog", async () => {
@@ -934,6 +942,12 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
     await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
     await user.click(screen.getByTestId("contacts-address-detail-delete"));
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    });
+
     await user.click(screen.getByTestId("contacts-delete-address-confirm"));
 
     await waitFor(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -849,7 +849,7 @@ describe("Contacts integration", () => {
     });
   });
 
-  it("should open the delete address sheet from the address detail sheet", async () => {
+  it("should open the signer sheet before deleting an address", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withContactsPageReadyState(
         { lwmContacts: { enabled: true, params: { newBadge: false } } },
@@ -862,8 +862,17 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByTestId("contacts-address-detail-delete"));
 
-    expect(await screen.findByTestId("contacts-delete-address-confirm")).toBeVisible();
-    expect(screen.getByText("Delete address?")).toBeVisible();
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+    expect(screen.getByText("Confirm on your device")).toBeVisible();
+    expect(screen.queryByTestId("contacts-delete-address-confirm")).toBeNull();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(screen.getByTestId("contacts-delete-address-confirm")).toBeVisible();
+      expect(screen.getByText("Delete address?")).toBeVisible();
+    });
   });
 
   it("should delete an address and close the address detail sheet", async () => {
@@ -878,7 +887,13 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByTestId("contacts-address-detail-delete"));
-    await user.press(await screen.findByTestId("contacts-delete-address-confirm"));
+    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-delete-address-confirm")).toBeVisible();
+    });
+
+    await user.press(screen.getByTestId("contacts-delete-address-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-delete-address-confirm")).toBeNull();

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
@@ -1,5 +1,5 @@
 import type { ContactAddress, ContactAddressId, ContactId } from "@domain/entity-contact";
-import { CONTACT_ADDRESS_EDIT_REQUIREMENT } from "./editRequirement";
+import { CONTACT_ADDRESS_DELETE_REQUIREMENT, CONTACT_ADDRESS_EDIT_REQUIREMENT } from "./editRequirement";
 import type {
   ContactAddressDeleteLifecycle,
   ContactAddressDetailDeleteIntent,
@@ -40,6 +40,7 @@ export function createContactAddressDetailDeleteIntent(
     type: "delete-address",
     contactId,
     addressId,
+    deleteRequirement: CONTACT_ADDRESS_DELETE_REQUIREMENT,
   };
 }
 

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.web.test.ts
@@ -43,7 +43,7 @@ describe("createContactAddressDetailEditIntent", () => {
 });
 
 describe("createContactAddressDetailDeleteIntent", () => {
-  it("exposes a delete-address intent for the selected address", () => {
+  it("exposes a delete-address intent with a signer-required requirement for the selected address", () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
 
@@ -51,6 +51,10 @@ describe("createContactAddressDetailDeleteIntent", () => {
       type: "delete-address",
       contactId: contact.id,
       addressId: address.id,
+      deleteRequirement: {
+        type: "confirmation-required",
+        reason: "contact-has-address",
+      },
     });
   });
 });

--- a/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
+++ b/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
@@ -15,6 +15,8 @@ export const CONTACT_ADDRESS_EDIT_REQUIREMENT = {
   reason: "contact-has-address",
 } as const satisfies ContactEditRequirement;
 
+export const CONTACT_ADDRESS_DELETE_REQUIREMENT = CONTACT_ADDRESS_EDIT_REQUIREMENT;
+
 export function resolveContactEditRequirement(contact: Contact): ContactEditRequirement {
   return contact.addresses.length > 0
     ? { type: "confirmation-required", reason: "contact-has-address" }

--- a/features/flow/contacts/src/steps/Detail/model/signerPendingAction.ts
+++ b/features/flow/contacts/src/steps/Detail/model/signerPendingAction.ts
@@ -1,0 +1,27 @@
+import type {
+  ContactAddressDetailDeleteIntent,
+  ContactAddressDetailEditIntent,
+} from "../types";
+
+export type SignerPendingAction = "edit" | "delete";
+
+type SignerValidationTarget = Readonly<{
+  contactId: ContactAddressDetailEditIntent["contactId"];
+  addressId: ContactAddressDetailEditIntent["addressId"];
+}>;
+
+export function resolveSignerValidationTarget(
+  pendingAction: SignerPendingAction | null,
+  editIntent: ContactAddressDetailEditIntent | undefined,
+  deleteIntent: ContactAddressDetailDeleteIntent,
+): SignerValidationTarget | undefined {
+  if (pendingAction === "edit") {
+    return editIntent;
+  }
+
+  if (pendingAction === "delete") {
+    return deleteIntent;
+  }
+
+  return undefined;
+}

--- a/features/flow/contacts/src/steps/Detail/types.ts
+++ b/features/flow/contacts/src/steps/Detail/types.ts
@@ -135,6 +135,7 @@ export type ContactAddressDetailDeleteIntent = Readonly<{
   type: "delete-address";
   contactId: ContactId;
   addressId: ContactAddressId;
+  deleteRequirement: ContactEditRequirement;
 }>;
 
 export type ContactAddressDeleteLifecycle =
@@ -149,4 +150,5 @@ export type ContactAddressDetailActionsViewModel = Readonly<{
   deleteIntent: ContactAddressDetailDeleteIntent;
   deleteLifecycle: ContactAddressDeleteLifecycle;
   isSignerRequiredForEdit: boolean;
+  isSignerRequiredForDelete: boolean;
 }>;

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
@@ -7,6 +7,10 @@ import {
 import { ContactAddressIdSchema } from "@domain/entity-contact";
 import { useCallback, useEffect, useState } from "react";
 import type { ContactAddressDetailActionsPorts } from "./model/ports";
+import {
+  resolveSignerValidationTarget,
+  type SignerPendingAction,
+} from "./model/signerPendingAction";
 import type { ContactAddressDetailSendIntent } from "./types";
 import { useContactAddressDetailActionsViewModel } from "./useContactAddressDetailActionsViewModel";
 import { useContactEditSignerUiState } from "./useContactEditSignerUiState";
@@ -53,28 +57,36 @@ export function useContactAddressDetailActionsFlowViewModel({
   const {
     sendIntent,
     editIntent,
+    deleteIntent,
     deleteLifecycle,
     openDelete,
     cancelDelete,
     confirmDelete: confirmDeleteAction,
     isSignerRequiredForEdit,
+    isSignerRequiredForDelete,
   } = useContactAddressDetailActionsViewModel(contactId, resolvedAddressId, ports);
   const {
     editUiState,
     openSignerDialog,
     openSignerMismatchDialog,
     openEditDialog,
-    onSignerCancel,
+    closeSignerDialog,
+    onSignerCancel: closeSignerOnCancel,
     onSignerMismatchCancel,
     onConnectDifferentDevice,
     onEditClose: closeEditUiState,
     resetEditUiState,
   } = useContactEditSignerUiState();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [signerPendingAction, setSignerPendingAction] = useState<SignerPendingAction | null>(null);
   const isSelectionActive = addressId !== undefined;
   const canSend = isSelectionActive && sendIntent !== undefined;
   const canEdit = isSelectionActive && editIntent !== undefined;
   const canDelete = isSelectionActive;
+
+  const clearSignerPendingAction = useCallback(() => {
+    setSignerPendingAction(null);
+  }, []);
 
   const onSendPress = useCallback(() => {
     if (sendIntent === undefined) {
@@ -90,6 +102,7 @@ export function useContactAddressDetailActionsFlowViewModel({
     }
 
     if (isSignerRequiredForEdit) {
+      setSignerPendingAction("edit");
       openSignerDialog();
       return;
     }
@@ -98,14 +111,21 @@ export function useContactAddressDetailActionsFlowViewModel({
   }, [editIntent, isSignerRequiredForEdit, openEditDialog, openSignerDialog]);
 
   const onSignerConfirm = useCallback(async () => {
-    if (editIntent === undefined) {
+    const pendingAction = signerPendingAction;
+    const validationTarget = resolveSignerValidationTarget(
+      pendingAction,
+      editIntent,
+      deleteIntent,
+    );
+
+    if (validationTarget === undefined || pendingAction === null) {
       return;
     }
 
     const [expectedSignerId, currentSignerId] = await Promise.all([
       ports.signerValidation.getExpectedSignerId({
-        contactId: editIntent.contactId,
-        addressId: editIntent.addressId,
+        contactId: validationTarget.contactId,
+        addressId: validationTarget.addressId,
       }),
       ports.signerValidation.getCurrentSignerId(),
     ]);
@@ -116,8 +136,31 @@ export function useContactAddressDetailActionsFlowViewModel({
       return;
     }
 
-    openEditDialog();
-  }, [editIntent, openEditDialog, openSignerMismatchDialog, ports.signerValidation]);
+    clearSignerPendingAction();
+
+    if (pendingAction === "edit") {
+      openEditDialog();
+      return;
+    }
+
+    closeSignerDialog();
+    openDelete();
+  }, [
+    clearSignerPendingAction,
+    closeSignerDialog,
+    deleteIntent,
+    editIntent,
+    openDelete,
+    openEditDialog,
+    openSignerMismatchDialog,
+    ports.signerValidation,
+    signerPendingAction,
+  ]);
+
+  const onSignerCancel = useCallback(() => {
+    clearSignerPendingAction();
+    closeSignerOnCancel();
+  }, [clearSignerPendingAction, closeSignerOnCancel]);
 
   const onEditClose = useCallback(() => {
     closeEditUiState();
@@ -128,8 +171,14 @@ export function useContactAddressDetailActionsFlowViewModel({
       return;
     }
 
+    if (isSignerRequiredForDelete) {
+      setSignerPendingAction("delete");
+      openSignerDialog();
+      return;
+    }
+
     openDelete();
-  }, [canDelete, openDelete]);
+  }, [canDelete, isSignerRequiredForDelete, openDelete, openSignerDialog]);
 
   const confirmDelete = useCallback(async () => {
     if (!canDelete) {
@@ -157,10 +206,11 @@ export function useContactAddressDetailActionsFlowViewModel({
 
   useEffect(() => {
     if (addressId === undefined) {
+      clearSignerPendingAction();
       resetEditUiState();
       cancelDelete();
     }
-  }, [addressId, cancelDelete, resetEditUiState]);
+  }, [addressId, cancelDelete, clearSignerPendingAction, resetEditUiState]);
 
   return {
     canSend,

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -213,6 +213,57 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
     });
   });
 
+  it("should open the signer dialog before deleting an address", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsFlowViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          ports: createPorts(),
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.onDeletePress();
+    });
+
+    expect(result.current.editUiState).toBe("signer-open");
+    expect(result.current.deleteLifecycle).toEqual({ status: "idle" });
+  });
+
+  it("should open delete state after signer confirmation", async () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () =>
+        useContactAddressDetailActionsFlowViewModel({
+          contactId: contact.id,
+          addressId: address.id,
+          ports: createPorts(),
+        }),
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.onDeletePress();
+    });
+    await act(async () => {
+      await result.current.onSignerConfirm();
+    });
+
+    expect(result.current.editUiState).toBe("closed");
+    expect(result.current.deleteLifecycle).toEqual({
+      status: "open",
+      contactId: contact.id,
+      addressId: address.id,
+    });
+  });
+
   it("should delete an address and close the detail dialog on success", async () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
@@ -232,6 +283,9 @@ describe("useContactAddressDetailActionsFlowViewModel", () => {
 
     act(() => {
       result.current.onDeletePress();
+    });
+    await act(async () => {
+      await result.current.onSignerConfirm();
     });
 
     expect(result.current.deleteLifecycle).toEqual({

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.ts
@@ -62,6 +62,7 @@ export function useContactAddressDetailActionsViewModel(
     [contactId, addressId],
   );
   const isSignerRequiredForEdit = isSignerConfirmationRequired(editIntent?.editRequirement);
+  const isSignerRequiredForDelete = isSignerConfirmationRequired(deleteIntent.deleteRequirement);
 
   const openDelete = useCallback(() => {
     setDeleteLifecycle(createOpenContactAddressDeleteLifecycle(contactId, addressId));
@@ -81,6 +82,7 @@ export function useContactAddressDetailActionsViewModel(
     deleteIntent,
     deleteLifecycle,
     isSignerRequiredForEdit,
+    isSignerRequiredForDelete,
     openDelete,
     cancelDelete,
     confirmDelete,

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
@@ -87,7 +87,7 @@ describe("useContactAddressDetailActionsViewModel", () => {
     expect(result.current.editIntent).toBeUndefined();
   });
 
-  it("exposes a delete intent for the selected address", () => {
+  it("exposes a delete intent with a signer-required requirement for the selected address", () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;
     const Wrapper = makeWrapper([mockMeContact(), contact]);
@@ -100,7 +100,12 @@ describe("useContactAddressDetailActionsViewModel", () => {
       type: "delete-address",
       contactId: contact.id,
       addressId: address.id,
+      deleteRequirement: {
+        type: "confirmation-required",
+        reason: "contact-has-address",
+      },
     });
+    expect(result.current.isSignerRequiredForDelete).toBe(true);
   });
 
   it("opens, cancels, and confirms delete through the mocked lifecycle", async () => {

--- a/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactEditSignerUiState.ts
@@ -11,6 +11,7 @@ export type UseContactEditSignerUiStateResult = Readonly<{
   openSignerDialog: () => void;
   openSignerMismatchDialog: () => void;
   openEditDialog: () => void;
+  closeSignerDialog: () => void;
   onSignerConfirm: () => void;
   onSignerCancel: () => void;
   onSignerMismatchCancel: () => void;
@@ -32,6 +33,10 @@ export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult
 
   const openEditDialog = useCallback(() => {
     setEditUiState("edit-open");
+  }, []);
+
+  const closeSignerDialog = useCallback(() => {
+    setEditUiState("closed");
   }, []);
 
   const onSignerConfirm = useCallback(() => {
@@ -65,6 +70,7 @@ export function useContactEditSignerUiState(): UseContactEditSignerUiStateResult
     openSignerDialog,
     openSignerMismatchDialog,
     openEditDialog,
+    closeSignerDialog,
     onSignerConfirm,
     onSignerCancel,
     onSignerMismatchCancel,


### PR DESCRIPTION
## Summary
- Expose `deleteRequirement` and `isSignerRequiredForDelete` for address detail actions in `@features/flow-contacts`
- Route delete through the shared signer dialog before opening the mocked delete confirmation lifecycle
- Add unit tests covering edit and delete signer requirements

[LIVE-33954](https://ledgerhq.atlassian.net/browse/LIVE-33954)
[LIVE-33955](https://ledgerhq.atlassian.net/browse/LIVE-33955)
[LIVE-33956](https://ledgerhq.atlassian.net/browse/LIVE-33956)



[LIVE-33954]: https://ledgerhq.atlassian.net/browse/LIVE-33954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33955]: https://ledgerhq.atlassian.net/browse/LIVE-33955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-33956]: https://ledgerhq.atlassian.net/browse/LIVE-33956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


https://github.com/user-attachments/assets/3e0b7b75-e1fd-479e-817e-72e4904a7023

https://github.com/user-attachments/assets/13c40692-5f29-4fe9-a740-461b6cf61075



