### PR TITLE
[LWD] feat(dynamic-content): read braze category cards on desktop

### DIFF
--- a/.changeset/hungry-donkeys-invent.md
+++ b/.changeset/hungry-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Add the Braze category content cards data layer on desktop, with single and bulk dismiss

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/__tests__/useDynamicContent.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/__tests__/useDynamicContent.test.ts
@@ -1,0 +1,158 @@
+import * as braze from "@braze/web-sdk";
+import type { Card as BrazeCard } from "@braze/web-sdk";
+import { act, renderHook } from "tests/testSetup";
+import {
+  DynamicContentState,
+  INITIAL_STATE as DYNAMIC_CONTENT_INITIAL_STATE,
+} from "~/renderer/reducers/dynamicContent";
+import { INITIAL_STATE as SETTINGS_INITIAL_STATE } from "~/renderer/reducers/settings";
+import {
+  CategoryContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
+  LocationContentCard,
+} from "~/types/dynamicContent";
+import { useDynamicContent } from "../useDynamicContent";
+
+jest.mock("@braze/web-sdk", () => ({
+  ...require("tests/mocks/brazeWebSdk").getBrazeWebSdkJestMock(),
+  logCardDismissal: jest.fn(),
+}));
+
+const logCardDismissal = jest.mocked(braze.logCardDismissal);
+
+const CATEGORY: CategoryContentCard = {
+  id: "category-1",
+  categoryId: "alwayson",
+  title: "Get a Ledger",
+  description: "Secure your assets",
+  location: LocationContentCard.Portfolio,
+  cardsLayout: ContentCardsLayout.carousel,
+  cardsType: ContentCardsType.smallSquare,
+  type: ContentCardsType.category,
+  created: new Date("2026-01-01"),
+};
+
+const childCard = (id: string): BrazeCard =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  ({
+    id,
+    extras: { categoryId: "alwayson", type: "small_square" },
+  }) as unknown as BrazeCard;
+
+const CHILD_A = childCard("child-a");
+const CHILD_B = childCard("child-b");
+
+const trackedUser = {
+  ...SETTINGS_INITIAL_STATE,
+  shareAnalytics: true,
+  sharePersonalizedRecommandations: false,
+};
+const optedOutUser = { ...trackedUser, shareAnalytics: false };
+
+const renderDynamicContent = (
+  dynamicContent: Partial<DynamicContentState> = {
+    categoriesCards: [CATEGORY],
+    desktopCards: [CHILD_A, CHILD_B],
+  },
+  settings = trackedUser,
+) =>
+  renderHook(() => useDynamicContent(), {
+    initialState: {
+      dynamicContent: { ...DYNAMIC_CONTENT_INITIAL_STATE, ...dynamicContent },
+      settings,
+    },
+  });
+
+describe("useDynamicContent", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should expose the categories and their child cards", () => {
+    const { result } = renderDynamicContent();
+
+    expect(result.current.categoriesCards).toEqual([CATEGORY]);
+    expect(result.current.categoryChildCards).toEqual([CHILD_A, CHILD_B]);
+  });
+
+  it("should remove the dismissed card from the store", () => {
+    const { result, store } = renderDynamicContent();
+
+    act(() => {
+      result.current.dismissCard("child-a");
+    });
+
+    expect(store.getState().dynamicContent.desktopCards).toEqual([CHILD_B]);
+  });
+
+  it("should dismiss every card at once when closing all", () => {
+    const { result, store } = renderDynamicContent();
+
+    act(() => {
+      result.current.dismissCards(["child-a", "child-b"]);
+    });
+
+    expect(store.getState().dynamicContent.desktopCards).toEqual([]);
+  });
+
+  it("should remove the category itself when it is the dismissed card", () => {
+    const { result, store } = renderDynamicContent();
+
+    act(() => {
+      result.current.dismissCard("category-1");
+    });
+
+    expect(store.getState().dynamicContent.categoriesCards).toEqual([]);
+  });
+
+  it("should report that nothing happened for a card it does not know", () => {
+    const { result, store } = renderDynamicContent();
+    const stateBefore = store.getState();
+
+    let dismissed = true;
+    act(() => {
+      dismissed = result.current.dismissCards(["never-served"]);
+    });
+
+    expect(dismissed).toBe(false);
+    expect(store.getState()).toBe(stateBefore);
+  });
+
+  it("should tell braze about the dismissal when the user is tracked", () => {
+    const { result } = renderDynamicContent();
+
+    act(() => {
+      result.current.dismissCard("child-a");
+    });
+
+    expect(logCardDismissal).toHaveBeenCalledWith(CHILD_A);
+  });
+
+  it("should persist the dismissal locally instead of calling braze when the user opted out", () => {
+    const { result, store } = renderDynamicContent(undefined, optedOutUser);
+
+    act(() => {
+      result.current.dismissCard("child-a");
+    });
+
+    expect(logCardDismissal).not.toHaveBeenCalled();
+    expect(store.getState().settings.dismissedContentCards["child-a"]).toEqual(expect.any(Number));
+  });
+
+  it("should never send debug cards from the braze dev tools to braze", () => {
+    const localChild = childCard("local-child");
+    const { result, store } = renderDynamicContent({
+      desktopCards: [CHILD_A],
+      localCategoriesCards: [CATEGORY],
+      localCategoryChildCards: [localChild],
+    });
+
+    act(() => {
+      result.current.dismissCards(["local-child", "child-a"]);
+    });
+
+    expect(logCardDismissal).toHaveBeenCalledTimes(1);
+    expect(logCardDismissal).toHaveBeenCalledWith(CHILD_A);
+    expect(store.getState().dynamicContent.localCategoryChildCards).toEqual([]);
+    expect(store.getState().dynamicContent.desktopCards).toEqual([]);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/useDynamicContent.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/hooks/useDynamicContent.ts
@@ -1,0 +1,114 @@
+import * as braze from "@braze/web-sdk";
+import type { Card as BrazeCard } from "@braze/web-sdk";
+import { useCallback, useMemo } from "react";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
+
+import {
+  setCategoriesCards,
+  setDesktopCards,
+  setLocalCategoryCards,
+} from "~/renderer/actions/dynamicContent";
+import { setDismissedContentCards } from "~/renderer/actions/settings";
+import {
+  categoriesContentCardFromBrazeSelector,
+  categoriesContentCardSelector,
+  categoryChildCardsSelector,
+  desktopContentCardSelector,
+  localCategoriesContentCardSelector,
+  localCategoryChildCardsSelector,
+} from "~/renderer/reducers/dynamicContent";
+import { trackingEnabledSelector } from "~/renderer/reducers/settings";
+import type { CategoryContentCard } from "~/types/dynamicContent";
+
+export type UseDynamicContentResult = {
+  categoriesCards: CategoryContentCard[];
+  categoryChildCards: BrazeCard[];
+  dismissCard: (cardId: string) => boolean;
+  dismissCards: (cardIds: readonly string[]) => boolean;
+};
+
+export function useDynamicContent(): UseDynamicContentResult {
+  const dispatch = useDispatch();
+  const categoriesCards = useSelector(categoriesContentCardSelector);
+  const categoryChildCards = useSelector(categoryChildCardsSelector);
+  const brazeCategoriesCards = useSelector(categoriesContentCardFromBrazeSelector);
+  const brazeCards = useSelector(desktopContentCardSelector);
+  const localCategoriesCards = useSelector(localCategoriesContentCardSelector);
+  const localCategoryChildCards = useSelector(localCategoryChildCardsSelector);
+  const isTrackedUser = useSelector(trackingEnabledSelector);
+
+  const localCardIds = useMemo(
+    () =>
+      new Set([
+        ...localCategoriesCards.map(card => card.id),
+        ...localCategoryChildCards.map(card => String(card.id)),
+      ]),
+    [localCategoriesCards, localCategoryChildCards],
+  );
+
+  const brazeCardIds = useMemo(
+    () =>
+      new Set([
+        ...brazeCards.map(card => String(card.id)),
+        ...brazeCategoriesCards.map(card => card.id),
+      ]),
+    [brazeCards, brazeCategoriesCards],
+  );
+
+  const logDismissToBraze = useCallback(
+    (cardId: string) => {
+      const brazeCard = brazeCards.find(card => String(card.id) === cardId);
+      if (!brazeCard) return;
+
+      if (isTrackedUser) {
+        braze.logCardDismissal(brazeCard);
+      } else {
+        dispatch(setDismissedContentCards({ id: cardId, timestamp: Date.now() }));
+      }
+    },
+    [brazeCards, isTrackedUser, dispatch],
+  );
+
+  const dismissCards = useCallback(
+    (cardIds: readonly string[]): boolean => {
+      const localIds = cardIds.filter(cardId => localCardIds.has(cardId));
+      const brazeIds = cardIds.filter(cardId => brazeCardIds.has(cardId));
+      if (localIds.length === 0 && brazeIds.length === 0) return false;
+
+      const dismissed = new Set([...localIds, ...brazeIds]);
+
+      if (localIds.length > 0) {
+        dispatch(
+          setLocalCategoryCards({
+            categories: localCategoriesCards.filter(card => !dismissed.has(card.id)),
+            childCards: localCategoryChildCards.filter(card => !dismissed.has(String(card.id))),
+          }),
+        );
+      }
+
+      if (brazeIds.length > 0) {
+        dispatch(setDesktopCards(brazeCards.filter(card => !dismissed.has(String(card.id)))));
+        dispatch(setCategoriesCards(brazeCategoriesCards.filter(card => !dismissed.has(card.id))));
+        brazeIds.forEach(cardId => {
+          logDismissToBraze(cardId);
+        });
+      }
+
+      return true;
+    },
+    [
+      dispatch,
+      localCardIds,
+      brazeCardIds,
+      localCategoriesCards,
+      localCategoryChildCards,
+      brazeCards,
+      brazeCategoriesCards,
+      logDismissToBraze,
+    ],
+  );
+
+  const dismissCard = useCallback((cardId: string) => dismissCards([cardId]), [dismissCards]);
+
+  return { categoriesCards, categoryChildCards, dismissCard, dismissCards };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/__tests__/categories.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/__tests__/categories.test.ts
@@ -1,0 +1,125 @@
+import type { Card as BrazeCard } from "@braze/web-sdk";
+import {
+  CategoryContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
+  LocationContentCard,
+} from "~/types/dynamicContent";
+import {
+  dedupeCategoriesByCategoryId,
+  filterCategoriesByLocation,
+  formatCategories,
+} from "../categories";
+
+const aCategory = (overrides: Partial<CategoryContentCard> = {}): CategoryContentCard => ({
+  id: "category-1",
+  categoryId: "alwayson",
+  title: "Category",
+  description: "Description",
+  location: LocationContentCard.Portfolio,
+  cardsLayout: ContentCardsLayout.carousel,
+  cardsType: ContentCardsType.smallSquare,
+  type: ContentCardsType.category,
+  created: new Date("2026-01-01"),
+  ...overrides,
+});
+
+const aChildCard = (categoryId: string | undefined, id = "child-1"): BrazeCard =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  ({ id, extras: categoryId ? { categoryId } : {} }) as unknown as BrazeCard;
+
+describe("filterCategoriesByLocation", () => {
+  it("should keep only the categories matching the requested location", () => {
+    const topPortfolio = aCategory({
+      id: "a",
+      location: LocationContentCard.Portfolio,
+    });
+    const bottomPortfolio = aCategory({
+      id: "b",
+      location: LocationContentCard.BottomPortfolio,
+    });
+
+    const result = filterCategoriesByLocation(
+      [topPortfolio, bottomPortfolio],
+      LocationContentCard.Portfolio,
+    );
+
+    expect(result).toEqual([topPortfolio]);
+  });
+
+  it("should return an empty list when no category matches", () => {
+    const bottomPortfolio = aCategory({ location: LocationContentCard.BottomPortfolio });
+
+    expect(filterCategoriesByLocation([bottomPortfolio], LocationContentCard.Portfolio)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("dedupeCategoriesByCategoryId", () => {
+  it("should keep the first category of each categoryId", () => {
+    const first = aCategory({ id: "a", categoryId: "alwayson" });
+    const duplicate = aCategory({ id: "b", categoryId: "alwayson" });
+    const other = aCategory({ id: "c", categoryId: "promo" });
+
+    expect(dedupeCategoriesByCategoryId([first, duplicate, other])).toEqual([first, other]);
+  });
+
+  it("should drop categories that have no categoryId, as no child can ever match them", () => {
+    const withoutId = aCategory({ id: "a", categoryId: undefined });
+    const withId = aCategory({ id: "b", categoryId: "promo" });
+
+    expect(dedupeCategoriesByCategoryId([withoutId, withId])).toEqual([withId]);
+  });
+});
+
+describe("formatCategories", () => {
+  it("should attach the child cards declaring the category id", () => {
+    const category = aCategory({ categoryId: "alwayson" });
+    const child = aChildCard("alwayson");
+    const unrelated = aChildCard("promo", "child-2");
+
+    expect(formatCategories([category], [child, unrelated])).toEqual([
+      { category, cards: [child] },
+    ]);
+  });
+
+  it("should not let a category without an id swallow the cards that have no category", () => {
+    const misconfigured = aCategory({ id: "a", categoryId: undefined });
+    const standaloneCard = aChildCard(undefined, "portfolio-card");
+
+    expect(formatCategories([misconfigured], [standaloneCard])).toEqual([]);
+  });
+
+  it("should drop categories that have no child card", () => {
+    const withChild = aCategory({ id: "a", categoryId: "alwayson" });
+    const withoutChild = aCategory({ id: "b", categoryId: "empty" });
+
+    const result = formatCategories([withChild, withoutChild], [aChildCard("alwayson")]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].category).toBe(withChild);
+  });
+
+  it("should order categories by their order extra", () => {
+    const second = aCategory({ id: "a", categoryId: "second", order: 2 });
+    const first = aCategory({ id: "b", categoryId: "first", order: 1 });
+
+    const result = formatCategories(
+      [second, first],
+      [aChildCard("second", "child-a"), aChildCard("first", "child-b")],
+    );
+
+    expect(result.map(({ category }) => category.categoryId)).toEqual(["first", "second"]);
+  });
+
+  it("should not mutate the categories it receives", () => {
+    const second = aCategory({ id: "a", categoryId: "second", order: 2 });
+    const first = aCategory({ id: "b", categoryId: "first", order: 1 });
+    const categories = [second, first];
+
+    formatCategories(categories, [aChildCard("second"), aChildCard("first", "child-b")]);
+
+    expect(categories).toEqual([second, first]);
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/categories.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/categories.ts
@@ -1,0 +1,42 @@
+import type { Card as BrazeCard } from "@braze/web-sdk";
+import { compareCards } from "~/renderer/hooks/useBraze";
+import { CategoryContentCard, LocationContentCard } from "~/types/dynamicContent";
+
+export type FormattedCategory = {
+  category: CategoryContentCard;
+  cards: BrazeCard[];
+};
+
+export const filterCategoriesByLocation = (
+  categories: CategoryContentCard[],
+  locationId: LocationContentCard,
+) => categories.filter(category => category.location === locationId);
+
+export const dedupeCategoriesByCategoryId = (categories: CategoryContentCard[]) => {
+  const seenCategoryIds = new Set<string>();
+  const uniqueCategories: CategoryContentCard[] = [];
+
+  for (const category of categories) {
+    if (!category.categoryId) continue;
+    if (seenCategoryIds.has(category.categoryId)) continue;
+    seenCategoryIds.add(category.categoryId);
+    uniqueCategories.push(category);
+  }
+
+  return uniqueCategories;
+};
+
+/**
+ * Rebuilds the parent/child tree Braze flattens: each category is paired with the
+ * raw cards declaring its `categoryId`. Categories without any child are dropped.
+ */
+export const formatCategories = (
+  categories: CategoryContentCard[],
+  childCards: BrazeCard[],
+): FormattedCategory[] =>
+  dedupeCategoriesByCategoryId([...categories].sort(compareCards))
+    .map(category => ({
+      category,
+      cards: childCards.filter(childCard => childCard.extras?.categoryId === category.categoryId),
+    }))
+    .filter(({ cards }) => cards.length > 0);

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/constants/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/constants/index.ts
@@ -1,1 +1,4 @@
 export const OFFLINE_SEEN_DELAY = 2e3;
+
+/** Category id Braze uses for the always-on hardware carousel on the portfolio page. */
+export const ALWAYS_ON_CATEGORY_ID = "alwayson";

--- a/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/GenericAwarenessModal/__tests__/GenericAwarenessModalView.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import { fireEvent, render, screen, waitFor } from "tests/testSetup";
 import type { State } from "~/renderer/reducers";
+import { INITIAL_STATE as DYNAMIC_CONTENT_INITIAL_STATE } from "~/renderer/reducers/dynamicContent";
 import { track, trackPage } from "~/renderer/analytics/segment";
 import { closeGenericAwarenessModalDialog } from "LLD/features/GenericAwarenessModal/genericAwarenessModalDialog";
 import GenericAwarenessModalView from "../GenericAwarenessModalView";
@@ -75,13 +76,10 @@ describe("GenericAwarenessModalView", () => {
     renderOpenAwarenessModalView(carouselCampaignCard, {
       initialState: createGenericAwarenessModalTestState({
         dynamicContent: {
+          ...DYNAMIC_CONTENT_INITIAL_STATE,
           desktopCards: [
             { id: CAROUSEL_CAMPAIGN_ID, title: "Carousel card" } as unknown as BrazeCard,
           ],
-          portfolioCards: [],
-          bottomPortfolioCards: [],
-          actionCards: [],
-          notificationsCards: [],
         },
         settings: {
           shareAnalytics: true,

--- a/apps/ledger-live-desktop/src/renderer/actions/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/renderer/actions/dynamicContent.ts
@@ -1,6 +1,7 @@
 import type { Card as BrazeCard } from "@braze/web-sdk";
 import {
   ActionContentCard,
+  CategoryContentCard,
   PortfolioContentCard,
   NotificationContentCard,
 } from "~/types/dynamicContent";
@@ -27,5 +28,18 @@ export const setActionCards = (payload: ActionContentCard[]) => ({
 
 export const setNotificationsCards = (payload: NotificationContentCard[]) => ({
   type: "DYNAMIC_CONTENT_SET_NOTIFICATIONS_CARDS",
+  payload,
+});
+
+export const setCategoriesCards = (payload: CategoryContentCard[]) => ({
+  type: "DYNAMIC_CONTENT_SET_CATEGORIES_CARDS",
+  payload,
+});
+
+export const setLocalCategoryCards = (payload: {
+  categories: CategoryContentCard[];
+  childCards: BrazeCard[];
+}) => ({
+  type: "DYNAMIC_CONTENT_SET_LOCAL_CATEGORY_CARDS",
   payload,
 });

--- a/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useBraze.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/__tests__/useBraze.test.ts
@@ -1,0 +1,106 @@
+import type { ClassicCard } from "@braze/web-sdk";
+import { ContentCardsLayout, ContentCardsType, LocationContentCard } from "~/types/dynamicContent";
+
+jest.mock("@braze/web-sdk", () => require("tests/mocks/brazeWebSdk").getBrazeWebSdkJestMock());
+
+import { filterByType, mapAsCategoryContentCard } from "../useBraze";
+
+const aBrazeCard = (extras: Record<string, string>, id = "card-1") =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  ({
+    id,
+    updated: new Date("2026-01-01"),
+    viewed: false,
+    extras,
+  }) as unknown as ClassicCard;
+
+describe("filterByType", () => {
+  it("should keep only the cards declaring the requested type", () => {
+    const category = aBrazeCard({ type: "category" }, "category-1");
+    const child = aBrazeCard({ type: "small_square" }, "child-1");
+
+    expect(filterByType([category, child], ContentCardsType.category)).toEqual([category]);
+  });
+
+  it("should ignore cards without a type", () => {
+    const placement = aBrazeCard({ location: "portfolio" });
+
+    expect(filterByType([placement], ContentCardsType.category)).toEqual([]);
+  });
+});
+
+describe("mapAsCategoryContentCard", () => {
+  it("should place the alwayson category on the portfolio carousel", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "alwayson",
+      cardsLayout: "carousel",
+      cardsType: "small_square",
+    });
+
+    expect(mapAsCategoryContentCard(card).location).toBe(LocationContentCard.Portfolio);
+  });
+
+  it("should keep the declared location for any other category", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "promo",
+      location: "portfolio",
+      cardsLayout: "grid",
+      cardsType: "hero",
+    });
+
+    expect(mapAsCategoryContentCard(card).location).toBe(LocationContentCard.Portfolio);
+  });
+
+  it("should expose the braze extras as typed category fields", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "alwayson",
+      title: "Get a Ledger",
+      description: "Secure your assets",
+      cta: "Discover",
+      order: "2",
+      cardsLayout: "carousel",
+      cardsType: "small_square",
+    });
+
+    expect(mapAsCategoryContentCard(card)).toMatchObject({
+      id: "card-1",
+      categoryId: "alwayson",
+      title: "Get a Ledger",
+      description: "Secure your assets",
+      cta: "Discover",
+      order: 2,
+      cardsLayout: ContentCardsLayout.carousel,
+      cardsType: ContentCardsType.smallSquare,
+      type: ContentCardsType.category,
+    });
+  });
+
+  it("should read the boolean extras braze sends as strings", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "alwayson",
+      isDismissable: "true",
+      hasPagination: "true",
+      centeredText: "false",
+    });
+
+    expect(mapAsCategoryContentCard(card)).toMatchObject({
+      isDismissable: true,
+      hasPagination: true,
+      centeredText: false,
+    });
+  });
+
+  it("should append the resolved location to the deeplink", () => {
+    const card = aBrazeCard({
+      type: "category",
+      id: "alwayson",
+      link: "ledgerlive://discover",
+    });
+
+    expect(mapAsCategoryContentCard(card).link).toContain("portfolio");
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/hooks/useBraze.ts
@@ -6,12 +6,16 @@ import { appendDeeplinkLocationIfDefined } from "@ledgerhq/live-common/deeplinks
 import { getEnv } from "@shared/env";
 import { useCallback, useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { ALWAYS_ON_CATEGORY_ID } from "LLD/features/DynamicContent/utils/constants";
 
 import { userIdSelector } from "@domain/entity-client-identity";
 import { getBrazeConfig } from "~/braze-setup";
 import {
   ActionContentCard,
+  CategoryContentCard,
   ContentCard as LedgerContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
   LocationContentCard,
   NotificationContentCard,
   Platform,
@@ -20,6 +24,7 @@ import {
 import { processGenericAwarenessModalBrazeCards } from "@ledgerhq/live-common/genericAwarenessModal";
 import {
   setActionCards,
+  setCategoriesCards,
   setDesktopCards,
   setNotificationsCards,
   setPortfolioCards,
@@ -46,6 +51,9 @@ const getDesktopCards = (elem: braze.ContentCards) =>
 
 export const filterByPage = (array: braze.Card[], page: LocationContentCard) =>
   array.filter(card => card.extras?.location === page);
+
+export const filterByType = (array: braze.Card[], type: ContentCardsType) =>
+  array.filter(card => card.extras?.type === type);
 
 export const compareCards = (a: LedgerContentCard, b: LedgerContentCard) => {
   if (a.order && !b.order) {
@@ -103,6 +111,36 @@ export const mapAsPortfolioContentCard = (card: ClassicCard): PortfolioContentCa
 export const mapAsBottomPortfolioContentCard = (card: ClassicCard): PortfolioContentCard =>
   mapBrazeCardToPortfolioContentCard(card, LocationContentCard.BottomPortfolio);
 
+export const mapAsCategoryContentCard = (card: ClassicCard): CategoryContentCard => {
+  const location =
+    card.extras?.id === ALWAYS_ON_CATEGORY_ID
+      ? LocationContentCard.Portfolio
+      : // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        (card.extras?.location as LocationContentCard);
+
+  return {
+    id: String(card.id),
+    categoryId: card.extras?.id,
+    location,
+    created: card.updated ?? null,
+    viewed: card.viewed,
+    order: parseOrder(card.extras?.order),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    cardsLayout: card.extras?.cardsLayout as ContentCardsLayout,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    cardsType: card.extras?.cardsType as ContentCardsType,
+    type: ContentCardsType.category,
+    title: card.extras?.title,
+    description: card.extras?.description,
+    link: appendDeeplinkLocationIfDefined(card.extras?.link, location),
+    cta: card.extras?.cta,
+    isDismissable: card.extras?.isDismissable === "true",
+    hasPagination: card.extras?.hasPagination === "true",
+    centeredText: card.extras?.centeredText === "true",
+    extras: card.extras,
+  };
+};
+
 export const mapAsNotificationContentCard = (card: ClassicCard): NotificationContentCard => ({
   created: card.updated ?? null,
   cta: card.extras?.cta,
@@ -122,10 +160,15 @@ export const mapAsNotificationContentCard = (card: ClassicCard): NotificationCon
 export function useBraze() {
   const dispatch = useDispatch();
   const devMode = useSelector(developerModeSelector);
-  const contentCardsDissmissed = useSelector(dismissedContentCardsSelector);
+  const contentCardsDismissed = useSelector(dismissedContentCardsSelector);
   const isTrackedUser = useSelector(trackingEnabledSelector);
   const anonymousBrazeId = useRef(useSelector(anonymousBrazeIdSelector));
   const userId = useSelector(userIdSelector);
+
+  // Read through a ref so that dismissing a card does not re-run the whole Braze
+  // init, which would open a new session and stack another card subscription.
+  const contentCardsDismissedRef = useRef(contentCardsDismissed);
+  contentCardsDismissedRef.current = contentCardsDismissed;
 
   const initBraze = useCallback(async () => {
     const brazeConfig = getBrazeConfig();
@@ -158,12 +201,11 @@ export function useBraze() {
 
     braze.requestContentCardsRefresh();
 
-    braze.subscribeToContentCardsUpdates(cards => {
+    const subscriptionId = braze.subscribeToContentCardsUpdates(cards => {
       const desktopCards = getDesktopCards(cards);
-      const dismissedCardIds = Object.keys(contentCardsDissmissed ?? {});
-      const filteredDesktopCards = desktopCards.filter(
-        card => !dismissedCardIds.includes(String(card.id)),
-      );
+      const dismissedCardIds = Object.keys(contentCardsDismissedRef.current ?? {});
+      const hiddenCardIds = new Set(dismissedCardIds);
+      const filteredDesktopCards = desktopCards.filter(card => !hiddenCardIds.has(String(card.id)));
 
       const portfolioCards = filterByPage(filteredDesktopCards, LocationContentCard.Portfolio)
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -191,6 +233,14 @@ export function useBraze() {
         .map(card => mapAsNotificationContentCard(card as ClassicCard))
         .sort(compareCards);
 
+      const categoriesCards = filterByType(filteredDesktopCards, ContentCardsType.category)
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        .map(card => mapAsCategoryContentCard(card as ClassicCard))
+        // A container without an id can never be matched by a child card, and would
+        // otherwise pair with every card that has no categoryId at all.
+        .filter(card => !!card.categoryId)
+        .sort(compareCards);
+
       const genericAwarenessModalBrazeCardsFromBraze = filterByPage(
         filteredDesktopCards,
         LocationContentCard.GenericAwarenessModal,
@@ -209,15 +259,32 @@ export function useBraze() {
       dispatch(setBottomPortfolioCards(bottomPortfolioCards));
       dispatch(setActionCards(actionCards));
       dispatch(setNotificationsCards(notificationsCards));
+      dispatch(setCategoriesCards(categoriesCards));
       dispatch(setGenericAwarenessModalContentCards(genericAwarenessModalContentCards));
     });
 
     braze.automaticallyShowInAppMessages();
     braze.openSession();
-  }, [dispatch, devMode, isTrackedUser, contentCardsDissmissed, anonymousBrazeId, userId]);
+
+    return subscriptionId;
+  }, [dispatch, devMode, isTrackedUser, anonymousBrazeId, userId]);
 
   useEffect(() => {
-    initBraze();
+    let subscriptionId: string | undefined;
+    let cancelled = false;
+
+    initBraze().then(id => {
+      if (cancelled && id) {
+        braze.removeSubscription(id);
+        return;
+      }
+      subscriptionId = id;
+    });
+
+    return () => {
+      cancelled = true;
+      if (subscriptionId) braze.removeSubscription(subscriptionId);
+    };
   }, [initBraze]);
 
   // TODO should there be an interval to periodically purge dismissed cards?

--- a/apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/renderer/reducers/dynamicContent.ts
@@ -3,6 +3,7 @@ import { handleActions } from "redux-actions";
 import { createSelector } from "reselect";
 import {
   ActionContentCard,
+  CategoryContentCard,
   NotificationContentCard,
   PortfolioContentCard,
 } from "~/types/dynamicContent";
@@ -18,14 +19,23 @@ export type DynamicContentState = {
   bottomPortfolioCards: PortfolioContentCard[];
   actionCards: ActionContentCard[];
   notificationsCards: NotificationContentCard[];
+  /** Category container cards, grouping child cards that share their categoryId */
+  categoriesCards: CategoryContentCard[];
+  /** Debug categories from the Braze dev tools, merged in selectors so Braze pushes don't wipe them */
+  localCategoriesCards: CategoryContentCard[];
+  /** Debug category children from the Braze dev tools, merged in selectors */
+  localCategoryChildCards: BrazeCard[];
 };
 
-const state: DynamicContentState = {
+export const INITIAL_STATE: DynamicContentState = {
   desktopCards: [],
   portfolioCards: [],
   bottomPortfolioCards: [],
   actionCards: [],
   notificationsCards: [],
+  categoriesCards: [],
+  localCategoriesCards: [],
+  localCategoryChildCards: [],
 };
 
 type HandlersPayloads = {
@@ -34,6 +44,11 @@ type HandlersPayloads = {
   DYNAMIC_CONTENT_SET_BOTTOM_PORTFOLIO_CARDS: PortfolioContentCard[];
   DYNAMIC_CONTENT_SET_ACTION_CARDS: ActionContentCard[];
   DYNAMIC_CONTENT_SET_NOTIFICATIONS_CARDS: NotificationContentCard[];
+  DYNAMIC_CONTENT_SET_CATEGORIES_CARDS: CategoryContentCard[];
+  DYNAMIC_CONTENT_SET_LOCAL_CATEGORY_CARDS: {
+    categories: CategoryContentCard[];
+    childCards: BrazeCard[];
+  };
 };
 type DynamicContentHandlers<PreciseKey = true> = Handlers<
   DynamicContentState,
@@ -77,6 +92,21 @@ const handlers: DynamicContentHandlers = {
     ...state,
     notificationsCards: payload,
   }),
+  DYNAMIC_CONTENT_SET_CATEGORIES_CARDS: (
+    state: DynamicContentState,
+    { payload }: { payload: CategoryContentCard[] },
+  ) => ({
+    ...state,
+    categoriesCards: payload,
+  }),
+  DYNAMIC_CONTENT_SET_LOCAL_CATEGORY_CARDS: (
+    state: DynamicContentState,
+    { payload }: { payload: { categories: CategoryContentCard[]; childCards: BrazeCard[] } },
+  ) => ({
+    ...state,
+    localCategoriesCards: payload.categories,
+    localCategoryChildCards: payload.childCards,
+  }),
 };
 
 // Selectors
@@ -93,6 +123,29 @@ export const bottomPortfolioContentCardSelector = (state: {
 
 export const actionContentCardSelector = (state: { dynamicContent: DynamicContentState }) =>
   state.dynamicContent.actionCards;
+
+export const categoriesContentCardSelector = createSelector(
+  (state: { dynamicContent: DynamicContentState }) => state.dynamicContent.categoriesCards,
+  (state: { dynamicContent: DynamicContentState }) => state.dynamicContent.localCategoriesCards,
+  (categoriesCards, localCategoriesCards) => categoriesCards.concat(localCategoriesCards),
+);
+
+export const categoryChildCardsSelector = createSelector(
+  (state: { dynamicContent: DynamicContentState }) => state.dynamicContent.desktopCards,
+  (state: { dynamicContent: DynamicContentState }) => state.dynamicContent.localCategoryChildCards,
+  (desktopCards, localCategoryChildCards) => desktopCards.concat(localCategoryChildCards),
+);
+
+export const categoriesContentCardFromBrazeSelector = (state: {
+  dynamicContent: DynamicContentState;
+}) => state.dynamicContent.categoriesCards;
+
+export const localCategoriesContentCardSelector = (state: {
+  dynamicContent: DynamicContentState;
+}) => state.dynamicContent.localCategoriesCards;
+
+export const localCategoryChildCardsSelector = (state: { dynamicContent: DynamicContentState }) =>
+  state.dynamicContent.localCategoryChildCards;
 
 type NotificationsContentCardState = {
   dynamicContent: DynamicContentState;
@@ -114,5 +167,5 @@ export const notificationsContentCardSelector = createSelector(
 
 export default handleActions<DynamicContentState, HandlersPayloads[keyof HandlersPayloads]>(
   handlers as unknown as DynamicContentHandlers<false>,
-  state,
+  INITIAL_STATE,
 );

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Hooks/useGenerateLocalBraze.ts
@@ -1,20 +1,28 @@
+import type { Card as BrazeCard } from "@braze/web-sdk";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
+import { ALWAYS_ON_CATEGORY_ID } from "LLD/features/DynamicContent/utils/constants";
 import {
   setPortfolioCards,
   setBottomPortfolioCards,
   setActionCards,
   setNotificationsCards,
+  setLocalCategoryCards,
 } from "~/renderer/actions/dynamicContent";
 import {
   portfolioContentCardSelector,
   bottomPortfolioContentCardSelector,
   actionContentCardSelector,
   notificationsContentCardSelector,
+  localCategoriesContentCardSelector,
+  localCategoryChildCardsSelector,
 } from "~/renderer/reducers/dynamicContent";
 import {
   PortfolioContentCard,
   ActionContentCard,
   NotificationContentCard,
+  CategoryContentCard,
+  ContentCardsLayout,
+  ContentCardsType,
   LocationContentCard,
 } from "~/types/dynamicContent";
 
@@ -97,6 +105,62 @@ const generateNewNotificationCard = (
   isMock: true,
 });
 
+const DEFAULT_CATEGORY_CHILD_COUNT = 3;
+
+const generateNewCategoryCard = (
+  categoryId: string,
+  title: string,
+  description: string,
+  cta: string,
+  order?: number,
+): CategoryContentCard => ({
+  id: `local-category-${categoryId}`,
+  categoryId,
+  title,
+  description,
+  cta,
+  location: LocationContentCard.Portfolio,
+  cardsLayout: ContentCardsLayout.carousel,
+  cardsType: ContentCardsType.smallSquare,
+  type: ContentCardsType.category,
+  created: new Date(),
+  order,
+  isMock: true,
+  isDismissable: true,
+  hasPagination: true,
+});
+
+const generateNewCategoryChildCards = (
+  categoryId: string,
+  title: string,
+  description: string,
+  image: string,
+  cta: string,
+  path: string,
+  count: number,
+): BrazeCard[] =>
+  Array.from({ length: count }, (_, index) => {
+    const childIndex = index + 1;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    return {
+      id: `local-category-child-${categoryId}-${childIndex}`,
+      updated: new Date(),
+      viewed: false,
+      extras: {
+        platform: "desktop",
+        type: ContentCardsType.smallSquare,
+        categoryId,
+        title: `${title} ${childIndex}`,
+        description,
+        media: image,
+        mediaType: "image",
+        cta,
+        link: path,
+        order: String(childIndex),
+      },
+    } as unknown as BrazeCard;
+  });
+
 export const useGenerateLocalBraze = () => {
   const dispatch = useDispatch();
 
@@ -104,6 +168,8 @@ export const useGenerateLocalBraze = () => {
   const bottomPortfolioCards = useSelector(bottomPortfolioContentCardSelector);
   const actionCards = useSelector(actionContentCardSelector);
   const notificationCards = useSelector(notificationsContentCardSelector);
+  const localCategoriesCards = useSelector(localCategoriesContentCardSelector);
+  const localCategoryChildCards = useSelector(localCategoryChildCardsSelector);
 
   const addLocalPortfolioCard = (
     title: string,
@@ -203,11 +269,43 @@ export const useGenerateLocalBraze = () => {
     dispatch(setNotificationsCards([...notificationCards, newCard]));
   };
 
+  const addLocalCategoryCard = (
+    title: string,
+    description: string,
+    image: string,
+    cta: string,
+    path: string,
+    order?: number,
+  ) => {
+    // The first category impersonates the real always-on campaign; the next ones need
+    // their own id, otherwise the dedupe would drop them and nothing would show up.
+    const categoryId =
+      localCategoriesCards.length === 0 ? ALWAYS_ON_CATEGORY_ID : `local-${Date.now()}`;
+
+    const category = generateNewCategoryCard(categoryId, title, description, cta, order);
+    const childCards = generateNewCategoryChildCards(
+      categoryId,
+      title,
+      description,
+      image,
+      cta,
+      path,
+      DEFAULT_CATEGORY_CHILD_COUNT,
+    );
+    dispatch(
+      setLocalCategoryCards({
+        categories: [...localCategoriesCards, category],
+        childCards: [...localCategoryChildCards, ...childCards],
+      }),
+    );
+  };
+
   const dismissLocalCards = () => {
     dispatch(setPortfolioCards([]));
     dispatch(setBottomPortfolioCards([]));
     dispatch(setActionCards([]));
     dispatch(setNotificationsCards([]));
+    dispatch(setLocalCategoryCards({ categories: [], childCards: [] }));
   };
 
   return {
@@ -215,6 +313,7 @@ export const useGenerateLocalBraze = () => {
     addLocalBottomPortfolioCard,
     addLocalActionCard,
     addLocalNotificationCard,
+    addLocalCategoryCard,
     dismissLocalCards,
   };
 };

--- a/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
+++ b/apps/ledger-live-desktop/src/renderer/screens/settings/sections/Developer/BrazeTools/Modal/Body.tsx
@@ -9,7 +9,8 @@ type TabKey =
   | "NotificationContentCard"
   | "ActionContentCard"
   | "PortfolioContentCard"
-  | "BottomPortfolioContentCard";
+  | "BottomPortfolioContentCard"
+  | "CategoryContentCard";
 
 const FormRow = styled(Flex)`
   align-items: center;
@@ -83,6 +84,7 @@ export const ModalBody: React.FC = () => {
     addLocalBottomPortfolioCard,
     addLocalActionCard,
     addLocalNotificationCard,
+    addLocalCategoryCard,
     dismissLocalCards,
   } = useGenerateLocalBraze();
 
@@ -145,6 +147,8 @@ export const ModalBody: React.FC = () => {
       );
     } else if (selectedTab === "NotificationContentCard") {
       addLocalNotificationCard(title, description, cta, false, url, path, order);
+    } else if (selectedTab === "CategoryContentCard") {
+      addLocalCategoryCard(title, description, image, cta, path, order);
     }
     dispatch({ type: "RESET_FORM" });
   };
@@ -179,6 +183,10 @@ export const ModalBody: React.FC = () => {
     {
       key: "BottomPortfolioContentCard",
       label: t("settings.developer.brazeTools.modal.fields.bottomPortfolio"),
+    },
+    {
+      key: "CategoryContentCard",
+      label: "Category (hardware carousel)",
     },
   ];
 
@@ -321,6 +329,23 @@ export const ModalBody: React.FC = () => {
       {
         field: "path",
         placeholder: "Path",
+        label: t("settings.developer.brazeTools.modal.fields.path"),
+      },
+    ],
+    CategoryContentCard: [
+      {
+        field: "image",
+        placeholder: "Media URL applied to every child card",
+        label: t("settings.developer.brazeTools.modal.fields.image"),
+      },
+      {
+        field: "cta",
+        placeholder: "CTA",
+        label: t("settings.developer.brazeTools.modal.fields.cta"),
+      },
+      {
+        field: "path",
+        placeholder: "In-app path (deep link)",
         label: t("settings.developer.brazeTools.modal.fields.path"),
       },
     ],

--- a/apps/ledger-live-desktop/src/types/dynamicContent.ts
+++ b/apps/ledger-live-desktop/src/types/dynamicContent.ts
@@ -1,5 +1,5 @@
 export enum LocationContentCard {
-  /** Top carousel on portfolio page (placement "portfolio") */
+  /** Top carousel on portfolio page — direct cards and category containers (e.g. alwayson hardware carousel) */
   Portfolio = "portfolio",
   /** Bottom carousel on portfolio page (placement "bottom_portfolio") */
   BottomPortfolio = "bottom_portfolio",
@@ -11,6 +11,21 @@ export enum LocationContentCard {
 
 export enum Platform {
   Desktop = "desktop",
+}
+
+export enum ContentCardsType {
+  smallSquare = "small_square",
+  mediumSquare = "medium_square",
+  bigSquare = "big_square",
+  action = "action",
+  category = "category",
+  hero = "hero",
+}
+
+export enum ContentCardsLayout {
+  unique = "unique",
+  carousel = "carousel",
+  grid = "grid",
 }
 
 export type ContentCard = {
@@ -38,6 +53,23 @@ export type NotificationContentCard = ContentCard & {
   viewed: boolean;
   url?: string;
   path?: string;
+};
+
+/**
+ * Container card grouping child cards that share its `categoryId`.
+ * Children are kept raw in the store and mapped at render time using `cardsType`.
+ */
+export type CategoryContentCard = ContentCard & {
+  categoryId?: string;
+  cardsLayout: ContentCardsLayout;
+  cardsType: ContentCardsType;
+  type: ContentCardsType.category;
+  cta?: string;
+  link?: string;
+  viewed?: boolean;
+  isDismissable?: boolean;
+  hasPagination?: boolean;
+  centeredText?: boolean;
 };
 
 export type PortfolioContentCard = ContentCard & {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Ports the mobile Braze category content cards data layer to desktop. Desktop now ingests extras.type=category containers, builds the parent/child tree via categoryId, and exposes useDynamicContent with single and bulk dismiss. No UI in this PR.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35389]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-35389]: https://ledgerhq.atlassian.net/browse/LIVE-35389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ