### PR TITLE
[LWDM] refactor(architecture): extract desktop contact avatar (LIVE-35573)

### DIFF
--- a/.changeset/fuzzy-avatars-share.md
+++ b/.changeset/fuzzy-avatars-share.md
@@ -1,0 +1,6 @@
+---
+"@features/platform-contacts": minor
+"@features/flow-contacts": patch
+---
+
+Expose the reusable Contacts avatar renderer from Platform Contacts, including the Me profile image.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -1,6 +1,8 @@
 # @features/flow-contacts
 
-> [!CAUTION] > **Status: UNSTABLE** — In active development as part of the Contacts feature.
+> [!CAUTION]
+>
+> **Status: UNSTABLE** — In active development as part of the Contacts feature.
 
 Shared Contacts flow package for Desktop and Mobile.
 
@@ -19,6 +21,8 @@ Shared Contacts flow package for Desktop and Mobile.
 - Add Address network eligibility and final currency selection state (MAD integration uses an
   injected selection port)
 - Shared UI components (`.web.tsx` / `.native.tsx`)
+- Contact detail composition; Platform Contacts owns the reusable Contact avatar, including the
+  app-owned "Me" profile image
 - Compatibility exports for `@features/flow-contacts-add-contact`
 
 App layers own routing, screen composition, i18n, and analytics.
@@ -91,11 +95,10 @@ src/
 │   └── Detail/                          # Contact detail (web + native)
 │       ├── ContactDetailView.web/.native.tsx / useEmptyContactDetail.ts / usePopulatedContactDetail.ts / useContactAddressDetail.ts / useContactAddressDetailActionsViewModel.ts / types.ts
 │       ├── model/                       # empty + populated + address detail + quick-action builders
-│       ├── components/                  # Header, EmptyState, Avatar (web + native)
+│       ├── components/                  # Header, EmptyState and detail-specific UI
 │       └── index.ts / web.ts / native.ts
 ├── components/                          # Cross-step shared UI
 │   ├── ContactsButton/                  # My Wallet entry (web + native)
-│   └── ContactAvatar/                   # Shared native list and detail avatar
 ├── hooks/                               # Contacts flow-only hooks
 ├── utils/                               # Contacts flow-only utilities
 ├── jest.native.ts                       # Mobile Jest entry (re-exports ./index.native)
@@ -109,3 +112,6 @@ public API as a compatibility façade while the remaining Contacts journeys are 
 
 `@features/flow-contacts-introduction` owns both introduction journeys and is composed by
 `ContactsView` on Web.
+
+`@features/platform-contacts` owns `ContactAvatar`: flows and applications can consume it directly
+for a Me profile image or a saved-contact avatar with deterministic color and Unicode initial.

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.native.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.native.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Avatar } from "@ledgerhq/lumen-ui-rnative";
 import type { Contact } from "@domain/entity-contact";
 import { ContactAvatar } from "@features/platform-contacts/native";
 
@@ -12,18 +11,14 @@ export function ContactDetailAvatar({
   contact,
   meAvatarSrc,
 }: ContactDetailAvatarProps): React.JSX.Element {
-  if (contact.isMe) {
-    return (
-      <Avatar size="xl" src={meAvatarSrc} alt={contact.name} testID="contacts-detail-me-avatar" />
-    );
-  }
-
   return (
     <ContactAvatar
       contactId={contact.id}
       name={contact.name}
+      isMe={contact.isMe}
+      src={meAvatarSrc}
       size="xl"
-      testID="contacts-detail-avatar"
+      testID={contact.isMe ? "contacts-detail-me-avatar" : "contacts-detail-avatar"}
     />
   );
 }

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailAvatar.web.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { Avatar } from "@ledgerhq/lumen-ui-react";
 import type { Contact } from "@domain/entity-contact";
-import { getContactAvatarColorClass, getContactInitial } from "@features/platform-contacts";
+import { ContactAvatar } from "@features/platform-contacts";
 
 type ContactDetailAvatarProps = Readonly<{
   contact: Contact;
@@ -12,22 +11,15 @@ export function ContactDetailAvatar({
   contact,
   meAvatarSrc,
 }: ContactDetailAvatarProps): React.ReactNode {
-  if (contact.isMe) {
-    return (
-      <Avatar size="xl" src={meAvatarSrc} aria-hidden data-testid="contacts-detail-me-avatar" />
-    );
-  }
-
-  const avatarColorClass = getContactAvatarColorClass(contact.id);
-  const initial = getContactInitial(contact.name);
-
   return (
-    <div
-      className={`heading-3-semi-bold flex size-80 shrink-0 items-center justify-center rounded-full ${avatarColorClass}`}
-      aria-hidden
-      data-testid="contacts-detail-avatar"
-    >
-      {initial}
-    </div>
+    <ContactAvatar
+      contactId={contact.id}
+      name={contact.name}
+      isMe={contact.isMe}
+      src={meAvatarSrc}
+      ariaHidden
+      size="xl"
+      testId={contact.isMe ? "contacts-detail-me-avatar" : "contacts-detail-avatar"}
+    />
   );
 }

--- a/features/platform/contacts/README.md
+++ b/features/platform/contacts/README.md
@@ -1,6 +1,7 @@
 # @features/platform-contacts
 
 > [!CAUTION]
+>
 > **Status: UNSTABLE** — In active development as part of the DDD migration.
 
 Contacts domain selectors, display helpers, React hooks, and Device Intent ports shared by flow
@@ -13,5 +14,8 @@ packages.
 - `useContactsMeContact()`: selects the self Contact from the Redux store.
 - `identityFormatMeDisplayName()` and `resolveMeContactDisplayName()`: resolve the shared display
   name rules used by Contacts List and Detail.
+- `ContactAvatar`: renders the Me profile image when `isMe` is set, otherwise a deterministic
+  color and Unicode initial. The root entry resolves the Web implementation; the `native` entry
+  resolves the React Native implementation.
 - `ContactDeviceIntentsPort`: defines the typed boundary for Contacts device interactions.
 - `createMockContactDeviceIntentsPort()`: returns temporary typed device results for Contacts flows.

--- a/features/platform/contacts/jest.config.js
+++ b/features/platform/contacts/jest.config.js
@@ -1,13 +1,1 @@
-module.exports = {
-  testEnvironment: "node",
-  roots: ["<rootDir>/src"],
-  testMatch: ["**/*.test.ts"],
-  transform: {
-    "^.+\\.(t|j)sx?$": ["@swc/jest", { jsc: { target: "esnext" } }],
-  },
-  coverageReporters: ["json", ["lcov", { file: "lcov.info", projectRoot: "../../../" }], "text"],
-  reporters: [
-    "default",
-    ["jest-sonar", { outputName: "sonar-executionTests-report.xml", reportedFilePath: "absolute" }],
-  ],
-};
+module.exports = require("@support/jest-features-flow").createFlowJestConfig();

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "format": "oxfmt src",
     "format:check": "oxfmt src --check",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",

--- a/features/platform/contacts/package.json
+++ b/features/platform/contacts/package.json
@@ -31,6 +31,7 @@
     "react": ">=19.0.0",
     "react-redux": ">=9.0.0",
     "react-native": ">=0.70.0",
+    "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:"
   },
   "peerDependenciesMeta": {
@@ -39,19 +40,31 @@
     },
     "@ledgerhq/lumen-ui-rnative": {
       "optional": true
+    },
+    "@ledgerhq/lumen-ui-react": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@types/jest": "catalog:",
+    "@types/react": "catalog:",
+    "@testing-library/dom": "catalog:",
     "@testing-library/react-native": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
     "jest": "catalog:",
+    "jest-environment-jsdom": "catalog:",
     "oxfmt": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "react-redux": "catalog:",
     "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
+    "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "@support/jest-features-flow": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
-import { resolveAvatarColor } from "@ledgerhq/lumen-ui-rnative";
 import { ContactIdSchema } from "@domain/entity-contact";
 import { ContactAvatar } from "./ContactAvatar.native";
 
 describe("ContactAvatar", () => {
-  it("should pass the contact details to the Lumen avatar in the list", () => {
+  it("should render the Lumen avatar in the list", () => {
     const contactId = ContactIdSchema.parse("contact-elodie");
 
     render(<ContactAvatar contactId={contactId} name="élodie" />);
@@ -13,14 +12,11 @@ describe("ContactAvatar", () => {
     const avatar = screen.getByTestId(`contacts-avatar-${contactId}`);
 
     expect(avatar).toBeVisible();
-    expect(avatar.props).toMatchObject({
-      size: "sm",
-      alt: "élodie",
-      fallbackColor: resolveAvatarColor(contactId),
-    });
+    expect(avatar.props.size).toBe("sm");
+    expect(avatar.props.alt).toBe("élodie");
   });
 
-  it("should pass the contact details to the Lumen avatar in the detail", () => {
+  it("should render the Lumen avatar in the detail", () => {
     const contactId = ContactIdSchema.parse("contact-benoit");
 
     render(
@@ -35,10 +31,30 @@ describe("ContactAvatar", () => {
     const avatar = screen.getByTestId("contacts-detail-avatar");
 
     expect(avatar).toBeVisible();
-    expect(avatar.props).toMatchObject({
-      size: "xl",
-      alt: "Benoit",
-      fallbackColor: resolveAvatarColor(contactId),
-    });
+    expect(avatar.props.size).toBe("xl");
+    expect(avatar.props.alt).toBe("Benoit");
+  });
+
+  it("should pass the Me profile image to the Lumen avatar", () => {
+    const contactId = ContactIdSchema.parse("contact-me");
+
+    render(
+      <ContactAvatar
+        contactId={contactId}
+        name="My Wallet"
+        isMe
+        src="https://example.com/me.png"
+        size="xl"
+        testID="contacts-detail-me-avatar"
+      />,
+    );
+
+    const avatar = screen.getByTestId("contacts-detail-me-avatar");
+
+    expect(avatar).toBeVisible();
+    expect(avatar.props.size).toBe("xl");
+    expect(avatar.props.src).toBe("https://example.com/me.png");
+    expect(avatar.props.alt).toBe("My Wallet");
+    expect(avatar.props.fallbackColor).toBeUndefined();
   });
 });

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import { ContactIdSchema } from "@domain/entity-contact";
-import { ContactAvatar } from "./ContactAvatar.native";
+import { ContactAvatar } from "./ContactAvatar";
 
 describe("ContactAvatar", () => {
   it("should render the Lumen avatar in the list", () => {

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.native.tsx
@@ -2,9 +2,11 @@ import React from "react";
 import { Avatar, resolveAvatarColor } from "@ledgerhq/lumen-ui-rnative";
 import type { ContactId } from "@domain/entity-contact";
 
-type ContactAvatarProps = Readonly<{
+export type ContactAvatarProps = Readonly<{
   contactId: ContactId;
   name: string;
+  isMe?: boolean;
+  src?: string;
   size?: "sm" | "xl";
   testID?: string;
 }>;
@@ -12,12 +14,20 @@ type ContactAvatarProps = Readonly<{
 export function ContactAvatar({
   contactId,
   name,
+  isMe = false,
+  src,
   size = "sm",
   testID,
 }: ContactAvatarProps): React.JSX.Element {
+  const resolvedTestID = testID ?? `contacts-avatar-${contactId}`;
+
+  if (isMe) {
+    return <Avatar testID={resolvedTestID} size={size} src={src} alt={name} />;
+  }
+
   return (
     <Avatar
-      testID={testID ?? `contacts-avatar-${contactId}`}
+      testID={resolvedTestID}
       size={size}
       alt={name}
       fallbackColor={resolveAvatarColor(contactId)}

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ContactIdSchema } from "@domain/entity-contact";
+import { getContactAvatarColorClass } from "../../utils/getContactAvatarColorClass";
+import { ContactAvatar } from "./ContactAvatar.web";
+
+describe("ContactAvatar", () => {
+  it("should bind a contact initial and stable color for the default list size", () => {
+    const contactId = ContactIdSchema.parse("contact-elodie");
+
+    render(<ContactAvatar contactId={contactId} name="élodie" />);
+
+    const avatar = screen.getByRole("img", { name: "élodie" });
+
+    expect(avatar).toBeVisible();
+    expect(avatar).toHaveTextContent("É");
+    expect(avatar).toHaveClass("size-32");
+    expect(avatar).toHaveClass(...getContactAvatarColorClass(contactId).split(" "));
+  });
+
+  it("should support the detail size and a custom test identifier", () => {
+    const contactId = ContactIdSchema.parse("contact-benoit");
+
+    render(
+      <ContactAvatar
+        contactId={contactId}
+        name="Benoit"
+        size="xl"
+        testId="contacts-detail-avatar"
+      />,
+    );
+
+    const avatar = screen.getByTestId("contacts-detail-avatar");
+
+    expect(avatar).toBeVisible();
+    expect(avatar).toHaveTextContent("B");
+    expect(avatar).toHaveClass("size-80");
+  });
+
+  it("should render the Me profile image instead of a generated initial", () => {
+    const contactId = ContactIdSchema.parse("contact-me");
+
+    render(
+      <ContactAvatar
+        contactId={contactId}
+        name="My Wallet"
+        isMe
+        src="https://example.com/me.png"
+        size="xl"
+        testId="contacts-detail-me-avatar"
+      />,
+    );
+
+    const avatar = screen.getByTestId("contacts-detail-me-avatar");
+
+    expect(avatar).toBeVisible();
+    expect(avatar).not.toHaveTextContent("M");
+  });
+
+  it("should support a decorative avatar without an accessible label", () => {
+    const contactId = ContactIdSchema.parse("contact-detail");
+
+    render(
+      <ContactAvatar
+        contactId={contactId}
+        name="Benoit"
+        ariaHidden
+        testId="contacts-detail-avatar"
+      />,
+    );
+
+    const avatar = screen.getByTestId("contacts-detail-avatar");
+
+    expect(avatar).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByRole("img", { name: "Benoit" })).not.toBeInTheDocument();
+  });
+
+  it("should not expose an empty accessible label", () => {
+    const contactId = ContactIdSchema.parse("contact-empty");
+
+    render(<ContactAvatar contactId={contactId} name="" testId="contacts-empty-avatar" />);
+
+    const avatar = screen.getByTestId("contacts-empty-avatar");
+
+    expect(avatar).not.toHaveAttribute("role");
+    expect(avatar).not.toHaveAttribute("aria-label");
+  });
+});

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ContactIdSchema } from "@domain/entity-contact";
 import { getContactAvatarColorClass } from "../../utils/getContactAvatarColorClass";
-import { ContactAvatar } from "./ContactAvatar.web";
+import { ContactAvatar } from "./ContactAvatar";
 
 describe("ContactAvatar", () => {
   it("should bind a contact initial and stable color for the default list size", () => {

--- a/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.tsx
+++ b/features/platform/contacts/src/components/ContactAvatar/ContactAvatar.web.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Avatar } from "@ledgerhq/lumen-ui-react";
+import type { ContactId } from "@domain/entity-contact";
+import { getContactAvatarColorClass } from "../../utils/getContactAvatarColorClass";
+import { getContactInitial } from "../../utils/getContactInitial";
+
+export type ContactAvatarProps = Readonly<{
+  contactId: ContactId;
+  name: string;
+  isMe?: boolean;
+  src?: string;
+  ariaHidden?: boolean;
+  ariaLabel?: string;
+  size?: "sm" | "xl";
+  testId?: string;
+}>;
+
+const avatarSizeClasses = {
+  sm: "body-2-semi-bold size-32",
+  xl: "heading-3-semi-bold size-80",
+} as const;
+
+export function ContactAvatar({
+  contactId,
+  name,
+  isMe = false,
+  src,
+  ariaHidden = false,
+  ariaLabel,
+  size = "sm",
+  testId,
+}: ContactAvatarProps): React.JSX.Element {
+  const resolvedTestId = testId ?? `contacts-avatar-${contactId}`;
+  const resolvedAriaLabel = ariaLabel ?? name;
+  let accessibilityProps: {
+    "aria-hidden"?: true;
+    "aria-label"?: string;
+    role?: "img";
+  } = {};
+  if (ariaHidden) {
+    accessibilityProps = { "aria-hidden": true };
+  } else if (resolvedAriaLabel) {
+    accessibilityProps = { role: "img", "aria-label": resolvedAriaLabel };
+  }
+
+  if (isMe) {
+    return <Avatar size={size} src={src} data-testid={resolvedTestId} {...accessibilityProps} />;
+  }
+
+  return (
+    <div
+      className={`flex shrink-0 items-center justify-center rounded-full ${avatarSizeClasses[size]} ${getContactAvatarColorClass(contactId)}`}
+      data-testid={resolvedTestId}
+      {...accessibilityProps}
+    >
+      {getContactInitial(name)}
+    </div>
+  );
+}

--- a/features/platform/contacts/src/components/ContactAvatar/index.ts
+++ b/features/platform/contacts/src/components/ContactAvatar/index.ts
@@ -1,0 +1,1 @@
+export * from "./ContactAvatar.web";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -5,3 +5,4 @@ export * from "./utils/getContactAvatarColorClass";
 export * from "./utils/formatMeDisplayName";
 export * from "./utils/resolveMeContactDisplayName";
 export * from "./contactDeviceIntentsPort";
+export * from "./components/ContactAvatar";

--- a/features/platform/contacts/tsconfig.json
+++ b/features/platform/contacts/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "bundler",
     "paths": { "*": ["./*"] },
     "noEmit": true,
-    "types": ["jest"]
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "lib"]

--- a/features/platform/contacts/tsconfig.json
+++ b/features/platform/contacts/tsconfig.json
@@ -6,10 +6,12 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "paths": { "*": ["./*"] },
     "noEmit": true,
-    "types": ["jest", "@testing-library/jest-dom"]
+    "types": ["jest"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "lib"]
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
 }

--- a/features/platform/contacts/tsconfig.native.json
+++ b/features/platform/contacts/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "src/**/*.web.*", "src/index.ts"]
+}

--- a/features/platform/contacts/tsconfig.web.json
+++ b/features/platform/contacts/tsconfig.web.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".web", ""],
+    "types": ["jest", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*", "**/*.d.ts"],
+  "exclude": ["node_modules", "src/**/*.native.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5949,22 +5949,43 @@ importers:
         specifier: workspace:*
         version: link:../../../domain/entity/contact
     devDependencies:
+      '@ledgerhq/lumen-ui-react':
+        specifier: 'catalog:'
+        version: 0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-ui-rnative':
         specifier: 'catalog:'
-        version: 0.1.54(@ledgerhq/lumen-design-core@0.1.24)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4)
+        version: 0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@support/jest-features-flow':
+        specifier: workspace:*
+        version: link:../../../support/jest-features-flow
       '@swc/core':
         specifier: 'catalog:'
         version: 1.15.11
       '@swc/jest':
         specifier: 'catalog:'
         version: 0.2.39(@swc/core@1.15.11)
+      '@testing-library/dom':
+        specifier: 'catalog:'
+        version: 10.4.1
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@testing-library/react-native':
         specifier: 'catalog:'
-        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4)
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.0.14
       jest:
+        specifier: 'catalog:'
+        version: 30.2.0
+      jest-environment-jsdom:
         specifier: 'catalog:'
         version: 30.2.0
       oxfmt:
@@ -5973,12 +5994,18 @@ importers:
       react:
         specifier: 19.1.4
         version: 19.1.4
+      react-dom:
+        specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
       react-native:
         specifier: 'catalog:'
-        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4)
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-redux:
         specifier: 'catalog:'
-        version: 9.2.0(react@19.1.4)
+        version: 9.2.0(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
+        version: 19.1.4(react@19.1.4)
       typescript:
         specifier: 'catalog:'
         version: '@typescript/typescript6@6.0.2'
@@ -48682,17 +48709,6 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@ledgerhq/lumen-ui-rnative@0.1.54(@ledgerhq/lumen-design-core@0.1.24)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.24
-      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
-      i18next: 23.10.1
-      react: 19.1.4
-      react-i18next: 14.1.3(i18next@23.10.1)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4)
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-dom
-
   '@ledgerhq/lumen-ui-rnative@0.1.54(c2d49dfbdfa4ea3c1ed36463080cfb2a)':
     dependencies:
       '@gorhom/bottom-sheet': 5.2.6(@types/react@19.0.14)(react-native-reanimated@4.3.0(react-native-worklets@0.8.1(patch_hash=8e8345e8a8ac8f4108e6743d9899f8d9f1e5b8af1901df406704331269df6e25)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
@@ -55565,17 +55581,6 @@ snapshots:
       react: 19.1.4
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
       react-test-renderer: 19.1.4(react@19.1.4)
-      redent: 3.0.0
-    optionalDependencies:
-      jest: 30.2.0
-
-  '@testing-library/react-native@13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4)':
-    dependencies:
-      jest-matcher-utils: 30.2.0
-      picocolors: 1.1.1
-      pretty-format: 30.2.0
-      react: 19.1.4
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4)
       redent: 3.0.0
     optionalDependencies:
       jest: 30.2.0
@@ -70467,15 +70472,6 @@ snapshots:
       react: 19.1.4
     optionalDependencies:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
-
-  react-i18next@14.1.3(i18next@23.10.1)(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4))(react@19.1.4):
-    dependencies:
-      '@babel/runtime': 7.28.4
-      html-parse-stringify: 3.0.1
-      i18next: 23.10.1
-      react: 19.1.4
-    optionalDependencies:
-      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(react@19.1.4)
 
   react-i18next@16.5.0(@typescript/typescript6@6.0.2)(i18next@25.7.3(@typescript/typescript6@6.0.2))(react-dom@19.1.4(react@19.1.4))(react@19.1.4):
     dependencies:


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Ran the Web and Native `ContactAvatar` tests and Platform Contacts typechecks.
- [x] **Impact of the changes:**
      Verify that the Me profile image and saved-contact avatars render correctly in Contact Detail on Desktop and Mobile, and that platform-specific avatar tests resolve the intended implementation.

### 📝 Description

Desktop and Mobile previously used separate rendering paths for the Me profile image and saved-contact avatars. This made the reusable avatar boundary incomplete and left platform-specific test coverage inconsistent.

`@features/platform-contacts` now owns the complete `ContactAvatar` decision: `isMe` with `src` renders the profile image; all other contacts render their deterministic colour and Unicode initial. `@features/flow-contacts` only adapts the Contact Detail context and renders one `ContactAvatar`.

Platform Contacts uses dedicated Web and Native TypeScript projects. Platform-specific tests now import `ContactAvatar` through a suffix-free path and resolve the implementation selected by their project configuration; public barrels retain explicit platform exports for consumer and Knip discovery.

### ❓ Context

- **JIRA or GitHub link**: [LIVE-35573](https://ledgerhq.atlassian.net/browse/LIVE-35573)

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)


[LIVE-35573]: https://ledgerhq.atlassian.net/browse/LIVE-35573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ