### PR TITLE
[LWD] fix(desktop): use full-width LNS upsell banner in notification center

### DIFF
--- a/.changeset/notif-center-upsell-revamp.md
+++ b/.changeset/notif-center-upsell-revamp.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Use full-width LNS upsell MediaBanner in notification center

--- a/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/LNSUpsell/components/LNSUpsellBanner/index.tsx
@@ -30,8 +30,15 @@ function View({
   if (variant.type === "none") return null;
 
   if (shouldUseLumenMediaBanner) {
+    const isNotificationCenter = location === "notification_center";
     return (
-      <Flex width="50%" maxWidth="50%" minWidth={0} alignSelf="flex-start" {...boxProps}>
+      <Flex
+        width={isNotificationCenter ? "100%" : "50%"}
+        maxWidth={isNotificationCenter ? "100%" : "50%"}
+        minWidth={0}
+        alignSelf="flex-start"
+        {...boxProps}
+      >
         <LNSUpsellMediaBanner
           title={t(`lnsUpsellMediaBanner.${tracking}.title`)}
           description={t(`lnsUpsellMediaBanner.${tracking}.description`)}


### PR DESCRIPTION
### 📝 Description

When `lwdWallet40.brazePlacement` is enabled, the LNS upsell in Notification Center renders as a Lumen `MediaBanner`. The component reused the Portfolio grid layout defaults (`width="50%"`), so the banner only occupied half of the notification panel width.

**Solution:** use full width (`100%`) for `MediaBanner` when `location === "notification_center"`, while keeping the 50% layout for Portfolio/Braze grid surfaces.

| Before | After |
|--------|-------|
| ![Notification center upsell at 50% width](https://github.com/LedgerHQ/ledger-live/releases/download/untagged-1c65033797b13e844424/live-35385-notif-center-before.png) | ![Notification center upsell at 100% width](https://github.com/LedgerHQ/ledger-live/releases/download/untagged-1c65033797b13e844424/live-35385-notif-center-after.png) |

### ✅ Test plan

- [ ] Enable `feature_lld_nano_s_upsell_banners` with `notification_center: true` for opted-in Nano S users
- [ ] Enable `lwdWallet40.brazePlacement`
- [ ] Open Notification Center → upsell `MediaBanner` spans full panel width
- [ ] Verify Portfolio upsell banner still renders at 50% in the Braze grid
- [ ] Verify unread badge on the bell still clears after opening Notification Center

### 🔗 Context

- **JIRA issue**: [LIVE-35385](https://ledgerhq.atlassian.net/browse/LIVE-35385)

[LIVE-35385]: https://ledgerhq.atlassian.net/browse/LIVE-35385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ