### PR TITLE
ci(support): add build-and-test-pr swimlane

### DIFF
--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -154,6 +154,16 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-devtools-reusable.yml@develop
     secrets: inherit
 
+  test-support:
+    name: "Test Support"
+    permissions:
+      id-token: write
+      contents: read
+    needs: determine-affected
+    if: ${{contains(needs.determine-affected.outputs.paths, 'support') && !github.event.pull_request.head.repo.fork}}
+    uses: LedgerHQ/ledger-live/.github/workflows/test-support-reusable.yml@develop
+    secrets: inherit
+
   enforce-boundaries:
     name: "Enforce Module Boundaries"
     permissions:
@@ -289,6 +299,7 @@ jobs:
       - test-shared
       - test-domain
       - test-devtools
+      - test-support
       - test-design-system
       - build-web-tools
       - test-cli

--- a/.github/workflows/test-support-reusable.yml
+++ b/.github/workflows/test-support-reusable.yml
@@ -1,0 +1,42 @@
+name: "[Support] - Test - Called"
+
+on:
+  workflow_call:
+    outputs:
+      coverage_generated:
+        value: ${{ jobs.test-support.outputs.coverage_generated }}
+
+    secrets:
+      AWS_ACCOUNT_ID_PROD:
+        required: false
+      AWS_CACHE_OIDC_ROLE_ARN_BRANCH:
+        required: false
+      AWS_CACHE_OIDC_ROLE_ARN_DEVELOP:
+        required: false
+      AWS_CACHE_REGION:
+        required: false
+      AWS_CACHE_ROLE_NAME:
+        required: false
+      NX_KEY:
+        required: false
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: |
+          If you run this manually, and want to run on a PR, the correct ref should be refs/pull/{PR_NUMBER}/merge to
+          have the "normal" scenario involving checking out a merge commit between your branch and the base branch.
+          If you want to run only on a branch or specific commit, you can use either the sha or the branch name instead (prefer the first version for PRs).
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  test-support:
+    name: "Support Test"
+    uses: LedgerHQ/ledger-live/.github/workflows/test-scope-reusable.yml@develop
+    secrets: inherit
+    with:
+      scope: support
+      ref: ${{ inputs.ref || github.sha }}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

## Problem

#20626 unified scope testing behind `test-scope-reusable.yml` and deliberately dropped `support/` from the existing `test-libs-reusable.yml` job. That left the two `@support/*` packages (jest-devtools, jest-features-flow) with no CI checks on PRs that touch them.

## Change

- **New `test-support-reusable.yml`** — thin delegator to `test-scope-reusable.yml` with `scope: support`, matching the pattern introduced in #20626.
- **`build-and-test-pr.yml`** — new `test-support` job gated on `contains(...paths, 'support')`, added to the `ok` gate.

The `scope:support` nx tag is already inferred automatically by the `project-tags` plugin, so no project-level changes are needed. Coverage is a no-op (neither package has a `coverage` script); `typecheck` and `format:check` will run via `nx-codechecks`.

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/31479893765/job/93746328673
Ticket: https://ledgerhq.atlassian.net/browse/LIVE-35675