### PR TITLE
fix(hw-app-aptos,hw-app-canton): fail closed on invalid BIP32 path segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-aptos/src/bip32.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/src/bip32.ts
@@ -24,6 +24,15 @@ export function bip32asBuffer(path: string): Buffer {
   return pathElementsToBuffer(pathElements);
 }
 
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
 export function pathStringToArray(path: string): number[] {
+  for (const segment of path.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
   return bippath.fromString(path).toPathArray();
 }

--- a/libs/ledgerjs/packages/hw-app-aptos/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-aptos/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { pathStringToArray } from "../src/bip32";
+
+describe("pathStringToArray", () => {
+  it("should parse a valid Aptos path", () => {
+    const path = pathStringToArray("44'/637'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      637 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => pathStringToArray("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => pathStringToArray("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => pathStringToArray("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});

--- a/libs/ledgerjs/packages/hw-app-canton/src/Canton.ts
+++ b/libs/ledgerjs/packages/hw-app-canton/src/Canton.ts
@@ -1,6 +1,6 @@
 import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import type Transport from "@ledgerhq/hw-transport";
-import BIPPath from "bip32-path";
+import { resolveBip32Path } from "./bip32Path";
 
 export type * from "./types";
 
@@ -467,8 +467,7 @@ export default class Canton {
    * @private
    */
   private serializeBipPath(pathString: string): Buffer {
-    const bipPath = BIPPath.fromString(pathString).toPathArray();
-    return this.serializePath(bipPath);
+    return this.serializePath(resolveBip32Path(pathString));
   }
 
   /**

--- a/libs/ledgerjs/packages/hw-app-canton/src/bip32Path.ts
+++ b/libs/ledgerjs/packages/hw-app-canton/src/bip32Path.ts
@@ -1,0 +1,14 @@
+import BIPPath from "bip32-path";
+
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ */
+export function resolveBip32Path(originalPath: string): number[] {
+  for (const segment of originalPath.split("/")) {
+    if (!/^\d+[hH']?$/.test(segment)) {
+      throw new Error(`Invalid BIP32 path segment: ${segment}`);
+    }
+  }
+  return BIPPath.fromString(originalPath).toPathArray();
+}

--- a/libs/ledgerjs/packages/hw-app-canton/tests/path.test.ts
+++ b/libs/ledgerjs/packages/hw-app-canton/tests/path.test.ts
@@ -1,0 +1,22 @@
+import { resolveBip32Path } from "../src/bip32Path";
+
+describe("resolveBip32Path", () => {
+  it("should parse a valid Canton path", () => {
+    const path = resolveBip32Path("44'/6767'/0'/0'/0'");
+    expect(path).toEqual([
+      44 + 0x80000000,
+      6767 + 0x80000000,
+      0x80000000,
+      0x80000000,
+      0x80000000,
+    ]);
+  });
+
+  it("should reject truncated/garbage segments instead of truncating via bip32-path", () => {
+    expect(() => resolveBip32Path("44'/12abc'/0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+    expect(() => resolveBip32Path("44'/NOTAINDEX'/0'/0'/0'")).toThrow(
+      /Invalid BIP32 path segment/,
+    );
+    expect(() => resolveBip32Path("44'//0'/0'/0'")).toThrow(/Invalid BIP32 path segment/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` silently truncates garbage path segments (e.g. `12abc'` → unhardened `12`).
- Validate each BIP32 segment with `/^\d+[hH']?$/` before `BIPPath.fromString` / `bippath.fromString` in Aptos (`pathStringToArray`) and Canton (`serializeBipPath` via new `resolveBip32Path`).
- Sibling of #20598, #20599, #20601–#20605.

## Test plan
- [x] Added `tests/path.test.ts` in both packages (valid path + truncated/garbage reject)
- [x] Local tip-reverify of helpers against tip `d041b8cc`
- [ ] CI package tests for `hw-app-aptos` / `hw-app-canton`


Made with [Cursor](https://cursor.com)