### PR TITLE
[LWDM] fix(send): validate custom fees against native balance for evm tokens

### DIFF
--- a/.changeset/metal-nails-type.md
+++ b/.changeset/metal-nails-type.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+fix(send): validate custom fees against native balance for evm tokens

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/__tests__/useCustomFeesViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/CustomFees/hooks/__tests__/useCustomFeesViewModel.test.ts
@@ -3,7 +3,7 @@ import { BigNumber } from "bignumber.js";
 import { act } from "@testing-library/react";
 import { renderHook } from "tests/testSetup";
 import type { Transaction, TransactionStatus } from "@ledgerhq/live-common/generated/types";
-import type { AccountLike } from "@ledgerhq/types-live";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { useCustomFeesViewModel } from "../useCustomFeesViewModel";
 import type { SendFlowTransactionActions } from "@ledgerhq/live-common/flows/send/types";
@@ -152,6 +152,22 @@ function createMockAccount(): AccountLike {
   } as unknown as AccountLike;
 }
 
+function createMockTokenAccount(parentId: string): AccountLike {
+  return {
+    id: "usdc-account-1",
+    parentId,
+    type: "TokenAccount",
+    token: {
+      id: "ethereum/erc20/usd__coin",
+      name: "USD Coin",
+      ticker: "USDC",
+      units: [{ code: "USDC", magnitude: 6, name: "USD Coin" }],
+    },
+    balance: new BigNumber("100000000"),
+    spendableBalance: new BigNumber("100000000"),
+  } as unknown as AccountLike;
+}
+
 function createMockTransaction(): Transaction {
   return {
     family: "evm",
@@ -212,6 +228,64 @@ describe("useCustomFeesViewModel - EIP-1559 Validation", () => {
       "maxPriorityFeePerGas",
       "maxFeePerGas",
     ]);
+  });
+
+  it("should validate token transfer fees against the parent native balance", () => {
+    const parentAccount = createMockAccount() as Account;
+    const account = createMockTokenAccount(parentAccount.id);
+    const transaction = {
+      ...createMockTransaction(),
+      amount: new BigNumber("10000000"),
+      subAccountId: account.id,
+    } as Transaction;
+
+    const { result } = renderHook(() =>
+      useCustomFeesViewModel({
+        account,
+        parentAccount,
+        transaction,
+        status: createMockStatus(),
+        currency: createMockCurrency(),
+        transactionActions: createMockTransactionActions(),
+        onConfirm: jest.fn(),
+      }),
+    );
+
+    const maxFeeInput = result.current.inputs.find(input => input.key === "maxFeePerGas");
+
+    expect(maxFeeInput?.error).toBeNull();
+    expect(result.current.isConfirmDisabled).toBe(false);
+  });
+
+  it("should flag insufficient balance when the parent native account cannot cover fees", () => {
+    const parentAccount = {
+      ...createMockAccount(),
+      balance: new BigNumber("1000"),
+      spendableBalance: new BigNumber("1000"),
+    } as Account;
+    const account = createMockTokenAccount(parentAccount.id);
+    const transaction = {
+      ...createMockTransaction(),
+      amount: new BigNumber("10000000"),
+      subAccountId: account.id,
+    } as Transaction;
+
+    const { result } = renderHook(() =>
+      useCustomFeesViewModel({
+        account,
+        parentAccount,
+        transaction,
+        status: createMockStatus(),
+        currency: createMockCurrency(),
+        transactionActions: createMockTransactionActions(),
+        onConfirm: jest.fn(),
+      }),
+    );
+
+    const maxFeeInput = result.current.inputs.find(input => input.key === "maxFeePerGas");
+
+    expect(maxFeeInput?.error).toBe("newSendFlow.insufficientBalanceFees");
+    expect(result.current.isConfirmDisabled).toBe(true);
   });
 
   it("should expose custom fee assets when descriptor provides them", () => {

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeeValidation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/__tests__/useCustomFeeValidation.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { BigNumber } from "bignumber.js";
+import { renderHook } from "@testing-library/react";
+import type { Account, AccountLike } from "@ledgerhq/types-live";
+import type { Transaction, TransactionStatus } from "../../../../../coin-modules/transaction-types";
+import { useCustomFeeValidation } from "../useCustomFeeValidation";
+
+function createNativeAccount(balance: string): Account {
+  return {
+    id: "eth-account-1",
+    type: "Account",
+    balance: new BigNumber(balance),
+    spendableBalance: new BigNumber(balance),
+  } as Account;
+}
+
+function createTokenAccount(parentId: string, balance: string): AccountLike {
+  return {
+    id: "usdc-account-1",
+    parentId,
+    type: "TokenAccount",
+    balance: new BigNumber(balance),
+    spendableBalance: new BigNumber(balance),
+  } as AccountLike;
+}
+
+function createStatus(): TransactionStatus {
+  return {
+    errors: {},
+    warnings: {},
+    estimatedFees: new BigNumber(0),
+  } as TransactionStatus;
+}
+
+function createTransaction(amount: string, subAccountId?: string): Transaction {
+  return {
+    family: "evm",
+    amount: new BigNumber(amount),
+    useAllAmount: false,
+    subAccountId: subAccountId ?? null,
+  } as Transaction;
+}
+
+const activeInputs = [{ key: "maxFeePerGas", type: "number" as const }] as const;
+
+describe("useCustomFeeValidation", () => {
+  it("does not flag insufficient balance when token amount and native fees use different accounts", () => {
+    const nativeAccount = createNativeAccount("1000000000000000000");
+    const tokenAccount = createTokenAccount(nativeAccount.id, "100000000");
+
+    const { result } = renderHook(() =>
+      useCustomFeeValidation({
+        account: tokenAccount,
+        feePayerAccount: nativeAccount,
+        transaction: createTransaction("10000000", tokenAccount.id),
+        status: createStatus(),
+        activeInputs,
+        values: { maxFeePerGas: "10000000000" },
+        estimatedFeesForValidation: new BigNumber("210000000000000"),
+        bridgeHasInsufficientBalance: false,
+        hasCustomFeeConfig: true,
+      }),
+    );
+
+    expect(result.current.hasInsufficientBalance).toBe(false);
+  });
+
+  it("flags insufficient balance when native fee payer cannot cover the estimated fees", () => {
+    const nativeAccount = createNativeAccount("1000");
+    const tokenAccount = createTokenAccount(nativeAccount.id, "100000000");
+
+    const { result } = renderHook(() =>
+      useCustomFeeValidation({
+        account: tokenAccount,
+        feePayerAccount: nativeAccount,
+        transaction: createTransaction("10000000", tokenAccount.id),
+        status: createStatus(),
+        activeInputs,
+        values: { maxFeePerGas: "10000000000" },
+        estimatedFeesForValidation: new BigNumber("210000000000000"),
+        bridgeHasInsufficientBalance: false,
+        hasCustomFeeConfig: true,
+      }),
+    );
+
+    expect(result.current.hasInsufficientBalance).toBe(true);
+  });
+
+  it("compares amount plus fees when sender and fee payer use the same account", () => {
+    const nativeAccount = createNativeAccount("1000000000000000000");
+
+    const { result } = renderHook(() =>
+      useCustomFeeValidation({
+        account: nativeAccount,
+        feePayerAccount: nativeAccount,
+        transaction: createTransaction("99000000000000000000"),
+        status: createStatus(),
+        activeInputs,
+        values: { maxFeePerGas: "10000000000" },
+        estimatedFeesForValidation: new BigNumber("210000000000000"),
+        bridgeHasInsufficientBalance: false,
+        hasCustomFeeConfig: true,
+      }),
+    );
+
+    expect(result.current.hasInsufficientBalance).toBe(true);
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeeValidation.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeeValidation.ts
@@ -12,6 +12,7 @@ import {
 
 type UseCustomFeeValidationParams = Readonly<{
   account: AccountLike;
+  feePayerAccount: AccountLike | null;
   transaction: Transaction;
   status: TransactionStatus;
   activeInputs: readonly CustomFeeInputDescriptor[];
@@ -30,6 +31,7 @@ type UseCustomFeeValidationResult = Readonly<{
 
 export function useCustomFeeValidation({
   account,
+  feePayerAccount,
   transaction,
   status,
   activeInputs,
@@ -66,22 +68,27 @@ export function useCustomFeeValidation({
   }, [values]);
 
   const hasInsufficientBalance = useMemo(() => {
-    const spendable = "spendableBalance" in account ? account.spendableBalance : undefined;
-    const balance = "balance" in account ? account.balance : new BigNumber(0);
-    const availableBalance = spendable ?? balance ?? new BigNumber(0);
+    const spendable =
+      feePayerAccount && "spendableBalance" in feePayerAccount
+        ? feePayerAccount.spendableBalance
+        : undefined;
+    const balance =
+      feePayerAccount && "balance" in feePayerAccount ? feePayerAccount.balance : undefined;
+    const availableBalance = spendable ?? balance;
     const txAmount = transaction.amount ?? new BigNumber(0);
-    // In max mode, amount is adjusted by the bridge to fit remaining balance.
-    // Local insufficient check should only fail when fees alone exceed available balance.
-    const totalCost = transaction.useAllAmount
-      ? estimatedFeesForValidation
-      : txAmount.plus(estimatedFeesForValidation);
-    const exceedsSpendable = totalCost.gt(availableBalance);
+    const amountAndFeesUseSameBalance = feePayerAccount?.id === account.id;
+    const totalCost =
+      transaction.useAllAmount || !amountAndFeesUseSameBalance
+        ? estimatedFeesForValidation
+        : txAmount.plus(estimatedFeesForValidation);
+    const exceedsSpendable = availableBalance !== undefined && totalCost.gt(availableBalance);
     const fromStatus = Object.entries(status.errors ?? {}).some(
       ([key, error]) => key === "insufficientBalanceFees" || hasInsufficientBalanceErrorName(error),
     );
     return exceedsSpendable || fromStatus || bridgeHasInsufficientBalance;
   }, [
     account,
+    feePayerAccount,
     transaction.amount,
     transaction.useAllAmount,
     estimatedFeesForValidation,

--- a/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
+++ b/libs/ledger-live-common/src/flows/send/customFees/hooks/useCustomFeesViewModelCore.ts
@@ -212,6 +212,14 @@ export function useCustomFeesViewModelCore({
   const selectedInputValueTransform = selectedAsset?.customFeeInputValueTransform ?? null;
   const selectedInputValueTransformId = selectedInputValueTransform ? selectedAssetId : null;
   const feeCurrencyAccountId = sendFeatures.getFeeCurrencyAccountId(accountCurrency, transaction);
+  const feePayerAccount = useMemo<AccountLike | null>(
+    () =>
+      feeCurrencyAccountId
+        ? (mainAccount.subAccounts?.find(subAccount => subAccount.id === feeCurrencyAccountId) ??
+          null)
+        : mainAccount,
+    [feeCurrencyAccountId, mainAccount],
+  );
   const { displayCurrency } = useMemo(
     () =>
       resolveFeeDisplayContext({
@@ -336,6 +344,7 @@ export function useCustomFeesViewModelCore({
     insufficientBalanceTargetInputKey,
   } = useCustomFeeValidation({
     account,
+    feePayerAccount,
     transaction,
     status,
     activeInputs,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

When sending a token evm with custom fee in the new send flow, the local balance check incorrectly added the token amount and gas fees (in wei) and compared the result to the token balance, so users were almost always blocked with `insufficient balance to cover the network fees`

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35676)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
