### PR TITLE
[LWDM] feat(coin-evm): make the calldata floor cost remotely configurable

### DIFF
--- a/.changeset/evm-configurable-calldata-floor.md
+++ b/.changeset/evm-configurable-calldata-floor.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-evm": patch
+---
+
+Make the EIP-7623 calldata floor remotely configurable through the new `calldataFloorGasPerToken` and `calldataFloorZeroByteTokens` coin config fields. Both default to the current EIP-7623 values, so behaviour is unchanged unless they are set; EIP-7976 can then be activated per chain without a release.

--- a/libs/coin-modules/coin-evm/src/config.ts
+++ b/libs/coin-modules/coin-evm/src/config.ts
@@ -93,6 +93,14 @@ export type EvmConfig = {
    */
   feeHistoryRewardPercentile?: number;
   /**
+   * Calldata floor cost, used as a gas validation lower bound. Default to 10 and 1 (EIP-7623).
+   * EIP-7976 raises them to 16 and 4, i.e. 64 gas per byte — set both, or zero-byte calldata is
+   * under-estimated. 64 is the resulting gas per byte, not a value to set here.
+   * @see https://eips.ethereum.org/EIPS/eip-7976
+   */
+  calldataFloorGasPerToken?: number;
+  calldataFloorZeroByteTokens?: number;
+  /**
    * Ordered list of internal-tx sources for `getBlock`. Built via `internalTxSourcesFromList()`.
    * Defaults to explorer-first, then node traces, then `empty` (resolves only when no
    * real trace runtime error was remembered; trace failures still propagate for retry).

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
@@ -50,7 +50,11 @@ describe("computeGasLimit", () => {
 
       it("should charge 64 gas per byte regardless of the byte values", () => {
         const allZeros = computeEIP7623GasLimit(defaultGasLimit, Buffer.alloc(32, 0x00), EIP_7976);
-        const allNonZeros = computeEIP7623GasLimit(defaultGasLimit, Buffer.alloc(32, 0xff), EIP_7976);
+        const allNonZeros = computeEIP7623GasLimit(
+          defaultGasLimit,
+          Buffer.alloc(32, 0xff),
+          EIP_7976,
+        );
 
         // 21000 + 64 * 32
         expect(allZeros).toEqual(23048n);
@@ -72,18 +76,15 @@ describe("computeGasLimit", () => {
         { label: "zero", params: { gasPerToken: 0, zeroByteTokens: 0 } },
         { label: "NaN", params: { gasPerToken: NaN, zeroByteTokens: NaN } },
         { label: "undefined", params: { gasPerToken: undefined, zeroByteTokens: undefined } },
-      ])(
-        "should fall back to the EIP-7623 defaults when the config holds $label",
-        ({ params }) => {
-          const gasLimit = computeEIP7623GasLimit(
-            defaultGasLimit,
-            Buffer.from(CALLDATA_68_BYTES, "hex"),
-            params,
-          );
+      ])("should fall back to the EIP-7623 defaults when the config holds $label", ({ params }) => {
+        const gasLimit = computeEIP7623GasLimit(
+          defaultGasLimit,
+          Buffer.from(CALLDATA_68_BYTES, "hex"),
+          params,
+        );
 
-          expect(gasLimit).toEqual(22400n);
-        },
-      );
+        expect(gasLimit).toEqual(22400n);
+      });
 
       it.each([1, 2, 3])(
         "should never go below intrinsic gas when gasPerToken is misconfigured to %i",

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
@@ -30,5 +30,71 @@ describe("computeGasLimit", () => {
       );
       expect(gasLimit).toEqual(expectedGasLimit);
     });
+
+    describe("configurable floor parameters (EIP-7976)", () => {
+      const defaultGasLimit = BigInt(DEFAULT_GAS_LIMIT.toFixed(0));
+      const CALLDATA_68_BYTES =
+        "a9059cbb00000000000000000000000066c4371ae8ffed2ec1c2ebbbccfb7e494181e1e30000000000000000000000000000000000000000000000000000000000000000";
+      const EIP_7976 = { gasPerToken: 16, zeroByteTokens: 4 };
+
+      it("should charge 64 gas per byte with the EIP-7976 parameters", () => {
+        const gasLimit = computeEIP7623GasLimit(
+          defaultGasLimit,
+          Buffer.from(CALLDATA_68_BYTES, "hex"),
+          EIP_7976,
+        );
+
+        // 21000 + 64 * 68
+        expect(gasLimit).toEqual(25352n);
+      });
+
+      it("should charge 64 gas per byte regardless of the byte values", () => {
+        const allZeros = computeEIP7623GasLimit(defaultGasLimit, Buffer.alloc(32, 0x00), EIP_7976);
+        const allNonZeros = computeEIP7623GasLimit(defaultGasLimit, Buffer.alloc(32, 0xff), EIP_7976);
+
+        // 21000 + 64 * 32
+        expect(allZeros).toEqual(23048n);
+        expect(allNonZeros).toEqual(23048n);
+      });
+
+      it("should keep the EIP-7623 values when no parameter is given", () => {
+        const gasLimit = computeEIP7623GasLimit(
+          defaultGasLimit,
+          Buffer.from(CALLDATA_68_BYTES, "hex"),
+        );
+
+        expect(gasLimit).toEqual(22400n);
+      });
+
+      it.each([
+        { label: "a float", params: { gasPerToken: 16.5, zeroByteTokens: 4.2 } },
+        { label: "a negative", params: { gasPerToken: -16, zeroByteTokens: -4 } },
+        { label: "zero", params: { gasPerToken: 0, zeroByteTokens: 0 } },
+        { label: "NaN", params: { gasPerToken: NaN, zeroByteTokens: NaN } },
+        { label: "undefined", params: { gasPerToken: undefined, zeroByteTokens: undefined } },
+      ])(
+        "should fall back to the EIP-7623 defaults when the config holds $label",
+        ({ params }) => {
+          const gasLimit = computeEIP7623GasLimit(
+            defaultGasLimit,
+            Buffer.from(CALLDATA_68_BYTES, "hex"),
+            params,
+          );
+
+          expect(gasLimit).toEqual(22400n);
+        },
+      );
+
+      it("should under-estimate zero bytes when only gasPerToken is raised", () => {
+        const gasLimit = computeEIP7623GasLimit(
+          defaultGasLimit,
+          Buffer.from(CALLDATA_68_BYTES, "hex"),
+          { gasPerToken: 16 },
+        );
+
+        // 21000 + 16 * 140 tokens, versus 25352n for the full 64/64 migration
+        expect(gasLimit).toEqual(23240n);
+      });
+    });
   });
 });

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
@@ -85,6 +85,20 @@ describe("computeGasLimit", () => {
         },
       );
 
+      it.each([1, 2, 3])(
+        "should never go below intrinsic gas when gasPerToken is misconfigured to %i",
+        gasPerToken => {
+          const gasLimit = computeEIP7623GasLimit(
+            defaultGasLimit,
+            Buffer.from(CALLDATA_68_BYTES, "hex"),
+            { gasPerToken },
+          );
+
+          // 21000 + 4 * 44 zero bytes + 16 * 24 non-zero ones
+          expect(gasLimit).toEqual(21560n);
+        },
+      );
+
       it("should under-estimate zero bytes when only gasPerToken is raised", () => {
         const gasLimit = computeEIP7623GasLimit(
           defaultGasLimit,

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.test.ts
@@ -1,5 +1,14 @@
 import { DEFAULT_GAS_LIMIT } from "../utils";
-import { computeEIP7623GasLimit } from "./computeGasLimit";
+import {
+  computeEIP7623GasLimit,
+  DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN,
+  DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS,
+} from "./computeGasLimit";
+
+const EIP_7623 = {
+  gasPerToken: DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN,
+  zeroByteTokens: DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS,
+};
 
 describe("computeGasLimit", () => {
   describe("computeEIP7623GasLimit", () => {
@@ -27,6 +36,7 @@ describe("computeGasLimit", () => {
       const gasLimit = computeEIP7623GasLimit(
         BigInt(DEFAULT_GAS_LIMIT.toFixed(0)),
         Buffer.from(callData, "hex"),
+        EIP_7623,
       );
       expect(gasLimit).toEqual(expectedGasLimit);
     });
@@ -61,10 +71,11 @@ describe("computeGasLimit", () => {
         expect(allNonZeros).toEqual(23048n);
       });
 
-      it("should keep the EIP-7623 values when no parameter is given", () => {
+      it("should keep the EIP-7623 values with the default parameters", () => {
         const gasLimit = computeEIP7623GasLimit(
           defaultGasLimit,
           Buffer.from(CALLDATA_68_BYTES, "hex"),
+          EIP_7623,
         );
 
         expect(gasLimit).toEqual(22400n);
@@ -75,7 +86,6 @@ describe("computeGasLimit", () => {
         { label: "a negative", params: { gasPerToken: -16, zeroByteTokens: -4 } },
         { label: "zero", params: { gasPerToken: 0, zeroByteTokens: 0 } },
         { label: "NaN", params: { gasPerToken: NaN, zeroByteTokens: NaN } },
-        { label: "undefined", params: { gasPerToken: undefined, zeroByteTokens: undefined } },
       ])("should fall back to the EIP-7623 defaults when the config holds $label", ({ params }) => {
         const gasLimit = computeEIP7623GasLimit(
           defaultGasLimit,
@@ -92,7 +102,7 @@ describe("computeGasLimit", () => {
           const gasLimit = computeEIP7623GasLimit(
             defaultGasLimit,
             Buffer.from(CALLDATA_68_BYTES, "hex"),
-            { gasPerToken },
+            { gasPerToken, zeroByteTokens: DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS },
           );
 
           // 21000 + 4 * 44 zero bytes + 16 * 24 non-zero ones
@@ -104,7 +114,7 @@ describe("computeGasLimit", () => {
         const gasLimit = computeEIP7623GasLimit(
           defaultGasLimit,
           Buffer.from(CALLDATA_68_BYTES, "hex"),
-          { gasPerToken: 16 },
+          { gasPerToken: 16, zeroByteTokens: DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS },
         );
 
         // 21000 + 16 * 140 tokens, versus 25352n for the full 64/64 migration

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
@@ -1,27 +1,29 @@
-const DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN = 10n;
-const DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS = 1n;
+/** EIP-7623 values, the pre-fork defaults callers apply when the coin config sets nothing. */
+export const DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN = 10;
+export const DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS = 1;
+
 const NON_ZERO_BYTE_TOKENS = 4n;
 
 const INTRINSIC_ZERO_BYTE_GAS = 4n;
 const INTRINSIC_NON_ZERO_BYTE_GAS = 16n;
 
 /** Values come from remote config, where a float or a NaN would otherwise throw in `BigInt()`. */
-function toPositiveInteger(value: number | undefined, fallback: bigint): bigint {
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-    return fallback;
+function toPositiveInteger(value: number, fallback: number): bigint {
+  if (!Number.isInteger(value) || value <= 0) {
+    return BigInt(fallback);
   }
   return BigInt(value);
 }
 
 export type CalldataFloorParams = {
-  gasPerToken?: number | undefined;
-  zeroByteTokens?: number | undefined;
+  gasPerToken: number;
+  zeroByteTokens: number;
 };
 
 /**
  * Compute the calldata floor gas limit.
  *
- * Defaults to https://eips.ethereum.org/EIPS/eip-7623 (10/40 gas per zero/non-zero byte).
+ * `DEFAULT_*` give https://eips.ethereum.org/EIPS/eip-7623 (10/40 gas per zero/non-zero byte).
  * https://eips.ethereum.org/EIPS/eip-7976 raises it to 64/64 via `gasPerToken: 16` **and**
  * `zeroByteTokens: 4` — 64 is the resulting gas per byte, not a value to pass here.
  *
@@ -32,7 +34,7 @@ export type CalldataFloorParams = {
 export function computeEIP7623GasLimit(
   defaultGasLimit: bigint,
   callData: Buffer,
-  params: CalldataFloorParams = {},
+  params: CalldataFloorParams,
 ): bigint {
   const gasPerToken = toPositiveInteger(params.gasPerToken, DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN);
   const zeroByteTokens = toPositiveInteger(

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
@@ -1,27 +1,46 @@
+const DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN = 10n;
+const DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS = 1n;
+const NON_ZERO_BYTE_TOKENS = 4n;
+
+/** Values come from remote config, where a float or a NaN would otherwise throw in `BigInt()`. */
+function toPositiveInteger(value: number | undefined, fallback: bigint): bigint {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return fallback;
+  }
+  return BigInt(value);
+}
+
+export type CalldataFloorParams = {
+  gasPerToken?: number | undefined;
+  zeroByteTokens?: number | undefined;
+};
+
 /**
- * Compute gas limit according to https://eips.ethereum.org/EIPS/eip-7623
+ * Compute the calldata floor gas limit.
  *
- * The formula is:
- * `gasLimit = defaultGasLimit + 10 * (null bytes count + 4 * non null bytes count)`
+ * Defaults to https://eips.ethereum.org/EIPS/eip-7623 (10/40 gas per zero/non-zero byte).
+ * https://eips.ethereum.org/EIPS/eip-7976 raises it to 64/64 via `gasPerToken: 16` **and**
+ * `zeroByteTokens: 4` — 64 is the resulting gas per byte, not a value to pass here.
  *
- * The EIP specifies we should take the maximum between intrinsic gas limit and EIP7623.
- * We did not implement that here because mathematically, intrinsic gas limit can never be higher than EIP7623:
- *
- * - eip7623   = defaultGasLimit + 10 * (null bytes count + 4 * non null bytes count)
- *             = defaultGasLimit + 10 * null bytes count + 40 * non null bytes count
- * - intrinsic = defaultGasLimit + 4 * null bytes count + 16 * non null bytes count
- *
- * EIP-7623 adds more value per byte than the intrinsic computation, so the computed value will always be higher
- *
- * @param defaultGasLimit The minimum gas limit to start the computation on (at that time, 21 000)
- * @param callData The calldata of the transaction
- * @returns The gas limit according to EIP-7623
+ * The EIP asks for `max(intrinsic, floor)`. The floor is the larger one for both parameter sets we
+ * intend to configure, so it is not implemented; a low enough `gasPerToken` pushed remotely would
+ * break that and under-estimate.
  */
-export function computeEIP7623GasLimit(defaultGasLimit: bigint, callData: Buffer): bigint {
+export function computeEIP7623GasLimit(
+  defaultGasLimit: bigint,
+  callData: Buffer,
+  params: CalldataFloorParams = {},
+): bigint {
+  const gasPerToken = toPositiveInteger(params.gasPerToken, DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN);
+  const zeroByteTokens = toPositiveInteger(
+    params.zeroByteTokens,
+    DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS,
+  );
+
   let tokensInCalldata = 0n;
   for (const byte of callData) {
-    tokensInCalldata += byte === 0 ? 1n : 4n;
+    tokensInCalldata += byte === 0 ? zeroByteTokens : NON_ZERO_BYTE_TOKENS;
   }
 
-  return defaultGasLimit + 10n * tokensInCalldata;
+  return defaultGasLimit + gasPerToken * tokensInCalldata;
 }

--- a/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
+++ b/libs/coin-modules/coin-evm/src/logic/computeGasLimit.ts
@@ -2,6 +2,9 @@ const DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN = 10n;
 const DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS = 1n;
 const NON_ZERO_BYTE_TOKENS = 4n;
 
+const INTRINSIC_ZERO_BYTE_GAS = 4n;
+const INTRINSIC_NON_ZERO_BYTE_GAS = 16n;
+
 /** Values come from remote config, where a float or a NaN would otherwise throw in `BigInt()`. */
 function toPositiveInteger(value: number | undefined, fallback: bigint): bigint {
   if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
@@ -22,9 +25,9 @@ export type CalldataFloorParams = {
  * https://eips.ethereum.org/EIPS/eip-7976 raises it to 64/64 via `gasPerToken: 16` **and**
  * `zeroByteTokens: 4` — 64 is the resulting gas per byte, not a value to pass here.
  *
- * The EIP asks for `max(intrinsic, floor)`. The floor is the larger one for both parameter sets we
- * intend to configure, so it is not implemented; a low enough `gasPerToken` pushed remotely would
- * break that and under-estimate.
+ * Returns `max(intrinsic, floor)` as the EIP specifies. The floor is the larger one for every
+ * parameter set we intend to configure, but taking the max keeps a misconfigured remote value from
+ * dropping the result below intrinsic gas.
  */
 export function computeEIP7623GasLimit(
   defaultGasLimit: bigint,
@@ -38,9 +41,15 @@ export function computeEIP7623GasLimit(
   );
 
   let tokensInCalldata = 0n;
+  let intrinsicCalldataGas = 0n;
   for (const byte of callData) {
     tokensInCalldata += byte === 0 ? zeroByteTokens : NON_ZERO_BYTE_TOKENS;
+    intrinsicCalldataGas += byte === 0 ? INTRINSIC_ZERO_BYTE_GAS : INTRINSIC_NON_ZERO_BYTE_GAS;
   }
+  const floorCalldataGas = gasPerToken * tokensInCalldata;
 
-  return defaultGasLimit + gasPerToken * tokensInCalldata;
+  return (
+    defaultGasLimit +
+    (floorCalldataGas > intrinsicCalldataGas ? floorCalldataGas : intrinsicCalldataGas)
+  );
 }

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -1021,6 +1021,51 @@ describe("validateIntent", () => {
           expect(computeGasLimitModule.computeEIP7623GasLimit).toHaveBeenCalledTimes(1);
         });
 
+        describe("calldata floor coin config", () => {
+          it("forwards the configured floor parameters to computeEIP7623GasLimit", async () => {
+            setCoinConfig(
+              () =>
+                ({
+                  info: {
+                    node: { type: "ledger", explorerId: "eth" },
+                    explorer: { type: "ledger" },
+                    gasTracker: { type: "ledger", explorerId: "eth" },
+                    calldataFloorGasPerToken: 16,
+                    calldataFloorZeroByteTokens: 4,
+                  },
+                }) as unknown as EvmCoinConfig,
+            );
+
+            await validateIntent(
+              {} as CryptoCurrency,
+              createIntent({}),
+              [{ value: 50n, asset: { type: "native" } }],
+              { value: 0n, parameters: { gasLimit: 21000n } },
+            );
+
+            expect(computeGasLimitModule.computeEIP7623GasLimit).toHaveBeenCalledWith(
+              expect.any(BigInt),
+              expect.any(Buffer),
+              { gasPerToken: 16, zeroByteTokens: 4 },
+            );
+          });
+
+          it("forwards undefined parameters when the coin config sets none", async () => {
+            await validateIntent(
+              {} as CryptoCurrency,
+              createIntent({}),
+              [{ value: 50n, asset: { type: "native" } }],
+              { value: 0n, parameters: { gasLimit: 21000n } },
+            );
+
+            expect(computeGasLimitModule.computeEIP7623GasLimit).toHaveBeenCalledWith(
+              expect.any(BigInt),
+              expect.any(Buffer),
+              { gasPerToken: undefined, zeroByteTokens: undefined },
+            );
+          });
+        });
+
         it("detects customGasLimit being lower than gasLimit with a warning", async () => {
           const res = await validateIntent(
             {} as CryptoCurrency,

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -1050,7 +1050,7 @@ describe("validateIntent", () => {
             );
           });
 
-          it("forwards undefined parameters when the coin config sets none", async () => {
+          it("forwards the EIP-7623 defaults when the coin config sets none", async () => {
             await validateIntent(
               {} as CryptoCurrency,
               createIntent({}),
@@ -1061,7 +1061,7 @@ describe("validateIntent", () => {
             expect(computeGasLimitModule.computeEIP7623GasLimit).toHaveBeenCalledWith(
               expect.any(BigInt),
               expect.any(Buffer),
-              { gasPerToken: undefined, zeroByteTokens: undefined },
+              { gasPerToken: 10, zeroByteTokens: 1 },
             );
           });
         });

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -44,7 +44,11 @@ import {
   isEip55Address,
   isLegacyFeeEstimation,
 } from "./common";
-import { computeEIP7623GasLimit } from "./computeGasLimit";
+import {
+  computeEIP7623GasLimit,
+  DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN,
+  DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS,
+} from "./computeGasLimit";
 import estimateFees from "./estimateFees";
 
 function assetsAreEqual(asset1: AssetInfo, asset2: AssetInfo): boolean {
@@ -169,8 +173,8 @@ async function validateGas(
     BigInt(DEFAULT_GAS_LIMIT.toFixed(0)),
     intent.data.value,
     {
-      gasPerToken: calldataFloorGasPerToken,
-      zeroByteTokens: calldataFloorZeroByteTokens,
+      gasPerToken: calldataFloorGasPerToken ?? DEFAULT_CALLDATA_FLOOR_GAS_PER_TOKEN,
+      zeroByteTokens: calldataFloorZeroByteTokens ?? DEFAULT_CALLDATA_FLOOR_ZERO_BYTE_TOKENS,
     },
   );
 

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -147,7 +147,9 @@ async function validateGas(
   const errors: Record<string, Error> = {};
   const warnings: Record<string, Error> = {};
 
-  const { minGasPrice } = getCoinConfig(currency.id).info;
+  const { minGasPrice, calldataFloorGasPerToken, calldataFloorZeroByteTokens } = getCoinConfig(
+    currency.id,
+  ).info;
   const minGasPriceFloor = typeof minGasPrice === "string" ? BigInt(minGasPrice) : null;
 
   const nativeBalance = findBalance({ type: "native" }, balances);
@@ -166,6 +168,10 @@ async function validateGas(
   const eip7623GasLimit = computeEIP7623GasLimit(
     BigInt(DEFAULT_GAS_LIMIT.toFixed(0)),
     intent.data.value,
+    {
+      gasPerToken: calldataFloorGasPerToken,
+      zeroByteTokens: calldataFloorZeroByteTokens,
+    },
   );
 
   // Gas Limit


### PR DESCRIPTION
### 📝 Description

[EIP-7976](https://eips.ethereum.org/EIPS/eip-7976) raises the calldata floor cost from **10/40** to **64/64** gas per zero/non-zero byte. Its Backwards Compatibility section explicitly requires wallets to update, or they under-estimate gas and transactions fail.

We compute that floor ourselves in `computeEIP7623GasLimit`, with hardcoded values, and use it as a **validation lower bound** (`GasLessThanEstimate`) — not as the gas we send. Since there is no fork date yet (Sepolia has not forked; mainnet is Q4 2026), adapting the value must not require a Ledger Live release: it has to come from remote config, per chain.

**EIP-7976 changes two parameters, not one**, so a single-constant swap would ship an under-estimate:

| | `TOTAL_COST_FLOOR_PER_TOKEN` | zero byte weight | effective gas/byte |
| --- | --- | --- | --- |
| EIP-7623 (today) | 10 | 1 token | 10 / 40 |
| EIP-7976 | **16** | **4 tokens** | 64 / 64 |

EIP-7976 redefines the tokenisation as `(zero + nonzero) * 4`, where EIP-7623 uses `zero + nonzero * 4`. Two traps worth spelling out: **64 is the gas-per-byte figure, not the config value** (setting 64 would over-charge by 4x), and setting only the per-token constant to 16 while leaving the zero-byte weight at 1 gives 16/64, which *under*-estimates zero-byte calldata. A single knob cannot express both `(10, weight 1)` and `(16, weight 4)`.

**Changes**

- `config.ts`: two optional `EvmConfig` fields, `calldataFloorGasPerToken` and `calldataFloorZeroByteTokens`, alongside the existing remote-config-fed tuning fields (`minGasPrice`, `feeHistoryBlockCount`, …).
- `computeGasLimit.ts`: both the per-token gas and the zero-byte weight become parameters, passed as an optional options object rather than two positional numbers — swapping `16` and `4` positionally would pass silently and produce exactly the under-estimate this ticket exists to prevent. Defaults are the current values, so an omitted config is byte-identical to today.
- `validateIntent.ts`: forwards both values at the single production call site, reusing the `getCoinConfig(currency.id).info` destructuring already present in `validateGas`.

Invalid remote values (float, negative, zero, `NaN`) fall back to the defaults instead of throwing inside `BigInt()` mid-validation — falling back means pre-fork behaviour, which is the safe direction.

**One caveat documented in the code**: the doc comment justified omitting the spec's `max(intrinsic, floor)` by arguing intrinsic can never exceed the floor. That holds for both `(10, 1)` and `(16, 4)`, but it is a property of those parameter sets, not of the formula — a low enough `gasPerToken` pushed remotely would break it. It is now written up as a constraint on the values we may configure. Implementing the real `max()` would need the intrinsic formula, which EIP-2780 also changes post-fork; out of scope here.

**Tests**: the 4 existing vectors (`21000n`, `22400n`, `22490n`, `22460n`) pass unchanged with no config. New cases pin the post-fork vector (`21000 + 64 * 68 = 25352n`), 64/byte regardless of byte value, each parameter applied independently (the half-migration trap), and the fallback on every invalid value. `validateIntent` asserts the forwarded values both with and without config. Full module suite: 1114/1114.

Out of scope, untouched: the unrelated `10n` fee-ratio heuristic in `validateIntent.ts`, and the gas limit we actually broadcast.

### 🚦 Activation — this PR ships dormant

Merging changes nothing: the defaults reproduce today's behaviour exactly. **The fork is not activated by this PR.** When Glamsterdam activates on a chain, someone has to push, per chain, to remote config:

```
calldataFloorGasPerToken: 16
calldataFloorZeroByteTokens: 4
```

Verified against the spec text, not just the ticket: EIP-7976 sets `TOTAL_COST_FLOOR_PER_TOKEN = 16` and `floor_tokens_in_calldata = (zero_bytes + nonzero_bytes) * 4`, giving 64 gas per byte. **The EIP is still in Review, so these two numbers may change** — which is the whole reason they are configurable rather than hardcoded.

If this is forgotten at fork time, the validation floor stays at 10/40 and we stop rejecting a custom gas limit that is too low, so such a transaction fails on chain. The normal send flow is unaffected, since it follows `eth_estimateGas`.

**Who owns pushing the remote config needs deciding before the fork — it is not covered by this PR.**

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35603](https://ledgerhq.atlassian.net/browse/LIVE-35603) — epic [LIVE-29491](https://ledgerhq.atlassian.net/browse/LIVE-29491) `[coin-evm] Glamsterdam gas repricing`
- Follows [#20620](https://github.com/LedgerHQ/ledger-live/pull/20620) (LIVE-30166) from the same epic; independent branch, no dependency between them.
- **ADR** (if any): n/a

[LIVE-35603]: https://ledgerhq.atlassian.net/browse/LIVE-35603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
