### PR TITLE
fix(hw-app-str,hw-app-kaspa): fail closed on invalid BIP32 segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-kaspa/src/Kaspa.ts
+++ b/libs/ledgerjs/packages/hw-app-kaspa/src/Kaspa.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { publicKeyToAddress } from "./kaspa-util";
 import { KaspaHwTransaction } from "./kaspaHwTransaction";
 
-import BIP32Path from "bip32-path";
+import { resolveBip32Path } from "./bip32Path";
 
 // Get Address
 const P1_NON_CONFIRM = 0x00;
@@ -29,8 +29,7 @@ const INS = {
 };
 
 function pathToBuffer(originalPath) {
-  const pathNums = BIP32Path.fromString(originalPath).toPathArray();
-  return serializePath(pathNums);
+  return serializePath(resolveBip32Path(originalPath));
 }
 
 function serializePath(path) {

--- a/libs/ledgerjs/packages/hw-app-kaspa/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-kaspa/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIP32Path from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIP32Path.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-kaspa/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-kaspa/tests/path.test.ts
@@ -1,0 +1,14 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Kaspa path", () => {
+    const path = resolveBip32Path("44'/111111'/0'/0/0");
+    expect(path).toEqual([44 + 0x80000000, 111111 + 0x80000000, 0x80000000, 0, 0]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'//0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-str/src/Str.ts
+++ b/libs/ledgerjs/packages/hw-app-str/src/Str.ts
@@ -15,7 +15,7 @@
  *  limitations under the License.
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
+import { resolveHardenedBip32Path } from "./bip32Path";
 import {
   StellarHashSigningNotEnabledError,
   StellarDataParsingFailedError,
@@ -251,12 +251,7 @@ const remapErrors = e => {
 };
 
 const pathToBuffer = (originalPath: string) => {
-  const path = originalPath
-    .split("/")
-    .map(value => (value.endsWith("'") || value.endsWith("h") ? value : `${value}'`))
-    .join("/");
-  const pathNums: number[] = BIPPath.fromString(path).toPathArray();
-  return serializePath(pathNums);
+  return serializePath(resolveHardenedBip32Path(originalPath));
 };
 
 const serializePath = (path: number[]) => {

--- a/libs/ledgerjs/packages/hw-app-str/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-str/src/bip32Path.ts
@@ -1,0 +1,20 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Harden every path segment (Stellar/Ed25519) then parse with bip32-path.
+ * Fail closed on truncated/garbage segments that bip32-path would silently shorten.
+ */
+export function resolveHardenedBip32Path(originalPath: string): number[] {
+  const path = originalPath
+    .split("/")
+    .map(value =>
+      value.endsWith("'") || value.endsWith("h") || value.endsWith("H") ? value : `${value}'`,
+    )
+    .join("/");
+  for (const segment of path.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(path).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-str/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-str/tests/path.test.ts
@@ -1,0 +1,16 @@
+import { resolveHardenedBip32Path } from "../src/bip32Path";
+
+describe("resolveHardenedBip32Path", () => {
+  it("should harden and parse a valid Stellar path", () => {
+    const path = resolveHardenedBip32Path("44'/148'/0'");
+    expect(path).toEqual([44 + 0x80000000, 148 + 0x80000000, 0x80000000]);
+  });
+
+  it("should reject truncated/garbage segments instead of de-hardening via bip32-path", () => {
+    expect(() => resolveHardenedBip32Path("44'/12abc'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveHardenedBip32Path("44'/NOTAINDEX'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveHardenedBip32Path("44'//0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` truncates garbage path segments (`12abc'` → unhardened `12`) before device APDUs in `hw-app-str` and `hw-app-kaspa`.
- Same class as open #20601 (solana/helium) and #20598/#20599.
- Validate `/^\d+[hH']?$/` before `BIPPath.fromString`. Str still hardens every segment for Ed25519; Kaspa validates the path as provided.

## Test plan
- [x] Local tip-reverify: bare `BIPPath.fromString("44'/12abc'/0'")` → `[0x8000002c, 0xc, 0x80000000]`; helpers reject with `Invalid BIP32 path segment`
- [x] Added `tests/path.test.ts` in both packages (valid path + garbage/`NOTAINDEX`/empty segment)
- Tip parent: `d041b8cc`

Commit is SSH-signed.


Made with [Cursor](https://cursor.com)