### PR TITLE
[LWDM] fix(wallet-api): always enforce deeplink scheme allowlist

### DIFF
--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/CustomHandlers.ts
@@ -21,25 +21,24 @@ import { handlers as deeplinkHandlers } from "@ledgerhq/live-common/wallet-api/C
 import { isUrlSafe } from "@ledgerhq/live-common/wallet-api/CustomDeeplink/isUrlSafe";
 import { handlers as liveAppModalHandlers } from "@ledgerhq/live-common/wallet-api/LiveAppModal/server";
 import { resolveLiveAppModalParams } from "@ledgerhq/live-common/wallet-api/LiveAppModal/types";
-import { useFeature } from "@features/platform-feature-flags";
 
 type DeeplinkOpenHandlerParams = { url: string };
 
 type CreateDeeplinkOpenHandlerParams = {
-  isDeeplinkOpenHardeningEnabled: boolean;
   openDeepLink?: (url: string) => void;
 };
 
 export function createDeeplinkOpenHandler({
-  isDeeplinkOpenHardeningEnabled,
   openDeepLink = url => ipcRenderer.send("deep-linking", url),
-}: CreateDeeplinkOpenHandlerParams) {
+}: CreateDeeplinkOpenHandlerParams = {}) {
   return (params?: DeeplinkOpenHandlerParams) => {
     if (!params) {
       return;
     }
 
-    if (isDeeplinkOpenHardeningEnabled && !isUrlSafe(params.url)) {
+    // Scheme allowlist is always enforced (not behind lwdDeeplinkOpenHardening).
+    // That flag still gates locked-app deeplink deferral in useDeeplinking.
+    if (!isUrlSafe(params.url)) {
       console.warn("Blocked unsafe custom.deeplink.open URL");
       track("custom.deeplink.open blocked", { reason: "scheme" });
       return;
@@ -183,19 +182,15 @@ export function useACRECustomHandlers(manifest: WebviewProps["manifest"], accoun
 }
 
 export function useDeeplinkCustomHandlers() {
-  const isDeeplinkOpenHardeningEnabled = useFeature("lwdDeeplinkOpenHardening")?.enabled === true;
-
   return useMemo<WalletAPICustomHandlers>(() => {
     return {
       ...deeplinkHandlers({
         uiHooks: {
-          "custom.deeplink.open": createDeeplinkOpenHandler({
-            isDeeplinkOpenHardeningEnabled,
-          }),
+          "custom.deeplink.open": createDeeplinkOpenHandler(),
         },
       }),
     };
-  }, [isDeeplinkOpenHardeningEnabled]);
+  }, []);
 }
 
 export function useLiveAppModalCustomHandlers(manifest: WebviewProps["manifest"]) {

--- a/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/__tests__/CustomHandlers.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/components/WebPlatformPlayer/__tests__/CustomHandlers.test.ts
@@ -25,27 +25,11 @@ describe("createDeeplinkOpenHandler", () => {
     warnSpy.mockRestore();
   });
 
-  it("should forward dangerous URLs when hardening is disabled", () => {
-    const openDeepLink = jest.fn();
-    const handler = createDeeplinkOpenHandler({
-      isDeeplinkOpenHardeningEnabled: false,
-      openDeepLink,
-    });
-
-    handler({ url: "file:///etc/passwd" });
-
-    expect(openDeepLink).toHaveBeenCalledWith("file:///etc/passwd");
-    expect(mockTrack).not.toHaveBeenCalled();
-  });
-
   it.each(["file:///etc/passwd", "javascript:alert(1)", "smb://attacker/share", "itms-apps://app"])(
-    "should block %s when hardening is enabled",
+    "should block %s",
     url => {
       const openDeepLink = jest.fn();
-      const handler = createDeeplinkOpenHandler({
-        isDeeplinkOpenHardeningEnabled: true,
-        openDeepLink,
-      });
+      const handler = createDeeplinkOpenHandler({ openDeepLink });
 
       handler({ url });
 
@@ -62,12 +46,9 @@ describe("createDeeplinkOpenHandler", () => {
     "ledgerlive://swap",
     "ledgerwallet://settings",
     "mailto:support@ledger.com",
-  ])("should forward %s when hardening is enabled", url => {
+  ])("should forward %s", url => {
     const openDeepLink = jest.fn();
-    const handler = createDeeplinkOpenHandler({
-      isDeeplinkOpenHardeningEnabled: true,
-      openDeepLink,
-    });
+    const handler = createDeeplinkOpenHandler({ openDeepLink });
 
     handler({ url });
 

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/CustomHandlers.ts
@@ -41,7 +41,10 @@ export function createDeeplinkOpenHandler({
       return;
     }
 
-    if (isDeeplinkOpenHardeningEnabled && !isUrlSafe(params.url)) {
+    // Scheme allowlist is always enforced. The feature flag only gates the
+    // locked-app deferral so remote config cannot re-enable file:// / smb:// /
+    // javascript: opens from a Live App with custom.deeplink.open.
+    if (!isUrlSafe(params.url)) {
       console.warn("Blocked unsafe custom.deeplink.open URL");
       track("custom.deeplink.open blocked", { reason: "scheme" });
       return;

--- a/apps/ledger-live-mobile/src/components/WebPlatformPlayer/__tests__/CustomHandlers.test.ts
+++ b/apps/ledger-live-mobile/src/components/WebPlatformPlayer/__tests__/CustomHandlers.test.ts
@@ -19,22 +19,24 @@ describe("createDeeplinkOpenHandler", () => {
     warnSpy.mockRestore();
   });
 
-  it("should forward dangerous URLs when hardening is disabled", () => {
+  it("should block dangerous URLs even when hardening flag is disabled", () => {
     const openURL = jest.fn();
     const handler = createDeeplinkOpenHandler({
       isDeeplinkOpenHardeningEnabled: false,
-      isLocked: true,
+      isLocked: false,
       openURL,
     });
 
     handler({ url: "file:///etc/passwd" });
 
-    expect(openURL).toHaveBeenCalledWith("file:///etc/passwd");
-    expect(mockTrack).not.toHaveBeenCalled();
+    expect(openURL).not.toHaveBeenCalled();
+    expect(mockTrack).toHaveBeenCalledWith("custom.deeplink.open blocked", {
+      reason: "scheme",
+    });
   });
 
   it.each(["file:///etc/passwd", "javascript:alert(1)", "smb://attacker/share", "itms-apps://app"])(
-    "should block %s when hardening is enabled",
+    "should block %s (scheme allowlist always on)",
     url => {
       const openURL = jest.fn();
       const handler = createDeeplinkOpenHandler({


### PR DESCRIPTION
### Description

`custom.deeplink.open` only called `isUrlSafe` when `lwmDeeplinkOpenHardening` / `lwdDeeplinkOpenHardening` was enabled. Those flags are created with `flag()` and default to `enabled: false`, so a Live App granted `custom.deeplink.open` could open dangerous schemes (`file://`, `smb://`, `javascript:`, …). Mobile sinks to `Linking.openURL`.

Previous behaviour (fail-open): scheme check skipped when the remote flag is unset/false.
Fix: always enforce the scheme allowlist. Keep the feature flag only for the locked-app deferral on mobile (`useDeeplinking` on desktop still uses the flag for lock gating).

Automated check: CustomHandlers unit tests now assert `file:///etc/passwd` is blocked even when the hardening flag is disabled (and still block the other unsafe schemes).

### Context

- **JIRA / GitHub issue**: n/a (hardening)
- **ADR** (if any): n/a

### Attacker model

A Wallet API Live App (or compromised partner app) with `custom.deeplink.open`, on a client where the remote flag is unset/false (code default). The Live App does not need OS shell; it only needs the deeplink permission.

### Test plan

- [x] Updated `ledger-live-mobile` / `ledger-live-desktop` CustomHandlers unit tests for always-on scheme allowlist
- [x] Local red/green harness: patched path blocks `file://` with flag off; reverted path opens it
- [ ] CI


Made with [Cursor](https://cursor.com)