### PR TITLE
test(e2e): identify lw ci and llocal acquired speculinho instances

### DIFF
--- a/libs/live-e2e-shared/src/speculosCI.ts
+++ b/libs/live-e2e-shared/src/speculosCI.ts
@@ -33,8 +33,9 @@ function slugify(name: string): string {
  */
 function makeRunId(deviceParams: DeviceParams): string {
   const slug = slugify(deviceParams.appName) || "app";
-  const suffix = uniqueId().replace(/-/g, "").slice(0, 12);
-  const combined = `${slug.slice(0, 20)}-${suffix}`;
+  const id = uniqueId().replaceAll("-", "").slice(0, 12);
+  const environment = process.env.CI ? "ci" : "local";
+  const combined = `${slug.slice(0, 20)}-lw-${environment}-${id}`;
   return combined.slice(0, 63);
 }
 


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Add minimum identifiers to URL to debug speculinho instance was reqeusted by Ledger Wallet and CI vs local environment.

[Example](https://github.com/LedgerHQ/ledger-live/actions/runs/31396269255/job/93481347108) run:
```
14:15:26.076 detox[2600] i Speculos is ready at https://ethereum-lw-ci-f231d0a0c78b.speculos.ledgerlabs.net/
```
Will be visible on this [dashboard](https://grafana.infra.ledgerlabs.net/d/speculinho-overview/speculinho3a-operator-overview?orgId=1&from=now-1h&to=now&timezone=browser&var-DS_PROMETHEUS=1e5y92dGz&var-DS_K8S=1e5y92dGz&var-cluster=$__all&var-namespace=$__all&var-max_instances=300&refresh=30s).

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/QAA-1421
