### PR TITLE
fix(hw-app-polkadot,hw-app-multiversx): fail closed on invalid BIP32 segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-multiversx/src/MultiversX.ts
+++ b/libs/ledgerjs/packages/hw-app-multiversx/src/MultiversX.ts
@@ -1,6 +1,6 @@
 import type Transport from "@ledgerhq/hw-transport";
 import { Address } from "@multiversx/sdk-core";
-import BIPPath from "bip32-path";
+import { resolveBip32Path } from "./bip32Path";
 
 const CHUNK_SIZE = 150;
 const CURVE_MASK = 0x80;
@@ -83,7 +83,7 @@ export default class MultiversX {
     publicKey: string;
     address: string;
   }> {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const data = this.serializePath(bipPath);
     const response = await this.transport.send(
       CLA,
@@ -114,7 +114,7 @@ export default class MultiversX {
    * result : Buffer;
    */
   async setAddress(path: string, display?: boolean) {
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const data = this.serializePath(bipPath);
     await this.transport.send(CLA, INS.SET_ADDRESS, display ? 0x01 : 0x00, 0x00, data, [
       SW_OK,

--- a/libs/ledgerjs/packages/hw-app-multiversx/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-multiversx/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-multiversx/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-multiversx/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid MultiversX path", () => {
+    const path = resolveBip32Path("44'/508'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      508 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveBip32Path("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/src/Polkadot.ts
@@ -15,9 +15,9 @@
  *  limitations under the License.
  ********************************************************************************/
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
 import { UserRefusedAddress } from "@ledgerhq/hw-transport/errors";
 import { PolkadotGenericApp } from "@zondax/ledger-substrate";
+import { resolveBip32Path } from "./bip32Path";
 
 const INS = {
   GET_VERSION: 0x00,
@@ -72,7 +72,7 @@ export default class Polkadot {
     return_code: number;
   }> {
     const CLA = 0xf9;
-    const bipPath = BIPPath.fromString(path).toPathArray();
+    const bipPath = resolveBip32Path(path);
     const bip44Path = this.serializePath(bipPath, ss58prefix);
     return this.transport
       .send(CLA, INS.GET_ADDR_ED25519, showAddrInDevice ? 1 : 0, 0, bip44Path, [SW_OK, SW_CANCEL])

--- a/libs/ledgerjs/packages/hw-app-polkadot/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-polkadot/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-polkadot/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Polkadot path", () => {
+    const path = resolveBip32Path("44'/354'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      354 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveBip32Path("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` truncates garbage path segments (`12abc'` → unhardened `12`) in `hw-app-polkadot` and `hw-app-multiversx` before device APDUs.
- Same class as open #20601–#20604 and #20598/#20599.
- Validate `/^\d+[hH']?$/` before `BIPPath.fromString` (paths kept as provided).

## Test plan
- [x] Local tip-reverify: helpers accept valid Polkadot/MultiversX paths and reject `12abc'` / `NOTAINDEX` / empty segment
- [x] Added `tests/path.test.ts` in both packages
- Tip parent: `d041b8cc`

Commit is SSH-signed.


Made with [Cursor](https://cursor.com)