### PR TITLE
[LWDM] chore(aggregated-assets): retarget libs and the store roots (LIVE-35230)

### DIFF
--- a/.changeset/tidy-hawks-retarget.md
+++ b/.changeset/tidy-hawks-retarget.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/live-common": patch
+"@ledgerhq/asset-detail": patch
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Retarget the remaining libs consumers and both store roots off the dada-client shims

--- a/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/rtkQueryApi.ts
@@ -1,12 +1,12 @@
 import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
-import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
 import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
 import {
   calApi,
   coinMarketCapApi,
   countervaluesApi,
+  dadaApi,
   pushDevicesApi,
   swapApi,
 } from "@shared/api-services";
@@ -16,7 +16,7 @@ import { counterValuesApi } from "@ledgerhq/live-common/counterValues/state-mana
 // Add new RTK Query API here. `@shared/api-services` entries own one backend each; the endpoints are
 // injected by the `@domain/api-*` use-case packages, which the view-models import directly.
 const APIs = {
-  [assetsDataApi.reducerPath]: assetsDataApi,
+  [dadaApi.reducerPath]: dadaApi,
   [calApi.reducerPath]: calApi,
   [coinMarketCapApi.reducerPath]: coinMarketCapApi,
   [countervaluesApi.reducerPath]: countervaluesApi,

--- a/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
+++ b/apps/ledger-live-mobile/src/context/rtkQueryApi.ts
@@ -1,12 +1,12 @@
 import type { Middleware, Reducer, Tuple } from "@reduxjs/toolkit";
 import { ofacGeoBlockApi } from "@ledgerhq/live-common/api/ofacGeoBlockApi";
-import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
 import { marketApi } from "@ledgerhq/live-common/market/state-manager/api";
 import { cgApi } from "@ledgerhq/live-common/cg-client/state-manager/api";
 import {
   calApi,
   coinMarketCapApi,
   countervaluesApi,
+  dadaApi,
   pushDevicesApi,
   swapApi,
 } from "@shared/api-services";
@@ -15,7 +15,7 @@ import { counterValuesApi } from "@ledgerhq/live-common/counterValues/state-mana
 // Add new RTK Query API here. `@shared/api-services` entries own one backend each; the endpoints are
 // injected by the `@domain/api-*` use-case packages, which the view-models import directly.
 const APIs = {
-  [assetsDataApi.reducerPath]: assetsDataApi,
+  [dadaApi.reducerPath]: dadaApi,
   [calApi.reducerPath]: calApi,
   [coinMarketCapApi.reducerPath]: coinMarketCapApi,
   [countervaluesApi.reducerPath]: countervaluesApi,

--- a/libs/asset-detail/package.json
+++ b/libs/asset-detail/package.json
@@ -19,8 +19,10 @@
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "dependencies": {
+    "@domain/api-aggregated-assets": "workspace:*",
     "@domain/entity-currency": "workspace:*",
     "@domain/entity-currency-crypto": "workspace:*",
+    "@features/platform-aggregated-assets": "workspace:*",
     "@ledgerhq/asset-aggregation": "workspace:*",
     "@ledgerhq/live-common": "workspace:*"
   },

--- a/libs/asset-detail/src/hooks/__tests__/resolveNetworkLedgerIds.test.ts
+++ b/libs/asset-detail/src/hooks/__tests__/resolveNetworkLedgerIds.test.ts
@@ -1,4 +1,4 @@
-import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import type { AssetsDataWithPagination } from "@domain/api-aggregated-assets";
 import { resolveNetworkLedgerIds } from "../useReceiveNetworkLedgerIds";
 
 const TETHER_META_ID = "urn:crypto:meta-currency:tether";

--- a/libs/asset-detail/src/hooks/useAssetMarketData.ts
+++ b/libs/asset-detail/src/hooks/useAssetMarketData.ts
@@ -7,9 +7,8 @@ import type {
   MarketItemResponse,
 } from "@ledgerhq/live-common/market/utils/types";
 import { REFETCH_TIME_ONE_MINUTE, BASIC_REFETCH } from "@ledgerhq/live-common/market/utils/timers";
-import { assetsDataApi } from "@ledgerhq/live-common/dada-client/state-manager/api";
-import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
-import { selectCurrency } from "@ledgerhq/live-common/dada-client/utils/currencySelection";
+import { assetsDataApi } from "@domain/api-aggregated-assets";
+import { selectCurrency, useAssetsData } from "@features/platform-aggregated-assets";
 import { useUsdToFiatRate } from "@ledgerhq/live-common/counterValues/hooks/useUsdToFiatRate";
 import { applyDadaMarketFallback } from "../utils/applyDadaMarketFallback";
 import { resolveDadaMarket } from "../utils/resolveDadaMarket";

--- a/libs/asset-detail/src/hooks/useReceiveNetworkLedgerIds.ts
+++ b/libs/asset-detail/src/hooks/useReceiveNetworkLedgerIds.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { toSlug } from "@ledgerhq/asset-aggregation/assetDistribution/index";
-import { useAssetsData } from "@ledgerhq/live-common/dada-client/hooks/useAssetsData";
-import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import { useAssetsData } from "@features/platform-aggregated-assets";
+import type { AssetsDataWithPagination } from "@domain/api-aggregated-assets";
 import type { ReceiveNetworkLedgerIdsInput } from "../types";
 
 type MetaHints = Pick<

--- a/libs/asset-detail/src/utils/__tests__/resolveDadaMarket.test.ts
+++ b/libs/asset-detail/src/utils/__tests__/resolveDadaMarket.test.ts
@@ -1,4 +1,4 @@
-import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import type { AssetsDataWithPagination } from "@domain/api-aggregated-assets";
 import { resolveDadaMarket } from "../resolveDadaMarket";
 
 const ETH = "ethereum/erc20/usd_coin";

--- a/libs/asset-detail/src/utils/resolveDadaMarket.ts
+++ b/libs/asset-detail/src/utils/resolveDadaMarket.ts
@@ -1,4 +1,4 @@
-import type { AssetsDataWithPagination } from "@ledgerhq/live-common/dada-client/state-manager/types";
+import type { AssetsDataWithPagination } from "@domain/api-aggregated-assets";
 
 type DadaMarket = AssetsDataWithPagination["markets"][string];
 

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -830,6 +830,7 @@
   ],
   "ignoreUnused": [
     "@cardano-foundation/ledgerjs-hw-app-cardano",
+    "@domain/entity-aggregated-asset",
     "@ledgerhq/asset-aggregation",
     "@ledgerhq/coin-hypercore",
     "@ledgerhq/coin-zcash",

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useLeftApyModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useLeftApyModule.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
-import { ApyType } from "../../../dada-client/types/trend";
-import { useInterestRatesByCurrencies } from "../../../dada-client/hooks/useInterestRatesByCurrencies";
+import type { ApyType } from "@domain/entity-interest-rate";
+import { useInterestRatesByCurrencies } from "@features/platform-aggregated-assets";
 import { getInterestRateForAsset } from "../../utils/getInterestRateForAsset";
 import { AssetConfigurationOptions } from "../../utils/type";
 

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useLeftMarketTrendModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useLeftMarketTrendModule.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
-import { useMarketByCurrencies } from "../../../dada-client/hooks/useMarketByCurrencies";
+import { useMarketByCurrencies } from "@features/platform-aggregated-assets";
 import { AssetConfigurationOptions } from "../../utils/type";
 
 const createMarketTrendItem = ({

--- a/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/modules/useRightMarketTrendModule.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { roundFiatPrice } from "@ledgerhq/live-currency-format";
-import { useMarketByCurrencies } from "../../../dada-client/hooks/useMarketByCurrencies";
+import { useMarketByCurrencies } from "@features/platform-aggregated-assets";
 import counterValueFormatter from "../../../market/utils/countervalueFormatter";
 import { useUsdToFiatRate } from "../../../counterValues/hooks/useUsdToFiatRate";
 import { AssetConfigurationOptions } from "../../utils/type";

--- a/libs/ledger-live-common/src/modularDrawer/hooks/useLeftAccountsApy.tsx
+++ b/libs/ledger-live-common/src/modularDrawer/hooks/useLeftAccountsApy.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AccountModuleParams, NetworkWithCount, NetworkConfigurationOptions } from "../utils/type";
-import { useInterestRatesByCurrencies } from "../../dada-client/hooks/useInterestRatesByCurrencies";
+import { useInterestRatesByCurrencies } from "@features/platform-aggregated-assets";
 import { getInterestRateForAsset } from "../utils/getInterestRateForAsset";
 
 export function useLeftAccountsApyModule(

--- a/libs/ledger-live-common/src/modularDrawer/utils/__tests__/buildAssetsSorted.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/__tests__/buildAssetsSorted.test.ts
@@ -2,7 +2,7 @@ import {
   mockAssetsData,
   mockBitcoinAssetsData,
   mockUsdcAssetsData,
-} from "../../../dada-client/__mocks__/assets.mock";
+} from "@domain/api-aggregated-assets/mock";
 import { buildAssetsSorted } from "../buildAssetsSorted";
 
 describe("buildAssetsSorted", () => {

--- a/libs/ledger-live-common/src/modularDrawer/utils/__tests__/getInterestRateForAsset.test.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/__tests__/getInterestRateForAsset.test.ts
@@ -4,7 +4,7 @@ import {
   mockScrollCryptoCurrency,
   usdcToken,
 } from "../../__mocks__/currencies.mock";
-import { ApyType } from "../../../dada-client/types/trend";
+import type { ApyType } from "@domain/entity-interest-rate";
 
 describe("getInterestRateForAsset", () => {
   const networks = [mockEthCryptoCurrency, usdcToken];

--- a/libs/ledger-live-common/src/modularDrawer/utils/buildAssetsSorted.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/buildAssetsSorted.ts
@@ -1,4 +1,4 @@
-import type { AssetsData } from "../../dada-client/entities";
+import type { AssetsData } from "@domain/api-aggregated-assets";
 import type { AssetData } from "./type";
 
 type BuildAssetsSortedOptions = Readonly<{

--- a/libs/ledger-live-common/src/modularDrawer/utils/type.ts
+++ b/libs/ledger-live-common/src/modularDrawer/utils/type.ts
@@ -4,10 +4,9 @@ import { CryptoOrTokenCurrency, Currency } from "@domain/entity-currency";
 import { AccountLike } from "@ledgerhq/types-live";
 import type { ComponentType, ReactNode, ReactElement } from "react";
 import { EnhancedModularDrawerConfiguration } from "../../wallet-api/ModularDrawer/types";
-import { InterestRate } from "../../dada-client/entities";
 import { MarketItemResponse } from "../../market/utils/types";
 import BigNumber from "bignumber.js";
-import type { Apy, ApyType } from "@domain/entity-interest-rate";
+import type { Apy, ApyType, InterestRate } from "@domain/entity-interest-rate";
 
 export type ApyIndicatorComponent = ComponentType<Apy>;
 

--- a/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
+++ b/libs/ledger-live-common/src/portfolio/__tests__/useAssetDistribution.test.ts
@@ -19,7 +19,7 @@ jest.mock("@ledgerhq/asset-aggregation/assetDistribution/index", () => ({
 }));
 
 const mockUseChunkedAssetsData = jest.fn();
-jest.mock("../../dada-client/hooks/useChunkedAssetsData", () => ({
+jest.mock("@features/platform-aggregated-assets", () => ({
   useChunkedAssetsData: (...args: unknown[]) => mockUseChunkedAssetsData(...args),
 }));
 

--- a/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
+++ b/libs/ledger-live-common/src/portfolio/useAssetDistribution.ts
@@ -4,7 +4,7 @@ import type { Currency } from "@domain/entity-currency";
 import { useCountervaluesState } from "@ledgerhq/live-countervalues-react";
 import { buildAssetDistribution } from "@ledgerhq/asset-aggregation/assetDistribution/index";
 import { flattenAccounts, getAccountCurrency } from "../account/helpers";
-import { useChunkedAssetsData } from "../dada-client/hooks/useChunkedAssetsData";
+import { useChunkedAssetsData } from "@features/platform-aggregated-assets";
 
 export type DistributionResult = AssetsDistribution & { isLoading: boolean };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5847,12 +5847,18 @@ importers:
 
   libs/asset-detail:
     dependencies:
+      '@domain/api-aggregated-assets':
+        specifier: workspace:*
+        version: link:../../domain/api/aggregated-assets
       '@domain/entity-currency':
         specifier: workspace:*
         version: link:../../domain/entity/currency
       '@domain/entity-currency-crypto':
         specifier: workspace:*
         version: link:../../domain/entity/currency-crypto
+      '@features/platform-aggregated-assets':
+        specifier: workspace:*
+        version: link:../../features/platform/aggregated-assets
       '@ledgerhq/asset-aggregation':
         specifier: workspace:*
         version: link:../asset-aggregation


### PR DESCRIPTION
### 📝 Description

**Problem.** The DADA migration left one-line re-export shims at the old `dada-client` paths so consumers could move in batches. Mobile ([#20612](https://github.com/LedgerHQ/ledger-live/pull/20612)) and desktop ([#20624](https://github.com/LedgerHQ/ledger-live/pull/20624)) are done; 17 consumers were still reading through the shims.

**Solution.** Retarget the rest — 11 files in `live-common` (`modularDrawer`, `portfolio`), 6 in `asset-detail`, and the **two app store roots** that both app PRs deliberately left behind.

**`grep -rn "dada-client"` now returns nothing outside `libs/ledger-live-common/src/dada-client` itself.** All 22 shims are orphaned, so [LIVE-35231](https://ledgerhq.atlassian.net/browse/LIVE-35231) can delete the tree.

### 🔑 The store roots register `dadaApi`, not `assetsDataApi`

Both roots now take `dadaApi` from `@shared/api-services` instead of `assetsDataApi` from the domain package. Registering a reducer is a composition-root concern about the **backend**, not about a use case — and `@shared/api-services` is where the `createApi` base lives.

This is safe because `injectEndpoints` mutates the base in place, but "safe because" deserves evidence rather than assertion. A throwaway probe confirmed all three properties it rests on:

- `dadaApi` and `assetsDataApi` are the **same object**
- `dadaApi.reducerPath` is still the frozen `"assetsDataApi"` that `createCurrencyDataSelector` scans **by string**
- a store built from `dadaApi` carries the injected endpoints (`getAssetsData`, `getChunkedAssetsData`)

Had any been false, every DADA query would have failed at the hook level **with no type error** — `pages` is typed `Array<Record<string, unknown>>`, so nothing in that path can fail to compile. That is exactly the trap the ticket flags.

### 🧩 `dada-client/entities` needed splitting per symbol

A blanket rewrite would have been wrong: the shim re-exports `InterestRate` from `@domain/entity-interest-rate` and `AssetsData` from `@domain/api-aggregated-assets`. The two `modularDrawer` files that used it take one symbol each, so they now point at different packages.

### 🔎 One knip finding, investigated rather than suppressed on sight

knip reports `@domain/entity-aggregated-asset` as an unused dependency of `live-common` after this change, because this PR removes the last non-shim importer.

I first tried deleting it as dead code. **That broke the build** — three files still import `./entities`: `dada-client/index.ts` and, importantly, **two LIVE-35224 characterization tests** that take `RawApiResponse` from it. Those must pass unmodified, so the shim stays until LIVE-35231.

I then verified the dependency is genuinely required: removed it, ran a real `pnpm install` so the workspace link actually disappeared, and typecheck failed with `Cannot find module '@domain/entity-aggregated-asset'`.

So the finding is a **false positive** — the only usage is `export type { CryptoAssetMeta } from …`, a type-only re-export that knip's runtime-dependency analysis doesn't credit. It is suppressed with a one-line `ignoreUnused` entry, and disappears with the tree in LIVE-35231.

> Noticed in passing, not fixed here: `.unimportedrc.json` still lists three `entities/*` files deleted back in LIVE-35227. Harmless, and worth clearing alongside the tree rather than widening this diff.

### ✅ Verification

- **live-common** typecheck 0 errors under CI's command; **171 tests** (`dada-client` + `portfolio` + `modularDrawer`).
- **asset-detail** typecheck 0 errors; **92 tests**.
- **Desktop** typecheck ✅ All Good, **5365 tests**; **mobile** typecheck ✅ All Good, **4219 tests** — **zero failed tests** in either.
- knip clean; `oxfmt --check` clean; `nx run enforce-boundaries:lint:boundaries` exits 0.
- `pnpm install --frozen-lockfile` succeeds; lockfile diff is **6 insertions, 0 deletions**.

Three suite-level failures are pre-existing flakes, all byte-identical to develop and none referencing DADA: two desktop suites on the same Electron `ipcRenderer.send` error, and mobile `BorrowSection`. The desktop flake rotates identity between runs (`Send/Signature` → `CantonOnboard` → `SyncOnboardingCompletion` across four runs), which is what confirms it isn't this branch.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35230](https://ledgerhq.atlassian.net/browse/LIVE-35230) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **ADR**: [DADA DDD compliant](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7382761502/DADA+DDD+compliant)
- **Predecessors**: [#20540](https://github.com/LedgerHQ/ledger-live/pull/20540) (platform layer) · [#20612](https://github.com/LedgerHQ/ledger-live/pull/20612) (mobile) · [#20624](https://github.com/LedgerHQ/ledger-live/pull/20624) (desktop)
- **Unblocks**: LIVE-35231 — delete the shims and the `dada-client` tree


[LIVE-35231]: https://ledgerhq.atlassian.net/browse/LIVE-35231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35230]: https://ledgerhq.atlassian.net/browse/LIVE-35230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ