### PR TITLE
[LWM] chore(analytics): lazy onboarding banner traits 

### DIFF
--- a/.changeset/clear-orbit-open.md
+++ b/.changeset/clear-orbit-open.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Expose lazyOnboardingBanner flag enabled state and mode on Segment identify

--- a/apps/ledger-live-mobile/src/analytics/__tests__/segment.lazyOnboardingBanner.test.ts
+++ b/apps/ledger-live-mobile/src/analytics/__tests__/segment.lazyOnboardingBanner.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for lazyOnboardingBanner identify traits via extraProperties → track().
+ */
+import { waitFor } from "@testing-library/react-native";
+import { configureStore } from "@reduxjs/toolkit";
+import type { FeatureId, Features } from "@shared/feature-flags";
+import reducers from "~/reducers";
+import type { AppStore } from "~/reducers";
+import { setAnalytics, setAnalyticsConsentInfo } from "~/actions/settings";
+import * as segment from "../segment";
+
+jest.unmock("../segment");
+
+const { _trackMock: mockTrack } = require("@segment/analytics-react-native") as {
+  _trackMock: jest.Mock;
+};
+
+const analyticsConsentInfo = {
+  consentDate: "2026-04-29T00:00:00.000Z",
+  privacyPolicyVersion: 1,
+};
+
+const makeStore = (): AppStore =>
+  configureStore({
+    reducer: reducers,
+    middleware: getDefaultMiddleware =>
+      getDefaultMiddleware({
+        serializableCheck: false,
+        immutableCheck: false,
+      }),
+  }) as AppStore;
+
+describe("segment lazyOnboardingBanner traits", () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    segment.setAnalyticsFeatureFlagMethod(null);
+    jest.useFakeTimers();
+  });
+
+  let store: AppStore;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = makeStore();
+    store.dispatch(setAnalyticsConsentInfo(analyticsConsentInfo));
+    store.dispatch(setAnalytics(true));
+  });
+
+  it("includes false banner traits when the feature-flag method is unset", async () => {
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({
+          lazyOnboardingBanner: false,
+          lazyOnboardingBannerMode: null,
+        }),
+      ),
+    );
+  });
+
+  it("includes mode only when lazyOnboardingBanner is enabled", async () => {
+    segment.setAnalyticsFeatureFlagMethod(<T extends FeatureId>(key: T): Features[T] | null => {
+      if (key === "lazyOnboardingBanner") {
+        return {
+          enabled: true,
+          params: { mode: "shop_direct", link: "https://shop.ledger.com" },
+        } as Features[T];
+      }
+      return null;
+    });
+
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({
+          lazyOnboardingBanner: true,
+          lazyOnboardingBannerMode: "shop_direct",
+        }),
+      ),
+    );
+  });
+
+  it("omits mode when lazyOnboardingBanner is disabled even if params exist", async () => {
+    segment.setAnalyticsFeatureFlagMethod(<T extends FeatureId>(key: T): Features[T] | null => {
+      if (key === "lazyOnboardingBanner") {
+        return {
+          enabled: false,
+          params: { mode: "feature_intro", link: "https://shop.ledger.com" },
+        } as Features[T];
+      }
+      return null;
+    });
+
+    await segment.start(store);
+    mockTrack.mockClear();
+
+    segment.track("TestEvent", {});
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        "TestEvent",
+        expect.objectContaining({
+          lazyOnboardingBanner: false,
+          lazyOnboardingBannerMode: null,
+        }),
+      ),
+    );
+  });
+});

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -297,9 +297,11 @@ const getLazyOnboardingBannerAttributes = () => {
     return { lazyOnboardingBanner: false, lazyOnboardingBannerMode: null };
   }
   const flag = analyticsFeatureFlagMethod("lazyOnboardingBanner");
+  const enabled = !!flag?.enabled;
   return {
-    lazyOnboardingBanner: !!flag?.enabled,
-    lazyOnboardingBannerMode: flag?.params?.mode ?? null,
+    lazyOnboardingBanner: enabled,
+    // Only expose mode for the enabled cohort — defaults still exist when the flag is off.
+    lazyOnboardingBannerMode: enabled ? (flag?.params?.mode ?? null) : null,
   };
 };
 

--- a/apps/ledger-live-mobile/src/analytics/segment.ts
+++ b/apps/ledger-live-mobile/src/analytics/segment.ts
@@ -292,6 +292,17 @@ const getProductTourAttributes = () => {
   };
 };
 
+const getLazyOnboardingBannerAttributes = () => {
+  if (!analyticsFeatureFlagMethod) {
+    return { lazyOnboardingBanner: false, lazyOnboardingBannerMode: null };
+  }
+  const flag = analyticsFeatureFlagMethod("lazyOnboardingBanner");
+  return {
+    lazyOnboardingBanner: !!flag?.enabled,
+    lazyOnboardingBannerMode: flag?.params?.mode ?? null,
+  };
+};
+
 const getPayTabAttributes = () => {
   if (!analyticsFeatureFlagMethod) return false;
   const payTab = analyticsFeatureFlagMethod("lwmPayTab");
@@ -440,6 +451,7 @@ const extraProperties = async (store: AppStore) => {
 
   const backupHubAttributes = getBackupHubAttributes();
   const productTourAttributes = getProductTourAttributes();
+  const lazyOnboardingBannerAttributes = getLazyOnboardingBannerAttributes();
   const payTabAttributes = getPayTabAttributes();
 
   return {
@@ -478,6 +490,7 @@ const extraProperties = async (store: AppStore) => {
     ...mevProtectionAttributes,
     ...backupHubAttributes,
     ...productTourAttributes,
+    ...lazyOnboardingBannerAttributes,
     migrationToMMKV,
     tokenWithFunds,
     isLDMKTransportEnabled: ldmkTransport?.enabled,

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
@@ -202,9 +202,9 @@ describe("LazyOnboardingTour", () => {
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "close",
+        button: "Close",
         page: LAZY_ONBOARDING_TOUR_PAGE,
-        step: 0,
+        card: 1,
       }),
     );
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
@@ -219,9 +219,9 @@ describe("LazyOnboardingTour", () => {
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "continue",
+        button: "Continue",
         page: LAZY_ONBOARDING_TOUR_PAGE,
-        step: 0,
+        card: 1,
         mode: "feature_intro",
       }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
@@ -204,6 +204,7 @@ describe("LazyOnboardingTour", () => {
       expect.objectContaining({
         button: "close",
         page: LAZY_ONBOARDING_TOUR_PAGE,
+        step: 0,
       }),
     );
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/__integrations__/LazyOnboardingBanner.integration.test.tsx
@@ -199,6 +199,14 @@ describe("LazyOnboardingTour", () => {
 
     await user.press(screen.getByTestId("lazy-onboarding-tour-close-button"));
     expect(screen.queryByText(SLIDE_TITLES[0])).toBeNull();
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "close",
+        page: LAZY_ONBOARDING_TOUR_PAGE,
+      }),
+    );
+    expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
   });
 
   it("should track continue when the primary button is pressed", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/analytics.test.ts
@@ -1,0 +1,95 @@
+import { screen, track } from "~/analytics";
+import {
+  trackLazyOnboardingTourBuyClicked,
+  trackLazyOnboardingTourCloseClicked,
+  trackLazyOnboardingTourContinueClicked,
+  trackLazyOnboardingTourDismissed,
+  trackLazyOnboardingTourDoneClicked,
+  trackLazyOnboardingTourOpened,
+  trackLazyOnboardingTourShopReached,
+  trackLazyOnboardingTourStepViewed,
+  type LazyOnboardingTourSharedAnalyticsProps,
+} from "../analytics";
+import { LAZY_ONBOARDING_TOUR_PAGE, LAZY_ONBOARDING_TOUR_SHOP_PAGE } from "../const";
+
+jest.mock("~/analytics", () => ({
+  screen: jest.fn(),
+  track: jest.fn(),
+}));
+
+const sharedProps: LazyOnboardingTourSharedAnalyticsProps = {
+  hasConnectedDevice: false,
+  personalRecoOptIn: true,
+  offerType: "none",
+  platform: "llm",
+  source: "lazy onboarding",
+  mode: "feature_intro",
+};
+
+describe("LazyOnboardingTour analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("tracks tour open once and ignores duplicate opens", () => {
+    expect(trackLazyOnboardingTourOpened(sharedProps, false)).toBe(true);
+    expect(screen).toHaveBeenCalledWith(LAZY_ONBOARDING_TOUR_PAGE, undefined, {
+      name: "lazy onboarding tour",
+      card: 1,
+      ...sharedProps,
+    });
+
+    expect(trackLazyOnboardingTourOpened(sharedProps, true)).toBe(false);
+    expect(screen).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks product_tour_card for new slides and skips duplicates", () => {
+    expect(trackLazyOnboardingTourStepViewed(1, sharedProps, null)).toBe(1);
+    expect(track).toHaveBeenCalledWith(
+      "product_tour_card",
+      expect.objectContaining({ page: LAZY_ONBOARDING_TOUR_PAGE, card: 2 }),
+    );
+
+    expect(trackLazyOnboardingTourStepViewed(1, sharedProps, 1)).toBe(1);
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks continue, buy, close, dismiss, done, and shop events", () => {
+    trackLazyOnboardingTourContinueClicked(0, sharedProps);
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Continue", card: 1 }),
+    );
+
+    trackLazyOnboardingTourBuyClicked(2, sharedProps);
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Buy a Ledger device", card: 3 }),
+    );
+
+    trackLazyOnboardingTourCloseClicked(1, sharedProps);
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Close", card: 2 }),
+    );
+
+    trackLazyOnboardingTourDismissed(1, sharedProps);
+    expect(track).toHaveBeenCalledWith(
+      "modal_dismissed",
+      expect.objectContaining({ page: LAZY_ONBOARDING_TOUR_PAGE, card: 2 }),
+    );
+
+    trackLazyOnboardingTourDoneClicked(sharedProps);
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Done", page: LAZY_ONBOARDING_TOUR_PAGE }),
+    );
+
+    trackLazyOnboardingTourShopReached(sharedProps);
+    expect(screen).toHaveBeenCalledWith(LAZY_ONBOARDING_TOUR_SHOP_PAGE, undefined, {
+      name: "shop",
+      ...sharedProps,
+      source: "lazy onboarding tour",
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -73,6 +73,7 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
       expect.objectContaining({
         button: "close",
         page: LAZY_ONBOARDING_TOUR_PAGE,
+        step: 0,
       }),
     );
 

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -48,7 +48,7 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
       "modal_dismissed",
       expect.objectContaining({
         page: LAZY_ONBOARDING_TOUR_PAGE,
-        step: 0,
+        card: 1,
         source: "lazy onboarding",
         mode: "feature_intro",
         platform: "llm",
@@ -71,9 +71,9 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "close",
+        button: "Close",
         page: LAZY_ONBOARDING_TOUR_PAGE,
-        step: 0,
+        card: 1,
       }),
     );
 
@@ -98,7 +98,7 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
     expect(track).toHaveBeenCalledWith(
       "button_clicked",
       expect.objectContaining({
-        button: "done",
+        button: "Done",
         page: LAZY_ONBOARDING_TOUR_PAGE,
       }),
     );

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { track } from "~/analytics";
+import { LAZY_ONBOARDING_TOUR_PAGE } from "../const";
+import {
+  __resetLazyOnboardingTourControllerForTests,
+  lazyOnboardingTourController,
+} from "../lazyOnboardingTourController";
+import { useLazyOnboardingTourDrawerViewModel } from "../useLazyOnboardingTourDrawerViewModel";
+
+jest.mock("~/analytics", () => ({
+  ...jest.requireActual("~/analytics"),
+  track: jest.fn(),
+  screen: jest.fn(),
+}));
+
+const SHOP_LINK = "https://shop.ledger.com/?product=flex";
+
+function renderTourViewModel() {
+  return renderHook(() => useLazyOnboardingTourDrawerViewModel(), {
+    overrideInitialState: withFlagOverrides({
+      lazyOnboardingBanner: {
+        enabled: true,
+        params: { mode: "feature_intro", link: SHOP_LINK },
+      },
+    }),
+  });
+}
+
+describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetLazyOnboardingTourControllerForTests();
+  });
+
+  it("should track modal_dismissed with stable keys on swipe/backdrop dismiss", () => {
+    const { result } = renderTourViewModel();
+
+    act(() => {
+      lazyOnboardingTourController.open();
+    });
+    expect(result.current?.isOpen).toBe(true);
+
+    act(() => {
+      result.current?.onClose();
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "modal_dismissed",
+      expect.objectContaining({
+        page: LAZY_ONBOARDING_TOUR_PAGE,
+        step: 0,
+        source: "lazy onboarding",
+        mode: "feature_intro",
+        platform: "llm",
+      }),
+    );
+    expect(result.current?.isOpen).toBe(false);
+  });
+
+  it("should track button close and not modal_dismissed when the X is pressed", () => {
+    const { result } = renderTourViewModel();
+
+    act(() => {
+      lazyOnboardingTourController.open();
+    });
+
+    act(() => {
+      result.current?.onCloseButtonPress();
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "close",
+        page: LAZY_ONBOARDING_TOUR_PAGE,
+      }),
+    );
+
+    act(() => {
+      result.current?.onClose();
+    });
+
+    expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+  });
+
+  it("should not track modal_dismissed when Done closes the tour", () => {
+    const { result } = renderTourViewModel();
+
+    act(() => {
+      lazyOnboardingTourController.open();
+    });
+
+    act(() => {
+      result.current?.onDone();
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        button: "done",
+        page: LAZY_ONBOARDING_TOUR_PAGE,
+      }),
+    );
+
+    act(() => {
+      result.current?.onClose();
+    });
+
+    expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/__tests__/useLazyOnboardingTourDrawerViewModel.test.ts
@@ -1,6 +1,7 @@
+import { Linking } from "react-native";
 import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
-import { track } from "~/analytics";
-import { LAZY_ONBOARDING_TOUR_PAGE } from "../const";
+import { screen, track } from "~/analytics";
+import { LAZY_ONBOARDING_TOUR_PAGE, LAZY_ONBOARDING_TOUR_SHOP_PAGE } from "../const";
 import {
   __resetLazyOnboardingTourControllerForTests,
   lazyOnboardingTourController,
@@ -15,11 +16,11 @@ jest.mock("~/analytics", () => ({
 
 const SHOP_LINK = "https://shop.ledger.com/?product=flex";
 
-function renderTourViewModel() {
+function renderTourViewModel(enabled = true) {
   return renderHook(() => useLazyOnboardingTourDrawerViewModel(), {
     overrideInitialState: withFlagOverrides({
       lazyOnboardingBanner: {
-        enabled: true,
+        enabled,
         params: { mode: "feature_intro", link: SHOP_LINK },
       },
     }),
@@ -108,5 +109,49 @@ describe("useLazyOnboardingTourDrawerViewModel dismiss analytics", () => {
     });
 
     expect(track).not.toHaveBeenCalledWith("modal_dismissed", expect.anything());
+  });
+
+  it("should track continue, slide change, and buy with shop screen", () => {
+    const { result } = renderTourViewModel();
+
+    act(() => {
+      lazyOnboardingTourController.open();
+    });
+
+    expect(screen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_TOUR_PAGE,
+      undefined,
+      expect.objectContaining({ name: "lazy onboarding tour", card: 1 }),
+    );
+
+    act(() => {
+      result.current?.onContinue(0);
+      result.current?.onSlideChange(1);
+      result.current?.onBuy(1);
+    });
+
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Continue", card: 1 }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "product_tour_card",
+      expect.objectContaining({ page: LAZY_ONBOARDING_TOUR_PAGE, card: 2 }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({ button: "Buy a Ledger device", card: 2 }),
+    );
+    expect(Linking.openURL).toHaveBeenCalled();
+    expect(screen).toHaveBeenCalledWith(
+      LAZY_ONBOARDING_TOUR_SHOP_PAGE,
+      undefined,
+      expect.objectContaining({ name: "shop", source: "lazy onboarding tour" }),
+    );
+  });
+
+  it("should return null when the feature is disabled", () => {
+    const { result } = renderTourViewModel(false);
+    expect(result.current).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
@@ -10,6 +10,9 @@ export type LazyOnboardingTourSharedAnalyticsProps = Readonly<{
   mode: "feature_intro";
 }>;
 
+/** Convert 0-based slide index to 1-based analytics card. */
+const toCard = (slideIndex: number) => slideIndex + 1;
+
 export const trackLazyOnboardingTourOpened = (
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
   hasTrackedTourOpen: boolean,
@@ -20,7 +23,7 @@ export const trackLazyOnboardingTourOpened = (
 
   screen(LAZY_ONBOARDING_TOUR_PAGE, undefined, {
     name: "lazy onboarding tour",
-    step: 0,
+    card: 1,
     ...sharedProps,
   });
 
@@ -28,66 +31,66 @@ export const trackLazyOnboardingTourOpened = (
 };
 
 export const trackLazyOnboardingTourStepViewed = (
-  step: number,
+  slideIndex: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
-  lastTrackedStepIndex: number | null,
+  lastTrackedSlideIndex: number | null,
 ): number | null => {
-  if (lastTrackedStepIndex === step) {
-    return lastTrackedStepIndex;
+  if (lastTrackedSlideIndex === slideIndex) {
+    return lastTrackedSlideIndex;
   }
 
-  screen(LAZY_ONBOARDING_TOUR_PAGE, undefined, {
-    name: "lazy onboarding tour",
-    step,
+  track("product_tour_card", {
+    page: LAZY_ONBOARDING_TOUR_PAGE,
+    card: toCard(slideIndex),
     ...sharedProps,
   });
 
-  return step;
+  return slideIndex;
 };
 
 export const trackLazyOnboardingTourContinueClicked = (
-  step: number,
+  slideIndex: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("button_clicked", {
-    button: "continue",
+    button: "Continue",
     page: LAZY_ONBOARDING_TOUR_PAGE,
-    step,
+    card: toCard(slideIndex),
     ...sharedProps,
   });
 };
 
 export const trackLazyOnboardingTourBuyClicked = (
-  step: number,
+  slideIndex: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("button_clicked", {
-    button: "buy a ledger device",
+    button: "Buy a Ledger device",
     page: LAZY_ONBOARDING_TOUR_PAGE,
-    step,
+    card: toCard(slideIndex),
     ...sharedProps,
   });
 };
 
 export const trackLazyOnboardingTourCloseClicked = (
-  step: number,
+  slideIndex: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("button_clicked", {
-    button: "close",
+    button: "Close",
     page: LAZY_ONBOARDING_TOUR_PAGE,
-    step,
+    card: toCard(slideIndex),
     ...sharedProps,
   });
 };
 
 export const trackLazyOnboardingTourDismissed = (
-  step: number,
+  slideIndex: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("modal_dismissed", {
     page: LAZY_ONBOARDING_TOUR_PAGE,
-    step,
+    card: toCard(slideIndex),
     ...sharedProps,
   });
 };
@@ -96,7 +99,7 @@ export const trackLazyOnboardingTourDoneClicked = (
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("button_clicked", {
-    button: "done",
+    button: "Done",
     page: LAZY_ONBOARDING_TOUR_PAGE,
     ...sharedProps,
   });

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
@@ -70,11 +70,13 @@ export const trackLazyOnboardingTourBuyClicked = (
 };
 
 export const trackLazyOnboardingTourCloseClicked = (
+  step: number,
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {
   track("button_clicked", {
     button: "close",
     page: LAZY_ONBOARDING_TOUR_PAGE,
+    step,
     ...sharedProps,
   });
 };

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/analytics.ts
@@ -79,6 +79,17 @@ export const trackLazyOnboardingTourCloseClicked = (
   });
 };
 
+export const trackLazyOnboardingTourDismissed = (
+  step: number,
+  sharedProps: LazyOnboardingTourSharedAnalyticsProps,
+) => {
+  track("modal_dismissed", {
+    page: LAZY_ONBOARDING_TOUR_PAGE,
+    step,
+    ...sharedProps,
+  });
+};
+
 export const trackLazyOnboardingTourDoneClicked = (
   sharedProps: LazyOnboardingTourSharedAnalyticsProps,
 ) => {

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
@@ -8,6 +8,7 @@ import {
   trackLazyOnboardingTourBuyClicked,
   trackLazyOnboardingTourCloseClicked,
   trackLazyOnboardingTourContinueClicked,
+  trackLazyOnboardingTourDismissed,
   trackLazyOnboardingTourDoneClicked,
   trackLazyOnboardingTourOpened,
   trackLazyOnboardingTourShopReached,
@@ -15,6 +16,8 @@ import {
   type LazyOnboardingTourSharedAnalyticsProps,
 } from "./analytics";
 import { lazyOnboardingTourController } from "./lazyOnboardingTourController";
+
+type CloseSource = "cross" | "external" | "internal";
 
 export type LazyOnboardingTourDrawerViewModel = Readonly<{
   isOpen: boolean;
@@ -37,6 +40,7 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
   const hasClosedRef = useRef(false);
   const hasTrackedTourOpenRef = useRef(false);
   const lastTrackedStepIndexRef = useRef<number | null>(null);
+  const closeSourceRef = useRef<CloseSource>("external");
 
   const isFeatureEnabled = feature?.enabled === true;
   const link = typeof feature?.params?.link === "string" ? feature.params.link : "";
@@ -64,6 +68,7 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
 
   const openDrawer = useCallback(() => {
     hasClosedRef.current = false;
+    closeSourceRef.current = "external";
     setIsOpen(true);
   }, []);
 
@@ -97,11 +102,17 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
     }
   }, [closeDrawer, isFeatureEnabled, isOpen]);
 
+  // QueuedBottomSheet onClose — swipe / backdrop. Skip when X or Done already closed it.
   const onClose = useCallback(() => {
+    if (closeSourceRef.current === "external") {
+      trackLazyOnboardingTourDismissed(lastTrackedStepIndexRef.current ?? 0, sharedAnalyticsProps);
+    }
+    closeSourceRef.current = "external";
     closeDrawer();
-  }, [closeDrawer]);
+  }, [closeDrawer, sharedAnalyticsProps]);
 
   const onCloseButtonPress = useCallback(() => {
+    closeSourceRef.current = "cross";
     trackLazyOnboardingTourCloseClicked(sharedAnalyticsProps);
     closeDrawer();
   }, [closeDrawer, sharedAnalyticsProps]);
@@ -134,6 +145,7 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
   );
 
   const onDone = useCallback(() => {
+    closeSourceRef.current = "internal";
     trackLazyOnboardingTourDoneClicked(sharedAnalyticsProps);
     closeDrawer();
   }, [closeDrawer, sharedAnalyticsProps]);

--- a/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LazyOnboardingBanner/components/LazyOnboardingTour/useLazyOnboardingTourDrawerViewModel.ts
@@ -113,7 +113,7 @@ export function useLazyOnboardingTourDrawerViewModel(): LazyOnboardingTourDrawer
 
   const onCloseButtonPress = useCallback(() => {
     closeSourceRef.current = "cross";
-    trackLazyOnboardingTourCloseClicked(sharedAnalyticsProps);
+    trackLazyOnboardingTourCloseClicked(lastTrackedStepIndexRef.current ?? 0, sharedAnalyticsProps);
     closeDrawer();
   }, [closeDrawer, sharedAnalyticsProps]);
 


### PR DESCRIPTION
### 📝 Description

The `lazyOnboardingBanner` feature flag was not visible on Segment identify, so analytics could not segment users by rollout cohort or banner mode.

This PR exposes the flag on identify user traits, following the same pattern as other Engagement flags (e.g. `lwmProductTour`):

- `lazyOnboardingBanner` (boolean) — whether the flag is enabled
- `lazyOnboardingBannerMode` (`shop_direct` | `feature_intro` | `null`) — mode from flag params

This is the first slice of [LIVE-35259](https://ledgerhq.atlassian.net/browse/LIVE-35259) (banner copy + analytics finalisation). Banner impression/CTA/dismiss events and final copy are out of scope for this PR.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35259](https://ledgerhq.atlassian.net/browse/LIVE-35259)


[LIVE-35259]: https://ledgerhq.atlassian.net/browse/LIVE-35259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35259]: https://ledgerhq.atlassian.net/browse/LIVE-35259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ