### PR TITLE
ci(codecheck): run codechecks for every lib scope (LIVE-35675)

### DIFF
--- a/.github/workflows/test-devtools-reusable.yml
+++ b/.github/workflows/test-devtools-reusable.yml
@@ -35,70 +35,8 @@ permissions:
 jobs:
   test-devtools:
     name: "DevTools Test"
-    timeout-minutes: 10
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
-      FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
-
-    runs-on: [ledger-live-linux-8CPU-32RAM]
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - name: JFrog npm auth
-        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
-        with:
-          registry: ${{ vars.ARTIFACTORY_URL }}
-
-      - name: Install dependencies
-        run: pnpm i --filter="@devtools/*..."
-
-      - name: Run coverage on devtools packages
-        run: |
-          mkdir -p ${{ github.workspace }}/coverage
-          touch ${{ github.workspace }}/coverage/lcov.info
-          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-
-          pnpm exec nx run-many -t coverage --projects=tag:scope:devtools --parallel=4 -- --maxWorkers=2
-
-      - name: Process coverage files
-        id: process-coverage
-        run: |
-          for package_json in $(find ./devtools -name "package.json" -not -path "*/node_modules/*"); do
-            pkg=$(dirname "$package_json")
-            echo "Processing package at path: $pkg"
-            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
-              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
-                echo "Appending coverage files for $pkg"
-                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
-                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-              fi
-            else
-              echo "No coverage script found for $pkg, skipping."
-            fi
-          done
-        shell: bash
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
-        id: generate_coverage
-        with:
-          name: coverage-devtools
-          path: ${{ github.workspace }}/coverage
+    uses: LedgerHQ/ledger-live/.github/workflows/test-scope-reusable.yml@develop
+    secrets: inherit
+    with:
+      scope: devtools
+      ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/test-domain-reusable.yml
+++ b/.github/workflows/test-domain-reusable.yml
@@ -35,73 +35,9 @@ permissions:
 jobs:
   test-domain:
     name: "Domain Test"
-    timeout-minutes: 10
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
-      FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
-
-    runs-on: [ledger-live-linux-8CPU-32RAM]
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - name: JFrog npm auth
-        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
-        with:
-          registry: ${{ vars.ARTIFACTORY_URL }}
-
-      - name: Install dependencies
-        run: pnpm i --filter="./domain/**" --filter="./shared/**"
-
-      - name: Check export rules
-        run: pnpm exec nx run-many -t check-export-rules
-
-      - name: Run coverage on domain packages
-        run: |
-          mkdir -p ${{ github.workspace }}/coverage
-          touch ${{ github.workspace }}/coverage/lcov.info
-          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-
-          pnpm exec nx run-many -t coverage --projects=tag:scope:domain --parallel=4 -- --maxWorkers=2
-
-      - name: Process coverage files
-        id: process-coverage
-        run: |
-          for package_json in $(find ./domain -name "package.json" -not -path "*/node_modules/*"); do
-            pkg=$(dirname "$package_json")
-            echo "Processing package at path: $pkg"
-            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
-              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
-                echo "Appending coverage files for $pkg"
-                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
-                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-              fi
-            else
-              echo "No coverage script found for $pkg, skipping."
-            fi
-          done
-        shell: bash
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
-        id: generate_coverage
-        with:
-          name: coverage-domain
-          path: ${{ github.workspace }}/coverage
+    uses: LedgerHQ/ledger-live/.github/workflows/test-scope-reusable.yml@develop
+    secrets: inherit
+    with:
+      scope: domain
+      extra-targets: check-export-rules
+      ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/test-features-reusable.yml
+++ b/.github/workflows/test-features-reusable.yml
@@ -35,70 +35,9 @@ permissions:
 jobs:
   test-features:
     name: "Features Test"
-    timeout-minutes: 20
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
-      FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
-
-    runs-on: [ledger-live-linux-8CPU-32RAM]
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - name: JFrog npm auth
-        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
-        with:
-          registry: ${{ vars.ARTIFACTORY_URL }}
-
-      - name: Install dependencies
-        run: pnpm i --filter="@features/*..." --filter="./shared/**" --filter="./domain/**"
-
-      - name: Run coverage on feature packages
-        run: |
-          mkdir -p ${{ github.workspace }}/coverage
-          touch ${{ github.workspace }}/coverage/lcov.info
-          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-
-          pnpm exec nx run-many -t coverage --projects=tag:scope:features --parallel=4 -- --maxWorkers=2
-
-      - name: Process coverage files
-        id: process-coverage
-        run: |
-          for package_json in $(find ./features -name "package.json" -not -path "*/node_modules/*"); do
-            pkg=$(dirname "$package_json")
-            echo "Processing feature at path: $pkg"
-            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
-              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
-                echo "Appending coverage files for $pkg"
-                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
-                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-              fi
-            else
-              echo "No coverage script found for $pkg, skipping."
-            fi
-          done
-        shell: bash
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
-        id: generate_coverage
-        with:
-          name: coverage-features
-          path: ${{ github.workspace }}/coverage
+    uses: LedgerHQ/ledger-live/.github/workflows/test-scope-reusable.yml@develop
+    secrets: inherit
+    with:
+      scope: features
+      timeout-minutes: 20
+      ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/test-libs-reusable.yml
+++ b/.github/workflows/test-libs-reusable.yml
@@ -188,28 +188,12 @@ jobs:
         with:
           registry: ${{ vars.ARTIFACTORY_URL }}
       - name: Install dependencies
-        run: pnpm i
-      - name: Check formatting of affected libraries
-        id: format-check-libs
-        if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
-        run: pnpm exec nx run-many -t format:check --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
-      - name: Lint affected libraries
-        id: lint-libs
-        run: pnpm exec nx run-many -t lint --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false -- --quiet
-      - name: Typecheck affected libraries
-        id: typecheck-libs
-        run: pnpm exec nx run-many -t typecheck --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
-      - name: Test unimported files
-        id: unimported
-        run: pnpm exec nx run-many -t unimported --exclude=ledger-live-desktop,live-mobile,@ledgerhq/live-cli,@ledgerhq/web-tools,ledger-live-desktop-e2e-tests,ledger-live-mobile-e2e-tests --parallel=3 --nxBail=false
-        shell: bash
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: ${{ !cancelled() }}
+        run: pnpm i --filter="{./libs/**}..."
+      - name: Codechecks
+        uses: LedgerHQ/ledger-live/tools/actions/composites/nx-codechecks@develop
         with:
-          script: |
-            const fs = require("fs");
-            fs.writeFileSync("summary-typecheck.txt", "${{ steps.typecheck-libs.outcome }}", "utf-8");
-            fs.writeFileSync("summary-lint.txt", "${{ steps.lint-libs.outcome }}", "utf-8");
+          projects: tag:scope:libs
+          emit-summaries: "true"
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/test-scope-reusable.yml
+++ b/.github/workflows/test-scope-reusable.yml
@@ -1,0 +1,139 @@
+name: "[Scope] - Test - Called"
+
+on:
+  workflow_call:
+    inputs:
+      scope:
+        description: "Scope to test. Must match both the directory name and the scope:<name> Nx tag (e.g. features)."
+        type: string
+        required: true
+      extra-targets:
+        description: "Comma-separated Nx targets to run before coverage (e.g. check-export-rules)."
+        type: string
+        required: false
+        default: ""
+      timeout-minutes:
+        description: "Job timeout."
+        type: number
+        required: false
+        default: 10
+      ref:
+        description: "Ref to check out. Defaults to github.sha."
+        type: string
+        required: false
+
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.test-scope.outputs.coverage_generated }}
+
+    secrets:
+      AWS_ACCOUNT_ID_PROD:
+        required: false
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH:
+        required: false
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP:
+        required: false
+      AWS_CACHE_REGION:
+        required: false
+      AWS_CACHE_ROLE_NAME:
+        required: false
+      NX_KEY:
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-scope:
+    name: "Coverage & Codecheck"
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      NODE_OPTIONS: "--max-old-space-size=7168"
+      FORCE_COLOR: 3
+      CI_OS: ubuntu-22.04
+    outputs:
+      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
+
+    runs-on: [ledger-live-linux-8CPU-32RAM]
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup the caches
+        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
+        id: setup-caches
+        with:
+          use-mise: true
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
+          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
+          nx-key: ${{ secrets.NX_KEY }}
+          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
+          region: ${{ secrets.AWS_CACHE_REGION }}
+
+      - name: JFrog npm auth
+        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
+        with:
+          registry: ${{ vars.ARTIFACTORY_URL }}
+
+      - name: Install dependencies
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: pnpm i --filter="{./$SCOPE/**}..."
+        shell: bash
+
+      - name: Run extra targets
+        if: ${{ inputs.extra-targets != '' }}
+        env:
+          EXTRA_TARGETS: ${{ inputs.extra-targets }}
+          SCOPE: ${{ inputs.scope }}
+        run: pnpm exec nx run-many -t "$EXTRA_TARGETS" --projects="tag:scope:$SCOPE"
+        shell: bash
+
+      - name: Run coverage
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: |
+          mkdir -p ${{ github.workspace }}/coverage
+          touch ${{ github.workspace }}/coverage/lcov.info
+          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+
+          pnpm exec nx run-many -t coverage --projects="tag:scope:$SCOPE" --parallel=4 -- --maxWorkers=2
+        shell: bash
+
+      - name: Process coverage files
+        id: process-coverage
+        env:
+          SCOPE: ${{ inputs.scope }}
+        run: |
+          for package_json in $(find "./$SCOPE" -name "package.json" -not -path "*/node_modules/*"); do
+            pkg=$(dirname "$package_json")
+            echo "Processing package at path: $pkg"
+            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
+              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
+                echo "Appending coverage files for $pkg"
+                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
+                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
+              fi
+            else
+              echo "No coverage script found for $pkg, skipping."
+            fi
+          done
+        shell: bash
+
+      - name: Codechecks
+        if: ${{ !cancelled() }}
+        uses: LedgerHQ/ledger-live/tools/actions/composites/nx-codechecks@develop
+        with:
+          projects: "tag:scope:${{ inputs.scope }}"
+          parallel: "4"
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        if: ${{ !cancelled() }}
+        id: generate_coverage
+        with:
+          name: coverage-${{ inputs.scope }}
+          path: ${{ github.workspace }}/coverage

--- a/.github/workflows/test-shared-reusable.yml
+++ b/.github/workflows/test-shared-reusable.yml
@@ -35,70 +35,8 @@ permissions:
 jobs:
   test-shared:
     name: "Shared Test"
-    timeout-minutes: 10
-    env:
-      NODE_OPTIONS: "--max-old-space-size=7168"
-      FORCE_COLOR: 3
-      CI_OS: ubuntu-22.04
-    outputs:
-      coverage_generated: ${{ contains(steps.generate_coverage.outcome, 'success') }}
-
-    runs-on: [ledger-live-linux-8CPU-32RAM]
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Setup the caches
-        uses: LedgerHQ/ledger-live/tools/actions/composites/setup-caches@develop
-        id: setup-caches
-        with:
-          use-mise: true
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-develop-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_DEVELOP }}
-          cache-branch-role-arn: ${{ secrets.AWS_CACHE_OIDC_ROLE_ARN_BRANCH }}
-          nx-key: ${{ secrets.NX_KEY }}
-          accountId: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
-          roleName: ${{ secrets.AWS_CACHE_ROLE_NAME }}
-          region: ${{ secrets.AWS_CACHE_REGION }}
-
-      - name: JFrog npm auth
-        uses: LedgerHQ/ledger-live/tools/actions/composites/jfrog-npm-auth@develop
-        with:
-          registry: ${{ vars.ARTIFACTORY_URL }}
-
-      - name: Install dependencies
-        run: pnpm i --filter="./shared/**"
-
-      - name: Run coverage on shared packages
-        run: |
-          mkdir -p ${{ github.workspace }}/coverage
-          touch ${{ github.workspace }}/coverage/lcov.info
-          touch ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-
-          pnpm exec nx run-many -t coverage --projects=tag:scope:shared --parallel=4 -- --maxWorkers=2
-
-      - name: Process coverage files
-        id: process-coverage
-        run: |
-          for package_json in $(find ./shared -name "package.json" -not -path "*/node_modules/*"); do
-            pkg=$(dirname "$package_json")
-            echo "Processing package at path: $pkg"
-            if [ -f "$package_json" ] && jq -e '.scripts.coverage' "$package_json" > /dev/null 2>&1; then
-              if [ -f "$pkg/coverage/lcov.info" ] && [ -f "$pkg/coverage/sonar-executionTests-report.xml" ]; then
-                echo "Appending coverage files for $pkg"
-                cat "$pkg/coverage/lcov.info" >> ${{ github.workspace }}/coverage/lcov.info
-                cat "$pkg/coverage/sonar-executionTests-report.xml" >> ${{ github.workspace }}/coverage/sonar-executionTests-report.xml
-              fi
-            else
-              echo "No coverage script found for $pkg, skipping."
-            fi
-          done
-        shell: bash
-
-      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        if: ${{ !cancelled() }}
-        id: generate_coverage
-        with:
-          name: coverage-shared
-          path: ${{ github.workspace }}/coverage
+    uses: LedgerHQ/ledger-live/.github/workflows/test-scope-reusable.yml@develop
+    secrets: inherit
+    with:
+      scope: shared
+      ref: ${{ inputs.ref || github.sha }}

--- a/tools/actions/composites/nx-codechecks/action.yml
+++ b/tools/actions/composites/nx-codechecks/action.yml
@@ -1,0 +1,62 @@
+name: nx-codechecks
+description: Runs format:check, lint, typecheck and unimported for a set of Nx projects
+
+inputs:
+  projects:
+    description: "Nx project selector, e.g. tag:scope:libs"
+    required: true
+  parallel:
+    description: "Nx parallelism for each target"
+    required: false
+    default: "3"
+  emit-summaries:
+    description: "Write summary-typecheck.txt and summary-lint.txt to the workspace"
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Check formatting
+      id: format-check
+      if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.event_name == 'workflow_dispatch'
+      run: pnpm exec nx run-many -t format:check --projects="$PROJECTS" --parallel="$PARALLEL" --nxBail=false
+      shell: bash
+      env:
+        PROJECTS: ${{ inputs.projects }}
+        PARALLEL: ${{ inputs.parallel }}
+
+    - name: Lint
+      id: lint
+      run: pnpm exec nx run-many -t lint --projects="$PROJECTS" --parallel="$PARALLEL" --nxBail=false -- --quiet
+      shell: bash
+      env:
+        PROJECTS: ${{ inputs.projects }}
+        PARALLEL: ${{ inputs.parallel }}
+
+    - name: Typecheck
+      id: typecheck
+      run: pnpm exec nx run-many -t typecheck --projects="$PROJECTS" --parallel="$PARALLEL" --nxBail=false
+      shell: bash
+      env:
+        PROJECTS: ${{ inputs.projects }}
+        PARALLEL: ${{ inputs.parallel }}
+
+    - name: Test unimported files
+      id: unimported
+      run: pnpm exec nx run-many -t unimported --projects="$PROJECTS" --parallel="$PARALLEL" --nxBail=false
+      shell: bash
+      env:
+        PROJECTS: ${{ inputs.projects }}
+        PARALLEL: ${{ inputs.parallel }}
+
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      if: ${{ inputs.emit-summaries == 'true' && !cancelled() }}
+      env:
+        TYPECHECK_OUTCOME: ${{ steps.typecheck.outcome }}
+        LINT_OUTCOME: ${{ steps.lint.outcome }}
+      with:
+        script: |
+          const fs = require("fs");
+          fs.writeFileSync("summary-typecheck.txt", process.env.TYPECHECK_OUTCOME, "utf-8");
+          fs.writeFileSync("summary-lint.txt", process.env.LINT_OUTCOME, "utf-8");


### PR DESCRIPTION
## Problem

`test-libs-reusable.yml` defines a job displayed as "Libraries Codecheck", but its four checks were repo-wide — `nx run-many … --exclude=<6 projects>`, not `--projects=tag:scope:libs`. Its caller gates it on `contains(needs.determine-affected.outputs.paths, 'libs')`.

So a PR touching only `features/`, `domain/`, `shared/` or `devtools/` was never formatted, linted, typechecked or unimported-checked anywhere. The sibling workflows didn't cover it: features/shared ran only `coverage`, domain added only `check-export-rules`. 37 projects in those four scopes have no `libs/` dependent, so the gate never fired for them.

## Change

- **New `tools/actions/composites/nx-codechecks`** — one definition of the four targets, selector-parameterised, all `--nxBail=false`. Optional `emit-summaries` keeps the libs `report` job's per-target granularity.
- **New `.github/workflows/test-scope-reusable.yml`** — one job owning a scope's full pipeline. The codecheck step carries `if: ${{ !cancelled() }}`, so a failing test no longer hides typecheck errors and a failing typecheck no longer costs Sonar its coverage artifact.
- **The four sibling workflows** become ~42-line delegators, keeping their `workflow_dispatch` entry points and `coverage_generated` outputs.
- **`test-libs-reusable.yml`** uses the composite with `projects: tag:scope:libs`. The hand-maintained `--exclude=` list is gone; excluding apps and e2e is now structural.

Net: 291 lines deleted, 30 added.

## Scope calls

`tools/actions/*` (9), `support/*` (2) and `tests/dummy-wallet-app` lose `format:check`/`lint`/`typecheck` deliberately. `apps/wallet-cli` also drops out of the libs job but keeps full coverage in `build-wallet-cli-reusable.yml` - it was duplicated before. Follow up pending

`build-and-test-push.yml` is unchanged, so develop pushes still run libs + features only. Follow-up.

Test Commit: https://github.com/LedgerHQ/ledger-live/actions/runs/31381570217
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-35675