### PR TITLE
fix(hw-app-cosmos,hw-app-xrp): fail closed on invalid BIP32 segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-cosmos/src/Cosmos.ts
+++ b/libs/ledgerjs/packages/hw-app-cosmos/src/Cosmos.ts
@@ -15,8 +15,8 @@
  *  limitations under the License.
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
 import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import { resolveBip32Path } from "./bip32Path";
 const CHUNK_SIZE = 250;
 const CLA = 0x55;
 const APP_KEY = "CSM";
@@ -106,7 +106,7 @@ export default class Cosmos {
     publicKey: string;
     address: string;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const serializedPath = this.serializePath(bipPath);
     const data = Buffer.concat([this.serializeHRP(hrp), serializedPath]);
     return this.transport
@@ -142,7 +142,7 @@ export default class Cosmos {
     signature: null | Buffer;
     return_code: number | string;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const serializedPath = this.serializePath(bipPath);
     const chunks: Buffer[] = [];
     chunks.push(serializedPath);

--- a/libs/ledgerjs/packages/hw-app-cosmos/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-cosmos/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-cosmos/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-cosmos/tests/path.test.ts
@@ -1,0 +1,14 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Cosmos path", () => {
+    const path = resolveBip32Path("44'/118'/0'/0/0");
+    expect(path).toEqual([44 + 0x80000000, 118 + 0x80000000, 0x80000000, 0, 0]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'//0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-xrp/src/Xrp.ts
+++ b/libs/ledgerjs/packages/hw-app-xrp/src/Xrp.ts
@@ -1,5 +1,5 @@
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
+import { resolveBip32Path } from "./bip32Path";
 /**
  * XRP API
  *
@@ -81,7 +81,7 @@ export default class Xrp {
     address: string;
     chainCode?: string;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const curveMask = ed25519 ? 0x80 : 0x40;
     const cla = 0xe0;
     const ins = 0x02;
@@ -128,7 +128,7 @@ export default class Xrp {
    * const signature = await xrp.signTransaction("44'/144'/0'/0/0", "12000022800000002400000002614000000001315D3468400000000000000C73210324E5F600B52BB3D9246D49C4AB1722BA7F32B7A3E4F9F2B8A1A28B9118CC36C48114F31B152151B6F42C1D61FE4139D34B424C8647D183142ECFC1831F6E979C6DA907E88B1CAD602DB59E2F");
    */
   async signTransaction(path: string, rawTxHex: string, ed25519?: boolean): Promise<string> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const rawTx = Buffer.from(rawTxHex, "hex");
     const curveMask = ed25519 ? 0x80 : 0x40;
     const apdus: {

--- a/libs/ledgerjs/packages/hw-app-xrp/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-xrp/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-xrp/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-xrp/tests/path.test.ts
@@ -1,0 +1,14 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid XRP path", () => {
+    const path = resolveBip32Path("44'/144'/0'/0/0");
+    expect(path).toEqual([44 + 0x80000000, 144 + 0x80000000, 0x80000000, 0, 0]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'//0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` truncates garbage path segments (`12abc'` → unhardened `12`) in `hw-app-cosmos` and `hw-app-xrp` before device APDUs.
- Same class as open #20601 (solana/helium), #20602 (str/kaspa), #20598/#20599.
- Validate `/^\d+[hH']?$/` before `BIPPath.fromString` (paths kept as provided; no force-harden).

## Test plan
- [x] Local tip-reverify: helpers accept `44'/118'/0'/0/0` / `44'/144'/0'/0/0` and reject `12abc'` / `NOTAINDEX` / empty segment
- [x] Added `tests/path.test.ts` in both packages
- Tip parent: `d041b8cc`

Commit is SSH-signed.


Made with [Cursor](https://cursor.com)