### PR TITLE
test(e2e): link aleo public send to B2CQA-6267 test case (B2CQA-6267)

### DIFF
--- a/e2e/desktop/tests/specs/send.tx.spec.ts
+++ b/e2e/desktop/tests/specs/send.tx.spec.ts
@@ -267,7 +267,7 @@ const transactionE2E = [
   },
   {
     transaction: new Transaction(Account.ALEO_1, Account.ALEO_2, "0.000001"),
-    xrayTicket: "B2CQA-4731",
+    xrayTicket: "B2CQA-6267",
     extraCliCommands: [shareViewKeyCommand(Account.ALEO_1)],
   },
 ];


### PR DESCRIPTION
### 📝 Description

The Aleo public-send case in the desktop E2E send suite was annotated with the TMS ticket **B2CQA-4731**, which is a **Task**, not a **Test** case. As a result, the Aleo public send had no proper Test-type case backing it in Xray/TMS.

This PR repoints the Aleo entry in `e2e/desktop/tests/specs/send.tx.spec.ts` to a new **Test**-type case **B2CQA-6267 — "[ALEO] Public send/receive (native)"** created in the B2CQA project (`Regression prerelease = Yes`, `Automated on = LLD (Speculos)`, `Platform = LWD`, `Component = Send/Receive`). The new Test case is linked ("relates to") the original Task B2CQA-4731 for traceability.

There is no behavioural change to the test itself — it still exercises the default `transfer_public` (transparent balance) flow from `Account.ALEO_1` to `Account.ALEO_2`.

```diff
   transaction: new Transaction(Account.ALEO_1, Account.ALEO_2, "0.000001"),
-  xrayTicket: "B2CQA-4731",
+  xrayTicket: "B2CQA-6267",
   extraCliCommands: [shareViewKeyCommand(Account.ALEO_1)],
```

### 🔗 Context

- **JIRA / GitHub issue**: [B2CQA-6267](https://ledgerhq.atlassian.net/browse/B2CQA-6267) (new Test case) — relates to [B2CQA-4731](https://ledgerhq.atlassian.net/browse/B2CQA-4731) (original Task)
- **ADR** (if any): n/a



[B2CQA-6267]: https://ledgerhq.atlassian.net/browse/B2CQA-6267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ