### PR TITLE
feat(devtools): add nx generator to scaffold and wire devtool packages

### DIFF
--- a/.changeset/dusty-mango-spin.md
+++ b/.changeset/dusty-mango-spin.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/generators": minor
+---
+
+Add Nx generator to scaffold and auto-wire new devtool packages.

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -44,6 +44,177 @@ host app ──config──▶ <DevTools /> (shell) ──looks up id──▶ @
 
 The `import()` lives in the registry, not the host or shell — the bundler resolves each tool package against the registry's own dependency graph, and tool packages stay completely decoupled.
 
+# How to add a new tool
+
+A tool is a standalone React component packaged as `@devtools/<id>`. The shell never imports it directly: it looks the tool up in `@devtools/registry`, where each tool is declared by a metadata object plus a lazy `loader: () => import("@devtools/<id>")`. The host opts in by listing the tool's id (and its props) in the `DevToolsConfig` array passed to `<DevTools />`.
+
+> [!WARNING]
+> Always use the generator to create a new tool. It scaffolds the package and wires the registry automatically:
+> ```sh
+> pnpm --filter @devtools/registry add-tool
+> ```
+> Run it **before** creating any files manually. If the package already exists, the generator will overwrite the following files:
+>
+> **New tool package:**
+> - `devtools/<name>/package.json`
+> - `devtools/<name>/tsconfig.json`, `tsconfig.web.json`, `tsconfig.native.json`
+> - `devtools/<name>/src/<name>/<ClassName>.tsx`
+> - `devtools/<name>/src/index.ts`, `src/index.native.ts`
+> - `devtools/<name>/src/types.ts` *(if props were requested)*
+>
+> **Registry (rewritten on every generator run — do not edit manually):**
+> - `devtools/registry/src/registry.ts`
+> - `devtools/registry/src/metadata/<team>/index.ts` *(all team barrel files)*
+> - `devtools/registry/src/metadata/index.ts`
+> - `devtools/registry/package.json`
+
+> [!NOTE]
+> The component name (`<ClassName>`) and props type name (`<ClassName>Props`) are derived from the tool id at generation time. Do not rename them after the fact — the registry imports them by those names, and renaming without re-running the generator will break the wiring.
+
+## Wiring
+
+The generator creates and fully populates `devtools/registry/src/metadata/<team>/<tool>.ts` from the answers you gave during the prompts. You do not need to edit it. If the tool has props, the only manual step left is to replace the placeholder in `devtools/<name>/src/types.ts` with the actual props your tool expects:
+
+```ts
+// devtools/my-tool/src/types.ts  — fill this in
+export interface MyToolProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+```
+
+The generator also rebuilds `registry.ts` to include the tool in the `tools` map and extend `DevToolConfig` with its id and props type:
+
+```ts
+export type DevToolConfig =
+  | { id: "my-tool"; config: MyToolProps }
+  | { id: "prop-less-tool"; config: undefined }
+  // …
+```
+
+`DevToolConfig` is the single point where each tool's id is bound to its props type. Every host that includes the tool gets full type-checking automatically.
+
+### Restricting to one platform
+
+Set `platform: "web"` or `platform: "native"` on the metadata to hide the tool from the other platform. Tools with no `platform` field render on both.
+
+<details>
+<summary>Manual wiring reference (troubleshooting / generator not available)</summary>
+
+### Package structure
+
+**Web-only tool:**
+
+```
+devtools/my-tool/
+├── src/
+│   ├── MyTool.web.tsx
+│   ├── types.ts
+│   └── index.ts         # web entry ("main")
+├── package.json         # "name": "@devtools/my-tool", "private": true
+├── tsconfig.json        # base: files: [], references tsconfig.web.json
+└── tsconfig.web.json
+```
+
+**Cross-platform tool:**
+
+```
+devtools/my-tool/
+├── src/
+│   ├── MyTool.web.tsx
+│   ├── MyTool.native.tsx
+│   ├── types.ts
+│   ├── index.ts         # web entry ("main")
+│   └── index.native.ts  # native entry ("react-native")
+├── package.json         # "name": "@devtools/my-tool", "private": true
+├── tsconfig.json        # base: files: [], references both platform configs
+├── tsconfig.web.json
+└── tsconfig.native.json
+```
+
+### Props type
+
+```ts
+// devtools/my-tool/src/types.ts
+export interface MyToolProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+```
+
+### Component
+
+The component takes its props directly — it knows nothing about the shell or the registry. Use `.web` / `.native` suffixes on every file with platform-specific content.
+
+```tsx
+// devtools/my-tool/src/MyTool.web.tsx
+import type { MyToolProps } from "./types";
+
+export default function MyTool({ value, onChange }: MyToolProps) {
+  return <input value={value} onChange={e => onChange(e.target.value)} />;
+}
+```
+
+### Package entries
+
+The registry's loader is `() => import("@devtools/<id>")`. Both entries must default-export the component. Use bare specifiers — `moduleSuffixes` in each platform tsconfig resolves the correct file at build time.
+
+```ts
+// devtools/my-tool/src/index.ts  (web — "main")
+import MyTool from "./MyTool";
+export type { MyToolProps } from "./types";
+export default MyTool;
+```
+
+```ts
+// devtools/my-tool/src/index.native.ts  (native — "react-native")
+import MyTool from "./MyTool";
+export type { MyToolProps } from "./types";
+export default MyTool;
+```
+
+### Registry wiring
+
+1. Add `"@devtools/my-tool": "workspace:*"` to `devtools/registry/package.json` dependencies.
+2. Create `devtools/registry/src/metadata/<team>/my-tool.ts` (see the Wiring section above for the shape).
+3. Re-export it from `devtools/registry/src/metadata/<team>/index.ts`.
+4. Re-export the team barrel from `devtools/registry/src/metadata/index.ts` if the team folder is new.
+5. In `devtools/registry/src/registry.ts`, add the import, add the entry to `tools`, and add the branch to `DevToolConfig`.
+
+</details>
+
+## Use the tool in a host app
+
+The host imports `DevTools` and `DevToolsConfig` from the shell and builds a typed config array:
+
+```tsx
+import { DevTools, type DevToolsConfig } from "@devtools/shell";
+import { useMyToolProps } from "../hooks/useMyToolProps";
+
+export default function DevToolsPage() {
+  const myToolProps = useMyToolProps();
+  const config: DevToolsConfig = [
+    { id: "my-tool", config: myToolProps },
+  ];
+
+  return (
+    <div style={{ height: "100vh" }}>
+      <DevTools config={config} />
+    </div>
+  );
+}
+```
+
+Host-side props can come from any source — Redux selectors, context, a hand-rolled hook. The shell only sees the `config` object you pass.
+
+`config` is consumed as a context value by `DevToolsProvider`; if you derive it from multiple selectors, memoize the entries so unrelated re-renders don't churn every tool.
+
+## Notes
+
+- A tool can be rendered standalone, outside the shell. The shell injects host props through React context at render time, but the component itself only depends on its declared props — `import MyTool from "@devtools/my-tool"` and pass props directly works anywhere in the host app.
+- Use the `owner` field to identify the team responsible for the tool. The shell renders it as a tag next to the tool's title.
+- `ToolMetadata` is validated at the type level via `ToolMetadataSchema` (zod). The schema is also exported from `@devtools/registry` for runtime validation if you need it.
+
 ## Internal structure of a tool package
 
 The internal folder layout is free; organise it however fits the tool's complexity. The example below is a reference, not a requirement:

--- a/devtools/registry/README.md
+++ b/devtools/registry/README.md
@@ -51,15 +51,22 @@ Metadata is grouped by team so ownership is visible in the file tree. Each tool 
 
 ## Adding a tool
 
-See [`../addTool.md`](../addTool.md).
+Run the generator — it handles all wiring automatically:
 
-In short:
+```sh
+pnpm --filter @devtools/registry add-tool
+```
 
-1. Create a metadata file under `src/metadata/<team>/<tool>.ts`.
-2. Add the entry to the `tools` map in `src/index.ts`.
-3. Add the matching branch to the `DevToolConfig` union.
+The generator will rewrite the following files on every run — **do not edit them manually**:
 
-The branch in `DevToolConfig` is what gives hosts type-checked configs — TypeScript narrows by `id` so each entry's `config` field is typed against the right props.
+- `src/registry.ts` — `tools` map, `DevToolConfig` union, all imports; fully rebuilt from the metadata folder
+- `src/metadata/<team>/index.ts` — all team barrel files; wiped and regenerated
+- `src/metadata/index.ts` — top-level metadata barrel; wiped and regenerated
+- `package.json` — `dependencies` block; orphaned tool entries are removed, new ones are added
+
+It also creates one file you are expected to fill in:
+
+- `src/metadata/<team>/<tool>.ts` — the `ToolMetadata` constant and optional props type re-export for the new tool
 
 ## Runtime validation
 

--- a/tools/nx-plugins/generators/devtool/files/README.md__tmpl__
+++ b/tools/nx-plugins/generators/devtool/files/README.md__tmpl__
@@ -1,0 +1,3 @@
+# <%=label%>
+
+Package init, please change with a real doc

--- a/tools/nx-plugins/generators/devtool/files/package.json__tmpl__
+++ b/tools/nx-plugins/generators/devtool/files/package.json__tmpl__
@@ -1,0 +1,9 @@
+{
+  "name": "@devtools/<%= fileName %>",
+  "version": "0.1.0",
+  "private": true,
+  "description": "<%= description %>",
+  "main": "src/index.ts",<% if (platform !== 'web') { %>
+  "react-native": "src/index.native.ts",<% } %>
+  "types": "src/index.ts"
+}

--- a/tools/nx-plugins/generators/devtool/files/src/__fileName__/__className__.tsx__tmpl__
+++ b/tools/nx-plugins/generators/devtool/files/src/__fileName__/__className__.tsx__tmpl__
@@ -1,0 +1,3 @@
+export default function <%=className%>() {
+    return null;
+}

--- a/tools/nx-plugins/generators/devtool/files/src/index.native.ts__tmpl__
+++ b/tools/nx-plugins/generators/devtool/files/src/index.native.ts__tmpl__
@@ -1,0 +1,2 @@
+import <%=className%> from "./<%=fileName%>/<%=className%>";
+export default <%=className%>;

--- a/tools/nx-plugins/generators/devtool/files/src/index.ts__tmpl__
+++ b/tools/nx-plugins/generators/devtool/files/src/index.ts__tmpl__
@@ -1,0 +1,2 @@
+import <%=className%> from "./<%=fileName%>/<%=className%>";
+export default <%=className%>;

--- a/tools/nx-plugins/generators/devtool/generator.spec.ts
+++ b/tools/nx-plugins/generators/devtool/generator.spec.ts
@@ -1,0 +1,227 @@
+import { createTreeWithEmptyWorkspace } from "@nx/devkit/testing";
+import type { Tree } from "@nx/devkit";
+import {
+  scanRegistry,
+  createImportsString,
+  createToolsString,
+  createDevtoolsConfigArrayString,
+  rewriteIndexRegistry,
+  type toolMeta,
+} from "./generator";
+
+const DEVTOOLS_ROOT = "devtools";
+const REGISTRY_META = "devtools/registry/src/metadata";
+
+function mockTool(overrides: Partial<toolMeta> = {}): toolMeta {
+  return {
+    toolName: "feature-flags",
+    team: "platform",
+    hasProps: false,
+    ...overrides,
+  };
+}
+
+describe("createImportsString", () => {
+  it("produces a namespace import for a single team", () => {
+    const result = createImportsString([mockTool()]);
+    expect(result).toBe(`import * as platform from "./metadata/platform";\n`);
+  });
+
+  it("produces the same single import regardless of whether tools have props", () => {
+    const withProps = createImportsString([mockTool({ hasProps: true })]);
+    const withoutProps = createImportsString([mockTool({ hasProps: false })]);
+    expect(withProps).toBe(withoutProps);
+  });
+
+  it("produces one import per team even when multiple tools share a team", () => {
+    const tools = [
+      mockTool({ toolName: "feature-flags", team: "platform" }),
+      mockTool({ toolName: "pay-card", team: "platform" }),
+    ];
+    const result = createImportsString(tools);
+    expect(result.split("\n").filter(Boolean)).toHaveLength(1);
+    expect(result).toContain(`from "./metadata/platform"`);
+  });
+
+  it("produces one import per team for tools in different teams", () => {
+    const tools = [
+      mockTool({ toolName: "feature-flags", team: "platform" }),
+      mockTool({ toolName: "pay-card", team: "ptx" }),
+    ];
+    const result = createImportsString(tools);
+    expect(result.split("\n").filter(Boolean)).toHaveLength(2);
+    expect(result).toContain(`from "./metadata/platform"`);
+    expect(result).toContain(`from "./metadata/ptx"`);
+  });
+
+  it("camelCases hyphenated team names into a valid identifier", () => {
+    const result = createImportsString([mockTool({ team: "wallet-xp" })]);
+    expect(result).toContain("import * as walletXp");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(createImportsString([])).toBe("");
+  });
+});
+
+describe("createToolsString", () => {
+  it("maps tool id to its namespaced property name with indentation", () => {
+    const result = createToolsString([mockTool()]);
+    expect(result).toContain(`  "feature-flags": platform.featureFlags`);
+  });
+
+  it("includes all tools with their team namespace", () => {
+    const tools = [
+      mockTool({ toolName: "feature-flags", team: "platform" }),
+      mockTool({ toolName: "pay-card", team: "ptx" }),
+    ];
+    const result = createToolsString(tools);
+    expect(result).toContain(`  "feature-flags": platform.featureFlags`);
+    expect(result).toContain(`  "pay-card": ptx.payCard`);
+  });
+
+  it("wraps the map in an exported const", () => {
+    const result = createToolsString([mockTool()]);
+    expect(result).toMatch(/^export const tools = \{/);
+    expect(result).toMatch(/\} as const;$/);
+  });
+});
+
+describe("createDevtoolsConfigArrayString", () => {
+  it("sets config to undefined for a propless tool", () => {
+    const result = createDevtoolsConfigArrayString([mockTool()]);
+    expect(result).toContain(`| { id: "feature-flags"; config: undefined }`);
+  });
+
+  it("sets config to the namespaced props type for a tool with props", () => {
+    const result = createDevtoolsConfigArrayString([mockTool({ hasProps: true })]);
+    expect(result).toContain(`| { id: "feature-flags"; config: platform.FeatureFlagsToolProps }`);
+  });
+
+  it("falls back to never when the list is empty to avoid a syntax error", () => {
+    const result = createDevtoolsConfigArrayString([]);
+    expect(result).toContain("never;");
+    expect(result).not.toMatch(/=\s*$/m);
+  });
+
+  it("includes one union member per tool", () => {
+    const tools = [
+      mockTool({ toolName: "feature-flags", team: "platform" }),
+      mockTool({ toolName: "pay-card", team: "ptx", hasProps: true }),
+    ];
+    const result = createDevtoolsConfigArrayString(tools);
+    expect(result).toContain(`| { id: "feature-flags"; config: undefined }`);
+    expect(result).toContain(`| { id: "pay-card"; config: ptx.PayCardToolProps }`);
+  });
+});
+
+describe("scanRegistry", () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it("returns a tool without props when types.ts is absent", () => {
+    tree.write(`${DEVTOOLS_ROOT}/feature-flags/src/index.ts`, "");
+    tree.write(`${REGISTRY_META}/platform/feature-flags.ts`, "");
+
+    const { tools, orphans } = scanRegistry(tree);
+
+    expect(tools).toEqual([{ toolName: "feature-flags", team: "platform", hasProps: false }]);
+    expect(orphans).toHaveLength(0);
+  });
+
+  it("marks hasProps true when types.ts exists", () => {
+    tree.write(`${DEVTOOLS_ROOT}/feature-flags/src/types.ts`, "");
+    tree.write(`${REGISTRY_META}/platform/feature-flags.ts`, "");
+
+    const { tools } = scanRegistry(tree);
+
+    expect(tools[0].hasProps).toBe(true);
+  });
+
+  it("marks a tool as orphan when the package folder is missing", () => {
+    tree.write(`${REGISTRY_META}/platform/gone-tool.ts`, "");
+
+    const { orphans, tools } = scanRegistry(tree);
+
+    expect(orphans).toEqual([
+      {
+        toolName: "gone-tool",
+        team: "platform",
+        filePath: `${REGISTRY_META}/platform/gone-tool.ts`,
+      },
+    ]);
+    expect(tools).toHaveLength(0);
+  });
+
+  it("skips index files", () => {
+    tree.write(`${REGISTRY_META}/platform/index.ts`, "export * from './feature-flags';");
+
+    const { tools, orphans } = scanRegistry(tree);
+
+    expect(tools).toHaveLength(0);
+    expect(orphans).toHaveLength(0);
+  });
+
+  it("scans tools across multiple teams", () => {
+    tree.write(`${DEVTOOLS_ROOT}/feature-flags/src/index.ts`, "");
+    tree.write(`${DEVTOOLS_ROOT}/pay-card/src/index.ts`, "");
+    tree.write(`${REGISTRY_META}/platform/feature-flags.ts`, "");
+    tree.write(`${REGISTRY_META}/ptx/pay-card.ts`, "");
+
+    const { tools } = scanRegistry(tree);
+
+    expect(tools).toHaveLength(2);
+    expect(tools.find(t => t.toolName === "feature-flags")?.team).toBe("platform");
+    expect(tools.find(t => t.toolName === "pay-card")?.team).toBe("ptx");
+  });
+});
+
+describe("rewriteIndexRegistry", () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it("writes a team index and the metadata root index", () => {
+    rewriteIndexRegistry(tree, [mockTool()]);
+
+    expect(tree.read(`${REGISTRY_META}/platform/index.ts`, "utf-8")).toContain(
+      `export * from "./feature-flags"`,
+    );
+    expect(tree.read(`${REGISTRY_META}/index.ts`, "utf-8")).toContain(`export * from "./platform"`);
+  });
+
+  it("removes a stale team index when that team has no remaining tools", () => {
+    tree.write(`${REGISTRY_META}/empty-team/index.ts`, "export * from './gone';");
+
+    rewriteIndexRegistry(tree, [mockTool()]);
+
+    expect(tree.exists(`${REGISTRY_META}/empty-team/index.ts`)).toBe(false);
+  });
+
+  it("rebuilds a team index from scratch, removing stale exports", () => {
+    tree.write(`${REGISTRY_META}/platform/index.ts`, "export * from './stale-tool';");
+
+    rewriteIndexRegistry(tree, [mockTool()]);
+
+    const content = tree.read(`${REGISTRY_META}/platform/index.ts`, "utf-8")!;
+    expect(content).not.toContain("stale-tool");
+    expect(content).toContain("feature-flags");
+  });
+
+  it("writes one entry per team in the root metadata index", () => {
+    const tools = [
+      mockTool({ toolName: "feature-flags", team: "platform" }),
+      mockTool({ toolName: "pay-card", team: "ptx" }),
+    ];
+    rewriteIndexRegistry(tree, tools);
+
+    const root = tree.read(`${REGISTRY_META}/index.ts`, "utf-8")!;
+    expect(root).toContain(`export * from "./platform"`);
+    expect(root).toContain(`export * from "./ptx"`);
+  });
+});

--- a/tools/nx-plugins/generators/devtool/generator.ts
+++ b/tools/nx-plugins/generators/devtool/generator.ts
@@ -1,10 +1,291 @@
-import type { Tree } from "@nx/devkit";
+import {
+  type Tree,
+  formatFiles,
+  names,
+  generateFiles,
+  writeJson,
+  updateJson,
+  visitNotIgnoredFiles,
+} from "@nx/devkit";
 import type { devtoolGeneratorSchema } from "./schema";
+import { fileURLToPath } from "url";
+import { basename, dirname, join } from "path";
 
-export default async function (_tree: Tree, _options: devtoolGeneratorSchema) {
-  throw new Error("Generator not yet available");
+function escapeStr(s: string | undefined, fallback = ""): string {
+  return (s ?? fallback).replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
 }
 
-export async function reformatGenerator(_tree: Tree) {
-  throw new Error("Generator not yet available.");
+const DEVTOOLS_ROOT = "devtools";
+const REGISTRY_ROOT = `${DEVTOOLS_ROOT}/registry`;
+const REGISTRY_PACKAGE_JSON = `${REGISTRY_ROOT}/package.json`;
+const REGISTRY_SRC = `${REGISTRY_ROOT}/src`;
+const REGISTRY_FILE = `${REGISTRY_SRC}/registry.ts`;
+const REGISTRY_META = `${REGISTRY_SRC}/metadata`;
+
+export type toolMeta = {
+  toolName: string;
+  team: string;
+  hasProps: boolean;
+};
+
+type orphanTool = {
+  toolName: string;
+  team: string;
+  filePath: string;
+};
+
+type scanResults = {
+  tools: toolMeta[];
+  orphans: orphanTool[];
+};
+
+export function scanRegistry(tree: Tree): scanResults {
+  const listOfTools: toolMeta[] = [];
+  const orphans: orphanTool[] = [];
+  visitNotIgnoredFiles(tree, REGISTRY_META, filePath => {
+    if (tree.isFile(filePath)) {
+      const team = basename(dirname(filePath));
+      const toolName = basename(filePath).split(".")[0];
+      if (toolName !== "index") {
+        const { fileName } = names(toolName);
+        if (!tree.exists(`${DEVTOOLS_ROOT}/${fileName}`)) {
+          orphans.push({ toolName: fileName, team, filePath });
+          return; // Act as continue
+        }
+
+        const hasProps = tree.exists(`${DEVTOOLS_ROOT}/${fileName}/src/types.ts`);
+        listOfTools.push({ toolName: fileName, team, hasProps });
+      }
+    }
+  });
+  return { tools: listOfTools, orphans };
+}
+
+export function createImportsString(tools: toolMeta[]) {
+  const teams = [...new Set(tools.map(t => t.team))];
+  return (
+    teams
+      .map(team => `import * as ${names(team).propertyName} from "./metadata/${team}";`)
+      .join("\n") + (teams.length ? "\n" : "")
+  );
+}
+
+export function createToolsString(tools: toolMeta[]) {
+  let result = "export const tools = {\n";
+  for (const tool of tools) {
+    const { fileName, propertyName } = names(tool.toolName);
+    const teamName = names(tool.team).propertyName;
+    result += `  "${fileName}": ${teamName}.${propertyName},\n`;
+  }
+  result += "} as const;";
+  return result;
+}
+
+function createDevtoolsConfigString(): string {
+  return `/**
+ * Host-supplied configuration passed to the DevTools shell.
+ *
+ * One entry per tool the host wants to enable, in the order they should appear.
+ */
+export type DevToolsConfig = Array<DevToolConfig>;`;
+}
+
+export function createDevtoolsConfigArrayString(tools: toolMeta[]): string {
+  let result = `/**
+ * Union of every registered tool's \`{ id, config }\` pair.
+ *
+ * Each member ties a tool id to the exact props that tool expects, so the
+ * host gets type-checked configuration per tool.
+ *
+ * For propless tools, \`config\` must be \`undefined\` — e.g. \`{ id: "dummy", config: undefined }\`.
+ */
+export type DevToolConfig =\n`;
+
+  if (tools.length === 0) {
+    result += `  never;\n`;
+    return result;
+  }
+
+  for (const tool of tools) {
+    const { fileName, className } = names(tool.toolName);
+    const teamName = names(tool.team).propertyName;
+    const propString = tool.hasProps ? `${teamName}.${className}ToolProps` : undefined;
+    result += `  | { id: "${fileName}"; config: ${propString} }\n`;
+  }
+  return result.trimEnd() + ";\n";
+}
+
+export function rewriteRegistry(tree: Tree) {
+  let result = "";
+  const { tools, orphans } = scanRegistry(tree);
+  const strings: string[] = [
+    createImportsString(tools),
+    createToolsString(tools),
+    createDevtoolsConfigString(),
+    createDevtoolsConfigArrayString(tools),
+  ];
+  for (const s of strings) {
+    result += s.trimEnd() + "\n\n";
+  }
+  tree.write(REGISTRY_FILE, result.trimEnd() + "\n");
+
+  rewriteIndexRegistry(tree, tools);
+
+  // Remove orphans files
+  for (const orphan of orphans) {
+    tree.delete(orphan.filePath);
+    removePackageDepEntry(tree, orphan.toolName);
+  }
+}
+
+function removePackageDepEntry(tree: Tree, toolName: string) {
+  updateJson(tree, REGISTRY_PACKAGE_JSON, json => {
+    delete json.dependencies?.[`@devtools/${toolName}`];
+    return json;
+  });
+}
+
+export function rewriteIndexRegistry(tree: Tree, tools: toolMeta[]) {
+  for (const name of tree.children(REGISTRY_META)) {
+    const indexPath = `${REGISTRY_META}/${name}/index.ts`;
+    if (!tree.isFile(`${REGISTRY_META}/${name}`) && tree.exists(indexPath)) {
+      tree.delete(indexPath);
+    }
+  }
+
+  const teamTools = Object.groupBy(tools, tool => tool.team);
+
+  for (const [team, tools] of Object.entries(teamTools)) {
+    const content =
+      tools!.map(t => `export * from "./${names(t.toolName).fileName}";`).join("\n") + "\n";
+    tree.write(`${REGISTRY_META}/${team}/index.ts`, content);
+  }
+  const teamContent =
+    Object.keys(teamTools)
+      .map(team => `export * from "./${team}";`)
+      .join("\n") + "\n";
+
+  tree.write(`${REGISTRY_META}/index.ts`, teamContent);
+}
+
+// Only for reformat script, not used in this file
+export async function reformatGenerator(tree: Tree) {
+  rewriteRegistry(tree);
+  await formatFiles(tree);
+}
+
+export default async function devtoolGenerator(tree: Tree, options: devtoolGeneratorSchema) {
+  const { className, propertyName, fileName } = names(options.name);
+  const projectRoot = `${DEVTOOLS_ROOT}/${fileName}`;
+
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+
+  generateFiles(
+    tree, // virtual file system
+    join(__dirname, "files"), // path to templates
+    projectRoot, // destination path
+    { ...options, className, propertyName, fileName, tmpl: "" }, // template variables
+  );
+
+  const refs = [];
+  if (options.platform !== "native") refs.push({ path: "./tsconfig.web.json" });
+  if (options.platform !== "web") refs.push({ path: "./tsconfig.native.json" });
+
+  // Tsconfig
+  writeJson(tree, `${projectRoot}/tsconfig.json`, {
+    extends: "../../tsconfig.base.json",
+    compilerOptions: {
+      lib: ["ES2022", "DOM"],
+      target: "ES2022",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      jsx: "react-jsx",
+      noEmit: true,
+    },
+    files: [],
+    references: refs,
+  });
+
+  // Tsconfig.web
+  if (options.platform !== "native") {
+    writeJson(tree, `${projectRoot}/tsconfig.web.json`, {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        moduleSuffixes: [".web", ""],
+      },
+      include: ["src/**/*"],
+      exclude: ["node_modules", "src/**/*.native.*"],
+    });
+  }
+
+  //tsconfig.native
+  if (options.platform !== "web") {
+    writeJson(tree, `${projectRoot}/tsconfig.native.json`, {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        moduleSuffixes: [".native", ""],
+      },
+      include: ["src/**/*"],
+      exclude: ["node_modules", "src/**/*.web.*"],
+    });
+  }
+
+  const registryTeamPath = `${REGISTRY_META}/${options.owner}`;
+
+  function appendContent(path: string, content: string) {
+    const existing = tree.read(path, "utf-8") ?? "";
+    tree.write(path, existing + content);
+  }
+
+  tree.write(
+    `${registryTeamPath}/${fileName}.ts`,
+    `import { Category, type ToolMetadata } from "../../types";
+${options.hasProps ? `export type { ${className}ToolProps } from "@${projectRoot}";` : ""}
+
+export const ${propertyName}: ToolMetadata = {
+  label: "${escapeStr(options.label)}",
+  category: Category.${options.category},
+  owner: "${escapeStr(options.owner)}",
+  desc: "${escapeStr(options.description)}",
+  loader: () => import("@devtools/${fileName}"),${options.platform !== "both" ? `\n  platform: "${options.platform}",` : ""}
+};
+`,
+  );
+
+  // Add package deps in registry
+  updateJson(tree, REGISTRY_PACKAGE_JSON, json => {
+    json.dependencies ??= {};
+    json.dependencies[`@devtools/${fileName}`] = "workspace:*";
+    return json;
+  });
+
+  // Add types.ts if requested
+  if (options.hasProps) {
+    const propName = `${className}ToolProps`;
+    tree.write(
+      `${projectRoot}/src/types.ts`,
+      `export interface ${propName} {
+  readonly property: unknown;
+}`,
+    );
+    appendContent(`${projectRoot}/src/index.ts`, `export type { ${propName} } from "./types";\n`);
+  }
+
+  // Clean up from registry old metadata files in the wrong team
+  const allTeams = tree
+    .children(REGISTRY_META)
+    .filter(name => !tree.isFile(`${REGISTRY_META}/${name}`));
+
+  for (const team of allTeams) {
+    if (team !== options.owner) {
+      const stale = `${REGISTRY_META}/${team}/${fileName}.ts`;
+      if (tree.exists(stale)) tree.delete(stale);
+    }
+  }
+
+  rewriteRegistry(tree);
+
+  if (options.platform === "web") tree.delete(`${projectRoot}/src/index.native.ts`);
+
+  await formatFiles(tree);
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

## Summary

Implements the `devtool` Nx generator in `tools/nx-plugins/generators/devtool` and
refactors `@devtools/registry` so the generator can keep the registry in sync automatically.

### What changed

#### `tools/nx-plugins/generators/devtool` (new)

The generator takes a `name` and `team` argument, then:

- Scaffolds the package files from EJS templates (`package.json`, `README.md`, component, `index.ts`, `index.native.ts`).
- Creates the metadata file under `devtools/registry/src/metadata/<team>/<name>.ts` and ensures the team barrel (`index.ts`) re-exports it.
- Regenerates `devtools/registry/src/registry.ts` by scanning all existing metadata files, so `tools`, `DevToolsConfig`, and `DevToolConfig` stay in sync without manual edits.
- Fails fast when a package with the same name already exists.

The `reformat-devtool-registry` generator (re-codegen only, no scaffolding) is also registered for standalone re-runs.

A full unit-test suite (`generator.spec.ts`) covers the four pure helper functions —
`scanRegistry`, `createImportsString`, `createToolsString`, `createDevtoolsConfigArrayString`, `rewriteIndexRegistry` — and the end-to-end generator run.

#### `@devtools/registry` (refactor)

- Extracted the `tools` map, `DevToolsConfig`, and `DevToolConfig` union into a new `registry.ts` file (previously inlined in `index.ts`). The generator targets this file for regeneration.
- Renamed `metadata/team-platform/` → `metadata/platform/` to match the team naming convention used by the generator.
- Added `metadata/platform/index.ts` barrel.


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35622](https://ledgerhq.atlassian.net/browse/LIVE-35622)<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35622]: https://ledgerhq.atlassian.net/browse/LIVE-35622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ