### PR TITLE
fix(hw-app-btc): fail closed on invalid BIP32 path segments

### DIFF
--- a/libs/ledgerjs/packages/hw-app-btc/src/bip32.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/bip32.ts
@@ -36,7 +36,19 @@ export function pathArrayToString(pathElements: number[]): string {
   return bippath.fromPathArray(pathElements).toString();
 }
 
+/**
+ * Parse a BIP32 path with bip32-path, failing closed on truncated/garbage segments
+ * that bip32-path would silently shorten (e.g. "12abc'" → 12).
+ * Optional leading "m" master prefix is allowed.
+ */
 export function pathStringToArray(path: string): number[] {
+  const segments = path.split("/");
+  const start = segments[0] === "m" ? 1 : 0;
+  for (let i = start; i < segments.length; i++) {
+    if (!/^\d+[hH']?$/.test(segments[i])) {
+      throw new Error(`Invalid BIP32 path segment: ${segments[i]}`);
+    }
+  }
   return bippath.fromString(path).toPathArray();
 }
 

--- a/libs/ledgerjs/packages/hw-app-btc/src/signMessage.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/src/signMessage.ts
@@ -1,5 +1,5 @@
 import type Transport from "@ledgerhq/hw-transport";
-import bippath from "bip32-path";
+import { pathStringToArray } from "./bip32";
 import { MAX_SCRIPT_BLOCK } from "./constants";
 export async function signMessage(
   transport: Transport,
@@ -15,7 +15,7 @@ export async function signMessage(
   r: string;
   s: string;
 }> {
-  const paths = bippath.fromString(path).toPathArray();
+  const paths = pathStringToArray(path);
   const message = Buffer.from(messageHex, "hex");
   let offset = 0;
 

--- a/libs/ledgerjs/packages/hw-app-btc/tests/bip32.test.ts
+++ b/libs/ledgerjs/packages/hw-app-btc/tests/bip32.test.ts
@@ -264,6 +264,16 @@ describe("bip32 utilities", () => {
         0x80000054, 0x80000000, 0x80000000, 0, 5,
       ]);
     });
+
+    test("rejects truncated/garbage segments instead of truncating via bip32-path", () => {
+      expect(() => pathStringToArray("m/44'/12abc'/0'/0/0")).toThrow(
+        /Invalid BIP32 path segment/,
+      );
+      expect(() => pathStringToArray("m/44'/NOTAINDEX'/0'/0/0")).toThrow(
+        /Invalid BIP32 path segment/,
+      );
+      expect(() => pathStringToArray("m/44'//0'/0/0")).toThrow(/Invalid BIP32 path segment/);
+    });
   });
 
   describe("pathArrayToString", () => {


### PR DESCRIPTION
## Summary
- `bip32-path@0.4.2` silently truncates garbage path segments (e.g. `12abc'` → unhardened `12`).
- Validate each BIP32 segment with `/^\d+[hH']?$/` (optional leading `m`) before parse in `pathStringToArray`.
- Route `signMessage` through the same helper instead of bare `bippath.fromString`.
- Sibling of #20598, #20599, #20601–#20606.

## Test plan
- [x] Extended `tests/bip32.test.ts` (valid `m/...` paths + truncated/garbage reject)
- [x] Local tip-reverify of path helper against tip `d041b8cc`
- [ ] CI package tests for `hw-app-btc`


Made with [Cursor](https://cursor.com)