### PR TITLE
fix(flow-contacts): remove unused exports, de-alias delete requirement

### DIFF
--- a/.changeset/thick-maps-attack.md
+++ b/.changeset/thick-maps-attack.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+fix(flow-contacts): remove unused exports, de-alias delete requirement

--- a/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
+++ b/features/flow/contacts/src/steps/Detail/model/editRequirement.ts
@@ -15,7 +15,10 @@ export const CONTACT_ADDRESS_EDIT_REQUIREMENT = {
   reason: "contact-has-address",
 } as const satisfies ContactEditRequirement;
 
-export const CONTACT_ADDRESS_DELETE_REQUIREMENT = CONTACT_ADDRESS_EDIT_REQUIREMENT;
+export const CONTACT_ADDRESS_DELETE_REQUIREMENT = {
+  type: "confirmation-required",
+  reason: "contact-has-address",
+} as const satisfies ContactEditRequirement;
 
 export function resolveContactEditRequirement(contact: Contact): ContactEditRequirement {
   return contact.addresses.length > 0

--- a/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/signerEditUiState.ts
@@ -1,13 +1,5 @@
 export type SignerEditUiState = "closed" | "signer-open" | "signer-mismatch" | "edit-open";
 
-export function resolveEditUiStateOnPress(isSignerRequired: boolean): SignerEditUiState {
-  return isSignerRequired ? "signer-open" : "edit-open";
-}
-
-export function resolveEditUiStateOnSignerCancel(current: SignerEditUiState): SignerEditUiState {
-  return current === "signer-open" ? "closed" : current;
-}
-
 export function resolveEditUiStateOnSignerMismatch(): SignerEditUiState {
   return "signer-mismatch";
 }


### PR DESCRIPTION
### 📝 Description

Removes dead code in `@features/flow-contacts` that fails the `unimported` (knip) check. The task fails CI whenever a large-blast-radius PR pulls this package into the affected set.

No behaviour change; both requirement constants remain in use, and `@features/flow-contacts:unimported` now passes.

### 🔗 Context

- **JIRA / GitHub issue**: N/A — knip hygiene [surfaced](https://github.com/LedgerHQ/ledger-live/actions/runs/31446862779/job/93643001800?pr=20442) by CI #20442
- **ADR** (if any): N/A