### PR TITLE
[LWDM] refactor(asset-aggregation): derive the DADA views (LIVE-35331)

### DIFF
--- a/.changeset/wise-otters-derive.md
+++ b/.changeset/wise-otters-derive.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/asset-aggregation": patch
+---
+
+Derive assetDistribution's DADA views from the domain types instead of hand-declaring them

--- a/libs/asset-aggregation/package.json
+++ b/libs/asset-aggregation/package.json
@@ -19,6 +19,8 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@domain/api-aggregated-assets": "workspace:*",
+    "@domain/entity-aggregated-asset": "workspace:*",
     "@domain/entity-currency": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
     "@domain/entity-currency-token": "workspace:*",

--- a/libs/asset-aggregation/src/assetDistribution/types.ts
+++ b/libs/asset-aggregation/src/assetDistribution/types.ts
@@ -4,26 +4,23 @@ import type {
   DistributionItem,
   NetworkDistributionDetail,
 } from "@ledgerhq/types-live";
+import type { CryptoAssetMeta } from "@domain/entity-aggregated-asset";
+import type { AssetsData } from "@domain/api-aggregated-assets";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 
-/** Minimal shape of DADA's CryptoAssetMeta needed by buildAssetDistribution. */
-export interface CryptoAssetMetaLike {
-  id: string;
-  ticker?: string;
-  assetsIds: Record<string, string>;
-}
+/* Only what buildAssetDistribution reads. Derived from the domain types so they cannot drift. */
 
-/** Minimal shape of the DADA market entry needed for marketId resolution. */
-export interface MarketEntryLike {
-  id?: string;
-}
+/** `ticker` stays optional: the mismatch guard is skipped when it is absent. */
+export type CryptoAssetMetaLike = Pick<CryptoAssetMeta, "id" | "assetsIds"> &
+  Partial<Pick<CryptoAssetMeta, "ticker">>;
 
-/** Minimal shape of the DADA AssetsData needed by buildAssetDistribution. */
-export interface AssetsDataLike {
+export type MarketEntryLike = Pick<AssetsData["markets"][string], "id">;
+
+export type AssetsDataLike = {
   cryptoAssets: Record<string, CryptoAssetMetaLike>;
   markets: Record<string, MarketEntryLike>;
-}
+};
 
 export interface BuildAssetDistributionOpts {
   showEmptyAccounts?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5792,6 +5792,12 @@ importers:
 
   libs/asset-aggregation:
     dependencies:
+      '@domain/api-aggregated-assets':
+        specifier: workspace:*
+        version: link:../../domain/api/aggregated-assets
+      '@domain/entity-aggregated-asset':
+        specifier: workspace:*
+        version: link:../../domain/entity/aggregated-asset
       '@domain/entity-currency':
         specifier: workspace:*
         version: link:../../domain/entity/currency


### PR DESCRIPTION
### 📝 Description

**Problem.** `libs/asset-aggregation/src/assetDistribution/types.ts` hand-declares three structural subsets of the DADA payload, each commented as a *"Minimal shape of DADA's …"* — because when they were written there was no importable domain type. The migration created one.

The duplication is not cosmetic: `libs/asset-aggregation` is a published package and these types are `buildAssetDistribution`'s public API. Because the local shapes are structurally **looser** than the real ones, drift between them would **never produce a type error** — the same failure mode documented on the copied market type in `@domain/api-aggregated-assets`.

**Solution.** Derive them from the domain types so they cannot drift:

| Was | Now |
| --- | --- |
| `interface CryptoAssetMetaLike { id; ticker?; assetsIds }` | `Pick<CryptoAssetMeta, "id" \| "assetsIds"> & Partial<Pick<CryptoAssetMeta, "ticker">>` |
| `interface MarketEntryLike { id? }` | `Pick<AssetsData["markets"][string], "id">` |
| `interface AssetsDataLike { cryptoAssets; markets }` | same two collections, built from the above |

### 🔍 Why they stay narrow instead of becoming the domain types outright

The ticket allows either — *"gone, or reduced to `Pick<>` / `Partial<>` aliases … with a comment saying why"*. I took the second, because the looseness turned out to be load-bearing:

**`ticker` must stay optional.** `buildAssetDistribution.ts:53` reads:

```ts
const metaTicker = cryptoAssets[metaCurrencyId]?.ticker?.toUpperCase();
if (metaTicker && candidate.ticker.toUpperCase() !== metaTicker) return undefined;
```

The mismatch guard is **deliberately skipped when the ticker is absent**, and the suite exercises both branches — one fixture omits `ticker` (skip path), another sets `"ARB"` to drive the rejection. `CryptoAssetMeta.ticker` is required, so swapping the type would have forced a `ticker` into the first fixture and **silently changed which path that test covers**. That reads as a no-op in review, which is exactly why it's worth stating.

**`AssetsDataLike` is a genuine narrowing.** `buildAssetDistribution` reads 2 of `AssetsData`'s 6 collections (`cryptoAssets`, `markets`). Requiring the full type would force every caller and fixture to supply `networks`, `cryptoOrTokenCurrencies`, `interestRates` and `currenciesOrder` that it never touches.

Both are now `Pick<>` over the domain types, so the anti-drift goal is met either way — the fields can no longer diverge, because they aren't re-declared.

### ✅ Verification

- `libs/asset-aggregation`: **74 tests passing, unchanged**; typecheck 0 errors.
- **The production path is provably intact** — a probe confirmed a real `AssetsData` is still assignable to `AssetsDataLike`, so `useAssetDistribution` passing live DADA data still compiles. This was the acceptance criterion most likely to break silently.
- `libs/ledger-live-common` typecheck 0 errors under CI's command; `src/portfolio` 4 tests passing.
- Desktop typecheck **✅ All Good!**; mobile typecheck **✅ All Good!**
- `nx run enforce-boundaries:lint:boundaries` exits 0.
- `pnpm install --frozen-lockfile` succeeds; lockfile diff is **6 insertions, 0 deletions**.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35331](https://ledgerhq.atlassian.net/browse/LIVE-35331) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **ADR**: [DADA DDD compliant](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7382761502/DADA+DDD+compliant)
- **Depends on**: [#20345](https://github.com/LedgerHQ/ledger-live/pull/20345) (LIVE-35226, merged — created the importable types)
- **Independent of the retarget chain**: touches no app files, so it does not interact with LIVE-35228 / 35229 / 35230


[LIVE-35331]: https://ledgerhq.atlassian.net/browse/LIVE-35331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ