### PR TITLE
fix(hw-app-hedera,hw-app-algorand): fail closed on invalid BIP32 segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-algorand/src/Algorand.ts
+++ b/libs/ledgerjs/packages/hw-app-algorand/src/Algorand.ts
@@ -15,8 +15,8 @@
  *  limitations under the License.
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
 import { UserRefusedOnDevice } from "@ledgerhq/hw-transport/errors";
+import { resolveBip32Path } from "./bip32Path";
 import { encodeAddress } from "./utils";
 const CHUNK_SIZE = 250;
 // const P1_FIRST = 0x00;
@@ -62,7 +62,7 @@ export default class Algorand {
     publicKey: string;
     address: string;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const buf = Buffer.alloc(4);
     buf.writeUInt32BE(bipPath[2], 0);
     return this.transport
@@ -100,7 +100,7 @@ export default class Algorand {
   ): Promise<{
     signature: null | Buffer;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const buf = Buffer.alloc(4);
     buf.writeUInt32BE(bipPath[2], 0);
     const chunks: Buffer[] = [];

--- a/libs/ledgerjs/packages/hw-app-algorand/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-algorand/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-algorand/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-algorand/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Algorand path", () => {
+    const path = resolveBip32Path("44'/283'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      283 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveBip32Path("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-hedera/src/Hedera.ts
+++ b/libs/ledgerjs/packages/hw-app-hedera/src/Hedera.ts
@@ -1,6 +1,6 @@
 import { UserRefusedOnDevice, UserRefusedAddress } from "@ledgerhq/hw-transport/errors";
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
+import { resolveBip32Path } from "./bip32Path";
 
 const CLA = 0xe0;
 
@@ -34,7 +34,7 @@ export default class Hedera {
    * @return the public key
    */
   async getPublicKey(path: string): Promise<string> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const serializedPath = this._serializePath(bipPath);
 
     const p1 = 0x01;

--- a/libs/ledgerjs/packages/hw-app-hedera/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-hedera/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-hedera/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-hedera/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Hedera path", () => {
+    const path = resolveBip32Path("44'/3030'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      3030 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveBip32Path("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` truncates garbage path segments (`12abc'` → unhardened `12`) in `hw-app-hedera` and `hw-app-algorand` before device APDUs.
- Same class as open #20601/#20602/#20603 and #20598/#20599.
- Validate `/^\d+[hH']?$/` before `BIPPath.fromString` (paths kept as provided).

## Test plan
- [x] Local tip-reverify: helpers accept valid Hedera/Algorand paths and reject `12abc'` / `NOTAINDEX` / empty segment
- [x] Added `tests/path.test.ts` in both packages
- Tip parent: `d041b8cc`

Commit is SSH-signed.


Made with [Cursor](https://cursor.com)