### PR TITLE
refactor(aggregated-assets): split api, use the base query (LIVE-35301)

### DIFF
--- a/.changeset/brave-endpoints-split.md
+++ b/.changeset/brave-endpoints-split.md
@@ -1,0 +1,5 @@
+---
+"@domain/api-aggregated-assets": patch
+---
+
+Split the DADA api into per-use-case endpoint modules and route every request through RTK's injected base query, so aborts, shared headers and HTTP error statuses are preserved

--- a/domain/api/aggregated-assets/src/accessors.ts
+++ b/domain/api/aggregated-assets/src/accessors.ts
@@ -1,16 +1,23 @@
 import { collectAllByCategory } from "./internals/collectAllByCategory";
+import type { DadaBaseQuery } from "./internals/requests";
 import type { GetAssetsByCategoryParams } from "./types";
 
 /** Every ticker in a category, across all pages. */
-export function fetchAllAssetsByCategory(queryArg: GetAssetsByCategoryParams) {
-  return collectAllByCategory(queryArg, data =>
+export function fetchAllAssetsByCategory(
+  queryArg: GetAssetsByCategoryParams,
+  baseQuery: DadaBaseQuery,
+) {
+  return collectAllByCategory(queryArg, baseQuery, data =>
     Object.values(data.cryptoAssets).map(a => a.ticker),
   );
 }
 
 /** Every per-network currency id in a category, across all pages. */
-export function fetchAllAssetCurrencyIdsByCategory(queryArg: GetAssetsByCategoryParams) {
-  return collectAllByCategory(queryArg, data =>
+export function fetchAllAssetCurrencyIdsByCategory(
+  queryArg: GetAssetsByCategoryParams,
+  baseQuery: DadaBaseQuery,
+) {
+  return collectAllByCategory(queryArg, baseQuery, data =>
     Object.values(data.cryptoAssets).flatMap(meta => Object.values(meta.assetsIds)),
   );
 }

--- a/domain/api/aggregated-assets/src/api.test.ts
+++ b/domain/api/aggregated-assets/src/api.test.ts
@@ -7,13 +7,11 @@ jest.mock("@shared/env", () => ({
   getEnv: jest.fn().mockReturnValue("https://dada.api.ledger.com/v1"),
 }));
 
+import { configureStore } from "@reduxjs/toolkit";
 import { getEnv } from "@shared/env";
-import {
-  assetsDataApi,
-  buildAssetsQueryParams,
-  fetchAllAssetsByCategory,
-  fetchAllAssetCurrencyIdsByCategory,
-} from "./index";
+import { assetsDataApi, buildAssetsQueryParams } from "./index";
+import { fetchAllAssetCurrencyIdsByCategory, fetchAllAssetsByCategory } from "./accessors";
+import { getApiErrorStatus, isApiError, isNetworkError } from "./errors";
 import { AssetCategory } from "./types";
 import type { RawApiResponse } from "./schema";
 
@@ -50,23 +48,29 @@ function makePage(tickers: string[]): RawApiResponse {
   };
 }
 
-function okResponse(body: RawApiResponse, nextCursor?: string): Response {
+/** A page as the base query returns it: parsed body plus the response for header access. */
+function okResponse(body: RawApiResponse, nextCursor?: string) {
   const headers = new Headers();
   if (nextCursor) headers.set("x-ledger-next", nextCursor);
-  return new Response(JSON.stringify(body), { status: 200, headers });
+  return { data: body, meta: { response: { headers } } };
 }
 
-function errorResponse(status: number, statusText: string): Response {
-  return new Response(null, { status, statusText });
-}
+let baseQuery: jest.Mock;
 
-function mockFetchPages(pages: { tickers: string[]; nextCursor?: string }[]): jest.SpyInstance {
-  const spy = jest.spyOn(globalThis, "fetch");
+function mockFetchPages(pages: { tickers: string[]; nextCursor?: string }[]): jest.Mock {
   for (const page of pages) {
-    spy.mockResolvedValueOnce(okResponse(makePage(page.tickers), page.nextCursor));
+    baseQuery.mockResolvedValueOnce(okResponse(makePage(page.tickers), page.nextCursor));
   }
-  return spy;
+  return baseQuery;
 }
+
+beforeEach(() => {
+  baseQuery = jest.fn();
+});
+
+/** The request descriptors handed to the base query, one per page walked. */
+const cursorOf = (call: number) =>
+  (baseQuery.mock.calls[call][0] as { params: Record<string, unknown> }).params.cursor;
 
 const defaultArgs = {
   category: AssetCategory.Stablecoins,
@@ -139,52 +143,46 @@ describe("fetchAllAssetsByCategory", () => {
       { tickers: ["TUSD", "FRAX"] },
     ]);
 
-    const result = await fetchAllAssetsByCategory(defaultArgs);
+    const result = await fetchAllAssetsByCategory(defaultArgs, baseQuery);
 
     expect(result).toEqual({ data: ["USDT", "USDC", "DAI", "BUSD", "TUSD", "FRAX"] });
     expect(spy).toHaveBeenCalledTimes(3);
 
-    expect(new URL(String(spy.mock.calls[0][0])).searchParams.has("cursor")).toBe(false);
-    expect(new URL(String(spy.mock.calls[1][0])).searchParams.get("cursor")).toBe("cursor-2");
-    expect(new URL(String(spy.mock.calls[2][0])).searchParams.get("cursor")).toBe("cursor-3");
+    expect(cursorOf(0)).toBeUndefined();
+    expect(cursorOf(1)).toBe("cursor-2");
+    expect(cursorOf(2)).toBe("cursor-3");
   });
 
   it("should return error and stop when a page fails", async () => {
-    const spy = jest.spyOn(globalThis, "fetch");
-    spy.mockResolvedValueOnce(okResponse(makePage(["USDT"]), "cursor-2"));
-    spy.mockResolvedValueOnce(errorResponse(502, "Bad Gateway"));
+    baseQuery.mockResolvedValueOnce(okResponse(makePage(["USDT"]), "cursor-2"));
+    baseQuery.mockResolvedValueOnce({ error: { status: 502, data: "Bad Gateway" } });
 
-    const result = await fetchAllAssetsByCategory(defaultArgs);
+    const result = await fetchAllAssetsByCategory(defaultArgs, baseQuery);
 
-    expect(result).toEqual({
-      error: { status: 502, data: "Failed to fetch assets by category: Bad Gateway" },
-    });
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ error: { status: 502, data: "Bad Gateway" } });
+    expect(baseQuery).toHaveBeenCalledTimes(2);
   });
 
   it("should return FETCH_ERROR on network failure", async () => {
-    jest.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network failure"));
+    baseQuery.mockResolvedValueOnce({ error: { status: "FETCH_ERROR", error: "Network failure" } });
 
-    const result = await fetchAllAssetsByCategory(defaultArgs);
+    const result = await fetchAllAssetsByCategory(defaultArgs, baseQuery);
 
-    expect(result).toEqual({
-      error: { status: "FETCH_ERROR", error: "Network failure" },
-    });
+    expect(result).toEqual({ error: { status: "FETCH_ERROR", error: "Network failure" } });
   });
 
   it("should block requests to untrusted hosts", async () => {
     getEnvMock.mockImplementation(() => "https://evil.example.com/v1");
-    const spy = jest.spyOn(globalThis, "fetch");
 
-    const result = await fetchAllAssetsByCategory(defaultArgs);
+    const result = await fetchAllAssetsByCategory(defaultArgs, baseQuery);
 
     expect(result).toEqual({
       error: {
-        status: "FETCH_ERROR",
+        status: "CUSTOM_ERROR",
         error: "Blocked request to untrusted host: evil.example.com",
       },
     });
-    expect(spy).not.toHaveBeenCalled();
+    expect(baseQuery).not.toHaveBeenCalled();
   });
 });
 
@@ -217,25 +215,24 @@ describe("fetchAllAssetCurrencyIdsByCategory", () => {
   });
 
   it("should aggregate and flatten currency ids across pages", async () => {
-    const spy = jest.spyOn(globalThis, "fetch");
-    spy.mockResolvedValueOnce(
+    baseQuery.mockResolvedValueOnce(
       okResponse(
         makePageWithIds([{ key: "aapl", assetsIds: { ethereum: "eth/aapl", solana: "sol/aapl" } }]),
         "cursor-2",
       ),
     );
-    spy.mockResolvedValueOnce(
+    baseQuery.mockResolvedValueOnce(
       okResponse(makePageWithIds([{ key: "tsla", assetsIds: { ethereum: "eth/tsla" } }])),
     );
 
-    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs, baseQuery);
 
     expect(result).toEqual({ data: ["eth/aapl", "sol/aapl", "eth/tsla"] });
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(baseQuery).toHaveBeenCalledTimes(2);
   });
 
   it("should skip assets that have no assetsIds", async () => {
-    jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    baseQuery.mockResolvedValueOnce(
       okResponse(
         makePageWithIds([
           { key: "aapl", assetsIds: {} },
@@ -244,26 +241,147 @@ describe("fetchAllAssetCurrencyIdsByCategory", () => {
       ),
     );
 
-    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs, baseQuery);
 
     expect(result).toEqual({ data: ["eth/tsla"] });
   });
 
   it("should return error and stop when a page fails", async () => {
-    const spy = jest.spyOn(globalThis, "fetch");
-    spy.mockResolvedValueOnce(
+    baseQuery.mockResolvedValueOnce(
       okResponse(
         makePageWithIds([{ key: "aapl", assetsIds: { ethereum: "eth/aapl" } }]),
         "cursor-2",
       ),
     );
-    spy.mockResolvedValueOnce(errorResponse(502, "Bad Gateway"));
+    baseQuery.mockResolvedValueOnce({ error: { status: 502, data: "Bad Gateway" } });
 
-    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs);
+    const result = await fetchAllAssetCurrencyIdsByCategory(stocksArgs, baseQuery);
 
     expect(result).toEqual({
-      error: { status: 502, data: "Failed to fetch assets by category: Bad Gateway" },
+      error: { status: 502, data: "Bad Gateway" },
     });
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(baseQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("requests issued through the store", () => {
+  const emptyPage = () =>
+    new Response(JSON.stringify(makePage([])), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+  function makeStore() {
+    return configureStore({
+      reducer: { [assetsDataApi.reducerPath]: assetsDataApi.reducer },
+      middleware: getDefault => getDefault().concat(assetsDataApi.middleware),
+    });
+  }
+
+  const { endpoints } = assetsDataApi;
+  const storeArgs = { product: "llm" as const, version: "1.0.0" };
+  const storeCategoryArgs = { ...storeArgs, category: AssetCategory.Stocks };
+
+  /* Only that the signal reaches the request. Breaking out of the walk itself is LIVE-35503. */
+  it("should attach an abort signal to the category walk's requests", async () => {
+    let signal: AbortSignal | undefined;
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((request: RequestInfo | URL) => {
+        if (request instanceof Request) signal = request.signal;
+        return Promise.resolve(emptyPage());
+      });
+
+    await makeStore().dispatch(
+      assetsDataApi.endpoints.getAssetsByCategory.initiate({
+        category: AssetCategory.Stocks,
+        product: "llm",
+        version: "1.0.0",
+      }),
+    );
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    fetchSpy.mockRestore();
+  });
+
+  it("should issue no request at all when the resolved host is untrusted", async () => {
+    getEnvMock.mockReturnValue("https://evil.example.com/v1");
+    const fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => Promise.resolve(emptyPage()));
+
+    const result = await makeStore().dispatch(
+      assetsDataApi.endpoints.getAssetData.initiate({ product: "llm", version: "1.0.0" }),
+    );
+
+    expect(result.status).toBe("rejected");
+    expect(result.error).toMatchObject({
+      message: expect.stringContaining("evil.example.com"),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+    getEnvMock.mockReturnValue("https://dada.api.ledger.com/v1");
+  });
+
+  /*
+   * Before the base query was adopted, the queryFn endpoints flattened an HTTP failure into
+   * FETCH_ERROR with the status only inside a message string, so isNetworkError answered true for a
+   * server error on some endpoints and false on others. These assert the shapes agree.
+   */
+  type RunEndpoint = () => Promise<{ error?: unknown }>;
+
+  const endpointCases: [string, RunEndpoint][] = [
+    ["getAssetData", () => makeStore().dispatch(endpoints.getAssetData.initiate(storeArgs))],
+    [
+      "getChunkedAssetsData",
+      () =>
+        makeStore().dispatch(
+          endpoints.getChunkedAssetsData.initiate({ ...storeArgs, currencyIds: ["bitcoin"] }),
+        ),
+    ],
+    [
+      "getAssetsByCategory",
+      () => makeStore().dispatch(endpoints.getAssetsByCategory.initiate(storeCategoryArgs)),
+    ],
+    [
+      "getAssetCurrencyIdsByCategory",
+      () =>
+        makeStore().dispatch(endpoints.getAssetCurrencyIdsByCategory.initiate(storeCategoryArgs)),
+    ],
+  ];
+
+  describe.each(endpointCases)("%s", (_name, runEndpoint) => {
+    it("should classify an HTTP 500 as an api error carrying the numeric status", async () => {
+      const fetchSpy = jest.spyOn(globalThis, "fetch").mockImplementation(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ message: "server exploded" }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      const { error } = await runEndpoint();
+
+      expect(isApiError(error)).toBe(true);
+      expect(getApiErrorStatus(error)).toBe(500);
+      expect(isNetworkError(error)).toBe(false);
+
+      fetchSpy.mockRestore();
+    });
+
+    it("should classify a transport failure as a network error", async () => {
+      const fetchSpy = jest
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(() => Promise.reject(new TypeError("Failed to fetch")));
+
+      const { error } = await runEndpoint();
+
+      expect(isNetworkError(error)).toBe(true);
+      expect(isApiError(error)).toBe(false);
+
+      fetchSpy.mockRestore();
+    });
   });
 });

--- a/domain/api/aggregated-assets/src/api.test.ts
+++ b/domain/api/aggregated-assets/src/api.test.ts
@@ -10,7 +10,10 @@ jest.mock("@shared/env", () => ({
 import { configureStore } from "@reduxjs/toolkit";
 import { getEnv } from "@shared/env";
 import { assetsDataApi, buildAssetsQueryParams } from "./index";
-import { fetchAllAssetCurrencyIdsByCategory, fetchAllAssetsByCategory } from "./accessors";
+import {
+  fetchAllAssetCurrencyIdsByCategory,
+  fetchAllAssetsByCategory,
+} from "./internals/accessors";
 import { getApiErrorStatus, isApiError, isNetworkError } from "./errors";
 import { AssetCategory } from "./types";
 import type { RawApiResponse } from "./schema";

--- a/domain/api/aggregated-assets/src/api.ts
+++ b/domain/api/aggregated-assets/src/api.ts
@@ -8,6 +8,7 @@ import {
   type PageParam,
 } from "./types";
 import { ONE_DAY_IN_SECONDS } from "./constants";
+import { isFetchBaseQueryError } from "./errors";
 import { transformAssetsResponse } from "./transforms";
 import { fetchAllAssetCurrencyIdsByCategory, fetchAllAssetsByCategory } from "./accessors";
 import { buildAssetsQueryParams } from "./requests";
@@ -64,65 +65,53 @@ export const assetsDataApi = dadaApi
         transformResponse: transformAssetsResponse,
       }),
       getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
-        queryFn: async queryArg => {
-          return fetchAllAssetsByCategory(queryArg);
-        },
+        queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
+          fetchAllAssetsByCategory(queryArg, baseQuery),
         keepUnusedDataFor: ONE_DAY_IN_SECONDS,
       }),
       getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
-        queryFn: async queryArg => {
-          return fetchAllAssetCurrencyIdsByCategory(queryArg);
-        },
+        queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
+          fetchAllAssetCurrencyIdsByCategory(queryArg, baseQuery),
         keepUnusedDataFor: ONE_DAY_IN_SECONDS,
       }),
       getChunkedAssetsData: build.query<AssetsData, GetAssetsDataParams>({
-        queryFn: async queryArg => {
-          try {
-            const chunks = chunkCurrencyIds(queryArg.currencyIds ?? []);
-            const baseUrl = resolveBaseUrl(queryArg);
+        queryFn: async (queryArg, _api, _extraOptions, baseQuery) => {
+          const chunks = chunkCurrencyIds(queryArg.currencyIds ?? []);
+          if (chunks.length === 0) return { data: emptyAssetsData() };
 
-            if (chunks.length === 0) {
-              return { data: emptyAssetsData() };
-            }
+          const results = await allSettled(
+            chunks.map(chunkIds =>
+              fetchAssetsPage(baseQuery, { ...queryArg, currencyIds: chunkIds }),
+            ),
+          );
 
-            const results = await allSettled(
-              chunks.map(chunkIds =>
-                fetchAssetsPage(baseUrl, { ...queryArg, currencyIds: chunkIds }),
-              ),
-            );
+          const responses = results.flatMap(r => (r.status === "fulfilled" ? [r.value] : []));
 
-            const responses = results.flatMap(r => (r.status === "fulfilled" ? [r.value] : []));
-
-            if (responses.length === 0) {
-              const firstError = results.find(r => r.status === "rejected");
-              const reason = firstError?.status === "rejected" ? firstError.reason : undefined;
-              return {
-                error: {
-                  status: "FETCH_ERROR",
-                  error: reason instanceof Error ? reason.message : "All DADA chunks failed",
-                },
-              };
-            }
-
-            const merged = responses.reduce<AssetsData>((acc, res) => {
-              deepMergeCryptoAssets(acc.cryptoAssets, res.cryptoAssets);
-              Object.assign(acc.networks, res.networks);
-              Object.assign(acc.cryptoOrTokenCurrencies, res.cryptoOrTokenCurrencies);
-              Object.assign(acc.interestRates, res.interestRates);
-              Object.assign(acc.markets, res.markets);
-              acc.currenciesOrder.metaCurrencyIds.push(...res.currenciesOrder.metaCurrencyIds);
-              return acc;
-            }, emptyAssetsData());
-
-            return { data: merged };
-          } catch (error) {
+          if (responses.length === 0) {
+            const firstRejection = results.find(r => r.status === "rejected");
+            const reason =
+              firstRejection?.status === "rejected" ? firstRejection.reason : undefined;
+            /* fetchAssetsPage rethrows the base query's error, so an HTTP status survives here. */
+            if (isFetchBaseQueryError(reason)) return { error: reason };
             return {
               error: {
-                status: "FETCH_ERROR",
-                error: error instanceof Error ? error.message : "Unknown error",
+                status: "CUSTOM_ERROR" as const,
+                error: reason instanceof Error ? reason.message : "All DADA chunks failed",
               },
             };
           }
+
+          const merged = responses.reduce<AssetsData>((acc, res) => {
+            deepMergeCryptoAssets(acc.cryptoAssets, res.cryptoAssets);
+            Object.assign(acc.networks, res.networks);
+            Object.assign(acc.cryptoOrTokenCurrencies, res.cryptoOrTokenCurrencies);
+            Object.assign(acc.interestRates, res.interestRates);
+            Object.assign(acc.markets, res.markets);
+            acc.currenciesOrder.metaCurrencyIds.push(...res.currenciesOrder.metaCurrencyIds);
+            return acc;
+          }, emptyAssetsData());
+
+          return { data: merged };
         },
         providesTags: [AssetsDataTags.Assets],
         keepUnusedDataFor: ONE_DAY_IN_SECONDS,

--- a/domain/api/aggregated-assets/src/api.ts
+++ b/domain/api/aggregated-assets/src/api.ts
@@ -1,123 +1,12 @@
-import { dadaApi } from "@shared/api-services";
-import {
-  AssetsDataTags,
-  type AssetsData,
-  type AssetsDataWithPagination,
-  type GetAssetsByCategoryParams,
-  type GetAssetsDataParams,
-  type PageParam,
-} from "./types";
-import { ONE_DAY_IN_SECONDS } from "./constants";
-import { isFetchBaseQueryError } from "./errors";
-import { transformAssetsResponse } from "./transforms";
-import { fetchAllAssetCurrencyIdsByCategory, fetchAllAssetsByCategory } from "./accessors";
-import { buildAssetsQueryParams } from "./requests";
-import { fetchAssetsPage, resolveBaseUrl } from "./internals/requests";
-import {
-  allSettled,
-  chunkCurrencyIds,
-  deepMergeCryptoAssets,
-  emptyAssetsData,
-} from "./internals/utils";
+import { categoriesApi } from "./internals/endpoints/categories";
 
 /*
- * `injectEndpoints` adds this use case's endpoints to the shared DADA service api, and
- * `enhanceEndpoints` widens its tag union in place — `injectEndpoints` does not accept `tagTypes`.
- * Both mutate and return the same object, so one reducer, one middleware and one cache slice serve
- * every use case on this backend.
- *
- * That single slice is load-bearing: `createCurrencyDataSelector` hand-scans
- * `state.assetsDataApi.queries` across every cache entry, which is how interest rates and market
- * trend fetched by one query reach a caller that ran a different one.
+ * The handle carrying every endpoint's type. `injectEndpoints` mutates and returns the shared base,
+ * so the chain in `internals/endpoints` exists only to accumulate types — this is the same object
+ * as `dadaBase`. The intermediate handles stay private: each names a partially-built api, and a
+ * store configured from one would compile while missing endpoints.
  */
-export const assetsDataApi = dadaApi
-  .enhanceEndpoints({ addTagTypes: [AssetsDataTags.Assets] })
-  .injectEndpoints({
-    endpoints: build => ({
-      getAssetsData: build.infiniteQuery<AssetsDataWithPagination, GetAssetsDataParams, PageParam>({
-        query: ({ pageParam, queryArg }) => ({
-          url: `${resolveBaseUrl(queryArg)}/assets`,
-          params: buildAssetsQueryParams(queryArg, { cursor: pageParam?.cursor }),
-        }),
-        providesTags: [AssetsDataTags.Assets],
-        transformResponse: transformAssetsResponse,
-        infiniteQueryOptions: {
-          initialPageParam: {
-            cursor: "",
-          },
-          getNextPageParam: lastPage => {
-            if (lastPage.pagination.nextCursor) {
-              return {
-                cursor: lastPage.pagination.nextCursor,
-              };
-            } else {
-              return undefined;
-            }
-          },
-        },
-      }),
-      getAssetData: build.query<AssetsDataWithPagination, GetAssetsDataParams>({
-        query: queryArg => ({
-          url: `${resolveBaseUrl(queryArg)}/assets`,
-          params: buildAssetsQueryParams(queryArg, { pageSize: 1 }),
-        }),
-        providesTags: [AssetsDataTags.Assets],
-        transformResponse: transformAssetsResponse,
-      }),
-      getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
-        queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
-          fetchAllAssetsByCategory(queryArg, baseQuery),
-        keepUnusedDataFor: ONE_DAY_IN_SECONDS,
-      }),
-      getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
-        queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
-          fetchAllAssetCurrencyIdsByCategory(queryArg, baseQuery),
-        keepUnusedDataFor: ONE_DAY_IN_SECONDS,
-      }),
-      getChunkedAssetsData: build.query<AssetsData, GetAssetsDataParams>({
-        queryFn: async (queryArg, _api, _extraOptions, baseQuery) => {
-          const chunks = chunkCurrencyIds(queryArg.currencyIds ?? []);
-          if (chunks.length === 0) return { data: emptyAssetsData() };
-
-          const results = await allSettled(
-            chunks.map(chunkIds =>
-              fetchAssetsPage(baseQuery, { ...queryArg, currencyIds: chunkIds }),
-            ),
-          );
-
-          const responses = results.flatMap(r => (r.status === "fulfilled" ? [r.value] : []));
-
-          if (responses.length === 0) {
-            const firstRejection = results.find(r => r.status === "rejected");
-            const reason =
-              firstRejection?.status === "rejected" ? firstRejection.reason : undefined;
-            /* fetchAssetsPage rethrows the base query's error, so an HTTP status survives here. */
-            if (isFetchBaseQueryError(reason)) return { error: reason };
-            return {
-              error: {
-                status: "CUSTOM_ERROR" as const,
-                error: reason instanceof Error ? reason.message : "All DADA chunks failed",
-              },
-            };
-          }
-
-          const merged = responses.reduce<AssetsData>((acc, res) => {
-            deepMergeCryptoAssets(acc.cryptoAssets, res.cryptoAssets);
-            Object.assign(acc.networks, res.networks);
-            Object.assign(acc.cryptoOrTokenCurrencies, res.cryptoOrTokenCurrencies);
-            Object.assign(acc.interestRates, res.interestRates);
-            Object.assign(acc.markets, res.markets);
-            acc.currenciesOrder.metaCurrencyIds.push(...res.currenciesOrder.metaCurrencyIds);
-            return acc;
-          }, emptyAssetsData());
-
-          return { data: merged };
-        },
-        providesTags: [AssetsDataTags.Assets],
-        keepUnusedDataFor: ONE_DAY_IN_SECONDS,
-      }),
-    }),
-  });
+export const assetsDataApi = categoriesApi;
 
 export const {
   useGetAssetsDataInfiniteQuery,

--- a/domain/api/aggregated-assets/src/index.ts
+++ b/domain/api/aggregated-assets/src/index.ts
@@ -3,7 +3,6 @@ export * from "./schema";
 export * from "./types";
 export * from "./transforms";
 export * from "./requests";
-export * from "./accessors";
 export * from "./api";
 export * from "./errors";
 export * from "./market";

--- a/domain/api/aggregated-assets/src/internals/accessors.ts
+++ b/domain/api/aggregated-assets/src/internals/accessors.ts
@@ -1,6 +1,6 @@
-import { collectAllByCategory } from "./internals/collectAllByCategory";
-import type { DadaBaseQuery } from "./internals/requests";
-import type { GetAssetsByCategoryParams } from "./types";
+import { collectAllByCategory } from "./collectAllByCategory";
+import type { DadaBaseQuery } from "./requests";
+import type { GetAssetsByCategoryParams } from "../types";
 
 /** Every ticker in a category, across all pages. */
 export function fetchAllAssetsByCategory(

--- a/domain/api/aggregated-assets/src/internals/base.ts
+++ b/domain/api/aggregated-assets/src/internals/base.ts
@@ -1,0 +1,11 @@
+import { dadaApi } from "@shared/api-services";
+import { AssetsDataTags } from "../types";
+
+/*
+ * `enhanceEndpoints` rather than `injectEndpoints`, which cannot declare `tagTypes`.
+ *
+ * All endpoint modules inject into this one base so a single cache slice serves every use case.
+ * `createCurrencyDataSelector` hand-scans `state.assetsDataApi.queries` across every entry, so
+ * splitting the slice would hide interest rates and market trend from callers of another endpoint.
+ */
+export const dadaBase = dadaApi.enhanceEndpoints({ addTagTypes: [AssetsDataTags.Assets] });

--- a/domain/api/aggregated-assets/src/internals/collectAllByCategory.test.ts
+++ b/domain/api/aggregated-assets/src/internals/collectAllByCategory.test.ts
@@ -33,123 +33,126 @@ const rawWith = (tickers: string[]): RawApiResponse => ({
 
 const tickersOf = (data: RawApiResponse) => Object.values(data.cryptoAssets).map(a => a.ticker);
 
-function page(body: RawApiResponse, nextCursor?: string): Response {
+/** A page as the base query returns it: parsed body plus the raw response for header access. */
+function page(body: RawApiResponse, nextCursor?: string) {
   const headers = new Headers();
   if (nextCursor) headers.set("x-ledger-next", nextCursor);
-  return new Response(JSON.stringify(body), { status: 200, headers });
+  return { data: body, meta: { response: { headers } } };
 }
 
 describe("collectAllByCategory", () => {
-  let fetchSpy: jest.SpyInstance;
+  let baseQuery: jest.Mock;
 
-  const urls = () => fetchSpy.mock.calls.map(c => new URL(c[0] as string));
+  /** The request descriptors handed to the base query, one per page walked. */
+  const requests = () =>
+    baseQuery.mock.calls.map(c => c[0] as { url: string; params: Record<string, unknown> });
 
   beforeEach(() => {
-    fetchSpy = jest.spyOn(globalThis, "fetch");
-  });
-
-  afterEach(() => {
-    fetchSpy.mockRestore();
+    baseQuery = jest.fn();
   });
 
   it("returns the projection of a single page", async () => {
-    fetchSpy.mockResolvedValueOnce(page(rawWith(["aaplx"])));
+    baseQuery.mockResolvedValueOnce(page(rawWith(["aaplx"])));
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
     expect(result).toEqual({ data: ["AAPLX"] });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(baseQuery).toHaveBeenCalledTimes(1);
   });
 
   it("sends the category, product, version and a fixed page size", async () => {
-    fetchSpy.mockResolvedValueOnce(page(rawWith([])));
+    baseQuery.mockResolvedValueOnce(page(rawWith([])));
 
-    await collectAllByCategory(queryArg, tickersOf);
+    await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
-    const url = urls()[0];
-    expect(url.pathname).toBe("/v1/assets");
-    expect(url.searchParams.get("categories")).toBe("stocks");
-    expect(url.searchParams.get("product")).toBe("llm");
-    expect(url.searchParams.get("minVersion")).toBe("1.0.0");
-    expect(url.searchParams.get("pageSize")).toBe("100");
+    const { url, params } = requests()[0];
+    expect(url).toBe("https://dada.api.ledger.com/v1/assets");
+    expect(params).toMatchObject({
+      categories: "stocks",
+      product: "llm",
+      minVersion: "1.0.0",
+      pageSize: 100,
+    });
   });
 
   it("does not send a cursor on the first request", async () => {
-    fetchSpy.mockResolvedValueOnce(page(rawWith([])));
+    baseQuery.mockResolvedValueOnce(page(rawWith([])));
 
-    await collectAllByCategory(queryArg, tickersOf);
+    await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
-    expect(urls()[0].searchParams.has("cursor")).toBe(false);
+    expect(requests()[0].params).not.toHaveProperty("cursor");
   });
 
   it("walks every page and concatenates the projections in order", async () => {
-    fetchSpy
+    baseQuery
       .mockResolvedValueOnce(page(rawWith(["aaplx"]), "cursor-2"))
       .mockResolvedValueOnce(page(rawWith(["teslax"]), "cursor-3"))
       .mockResolvedValueOnce(page(rawWith(["nvdax"])));
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
     expect(result).toEqual({ data: ["AAPLX", "TESLAX", "NVDAX"] });
-    expect(urls().map(u => u.searchParams.get("cursor"))).toEqual([null, "cursor-2", "cursor-3"]);
+    expect(requests().map(r => r.params.cursor)).toEqual([undefined, "cursor-2", "cursor-3"]);
   });
 
   it("stops when the next-cursor header is absent", async () => {
-    fetchSpy
+    baseQuery
       .mockResolvedValueOnce(page(rawWith(["aaplx"]), "cursor-2"))
       .mockResolvedValueOnce(page(rawWith(["teslax"])));
 
-    await collectAllByCategory(queryArg, tickersOf);
+    await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(baseQuery).toHaveBeenCalledTimes(2);
   });
 
   it("targets staging when asked", async () => {
-    fetchSpy.mockResolvedValueOnce(page(rawWith([])));
+    baseQuery.mockResolvedValueOnce(page(rawWith([])));
 
-    await collectAllByCategory({ ...queryArg, isStaging: true }, tickersOf);
+    await collectAllByCategory({ ...queryArg, isStaging: true }, baseQuery, tickersOf);
 
-    expect(urls()[0].hostname).toBe("dada.api.ledger-test.com");
+    expect(requests()[0].url).toBe("https://dada.api.ledger-test.com/v1/assets");
   });
 
-  it("returns the http status as an error and stops walking", async () => {
-    fetchSpy.mockResolvedValueOnce(
-      new Response("nope", { status: 500, statusText: "Internal Server Error" }),
-    );
+  /*
+   * The base query owns error shaping now, so its result is returned verbatim rather than being
+   * re-wrapped as a FETCH_ERROR — an HTTP failure keeps its numeric status.
+   */
+  it("returns the base query's error and stops walking", async () => {
+    baseQuery.mockResolvedValueOnce({ error: { status: 500, data: "Internal Server Error" } });
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
-    expect(result.error).toEqual({
-      status: 500,
-      data: "Failed to fetch assets by category: Internal Server Error",
-    });
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result.error).toEqual({ status: 500, data: "Internal Server Error" });
+    expect(baseQuery).toHaveBeenCalledTimes(1);
   });
 
   it("discards pages already collected when a later page fails", async () => {
-    fetchSpy
+    baseQuery
       .mockResolvedValueOnce(page(rawWith(["aaplx"]), "cursor-2"))
-      .mockResolvedValueOnce(new Response("nope", { status: 502, statusText: "Bad Gateway" }));
+      .mockResolvedValueOnce({ error: { status: 502, data: "Bad Gateway" } });
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
     expect(result.data).toBeUndefined();
     expect(result.error).toMatchObject({ status: 502 });
   });
 
-  it("maps a thrown network failure to a FETCH_ERROR", async () => {
-    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+  it("passes a network failure through as the base query reported it", async () => {
+    baseQuery.mockResolvedValueOnce({ error: { status: "FETCH_ERROR", error: "offline" } });
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
     expect(result.error).toEqual({ status: "FETCH_ERROR", error: "offline" });
   });
 
-  it("maps a non-Error rejection to a FETCH_ERROR", async () => {
-    fetchSpy.mockRejectedValueOnce("just a string");
+  it("rejects an untrusted base url before issuing any request", async () => {
+    const { getEnv } = jest.requireMock("@shared/env");
+    getEnv.mockReturnValueOnce("https://evil.example.com/v1");
 
-    const result = await collectAllByCategory(queryArg, tickersOf);
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
 
-    expect(result.error).toEqual({ status: "FETCH_ERROR", error: "Unknown error" });
+    expect(result.error).toMatchObject({ status: "CUSTOM_ERROR" });
+    expect(result.error).toMatchObject({ error: expect.stringContaining("evil.example.com") });
+    expect(baseQuery).not.toHaveBeenCalled();
   });
 });

--- a/domain/api/aggregated-assets/src/internals/collectAllByCategory.ts
+++ b/domain/api/aggregated-assets/src/internals/collectAllByCategory.ts
@@ -5,57 +5,55 @@ import type {
 } from "@reduxjs/toolkit/query/react";
 import type { RawApiResponse } from "../schema";
 import type { GetAssetsByCategoryParams } from "../types";
-import { assertDadaApiUrl } from "./utils";
-import { resolveBaseUrl } from "./requests";
+import { resolveBaseUrl, type DadaBaseQuery } from "./requests";
 
 /**
  * Walks every page of a category and collects one projection per asset.
  *
  * Internal: both public category accessors share it, nothing outside this package should call it.
+ * TODO(LIVE-35503): the walk is unbounded and only stops when the server clears the cursor.
  */
 export async function collectAllByCategory(
   queryArg: GetAssetsByCategoryParams,
+  baseQuery: DadaBaseQuery,
   extract: (data: RawApiResponse) => string[],
-): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta | undefined>> {
+): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta>> {
+  /*
+   * The host guard throws, and a rejected queryFn surfaces in RTK as an unhandled error. Convert it
+   * so no path out of this endpoint can throw — LIVE-35232 depends on that.
+   */
+  let baseUrl: string;
   try {
-    const baseUrl = resolveBaseUrl(queryArg);
-    const collected: string[] = [];
-    let cursor: string | undefined;
-
-    do {
-      const url = new URL(`${baseUrl}/assets`);
-      url.searchParams.set("categories", queryArg.category);
-      url.searchParams.set("product", queryArg.product);
-      url.searchParams.set("pageSize", "100");
-      url.searchParams.set("minVersion", queryArg.version);
-      if (cursor) {
-        url.searchParams.set("cursor", cursor);
-      }
-
-      assertDadaApiUrl(url);
-      const response = await fetch(url.toString());
-
-      if (!response.ok) {
-        return {
-          error: {
-            status: response.status,
-            data: `Failed to fetch assets by category: ${response.statusText}`,
-          },
-        };
-      }
-
-      const data: RawApiResponse = await response.json();
-      collected.push(...extract(data));
-      cursor = response.headers.get("x-ledger-next") || undefined;
-    } while (cursor);
-
-    return { data: collected };
+    baseUrl = resolveBaseUrl(queryArg);
   } catch (error) {
     return {
       error: {
-        status: "FETCH_ERROR",
-        error: error instanceof Error ? error.message : "Unknown error",
+        status: "CUSTOM_ERROR",
+        error: error instanceof Error ? error.message : "Unresolvable DADA base url",
       },
     };
   }
+
+  const collected: string[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const result = await baseQuery({
+      url: `${baseUrl}/assets`,
+      params: {
+        categories: queryArg.category,
+        product: queryArg.product,
+        pageSize: 100,
+        minVersion: queryArg.version,
+        ...(cursor && { cursor }),
+      },
+    });
+
+    if (result.error) return { error: result.error };
+
+    collected.push(...extract(result.data as RawApiResponse));
+    cursor = result.meta?.response?.headers.get("x-ledger-next") || undefined;
+  } while (cursor);
+
+  return { data: collected };
 }

--- a/domain/api/aggregated-assets/src/internals/endpoints/categories.ts
+++ b/domain/api/aggregated-assets/src/internals/endpoints/categories.ts
@@ -1,0 +1,24 @@
+import { ONE_DAY_IN_SECONDS } from "../../constants";
+import { fetchAllAssetCurrencyIdsByCategory, fetchAllAssetsByCategory } from "../accessors";
+import type { GetAssetsByCategoryParams } from "../../types";
+import { lookupApi } from "./lookup";
+
+/**
+ * Categorisation use case: "what is in category X."
+ *
+ * Walks every page and keeps one field per asset, so it returns strings rather than entities.
+ */
+export const categoriesApi = lookupApi.injectEndpoints({
+  endpoints: build => ({
+    getAssetsByCategory: build.query<string[], GetAssetsByCategoryParams>({
+      queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
+        fetchAllAssetsByCategory(queryArg, baseQuery),
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+    getAssetCurrencyIdsByCategory: build.query<string[], GetAssetsByCategoryParams>({
+      queryFn: (queryArg, _api, _extraOptions, baseQuery) =>
+        fetchAllAssetCurrencyIdsByCategory(queryArg, baseQuery),
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+  }),
+});

--- a/domain/api/aggregated-assets/src/internals/endpoints/lookup.ts
+++ b/domain/api/aggregated-assets/src/internals/endpoints/lookup.ts
@@ -1,0 +1,73 @@
+import { ONE_DAY_IN_SECONDS } from "../../constants";
+import { isFetchBaseQueryError } from "../../errors";
+import { buildAssetsQueryParams } from "../../requests";
+import { fetchAssetsPage, resolveBaseUrl } from "../requests";
+import { transformAssetsResponse } from "../../transforms";
+import { allSettled, chunkCurrencyIds, deepMergeCryptoAssets, emptyAssetsData } from "../utils";
+import {
+  AssetsDataTags,
+  type AssetsData,
+  type AssetsDataWithPagination,
+  type GetAssetsDataParams,
+} from "../../types";
+import { queryApi } from "./query";
+
+/**
+ * Lookup use case: "I have ids, hydrate them."
+ *
+ * `getChunkedAssetsData` succeeds when *any* chunk resolves — portfolio distribution relies on
+ * partial data rather than failing whole.
+ */
+export const lookupApi = queryApi.injectEndpoints({
+  endpoints: build => ({
+    getAssetData: build.query<AssetsDataWithPagination, GetAssetsDataParams>({
+      query: queryArg => ({
+        url: `${resolveBaseUrl(queryArg)}/assets`,
+        params: buildAssetsQueryParams(queryArg, { pageSize: 1 }),
+      }),
+      providesTags: [AssetsDataTags.Assets],
+      transformResponse: transformAssetsResponse,
+    }),
+    getChunkedAssetsData: build.query<AssetsData, GetAssetsDataParams>({
+      queryFn: async (queryArg, _api, _extraOptions, baseQuery) => {
+        const chunks = chunkCurrencyIds(queryArg.currencyIds ?? []);
+        if (chunks.length === 0) return { data: emptyAssetsData() };
+
+        const results = await allSettled(
+          chunks.map(chunkIds =>
+            fetchAssetsPage(baseQuery, { ...queryArg, currencyIds: chunkIds }),
+          ),
+        );
+
+        const responses = results.flatMap(r => (r.status === "fulfilled" ? [r.value] : []));
+
+        if (responses.length === 0) {
+          const firstRejection = results.find(r => r.status === "rejected");
+          const reason = firstRejection?.status === "rejected" ? firstRejection.reason : undefined;
+          /* fetchAssetsPage rethrows the base query's error, so an HTTP status survives here. */
+          if (isFetchBaseQueryError(reason)) return { error: reason };
+          return {
+            error: {
+              status: "CUSTOM_ERROR" as const,
+              error: reason instanceof Error ? reason.message : "All DADA chunks failed",
+            },
+          };
+        }
+
+        const merged = responses.reduce<AssetsData>((acc, res) => {
+          deepMergeCryptoAssets(acc.cryptoAssets, res.cryptoAssets);
+          Object.assign(acc.networks, res.networks);
+          Object.assign(acc.cryptoOrTokenCurrencies, res.cryptoOrTokenCurrencies);
+          Object.assign(acc.interestRates, res.interestRates);
+          Object.assign(acc.markets, res.markets);
+          acc.currenciesOrder.metaCurrencyIds.push(...res.currenciesOrder.metaCurrencyIds);
+          return acc;
+        }, emptyAssetsData());
+
+        return { data: merged };
+      },
+      providesTags: [AssetsDataTags.Assets],
+      keepUnusedDataFor: ONE_DAY_IN_SECONDS,
+    }),
+  }),
+});

--- a/domain/api/aggregated-assets/src/internals/endpoints/query.ts
+++ b/domain/api/aggregated-assets/src/internals/endpoints/query.ts
@@ -1,0 +1,29 @@
+import { dadaBase } from "../base";
+import { buildAssetsQueryParams } from "../../requests";
+import { resolveBaseUrl } from "../requests";
+import { transformAssetsResponse } from "../../transforms";
+import {
+  AssetsDataTags,
+  type AssetsDataWithPagination,
+  type GetAssetsDataParams,
+  type PageParam,
+} from "../../types";
+
+/** Query-driven use case: a cursor-paginated search over the whole aggregate. */
+export const queryApi = dadaBase.injectEndpoints({
+  endpoints: build => ({
+    getAssetsData: build.infiniteQuery<AssetsDataWithPagination, GetAssetsDataParams, PageParam>({
+      query: ({ pageParam, queryArg }) => ({
+        url: `${resolveBaseUrl(queryArg)}/assets`,
+        params: buildAssetsQueryParams(queryArg, { cursor: pageParam?.cursor }),
+      }),
+      providesTags: [AssetsDataTags.Assets],
+      transformResponse: transformAssetsResponse,
+      infiniteQueryOptions: {
+        initialPageParam: { cursor: "" },
+        getNextPageParam: lastPage =>
+          lastPage.pagination.nextCursor ? { cursor: lastPage.pagination.nextCursor } : undefined,
+      },
+    }),
+  }),
+});

--- a/domain/api/aggregated-assets/src/internals/requests.test.ts
+++ b/domain/api/aggregated-assets/src/internals/requests.test.ts
@@ -44,78 +44,65 @@ describe("resolveBaseUrl", () => {
 });
 
 describe("fetchAssetsPage", () => {
-  const baseUrl = "https://dada.api.ledger.com/v1";
-  let fetchSpy: jest.SpyInstance;
+  let baseQuery: jest.Mock;
 
-  const respondWith = (body: unknown, init?: ResponseInit) => {
-    fetchSpy.mockResolvedValue(new Response(JSON.stringify(body), { status: 200, ...init }));
-  };
-
-  const requestedUrl = () => new URL(fetchSpy.mock.calls[0][0] as string);
+  const request = () =>
+    baseQuery.mock.calls[0][0] as { url: string; params: Record<string, unknown> };
 
   beforeEach(() => {
-    fetchSpy = jest.spyOn(globalThis, "fetch");
+    baseQuery = jest.fn().mockResolvedValue({ data: emptyRaw });
   });
 
-  afterEach(() => {
-    fetchSpy.mockRestore();
+  it("targets the /assets path on the resolved base url", async () => {
+    await fetchAssetsPage(baseQuery, params());
+
+    expect(request().url).toBe("https://dada.api.ledger.com/v1/assets");
   });
 
-  it("targets the /assets path on the given base url", async () => {
-    respondWith(emptyRaw);
+  it("passes the query params to the base query rather than building a url", async () => {
+    await fetchAssetsPage(baseQuery, params({ currencyIds: ["bitcoin", "ethereum"] }));
 
-    await fetchAssetsPage(baseUrl, params());
-
-    expect(requestedUrl().pathname).toBe("/v1/assets");
+    expect(request().params).toMatchObject({
+      currencyIds: ["bitcoin", "ethereum"],
+      product: "llm",
+      minVersion: "1.0.0",
+      pageSize: 100,
+    });
   });
 
-  it("serialises the query params onto the url", async () => {
-    respondWith(emptyRaw);
+  it("omits absent params instead of sending them undefined", async () => {
+    await fetchAssetsPage(baseQuery, params());
 
-    await fetchAssetsPage(baseUrl, params({ currencyIds: ["bitcoin", "ethereum"] }));
-
-    const url = requestedUrl();
-    expect(url.searchParams.get("currencyIds")).toBe("bitcoin,ethereum");
-    expect(url.searchParams.get("product")).toBe("llm");
-    expect(url.searchParams.get("minVersion")).toBe("1.0.0");
-    expect(url.searchParams.get("pageSize")).toBe("100");
-  });
-
-  it("omits undefined params rather than sending the string 'undefined'", async () => {
-    respondWith(emptyRaw);
-
-    await fetchAssetsPage(baseUrl, params());
-
-    expect(requestedUrl().searchParams.has("search")).toBe(false);
+    expect(request().params).not.toHaveProperty("search");
   });
 
   it("returns the response with currencies converted", async () => {
-    respondWith(emptyRaw);
-
-    const result = await fetchAssetsPage(baseUrl, params());
+    const result = await fetchAssetsPage(baseQuery, params());
 
     expect(result.cryptoOrTokenCurrencies).toEqual({});
     expect(result.currenciesOrder).toEqual(emptyRaw.currenciesOrder);
   });
 
-  it("throws with the status when the response is not ok", async () => {
-    fetchSpy.mockResolvedValue(
-      new Response("nope", { status: 503, statusText: "Service Unavailable" }),
-    );
+  /*
+   * Rethrows the base query's own error object so the chunked endpoint can return it verbatim,
+   * which is how an HTTP failure keeps its numeric status instead of collapsing to FETCH_ERROR.
+   */
+  it("rethrows the base query's error when the request fails", async () => {
+    baseQuery.mockResolvedValue({ error: { status: 503, data: "Service Unavailable" } });
 
-    await expect(fetchAssetsPage(baseUrl, params())).rejects.toThrow(
-      "DADA fetch failed: 503 Service Unavailable",
-    );
+    await expect(fetchAssetsPage(baseQuery, params())).rejects.toEqual({
+      status: 503,
+      data: "Service Unavailable",
+    });
   });
 
-  /*
-   * This endpoint builds its own url instead of going through `baseQuery`, so the host guard is
-   * the only thing standing between a mis-resolved base url and a request to another host.
-   */
-  it("refuses to fetch from an untrusted host", async () => {
-    await expect(fetchAssetsPage("https://evil.example.com", params())).rejects.toThrow(
+  it("refuses an untrusted base url before issuing any request", async () => {
+    const { getEnv } = jest.requireMock("@shared/env");
+    getEnv.mockReturnValueOnce("https://evil.example.com/v1");
+
+    await expect(fetchAssetsPage(baseQuery, params())).rejects.toThrow(
       "Blocked request to untrusted host: evil.example.com",
     );
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(baseQuery).not.toHaveBeenCalled();
   });
 });

--- a/domain/api/aggregated-assets/src/internals/requests.ts
+++ b/domain/api/aggregated-assets/src/internals/requests.ts
@@ -1,52 +1,50 @@
 import { getEnv } from "@shared/env";
+import type {
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  QueryReturnValue,
+} from "@reduxjs/toolkit/query";
 import type { RawApiResponse } from "../schema";
 import type { AssetsData, GetAssetsDataParams } from "../types";
 import { convertApiAssets } from "../transforms";
 import { buildAssetsQueryParams } from "../requests";
-import { assertDadaApiUrl } from "./utils";
+import { assertDadaApiHost } from "./utils";
+
+type DadaQueryResult = QueryReturnValue<unknown, FetchBaseQueryError, FetchBaseQueryMeta>;
+
+/**
+ * The bound base query RTK hands to `queryFn` as its fourth argument: same fetch, headers and
+ * abort signal as a declarative `query`. `PromiseLike` matches RTK's own `MaybePromise`.
+ */
+export type DadaBaseQuery = (
+  arg: string | FetchArgs,
+) => DadaQueryResult | PromiseLike<DadaQueryResult>;
 
 /**
  * Picks prod or staging per request.
  *
- * Exists only because the shared DADA base query is configured with `baseUrl: ""`, so every
- * endpoint has to resolve its own absolute url. LIVE-35301 moves url ownership to
- * `@shared/api-services` via `extraArgument`, which removes the need for this.
+ * Per-request rather than store config because `isStaging` is derived from the modular-drawer
+ * feature flag at each call site, so both environments are reachable in one session.
  */
 export function resolveBaseUrl(queryArg: { isStaging?: boolean }): string {
-  return queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
+  const baseUrl = queryArg.isStaging ? getEnv("DADA_API_STAGING") : getEnv("DADA_API_PROD");
+  assertDadaApiHost(baseUrl);
+  return baseUrl;
 }
 
-/**
- * One page for one chunk of currency ids. Used by the chunked lookup endpoint.
- *
- * Hand-rolls `fetch` instead of going through the base query, which is why `assertDadaApiUrl` is
- * needed and why RTK's `AbortSignal` never reaches the request. `queryFn` receives `baseQuery` as
- * its fourth argument, so the fan-out could use it — see LIVE-35301.
- */
+/** One page for one chunk of currency ids, through the base query so aborts and errors behave. */
 export async function fetchAssetsPage(
-  baseUrl: string,
+  baseQuery: DadaBaseQuery,
   queryArg: GetAssetsDataParams,
 ): Promise<AssetsData> {
-  const params = buildAssetsQueryParams(queryArg);
-  const url = new URL(`${baseUrl}/assets`);
-  for (const [key, value] of Object.entries(params)) {
-    if (value !== undefined) {
-      url.searchParams.set(key, Array.isArray(value) ? value.join(",") : String(value));
-    }
-  }
+  const result = await baseQuery({
+    url: `${resolveBaseUrl(queryArg)}/assets`,
+    params: buildAssetsQueryParams(queryArg),
+  });
 
-  assertDadaApiUrl(url);
-  const response = await fetch(url.toString());
+  if (result.error) throw result.error;
 
-  if (!response.ok) {
-    throw new Error(`DADA fetch failed: ${response.status} ${response.statusText}`);
-  }
-
-  const raw: RawApiResponse = await response.json();
-  const enrichedCryptoOrTokenCurrencies = convertApiAssets(raw.cryptoOrTokenCurrencies);
-
-  return {
-    ...raw,
-    cryptoOrTokenCurrencies: enrichedCryptoOrTokenCurrencies,
-  };
+  const raw = result.data as RawApiResponse;
+  return { ...raw, cryptoOrTokenCurrencies: convertApiAssets(raw.cryptoOrTokenCurrencies) };
 }

--- a/domain/api/aggregated-assets/src/internals/utils.test.ts
+++ b/domain/api/aggregated-assets/src/internals/utils.test.ts
@@ -1,7 +1,7 @@
 import type { CryptoAssetMeta } from "@domain/entity-aggregated-asset";
 import {
   allSettled,
-  assertDadaApiUrl,
+  assertDadaApiHost,
   chunkCurrencyIds,
   deepMergeCryptoAssets,
   emptyAssetsData,
@@ -153,11 +153,11 @@ describe("emptyAssetsData", () => {
   });
 });
 
-describe("assertDadaApiUrl", () => {
+describe("assertDadaApiHost", () => {
   it.each(["https://dada.api.ledger.com/assets", "https://dada.api.ledger-test.com/assets"])(
     "allows the known DADA host %s",
     href => {
-      expect(() => assertDadaApiUrl(new URL(href))).not.toThrow();
+      expect(() => assertDadaApiHost(href)).not.toThrow();
     },
   );
 
@@ -170,17 +170,17 @@ describe("assertDadaApiUrl", () => {
     "https://dada.api.ledger.com.evil.example.com/assets",
     "https://ledger.com/assets",
   ])("blocks %s", href => {
-    expect(() => assertDadaApiUrl(new URL(href))).toThrow(/untrusted host/);
+    expect(() => assertDadaApiHost(href)).toThrow(/untrusted host/);
   });
 
   it("names the rejected hostname in the error", () => {
-    expect(() => assertDadaApiUrl(new URL("https://evil.example.com/assets"))).toThrow(
+    expect(() => assertDadaApiHost("https://evil.example.com/assets")).toThrow(
       "Blocked request to untrusted host: evil.example.com",
     );
   });
 
   it("matches on hostname only, ignoring port and protocol", () => {
-    expect(() => assertDadaApiUrl(new URL("http://dada.api.ledger.com:8080/x"))).not.toThrow();
+    expect(() => assertDadaApiHost("http://dada.api.ledger.com:8080/x")).not.toThrow();
   });
 });
 

--- a/domain/api/aggregated-assets/src/internals/utils.ts
+++ b/domain/api/aggregated-assets/src/internals/utils.ts
@@ -20,10 +20,11 @@ export function allSettled<T>(promises: Promise<T>[]): Promise<SettledResult<T>[
 
 const ALLOWED_DADA_HOSTS = new Set(["dada.api.ledger.com", "dada.api.ledger-test.com"]);
 
-/** Guards endpoints that issue their own `fetch` against a mis-resolved base url. */
-export function assertDadaApiUrl(url: URL): void {
-  if (!ALLOWED_DADA_HOSTS.has(url.hostname)) {
-    throw new Error(`Blocked request to untrusted host: ${url.hostname}`);
+/** Guards against a mis-resolved base url before any request is built from it. */
+export function assertDadaApiHost(baseUrl: string): void {
+  const { hostname } = new URL(baseUrl);
+  if (!ALLOWED_DADA_HOSTS.has(hostname)) {
+    throw new Error(`Blocked request to untrusted host: ${hostname}`);
   }
 }
 

--- a/domain/api/aggregated-assets/src/transforms.test.ts
+++ b/domain/api/aggregated-assets/src/transforms.test.ts
@@ -451,19 +451,18 @@ describe("getChunkedAssetsData", () => {
       ]);
 
       expect(result.data).toBeUndefined();
-      expect(result.error).toMatchObject({ status: "FETCH_ERROR" });
+      // The base query's error is returned verbatim, so the HTTP status survives.
+      expect(result.error).toMatchObject({ status: 500 });
     });
 
-    it("reports the first failure's message when everything fails", async () => {
+    it("keeps the failure's http status when everything fails", async () => {
       const result = await getChunked(
         ["bitcoin"],
         [new Response(null, { status: 500, statusText: "Server Error" })],
       );
 
-      expect(result.error).toMatchObject({
-        status: "FETCH_ERROR",
-        error: expect.stringContaining("500"),
-      });
+      // Was a FETCH_ERROR with 500 buried in a message string; now a structured status.
+      expect(result.error).toMatchObject({ status: 500 });
     });
   });
 
@@ -476,7 +475,7 @@ describe("getChunkedAssetsData", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.error).toMatchObject({
-      status: "FETCH_ERROR",
+      status: "CUSTOM_ERROR",
       error: expect.stringContaining("evil.example.com"),
     });
   });


### PR DESCRIPTION
### 📝 Description

**Problem.** All five DADA endpoints went in through **one** `injectEndpoints` call in a 139-line `api.ts`, and three of them ran raw `fetch` inside their `queryFn` instead of the configured base query.

**Solution.** Split the api into one module per use case, and route every request through the base query RTK already passes as `queryFn`'s fourth argument.

```
internals/endpoints/query.ts       getAssetsData                               cursor-paginated search
internals/endpoints/lookup.ts      getAssetData, getChunkedAssetsData          "I have ids, hydrate them"
internals/endpoints/categories.ts  getAssetsByCategory, …CurrencyIdsByCategory "what is in category X"
```

Each injects into the shared base in `internals/base.ts`, chaining so the type accumulates every endpoint. They sit under `internals/` because chaining means each module exports the handle the next builds on, and those are private — see the audit section below. `api.ts` keeps the public surface it always had: **`assetsDataApi` plus the five hooks, so no consumer moves.**

### 🔑 Still one cache slice — the constraint that matters

`injectEndpoints` mutates and returns the same object, so this stays one reducer, one middleware and one cache slice. That is load-bearing, not incidental: `createCurrencyDataSelector` **hand-scans `state.assetsDataApi.queries`** across every cache entry, which is how interest rates and market trend fetched by one query reach a caller that ran a different one.

Three separate `createApi` instances would have meant three `reducerPath`s and `undefined` from `useInterestRatesByCurrencies` / `useMarketByCurrencies` — **with no type error**, since `pages` is typed `Array<Record<string, unknown>>`. A test pins the literal `"assetsDataApi"`.

### 🩹 What adopting the base query actually fixed

The raw `fetch` cost three things. All are now covered by tests:

| | Before | After |
| --- | --- | --- |
| HTTP 500 | flattened to `FETCH_ERROR`, status only inside a message string | `{status: 500}` |
| `isNetworkError()` on a 500 | **true** on the queryFn endpoints, false on the declarative ones | `false` everywhere |
| `AbortSignal` | never reached the request | attached to every request |

The error-shape divergence is the important one: it meant `errors.ts` classified the *same* HTTP failure differently depending on which endpoint you asked. **8 new tests** assert all four failable endpoints agree, on both a 500 and a transport failure — so a future endpoint that hand-rolls its own request regresses loudly.

The host guard also moved into `resolveBaseUrl`, so it now guards **every** endpoint rather than only the hand-built urls. A throw there is caught by RTK and surfaces as a rejected query with **no request issued** — verified, it fails closed.

### ⚠️ Three ACs are not met, and one is not achievable as written

The ticket asks for the base url to move to `@shared/api-services` via `extraArgument`, with `isStaging` dropping out of the query args. **That cannot work.** `extraArgument` is fixed at `configureStore` time, but `isStaging` is derived per call from the modular-drawer feature flag —

```ts
modularDrawerFeature?.params?.backendEnvironment === "STAGING"
```

— at 6 call sites, while 4 others hardcode `false`. Prod and staging are both reachable **in a single session**, decided per query; a desktop test asserts `false` and `true` in the same suite. Hoisting it would silently pin every caller to whatever the store was built with.

So `resolveBaseUrl`, `internals/requests.ts` and `getEnv("DADA_API_*")` all stay under `domain/`, and `assertDadaApiUrl` stays (renamed `assertDadaApiHost`) — the AC permitted that last one with a recorded reason, which is this. The honest fix is a per-request environment override in the service, or moving the flag read to the composition root; both are bigger than a refactor ticket should absorb.

**Abort is half done.** The signal now reaches every request, but `collectAllByCategory` has no abort check between pages — a probe that always returned a next cursor ran unbounded. Breaking out of the walk stays with **LIVE-35503**, as its `TODO` in the code says.

### 🧪 Three characterization tests changed, exactly as the ticket predicted

Nothing else changed. All three are the error-shape fix landing:

- `"errors only when every chunk fails"` — `{status: "FETCH_ERROR"}` → `{status: 500}`
- `"reports the first failure's message when everything fails"` — the 500 was only inside a message string, now structured
- `"blocks a request to an untrusted host"` — reworked, the guard returns `CUSTOM_ERROR` rather than throwing

### 📖 Reviewing this

Three commits, and the first is the one to read closely:

1. `use the injected base query` — **the behaviour change**, applied to the original single `api.ts` so it is readable without the file moves on top. Arrives with its own coverage: the uniform error shape across all four failable endpoints, the restored abort signal, and the host guard failing closed.
2. `split the api per use case` — **pure reorganization**, no behaviour change.
3. `add changeset`

Each of the first two was built and checked on its own: `tsc` exit 0 with zero errors and **168 tests passing at both**, so neither is a broken intermediate state.

The two category accessors left the public barrel for `internals/`: they were only ever called by the endpoints that now wrap them, and `grep` confirms nothing outside this package referenced them.

### 🏛️ Audited against the DDD guideline

Checked against [Structure & Flow](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/6111232117/Guideline+Monorepo+DDD+Re-architecture+Structure+Flow).

**Compliant.** `domain/api` is assigned exactly *"network calls, API contracts, input/output transformations, Redux RTK"* — this split is that. Import rules hold: the package declares only `@domain/entity-*`, `@domain/api-currency-token`, `@shared/*` and `@reduxjs/toolkit`, with **no `@ledgerhq/*` dependency or import**. The one legacy edge it touches transitively, `@shared/env → @ledgerhq/live-env`, is a *sanctioned* exception recorded at `constraints.js:64`.

**One violation the audit caught, fixed here.** Chaining `injectEndpoints` means each endpoint module exports the handle the next one builds on. Left in the public barrel, that gave the package **four public names for one object** and let a consumer configure a store from a *partial* handle — compiles, half-works.

My first attempt named the hooks in the barrel to filter the handles out. `lint:structure` correctly rejected that, and its rule text explains why better than I had: needing `export { a } from "./x"` *"proves the target file mixes public and private, so the private part was never moved to an internals location."* The handles are private, so they moved — `internals/endpoints/` — and the barrel stays nothing but `export * from "./x"`. Both checks pass, and the use-case separation is untouched: the modules moved, they did not merge.

**Two pre-existing violations, deliberately not fixed here** — both folded into LIVE-35232 rather than widening this diff:

1. `errors.ts` has zero DADA knowledge (every symbol takes a `FetchBaseQueryError`), and the guideline says `domain` *"does not host cross-cutting helpers"*. It belongs in `@shared/api-services`.
2. `domain/api` exports React hooks, but the guideline gives *"React glue"* to `features/platform` — which already wraps all five. The consequence is real: three files bypass the platform layer and call `assetsDataApi.useGetAssetDataQuery` directly.

Neither is caught by `enforce-boundaries`: tag rules see which package imports which, not *what kind of symbol* crosses — so both pass a green boundary check.

### ✅ Verification

- **domain/api: 168 tests** (from 158) · `tsc` **exit 0, 0 errors**
- `@features/platform-aggregated-assets` 129 tests, `tsc` **exit 0** · `libs/asset-detail` 92 tests · live-common `portfolio` + `ModularDrawer` 17 tests, `tsc` clean
- **Desktop and mobile typecheck ✅ All Good** (rebased onto develop, 47 commits absorbed)
- All three commands the boundaries job runs: `enforce-boundaries:lint:boundaries` 0 · `enforce-package-structure:test` 0 · the `lint:structure` validator reports **`✓ package structure ok`** · knip 0 · `oxfmt --check` clean
- `pnpm install --frozen-lockfile` succeeds with **no lockfile change** — this touches one private package

`libs/asset-detail`'s standalone `tsc` exits 1 with **105 errors, every one of them in an unbuilt sibling lib** (`ledger-live-common` 76, `wallet-btc` 16, `ledgerjs/*` 8, …). Zero in its own source and zero in this package. This branch touches only `domain/api/aggregated-assets` and one changeset file, so none of them are attributable to it; its 92 tests pass.

**Not verified:** that both apps boot with populated Market and Portfolio data. That needs a manual run; worth a QA pass on Market and Portfolio.

Demo on lwm

https://github.com/user-attachments/assets/55959e7c-cb3f-422b-86e8-0ba5289a69a6


Without internet

<img height="400" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-08-12 at 09 46 23" src="https://github.com/user-attachments/assets/96c6e9f4-88c0-4f34-809a-579f9835332f" />


LWD

https://github.com/user-attachments/assets/4abbd4d7-d265-45f3-bd7b-9a340f83ad9a



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35301](https://ledgerhq.atlassian.net/browse/LIVE-35301) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **ADR**: [DADA DDD compliant](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7382761502/DADA+DDD+compliant)
- **Predecessor**: [#20667](https://github.com/LedgerHQ/ledger-live/pull/20667) (LIVE-35231, delete the shims) — **merged**, so this targets `develop` directly
- **Addresses** @ysitbon's comment on [#20345](https://github.com/LedgerHQ/ledger-live/pull/20345): *"c'est utilisé par un endpoint… à voir la pertinence de l'implém du coup"*
- **Leaves to LIVE-35503**: bounding and cancelling the category walk
- **Folded into [LIVE-35232](https://ledgerhq.atlassian.net/browse/LIVE-35232)**: two layer-ownership fixes this PR surfaced but does not make — moving the DADA-agnostic `errors.ts` to `@shared/api-services`, and taking the React hooks out of `domain/api` (see below)


[LIVE-35301]: https://ledgerhq.atlassian.net/browse/LIVE-35301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ