### PR TITLE
[LWD] feat(zcash): ironwood balance warning [LIVE-35598]

### DIFF
--- a/.changeset/heavy-birds-dress.md
+++ b/.changeset/heavy-birds-dress.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+Add private warning message for Ironwood only funds

--- a/.changeset/heavy-birds-dress.md
+++ b/.changeset/heavy-birds-dress.md
@@ -2,4 +2,4 @@
 "ledger-live-desktop": minor
 ---
 
-Add private warning message for Ironwood only funds
+Add a warning on Zcash accounts that the private balance excludes Sapling and Orchard shielded funds.

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/AccountBalanceSummaryFooter.tsx
@@ -11,6 +11,7 @@ import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
 import Box from "~/renderer/components/Box/Box";
 import Text from "~/renderer/components/Text";
 import InfoCircle from "~/renderer/icons/InfoCircle";
+import TriangleWarning from "~/renderer/icons/TriangleWarning";
 import ToolTip from "~/renderer/components/Tooltip";
 import ButtonV3 from "~/renderer/components/ButtonV3";
 import Spinner from "~/renderer/components/Spinner";
@@ -31,16 +32,40 @@ import {
 import { selectShieldedSubscriptions } from "~/renderer/reducers/shieldedSyncSubscriptions";
 import { useZcashShieldedSync } from "./useZcashShieldedSync";
 
-const Wrapper = styled(Box).attrs(() => ({
-  horizontal: true,
+const Container = styled(Box).attrs(() => ({
   mt: 4,
   p: 5,
   pb: 0,
-  scroll: true,
 }))`
   border-top: 1px solid ${p => p.theme.colors.neutral.c30};
+`;
+
+const Wrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  scroll: true,
+}))`
   justify-content: flex-start;
 `;
+
+const Separator = styled(Box).attrs(() => ({
+  mt: 4,
+}))`
+  border-top: 1px solid ${p => p.theme.colors.neutral.c30};
+`;
+
+const WarningWrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  alignItems: "center",
+  color: "warning.c70",
+  mt: 3,
+}))``;
+
+const WarningText = styled(Text).attrs(() => ({
+  fontSize: 3,
+  ff: "Inter|Medium",
+  color: "warning.c70",
+  ml: 2,
+}))``;
 
 const BalanceDetail = styled(Box).attrs(() => ({
   flex: "0 0 auto",
@@ -322,62 +347,71 @@ const AccountBalanceSummaryFooter = ({ account }: Props) => {
   const availableBalanceLabel = formatCurrencyUnit(unit, _availableBalance, formatConfig);
 
   return (
-    <Wrapper>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="zcash.account.availableBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="zcash.account.availableBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{availableBalanceLabel}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="zcash.account.transparentBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="zcash.account.transparentBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{transparentBalanceLabel}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="zcash.account.privateBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="zcash.account.privateBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue>
-          <Discreet>{privateBalanceLabel}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: syncState === "running" || syncState === "stopped" ? "row" : "column",
-          }}
-        >
-          <ActionButton t={t} syncState={syncState} updateSyncState={updateSyncState} />
-          <SyncProgress syncState={syncState} progress={progress} lastSync={lastSync} />
-        </div>
-        <EstimatedTimeRemaining
-          syncState={syncState}
-          estimatedTimeRemaining={estimatedTimeRemaining}
-        />
-      </BalanceDetail>
-    </Wrapper>
+    <Container>
+      <Wrapper>
+        <BalanceDetail>
+          <ToolTip content={<Trans i18nKey="zcash.account.availableBalanceTooltip" />}>
+            <TitleWrapper>
+              <Title>
+                <Trans i18nKey="zcash.account.availableBalance" />
+              </Title>
+              <InfoCircle size={13} />
+            </TitleWrapper>
+          </ToolTip>
+          <AmountValue>
+            <Discreet>{availableBalanceLabel}</Discreet>
+          </AmountValue>
+        </BalanceDetail>
+        <BalanceDetail>
+          <ToolTip content={<Trans i18nKey="zcash.account.transparentBalanceTooltip" />}>
+            <TitleWrapper>
+              <Title>
+                <Trans i18nKey="zcash.account.transparentBalance" />
+              </Title>
+              <InfoCircle size={13} />
+            </TitleWrapper>
+          </ToolTip>
+          <AmountValue>
+            <Discreet>{transparentBalanceLabel}</Discreet>
+          </AmountValue>
+        </BalanceDetail>
+        <BalanceDetail>
+          <ToolTip content={<Trans i18nKey="zcash.account.privateBalanceTooltip" />}>
+            <TitleWrapper>
+              <Title>
+                <Trans i18nKey="zcash.account.privateBalance" />
+              </Title>
+              <InfoCircle size={13} />
+            </TitleWrapper>
+          </ToolTip>
+          <AmountValue>
+            <Discreet>{privateBalanceLabel}</Discreet>
+          </AmountValue>
+        </BalanceDetail>
+        <BalanceDetail>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: syncState === "running" || syncState === "stopped" ? "row" : "column",
+            }}
+          >
+            <ActionButton t={t} syncState={syncState} updateSyncState={updateSyncState} />
+            <SyncProgress syncState={syncState} progress={progress} lastSync={lastSync} />
+          </div>
+          <EstimatedTimeRemaining
+            syncState={syncState}
+            estimatedTimeRemaining={estimatedTimeRemaining}
+          />
+        </BalanceDetail>
+      </Wrapper>
+      <Separator />
+      <WarningWrapper>
+        <TriangleWarning size={16} />
+        <WarningText>
+          <Trans i18nKey="zcash.account.privateBalanceWarning" />
+        </WarningText>
+      </WarningWrapper>
+    </Container>
   );
 };
 

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -24,6 +24,8 @@ const mockedSyncStateUpdater = jest.mocked(syncStateUpdater);
 
 const origToLocaleString = global.Date.prototype.toLocaleString;
 
+const PRIVATE_BALANCE_WARNING = "Private balance excludes Sapling and Orchard shielded funds";
+
 const makeUtxo = (value: number) => ({
   hash: "",
   outputIndex: 0,
@@ -64,6 +66,29 @@ describe("Bitcoin Account Balance Summary Footer", () => {
       expect(screen.getByText("Transparent balance")).toBeInTheDocument();
       expect(screen.getByText("Private balance")).toBeInTheDocument();
       expect(screen.getByTestId("show-private-balance-button")).toBeInTheDocument();
+      expect(screen.getByText(PRIVATE_BALANCE_WARNING)).toBeVisible();
+    });
+  });
+
+  it("should not render the private balance warning when zcashShielded is disabled", async () => {
+    mockedUseAccountUnit.mockReturnValue({
+      code: "ZEC",
+      name: "Zcash",
+      magnitude: 8,
+    });
+
+    render(
+      <AccountBalanceSummaryFooter
+        account={{ ...account, currency: { id: "zcash" } as CryptoCurrency }}
+      />,
+      {
+        initialState: withFlagOverrides({ zcashShielded: { enabled: false } }),
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(PRIVATE_BALANCE_WARNING)).not.toBeInTheDocument();
+      expect(screen.queryByText("Private balance")).not.toBeInTheDocument();
     });
   });
 
@@ -206,6 +231,7 @@ describe("Bitcoin Account Balance Summary Footer", () => {
       expect(screen.queryByText("Transparent balance")).not.toBeInTheDocument();
       expect(screen.queryByText("Private balance")).not.toBeInTheDocument();
       expect(screen.queryByTestId("show-private-balance-button")).not.toBeInTheDocument();
+      expect(screen.queryByText(PRIVATE_BALANCE_WARNING)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8897,7 +8897,8 @@
       "transparentBalance": "Transparent balance",
       "transparentBalanceTooltip": "Balance that is visible to the public",
       "privateBalance": "Private balance",
-      "privateBalanceTooltip": "Balance that is hidden from the public"
+      "privateBalanceTooltip": "Balance that is hidden from the public",
+      "privateBalanceWarning": "Private balance excludes Sapling and Orchard shielded funds"
     },
     "shielded": {
       "send": {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add a warning on Zcash accounts warning the user that the private balance field is excluding Sapling and Orchard funds. This is gated behind `zcashShielded` feature flag.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35598
