### PR TITLE
style(contacts): fix oxfmt formatting in address detail actions

### DIFF
--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsViewModel.ts
@@ -1,5 +1,8 @@
 import type { ContactAddress, ContactAddressId, ContactId } from "@domain/entity-contact";
-import { CONTACT_ADDRESS_DELETE_REQUIREMENT, CONTACT_ADDRESS_EDIT_REQUIREMENT } from "./editRequirement";
+import {
+  CONTACT_ADDRESS_DELETE_REQUIREMENT,
+  CONTACT_ADDRESS_EDIT_REQUIREMENT,
+} from "./editRequirement";
 import type {
   ContactAddressDeleteLifecycle,
   ContactAddressDetailDeleteIntent,

--- a/features/flow/contacts/src/steps/Detail/model/signerPendingAction.ts
+++ b/features/flow/contacts/src/steps/Detail/model/signerPendingAction.ts
@@ -1,7 +1,4 @@
-import type {
-  ContactAddressDetailDeleteIntent,
-  ContactAddressDetailEditIntent,
-} from "../types";
+import type { ContactAddressDetailDeleteIntent, ContactAddressDetailEditIntent } from "../types";
 
 export type SignerPendingAction = "edit" | "delete";
 

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.ts
@@ -112,11 +112,7 @@ export function useContactAddressDetailActionsFlowViewModel({
 
   const onSignerConfirm = useCallback(async () => {
     const pendingAction = signerPendingAction;
-    const validationTarget = resolveSignerValidationTarget(
-      pendingAction,
-      editIntent,
-      deleteIntent,
-    );
+    const validationTarget = resolveSignerValidationTarget(pendingAction, editIntent, deleteIntent);
 
     if (validationTarget === undefined || pendingAction === null) {
       return;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fixes failing `@features/flow-contacts` `format:check` CI on develop by applying oxfmt to three address-detail action files:

- `addressDetailActionsViewModel.ts`
- `signerPendingAction.ts`
- `useContactAddressDetailActionsFlowViewModel.ts`

### 🔗 Context

- **JIRA / GitHub issue**: N/A (CI formatting fix on develop)
- **ADR** (if any): N/A

## Test plan

- [x] `pnpm --filter @features/flow-contacts run format:check`