### PR TITLE
[LWDM] fix(coin-evm): skip system address logs in transfer detection

### DIFF
--- a/.changeset/evm-skip-system-address-logs.md
+++ b/.changeset/evm-skip-system-address-logs.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Skip logs emitted by SYSTEM_ADDRESS when parsing ERC20 transfers from receipts. EIP-7708 (Glamsterdam) makes every native transfer emit a log identical to an ERC20 `Transfer`, which would otherwise be reported as a transfer of a non-existent token.

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.common.ts
@@ -56,7 +56,14 @@ export const WETH_WITHDRAWAL_TOPIC =
 export const ERC20_MINT_TOPIC =
   "0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885";
 
+/** Emitter of the native transfer logs added by https://eips.ethereum.org/EIPS/eip-7708. */
+export const SYSTEM_ADDRESS = "0xfffffffffffffffffffffffffffffffffffffffe";
+
 const ZERO_ADDRESS_HEX = safeEncodeEIP55("0x0000000000000000000000000000000000000000");
+
+function isSystemLog(log: LogWithAddress): boolean {
+  return normalizeAddress(log.address) === SYSTEM_ADDRESS;
+}
 
 function topicToAddress(topic: string | undefined): string {
   if (!topic || topic.length < 66) return ZERO_ADDRESS_HEX;
@@ -127,6 +134,10 @@ function makeErc20Transfer(log: LogWithAddress, from: string, to: string): ERC20
  */
 export function parseERC20TransfersFromLogs(logs: ReadonlyArray<LogWithAddress>): ERC20Transfer[] {
   return logs.flatMap(log => {
+    // These mimic an ERC20 `Transfer` on a token that does not exist.
+    if (isSystemLog(log)) {
+      return [];
+    }
     if (isTransfer(log)) {
       return [makeErc20Transfer(log, topicToAddress(log.topics[1]), topicToAddress(log.topics[2]))];
     }

--- a/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
+++ b/libs/coin-modules/coin-evm/src/network/node/rpc.test.ts
@@ -21,6 +21,9 @@ import {
   withApi,
   destroyAllRpcProviders,
   parseERC20TransfersFromLogs,
+  SYSTEM_ADDRESS,
+  WETH_DEPOSIT_TOPIC,
+  ERC20_MINT_TOPIC,
 } from "./rpc.common";
 
 const nodeApi = createNodeApi({
@@ -410,6 +413,83 @@ describe("EVM Family", () => {
 
       it("should handle empty logs array", () => {
         expect(parseERC20TransfersFromLogs([])).toEqual([]);
+      });
+
+      describe("EIP-7708 SYSTEM_ADDRESS logs", () => {
+        // Shaped exactly like an ERC20 Transfer; only the emitter differs
+        const makeSystemTransferLog = (address: string) => ({
+          address,
+          topics: [
+            TRANSFER_TOPIC,
+            "0x000000000000000000000000534eef6db44fbeb71047ee3eb4cb16e572862af6",
+            "0x000000000000000000000000970402b253733a1f6f4f3cd1d07420006be2882d",
+          ],
+          data: "0x0000000000000000000000000000000000000000000000000000000000000001",
+        });
+
+        it("should skip Transfer-shaped logs emitted by SYSTEM_ADDRESS", () => {
+          expect(parseERC20TransfersFromLogs([makeSystemTransferLog(SYSTEM_ADDRESS)])).toEqual([]);
+        });
+
+        it("should skip SYSTEM_ADDRESS logs whatever the case of the emitter", () => {
+          expect(
+            parseERC20TransfersFromLogs([
+              makeSystemTransferLog("0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfE"),
+            ]),
+          ).toEqual([]);
+        });
+
+        it("should skip every log from SYSTEM_ADDRESS, not only Transfer-shaped ones", () => {
+          const logs = [
+            {
+              address: SYSTEM_ADDRESS,
+              topics: [
+                WETH_DEPOSIT_TOPIC,
+                "0x000000000000000000000000970402b253733a1f6f4f3cd1d07420006be2882d",
+              ],
+              data: "0x0000000000000000000000000000000000000000000000000000000000000001",
+            },
+            {
+              address: SYSTEM_ADDRESS,
+              topics: [
+                ERC20_MINT_TOPIC,
+                "0x000000000000000000000000970402b253733a1f6f4f3cd1d07420006be2882d",
+              ],
+              data: "0x0000000000000000000000000000000000000000000000000000000000000002",
+            },
+          ];
+
+          expect(parseERC20TransfersFromLogs(logs)).toEqual([]);
+        });
+
+        it("should still parse a genuine ERC20 Transfer sitting next to a system log", () => {
+          const logs = [
+            makeSystemTransferLog(SYSTEM_ADDRESS),
+            {
+              address: "0xabf26902fd7b624e0db40d31171ea9dddf078351",
+              topics: [
+                TRANSFER_TOPIC,
+                "0x000000000000000000000000534eef6db44fbeb71047ee3eb4cb16e572862af6",
+                "0x000000000000000000000000970402b253733a1f6f4f3cd1d07420006be2882d",
+              ],
+              data: "0x0000000000000000000000000000000000000000000000000000000000000003",
+            },
+          ];
+
+          const result = parseERC20TransfersFromLogs(logs);
+
+          expect(result).toEqual([
+            {
+              asset: {
+                type: "erc20",
+                assetReference: "0xaBf26902Fd7B624e0db40D31171eA9ddDf078351",
+              },
+              from: "0x534eeF6Db44FBeB71047EE3eb4CB16E572862aF6",
+              to: "0x970402B253733A1f6F4f3cd1d07420006be2882D",
+              value: "3",
+            },
+          ]);
+        });
       });
 
       it("should filter out logs with wrong number of topics", () => {


### PR DESCRIPTION
### 📝 Description

[EIP-7708](https://eips.ethereum.org/EIPS/eip-7708) (Glamsterdam) makes every non-zero native transfer emit a `LOG3` that is **byte-identical to an ERC-20 `Transfer`** — same `topics[0]`, 3 topics, 32 bytes of data. The only thing that distinguishes it is the emitter: `SYSTEM_ADDRESS` = `0xfffffffffffffffffffffffffffffffffffffffe`.

**Previous behaviour**: `parseERC20TransfersFromLogs` detects a transfer purely from the topic shape (`isTransfer`, `rpc.common.ts`), never looking at `log.address`. An EIP-7708 log satisfies all three conditions, so it would be turned into an `ERC20Transfer` whose `assetReference` is `0xFf…fE` — a token that does not exist. Post-fork, **every EVM account would accrue phantom token operations on essentially every transaction it takes part in**.

**Fix**: skip all logs emitted by `SYSTEM_ADDRESS`, before the `isTransfer` / `isWethDeposit` / `isWethWithdrawal` / `isMint` dispatch.

- New exported `SYSTEM_ADDRESS` constant, next to the existing topic constants.
- The guard reuses the existing `normalizeAddress` helper (`src/utils.ts`), so the comparison is case-insensitive and runs on the raw `log.address`, before `safeEncodeEIP55` is applied.
- **All** logs from that address are skipped, not only `Transfer`-shaped ones: nothing legitimate emits token events from it, and the EIP may add further system log shapes.
- `parseERC20TransfersFromLogs` is the single choke point (its two production call sites are both in the same file), so the guard is not repeated per caller.

**Regression cover**: 4 new cases — lowercase emitter skipped, checksummed/upper-cased emitter skipped, non-`Transfer` system logs skipped, and a genuine ERC-20 `Transfer` sitting next to a system log still parsed. The 72 pre-existing cases in `rpc.test.ts` pass unchanged (76/76).

Behaviour is unchanged on every pre-fork chain, since no such log exists today. No gas or fee maths is touched.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-30166](https://ledgerhq.atlassian.net/browse/LIVE-30166) — epic [LIVE-29491](https://ledgerhq.atlassian.net/browse/LIVE-29491) `[coin-evm] Glamsterdam gas repricing`
- **ADR** (if any): n/a

[LIVE-30166]: https://ledgerhq.atlassian.net/browse/LIVE-30166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ