### PR TITLE
test(e2e): mobile swapToEarn ETH deposit routing (v1 & v2)

### DIFF
--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -6,7 +6,7 @@ export default class EarnV2DashboardPage {
   maxPotentialRewards = "max-potential-rewards";
   walletHeaderAmount = "wallet-header-amount";
   rewardsSummary = "rewards-summary";
-  tokensToEarnBanner = "tokens-to-earn-banner";
+  crowdFavourites = "crowd-favourites";
   iceColdStartEarnCta = "ice-cold-start-earn-cta";
   assetItemTicker = (ticker: string) => `asset-item-ticker-${ticker}`;
   assetEarnCta = (ticker: string) => `asset-earn-cta-${ticker}`;
@@ -45,7 +45,7 @@ export default class EarnV2DashboardPage {
 
   @Step("Verify cold start page")
   async verifyColdStartPage() {
-    await waitWebElementByTestId(this.tokensToEarnBanner);
+    await waitWebElementByTestId(this.crowdFavourites);
   }
 
   @Step("Verify asset ready to earn")

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -205,7 +205,18 @@ export default class EarnV2DashboardPage {
   @Step("Expand v2 ETH provider card: $0")
   async expandV2EthProviderCard(providerId: string) {
     await waitWebElementByTestId(this.ethProviderPanel);
-    await tapWebElementByTestId(this.ethProviderCardTestId(providerId));
+    const depositCtaId = this.ethProviderDepositCta(
+      EarnV2DashboardPage.resolveEthProviderCardId(providerId),
+    );
+    // The card may already be expanded (e.g. auto-selected on load). Tapping an expanded card
+    // toggles it closed, so only tap if the deposit CTA isn't already visible.
+    const alreadyExpanded = await waitWebElementByTestId(depositCtaId, {
+      timeout: 1000,
+      throwOnTimeout: false,
+    });
+    if (!alreadyExpanded) {
+      await tapWebElementByTestId(this.ethProviderCardTestId(providerId));
+    }
   }
 
   @Step("Verify v2 ETH provider deposit CTA is visible: $0")

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -119,11 +119,16 @@ export default class EarnV2DashboardPage {
 
   // --- ETH deposit webview flow (amount -> provider -> partner dapp) ---
 
-  ethAmountInput = "amount-input-section-input";
-  ethAmountContinueCta = "input-button-mobile";
+  // swapToEarn is forwarded to the earn webview URL, and the earn app's proxy routes on it:
+  // enabled -> /v2/<os>/deposit, disabled -> /<os>/deposit. The two flows are separate screens
+  // with different test ids, so keep the v1 and v2 selectors distinct.
+  ethAmountInput = "amount-input-section-input"; // shared: both flows render this
+  ethAmountContinueCta = "input-button-mobile"; // v1 only
+  v2AmountContinueCta = "amount-continue-cta"; // v2 only
   ethProviderPanel = "eth-provider-panel";
-  ethProviderAllFilterChip = "filter-chip-all";
-  ethDepositProviderCta = "select-provider-button-mobile";
+  ethProviderAllFilterChip = "filter-chip-all"; // v1 only; v2 uses a segmented control
+  ethDepositProviderCta = "select-provider-button-mobile"; // v1 only
+  ethProviderDepositCta = (cardId: string) => `eth-provider-deposit-${cardId}`;
   // The provider card test id suffix is the backend `ID` enum value, which differs from the e2e
   // provider value, so map the providers we exercise.
   private static readonly ethProviderCardIds: Record<string, string> = {
@@ -131,6 +136,14 @@ export default class EarnV2DashboardPage {
     kiln_pooling: "KilnEthereumPooling",
     "stader-eth": "stader-eth",
   };
+
+  private static resolveEthProviderCardId(providerId: string) {
+    return EarnV2DashboardPage.ethProviderCardIds[providerId] ?? providerId;
+  }
+
+  private ethProviderCardTestId(providerId: string) {
+    return `eth-provider-card-${EarnV2DashboardPage.resolveEthProviderCardId(providerId)}`;
+  }
 
   @Step("Complete ETH deposit amount step with $0 ETH")
   async completeEthDepositAmountStep(amount: string) {
@@ -148,14 +161,58 @@ export default class EarnV2DashboardPage {
     // Kiln is "pooling"), so reset to "All" to make any provider selectable. Tapping directly (no
     // presence guard) asserts the chip exists — a regression in the filter bar fails loudly.
     await tapWebElementByTestId(this.ethProviderAllFilterChip);
-    const cardId = EarnV2DashboardPage.ethProviderCardIds[providerId] ?? providerId;
-    await tapWebElementByTestId(`eth-provider-card-${cardId}`);
+    await tapWebElementByTestId(this.ethProviderCardTestId(providerId));
   }
 
   @Step("Confirm ETH deposit provider selection")
   async confirmEthDepositProvider() {
     await waitForWebElementToBeEnabled(this.ethDepositProviderCta);
     await tapWebElementByTestId(this.ethDepositProviderCta);
+  }
+
+  // --- swapToEarn routing variants ---
+
+  // The earn app redirects "/" to /v2/<os>/deposit or /<os>/deposit based on the swapToEarn URL
+  // param, so the path segment proves which branch the proxy took. The v2 dashboard also lives
+  // under /v2/, so "/deposit" must be matched first before checking for the version segment.
+  @Step("Verify webview is on the v1 deposit flow")
+  async verifyV1DepositFlowVisible() {
+    const url = await waitForCurrentWebviewUrlToContain("/deposit");
+    jestExpect(url).not.toContain("/v2/");
+  }
+
+  @Step("Verify webview is on the v2 deposit flow")
+  async verifyV2DepositFlowVisible() {
+    const url = await waitForCurrentWebviewUrlToContain("/deposit");
+    jestExpect(url).toContain("/v2/");
+  }
+
+  @Step("Verify v1 deposit continue CTA is visible")
+  async verifyV1DepositContinueCtaVisible() {
+    await waitWebElementByTestId(this.ethAmountContinueCta);
+  }
+
+  @Step("Complete v2 ETH deposit amount step with $0 ETH")
+  async completeV2EthDepositAmountStep(amount: string) {
+    await waitWebElementByTestId(this.ethAmountInput);
+    await typeTextByWebTestId(this.ethAmountInput, amount);
+    await waitForWebElementToBeEnabled(this.v2AmountContinueCta);
+    await tapWebElementByTestId(this.v2AmountContinueCta);
+  }
+
+  // v2 provider cards expand in place to reveal their own Deposit CTA, rather than selecting a
+  // provider and confirming with a single shared button as v1 does.
+  @Step("Expand v2 ETH provider card: $0")
+  async expandV2EthProviderCard(providerId: string) {
+    await waitWebElementByTestId(this.ethProviderPanel);
+    await tapWebElementByTestId(this.ethProviderCardTestId(providerId));
+  }
+
+  @Step("Verify v2 ETH provider deposit CTA is visible: $0")
+  async verifyV2EthProviderDepositCtaVisible(providerId: string) {
+    await waitWebElementByTestId(
+      this.ethProviderDepositCta(EarnV2DashboardPage.resolveEthProviderCardId(providerId)),
+    );
   }
 
   @Step("Tap staking provider in EvmStakingDrawer: $0")

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -145,6 +145,14 @@ export default class EarnV2DashboardPage {
     return `eth-provider-card-${EarnV2DashboardPage.resolveEthProviderCardId(providerId)}`;
   }
 
+  // Lumen's expandable Card puts the onClick on CardHeader, not the card root div. Tapping the
+  // root via its testid calls .click() on the root, which bubbles up (not into CardHeader), so
+  // the handler never fires. Tapping the provider name — a child of CardHeader — bubbles up
+  // through CardHeader and correctly triggers the expand/collapse handler.
+  private ethProviderNameTestId(providerId: string) {
+    return `eth-provider-name-${EarnV2DashboardPage.resolveEthProviderCardId(providerId)}`;
+  }
+
   @Step("Complete ETH deposit amount step with $0 ETH")
   async completeEthDepositAmountStep(amount: string) {
     await waitWebElementByTestId(this.ethAmountInput);
@@ -215,7 +223,7 @@ export default class EarnV2DashboardPage {
       throwOnTimeout: false,
     });
     if (!alreadyExpanded) {
-      await tapWebElementByTestId(this.ethProviderCardTestId(providerId));
+      await tapWebElementByTestId(this.ethProviderNameTestId(providerId));
     }
   }
 

--- a/e2e/mobile/page/trade/earnV2Dashboard.page.ts
+++ b/e2e/mobile/page/trade/earnV2Dashboard.page.ts
@@ -145,14 +145,6 @@ export default class EarnV2DashboardPage {
     return `eth-provider-card-${EarnV2DashboardPage.resolveEthProviderCardId(providerId)}`;
   }
 
-  // Lumen's expandable Card puts the onClick on CardHeader, not the card root div. Tapping the
-  // root via its testid calls .click() on the root, which bubbles up (not into CardHeader), so
-  // the handler never fires. Tapping the provider name — a child of CardHeader — bubbles up
-  // through CardHeader and correctly triggers the expand/collapse handler.
-  private ethProviderNameTestId(providerId: string) {
-    return `eth-provider-name-${EarnV2DashboardPage.resolveEthProviderCardId(providerId)}`;
-  }
-
   @Step("Complete ETH deposit amount step with $0 ETH")
   async completeEthDepositAmountStep(amount: string) {
     await waitWebElementByTestId(this.ethAmountInput);
@@ -223,7 +215,15 @@ export default class EarnV2DashboardPage {
       throwOnTimeout: false,
     });
     if (!alreadyExpanded) {
-      await tapWebElementByTestId(this.ethProviderNameTestId(providerId));
+      // Lumen's expandable Card puts onClick on the inner CardHeader [role="button"], not on
+      // the card root. Detox's WebElement .tap() calls el.click() on the matched node, which
+      // dispatches the event on that node and bubbles upward — never down into CardHeader.
+      // Using runScript to call .click() on CardHeader directly (found via querySelector)
+      // fires on the correct target without relying on bubbling from a parent or child.
+      await getWebElementByTestId(this.ethProviderCardTestId(providerId)).runScript(el => {
+        const header = el.querySelector("[role=button]");
+        if (header) header.click();
+      });
     }
   }
 

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -299,6 +299,81 @@ export function runPositionToWithdrawalTest(account: Account, tmsLinks: string[]
   });
 }
 
+// --- swapToEarn routing variants ---
+
+// swapToEarn is forwarded to the earn webview URL and the earn app's proxy routes on it, so both
+// branches must be pinned explicitly: inheriting the ambient flag would make which deposit UI is
+// exercised non-deterministic.
+export function runSwapToEarnDisabledDepositTest(
+  account: Account,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Earn v2", () => {
+    beforeAll(async () => {
+      await beforeAllFunction({
+        userdata: "skip-onboarding",
+        speculosApp: account.currency.speculosApp,
+        featureFlags: {
+          ...EARN_V2_FLAGS,
+          ...FF_STAKE_PROGRAMS_MODAL,
+          swapToEarn: { enabled: false },
+        },
+        cliCommands: [liveDataWithAddressCommand(account)],
+        speculosForSetupOnly: true,
+      });
+    });
+
+    setTeamOwner(Team.EARN);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it(`[${account.currency.testLabel}] - Earn v2 CTA routes to v1 deposit when swapToEarn is disabled`, async () => {
+      await navigateToEarn();
+      await app.earnV2Dashboard.clickAssetEarnCta(account.currency.ticker);
+      await app.earnV2Dashboard.verifyV1DepositFlowVisible();
+      // v1 presents a single continue CTA on the amount step; v2 has no such test id.
+      await app.earnV2Dashboard.verifyV1DepositContinueCtaVisible();
+    });
+  });
+}
+
+export function runSwapToEarnEnabledDepositTest(
+  account: Account,
+  providerId: string,
+  tmsLinks: string[],
+  tags: string[],
+) {
+  describe("Earn v2", () => {
+    beforeAll(async () => {
+      await beforeAllFunction({
+        userdata: "skip-onboarding",
+        speculosApp: account.currency.speculosApp,
+        featureFlags: {
+          ...EARN_V2_FLAGS,
+          ...FF_STAKE_PROGRAMS_MODAL,
+          swapToEarn: { enabled: true },
+        },
+        cliCommands: [liveDataWithAddressCommand(account)],
+        speculosForSetupOnly: true,
+      });
+    });
+
+    setTeamOwner(Team.EARN);
+    tmsLinks.forEach(tmsLink => $TmsLink(tmsLink));
+    tags.forEach(tag => $Tag(tag));
+    it(`[${account.currency.testLabel}] - Earn v2 CTA routes to v2 deposit when swapToEarn is enabled`, async () => {
+      await navigateToEarn();
+      await app.earnV2Dashboard.clickAssetEarnCta(account.currency.ticker);
+      await app.earnV2Dashboard.verifyV2DepositFlowVisible();
+      await app.earnV2Dashboard.completeV2EthDepositAmountStep("0.02");
+      // The provider must be a "liquid" one: v2 defaults the category filter to liquid below the
+      // protocol-staking threshold, and its segmented control has no per-option test id to reset.
+      await app.earnV2Dashboard.expandV2EthProviderCard(providerId);
+      await app.earnV2Dashboard.verifyV2EthProviderDepositCtaVisible(providerId);
+    });
+  });
+}
+
 // --- Inline Add Account ---
 
 export function runInlineAddAccountTest(account: Account, tmsLinks: string[], tags: string[]) {

--- a/e2e/mobile/specs/earn/earnV2.ts
+++ b/e2e/mobile/specs/earn/earnV2.ts
@@ -3,14 +3,18 @@ import { Team } from "@ledgerhq/live-e2e-shared/enum/Team";
 import { setEnv } from "@shared/env";
 import { waitEarnReady } from "../../bridge/server";
 import { setTeamOwner } from "../../helpers/allure/allure-helper";
+import { FF_LWM_WALLET_40_Q2 } from "utils/featureFlagUtils";
 
 import type { ApplicationOptions } from "page";
-import type { PartialFeatures } from "@shared/feature-flags";
+import type { OptionalFeatureMap, PartialFeatures } from "@shared/feature-flags";
 
 setEnv("DISABLE_TRANSACTION_BROADCAST", true);
 
-const EARN_V2_FLAGS: PartialFeatures = {
+// Pinned so E2E_MOBILE_FEATURE_FLAGS can't downgrade earnUpselling and change the earn UI.
+// https://ledgerhq.atlassian.net/browse/LIVE-35026
+const EARN_V2_FLAGS: OptionalFeatureMap = {
   ptxEarnUi: { enabled: true, params: { value: "v2" } },
+  ...FF_LWM_WALLET_40_Q2,
 };
 
 // Pins the ETH deposit webview to the `basic_sorting` cohort (mirrors the desktop

--- a/e2e/mobile/specs/earn/earnV2_swapToEarnDisabled_v1Deposit_ETH_1.spec.ts
+++ b/e2e/mobile/specs/earn/earnV2_swapToEarnDisabled_v1Deposit_ETH_1.spec.ts
@@ -1,0 +1,10 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { runSwapToEarnDisabledDepositTest } from "./earnV2";
+
+const testConfig = {
+  account: Account.ETH_1,
+  tmsLinks: ["B2CQA-6136"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+};
+
+runSwapToEarnDisabledDepositTest(testConfig.account, testConfig.tmsLinks, testConfig.tags);

--- a/e2e/mobile/specs/earn/earnV2_swapToEarnEnabled_v2Deposit_ETH_1.spec.ts
+++ b/e2e/mobile/specs/earn/earnV2_swapToEarnEnabled_v2Deposit_ETH_1.spec.ts
@@ -1,0 +1,19 @@
+import { Account } from "@ledgerhq/live-e2e-shared/enum/Account";
+import { EarnProvider } from "@ledgerhq/live-e2e-shared/enum/Provider";
+import { runSwapToEarnEnabledDepositTest } from "./earnV2";
+
+const testConfig = {
+  account: Account.ETH_1,
+  // Must be a "liquid" provider: v2 defaults its category filter to liquid below the
+  // protocol-staking threshold, and the segmented control has no per-option test id to reset it.
+  provider: EarnProvider.STADER_LABS,
+  tmsLinks: ["B2CQA-6136"],
+  tags: ["@NanoSP", "@LNS", "@NanoX", "@Stax", "@Flex", "@NanoGen5", "@ethereum", "@family-evm"],
+};
+
+runSwapToEarnEnabledDepositTest(
+  testConfig.account,
+  testConfig.provider.name,
+  testConfig.tmsLinks,
+  testConfig.tags,
+);


### PR DESCRIPTION
### 📝 Description

Adds mobile e2e coverage for both `swapToEarn` ETH deposit routing branches. The earn app's proxy reads the `swapToEarn` URL param that ledger-live forwards to the webview and routes accordingly:

| | `swapToEarn: false` | `swapToEarn: true` |
|---|---|---|
| URL | `/<os>/deposit` | `/v2/<os>/deposit` |
| Amount continue | `input-button-mobile` | `amount-continue-cta` |
| Provider step | `select-provider-button-mobile` (shared CTA) | per-card `eth-provider-deposit-<id>` |

Neither branch was previously pinned, so which deposit UI ran depended on the ambient flag. **The existing ETH partner-dapp specs were silently exercising v1 only** — they assert `input-button-mobile` and `select-provider-button-mobile`, both v1-only test ids. The v2 deposit UI had no mobile coverage.

Two specs are added, each pinning `swapToEarn` explicitly:

- `earnV2_swapToEarnDisabledDeposit_ETH_1` — asserts v1 URL and `input-button-mobile` continue CTA
- `earnV2_swapToEarnEnabled_v2Deposit_ETH_1` — asserts v2 URL and absence of the v1 shared confirm button

#### `expandV2EthProviderCard` — current approach

The v2 provider step uses Lumen's `type="expandable"` Card. In this component, the `onClick` is wired exclusively to the inner `CardHeader` (rendered with `role="button"`), not the card root `div`. Detox WebElement `.tap()` calls `el.click()` on the matched node, which fires a DOM click event that bubbles **upward** — it never propagates down into `CardHeader`. The page object therefore uses `runScript` to `querySelector('[role=button]')` inside the card root and call `.click()` on the header directly.

This works but relies on a structural assumption about Lumen's DOM. The clean fix is to add a `data-testid` to `CardHeader` in earn-live-app (see TODO below), at which point `expandV2EthProviderCard` can be simplified to a direct `tapWebElementByTestId`.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34331](https://ledgerhq.atlassian.net/browse/LIVE-34331)
- **ADR**: n/a

### ☑️ TODO before ready for review

- [ ] Create Xray ticket for `earnV2_swapToEarnDisabledDeposit_ETH_1` (mobile equivalent of B2CQA-6136) and update `tmsLinks` in the spec
- [ ] Create Xray ticket for `earnV2_swapToEarnEnabled_v2Deposit_ETH_1` (new mobile-only test case) and update `tmsLinks` in the spec
- [ ] After earn-live-app PR [LedgerHQ/earn-live-app#1712](https://github.com/LedgerHQ/earn-live-app/pull/1712) is released, simplify `expandV2EthProviderCard` to use `tapWebElementByTestId("eth-provider-header-<id>")` directly instead of `runScript`

[LIVE-34331]: https://ledgerhq.atlassian.net/browse/LIVE-34331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ