### PR TITLE
[LWDM] fix(history): hide all operation types below dust threshold

### DIFF
--- a/.changeset/dust-filter-all-operation-types.md
+++ b/.changeset/dust-filter-all-operation-types.md
@@ -1,0 +1,8 @@
+---
+"@ledgerhq/ledger-wallet-framework": minor
+"@ledgerhq/live-common": minor
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+Fix dust filter so it hides every operation type below the threshold, not just IN/OUT. The dust predicate now uses the amount displayed in the operation row (IN/OUT/STAKE families, staking ops via fee), converted at the operation's own date so it matches the historical countervalue shown in the row (previously it compared against the latest rate, letting rows that display e.g. "$0.00" escape the filter). Day-grouping re-filters flattened internal and NFT child operations so sub-threshold children no longer leak into the list on mobile. The Asset Detail transactions/chart and the mobile operations pipeline now also request the USD→countervalue rate needed by the threshold, so filtering works on those screens for non-USD users.

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/ChartSection/useChartSectionViewModel.ts
@@ -40,6 +40,7 @@ import {
 } from "~/renderer/reducers/settings";
 import { hideTransactionsOnChartSelector } from "~/renderer/reducers/market";
 import { useHistoryOperationItemsForRootAccounts } from "LLD/features/History/hooks/useHistoryOperationItemsForRootAccounts";
+import { useRequestDustFilterCountervalueTracking } from "LLD/features/History/hooks/useRequestDustFilterCountervalueTracking";
 import {
   filterOperationTableItemsByAllowedAccountIds,
   filterTopLevelAccountsByAllowedAccountIds,
@@ -89,6 +90,7 @@ export function useChartSectionViewModel({
   distributionItem,
 }: UseChartSectionViewModelProps): ChartSectionViewModelResult {
   const { t } = useTranslation();
+  useRequestDustFilterCountervalueTracking();
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const counterCurrency = counterValueCurrency.ticker.toLowerCase();
   const fiatUnit = counterValueCurrency.units[0];

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/__tests__/useTransactionsSectionViewModel.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "tests/testSetup";
+import { act, renderHook, waitFor, withFlagOverrides } from "tests/testSetup";
 import { genAccount, genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { maticEth, usdcToken } from "@ledgerhq/live-common/modularDrawer/__mocks__/currencies.mock";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
@@ -103,6 +103,28 @@ describe("useTransactionsSectionViewModel", () => {
     const rows = result.current.table.getRowModel().rows;
     expect(rows.length).toBeGreaterThan(0);
     expect(rows.every(r => r.original.account.id === usdc.id)).toBe(true);
+  });
+
+  it("requests the USD countervalue tracking pair so the dust filter works on the asset page for non-USD users", async () => {
+    const account = genAccount("btc-root-dust-track", { currency: btc, operationsSize: 1 });
+    const distributionItem = buildDistributionItem({ currency: btc, accounts: [account] });
+
+    const { store } = renderHook(() => useTransactionsSectionViewModel(distributionItem), {
+      initialState: {
+        accounts: [account],
+        settings: { counterValue: "EUR" },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    await waitFor(() =>
+      expect(store.getState().countervaluesExtraTracking.extraTrackingPairs).toEqual([
+        expect.objectContaining({
+          from: expect.objectContaining({ ticker: "USD" }),
+          to: expect.objectContaining({ ticker: "EUR" }),
+        }),
+      ]),
+    );
   });
 
   it("navigates to history with accountIds and back path when see all is called", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/useTransactionsSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AssetDetail/components/TransactionsSection/useTransactionsSectionViewModel.ts
@@ -9,6 +9,7 @@ import { track } from "~/renderer/analytics/segment";
 import { ASSET_DETAIL_TRACKING_PAGE_NAME } from "LLD/features/AssetDetail/constants";
 import { useHistoryTable } from "LLD/features/History/hooks/useHistoryTable";
 import { useHistoryOperationItemsForRootAccounts } from "LLD/features/History/hooks/useHistoryOperationItemsForRootAccounts";
+import { useRequestDustFilterCountervalueTracking } from "LLD/features/History/hooks/useRequestDustFilterCountervalueTracking";
 import {
   filterOperationTableItemsByAllowedAccountIds,
   filterTopLevelAccountsByAllowedAccountIds,
@@ -31,6 +32,8 @@ export function useTransactionsSectionViewModel(
   const navigate = useNavigate();
   const { pathname: assetDetailPath } = useLocation();
   const allAccounts = useSelector(accountsSelector);
+
+  useRequestDustFilterCountervalueTracking();
 
   const rootAccounts = useMemo(() => {
     const allowed = new Set(distributionItem.accounts.map(a => a.id));

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/__tests__/useHistoryOperations.test.ts
@@ -22,6 +22,8 @@ const SMALL_NATIVE_IN_OP_ID = "small-native-in-op-id";
 const LARGE_NATIVE_IN_OP_ID = "large-native-in-op-id";
 const SMALL_NATIVE_OUT_OP_ID = "small-native-out-op-id";
 const LARGE_NATIVE_OUT_OP_ID = "large-native-out-op-id";
+const SMALL_NATIVE_REWARD_OP_ID = "small-native-reward-op-id";
+const LARGE_NATIVE_REWARD_OP_ID = "large-native-reward-op-id";
 
 const mockCalculate = calculate as jest.MockedFunction<typeof calculate>;
 
@@ -128,6 +130,24 @@ function createAccountWithNativeOutgoingOperations(): Account {
   const operations = [
     createNativeOperation(account.id, SMALL_NATIVE_OUT_OP_ID, "OUT", new BigNumber(1)),
     createNativeOperation(account.id, LARGE_NATIVE_OUT_OP_ID, "OUT", new BigNumber(2)),
+  ];
+
+  return {
+    ...account,
+    operations,
+    operationsCount: operations.length,
+  };
+}
+
+function createAccountWithNativeRewardOperations(): Account {
+  const account = genAccount("eth-native-reward-dust", {
+    currency: ETH_ACCOUNT.currency,
+    subAccountsCount: 0,
+    operationsSize: 0,
+  });
+  const operations = [
+    createNativeOperation(account.id, SMALL_NATIVE_REWARD_OP_ID, "REWARD", new BigNumber(1)),
+    createNativeOperation(account.id, LARGE_NATIVE_REWARD_OP_ID, "REWARD", new BigNumber(2)),
   ];
 
   return {
@@ -317,6 +337,30 @@ describe("useHistoryOperations", () => {
     });
 
     expect(result.current.map(item => item.operation.id)).toEqual([LARGE_NATIVE_OUT_OP_ID]);
+  });
+
+  it("filters non-transfer reward operations below the dust countervalue threshold", () => {
+    const account = createAccountWithNativeRewardOperations();
+    mockCalculate.mockImplementation((_state, query) => {
+      if (query.from === account.currency && query.value === 1) return 0.5;
+      if (query.from === account.currency && query.value === 2) return 2;
+      if (query.from.ticker === "USD") return 1;
+      return null;
+    });
+
+    const { result } = renderHook(() => useHistoryOperations(), {
+      initialState: {
+        accounts: [account],
+        settings: {
+          ...INITIAL_STATE,
+          filterTokenOperationsZeroAmount: false,
+          hideSmallValueTokenOperations: true,
+        },
+        ...withFlagOverrides({ lwdDustFiltering: { enabled: true } }),
+      },
+    });
+
+    expect(result.current.map(item => item.operation.id)).toEqual([LARGE_NATIVE_REWARD_OP_ID]);
   });
 
   it("keeps zero-value token operations when the dust feature flag is disabled", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useHistoryViewModel.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useMemo } from "react";
-import {
-  formatSmallValueOperationsThreshold,
-  SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
-} from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { formatSmallValueOperationsThreshold } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useHideSmallValueTokenOperations } from "~/renderer/actions/settings";
-import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
 import {
   historyDustFilterCounterValueCurrencyForDisplaySelector,
   historyDustFilterCountervaluesStateForDisplaySelector,
@@ -13,6 +9,7 @@ import {
   historyDustFilterLocaleSelector,
   markOperationsAsSeen,
 } from "~/renderer/reducers/history";
+import { useRequestDustFilterCountervalueTracking } from "./useRequestDustFilterCountervalueTracking";
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
@@ -77,25 +74,7 @@ export function useHistoryViewModel(): HistoryViewModel {
   const showDustFilterOption = useSelector(historyDustFilteringFeatureEnabledSelector);
   const counterValueCurrency = useSelector(historyDustFilterCounterValueCurrencyForDisplaySelector);
   const countervaluesState = useSelector(historyDustFilterCountervaluesStateForDisplaySelector);
-  useEffect(() => {
-    if (
-      !showDustFilterOption ||
-      !counterValueCurrency ||
-      counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
-    ) {
-      return;
-    }
-
-    dispatch(
-      addExtraTrackingPairs([
-        {
-          from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
-          to: counterValueCurrency,
-          startDate: new Date(),
-        },
-      ]),
-    );
-  }, [counterValueCurrency, dispatch, showDustFilterOption]);
+  useRequestDustFilterCountervalueTracking();
   const locale = useSelector(historyDustFilterLocaleSelector);
   const dustFilterThreshold = useMemo(() => {
     if (!counterValueCurrency) return "";

--- a/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useRequestDustFilterCountervalueTracking.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/History/hooks/useRequestDustFilterCountervalueTracking.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import { SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { addExtraTrackingPairs } from "~/renderer/reducers/countervaluesExtraTracking";
+import { historyDustFilterCounterValueCurrencyForDisplaySelector } from "~/renderer/reducers/history";
+
+/**
+ * Ensures the countervalues engine tracks the USD -> counter-value rate used to
+ * convert the dust threshold. Without it, `calculate(USD -> counter)` returns
+ * undefined for non-USD counter-value currencies, the threshold resolves to
+ * null and dust filtering silently no-ops.
+ *
+ * Must run on every screen that applies the dust filter (global History and
+ * Asset Detail transactions/chart), otherwise sub-threshold operations still
+ * appear there for non-USD users.
+ */
+export function useRequestDustFilterCountervalueTracking(): void {
+  const dispatch = useDispatch();
+  const counterValueCurrency = useSelector(historyDustFilterCounterValueCurrencyForDisplaySelector);
+
+  useEffect(() => {
+    if (
+      !counterValueCurrency ||
+      counterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
+    ) {
+      return;
+    }
+
+    dispatch(
+      addExtraTrackingPairs([
+        {
+          from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+          to: counterValueCurrency,
+          startDate: new Date(),
+        },
+      ]),
+    );
+  }, [counterValueCurrency, dispatch]);
+}

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/__integrations__/useOperationsV1.integration.test.ts
@@ -5,6 +5,7 @@ import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import * as generalActions from "~/actions/general";
 import { useOperationsV1 } from "../useOperationsV1";
 import { State } from "~/reducers/types";
 
@@ -15,6 +16,9 @@ jest.mock("@ledgerhq/live-countervalues/logic", () => ({
 
 const ETH = getCryptoCurrencyById("ethereum");
 const mockCalculate = calculate as jest.MockedFunction<typeof calculate>;
+const addExtraSessionTrackingPairSpy = jest
+  .spyOn(generalActions, "addExtraSessionTrackingPair")
+  .mockImplementation(() => {});
 
 const EVM_TOKEN: TokenCurrency = {
   type: "TokenCurrency",
@@ -34,6 +38,10 @@ const ZERO_VALUE_NATIVE_OP_ID = "zero-value-native-op-id";
 const NON_ZERO_VALUE_NATIVE_OP_ID = "non-zero-value-native-op-id";
 const SMALL_NATIVE_OUT_OP_ID = "small-native-out-op-id";
 const LARGE_NATIVE_OUT_OP_ID = "large-native-out-op-id";
+const SMALL_NATIVE_REWARD_OP_ID = "small-native-reward-op-id";
+const LARGE_NATIVE_REWARD_OP_ID = "large-native-reward-op-id";
+const PARENT_NATIVE_OP_ID = "parent-native-op-id";
+const DUST_INTERNAL_OP_ID = "dust-internal-op-id";
 
 function createZeroValueTokenOperation(tokenAccountId: string): Operation {
   return {
@@ -159,6 +167,56 @@ function createAccountWithNativeOutgoingDustOperations(): Account {
   };
 }
 
+function createAccountWithNativeRewardDustOperations(): Account {
+  const account = genAccount("eth-reward-dust", {
+    currency: ETH,
+    operationsSize: 0,
+  });
+  const smallReward = createNativeOperation(
+    account.id,
+    SMALL_NATIVE_REWARD_OP_ID,
+    "REWARD",
+    new BigNumber(1),
+  );
+
+  return {
+    ...account,
+    operations: [
+      smallReward,
+      {
+        ...smallReward,
+        id: LARGE_NATIVE_REWARD_OP_ID,
+        hash: LARGE_NATIVE_REWARD_OP_ID,
+        value: new BigNumber(2),
+      },
+    ],
+    operationsCount: 2,
+  };
+}
+
+function createAccountWithDustInternalOperation(): Account {
+  const account = genAccount("eth-internal-dust", {
+    currency: ETH,
+    operationsSize: 0,
+  });
+  const dustInternal = createNativeOperation(
+    account.id,
+    DUST_INTERNAL_OP_ID,
+    "IN",
+    new BigNumber(1),
+  );
+  const parentOp: Operation = {
+    ...createNativeOperation(account.id, PARENT_NATIVE_OP_ID, "IN", new BigNumber(2)),
+    internalOperations: [dustInternal],
+  };
+
+  return {
+    ...account,
+    operations: [parentOp],
+    operationsCount: 1,
+  };
+}
+
 const initialStateWithFilterEnabled = (state: State): State => ({
   ...state,
   settings: {
@@ -220,6 +278,23 @@ const initialStateWithDesktopDustFilterEnabled = withFlagOverrides(
     },
   },
   initialStateWithDustPreferenceEnabled,
+);
+
+const initialStateWithDustFilterEnabledEurCounterValue = withFlagOverrides(
+  {
+    lwmDustFiltering: {
+      enabled: true,
+    },
+  },
+  (state: State): State => ({
+    ...state,
+    settings: {
+      ...state.settings,
+      filterTokenOperationsZeroAmount: false,
+      hideSmallValueTokenOperations: true,
+      counterValue: "EUR",
+    },
+  }),
 );
 
 describe("useOperationsV1 integration", () => {
@@ -305,5 +380,65 @@ describe("useOperationsV1 integration", () => {
 
     expect(result.current.sections[0].data.length).toBe(1);
     expect(result.current.sections[0].data[0].id).toBe(LARGE_NATIVE_OUT_OP_ID);
+  });
+
+  it("should filter out non-transfer reward operations below the dust threshold", () => {
+    const accountWithNativeRewardDust = createAccountWithNativeRewardDustOperations();
+    mockCalculate.mockImplementation((_state, query) => {
+      if (query.from === ETH && query.value === 1) return 0.5;
+      if (query.from === ETH && query.value === 2) return 2;
+      if (query.from.ticker === "USD") return 1;
+      return null;
+    });
+
+    const { result } = renderHook(() => useOperationsV1([accountWithNativeRewardDust], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    expect(result.current.sections[0].data.length).toBe(1);
+    expect(result.current.sections[0].data[0].id).toBe(LARGE_NATIVE_REWARD_OP_ID);
+  });
+
+  it("requests the USD -> counter tracking pair so the dust filter works everywhere for non-USD users", () => {
+    const account = genAccount("eth-dust-track", { currency: ETH, operationsSize: 0 });
+
+    renderHook(() => useOperationsV1([account], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabledEurCounterValue,
+    });
+
+    expect(addExtraSessionTrackingPairSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: expect.objectContaining({ ticker: "USD" }),
+        to: expect.objectContaining({ ticker: "EUR" }),
+      }),
+    );
+  });
+
+  it("does not request a tracking pair when the counter value is already the USD reference", () => {
+    const account = genAccount("eth-dust-track-usd", { currency: ETH, operationsSize: 0 });
+
+    renderHook(() => useOperationsV1([account], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    expect(addExtraSessionTrackingPairSpy).not.toHaveBeenCalled();
+  });
+
+  it("should filter out dust internal operations nested under a non-dust parent", () => {
+    const accountWithDustInternal = createAccountWithDustInternalOperation();
+    mockCalculate.mockImplementation((_state, query) => {
+      if (query.from === ETH && query.value === 1) return 0.5;
+      if (query.from === ETH && query.value === 2) return 2;
+      if (query.from.ticker === "USD") return 1;
+      return null;
+    });
+
+    const { result } = renderHook(() => useOperationsV1([accountWithDustInternal], 50), {
+      overrideInitialState: initialStateWithDustFilterEnabled,
+    });
+
+    const ids = result.current.sections[0].data.map(op => op.id);
+    expect(ids).toContain(PARENT_NATIVE_OP_ID);
+    expect(ids).not.toContain(DUST_INTERNAL_OP_ID);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
+++ b/apps/ledger-live-mobile/src/screens/Analytics/Operations/useOperationsV1.ts
@@ -1,9 +1,13 @@
 import { groupAccountsOperationsByDay } from "@ledgerhq/ledger-wallet-framework/account/groupOperations";
 import { isAddressPoisoningOperation } from "@ledgerhq/ledger-wallet-framework/operation";
-import { isSmallValueOperation } from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
+import {
+  isSmallValueOperation,
+  SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+} from "@ledgerhq/live-common/hideSmallValueTokenOperations/smallValueOperationsThreshold";
 import { AccountLike, Operation } from "@ledgerhq/types-live";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useSelector } from "~/context/hooks";
+import { addExtraSessionTrackingPair } from "~/actions/general";
 import {
   counterValueCurrencySelector,
   filterTokenOperationsZeroAmountEnabledSelector,
@@ -34,6 +38,27 @@ export function useOperationsV1(
   const userCounterValueCurrency = useSelector(state =>
     shouldHideSmallValueTokenOperations ? counterValueCurrencySelector(state) : undefined,
   );
+
+  // The dust threshold is expressed in USD but compared in the user's counter
+  // value. Without a USD -> counter tracking pair, calculate(USD -> counter)
+  // returns undefined for non-USD users and the filter silently no-ops. Request
+  // it here so every screen that filters (asset detail, portfolio, account…)
+  // gets the rate, not only the dedicated Operations list screen.
+  useEffect(() => {
+    if (
+      !shouldHideSmallValueTokenOperations ||
+      !userCounterValueCurrency ||
+      userCounterValueCurrency.ticker === SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY.ticker
+    ) {
+      return;
+    }
+
+    addExtraSessionTrackingPair({
+      from: SMALL_VALUE_OPERATIONS_THRESHOLD_REFERENCE_CURRENCY,
+      to: userCounterValueCurrency,
+      startDate: new Date(),
+    });
+  }, [shouldHideSmallValueTokenOperations, userCounterValueCurrency]);
 
   const addressPoisoningFamilies = useAddressPoisoningOperationsFamilies({
     shouldFilter: shouldFilterTokenOpsZeroAmount,

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
@@ -222,9 +222,13 @@ describe("smallValueOperationsThreshold", () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const regularAccount = { type: "Account", currency: mockNativeCurrency } as AccountLike;
 
-    const buildOp = (type: string, value: BigNumber): Operation =>
+    const buildOp = (
+      type: string,
+      value: BigNumber,
+      fee: BigNumber = new BigNumber(0),
+    ): Operation =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      ({ type, value }) as Operation;
+      ({ type, value, fee }) as Operation;
 
     const mockSmallValueCalculations = (
       operationCurrency: CryptoCurrency | TokenCurrency,
@@ -240,7 +244,22 @@ describe("smallValueOperationsThreshold", () => {
       });
     };
 
-    it("should keep non-transfer operations without calling calculate", () => {
+    it.each(["NFT_IN", "NFT_OUT", "UNKNOWN"])(
+      "should keep operations without a displayable amount (%s) without calling calculate",
+      type => {
+        const result = isSmallValueOperation({
+          operation: buildOp(type, new BigNumber(1)),
+          account: regularAccount,
+          countervaluesState: mockCountervaluesState,
+          userCounterValueCurrency: EUR,
+        });
+
+        expect(result).toBe(false);
+        expect(mockCalculate).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should treat a zero-fee stake operation as dust without calling calculate", () => {
       const result = isSmallValueOperation({
         operation: buildOp("FEES", new BigNumber(0)),
         account: regularAccount,
@@ -248,8 +267,59 @@ describe("smallValueOperationsThreshold", () => {
         userCounterValueCurrency: EUR,
       });
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
       expect(mockCalculate).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { fiatValue: 49, expected: true, desc: "below threshold -> dust" },
+      { fiatValue: 51, expected: false, desc: "above threshold -> not dust" },
+    ])("should filter incoming reward operations $desc", ({ fiatValue, expected }) => {
+      mockSmallValueCalculations(mockNativeCurrency, fiatValue);
+
+      const result = isSmallValueOperation({
+        operation: buildOp("REWARD", new BigNumber(499_999)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(expected);
+    });
+
+    it("should filter outgoing delegate operations below the dust threshold", () => {
+      mockSmallValueCalculations(mockNativeCurrency, 49);
+
+      const result = isSmallValueOperation({
+        operation: buildOp("DELEGATE", new BigNumber(499_999)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("should filter stake operations whose fee is dust, using the fee as the amount", () => {
+      mockSmallValueCalculations(mockNativeCurrency, 49);
+
+      const result = isSmallValueOperation({
+        operation: buildOp("STAKE", new BigNumber(0), new BigNumber(499_999)),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(result).toBe(true);
+      expect(mockCalculate).toHaveBeenCalledWith(
+        mockCountervaluesState,
+        expect.objectContaining({
+          from: mockNativeCurrency,
+          to: EUR,
+          value: 499_999,
+          disableRounding: true,
+        }),
+      );
     });
 
     it("should return true when an incoming native operation has exactly 0 crypto value", () => {
@@ -355,6 +425,36 @@ describe("smallValueOperationsThreshold", () => {
       });
 
       expect(result).toBe(true);
+    });
+
+    it("should convert the operation amount at the operation's date so the filter matches the displayed countervalue", () => {
+      mockSmallValueCalculations(mockNativeCurrency, 49);
+      const operationDate = new Date("2021-01-01T00:00:00.000Z");
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const operation = {
+        type: "IN",
+        value: new BigNumber(499_999),
+        fee: new BigNumber(0),
+        date: operationDate,
+      } as Operation;
+
+      isSmallValueOperation({
+        operation,
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(mockCalculate).toHaveBeenCalledWith(
+        mockCountervaluesState,
+        expect.objectContaining({
+          from: mockNativeCurrency,
+          to: EUR,
+          value: 499_999,
+          disableRounding: true,
+          date: operationDate,
+        }),
+      );
     });
 
     it.each([

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
@@ -2,6 +2,10 @@ import BigNumber from "bignumber.js";
 import { calculate } from "@ledgerhq/live-countervalues/logic";
 import type { CounterValuesState } from "@ledgerhq/live-countervalues/types";
 import { getAccountCurrency } from "../account";
+import {
+  getOperationAmountNumber,
+  hasDisplayableOperationAmount,
+} from "@ledgerhq/ledger-wallet-framework/operation";
 import { getFiatCurrencyByTicker } from "@domain/entity-currency-fiat";
 import { formatCurrencyUnit } from "../currencies";
 import type { Unit } from "@domain/entity-currency-unit";
@@ -179,14 +183,18 @@ export function convertThresholdFromCountervalueMinorUnitToUsd({
 }
 
 /**
- * Returns `true` when an incoming or outgoing operation should be hidden as a
- * "small-value" (dust) transaction.
+ * Returns `true` when an operation should be hidden as a "small-value" (dust)
+ * transaction.
  *
  * An operation is considered dust when:
- * - its type is "IN" or "OUT", AND
- * - either its crypto value is exactly zero, OR its fiat countervalue is
+ * - it has a displayable amount (its type belongs to the IN, OUT or STAKE
+ *   families handled by {@link getOperationAmountNumber}), AND
+ * - either its displayed amount is exactly zero, OR its fiat countervalue is
  *   strictly below the configured USD threshold (defaults to $0.5,
  *   overridable via ff).
+ *
+ * Operation types without a displayed amount (e.g. `NFT_IN`, `NFT_OUT`,
+ * `UNKNOWN`) are never filtered.
  *
  * When the fiat countervalue cannot be computed (e.g. price feed unavailable),
  * the operation is NOT filtered so that legitimate transactions are never
@@ -194,7 +202,9 @@ export function convertThresholdFromCountervalueMinorUnitToUsd({
  *
  * The comparison is performed in the user's countervalue currency space:
  * we convert both the operation amount and the USD threshold to user-fiat
- * minor units, then compare those raw values.
+ * minor units, then compare those raw values. The operation amount is
+ * converted at the operation's own date so the filter matches the historical
+ * countervalue displayed for that row (what you see is what gets filtered).
  */
 export function isSmallValueOperation({
   operation,
@@ -209,22 +219,30 @@ export function isSmallValueOperation({
   /** The user's selected countervalue (fiat) currency, e.g. EUR.
    *  Countervalues are computed from the operation currency (native or token) to this currency. */
   userCounterValueCurrency: Currency;
-  /** USD threshold below which an incoming or outgoing operation is considered dust.
+  /** USD threshold below which an operation is considered dust.
    *  Defaults to MAX_SMALL_VALUE_OPERATIONS_THRESHOLD_USD ($0.5).
    *  Callers provide their product-specific dust-filter threshold. */
   thresholdUsd?: number;
 }): boolean {
-  if (operation.type !== "IN" && operation.type !== "OUT") return false;
+  if (!hasDisplayableOperationAmount(operation)) return false;
 
-  if (operation.value.isZero()) return true;
+  const operationAmount = getOperationAmountNumber(operation).abs();
+
+  if (operationAmount.isZero()) return true;
 
   const operationCurrency = getAccountCurrency(account);
 
+  // Convert at the operation's date, matching the historical countervalue shown
+  // in the UI (the history row uses `date: operation.date`). Using the latest
+  // rate here instead would let a row that displays e.g. "$0.00" escape the
+  // filter whenever the currency's price moved since the operation, or when no
+  // "latest" rate is loaded for that pair.
   const rawOpFiatValue = calculate(countervaluesState, {
     from: operationCurrency,
     to: userCounterValueCurrency,
-    value: operation.value.toNumber(),
+    value: operationAmount.toNumber(),
     disableRounding: true,
+    date: operation.date,
   });
 
   if (typeof rawOpFiatValue !== "number" || !Number.isFinite(rawOpFiatValue)) return false;

--- a/libs/ledger-wallet-framework/src/account/groupOperations.test.ts
+++ b/libs/ledger-wallet-framework/src/account/groupOperations.test.ts
@@ -123,4 +123,22 @@ describe("groupAccountOperationsByDay", () => {
     expect(result.sections.length).toBe(1);
     expect(result.sections[0].data.map((op: Operation) => op.id)).toEqual(["op1"]);
   });
+
+  it("re-applies filterOperation to flattened internal operations", () => {
+    const child = { ...createOp("child", "2024-01-01T10:00:00Z"), id: "child" };
+    const parent: Operation = {
+      ...createOp("parent", "2024-01-01T10:00:00Z"),
+      internalOperations: [child],
+    };
+
+    const acc = createAccount({ confirmed: [parent] });
+
+    const result = groupAccountsOperationsByDay([acc], {
+      count: 10,
+      filterOperation: (op: Operation) => op.id !== "child",
+    });
+
+    expect(result.sections.length).toBe(1);
+    expect(result.sections[0].data.map((op: Operation) => op.id)).toEqual(["parent"]);
+  });
 });

--- a/libs/ledger-wallet-framework/src/account/groupOperations.ts
+++ b/libs/ledger-wallet-framework/src/account/groupOperations.ts
@@ -155,7 +155,13 @@ export function groupAccountsOperationsByDay(
         indexes[bestOpInfo.accountI]++;
       }
 
-      const ops = flattenOperationWithInternalsAndNfts(bestOp);
+      const account = accounts[bestOpInfo.accountI];
+      const flattened = flattenOperationWithInternalsAndNfts(bestOp);
+      // bestOp already passed filterOperation during the scan above, so we only
+      // re-filter its flattened internal children here.
+      const ops = filterOperation
+        ? flattened.filter(op => op === bestOp || filterOperation(op, account))
+        : flattened;
       return {
         ops,
         date: bestOp.date,

--- a/libs/ledger-wallet-framework/src/operation.ts
+++ b/libs/ledger-wallet-framework/src/operation.ts
@@ -211,15 +211,33 @@ export const OPERATION_TYPE_STAKE_FAMILY = [
   "WITHDRAW_UNSTAKED",
 ];
 
+const OPERATION_TYPE_IN_FAMILY_SET = new Set(OPERATION_TYPE_IN_FAMILY);
+const OPERATION_TYPE_OUT_FAMILY_SET = new Set(OPERATION_TYPE_OUT_FAMILY);
+const OPERATION_TYPE_STAKE_FAMILY_SET = new Set(OPERATION_TYPE_STAKE_FAMILY);
+
 export function getOperationAmountNumber(op: Operation): BigNumber {
-  if (OPERATION_TYPE_IN_FAMILY.includes(op.type)) {
+  if (OPERATION_TYPE_IN_FAMILY_SET.has(op.type)) {
     return op.value;
-  } else if (OPERATION_TYPE_OUT_FAMILY.includes(op.type)) {
+  } else if (OPERATION_TYPE_OUT_FAMILY_SET.has(op.type)) {
     return op.value.negated();
-  } else if (OPERATION_TYPE_STAKE_FAMILY.includes(op.type)) {
+  } else if (OPERATION_TYPE_STAKE_FAMILY_SET.has(op.type)) {
     return op.fee.negated();
   }
   return new BigNumber(0);
+}
+
+/**
+ * Returns `true` when an operation type has an amount rendered in operation
+ * lists (via {@link getOperationAmountNumber}), i.e. it belongs to the IN, OUT
+ * or STAKE families. Types outside these families (e.g. `NFT_IN`, `NFT_OUT`,
+ * `UNKNOWN`) display no amount and return `false`.
+ */
+export function hasDisplayableOperationAmount(op: Operation): boolean {
+  return (
+    OPERATION_TYPE_IN_FAMILY_SET.has(op.type) ||
+    OPERATION_TYPE_OUT_FAMILY_SET.has(op.type) ||
+    OPERATION_TYPE_STAKE_FAMILY_SET.has(op.type)
+  );
 }
 
 export function getOperationAmountNumberWithInternals(op: Operation): BigNumber {


### PR DESCRIPTION
### 📝 Description

**Problem**: When the dust filter is activated, some transactions below the threshold (US$0.01) still appear on both Ledger Wallet Mobile and Desktop.

Two root causes:

1. The shared dust predicate `isSmallValueOperation` only considered `IN`/`OUT` operations and bailed out for every other type. But operation rows also render an amount for the OUT family (`FEES`, `DELEGATE`, `CREATE`, `REVEAL`, `BURN`, ...), the IN family (`REWARD`, `REWARD_PAYOUT`, `WITHDRAW`, ...) and the STAKE family (`FREEZE`, `VOTE`, `BOND`, `APPROVE`, `STAKE`, ... — rendered from the fee). So a sub-cent reward, fee or staking operation displayed a below-threshold amount yet was never hidden.
2. On mobile, `groupAccountsOperationsByDay` filtered only the parent operation and then expanded internal/NFT children unconditionally, so a dust internal operation nested under a non-dust parent still leaked into the list.

**Solution**:

- Generalised `isSmallValueOperation` to hide any operation with a *displayable* amount below the threshold, using `getOperationAmountNumber(op).abs()` (the same value shown in the row). Types with no displayed amount (`NFT_IN`, `NFT_OUT`, `UNKNOWN`, ...) stay visible. Added `hasDisplayableOperationAmount` in `@ledgerhq/ledger-wallet-framework`, backed by `Set`s shared with `getOperationAmountNumber`.
- Made `groupAccountsOperationsByDay` re-apply `filterOperation` to the flattened internal/NFT operations, matching what the desktop History pipeline already does.

Behaviour deliberately kept:
- Strict `<` comparison, so an operation worth exactly US$0.01 stays visible ("below 0.01").
- Operations whose countervalue cannot be computed (price feed unavailable) stay visible, so a real transaction is never hidden by a missing rate.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35220
- **ADR** (if any): _N/A_

### 🧪 Testing

- `@ledgerhq/ledger-wallet-framework`: added a `groupAccountsOperationsByDay` test asserting a dust internal child under a passing parent is dropped.
- `@ledgerhq/live-common`: rewrote the `isSmallValueOperation` suite for the new behaviour (dust `REWARD`/`DELEGATE`, fee-based `STAKE`, and `NFT_IN`/`NFT_OUT`/`UNKNOWN` staying visible).
- `ledger-live-desktop`: added a `useHistoryOperations` case for a dust non-transfer (`REWARD`) operation.
- `live-mobile`: added `useOperationsV1` integration cases for a dust `REWARD` and for a dust internal child under a non-dust parent.

QA focus: with the dust filter enabled on the History screen (LWM & LWD), verify that staking rewards, fees and other sub-US$0.01 operations of every type are hidden, that NFT operations remain visible, and that operations worth exactly US$0.01 remain visible.