### PR TITLE
fix(e2e): fix Borrow desktop multi-step approval polling

### DIFF
--- a/.changeset/fix-borrow-approval-step-e2e.md
+++ b/.changeset/fix-borrow-approval-step-e2e.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop-e2e-tests": patch
+---
+
+Fix Borrow desktop E2E multi-step approval polling so Give approval is clicked when visible instead of being skipped when authorize-depositing is enabled.

--- a/e2e/desktop/tests/page/borrow.page.ts
+++ b/e2e/desktop/tests/page/borrow.page.ts
@@ -339,17 +339,28 @@ export class BorrowPage extends WebViewAppPage {
     const deadline = Date.now() + 60_000;
     while (Date.now() < deadline) {
       if (await stepDone.isVisible()) return false;
-      if (await nextAuthorize.isEnabled()) return false;
-      if ((await giveApproval.isVisible()) && (await giveApproval.isEnabled())) {
-        await giveApproval.click();
-        return true;
+
+      if (await giveApproval.isVisible()) {
+        if (await giveApproval.isEnabled()) {
+          await giveApproval.click();
+          return true;
+        }
+        // Give approval is shown but still loading — keep polling instead of skipping.
+      } else if (await nextAuthorize.isEnabled()) {
+        // No give-approval control: allowance already granted on-chain.
+        return false;
       }
+
       await new Promise(resolve => setTimeout(resolve, 500));
     }
+
     if (await stepDone.isVisible()) return false;
+    if (await giveApproval.isVisible()) {
+      throw new Error(`${stepLabel}: give approval stayed disabled for 60s`);
+    }
     if (await nextAuthorize.isEnabled()) return false;
     throw new Error(
-      `${stepLabel}: give approval did not become clickable or auto-complete within 60s`,
+      `${stepLabel}: neither give approval nor the next authorize step became ready within 60s`,
     );
   }
 
@@ -364,8 +375,8 @@ export class BorrowPage extends WebViewAppPage {
     const authorizeDepositing = this.authorizeDepositingBtn(webview);
 
     if (await step1Done.isVisible()) return false;
-    if (await authorizeDepositing.isEnabled()) return false;
-    return (await giveApproval.isVisible()) && (await giveApproval.isEnabled());
+    if (await giveApproval.isVisible()) return true;
+    return !(await authorizeDepositing.isEnabled());
   }
 
   @step("Complete Give approval step if required")
@@ -620,8 +631,8 @@ export class BorrowPage extends WebViewAppPage {
     const authorizeRepay = this.authorizeRepayBtn(webview);
 
     if (await step1Done.isVisible()) return false;
-    if (await authorizeRepay.isEnabled()) return false;
-    return (await giveApproval.isVisible()) && (await giveApproval.isEnabled());
+    if (await giveApproval.isVisible()) return true;
+    return !(await authorizeRepay.isEnabled());
   }
 
   @step("Complete repay Give approval step if required")


### PR DESCRIPTION
### 📝 Description

**Problem**: On broadcast desktop E2E nightlies, the Borrow open-loan flow could skip the Give approval step when `borrow-authorize-depositing-button` appeared enabled, even though token approval was still required. The test then timed out waiting for the deposit authorize button.

**Solution**: Update `BorrowPage.clickGiveApprovalWhenReady` to keep polling and click `give-approval-button` whenever it is visible (including while disabled/loading). Only skip Give approval when Step 1 is marked done or the give-approval control is absent and the next authorize step is ready. Applied the same logic to repay Give approval helpers.

**Regression check**: `[ETH] - Borrow simulates a loan and completes the open-loan execution` (B2CQA-6065) with `enable_broadcast=true`.

### 🔗 Context

- **JIRA issue**: [LIVE-35536](https://ledgerhq.atlassian.net/browse/LIVE-3)

[LIVE-35536]: https://ledgerhq.atlassian.net/browse/LIVE-35536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ