### PR TITLE
fix(hw-app-solana,hw-app-helium): fail closed on invalid BIP32 segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-helium/src/serialization.ts
+++ b/libs/ledgerjs/packages/hw-app-helium/src/serialization.ts
@@ -37,13 +37,28 @@ const serializePath = (path: number[]): Buffer => {
   return buf;
 };
 
-export const pathToBuffer = (originalPath: string): Buffer => {
+/**
+ * Harden every path segment (Helium/Ed25519) then parse with bip32-path.
+ * Fail closed on truncated/garbage segments that bip32-path would silently shorten.
+ * Exported for unit tests.
+ */
+export function resolveHardenedBip32Path(originalPath: string): number[] {
   const path = originalPath
     .split("/")
-    .map(value => (value.endsWith("'") || value.endsWith("h") ? value : value + "'"))
+    .map(value => (value.endsWith("'") || value.endsWith("h") || value.endsWith("H") ? value : value + "'"))
     .join("/");
-  const pathNums: number[] = BIPPath.fromString(path).toPathArray();
-  return serializePath(pathNums);
+  for (const segment of path.split("/")) {
+    // Reject empty/non-numeric/truncated segments (e.g. "NOTAINDEX", "12abc'").
+    // bip32-path previously truncated "12abc'" to index 12 and dropped hardening.
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(path).toPathArray();
+}
+
+export const pathToBuffer = (originalPath: string): Buffer => {
+  return serializePath(resolveHardenedBip32Path(originalPath));
 };
 
 const serializeNumber = (amount: number | BigNumber | undefined): Buffer => {

--- a/libs/ledgerjs/packages/hw-app-helium/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-helium/tests/path.test.ts
@@ -1,0 +1,24 @@
+import { resolveHardenedBip32Path, pathToBuffer } from "../src/serialization";
+
+describe("resolveHardenedBip32Path", () => {
+  it("should harden and parse a valid Helium path", () => {
+    const path = resolveHardenedBip32Path("44'/904'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      904 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of de-hardening via bip32-path", () => {
+    expect(() => resolveHardenedBip32Path("44'/12abc'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveHardenedBip32Path("44'/NOTAINDEX'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveHardenedBip32Path("44'//0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+
+  it("pathToBuffer should fail closed on garbage segments", () => {
+    expect(() => pathToBuffer("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-solana/src/Solana.ts
+++ b/libs/ledgerjs/packages/hw-app-solana/src/Solana.ts
@@ -2,8 +2,8 @@ import Transport from "@ledgerhq/hw-transport";
 
 import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 
-import BIPPath from "bip32-path";
 import { DescriptorInput, buildDescriptor } from "./descriptor";
+import { resolveHardenedBip32Path } from "./bip32Path";
 
 const P1_NON_CONFIRM = 0x00;
 const P1_CONFIRM = 0x01;
@@ -239,12 +239,7 @@ export default class Solana {
   }
 
   private pathToBuffer(originalPath: string) {
-    const path = originalPath
-      .split("/")
-      .map(value => (value.endsWith("'") || value.endsWith("h") ? value : value + "'"))
-      .join("/");
-    const pathNums: number[] = BIPPath.fromString(path).toPathArray();
-    return this.serializePath(pathNums);
+    return this.serializePath(resolveHardenedBip32Path(originalPath));
   }
 
   private serializePath(path: number[]) {

--- a/libs/ledgerjs/packages/hw-app-solana/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-solana/src/bip32Path.ts
@@ -1,0 +1,20 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Harden every path segment (Solana/Ed25519) then parse with bip32-path.
+ * Fail closed on truncated/garbage segments that bip32-path would silently shorten.
+ */
+export function resolveHardenedBip32Path(originalPath: string): number[] {
+  const path = originalPath
+    .split("/")
+    .map(value => (value.endsWith("'") || value.endsWith("h") || value.endsWith("H") ? value : value + "'"))
+    .join("/");
+  for (const segment of path.split("/")) {
+    // Reject empty/non-numeric/truncated segments (e.g. "NOTAINDEX", "12abc'").
+    // bip32-path previously truncated "12abc'" to index 12 and dropped hardening.
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(path).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-solana/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-solana/tests/path.test.ts
@@ -1,0 +1,25 @@
+import { resolveHardenedBip32Path } from "../src/bip32Path";
+
+describe("resolveHardenedBip32Path", () => {
+  it("should harden and parse a valid Solana path", () => {
+    const path = resolveHardenedBip32Path("44'/501'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      501 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should auto-harden unhardened numeric segments", () => {
+    const path = resolveHardenedBip32Path("44/501/0");
+    expect(path).toEqual([44 + 0x80000000, 501 + 0x80000000, 0x80000000]);
+  });
+
+  it("should reject truncated/garbage segments instead of de-hardening via bip32-path", () => {
+    expect(() => resolveHardenedBip32Path("44'/12abc'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveHardenedBip32Path("44'/NOTAINDEX'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveHardenedBip32Path("44'//0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary

Sibling of #20598 / #20599 (hand-rolled `splitPath` / `bip32PathToBytes`).

`@ledgerhq/hw-app-solana` and `@ledgerhq/hw-app-helium` still send derivation paths through `bip32-path@0.4.2` after appending `'`. That library **truncates** garbage segments and can **drop hardening**:

- input segment `12abc'` → parsed index `12` (unhardened)
- so a path that looks hardened can derive a different key than the string implies

This PR validates each segment with `/^\d+[hH']?$/` **before** `BIPPath.fromString`, matching the fail-closed pattern in the sibling PRs.

## Changes

- `hw-app-solana`: extract `resolveHardenedBip32Path` in `bip32Path.ts`; use it from `pathToBuffer`
- `hw-app-helium`: same validation in `serialization.ts` `pathToBuffer`
- unit tests for accept + reject cases (`12abc'`, `NOTAINDEX`, empty segment)

## Test plan

- [x] `pnpm test -- path.test.ts` in `@ledgerhq/hw-app-solana` (Node 24)
- [x] `pnpm test -- path.test.ts` in `@ledgerhq/hw-app-helium` (Node 24)
- [ ] CI package tests green

## Notes

- Confirmed on tip `d041b8cc`: `BIPPath.fromString("44'/12abc'/0'")` → `[0x8000002c, 0xc, 0x80000000]`
- No device interaction required; pure path encoding fail-closed


Made with [Cursor](https://cursor.com)