### PR TITLE
fix(LIVE-15710): add missing inExtraId to fund protocol

### DIFF
--- a/.changeset/funny-seals-punch.md
+++ b/.changeset/funny-seals-punch.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/hw-app-exchange": patch
+---
+
+Add missing inExtraId to fund payload and align FundPayload key with the protocol contract

--- a/.changeset/funny-seals-punch.md
+++ b/.changeset/funny-seals-punch.md
@@ -1,5 +1,5 @@
 ---
-"@ledgerhq/hw-app-exchange": patch
+"@ledgerhq/hw-app-exchange": minor
 ---
 
 Add missing inExtraId to fund payload and align FundPayload key with the protocol contract

--- a/libs/ledgerjs/packages/hw-app-exchange/protocol.proto
+++ b/libs/ledgerjs/packages/hw-app-exchange/protocol.proto
@@ -40,4 +40,5 @@ message NewFundResponse {
     bytes    in_amount = 4;              // inAmount
     string   in_address = 5;             // account
     bytes    device_transaction_id = 6;  // nonce
+    string   in_extra_id = 7;            // inExtraId
 }

--- a/libs/ledgerjs/packages/hw-app-exchange/src/FundUtils.ts
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/FundUtils.ts
@@ -9,7 +9,7 @@ export type FundPayload = {
   inCurrency: string;
   accountName: string;
   userId: string;
-  payinExtraId?: string;
+  inExtraId?: string;
 };
 
 export async function decodeFundPayload(payload: string): Promise<FundPayload> {

--- a/libs/ledgerjs/packages/hw-app-exchange/src/generate-protocol.json
+++ b/libs/ledgerjs/packages/hw-app-exchange/src/generate-protocol.json
@@ -127,6 +127,10 @@
             "deviceTransactionId": {
               "type": "bytes",
               "id": 6
+            },
+            "inExtraId": {
+              "type": "string",
+              "id": 7
             }
           }
         }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

## Summary
- Add `inExtraId` to the fund protobuf contract (`NewFundResponse`)
- Rename `FundPayload.payinExtraId` → `inExtraId` to match the protocol key

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

https://ledgerhq.atlassian.net/jira/for-you?tab=assigned&selectedIssue=LIVE-15710
