### PR TITLE
[LWDM] feat(lwd): show recipient action only when no bridge error

### DIFF
--- a/.changeset/five-bears-exercise.md
+++ b/.changeset/five-bears-exercise.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/live-common": minor
+---
+
+feat(lwd): show recipient action only when no bridge error

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -27,13 +27,14 @@ export function AddressMatchedSection({ viewModel }: AddressMatchedSectionProps)
           </SubheaderRow>
         </Subheader>
       )}
-      <div className="-mx-8 flex flex-col">
+      <div className="flex flex-col mb-12 -mt-8">
         {suggestion.kind === "recipient-card" ? (
           <RecipientCard
             recipient={suggestion.recipient}
             description={suggestion.description}
             contact={suggestion.contact}
             isReady={suggestion.isReady}
+            showActions={suggestion.showActions}
             hasAddressBook={suggestion.hasAddressBook}
             addressBookUnsupportedLabel={suggestion.addressBookUnsupportedLabel}
             addContactLabel={suggestion.addContactLabel}

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -20,6 +20,7 @@ type RecipientCardProps = Readonly<{
   description?: string;
   contact?: MatchedContact;
   isReady: boolean;
+  showActions: boolean;
   hasAddressBook: boolean;
   addressBookUnsupportedLabel: string;
   addContactLabel: string;
@@ -42,6 +43,7 @@ export function RecipientCard({
   description,
   contact,
   isReady,
+  showActions,
   hasAddressBook,
   addressBookUnsupportedLabel,
   addContactLabel,
@@ -62,7 +64,7 @@ export function RecipientCard({
 
   return (
     <Card data-testid="send-recipient-card">
-      <CardHeader>
+      <CardHeader className={showActions ? undefined : "pb-16"}>
         <CardLeading>
           {contact ? (
             <div
@@ -87,29 +89,31 @@ export function RecipientCard({
         </CardLeading>
       </CardHeader>
 
-      <div className="flex gap-8 px-16 pb-16">
-        {!contact &&
-          (!isReady || hasAddressBook ? (
-            <div className="flex-1">{addContactButton}</div>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="flex flex-1">{addContactButton}</span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{addressBookUnsupportedLabel}</TooltipContent>
-            </Tooltip>
-          ))}
-        <Button
-          appearance="base"
-          size="sm"
-          className="flex-1"
-          onClick={onSend}
-          disabled={!isReady}
-          data-testid="send-recipient-card-send"
-        >
-          {sendLabel}
-        </Button>
-      </div>
+      {showActions && (
+        <div className="flex gap-8 px-16 pb-16">
+          {!contact &&
+            (!isReady || hasAddressBook ? (
+              <div className="flex-1">{addContactButton}</div>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="flex flex-1">{addContactButton}</span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{addressBookUnsupportedLabel}</TooltipContent>
+              </Tooltip>
+            ))}
+          <Button
+            appearance="base"
+            size="sm"
+            className="flex-1"
+            onClick={onSend}
+            disabled={!isReady}
+            data-testid="send-recipient-card-send"
+          >
+            {sendLabel}
+          </Button>
+        </div>
+      )}
     </Card>
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -20,17 +20,23 @@ function AddressMatchedSectionContainer({
   isContactsFeatureEnabled,
   hasAddressBook,
   isAddressComplete = true,
+  hasBridgeError = false,
+  isSanctioned = false,
 }: Readonly<{
   searchResult: AddressSearchResult;
   isContactsFeatureEnabled?: boolean;
   hasAddressBook?: boolean;
   isAddressComplete?: boolean;
+  hasBridgeError?: boolean;
+  isSanctioned?: boolean;
 }>) {
   const viewModel = useAddressMatchedSectionViewModel({
     searchResult,
     searchValue: address,
     onSelect: jest.fn(),
     isAddressComplete,
+    hasBridgeError,
+    isSanctioned,
     isContactsFeatureEnabled,
     hasAddressBook,
     addressBookFamilyName: "Ethereum",
@@ -46,12 +52,16 @@ function renderAddressMatchedSection(
     isContactsFeatureEnabled?: boolean;
     hasAddressBook?: boolean;
     isAddressComplete?: boolean;
+    hasBridgeError?: boolean;
+    isSanctioned?: boolean;
   },
 ) {
   return render(
     <AddressMatchedSectionContainer
       searchResult={searchResult}
       isAddressComplete={options?.isAddressComplete ?? true}
+      hasBridgeError={options?.hasBridgeError ?? false}
+      isSanctioned={options?.isSanctioned ?? false}
       isContactsFeatureEnabled={options?.isContactsFeatureEnabled}
       hasAddressBook={options?.hasAddressBook}
     />,
@@ -213,6 +223,203 @@ describe("AddressMatchedSection", () => {
     expect(screen.getByText("vitalik.eth")).toBeInTheDocument();
     expect(screen.getByText(address)).toBeInTheDocument();
     expect(screen.getByTestId("send-recipient-card-add-contact")).toBeEnabled();
+  });
+
+  it("hides recipient card actions when a bridge error is present", () => {
+    const searchResult: AddressSearchResult = {
+      status: "valid",
+      error: null,
+      resolvedAddress: address,
+      ensName: "vitalik.eth",
+      isLedgerAccount: false,
+      accountName: undefined,
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: false,
+      matchedRecentAddress: undefined,
+      matchedAccounts: [],
+      matchedContact: undefined,
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      isContactsFeatureEnabled: true,
+      hasAddressBook: true,
+      hasBridgeError: true,
+    });
+
+    expect(screen.getByTestId("send-recipient-card")).toBeInTheDocument();
+    expect(screen.getByText(address)).toBeInTheDocument();
+    expect(screen.queryByText("vitalik.eth")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-address-matched-title")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-recipient-card-send")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-recipient-card-add-contact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-matched-address-button")).not.toBeInTheDocument();
+  });
+
+  it("shows the recipient card instead of a legacy disabled row when a bridge error is present and Contacts is enabled", () => {
+    const searchResult: AddressSearchResult = {
+      status: "valid",
+      error: null,
+      resolvedAddress: address,
+      ensName: undefined,
+      isLedgerAccount: true,
+      accountName: "Ethereum 2",
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: false,
+      matchedRecentAddress: {
+        address,
+        currency: createMockCurrency({
+          id: "ethereum",
+          name: "Ethereum",
+          ticker: "ETH",
+        }),
+        lastUsedAt: new Date("2026-07-31T09:57:00.000Z"),
+        name: address,
+        isLedgerAccount: true,
+        accountId: "account_2",
+      },
+      matchedAccounts: [
+        {
+          account: createMockAccount({
+            id: "account_2",
+            freshAddress: address,
+          }),
+          accountName: undefined,
+          accountBalance: undefined,
+          accountBalanceFormatted: undefined,
+        },
+      ],
+      matchedContact: undefined,
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      isContactsFeatureEnabled: true,
+      hasBridgeError: true,
+    });
+
+    expect(screen.getByTestId("send-recipient-card")).toBeInTheDocument();
+    expect(screen.getByText(address)).toBeInTheDocument();
+    expect(screen.queryByTestId("send-address-matched-title")).not.toBeInTheDocument();
+    expect(screen.queryByText("Send to Ethereum 2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-matched-address-button")).not.toBeInTheDocument();
+  });
+
+  it("keeps the legacy disabled row when a bridge error is present and Contacts is disabled", () => {
+    const searchResult: AddressSearchResult = {
+      status: "valid",
+      error: null,
+      resolvedAddress: address,
+      ensName: undefined,
+      isLedgerAccount: true,
+      accountName: "Ethereum 2",
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: false,
+      matchedRecentAddress: {
+        address,
+        currency: createMockCurrency({
+          id: "ethereum",
+          name: "Ethereum",
+          ticker: "ETH",
+        }),
+        lastUsedAt: new Date("2026-07-31T09:57:00.000Z"),
+        name: address,
+        isLedgerAccount: true,
+        accountId: "account_2",
+      },
+      matchedAccounts: [
+        {
+          account: createMockAccount({
+            id: "account_2",
+            freshAddress: address,
+          }),
+          accountName: undefined,
+          accountBalance: undefined,
+          accountBalanceFormatted: undefined,
+        },
+      ],
+      matchedContact: undefined,
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      isContactsFeatureEnabled: false,
+      hasBridgeError: true,
+    });
+
+    expect(screen.queryByTestId("send-recipient-card")).not.toBeInTheDocument();
+    expect(screen.getByTestId("send-address-matched-title")).toBeInTheDocument();
+    expect(screen.getByTestId("send-matched-address-button")).toBeInTheDocument();
+  });
+
+  it("shows the recipient card without actions for a sanctioned address when Contacts is enabled", () => {
+    const searchResult: AddressSearchResult = {
+      status: "sanctioned",
+      error: "sanctioned",
+      resolvedAddress: address,
+      ensName: undefined,
+      isLedgerAccount: false,
+      accountName: undefined,
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: false,
+      matchedRecentAddress: undefined,
+      matchedAccounts: [],
+      matchedContact: undefined,
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      isContactsFeatureEnabled: true,
+      isSanctioned: true,
+    });
+
+    expect(screen.getByTestId("send-recipient-card")).toBeInTheDocument();
+    expect(screen.getByText(address)).toBeInTheDocument();
+    expect(screen.queryByTestId("send-address-matched-title")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-recipient-card-send")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-recipient-card-add-contact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-matched-address-button")).not.toBeInTheDocument();
+  });
+
+  it("keeps the legacy disabled row for a sanctioned address when Contacts is disabled", () => {
+    const searchResult: AddressSearchResult = {
+      status: "sanctioned",
+      error: "sanctioned",
+      resolvedAddress: address,
+      ensName: undefined,
+      isLedgerAccount: false,
+      accountName: undefined,
+      accountBalance: undefined,
+      accountBalanceFormatted: undefined,
+      isFirstInteraction: false,
+      matchedRecentAddress: undefined,
+      matchedAccounts: [],
+      matchedContact: undefined,
+      bridgeErrors: undefined,
+      bridgeWarnings: undefined,
+      hasBridgeValidationResult: true,
+    };
+
+    renderAddressMatchedSection(searchResult, {
+      isContactsFeatureEnabled: false,
+      isSanctioned: true,
+    });
+
+    expect(screen.queryByTestId("send-recipient-card")).not.toBeInTheDocument();
+    expect(screen.getByTestId("send-address-matched-title")).toBeInTheDocument();
+    expect(screen.getByTestId("send-matched-address-button")).toBeInTheDocument();
   });
 
   it("keeps the new ENS card visible while bridge validation is pending", () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
@@ -38,6 +38,7 @@ type RecipientCardSuggestion = Readonly<{
   description?: string;
   contact?: MatchedContact;
   isReady: boolean;
+  showActions: boolean;
   hasAddressBook: boolean;
   addressBookUnsupportedLabel: string;
   addContactLabel: string;
@@ -69,6 +70,33 @@ export function useAddressMatchedSectionViewModel({
   const isFirstInteractionBannerEnabled =
     useFeature("newSendFlowFirstInteractionBanner")?.enabled ?? false;
   const addressMatchedLabel = t("newSendFlow.addressMatched");
+  const recipientAddress = searchResult.resolvedAddress ?? searchValue;
+  const shouldShowErrorRecipientCard =
+    isContactsFeatureEnabled && isAddressComplete && (hasBridgeError || isSanctioned);
+
+  if (shouldShowErrorRecipientCard) {
+    return {
+      isVisible: true,
+      showHeader: false,
+      addressMatchedLabel,
+      suggestion: {
+        kind: "recipient-card",
+        recipient: recipientAddress,
+        contact: undefined,
+        isReady: false,
+        showActions: false,
+        hasAddressBook,
+        addressBookUnsupportedLabel: t("newSendFlow.addressBookUnsupported", {
+          family: addressBookFamilyName,
+        }),
+        addContactLabel: t("contacts.addContact"),
+        sendLabel: t("contacts.addressDetail.send"),
+        onSend: () => onSelect(recipientAddress, searchResult.ensName),
+      },
+      showFirstInteractionWarning: false,
+    };
+  }
+
   const presentation = getRecipientMatchPresentation({
     searchResult,
     searchValue,
@@ -123,6 +151,7 @@ export function useAddressMatchedSectionViewModel({
             : getAlreadyUsedDescription(presentation.matchedRecentAddress?.lastUsedAt),
           contact: presentation.matchedContact,
           isReady: presentation.isReady,
+          showActions: !hasBridgeError,
           hasAddressBook,
           addressBookUnsupportedLabel: t("newSendFlow.addressBookUnsupported", {
             family: addressBookFamilyName,

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/getRecipientMatchPresentation.test.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/__tests__/getRecipientMatchPresentation.test.ts
@@ -117,6 +117,29 @@ describe("getRecipientMatchPresentation", () => {
     });
   });
 
+  it("returns a recipient card for a bridge error when Contacts is enabled", () => {
+    expect(
+      getRecipientMatchPresentation({
+        searchResult: createSearchResult({
+          ensName: "vitalik.eth",
+          resolvedAddress: address,
+          status: "ens_resolved",
+        }),
+        searchValue: address,
+        isAddressComplete: true,
+        hasBridgeError: true,
+        isContactsFeatureEnabled: true,
+      }),
+    ).toEqual({
+      kind: "recipient-card",
+      recipientAddress: address,
+      ensName: "vitalik.eth",
+      matchedContact: undefined,
+      matchedRecentAddress: undefined,
+      isReady: false,
+    });
+  });
+
   it("returns a valid-address presentation after an unmatched address is complete", () => {
     expect(
       getRecipientMatchPresentation({

--- a/libs/ledger-live-common/src/flows/send/recipient/utils/getRecipientMatchPresentation.ts
+++ b/libs/ledger-live-common/src/flows/send/recipient/utils/getRecipientMatchPresentation.ts
@@ -109,7 +109,6 @@ export function getRecipientMatchPresentation({
   const shouldRenderRecipientCard =
     isContactsFeatureEnabled &&
     !isSanctioned &&
-    !hasBridgeError &&
     (hasMatchedContact ||
       hasENS ||
       hasExactMatchedAccount ||


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Hide the actions button if the bridge returns an error because of the recipient address in LWD (recipient step new send flow)

<img width="454" height="465" alt="image" src="https://github.com/user-attachments/assets/3202e90c-e0ed-426a-ba64-13bb9c2d4080" />
<img width="457" height="502" alt="image" src="https://github.com/user-attachments/assets/7dc63f61-c701-4468-a87b-703a0f8c541a" />


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35807)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
