### PR TITLE
[LWM] chore(e2e): add tests for memo on the new send flow

### DIFF
--- a/.changeset/honest-nails-build.md
+++ b/.changeset/honest-nails-build.md
@@ -1,0 +1,6 @@
+---
+"live-mobile": minor
+"ledger-live-mobile-e2e-tests": minor
+---
+
+Chore: add tests for memo on the new send flow

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoTypeSelect.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/Memo/MemoTypeSelect.tsx
@@ -52,7 +52,7 @@ function MemoTypeSelectComponent({ currencyId, options, value, onChange }: MemoT
 
   return (
     <>
-      <OptionListTrigger onPress={handleOpenSheet}>
+      <OptionListTrigger testID="send-memo-type-select" onPress={handleOpenSheet}>
         {selectedItem != null && (
           <Text typography="body1" lx={{ color: "base" }}>
             {selectedItem.label}
@@ -66,7 +66,7 @@ function MemoTypeSelectComponent({ currencyId, options, value, onChange }: MemoT
             <OptionListContent
               lx={{ marginBottom: "s24" }}
               renderItem={item => (
-                <OptionListItem value={item.value}>
+                <OptionListItem testID={`send-memo-type-option-${item.value}`} value={item.value}>
                   <OptionListItemContent>
                     <OptionListItemText>{item.label}</OptionListItemText>
                   </OptionListItemContent>

--- a/e2e/mobile/page/trade/newSendFlow.page.ts
+++ b/e2e/mobile/page/trade/newSendFlow.page.ts
@@ -6,11 +6,12 @@ export default class NewSendFlowPage {
   skipMemoConfirmId = "new-send-flow-skip-memo-confirm";
   addressConfirmId = "new-send-flow-address-confirm";
   memoInputId = "send-memo-input";
+  memoTypeSelectId = "send-memo-type-select";
   amountContinueEnabledButtonId = "enabled-amount-continue-button";
   signaturePromptId = "send-signature-prompt";
   successViewTransactionId = "send-confirmation-success-view-transaction";
 
-  @Step("Type address in search input: $0")
+  @Step("Fill recipient address and continue: $0")
   async setRecipientAndContinueNewFlow(address: string | undefined, memoTag?: string) {
     if (!address) throw new Error("Recipient address is not set");
     await typeTextById(this.recipientInputId, address);
@@ -29,6 +30,39 @@ export default class NewSendFlowPage {
     } else {
       await tapById(this.addressConfirmId);
     }
+  }
+
+  @Step("Type recipient address (stay on recipient step): $0")
+  async typeRecipientNewFlow(address: string | undefined) {
+    if (!address) throw new Error("Recipient address is not set");
+    await typeTextById(this.recipientInputId, address);
+  }
+
+  @Step("Open memo type dropdown and expect options: $0")
+  async expectMemoTypeOptions(optionValues: string[]) {
+    await waitForElementById(this.memoTypeSelectId);
+    await tapById(this.memoTypeSelectId);
+    for (const optionValue of optionValues) {
+      await waitForElementById(`send-memo-type-option-${optionValue}`);
+    }
+  }
+
+  @Step("Expect memo field to reject non-numeric input: $0")
+  async expectMemoRejectsNonNumericInput(rawInput: string, expectedSanitizedValue = "") {
+    await waitForElementById(this.memoInputId);
+    await typeTextById(this.memoInputId, rawInput);
+    // XRP tags are numeric-only: non-digits are stripped by sanitizeMemoValue, so the
+    // field never holds the rejected characters.
+    const actualValue = await getTextOfElement(this.memoInputId);
+    jestExpect(actualValue).toEqual(expectedSanitizedValue);
+  }
+
+  @Step("Expect memo field to retain numeric input: $0")
+  async expectMemoRetainsNumericInput(numericInput: string) {
+    await waitForElementById(this.memoInputId);
+    await typeTextById(this.memoInputId, numericInput);
+    const actualValue = await getTextOfElement(this.memoInputId);
+    jestExpect(actualValue).toEqual(numericInput);
   }
 
   @Step("Fill crypto amount: $0")

--- a/e2e/mobile/specs/send/newSendFlow.ts
+++ b/e2e/mobile/specs/send/newSendFlow.ts
@@ -1,4 +1,4 @@
-import { TransactionType } from "@ledgerhq/live-e2e-shared/models/Transaction";
+import { Transaction, TransactionType } from "@ledgerhq/live-e2e-shared/models/Transaction";
 import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
 import { BST_SEND_CURRENCIES, beforeAllFunction, SendTestOptions } from "./send";
@@ -36,5 +36,122 @@ export function runNewSendFlowTest(
       await app.operationDetails.checkRecipientAddress(transaction.accountToCredit);
       await app.operationDetails.checkTransactionType("OUT");
     });
+  });
+}
+
+export type NewSendMemoTestOptions = {
+  /**
+   * Non-numeric input used to assert numeric-only enforcement of the memo field. Only relevant for
+   * numeric "tag" families (XRP): when provided, asserts the field rejects it while retaining the
+   * transaction's numeric `memoTag`. Text-memo families (Stellar, Cosmos, Solana) omit it.
+   */
+  invalidMemoInput?: string;
+  /**
+   * Also broadcast a second transaction without a memo (skip path). Disable for families that
+   * reject a new transaction while a previous one is still pending (e.g. Stellar).
+   * @default true
+   */
+  broadcastWithoutMemo?: boolean;
+  /**
+   * Memo-type values expected in the memo-type dropdown (families with a memo-type selector, e.g.
+   * Stellar: NO_MEMO, MEMO_TEXT, MEMO_ID, MEMO_HASH, MEMO_RETURN). When provided, asserts the
+   * dropdown opens and shows these options.
+   */
+  memoTypeOptions?: string[];
+};
+
+/**
+ * Memo coverage for the new send flow, one describe per Xray TC (e.g. XRP = B2CQA-6037).
+ * `transaction.memoTag` must be a valid memo for the family under test. Verifies:
+ *  - numeric-only input enforcement when `invalidMemoInput` is provided (numeric "tag" families),
+ *  - the memo-type dropdown shows the expected options when `memoTypeOptions` is provided,
+ *  - the skip option bypasses the memo requirement,
+ *  - the transaction completes successfully with a memo, and without a memo (skip) unless
+ *    `broadcastWithoutMemo` is false.
+ */
+export function runNewSendMemoTest(
+  transaction: TransactionType,
+  tmsLinks: string[],
+  tags: string[],
+  options?: SendTestOptions,
+  memoOptions: NewSendMemoTestOptions = {},
+) {
+  const { invalidMemoInput, broadcastWithoutMemo = true, memoTypeOptions } = memoOptions;
+  setTeamOwner(
+    BST_SEND_CURRENCIES.has(transaction.accountToDebit.currency.id)
+      ? Team.BST
+      : Team.COIN_INTEGRATION,
+  );
+  tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+  tags.forEach(tag => $Tag(tag));
+
+  const label = transaction.accountToDebit.currency.testLabel;
+  // Same transaction but skipping the memo, so Speculos does not expect a memo on the device.
+  const noMemoTransaction = new Transaction(
+    transaction.accountToDebit,
+    transaction.accountToCredit,
+    transaction.amount,
+    transaction.speed,
+    "noTag",
+  );
+
+  describe("Send - new flow - Memo", () => {
+    beforeAll(async () => {
+      await beforeAllFunction(transaction, options);
+    });
+
+    if (invalidMemoInput !== undefined) {
+      it(`[${label}] - Memo enforces numeric-only input (new send flow): rejects ${invalidMemoInput}`, async () => {
+        await app.send.navigateToSendScreen(transaction.accountToDebit.accountName);
+        await app.newSend.typeRecipientNewFlow(transaction.accountToCredit.address);
+        await app.newSend.expectMemoRejectsNonNumericInput(invalidMemoInput);
+        if (transaction.memoTag) {
+          await app.newSend.expectMemoRetainsNumericInput(transaction.memoTag);
+        }
+      });
+    }
+
+    if (memoTypeOptions !== undefined) {
+      it(`[${label}] - Memo type dropdown shows all options (new send flow)`, async () => {
+        await app.send.navigateToSendScreen(transaction.accountToDebit.accountName);
+        await app.newSend.typeRecipientNewFlow(transaction.accountToCredit.address);
+        await app.newSend.expectMemoTypeOptions(memoTypeOptions);
+      });
+    }
+
+    it(`[${label}] - Send with Memo (new send flow)`, async () => {
+      await app.send.navigateToSendScreen(transaction.accountToDebit.accountName);
+      await app.newSend.setRecipientAndContinueNewFlow(
+        transaction.accountToCredit.address,
+        transaction.memoTag,
+      );
+      await app.newSend.setAmountAndReviewNewFlow(transaction.amount);
+      await app.newSend.waitForSignature();
+      // Speculos asserts the memo is displayed on the device review screen.
+      await app.speculos.signSendTransaction(transaction);
+      await app.newSend.tapViewTransaction();
+      await app.operationDetails.waitForOperationDetails();
+      await app.operationDetails.checkAccount(transaction.accountToDebit.accountName);
+      await app.operationDetails.checkRecipientAddress(transaction.accountToCredit);
+      await app.operationDetails.checkTransactionType("OUT");
+    });
+
+    if (broadcastWithoutMemo) {
+      it(`[${label}] - Send without Memo using skip (new send flow)`, async () => {
+        await app.send.navigateToSendScreen(noMemoTransaction.accountToDebit.accountName);
+        await app.newSend.setRecipientAndContinueNewFlow(
+          noMemoTransaction.accountToCredit.address,
+          noMemoTransaction.memoTag,
+        );
+        await app.newSend.setAmountAndReviewNewFlow(noMemoTransaction.amount);
+        await app.newSend.waitForSignature();
+        await app.speculos.signSendTransaction(noMemoTransaction);
+        await app.newSend.tapViewTransaction();
+        await app.operationDetails.waitForOperationDetails();
+        await app.operationDetails.checkAccount(noMemoTransaction.accountToDebit.accountName);
+        await app.operationDetails.checkRecipientAddress(noMemoTransaction.accountToCredit);
+        await app.operationDetails.checkTransactionType("OUT");
+      });
+    }
   });
 }

--- a/e2e/mobile/specs/send/newSendMemo/newSendMemoATOM.spec.ts
+++ b/e2e/mobile/specs/send/newSendMemo/newSendMemoATOM.spec.ts
@@ -1,0 +1,10 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runNewSendMemoTest } from "../newSendFlow";
+import { FF_NEW_SEND_FLOW_ENABLED } from "../../../utils/featureFlagUtils";
+
+runNewSendMemoTest(
+  new Transaction(Account.ATOM_1, Account.ATOM_2, "0.01", undefined, "memo123"),
+  ["B2CQA-6039"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@cosmos", "@family-cosmos"],
+  { featureFlags: FF_NEW_SEND_FLOW_ENABLED },
+);

--- a/e2e/mobile/specs/send/newSendMemo/newSendMemoSOL.spec.ts
+++ b/e2e/mobile/specs/send/newSendMemo/newSendMemoSOL.spec.ts
@@ -1,0 +1,12 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runNewSendMemoTest } from "../newSendFlow";
+import { FF_NEW_SEND_FLOW_ENABLED } from "../../../utils/featureFlagUtils";
+
+// The Ledger Solana app does not surface the memo on the device review screen, so Speculos does
+// not assert it; this test covers completion with and without a memo (skip).
+runNewSendMemoTest(
+  new Transaction(Account.SOL_1, Account.SOL_2, "0.01", undefined, "memo123"),
+  ["B2CQA-6040"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@solana", "@family-solana"],
+  { featureFlags: FF_NEW_SEND_FLOW_ENABLED },
+);

--- a/e2e/mobile/specs/send/newSendMemo/newSendMemoXLM.spec.ts
+++ b/e2e/mobile/specs/send/newSendMemo/newSendMemoXLM.spec.ts
@@ -1,0 +1,17 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runNewSendMemoTest } from "../newSendFlow";
+import { FF_NEW_SEND_FLOW_ENABLED } from "../../../utils/featureFlagUtils";
+
+// Stellar rejects a new transaction while a previous one is still pending, so we broadcast a
+// single transaction (with memo) rather than both a with- and without-memo transaction.
+runNewSendMemoTest(
+  new Transaction(Account.XLM_1, Account.XLM_2, "0.01", undefined, "memoText"),
+  ["B2CQA-6038"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@stellar", "@family-stellar"],
+  { featureFlags: FF_NEW_SEND_FLOW_ENABLED },
+  {
+    broadcastWithoutMemo: false,
+    // Labels shown: No Memo, Memo Text, Memo ID, Memo Hash, Memo Return.
+    memoTypeOptions: ["NO_MEMO", "MEMO_TEXT", "MEMO_ID", "MEMO_HASH", "MEMO_RETURN"],
+  },
+);

--- a/e2e/mobile/specs/send/newSendMemo/newSendMemoXRP.spec.ts
+++ b/e2e/mobile/specs/send/newSendMemo/newSendMemoXRP.spec.ts
@@ -1,0 +1,12 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runNewSendMemoTest } from "../newSendFlow";
+import { FF_NEW_SEND_FLOW_ENABLED } from "../../../utils/featureFlagUtils";
+
+// XRP uses a numeric destination tag: assert numeric-only enforcement plus send with/without memo.
+runNewSendMemoTest(
+  new Transaction(Account.XRP_1, Account.XRP_2, "0.01", undefined, "123456"),
+  ["B2CQA-6037"],
+  ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ripple", "@family-xrp"],
+  { featureFlags: FF_NEW_SEND_FLOW_ENABLED },
+  { invalidMemoInput: "abcXYZ" },
+);

--- a/e2e/mobile/utils/featureFlagUtils.ts
+++ b/e2e/mobile/utils/featureFlagUtils.ts
@@ -51,7 +51,7 @@ export const FF_NEW_SEND_FLOW_ENABLED = {
   newSendFlow: {
     enabled: true,
     params: {
-      families: ["cosmos", "polkadot"],
+      families: ["cosmos", "polkadot", "xrp", "stellar", "solana"],
       excludedCurrencyIds: [],
     },
   },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Implement E2E automated tests for the memo field in the New Send Flow for Stellar (XLM), XRP, Cosmos (ATOM), and Solana (SOL).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34582](https://ledgerhq.atlassian.net/browse/LIVE-34582)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-34582]: https://ledgerhq.atlassian.net/browse/LIVE-34582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ