### PR TITLE
[LWD] feat(contacts): render desktop signer-required address delete (LIVE-33955)

### DIFF
--- a/.changeset/desktop-contacts-address-delete-signer.md
+++ b/.changeset/desktop-contacts-address-delete-signer.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Show the signer confirmation dialog before address delete confirmation in Contacts.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -917,7 +917,7 @@ describe("Contacts integration", () => {
     expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
   });
 
-  it("should open the delete address dialog from the address detail dialog", async () => {
+  it("should open the signer dialog before deleting an address", async () => {
     const { user } = renderContactsScreen(populatedContactsPageState);
 
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
@@ -925,7 +925,15 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-address-detail-delete"));
 
     expect(screen.queryByTestId("contacts-address-detail-dialog")).not.toBeInTheDocument();
-    expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    expect(screen.getByTestId("contacts-edit-signer-dialog")).toBeVisible();
+    expect(screen.queryByTestId("contacts-delete-address-dialog")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-dialog")).not.toBeInTheDocument();
+      expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    });
   });
 
   it("should delete an address and close the address detail dialog", async () => {
@@ -934,6 +942,12 @@ describe("Contacts integration", () => {
     await user.click(screen.getByTestId("contacts-saved-row-contact-ben"));
     await user.click(screen.getByTestId("contacts-detail-address-row-address-ethereum"));
     await user.click(screen.getByTestId("contacts-address-detail-delete"));
+    await user.click(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-delete-address-dialog")).toBeVisible();
+    });
+
     await user.click(screen.getByTestId("contacts-delete-address-confirm"));
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Desktop already renders the signer dialog via shared `@features/flow-contacts` UI state mapping
- Update Contacts integration tests to assert the signer dialog appears before address delete confirmation

## Test plan
- [x] Desktop Contacts integration tests for signer-before-delete flow
- [ ] Merge after #20585


Made with [Cursor](https://cursor.com)