### PR TITLE
[LWDM] feat(lwd): display contact name in the send header

### DIFF
--- a/.changeset/nervous-moons-repeat.md
+++ b/.changeset/nervous-moons-repeat.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwd): display the contact name and avatar in the send header
+
+The Amount step now shows the matched contact instead of the truncated address, using the shared `ContactAvatar`. The Recipient card moves to the same component, so both steps render the same colour and initials.

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/RecipientHeaderPrefix.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/RecipientHeaderPrefix.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import type { ContactId } from "@domain/entity-contact";
+
+type RecipientHeaderPrefixProps = Readonly<{
+  contact: RecipientHeaderContact | undefined;
+  children: React.ReactNode;
+}>;
+
+export function RecipientHeaderPrefix({ contact, children }: RecipientHeaderPrefixProps) {
+  return (
+    <span className="flex items-center gap-8">
+      {children}
+      {contact && (
+        <ContactAvatar
+          contactId={contact.id as ContactId}
+          name={contact.name}
+          size="xs"
+          ariaHidden
+          testId="send-recipient-contact-avatar"
+        />
+      )}
+    </span>
+  );
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/SendHeader.tsx
@@ -13,6 +13,7 @@ import { useAvailableBalance } from "../hooks/useAvailableBalance";
 import { useSendHeaderMemo } from "../hooks/useSendHeaderMemo";
 import { useSendHeaderModel } from "../hooks/useSendHeaderModel";
 import { AddressDisclaimer } from "./AddressDisclaimer";
+import { RecipientHeaderPrefix } from "./RecipientHeaderPrefix";
 import { MemoTypeSelect } from "../screens/Recipient/components/Memo/MemoTypeSelect";
 import { MemoValueInput } from "../screens/Recipient/components/Memo/MemoValueInput";
 import { SkipMemoSection } from "../screens/Recipient/components/Memo/SkipMemoSection";
@@ -55,6 +56,7 @@ export function SendHeader() {
     handleQrCodeClick,
     handleScanPicked,
     isScannerOpen,
+    recipientContact,
     showBackButton,
     showMemoControls,
     showRecipientInput,
@@ -75,8 +77,13 @@ export function SendHeader() {
             <AddressInput
               className="w-full"
               value={addressInputValue}
+              readOnly
               hideClearButton
-              prefix={t("newSendFlow.to")}
+              prefix={
+                <RecipientHeaderPrefix contact={recipientContact}>
+                  {t("newSendFlow.to")}
+                </RecipientHeaderPrefix>
+              }
               suffix={<AddressDisclaimer />}
             />
             {/* Stops short of the trailing info icon so the disclaimer stays hoverable. */}
@@ -154,6 +161,7 @@ export function SendHeader() {
     showRecipientInput,
     isAmountStep,
     addressInputValue,
+    recipientContact,
     recipientSearch,
     uiConfig.recipientSupportsDomain,
     uiConfig.memoMaxLength,

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { SEND_FLOW_STEP } from "@ledgerhq/live-common/flows/send/types";
+import { SendHeader } from "../SendHeader";
+import { useSendHeaderModel } from "../../hooks/useSendHeaderModel";
+import { useFlowWizard } from "../../../FlowWizard/FlowWizardContext";
+import { useSendFlowData, useSendFlowActions } from "../../context/SendFlowContext";
+
+jest.mock("../../hooks/useSendHeaderModel");
+jest.mock("../../../FlowWizard/FlowWizardContext", () => ({ useFlowWizard: jest.fn() }));
+jest.mock("../../context/SendFlowContext", () => ({
+  useSendFlowData: jest.fn(),
+  useSendFlowActions: jest.fn(),
+}));
+jest.mock("../../hooks/useAvailableBalance", () => ({ useAvailableBalance: () => "" }));
+jest.mock("@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext", () => ({
+  useSendAmountDisplayMode: () => ({ displayMode: "fiat", setDisplayMode: jest.fn() }),
+}));
+jest.mock("../AddressDisclaimer", () => ({ AddressDisclaimer: () => null }));
+jest.mock("@ledgerhq/lumen-ui-react", () => ({
+  ...jest.requireActual("@ledgerhq/lumen-ui-react"),
+  DialogHeader: ({ title }: { title?: string }) => <div>{title}</div>,
+}));
+
+const mockedUseSendHeaderModel = jest.mocked(useSendHeaderModel);
+
+const baseModel = {
+  addressInputValue: "0x123456...12345678",
+  descriptionText: "Base 1 · $5,969.83",
+  handleBack: jest.fn(),
+  handleRecipientInputClick: jest.fn(),
+  handleRecipientInputChange: jest.fn(),
+  handleQrCodeClick: jest.fn(),
+  handleScanPicked: jest.fn(),
+  isScannerOpen: false,
+  recipientContact: undefined,
+  showBackButton: true,
+  showRecipientInput: true,
+  showMemoControls: false,
+  title: "Send ETH",
+  transactionErrorName: undefined,
+  transactionError: undefined,
+};
+
+describe("SendHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFlowWizard as jest.Mock).mockReturnValue({
+      currentStep: SEND_FLOW_STEP.AMOUNT,
+      currentStepConfig: { addressInput: true },
+      navigation: { goToNextStep: jest.fn() },
+    });
+    (useSendFlowData as jest.Mock).mockReturnValue({
+      state: {
+        account: { account: null, parentAccount: null, currency: null },
+        recipient: null,
+        transaction: { status: {} },
+      },
+      uiConfig: { hasMemo: false },
+      recipientSearch: { value: "", setValue: jest.fn(), clear: jest.fn() },
+    });
+    (useSendFlowActions as jest.Mock).mockReturnValue({
+      close: jest.fn(),
+      transaction: { setRecipient: jest.fn(), updateTransaction: jest.fn() },
+    });
+  });
+
+  it("shows the contact avatar and name when the recipient is a contact", () => {
+    mockedUseSendHeaderModel.mockReturnValue({
+      ...baseModel,
+      addressInputValue: "Benoit Jean",
+      recipientContact: { id: "contact-benoit", name: "Benoit Jean" },
+    });
+
+    render(<SendHeader />);
+
+    expect(screen.getByTestId("send-recipient-contact-avatar")).toHaveTextContent("BJ");
+    expect(screen.getByDisplayValue("Benoit Jean")).toBeVisible();
+  });
+
+  it("falls back to the address input when the recipient is not a contact", () => {
+    mockedUseSendHeaderModel.mockReturnValue(baseModel);
+
+    render(<SendHeader />);
+
+    expect(screen.queryByTestId("send-recipient-contact-avatar")).toBeNull();
+    expect(screen.getByDisplayValue("0x123456...12345678")).toBeVisible();
+  });
+
+  it.each([
+    ["a contact", { id: "contact-benoit", name: "Benoit Jean" }],
+    ["a plain address", undefined],
+  ])("goes back to the recipient step when clicking the header showing %s", (_, contact) => {
+    const handleRecipientInputClick = jest.fn();
+    mockedUseSendHeaderModel.mockReturnValue({
+      ...baseModel,
+      recipientContact: contact,
+      handleRecipientInputClick,
+    });
+
+    render(<SendHeader />);
+    screen.getByTestId("send-edit-recipient-button").click();
+
+    expect(handleRecipientInputClick).toHaveBeenCalled();
+  });
+
+  it("keeps the recipient field read-only on the amount step", () => {
+    mockedUseSendHeaderModel.mockReturnValue(baseModel);
+
+    render(<SendHeader />);
+
+    expect(screen.getByDisplayValue("0x123456...12345678")).toHaveAttribute("readonly");
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/__tests__/useSendHeaderModel.test.tsx
@@ -18,6 +18,10 @@ jest.mock("~/renderer/analytics/segment", () => ({
   track: jest.fn(),
   trackPage: jest.fn(),
 }));
+jest.mock("LLD/hooks/redux");
+jest.mock("@features/flow-contacts", () => ({
+  useContactsFeature: jest.fn(() => ({ isEnabled: false })),
+}));
 jest.mock("@ledgerhq/live-common/currencies/index", () => ({
   ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
   decodeURIScheme: jest.fn(),
@@ -29,6 +33,8 @@ import { useMaybeAccountName } from "~/renderer/reducers/wallet";
 import { track } from "~/renderer/analytics/segment";
 import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
 import { RecipientScannerProvider } from "../../context/RecipientScannerContext";
+import { useSelector } from "LLD/hooks/redux";
+import { useContactsFeature } from "@features/flow-contacts";
 
 type VM = ReturnType<typeof useSendHeaderModel>;
 let container: HTMLElement;
@@ -159,6 +165,61 @@ describe("useSendHeaderModel", () => {
 
       expect(latestVM?.title).toBe("Send ETH");
       expect(latestVM?.descriptionText).toBe("$5,969.83");
+    });
+  });
+
+  describe("recipient address input value on amount step", () => {
+    const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+    const CONTACT = {
+      id: "contact-benoit",
+      isMe: false,
+      name: "Benoit Jean",
+      addresses: [{ id: "address-1", currencyId: "ethereum", label: "Eth main", address: ADDRESS }],
+    };
+
+    const renderOnAmountStep = () => {
+      mockNavigation();
+      mockActions();
+      mockData({
+        account: { currency: { ticker: "ETH", id: "ethereum" }, account: {} },
+        recipient: { address: ADDRESS },
+        transaction: { status: {} },
+      });
+
+      renderHook();
+    };
+
+    it("shows the contact name when the recipient is a contact", () => {
+      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: true });
+      jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
+
+      renderOnAmountStep();
+
+      expect(latestVM?.recipientContact).toEqual({
+        id: "contact-benoit",
+        name: "Benoit Jean",
+      });
+      expect(latestVM?.addressInputValue).toBe("Benoit Jean");
+    });
+
+    it("shows the formatted address when the recipient is not a contact", () => {
+      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: true });
+      jest.mocked(useSelector).mockReturnValue([] as never);
+
+      renderOnAmountStep();
+
+      expect(latestVM?.recipientContact).toBeUndefined();
+      expect(latestVM?.addressInputValue).toBe("0x123456...12345678");
+    });
+
+    it("shows the formatted address when the contacts feature is disabled", () => {
+      (useContactsFeature as jest.Mock).mockReturnValue({ isEnabled: false });
+      jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
+
+      renderOnAmountStep();
+
+      expect(latestVM?.recipientContact).toBeUndefined();
+      expect(latestVM?.addressInputValue).toBe("0x123456...12345678");
     });
   });
 

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/hooks/useSendHeaderModel.ts
@@ -3,10 +3,12 @@ import { decodeURIScheme } from "@ledgerhq/live-common/currencies/index";
 import { t } from "i18next";
 import { useMemo, useCallback, useRef } from "react";
 import { useFlowWizard } from "../../FlowWizard/FlowWizardContext";
-import {
-  getRecipientDisplayValue,
-  getRecipientSearchPrefillValue,
-} from "@ledgerhq/live-common/flows/send/utils";
+import { getRecipientSearchPrefillValue } from "@ledgerhq/live-common/flows/send/utils";
+import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { useContactsFeature } from "@features/flow-contacts";
+import { selectContacts } from "@domain/entity-contact";
+import { useSelector } from "LLD/hooks/redux";
 import { buildTransactionPatchFromURIScheme } from "@ledgerhq/live-common/flows/send/utils/uriScheme";
 import {
   SendFlowBusinessContext,
@@ -33,6 +35,7 @@ type UseSendHeaderModelResult = Readonly<{
   handleQrCodeClick: () => void;
   handleScanPicked: (code: string) => void;
   isScannerOpen: boolean;
+  recipientContact: RecipientHeaderContact | undefined;
   showBackButton: boolean;
   showRecipientInput: boolean;
   showMemoControls: boolean;
@@ -49,6 +52,8 @@ export function useSendHeaderModel({
   const { state, uiConfig, recipientSearch, isRecipientAddressComplete } = useSendFlowData();
   const { close, transaction } = useSendFlowActions();
   const { isScannerOpen, closeScanner, toggleScanner } = useRecipientScanner();
+  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("desktop");
+  const contacts = useSelector(selectContacts);
 
   const currencyName = state.account.currency?.ticker ?? "";
   const accountName = useMaybeAccountName(state.account.account ?? undefined);
@@ -129,11 +134,22 @@ export function useSendHeaderModel({
     }
   }, [backTarget, close, closeScanner, currentStep, navigation, resetViewState, transaction]);
 
+  const recipientHeader = useMemo(
+    () =>
+      getRecipientHeaderPresentation({
+        recipient: state.recipient,
+        contacts,
+        currencyId: state.account.currency?.id,
+        isContactsFeatureEnabled: isContactsFeatureEnabled && isAmountStep,
+      }),
+    [contacts, isAmountStep, isContactsFeatureEnabled, state.account.currency?.id, state.recipient],
+  );
+
   const addressInputValue = useMemo(() => {
     if (isRecipientStep) return recipientSearch.value;
-    if (isAmountStep) return getRecipientDisplayValue(state.recipient);
+    if (isAmountStep) return recipientHeader.label;
     return recipientSearch.value;
-  }, [isRecipientStep, isAmountStep, recipientSearch.value, state.recipient]);
+  }, [isRecipientStep, isAmountStep, recipientHeader.label, recipientSearch.value]);
 
   const handleRecipientInputClick = useCallback(() => {
     if (!isAmountStep) return;
@@ -194,6 +210,7 @@ export function useSendHeaderModel({
     handleQrCodeClick,
     handleScanPicked,
     isScannerOpen: showScanner,
+    recipientContact: recipientHeader.contact,
     showBackButton,
     showMemoControls,
     showRecipientInput,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/RecipientContactRow.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/RecipientContactRow.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Text, View } from "react-native";
+import { useStyleSheet } from "@ledgerhq/lumen-ui-rnative/styles";
+import { ContactAvatar } from "@features/platform-contacts";
+import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import type { ContactId } from "@domain/entity-contact";
+
+import { AddressDisclaimer } from "./AddressDisclaimer";
+
+type RecipientContactRowProps = Readonly<{
+  contact: RecipientHeaderContact;
+  label: string;
+  value: string;
+}>;
+
+export function RecipientContactRow({ contact, label, value }: RecipientContactRowProps) {
+  const styles = useStyleSheet(
+    theme => ({
+      row: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: theme.spacings.s8,
+        minHeight: theme.sizes.s48,
+        paddingHorizontal: theme.spacings.s16,
+        borderRadius: theme.borderRadius.sm,
+        backgroundColor: theme.colors.bg.muted,
+      },
+      prefix: {
+        ...theme.typographies.body1,
+        color: theme.colors.text.base,
+      },
+      name: {
+        ...theme.typographies.body1,
+        flex: 1,
+        color: theme.colors.text.base,
+      },
+    }),
+    [],
+  );
+
+  return (
+    <View style={styles.row} testID="recipient-contact-row">
+      <Text style={styles.prefix}>{label}</Text>
+      <ContactAvatar
+        contactId={contact.id as ContactId}
+        name={contact.name}
+        size="xs"
+        testID="recipient-contact-avatar"
+      />
+      <Text style={styles.name} numberOfLines={1}>
+        {value}
+      </Text>
+      <AddressDisclaimer />
+    </View>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/SendHeader.tsx
@@ -16,6 +16,7 @@ import { Close } from "@ledgerhq/lumen-ui-rnative/symbols";
 import { useTranslation } from "~/context/Locale";
 
 import { AddressDisclaimer } from "./AddressDisclaimer";
+import { RecipientContactRow } from "./RecipientContactRow";
 import { useSendHeaderViewModel } from "../hooks/useSendHeaderViewModel";
 import { useSendFlowData } from "../context/SendFlowContext";
 import { track, usePageNameFromRoute } from "~/analytics";
@@ -121,15 +122,23 @@ export function SendHeader({ headerRight }: SendHeaderProps) {
             />
           ) : (
             <>
-              <AddressInput
-                prefix={t("send.newSendFlow.to")}
-                value={viewModel.formattedAddress}
-                editable={false}
-                hideClearButton
-                placeholder={viewModel.recipientPlaceholder}
-                inputStyle={styles.addressValue}
-                suffix={<AddressDisclaimer />}
-              />
+              {viewModel.recipientContact ? (
+                <RecipientContactRow
+                  contact={viewModel.recipientContact}
+                  label={t("send.newSendFlow.to")}
+                  value={viewModel.formattedAddress}
+                />
+              ) : (
+                <AddressInput
+                  prefix={t("send.newSendFlow.to")}
+                  value={viewModel.formattedAddress}
+                  editable={false}
+                  hideClearButton
+                  placeholder={viewModel.recipientPlaceholder}
+                  inputStyle={styles.addressValue}
+                  suffix={<AddressDisclaimer />}
+                />
+              )}
               <Pressable
                 style={styles.editOverlay}
                 accessibilityRole="button"

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/components/__tests__/SendHeader.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { fireEvent, render as rntlRender, screen } from "@testing-library/react-native";
+import { ThemeProvider } from "@ledgerhq/lumen-ui-rnative";
+import { ledgerLiveThemes } from "@ledgerhq/lumen-design-core";
+
+import { SendHeader } from "../SendHeader";
+import { useSendHeaderViewModel } from "../../hooks/useSendHeaderViewModel";
+import { useSendFlowData } from "../../context/SendFlowContext";
+
+jest.mock("../../hooks/useSendHeaderViewModel");
+jest.mock("../../context/SendFlowContext");
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+jest.mock("~/analytics", () => ({
+  useAnalytics: () => ({ track: jest.fn() }),
+  usePageNameFromRoute: () => "step amount",
+  track: jest.fn(),
+}));
+jest.mock("../AddressDisclaimer", () => ({ AddressDisclaimer: () => null }));
+
+function render(ui: React.ReactElement) {
+  return rntlRender(
+    <ThemeProvider themes={ledgerLiveThemes} colorScheme="dark">
+      {ui}
+    </ThemeProvider>,
+  );
+}
+
+const mockedUseSendHeaderViewModel = jest.mocked(useSendHeaderViewModel);
+const mockedUseSendFlowData = jest.mocked(useSendFlowData);
+
+const baseViewModel = {
+  title: "Send ETH",
+  descriptionText: "Base 1 · $5,969.83",
+  showTitle: true,
+  showHeaderRight: true,
+  canGoBack: true,
+  isRecipientStep: false,
+  isAmountStep: true,
+  showRecipientInput: true,
+  recipientSearch: { value: "", setValue: jest.fn(), clear: jest.fn() },
+  formattedAddress: "0x123456...12345678",
+  recipientContact: undefined,
+  recipientPlaceholder: "placeholder",
+  handleBackPress: jest.fn(),
+  handleClose: jest.fn(),
+  handleRecipientInputPress: jest.fn(),
+  setRecipientSearchValue: jest.fn(),
+  clearRecipientSearch: jest.fn(),
+  handleQrCodeClick: jest.fn(),
+};
+
+describe("SendHeader", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSendFlowData.mockReturnValue({
+      state: { account: { account: null, parentAccount: null } },
+    } as never);
+  });
+
+  it("shows the contact avatar and name when the recipient is a contact", () => {
+    mockedUseSendHeaderViewModel.mockReturnValue({
+      ...baseViewModel,
+      formattedAddress: "Benoit Jean",
+      recipientContact: { id: "contact-benoit", name: "Benoit Jean" },
+    });
+
+    render(<SendHeader />);
+
+    expect(screen.getByTestId("recipient-contact-avatar")).toBeVisible();
+    expect(screen.getByText("BJ")).toBeVisible();
+    expect(screen.getByText("Benoit Jean")).toBeVisible();
+  });
+
+  it("falls back to the address input when the recipient is not a contact", () => {
+    mockedUseSendHeaderViewModel.mockReturnValue(baseViewModel);
+
+    render(<SendHeader />);
+
+    expect(screen.queryByTestId("recipient-contact-row")).toBeNull();
+    expect(screen.getByDisplayValue("0x123456...12345678")).toBeVisible();
+  });
+
+  it.each([
+    ["a contact", { id: "contact-benoit", name: "Benoit Jean" }],
+    ["a plain address", undefined],
+  ])("goes back to the recipient step when pressing the header showing %s", (_, contact) => {
+    const handleRecipientInputPress = jest.fn();
+    mockedUseSendHeaderViewModel.mockReturnValue({
+      ...baseViewModel,
+      recipientContact: contact,
+      handleRecipientInputPress,
+    });
+
+    render(<SendHeader />);
+    fireEvent.press(screen.getByLabelText("send.newSendFlow.editRecipientAccessibilityLabel"));
+
+    expect(handleRecipientInputPress).toHaveBeenCalled();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/__tests__/useSendHeaderViewModel.test.ts
@@ -11,6 +11,8 @@ import { useSendAmountDisplayMode } from "@ledgerhq/live-common/flows/send/amoun
 import { useAvailableBalance } from "../useAvailableBalance";
 import { useCurrentSendFlowStep } from "../useCurrentSendFlowStep";
 import { useSendHeaderViewModel } from "../useSendHeaderViewModel";
+import { useSelector } from "~/context/hooks";
+import { useContactsFeature } from "@features/flow-contacts";
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: jest.fn(),
@@ -26,6 +28,10 @@ jest.mock("../../context/SendFlowContext");
 jest.mock("@ledgerhq/live-common/flows/send/amount/SendAmountDisplayModeContext");
 jest.mock("../useAvailableBalance");
 jest.mock("../useCurrentSendFlowStep");
+jest.mock("~/context/hooks");
+jest.mock("@features/flow-contacts", () => ({
+  useContactsFeature: jest.fn(() => ({ isEnabled: false })),
+}));
 
 const mockedUseNavigation = jest.mocked(useNavigation);
 const mockedUseMaybeAccountName = jest.mocked(useMaybeAccountName);
@@ -249,5 +255,77 @@ describe("useSendHeaderViewModel", () => {
       }),
     );
     expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  describe("recipient display on the amount step", () => {
+    const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+    const CONTACT = {
+      id: "contact-benoit",
+      isMe: false,
+      name: "Benoit Jean",
+      addresses: [{ id: "address-1", currencyId: "ethereum", label: "Eth main", address: ADDRESS }],
+    };
+
+    const mockAmountStep = () => {
+      mockedUseCurrentSendFlowStep.mockReturnValue([
+        SEND_FLOW_STEP.AMOUNT,
+        {
+          id: SEND_FLOW_STEP.AMOUNT,
+          addressInput: true,
+          canGoBack: true,
+          showTitle: true,
+          showHeaderRight: true,
+        },
+      ]);
+      mockedUseSendFlowData.mockReturnValue({
+        uiConfig: { recipientSupportsDomain: true },
+        recipientSearch: mockRecipientSearch,
+        state: {
+          account: {
+            account: mockAccount,
+            parentAccount: null,
+            currency: { ...mockAccount.currency, id: "ethereum" },
+          },
+          transaction: { transaction: { recipient: ADDRESS }, status: {} },
+          recipient: { address: ADDRESS },
+        },
+      } as never);
+    };
+
+    it("shows the contact name when the recipient is a contact", () => {
+      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: true } as never);
+      jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
+      mockAmountStep();
+
+      const { result } = renderHook(() => useSendHeaderViewModel());
+
+      expect(result.current.recipientContact).toEqual({
+        id: "contact-benoit",
+        name: "Benoit Jean",
+      });
+      expect(result.current.formattedAddress).toBe("Benoit Jean");
+    });
+
+    it("shows the formatted address when the recipient is not a contact", () => {
+      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: true } as never);
+      jest.mocked(useSelector).mockReturnValue([] as never);
+      mockAmountStep();
+
+      const { result } = renderHook(() => useSendHeaderViewModel());
+
+      expect(result.current.recipientContact).toBeUndefined();
+      expect(result.current.formattedAddress).toBe("0x123456...12345678");
+    });
+
+    it("shows the formatted address when the contacts feature is disabled", () => {
+      jest.mocked(useContactsFeature).mockReturnValue({ isEnabled: false } as never);
+      jest.mocked(useSelector).mockReturnValue([CONTACT] as never);
+      mockAmountStep();
+
+      const { result } = renderHook(() => useSendHeaderViewModel());
+
+      expect(result.current.recipientContact).toBeUndefined();
+      expect(result.current.formattedAddress).toBe("0x123456...12345678");
+    });
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/hooks/useSendHeaderViewModel.ts
@@ -16,10 +16,14 @@ import { useSendFlowData, useSendFlowActions } from "../context/SendFlowContext"
 import { useAvailableBalance } from "./useAvailableBalance";
 import { useCurrentSendFlowStep } from "./useCurrentSendFlowStep";
 import {
-  getRecipientDisplayValue,
   getRecipientSearchPrefillValue,
   SEND_ADDRESS_FORMAT_OPTIONS,
 } from "@ledgerhq/live-common/flows/send/utils";
+import { getRecipientHeaderPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import type { RecipientHeaderContact } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientHeaderPresentation";
+import { useContactsFeature } from "@features/flow-contacts";
+import { selectContacts } from "@domain/entity-contact";
+import { useSelector } from "~/context/hooks";
 import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
 import type { SendFlowNavigationProp } from "../types";
 
@@ -38,6 +42,7 @@ export type SendHeaderViewModel = {
     clear: () => void;
   };
   formattedAddress: string;
+  recipientContact: RecipientHeaderContact | undefined;
   recipientPlaceholder: string;
   handleBackPress: () => void;
   handleClose: () => void;
@@ -54,6 +59,8 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
   const { close, transaction, setRecipientSearchValue, clearRecipientSearch } =
     useSendFlowActions();
   const { displayMode } = useSendAmountDisplayMode();
+  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
+  const contacts = useSelector(selectContacts);
 
   const accountName = useMaybeAccountName(state.account.account);
   const [currentStep, currentStepConfig] = useCurrentSendFlowStep();
@@ -91,15 +98,32 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
     return { address } as const;
   }, [state.transaction.transaction?.recipient]);
 
+  const recipientHeader = useMemo(
+    () =>
+      getRecipientHeaderPresentation({
+        recipient: recipientFromTransaction,
+        contacts,
+        currencyId: state.account.currency?.id,
+        isContactsFeatureEnabled: isContactsFeatureEnabled && isAmountStep,
+      }),
+    [
+      contacts,
+      isAmountStep,
+      isContactsFeatureEnabled,
+      recipientFromTransaction,
+      state.account.currency?.id,
+    ],
+  );
+
   const formattedAddress = useMemo(() => {
     if (isRecipientStep) {
       return formatAddress(recipientSearch.value, SEND_ADDRESS_FORMAT_OPTIONS);
     }
     if (isAmountStep) {
-      return getRecipientDisplayValue(recipientFromTransaction);
+      return recipientHeader.label;
     }
     return "";
-  }, [isRecipientStep, isAmountStep, recipientSearch.value, recipientFromTransaction]);
+  }, [isRecipientStep, isAmountStep, recipientHeader.label, recipientSearch.value]);
 
   const handleBackPress = useCallback(() => {
     if (canGoBack) {
@@ -181,6 +205,7 @@ export function useSendHeaderViewModel(): SendHeaderViewModel {
     showRecipientInput,
     recipientSearch,
     formattedAddress,
+    recipientContact: recipientHeader.contact,
     recipientPlaceholder,
     handleBackPress,
     handleClose,

--- a/libs/ledger-live-common/.unimportedrc.json
+++ b/libs/ledger-live-common/.unimportedrc.json
@@ -642,6 +642,7 @@
     "src/flows/send/recipient/types.ts",
     "src/flows/send/recipient/utils/addressesMatch.ts",
     "src/flows/send/recipient/utils/findMatchedContact.ts",
+    "src/flows/send/recipient/utils/getRecipientHeaderPresentation.ts",
     "src/flows/send/recipient/utils/getRecipientMatchPresentation.ts",
     "src/flows/send/recipient/utils/hasContactsOnNetwork.ts",
     "src/flows/send/recipient/utils/memoValue.ts",

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/getRecipientHeaderPresentation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/getRecipientHeaderPresentation.test.ts
@@ -1,0 +1,66 @@
+import { getRecipientHeaderPresentation } from "../getRecipientHeaderPresentation";
+import type { Contact } from "../findMatchedContact";
+
+const ADDRESS = "0x1234567890abcdef1234567890abcdef12345678";
+const FORMATTED_ADDRESS = "0x123456...12345678";
+
+const contacts: readonly Contact[] = [
+  {
+    id: "contact-benoit",
+    isMe: false,
+    name: "Benoit Jean",
+    addresses: [{ id: "address-1", currencyId: "ethereum", label: "Eth main", address: ADDRESS }],
+  },
+];
+
+const baseArgs = {
+  recipient: { address: ADDRESS },
+  contacts,
+  currencyId: "ethereum",
+  isContactsFeatureEnabled: true,
+};
+
+describe("getRecipientHeaderPresentation", () => {
+  it("should return the contact when the address belongs to a contact", () => {
+    expect(getRecipientHeaderPresentation(baseArgs)).toEqual({
+      label: "Benoit Jean",
+      contact: { id: "contact-benoit", name: "Benoit Jean" },
+    });
+  });
+
+  it("should prefer the contact over the ENS name", () => {
+    expect(
+      getRecipientHeaderPresentation({
+        ...baseArgs,
+        recipient: { address: ADDRESS, ensName: "vitalik.eth" },
+      }).label,
+    ).toBe("Benoit Jean");
+  });
+
+  it("should fall back to the formatted address when no contact matches", () => {
+    expect(getRecipientHeaderPresentation({ ...baseArgs, contacts: [] })).toEqual({
+      label: FORMATTED_ADDRESS,
+      contact: undefined,
+    });
+  });
+
+  it("should fall back to the formatted address when the contacts feature is disabled", () => {
+    expect(
+      getRecipientHeaderPresentation({ ...baseArgs, isContactsFeatureEnabled: false }),
+    ).toEqual({ label: FORMATTED_ADDRESS, contact: undefined });
+  });
+
+  it("should fall back to the formatted address when the currency is unknown", () => {
+    expect(getRecipientHeaderPresentation({ ...baseArgs, currencyId: undefined })).toEqual({
+      label: FORMATTED_ADDRESS,
+      contact: undefined,
+    });
+  });
+
+  it("should return an empty label for a null recipient", () => {
+    expect(getRecipientHeaderPresentation({ ...baseArgs, recipient: null })).toEqual({
+      label: "",
+      contact: undefined,
+    });
+  });
+});

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/findMatchedContact.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/findMatchedContact.ts
@@ -2,7 +2,7 @@ import type { MatchedContact } from "../types";
 import { addressesMatch } from "./addressesMatch";
 import { resolveRecipientNetworkId } from "./resolveRecipientNetworkId";
 
-type Contact = Readonly<{
+export type Contact = Readonly<{
   id: string;
   isMe: boolean;
   name: string;

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/getRecipientHeaderPresentation.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/getRecipientHeaderPresentation.ts
@@ -1,0 +1,45 @@
+import type { RecipientData } from "../../types";
+import { getRecipientDisplayValue } from "../../utils";
+import { type Contact, findMatchedContact } from "./findMatchedContact";
+
+type GetRecipientHeaderPresentationArgs = Readonly<{
+  recipient: RecipientData | null;
+  contacts: readonly Contact[];
+  currencyId: string | undefined;
+  isContactsFeatureEnabled: boolean;
+}>;
+
+export type RecipientHeaderContact = Readonly<{
+  id: string;
+  name: string;
+}>;
+
+export type RecipientHeaderPresentation = Readonly<{
+  label: string;
+  contact: RecipientHeaderContact | undefined;
+}>;
+
+export function getRecipientHeaderPresentation({
+  recipient,
+  contacts,
+  currencyId,
+  isContactsFeatureEnabled,
+}: GetRecipientHeaderPresentationArgs): RecipientHeaderPresentation {
+  const address = recipient?.address;
+  const matchedContact =
+    isContactsFeatureEnabled && address && currencyId
+      ? findMatchedContact(contacts, address, currencyId)
+      : undefined;
+
+  if (!matchedContact) {
+    return { label: getRecipientDisplayValue(recipient), contact: undefined };
+  }
+
+  return {
+    label: matchedContact.contactName,
+    contact: {
+      id: matchedContact.contactId,
+      name: matchedContact.contactName,
+    },
+  };
+}


### PR DESCRIPTION
### 📝 Description

On the Amount step, the header showed the truncated recipient address. When that address belongs to an address book contact, it now shows the contact avatar and name. Follow-up to #20646, behind the same feature flag (`lwdContacts` / `lwmContacts`).

| Desktop | Mobile |
|---------|--------|
|<img width="516" height="666" alt="Screenshot 2026-08-11 at 12 35 37" src="https://github.com/user-attachments/assets/a22a9a6b-1958-4a01-89cb-6192affc7c58" /> |<img width="380" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 12 49 47" src="https://github.com/user-attachments/assets/218c6e29-c745-48db-901b-ef955e72bc3e" />|

**How**: one shared pure function, `getRecipientHeaderPresentation` (live-common), decides contact vs address; both headers render it. Contacts come from `useSelector(selectContacts)`, like `useAddressValidation`.

**Still open**

- **This should be a button, not an input.** `AddressInput.prefix` is typed `string`, so Desktop falls back to `BaseInput` and Mobile builds the row by hand. `BaseInput` is going private soon, and design confirms the element acts as a button here, which would remove both workarounds. `AddressInput` is being updated on the Lumen side. Only the Amount step is affected: QR code and validation live on the Recipient step, untouched.

Tested: the shared function, both view models, and both headers including the rendered initials and the click-to-edit affordance.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35752](https://ledgerhq.atlassian.net/browse/LIVE-35752)
- **ADR** (if any):


[LIVE-35752]: https://ledgerhq.atlassian.net/browse/LIVE-35752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
