### PR TITLE
fix(hw-app): fail closed on invalid BIP32 segments in tezos/vet/near

### DIFF
--- a/libs/ledgerjs/packages/hw-app-near/src/utils.ts
+++ b/libs/ledgerjs/packages/hw-app-near/src/utils.ts
@@ -1,14 +1,16 @@
 export const bip32PathToBytes = (path: string): Buffer => {
   const parts = path.split("/");
   return Buffer.concat(
-    parts
-      .map(part =>
-        part.endsWith("'")
-          ? Math.abs(parseInt(part.slice(0, -1))) | 0x80000000
-          : Math.abs(parseInt(part)),
-      )
-      .map(i32 =>
-        Buffer.from([(i32 >> 24) & 0xff, (i32 >> 16) & 0xff, (i32 >> 8) & 0xff, i32 & 0xff]),
-      ),
+    parts.map(part => {
+      // Fail closed: reject empty/non-numeric/truncated segments (e.g. "NOTAINDEX", "12abc'").
+      // NaN previously collapsed to hardened 0 via Math.abs(NaN)|0x80000000.
+      if (!/^\d+'?$/.test(part)) {
+        throw new Error(`Invalid BIP32 path segment: ${part}`);
+      }
+      const i32 = part.endsWith("'")
+        ? parseInt(part.slice(0, -1), 10) | 0x80000000
+        : parseInt(part, 10);
+      return Buffer.from([(i32 >> 24) & 0xff, (i32 >> 16) & 0xff, (i32 >> 8) & 0xff, i32 & 0xff]);
+    }),
   );
 };

--- a/libs/ledgerjs/packages/hw-app-near/tests/utils.unit.test.ts
+++ b/libs/ledgerjs/packages/hw-app-near/tests/utils.unit.test.ts
@@ -1,0 +1,16 @@
+import { bip32PathToBytes } from "../src/utils";
+
+describe("bip32PathToBytes", () => {
+  it("should encode a hardened path", () => {
+    const bytes = bip32PathToBytes("44'/397'/0'/0'/1'");
+    expect(bytes.length).toBe(20);
+    expect(bytes.readUInt32BE(0)).toBe(44 + 0x80000000);
+    expect(bytes.readUInt32BE(4)).toBe(397 + 0x80000000);
+  });
+
+  it("should reject non-numeric path segments instead of mapping NaN to hardened 0", () => {
+    expect(() => bip32PathToBytes("44'/NOTAINDEX'/0'/0'/1'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => bip32PathToBytes("44'/12abc'/0'/0'/1'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => bip32PathToBytes("44'//0'/0'/1'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-tezos/src/Tezos.ts
+++ b/libs/ledgerjs/packages/hw-app-tezos/src/Tezos.ts
@@ -186,22 +186,20 @@ export default class Tezos {
 }
 
 // TODO use bip32-path library
-function splitPath(path: string): number[] {
+export function splitPath(path: string): number[] {
   const result: number[] = [];
   const components = path.split("/");
-  components.forEach(element => {
-    let number = parseInt(element, 10);
-
-    if (isNaN(number)) {
-      return; // FIXME shouldn't it throws instead?
+  for (const element of components) {
+    // Fail closed: reject empty/non-numeric/truncated segments (e.g. "NOTAINDEX", "12abc'").
+    if (!/^\d+'?$/.test(element)) {
+      throw new Error(`Invalid BIP32 path segment: ${element}`);
     }
-
-    if (element.length > 1 && element[element.length - 1] === "'") {
+    let number = parseInt(element, 10);
+    if (element[element.length - 1] === "'") {
       number += 0x80000000;
     }
-
     result.push(number);
-  });
+  }
   return result;
 }
 

--- a/libs/ledgerjs/packages/hw-app-tezos/tests/splitPath.unit.test.ts
+++ b/libs/ledgerjs/packages/hw-app-tezos/tests/splitPath.unit.test.ts
@@ -1,0 +1,18 @@
+import { splitPath } from "../src/Tezos";
+
+describe("splitPath", () => {
+  it("should split derivation path correctly and respect hardened paths", () => {
+    expect(splitPath("44'/1729'/0'/0'")).toEqual([
+      44 + 0x80000000,
+      1729 + 0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject non-numeric path segments instead of skipping them", () => {
+    expect(() => splitPath("44'/NOTAINDEX'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => splitPath("44'/12abc'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => splitPath("44'//0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-vet/src/utils.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/src/utils.ts
@@ -1,16 +1,20 @@
 import { Buffer } from "buffer";
 
 export const splitPath = (path: string): number[] => {
-  return path
-    .split("/")
-    .map(elem => {
-      let num = parseInt(elem, 10);
-      if (elem.length > 1 && elem[elem.length - 1] === "'") {
-        num += 0x80000000;
-      }
-      return num;
-    })
-    .filter(num => !isNaN(num));
+  const result: number[] = [];
+  const components = path.split("/");
+  for (const element of components) {
+    // Fail closed: reject empty/non-numeric/truncated segments (e.g. "NOTAINDEX", "12abc'").
+    if (!/^\d+'?$/.test(element)) {
+      throw new Error(`Invalid BIP32 path segment: ${element}`);
+    }
+    let number = parseInt(element, 10);
+    if (element[element.length - 1] === "'") {
+      number += 0x80000000;
+    }
+    result.push(number);
+  }
+  return result;
 };
 
 export const splitRaw = (path: string, rawHex: string, isTransaction: boolean): Buffer[] => {

--- a/libs/ledgerjs/packages/hw-app-vet/tests/utils.unit.test.ts
+++ b/libs/ledgerjs/packages/hw-app-vet/tests/utils.unit.test.ts
@@ -1,0 +1,19 @@
+import { splitPath } from "../src/utils";
+
+describe("splitPath", () => {
+  it("should split derivation path correctly and respect hardened paths", () => {
+    expect(splitPath("44'/818'/0'/0'/0'")).toEqual([
+      44 + 0x80000000,
+      818 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject non-numeric path segments instead of filtering them", () => {
+    expect(() => splitPath("44'/NOTAINDEX'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => splitPath("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => splitPath("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- Sibling of #20598 (`hw-app-eth` / `trx` / `icon`): `hw-app-tezos`, `hw-app-vet`, and `hw-app-near` still failed open on invalid BIP32 path segments.
- Tezos/Vet skipped `NaN` segments (or filtered them); Near mapped `NaN` via `Math.abs(NaN) | 0x80000000` to hardened `0`. Callers could derive a different key than the path string implied.
- Reject any segment that is not digits with an optional hardening suffix; add unit coverage for the reject path.

## Test plan
- [x] Unit cases for tezos `splitPath`, vet `splitPath`, near `bip32PathToBytes` covering `NOTAINDEX`, truncated `12abc'`, and empty segments
- [ ] Package unit tests in CI

Tip: `d041b8cc` (develop). SSH-signed under SashaMIT.

Tooling assist: Cursor (author owns the change).

Made with [Cursor](https://cursor.com)