### PR TITLE
ci(contacts): add format checks

### DIFF
--- a/.changeset/clean-contacts-format-checks.md
+++ b/.changeset/clean-contacts-format-checks.md
@@ -1,0 +1,6 @@
+---
+"@domain/entity-contact": patch
+"@features/platform-contacts": patch
+---
+
+Add formatting checks to Contacts packages.

--- a/domain/entity/contact/package.json
+++ b/domain/entity/contact/package.json
@@ -12,6 +12,8 @@
   },
   "sideEffects": false,
   "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -30,6 +32,7 @@
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
     "jest": "catalog:",
+    "oxfmt": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -16,6 +16,8 @@
   },
   "sideEffects": false,
   "scripts": {
+    "format": "oxfmt src",
+    "format:check": "oxfmt src --check",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -45,6 +47,7 @@
     "@types/jest": "catalog:",
     "@testing-library/react-native": "catalog:",
     "jest": "catalog:",
+    "oxfmt": "catalog:",
     "react": "catalog:",
     "react-redux": "catalog:",
     "react-native": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4287,6 +4287,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -5653,6 +5656,9 @@ importers:
       jest:
         specifier: 'catalog:'
         version: 30.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.36.0
       react:
         specifier: 19.1.4
         version: 19.1.4


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No production behavior changed; targeted typechecks and Jest could not run because the local develop checkout has unresolved workspace dependencies.
- [x] **Impact of the changes:**
      CI will run formatting checks for Platform Contacts and Contact Entity alongside the existing Flow Contacts checks.

### 📝 Description

This PR closes a CI coverage gap in the dedicated Contacts packages. The three Contacts Flow packages already exposed `format:check` and `unimported`, while Platform Contacts and Contact Entity only exposed `unimported`.

It adds `oxfmt` plus `format` and `format:check` scripts to those two missing packages. The Libraries Codecheck workflow can now validate formatting across the complete dedicated Contacts package set.

Validation completed: Nx `format:check` passed for all five Contacts packages; Knip passed for Platform Contacts and Contact Entity; `git diff --check` and Commitlint passed.

### ❓ Context

- **JIRA or GitHub link**: Not applicable.

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)