### PR TITLE
[LWDM] feat(coin-evm): warn when the recipient account does not exist yet

### DIFF
--- a/.changeset/evm-new-account-recipient-warning.md
+++ b/.changeset/evm-new-account-recipient-warning.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/coin-evm": patch
+"@ledgerhq/live-common": patch
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Explain the higher network fees when sending to an address that does not exist yet. EIP-8037 charges account creation substantially more gas, and nothing in the send flow told the user why the fee jumped. The gas we send is unchanged: `eth_estimateGas` remains the only source.

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7435,6 +7435,9 @@
     "FeeTooHigh": {
       "title": "Network fees are above 10% of the amount"
     },
+    "RecipientIsNewAccount": {
+      "title": "This address has never received funds, activating it costs a higher network fee"
+    },
     "DustLimit": {
       "title": "Amount is lower than dust limit"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -491,6 +491,9 @@
     "FeeTooHigh": {
       "title": "Network fees are above 10% of the amount"
     },
+    "RecipientIsNewAccount": {
+      "title": "This address has never received funds, activating it costs a higher network fee"
+    },
     "FeeTooLow": {
       "title": "Fees are too low to be accepted by the network. Please increase them"
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Amount/components/AmountInputSection.tsx
@@ -12,6 +12,13 @@ type AmountInputSectionProps = Readonly<{
   toggleLabel: string;
 }>;
 
+/** Kept in sync with the desktop mapping in `AmountMessageText.tsx`. */
+const MESSAGE_COLORS = {
+  error: "error",
+  warning: "warning",
+  info: "base",
+} as const;
+
 export function AmountInputSection({ viewModel, message, toggleLabel }: AmountInputSectionProps) {
   const styles = useStyleSheet(
     theme => ({
@@ -74,17 +81,7 @@ export function AmountInputSection({ viewModel, message, toggleLabel }: AmountIn
       </Text>
       <View style={styles.messageContainer}>
         {message ? (
-          <Text
-            typography="body3"
-            lx={{
-              color:
-                message.type === "error"
-                  ? "error"
-                  : message.type === "warning"
-                    ? "warning"
-                    : "muted",
-            }}
-          >
+          <Text typography="body3" lx={{ color: MESSAGE_COLORS[message.type] }}>
             <TranslatedError error={message.error} />
           </Text>
         ) : null}

--- a/libs/coin-modules/coin-evm/src/errors.ts
+++ b/libs/coin-modules/coin-evm/src/errors.ts
@@ -220,3 +220,12 @@ export class ClaimRewardsFeesWarning extends Error {
     if (fields) Object.assign(this, fields);
   }
 }
+
+/** @see https://eips.ethereum.org/EIPS/eip-8037 — creating an account costs materially more gas. */
+export class RecipientIsNewAccount extends Error {
+  override name = "RecipientIsNewAccount";
+  constructor(message?: string, fields?: Record<string, unknown>) {
+    super(message || "RecipientIsNewAccount");
+    if (fields) Object.assign(this, fields);
+  }
+}

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.test.ts
@@ -22,6 +22,7 @@ import {
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
   PriorityFeeTooLow,
+  RecipientIsNewAccount,
   RedelegateDstValAddressRequired,
   ValAddressRequired,
 } from "../errors";
@@ -233,6 +234,97 @@ describe("validateIntent", () => {
           }),
         }),
       );
+    });
+
+    describe("new account recipient (EIP-8037)", () => {
+      const RECIPIENT = "0xe2ca7390e76c5A992749bB622087310d2e63ca29";
+
+      function nativeSendToRecipient(overrides = {}) {
+        return validateIntent(
+          {} as CryptoCurrency,
+          eip1559Intent({ amount: 1n, recipient: RECIPIENT, ...overrides }),
+          [{ value: 50n, asset: { type: "native" } }],
+          { value: 0n, parameters: { gasLimit: 21000n, maxFeePerGas: 1n } },
+        );
+      }
+
+      it("warns when the recipient has no balance and no nonce", async () => {
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(0));
+        nodeApiMock.getTransactionCount.mockResolvedValue(0);
+
+        const res = await nativeSendToRecipient();
+
+        expect(res.warnings).toEqual(
+          expect.objectContaining({ amount: new RecipientIsNewAccount() }),
+        );
+        expect(res.errors).not.toEqual(
+          expect.objectContaining({ amount: expect.any(RecipientIsNewAccount) }),
+        );
+      });
+
+      it("does not warn for an emptied account, which has a nonce", async () => {
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(0));
+        nodeApiMock.getTransactionCount.mockResolvedValue(4);
+
+        const res = await nativeSendToRecipient();
+
+        expect(res.warnings).not.toEqual(expect.objectContaining({ amount: expect.anything() }));
+      });
+
+      it("does not warn when the recipient holds a balance", async () => {
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(10));
+        nodeApiMock.getTransactionCount.mockResolvedValue(0);
+
+        const res = await nativeSendToRecipient();
+
+        expect(res.warnings).not.toEqual(expect.objectContaining({ amount: expect.anything() }));
+      });
+
+      it("does not probe the recipient on a token transfer", async () => {
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(0));
+        nodeApiMock.getTransactionCount.mockResolvedValue(0);
+
+        const res = await nativeSendToRecipient({
+          asset: { type: "erc20", assetReference: RECIPIENT },
+        });
+
+        expect(res.warnings).not.toEqual(expect.objectContaining({ amount: expect.anything() }));
+        expect(nodeApiMock.getCoinBalance).not.toHaveBeenCalled();
+      });
+
+      it("does not probe the recipient when the amount is zero", async () => {
+        const res = await nativeSendToRecipient({ amount: 0n });
+
+        expect(nodeApiMock.getCoinBalance).not.toHaveBeenCalled();
+        expect(res.warnings).not.toEqual(expect.objectContaining({ amount: expect.anything() }));
+      });
+
+      it("stays silent and does not throw when the node is unreachable", async () => {
+        nodeApiMock.getCoinBalance.mockRejectedValue(new Error("node down"));
+        nodeApiMock.getTransactionCount.mockResolvedValue(0);
+
+        const res = await nativeSendToRecipient();
+
+        expect(res.warnings).not.toEqual(expect.objectContaining({ amount: expect.anything() }));
+      });
+
+      it("leaves the fees and gas limit untouched", async () => {
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(10));
+        nodeApiMock.getTransactionCount.mockResolvedValue(2);
+        const withoutWarning = await nativeSendToRecipient();
+
+        nodeApiMock.getCoinBalance.mockResolvedValue(new BigNumber(0));
+        nodeApiMock.getTransactionCount.mockResolvedValue(0);
+        const withWarning = await nativeSendToRecipient();
+
+        expect(withWarning.warnings).toEqual(
+          expect.objectContaining({ amount: new RecipientIsNewAccount() }),
+        );
+        expect(withoutWarning.totalFees).toEqual(expect.any(BigInt));
+        expect(withWarning.totalFees).toEqual(withoutWarning.totalFees);
+        expect(withWarning.estimatedFees).toEqual(withoutWarning.estimatedFees);
+        expect(withWarning.amount).toEqual(withoutWarning.amount);
+      });
     });
 
     it("detects the recipient not being an EIP55 address with a warning", async () => {

--- a/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
+++ b/libs/coin-modules/coin-evm/src/logic/validateIntent.ts
@@ -26,6 +26,7 @@ import {
   PriorityFeeHigherThanMaxFee,
   PriorityFeeTooHigh,
   PriorityFeeTooLow,
+  RecipientIsNewAccount,
   RedelegateDstValAddressRequired,
   ValAddressRequired,
 } from "../errors";
@@ -34,6 +35,7 @@ import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import BigNumber from "bignumber.js";
 import { getCoinConfig } from "../config";
 import { getGasTracker } from "../network/gasTracker";
+import { getNodeApi } from "../network/node";
 import { isNative, StakingOperation, TransactionTypes } from "../types";
 import { STAKING_CONTRACTS } from "../staking";
 import { DEFAULT_GAS_LIMIT, isEthAddress, isStakingIntent } from "../utils";
@@ -107,6 +109,44 @@ function validateFeeRatio(
   }
 
   return { errors: {}, warnings: {} };
+}
+
+/**
+ * Warn that creating the recipient account costs more gas (EIP-8037). Informational only, as
+ * `eth_estimateGas` already accounts for it. Native sends only: a token transfer's `to` is the
+ * token contract, which always exists.
+ */
+async function validateNewAccountRecipient(
+  currency: CryptoCurrency,
+  intent: TransactionIntent<MemoNotSupported, BufferTxData>,
+  amount: bigint,
+): Promise<Pick<TransactionValidation, "errors" | "warnings">> {
+  const none = { errors: {}, warnings: {} };
+  const isPlainNativeSend =
+    isNative(intent.asset) &&
+    amount > 0n &&
+    !intent.data?.value?.length &&
+    !isStakingIntent(intent);
+
+  if (!isPlainNativeSend || !isEthAddress(intent.recipient)) {
+    return none;
+  }
+
+  try {
+    const nodeApi = getNodeApi(currency);
+    const [balance, nonce] = await Promise.all([
+      nodeApi.getCoinBalance(currency, intent.recipient),
+      nodeApi.getTransactionCount(currency, intent.recipient),
+    ]);
+
+    if (balance.isZero() && nonce === 0) {
+      return { errors: {}, warnings: { amount: new RecipientIsNewAccount() } };
+    }
+  } catch {
+    // An unreachable node must not fail the validation: no message is the current behaviour.
+  }
+
+  return none;
 }
 
 /**
@@ -460,6 +500,11 @@ export async function validateIntent(
     balances,
     estimatedFees,
   );
+  const { errors: newAccountErr, warnings: newAccountWarn } = await validateNewAccountRecipient(
+    currency,
+    intent,
+    amount,
+  );
 
   const errors = {
     ...recipientErr,
@@ -467,6 +512,7 @@ export async function validateIntent(
     ...gasErr,
     ...feeRatioErr,
     ...stakingErr,
+    ...newAccountErr,
   };
   const warnings = {
     ...recipientWarn,
@@ -474,6 +520,7 @@ export async function validateIntent(
     ...gasWarn,
     ...feeRatioWarn,
     ...stakingWarn,
+    ...newAccountWarn,
   };
 
   return {

--- a/libs/ledger-live-common/src/flows/send/amount/utils/__tests__/messages.test.ts
+++ b/libs/ledger-live-common/src/flows/send/amount/utils/__tests__/messages.test.ts
@@ -167,6 +167,18 @@ describe("getAmountScreenRawMessage", () => {
     });
   });
 
+  it("returns a new-account recipient warning as an info message", () => {
+    const newAccountWarning = createNamedError("RecipientIsNewAccount");
+    const status = createStatus({
+      warnings: { amount: newAccountWarning },
+    });
+
+    expect(getAmountScreenRawMessage({ status, hasRawAmount: true })).toEqual({
+      type: "info",
+      error: newAccountWarning,
+    });
+  });
+
   it("classifies the selected amount warning instead of another warning key", () => {
     const amountWarning = createNamedError("RecommendUndelegation");
     const feeTooHighWarning = createNamedError("FeeTooHigh");

--- a/libs/ledger-live-common/src/flows/send/amount/utils/messages.ts
+++ b/libs/ledger-live-common/src/flows/send/amount/utils/messages.ts
@@ -28,6 +28,9 @@ export function getAmountScreenMessage(params: {
   return null;
 }
 
+/** Warnings that explain the fee rather than flag a problem, rendered neutrally. */
+const INFORMATIONAL_AMOUNT_WARNINGS = new Set(["FeeTooHigh", "RecipientIsNewAccount"]);
+
 const AMOUNT_INPUT_BLOCKING_RECIPIENT_ERROR_SUFFIX = "SourceHasMultiSign";
 
 export function isAmountInputBlockingRecipientError(error: Error | undefined): boolean {
@@ -60,9 +63,10 @@ export function getAmountScreenRawMessage(params: {
   }
 
   if (amountWarning && params.hasRawAmount) {
-    const isFeeTooHigh = amountWarning.name === "FeeTooHigh";
-
-    return { type: isFeeTooHigh ? "info" : "warning", error: amountWarning };
+    return {
+      type: INFORMATIONAL_AMOUNT_WARNINGS.has(amountWarning.name) ? "info" : "warning",
+      error: amountWarning,
+    };
   }
 
   return null;


### PR DESCRIPTION
### 📝 Description

[EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) raises the cost of sending value to an account that does not exist yet (25,000 gas today, 183,600 post-fork). Nothing in the send flow tells the user why the fee jumped — a funds-loss risk on a fresh recipient address.

This adds an **explanatory message only**. `eth_estimateGas` already returns the correct value, so the gas we send is untouched: computing the charge ourselves would drift from the node.

- New `RecipientIsNewAccount` error, emitted by `validateIntent` as a **warning** (never an error, never blocking) when the recipient has balance `0` **and** nonce `0`.
- Rendered on the amount screen in neutral `info` styling, like `FeeTooHigh`.
- **Also fixes a cross-app inconsistency**: mobile picked the message colour with a ternary whose `else` branch returned `muted`, so there was no `info` style at all — anything that was not an error or a warning came out grey, while desktop declares an explicit `info` variant. Mobile now uses the same explicit mapping. Side effect worth flagging: **`FeeTooHigh` also turns from grey to base colour on mobile, for every coin.**
- Detection uses `nodeApi.getCoinBalance` + `getTransactionCount` — 2 RPC calls — not `getBalance`, which also fans out to token balances and the explorer.
- **Native sends only**: a token transfer's `to` is the token contract, which always exists. A new holder's first storage write is EIP-8038, a separate ticket.
- Emitted under the existing `warnings.amount` key, so the shared cross-coin selector needed one edit (the `info` classification) instead of two.
- An unreachable node yields no message rather than a failed validation.

### 📸 Screenshots

| Desktop | Mobile |
| --- | --- |
| <img width="584" height="723" alt="Screenshot 2026-08-11 at 09 26 59" src="https://github.com/user-attachments/assets/ea8681d2-4863-49cf-b5df-4c680fc51eb8" /> |<img width="380" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 10 41 16" src="https://github.com/user-attachments/assets/523c1ea7-46c4-4447-a0a3-2748d365667c" />|

### ✅ Tests

7 cases in `validateIntent.test.ts`: the warning, an emptied account (nonce > 0), a funded recipient, token transfers and zero amounts issuing **no** RPC call, node failure staying silent, and fees/amount identical with and without the message. One case in the shared `messages.test.ts` asserting `info`. coin-evm suite: 1108/1108.

### 🗣 Copy

> This address has never received funds, activating it costs a higher network fee

Accurate for an EOA: `nonce = 0` means the address has never spent, `balance = 0` that it holds nothing, so it has never received. It also says what the extra fee pays for (activating the account) rather than only that fees are higher.

⚠️ **Written by an engineer, not reviewed wording — needs a UX pass before leaving draft.** Other locales follow the usual translation process.

⚠️ **It wraps to two lines.** The message slot reserves a single line (`min-h-20`, `AmountInputSection.tsx`), so a two-line message pushes the dialog footer down and clips the Review button on a short window. **Pre-existing bug, not introduced here** — `NotEnoughGas` is longer and hits it harder — but this feature makes multi-line messages routine on a success path, and translations will be longer still. Worth a separate ticket.

### 🔗 Context

- **JIRA**: [LIVE-30167](https://ledgerhq.atlassian.net/browse/LIVE-30167) — epic [LIVE-29491](https://ledgerhq.atlassian.net/browse/LIVE-29491)
- Completes the epic with [#20620](https://github.com/LedgerHQ/ledger-live/pull/20620) and [#20625](https://github.com/LedgerHQ/ledger-live/pull/20625). Independent branches.
- The ticket's open question (amount vs recipient screen) was resolved in favour of the **amount screen**.


[LIVE-30167]: https://ledgerhq.atlassian.net/browse/LIVE-30167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

