### PR TITLE
[LWM] feat(contacts): render mobile signer-required address delete (LIVE-33956)

### DIFF
--- a/.changeset/mobile-contacts-address-delete-signer.md
+++ b/.changeset/mobile-contacts-address-delete-signer.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Show the signer confirmation sheet before address delete confirmation in Contacts.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -849,7 +849,7 @@ describe("Contacts integration", () => {
     });
   });
 
-  it("should open the delete address sheet from the address detail sheet", async () => {
+  it("should open the signer sheet before deleting an address", async () => {
     const { user } = render(<MyWalletNavigator />, {
       overrideInitialState: withContactsPageReadyState(
         { lwmContacts: { enabled: true, params: { newBadge: false } } },
@@ -862,8 +862,17 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByTestId("contacts-address-detail-delete"));
 
-    expect(await screen.findByTestId("contacts-delete-address-confirm")).toBeVisible();
-    expect(screen.getByText("Delete address?")).toBeVisible();
+    expect(await screen.findByTestId("contacts-edit-signer-confirm")).toBeVisible();
+    expect(screen.getByText("Confirm on your device")).toBeVisible();
+    expect(screen.queryByTestId("contacts-delete-address-confirm")).toBeNull();
+
+    await user.press(screen.getByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-edit-signer-confirm")).toBeNull();
+      expect(screen.getByTestId("contacts-delete-address-confirm")).toBeVisible();
+      expect(screen.getByText("Delete address?")).toBeVisible();
+    });
   });
 
   it("should delete an address and close the address detail sheet", async () => {
@@ -878,7 +887,13 @@ describe("Contacts integration", () => {
     await user.press(await screen.findByTestId("contacts-saved-contact-contact-ben"));
     await user.press(await screen.findByTestId("contacts-detail-address-row-address-ethereum"));
     await user.press(await screen.findByTestId("contacts-address-detail-delete"));
-    await user.press(await screen.findByTestId("contacts-delete-address-confirm"));
+    await user.press(await screen.findByTestId("contacts-edit-signer-confirm"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-delete-address-confirm")).toBeVisible();
+    });
+
+    await user.press(screen.getByTestId("contacts-delete-address-confirm"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("contacts-delete-address-confirm")).toBeNull();


### PR DESCRIPTION
## Summary
- Mobile already renders the signer sheet via shared `@features/flow-contacts` UI state mapping
- Update Contacts integration tests to assert the signer sheet appears before address delete confirmation

## Test plan
- [x] Mobile Contacts integration tests for signer-before-delete flow
- [ ] Merge after desktop PR in stack


Made with [Cursor](https://cursor.com)