### PR TITLE
[LWDM] feat(pay-card): persist the hero balance filter selection (LIVE-34894)

### DIFF
--- a/.changeset/pay-card-balance-filter.md
+++ b/.changeset/pay-card-balance-filter.md
@@ -1,0 +1,7 @@
+---
+"@domain/entity-pay-card": minor
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Persist the pay card hero balance filter across app restarts

--- a/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/middlewares/__tests__/db.test.ts
@@ -48,6 +48,7 @@ jest.mock("@domain/entity-client-identity", () => ({
 jest.mock("@domain/entity-pay-card", () => ({
   payCardPersistedSelector: (state: FakeState) => ({
     hasSeenFeatureTour: state.payCard.hasSeenFeatureTour,
+    balanceFilter: state.payCard.balanceFilter,
   }),
 }));
 
@@ -68,7 +69,12 @@ type FakeState = {
   featureFlags: { overrides: unknown; bannerVisible: unknown; remoteFlagsReady?: unknown };
   coinConfigOverrides: { overrides: Record<string, unknown> };
   largeScreenUpsellModal: { retries: number; lastSeenAt: number | null };
-  payCard: { isOpen: boolean; params: unknown; hasSeenFeatureTour: boolean };
+  payCard: {
+    isOpen: boolean;
+    params: unknown;
+    hasSeenFeatureTour: boolean;
+    balanceFilter: string;
+  };
   trustchain?: unknown;
 };
 
@@ -83,7 +89,7 @@ const baseState = (): FakeState => ({
   featureFlags: { overrides: {}, bannerVisible: false },
   coinConfigOverrides: { overrides: {} },
   largeScreenUpsellModal: { retries: 0, lastSeenAt: null },
-  payCard: { isOpen: false, params: null, hasSeenFeatureTour: false },
+  payCard: { isOpen: false, params: null, hasSeenFeatureTour: false, balanceFilter: "all" },
 });
 
 function runMiddleware(states: FakeState[], action: { type: string; payload?: unknown }) {
@@ -227,16 +233,24 @@ describe("DBMiddleware - payCard branch", () => {
     mockedSetKey.mockReset();
   });
 
-  it("persists only { hasSeenFeatureTour } under app/payCard on payCard/* actions", () => {
+  it("persists only { hasSeenFeatureTour, balanceFilter } under app/payCard on payCard/* actions", () => {
     const state: FakeState = {
       ...baseState(),
-      payCard: { isOpen: true, params: { platform: "cl-card" }, hasSeenFeatureTour: true },
+      payCard: {
+        isOpen: true,
+        params: { platform: "cl-card" },
+        hasSeenFeatureTour: true,
+        balanceFilter: "ethereum/erc20/usd__coin",
+      },
     };
 
     runMiddleware([state, state], { type: "payCard/markPayCardFeatureTourSeen" });
 
     expect(mockedSetKey).toHaveBeenCalledTimes(1);
-    expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", { hasSeenFeatureTour: true });
+    expect(mockedSetKey).toHaveBeenCalledWith("app", "payCard", {
+      hasSeenFeatureTour: true,
+      balanceFilter: "ethereum/erc20/usd__coin",
+    });
 
     const persisted = mockedSetKey.mock.calls[0][2] as Record<string, unknown>;
     expect(persisted).not.toHaveProperty("isOpen");

--- a/apps/ledger-live-mobile/src/components/DBSave.test.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.test.ts
@@ -21,31 +21,36 @@ describe("featureFlagsLense", () => {
 });
 
 describe("payCardPersistedSelector (mobile persistence lens)", () => {
-  it("projects only { hasSeenFeatureTour } — never the transient isOpen/params", () => {
+  it("projects only { hasSeenFeatureTour, balanceFilter } — never the transient isOpen/params", () => {
     const state = {
       payCard: {
         isOpen: true,
         params: { platform: "cl-card", name: "CL Card" },
         hasSeenFeatureTour: true,
+        balanceFilter: "ethereum/erc20/usd__coin",
       },
     } as unknown as State;
 
     const projected = payCardPersistedSelector(state);
 
-    expect(projected).toEqual({ hasSeenFeatureTour: true });
+    expect(projected).toEqual({
+      hasSeenFeatureTour: true,
+      balanceFilter: "ethereum/erc20/usd__coin",
+    });
     expect(projected).not.toHaveProperty("isOpen");
     expect(projected).not.toHaveProperty("params");
   });
 
   it("does not change when only transient fields change", () => {
     const base = {
-      payCard: { isOpen: false, params: null, hasSeenFeatureTour: false },
+      payCard: { isOpen: false, params: null, hasSeenFeatureTour: false, balanceFilter: "all" },
     } as unknown as State;
     const opened = {
       payCard: {
         isOpen: true,
         params: { platform: "cl-card", name: "CL Card" },
         hasSeenFeatureTour: false,
+        balanceFilter: "all",
       },
     } as unknown as State;
 

--- a/apps/ledger-live-mobile/src/components/DBSave.ts
+++ b/apps/ledger-live-mobile/src/components/DBSave.ts
@@ -297,7 +297,7 @@ export const ConfigureDBSaveEffects = () => {
   });
 
   useDBSaveEffect({
-    stateSelector: (state: State) => state.payCard.hasSeenFeatureTour,
+    stateSelector: (state: State) => state.payCard,
     save: savePayCardState,
     throttle: 500,
     getChangesStats: payCardPersistedNotEquals,

--- a/domain/entity/pay-card/src/constants.ts
+++ b/domain/entity/pay-card/src/constants.ts
@@ -1,0 +1,1 @@
+export const PAY_CARD_BALANCE_FILTER_ALL = "all";

--- a/domain/entity/pay-card/src/index.ts
+++ b/domain/entity/pay-card/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./constants";
 export * from "./schema";
 export * from "./types";
 export * from "./slice";

--- a/domain/entity/pay-card/src/selectors.ts
+++ b/domain/entity/pay-card/src/selectors.ts
@@ -1,4 +1,9 @@
-import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
+import type {
+  PayCardBalanceFilter,
+  PayCardParams,
+  PayCardPersistedState,
+  PayCardState,
+} from "./types";
 
 type PayCardStateRoot = {
   payCard: PayCardState;
@@ -20,9 +25,14 @@ export function selectPayCardHasSeenFeatureTour(state: PayCardStateRoot): boolea
   return state.payCard.hasSeenFeatureTour;
 }
 
+export function selectPayCardBalanceFilter(state: PayCardStateRoot): PayCardBalanceFilter {
+  return state.payCard.balanceFilter;
+}
+
 /** Returns only the persisted subset of the pay card state. */
 export function payCardPersistedSelector(state: PayCardStateRoot): PayCardPersistedState {
   return {
     hasSeenFeatureTour: state.payCard.hasSeenFeatureTour,
+    balanceFilter: state.payCard.balanceFilter,
   };
 }

--- a/domain/entity/pay-card/src/slice.test.ts
+++ b/domain/entity/pay-card/src/slice.test.ts
@@ -5,6 +5,7 @@ import {
   closePayCard,
   markPayCardFeatureTourSeen,
   resetPayCardFeatureTourSeen,
+  setPayCardBalanceFilter,
   restorePayCardPersistedState,
 } from "./slice";
 import {
@@ -12,8 +13,10 @@ import {
   selectPayCardIsOpen,
   selectPayCardParams,
   selectPayCardHasSeenFeatureTour,
+  selectPayCardBalanceFilter,
   payCardPersistedSelector,
 } from "./selectors";
+import { PAY_CARD_BALANCE_FILTER_ALL } from "./constants";
 
 const reducer = payCardSlice.reducer;
 const params = { platform: "cl-card", name: "CL Card" };
@@ -48,6 +51,21 @@ describe("payCard slice", () => {
     const state = reducer(seen, resetPayCardFeatureTourSeen());
     expect(state.hasSeenFeatureTour).toBe(false);
   });
+
+  it("defaults the balance filter to all", () => {
+    expect(payCardInitialState.balanceFilter).toBe(PAY_CARD_BALANCE_FILTER_ALL);
+  });
+
+  it("sets the balance filter to a stablecoin currencyId", () => {
+    const state = reducer(undefined, setPayCardBalanceFilter("ethereum/erc20/usd__coin"));
+    expect(state.balanceFilter).toBe("ethereum/erc20/usd__coin");
+  });
+
+  it("sets the balance filter back to all", () => {
+    const filtered = reducer(undefined, setPayCardBalanceFilter("ethereum/erc20/usd__coin"));
+    const state = reducer(filtered, setPayCardBalanceFilter(PAY_CARD_BALANCE_FILTER_ALL));
+    expect(state.balanceFilter).toBe(PAY_CARD_BALANCE_FILTER_ALL);
+  });
 });
 
 describe("restorePayCardPersistedState", () => {
@@ -81,6 +99,37 @@ describe("restorePayCardPersistedState", () => {
     expect(state.params).toEqual(params);
     expect(state.hasSeenFeatureTour).toBe(true);
   });
+
+  it("restores balanceFilter from a valid payload", () => {
+    const state = reducer(
+      undefined,
+      restorePayCardPersistedState({ balanceFilter: "ethereum/erc20/usd__coin" }),
+    );
+    expect(state.balanceFilter).toBe("ethereum/erc20/usd__coin");
+  });
+
+  it("ignores a non-string or empty balanceFilter", () => {
+    const emptyString = reducer(undefined, restorePayCardPersistedState({ balanceFilter: "" }));
+    expect(emptyString.balanceFilter).toBe(PAY_CARD_BALANCE_FILTER_ALL);
+
+    const nonString = reducer(
+      undefined,
+      // @ts-expect-error - guarding against malformed persisted data
+      restorePayCardPersistedState({ balanceFilter: 42 }),
+    );
+    expect(nonString.balanceFilter).toBe(PAY_CARD_BALANCE_FILTER_ALL);
+  });
+
+  it("merges balanceFilter without touching isOpen/params", () => {
+    const opened = reducer(undefined, openPayCard(params));
+    const state = reducer(
+      opened,
+      restorePayCardPersistedState({ balanceFilter: "ethereum/erc20/usd__coin" }),
+    );
+    expect(state.isOpen).toBe(true);
+    expect(state.params).toEqual(params);
+    expect(state.balanceFilter).toBe("ethereum/erc20/usd__coin");
+  });
 });
 
 describe("payCard selectors", () => {
@@ -106,8 +155,20 @@ describe("payCard selectors", () => {
     ).toBe(true);
   });
 
+  it("selectPayCardBalanceFilter reflects the current filter", () => {
+    expect(selectPayCardBalanceFilter(root())).toBe(PAY_CARD_BALANCE_FILTER_ALL);
+    expect(
+      selectPayCardBalanceFilter(
+        root(reducer(undefined, setPayCardBalanceFilter("ethereum/erc20/usd__coin"))),
+      ),
+    ).toBe("ethereum/erc20/usd__coin");
+  });
+
   it("payCardPersistedSelector returns only the persisted subset", () => {
     const state = reducer(undefined, openPayCard(params));
-    expect(payCardPersistedSelector(root(state))).toEqual({ hasSeenFeatureTour: false });
+    expect(payCardPersistedSelector(root(state))).toEqual({
+      hasSeenFeatureTour: false,
+      balanceFilter: PAY_CARD_BALANCE_FILTER_ALL,
+    });
   });
 });

--- a/domain/entity/pay-card/src/slice.ts
+++ b/domain/entity/pay-card/src/slice.ts
@@ -1,10 +1,17 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { PayCardParams, PayCardPersistedState, PayCardState } from "./types";
+import { PAY_CARD_BALANCE_FILTER_ALL } from "./constants";
+import type {
+  PayCardBalanceFilter,
+  PayCardParams,
+  PayCardPersistedState,
+  PayCardState,
+} from "./types";
 
 export const payCardInitialState: PayCardState = {
   isOpen: false,
   params: null,
   hasSeenFeatureTour: false,
+  balanceFilter: PAY_CARD_BALANCE_FILTER_ALL,
 };
 
 export const payCardSlice = createSlice({
@@ -25,13 +32,19 @@ export const payCardSlice = createSlice({
     resetPayCardFeatureTourSeen: state => {
       state.hasSeenFeatureTour = false;
     },
+    setPayCardBalanceFilter: (state, action: PayloadAction<PayCardBalanceFilter>) => {
+      state.balanceFilter = action.payload;
+    },
     restorePayCardPersistedState: (
       state,
       action: PayloadAction<Partial<PayCardPersistedState>>,
     ) => {
-      const { hasSeenFeatureTour } = action.payload ?? {};
+      const { hasSeenFeatureTour, balanceFilter } = action.payload ?? {};
       if (typeof hasSeenFeatureTour === "boolean") {
         state.hasSeenFeatureTour = hasSeenFeatureTour;
+      }
+      if (typeof balanceFilter === "string" && balanceFilter.length > 0) {
+        state.balanceFilter = balanceFilter;
       }
     },
   },
@@ -42,5 +55,6 @@ export const {
   closePayCard,
   markPayCardFeatureTourSeen,
   resetPayCardFeatureTourSeen,
+  setPayCardBalanceFilter,
   restorePayCardPersistedState,
 } = payCardSlice.actions;

--- a/domain/entity/pay-card/src/types.ts
+++ b/domain/entity/pay-card/src/types.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import { PAY_CARD_BALANCE_FILTER_ALL } from "./constants";
 import {
   PayCardLogoutResultSchema,
   PayCardParamsSchema,
@@ -26,13 +27,18 @@ export type PayCardLogoutResult = z.infer<typeof PayCardLogoutResultSchema>;
 
 export type PayCardParams = z.infer<typeof PayCardParamsSchema>;
 
+/** `"all"` or the currencyId of a single stablecoin. Never a ticker: ids are stable. */
+export type PayCardBalanceFilter = typeof PAY_CARD_BALANCE_FILTER_ALL | (string & {});
+
 export type PayCardState = Readonly<{
   isOpen: boolean;
   params: PayCardParams | null;
   hasSeenFeatureTour: boolean;
+  balanceFilter: PayCardBalanceFilter;
 }>;
 
 /** Subset of {@link PayCardState} that is persisted across app restarts. */
 export type PayCardPersistedState = Readonly<{
   hasSeenFeatureTour: boolean;
+  balanceFilter: PayCardBalanceFilter;
 }>;


### PR DESCRIPTION
### 📝 Description

The pay card hero lets the user narrow the displayed balance to a single stablecoin, but the selection lived only in memory: killing the app reset it back to "all". This is the shared domain part of that story — it makes the selection survive a restart.

`@domain/entity-pay-card` gains a `balanceFilter` field on `PayCardState`, holding either `"all"` or the **currencyId** of a single stablecoin. The currencyId is persisted rather than the ticker because ids are stable. Alongside it: a `setPayCardBalanceFilter` reducer and a `selectPayCardBalanceFilter` selector.

```ts
import {
  setPayCardBalanceFilter,
  selectPayCardBalanceFilter,
  PAY_CARD_BALANCE_FILTER_ALL,
} from "@domain/entity-pay-card";

dispatch(setPayCardBalanceFilter("ethereum/erc20/usd__coin"));
dispatch(setPayCardBalanceFilter(PAY_CARD_BALANCE_FILTER_ALL)); // back to "all"

const filter = useSelector(selectPayCardBalanceFilter);
```

Persistence needs no new wiring: the app-side plumbing added by LIVE-34861 / LIVE-34862 saves whatever `payCardPersistedSelector` returns, so extending that projection with `balanceFilter` and merging it back in `restorePayCardPersistedState` is enough for desktop to save and rehydrate it. `restorePayCardPersistedState` ignores a non-string or empty value so malformed persisted data falls back to `"all"`, and it merges without touching the transient `isOpen` / `params`.

One app-side fix was required, in the second commit: the mobile `DBSave` effect watched only `state.payCard.hasSeenFeatureTour`, so a `balanceFilter`-only change never reached `savePayCardState`. It now watches the whole slice and lets the existing `payCardPersistedNotEquals` comparator decide what is worth writing — transient `isOpen` / `params` changes still write nothing.

The fallback for a persisted id the user no longer holds (treat as `"all"`) belongs to the Story 2 balance view model, not here.

**Tests** — `slice.test.ts` covers the default, `setPayCardBalanceFilter` in both directions, `payCardPersistedSelector` including the field, and `restorePayCardPersistedState` merging it while leaving `isOpen` / `params` alone plus rejecting malformed values. The desktop and mobile persistence-lens tests were updated to assert the new projected shape.

**QA focus** — nothing is user-visible until the Story 2 filter UI dispatches the action, so the check is regression-only: the pay card feature tour must still be remembered across a restart on both desktop and mobile, and no pay card state should leak `isOpen` / `params` into storage.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34894](https://ledgerhq.atlassian.net/browse/LIVE-34894)
- Depends on the app-side persistence wiring from LIVE-34861 / LIVE-34862; consumed by the Story 2 filter UI.

[LIVE-34894]: https://ledgerhq.atlassian.net/browse/LIVE-34894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ