### PR TITLE
[LWDM] fix(zcash): shielded persistence [LIVE-35664]

### DIFF
--- a/.changeset/fix-zcash-shielded-ufvk-persistence.md
+++ b/.changeset/fix-zcash-shielded-ufvk-persistence.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-bitcoin": patch
+---
+
+Fix Zcash shielded state (the unified full viewing key) being dropped on every restart.

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/__tests__/adapter.test.ts
@@ -1,4 +1,7 @@
+import { BigNumber } from "bignumber.js";
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
 import { getChainAdapter } from "../../registry";
+import type { ZcashAccount, ZcashAccountRaw, ZcashPrivateInfo } from "../types";
 
 // Load the zcash adapter (side-effect registration)
 import "../index";
@@ -8,10 +11,10 @@ import "../index";
 // The shielded/PCZT path lives entirely in `@ledgerhq/coin-zcash` now. This
 // adapter only overrides the transparent-signer machinery
 // (getAddress/getWalletXpub/getFullViewingKey/createSigner, exercised in
-// index.test.ts) and the ZIP-317 fee resolution (transparent-fee-rate.test.ts).
-// Every other `ChainAdapter` hook is intentionally absent so the generic
-// Bitcoin bridge handles sync, balance, signing and status for every Zcash
-// send unconditionally — there is no feature flag branching left to test.
+// index.test.ts), the ZIP-317 fee resolution (transparent-fee-rate.test.ts)
+// and the shielded `privateInfo` (de)serialization — kept because the bitcoin
+// bridge reads Zcash accounts back at app startup, before the `zcashShielded`
+// flag is mirrored, so nothing else would persist the ufvk.
 describe("zcash chain adapter — reduced surface", () => {
   const adapter = getChainAdapter("zcash");
 
@@ -23,8 +26,6 @@ describe("zcash chain adapter — reduced surface", () => {
     expect(adapter.buildExtraSyncObservable).toBeUndefined();
     expect(adapter.computeAccountBalance).toBeUndefined();
     expect(adapter.resolveTransactionDetails).toBeUndefined();
-    expect(adapter.assignToAccountRaw).toBeUndefined();
-    expect(adapter.assignFromAccountRaw).toBeUndefined();
   });
 
   it("does not override signing/status/broadcast hooks (legacy Bitcoin PSBT path handles them)", () => {
@@ -33,5 +34,84 @@ describe("zcash chain adapter — reduced surface", () => {
     expect(adapter.getTransactionStatus).toBeUndefined();
     expect(adapter.estimateMaxSpendable).toBeUndefined();
     expect(adapter.prepareTransaction).toBeUndefined();
+  });
+});
+
+// Regression guard: the ufvk (and the shielded balances/notes) must survive a
+// persist → load round-trip through the bitcoin bridge, which is the family
+// that serves Zcash accounts at startup decode. Before this the shielded state
+// was dropped on load and then erased on the next save.
+describe("zcash chain adapter — shielded privateInfo (de)serialization", () => {
+  const adapter = getChainAdapter("zcash");
+
+  const privateInfo: ZcashPrivateInfo = {
+    saplingBalance: new BigNumber(0),
+    orchardBalance: new BigNumber(1234),
+    ironwoodBalance: new BigNumber(56),
+    syncState: "ready",
+    progress: 42,
+    estimatedTimeRemaining: { hours: 0, minutes: 3 },
+    ufvk: "uview-persisted",
+    birthday: "2022-05-31",
+    lastSyncTimestamp: 1_700_000_000_000,
+    lastProcessedBlock: 3_400_000,
+    transactions: [
+      {
+        id: "tx-1",
+        hex: "deadbeef",
+        blockHeight: 3_399_999,
+        blockHash: "hash-1",
+        timestamp: 1_699_999_999,
+        fee: new BigNumber(1000),
+        decryptedData: {
+          orchard_outputs: [
+            {
+              memo: "",
+              transfer_type: "incoming",
+              amount: new BigNumber(1234),
+              nullifier: "aa",
+              isSpent: false,
+            },
+          ],
+          sapling_outputs: [],
+        },
+      },
+    ],
+  };
+
+  it("exposes the serialization hooks", () => {
+    expect(typeof adapter.assignToAccountRaw).toBe("function");
+    expect(typeof adapter.assignFromAccountRaw).toBe("function");
+  });
+
+  it("round-trips the ufvk, balances and notes through raw", () => {
+    const account = { privateInfo } as unknown as ZcashAccount;
+    const accountRaw = {} as AccountRaw;
+
+    adapter.assignToAccountRaw!(account as unknown as Account, accountRaw);
+    const raw = accountRaw as ZcashAccountRaw;
+    expect(raw.privateInfo?.ufvk).toBe("uview-persisted");
+    expect(raw.privateInfo?.orchardBalance).toBe("1234");
+
+    const restoredAccount = {} as ZcashAccount;
+    adapter.assignFromAccountRaw!(accountRaw, restoredAccount as unknown as Account);
+    const restored = restoredAccount.privateInfo!;
+
+    expect(restored.ufvk).toBe("uview-persisted");
+    expect(restored.syncState).toBe("ready");
+    expect(restored.orchardBalance.toString()).toBe("1234");
+    expect(restored.ironwoodBalance.toString()).toBe("56");
+    expect(restored.lastProcessedBlock).toBe(3_400_000);
+    expect(restored.transactions[0].fee.toString()).toBe("1000");
+    expect(restored.transactions[0].decryptedData?.orchard_outputs[0].amount.toString()).toBe(
+      "1234",
+    );
+    expect(restored.transactions[0].decryptedData?.orchard_outputs[0].isSpent).toBe(false);
+  });
+
+  it("writes nothing when the account has no shielded state", () => {
+    const accountRaw = {} as AccountRaw;
+    adapter.assignToAccountRaw!({} as Account, accountRaw);
+    expect((accountRaw as ZcashAccountRaw).privateInfo).toBeUndefined();
   });
 });

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/index.ts
@@ -1,13 +1,15 @@
 import { pathStringToArray } from "@ledgerhq/ledger-wallet-framework/bridge/jsHelpers";
-import type { Account } from "@ledgerhq/types-live";
+import type { Account, AccountRaw } from "@ledgerhq/types-live";
 import type { BitcoinAddress, BitcoinXPub, SignerContext } from "../../signer";
 import type { Transaction } from "../../types";
 import { DmkSignerZcash } from "@ledgerhq/live-signer-zcash";
 import type { ZcashAddress, ZcashViewKey } from "@ledgerhq/live-signer-zcash";
 import { registerChainAdapter } from "../registry";
 import type { ChainAdapter } from "../types";
+import type { ZcashAccount, ZcashAccountRaw } from "./types";
 import { composeXpub } from "./xpub";
 import { resolveZcashFeePerByte } from "./transparent-fee-rate";
+import { fromZcashPrivateInfoRaw, toZcashPrivateInfoRaw } from "./serialization";
 
 // ── DMK transport helpers ─────────────────────────────────────────────────
 
@@ -53,6 +55,24 @@ const zcashChainAdapter: ChainAdapter = {
     const safeFeePerByte = transaction.feePerByte;
     if (!safeFeePerByte || safeFeePerByte.lte(0)) return undefined;
     return resolveZcashFeePerByte(account, transaction, safeFeePerByte);
+  },
+
+  // Persist the shielded state alongside the transparent bitcoinResources. The
+  // bitcoin bridge is what reads a Zcash account back at app startup (the
+  // `zcashShielded` flag is not mirrored yet then), so this must not be gated
+  // on the flag or the ufvk is lost on every restart.
+  assignToAccountRaw(account: Account, accountRaw: AccountRaw) {
+    const zcashAccount = account as ZcashAccount;
+    if (zcashAccount.privateInfo) {
+      (accountRaw as ZcashAccountRaw).privateInfo = toZcashPrivateInfoRaw(zcashAccount.privateInfo);
+    }
+  },
+
+  assignFromAccountRaw(accountRaw: AccountRaw, account: Account) {
+    const zcashPrivateInfoRaw = (accountRaw as ZcashAccountRaw).privateInfo;
+    if (zcashPrivateInfoRaw) {
+      (account as ZcashAccount).privateInfo = fromZcashPrivateInfoRaw(zcashPrivateInfoRaw);
+    }
   },
 
   getAddress(deviceId, { currency, path, verify }, signerContext: SignerContext) {

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/serialization.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/serialization.ts
@@ -1,0 +1,109 @@
+import { BigNumber } from "bignumber.js";
+import type {
+  DecryptedOutput,
+  DecryptedOutputRaw,
+  ZcashPrivateInfo,
+  ZcashPrivateInfoRaw,
+  ZcashSyncState,
+} from "./types";
+
+// Persistence of the shielded `privateInfo` (its unified full viewing key,
+// balances and decrypted notes) for a Zcash account served by the bitcoin
+// family bridge. This is flag-independent on purpose: accounts are decoded at
+// app startup, before the host has mirrored the `zcashShielded` flag, so the
+// bitcoin bridge is always the one that reads a persisted Zcash account back.
+// Without this the ufvk is dropped on every load and then erased on the next
+// save. The standalone @ledgerhq/coin-zcash module writes the same raw shape
+// when the flag is on, so the two round-trip interchangeably.
+
+function mapDecryptedOutput(output: DecryptedOutput): DecryptedOutputRaw {
+  return {
+    memo: output.memo,
+    transfer_type: output.transfer_type,
+    amount: output.amount.toString(),
+    ...(output.nullifier !== undefined && { nullifier: output.nullifier }),
+    ...(output.rho !== undefined && { rho: output.rho }),
+    ...(output.rseed !== undefined && { rseed: output.rseed }),
+    ...(output.cmx !== undefined && { cmx: output.cmx }),
+    ...(output.position !== undefined && { position: output.position }),
+    ...(output.recipient !== undefined && { recipient: output.recipient }),
+    ...(output.isSpent !== undefined && { is_spent: output.isSpent }),
+  };
+}
+
+function rehydrateOutput(raw: DecryptedOutputRaw): DecryptedOutput {
+  return {
+    memo: raw.memo,
+    transfer_type: raw.transfer_type,
+    amount: new BigNumber(raw.amount),
+    ...(raw.nullifier !== undefined && { nullifier: raw.nullifier }),
+    ...(raw.rho !== undefined && { rho: raw.rho }),
+    ...(raw.rseed !== undefined && { rseed: raw.rseed }),
+    ...(raw.cmx !== undefined && { cmx: raw.cmx }),
+    ...(raw.position !== undefined && { position: raw.position }),
+    ...(raw.recipient !== undefined && { recipient: raw.recipient }),
+    ...(raw.is_spent !== undefined && { isSpent: raw.is_spent }),
+  };
+}
+
+export function toZcashPrivateInfoRaw(info: ZcashPrivateInfo): ZcashPrivateInfoRaw {
+  return {
+    saplingBalance: info.saplingBalance.toString(),
+    orchardBalance: info.orchardBalance.toString(),
+    ironwoodBalance: info.ironwoodBalance.toString(),
+    lastSyncTimestamp: info.lastSyncTimestamp,
+    ufvk: info.ufvk,
+    syncState: info.syncState,
+    progress: info.progress,
+    estimatedTimeRemaining: info.estimatedTimeRemaining,
+    birthday: info.birthday,
+    lastProcessedBlock: info.lastProcessedBlock,
+    transactions: info.transactions.map(({ fee, transparentOut, decryptedData, ...tx }) => ({
+      ...tx,
+      fee: fee.toString(),
+      // Written out only when known: a transaction scanned before the scanner
+      // reported the transparent bundle has no value to state, and "0" would
+      // read as one. `hasTransparentInputs` needs no conversion and rides the
+      // spread, absent or not.
+      ...(transparentOut !== undefined && { transparentOut: transparentOut.toString() }),
+      decryptedData: {
+        orchard_outputs: (decryptedData?.orchard_outputs ?? []).map(mapDecryptedOutput),
+        sapling_outputs: (decryptedData?.sapling_outputs ?? []).map(mapDecryptedOutput),
+        ...(decryptedData?.ironwood_outputs && {
+          ironwood_outputs: decryptedData.ironwood_outputs.map(mapDecryptedOutput),
+        }),
+      },
+    })),
+  };
+}
+
+export function fromZcashPrivateInfoRaw(info: ZcashPrivateInfoRaw): ZcashPrivateInfo {
+  return {
+    saplingBalance: new BigNumber(info.saplingBalance),
+    orchardBalance: new BigNumber(info.orchardBalance),
+    // Guard accounts persisted before Ironwood support was added.
+    ironwoodBalance: new BigNumber(info.ironwoodBalance ?? "0"),
+    lastSyncTimestamp: info.lastSyncTimestamp,
+    ufvk: info.ufvk,
+    syncState: info.syncState as ZcashSyncState,
+    progress: info.progress,
+    estimatedTimeRemaining: info.estimatedTimeRemaining,
+    birthday: info.birthday,
+    lastProcessedBlock: info.lastProcessedBlock,
+    transactions: info.transactions.map(({ fee, transparentOut, decryptedData, ...tx }) => ({
+      ...tx,
+      fee: new BigNumber(fee),
+      // Read back only what was written: an account persisted before the
+      // scanner reported the transparent bundle states nothing about it, and
+      // zero would state something.
+      ...(transparentOut !== undefined && { transparentOut: new BigNumber(transparentOut) }),
+      decryptedData: {
+        orchard_outputs: (decryptedData?.orchard_outputs ?? []).map(rehydrateOutput),
+        sapling_outputs: (decryptedData?.sapling_outputs ?? []).map(rehydrateOutput),
+        ...(decryptedData?.ironwood_outputs && {
+          ironwood_outputs: decryptedData.ironwood_outputs.map(rehydrateOutput),
+        }),
+      },
+    })),
+  };
+}

--- a/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/serialization.ts
+++ b/libs/coin-modules/coin-bitcoin/src/chain-adapters/zcash/serialization.ts
@@ -15,6 +15,25 @@ import type {
 // Without this the ufvk is dropped on every load and then erased on the next
 // save. The standalone @ledgerhq/coin-zcash module writes the same raw shape
 // when the flag is on, so the two round-trip interchangeably.
+//
+// TODO: remove this module once the `zcashShielded` feature flag is retired and
+// Zcash is served by @ledgerhq/coin-zcash by default. At that point set the
+// Zcash `currency.family` to "zcash" (see domain/entity/currency-crypto) and
+// drop the flag-based routing in ledger-live-common's `resolveFamily`
+// (bridge/impl.ts): both decode and encode then resolve to coin-zcash
+// unconditionally, coin-bitcoin no longer serves Zcash, and this file — along
+// with the `assignToAccountRaw`/`assignFromAccountRaw` hooks in ./index.ts —
+// becomes dead code. coin-zcash's own bridge/serialization.ts already owns the
+// same round-trip, so persistence is preserved by that move alone.
+//
+// This holds only if the transparent transaction path is re-routed through
+// @ledgerhq/coin-zcash too. Today it is this chain-adapter — getAddress,
+// getWalletXpub, getFullViewingKey, createSigner and the ZIP-317 fee pricer in
+// ./index.ts — that backs the transparent PSBT flow whenever coin-bitcoin
+// serves Zcash. If that path stays on coin-bitcoin, then coin-bitcoin keeps
+// serving Zcash, `currency.family` cannot become "zcash", and this
+// serialization must stay. So the precondition for the cleanup above is that
+// coin-zcash owns the whole Zcash path, transparent included.
 
 function mapDecryptedOutput(output: DecryptedOutput): DecryptedOutputRaw {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,8 +94,8 @@ catalogs:
       specifier: 0.3.0
       version: 0.3.0
     '@ledgerhq/zcash-utils':
-      specifier: 1.1.1
-      version: 1.1.1
+      specifier: 2.0.0
+      version: 2.0.0
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
@@ -1074,7 +1074,7 @@ importers:
         version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 1.1.1
+        version: 2.0.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.1.4)
@@ -8335,7 +8335,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 1.1.1
+        version: 2.0.0
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -19768,8 +19768,8 @@ packages:
   '@ledgerhq/wallet-api-simulator@2.3.2':
     resolution: {integrity: sha512-EJaOBK+DM/R8hb+Mm83yl1Hv9ceU0rPjZK/OcNFw5IT0iU91kFy2j2vDoEcSiDcVeWINUcdENSWo+hPEavSdGg==}
 
-  '@ledgerhq/zcash-utils@1.1.1':
-    resolution: {integrity: sha512-leUKDOf4g8cU7UtFw0c9mAONN6xEzZBTF/bAHWPUwHbIqjVDAuJOGnAf31f9E5jYghATgnrCN1OkQ8b7Wg2Aiw==}
+  '@ledgerhq/zcash-utils@2.0.0':
+    resolution: {integrity: sha512-2dA3L12vxTtIE5QRz4M5rPLFe+ZKeJLVZI3RU2WW+4MYr2k/W99pfUZZfh0/q+HpqzcldmlYDrvu3/HoylMlLg==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -48307,7 +48307,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@ledgerhq/zcash-utils@1.1.1': {}
+  '@ledgerhq/zcash-utils@2.0.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   "@ledgerhq/lumen-ui-rnative-visualization": 0.1.29
   "@ledgerhq/lumen-ui-react-visualization": 0.1.28
   "@ledgerhq/lumen-utils-shared": "0.1.7"
-  "@ledgerhq/zcash-utils": 1.1.1
+  "@ledgerhq/zcash-utils": 2.0.0
   # React Native
   react-native: 0.81.6
   "@react-native/assets-registry": 0.81.6


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Restore the `privateInfo` serialization on coin-bitcoin's Zcash chain-adapter (`assignToAccountRaw`/`assignFromAccountRaw`), removed with the legacy chain-adapter. Accounts are decoded at app startup, before the host mirrors the `zcashShielded` flag, so the bitcoin family bridge is always the one that reads a persisted Zcash account back; with no adapter serialization the ufvk was lost on load and then erased on the next save. This is intentionally flag-independent and round-trips the same raw shape the standalone `@ledgerhq/coin-zcash` module writes when the flag is on.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35664
