### PR TITLE
[LWM] feat(lwm): show empty contacts state on recipient screen

### DIFF
--- a/.changeset/loud-donuts-reply.md
+++ b/.changeset/loud-donuts-reply.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+feat(lwm): show empty contacts state on recipient screen

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -4503,6 +4503,7 @@
         "title": "Paste from clipboard",
         "cta": "Paste"
       },
+      "contactsWillAppear": "Contacts will appear here",
       "editRecipientAccessibilityLabel": "Edit recipient",
       "sendTo": "Send to {{address}}",
       "addressMatched": "Address matched",

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientEmptyContactsState.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientEmptyContactsState.tsx
@@ -1,0 +1,25 @@
+import { Box, Spot, Text } from "@ledgerhq/lumen-ui-rnative";
+import { Contact } from "@ledgerhq/lumen-ui-rnative/symbols";
+import React from "react";
+import { useTranslation } from "~/context/Locale";
+
+export function RecipientEmptyContactsState() {
+  const { t } = useTranslation();
+
+  return (
+    <Box
+      lx={{
+        alignItems: "center",
+        gap: "s24",
+        paddingHorizontal: "s16",
+        paddingVertical: "s48",
+      }}
+      testID="send-recipient-empty-contacts-state"
+    >
+      <Spot appearance="icon" icon={Contact} size={72} />
+      <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+        {t("send.newSendFlow.contactsWillAppear")}
+      </Text>
+    </Box>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -8,6 +8,7 @@ import { AddressMatchedSection } from "./AddressMatchedSection";
 import { AddressValidationError } from "./AddressValidationError";
 import { LoadingState } from "./LoadingState";
 import { PasteFromClipboard } from "./PasteFromClipboard";
+import { RecipientEmptyContactsState } from "./RecipientEmptyContactsState";
 import { ValidationBanner } from "./ValidationBanner";
 
 type RecipientScreenViewProps = Readonly<{
@@ -27,6 +28,7 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
   const {
     isLoading,
     showInitialState,
+    showEmptyContactsState,
     result,
     searchValue,
     showBridgeSenderError,
@@ -58,6 +60,8 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
           {showInitialState && clipboardAddress && (
             <PasteFromClipboard address={clipboardAddress} onPaste={handlePasteFromClipboard} />
           )}
+
+          {showInitialState && showEmptyContactsState && <RecipientEmptyContactsState />}
 
           {showMemo && <MemoControls vm={memo} />}
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientEmptyContactsState.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/RecipientEmptyContactsState.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { RecipientEmptyContactsState } from "../RecipientEmptyContactsState";
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "send.newSendFlow.contactsWillAppear" ? "Contacts will appear here" : key,
+  }),
+}));
+
+jest.mock("@ledgerhq/lumen-ui-rnative", () => {
+  const RN = jest.requireActual<typeof import("react-native")>("react-native");
+  const Container = ({ children, testID }: { children: React.ReactNode; testID?: string }) => (
+    <RN.View testID={testID}>{children}</RN.View>
+  );
+  const Label = ({ children }: { children: React.ReactNode }) => <RN.Text>{children}</RN.Text>;
+
+  return {
+    Box: Container,
+    Spot: () => null,
+    Text: Label,
+  };
+});
+
+jest.mock("@ledgerhq/lumen-ui-rnative/symbols", () => ({
+  Contact: "Contact",
+}));
+
+describe("RecipientEmptyContactsState", () => {
+  it("renders the empty contacts placeholder", () => {
+    render(<RecipientEmptyContactsState />);
+
+    expect(screen.getByTestId("send-recipient-empty-contacts-state")).toBeOnTheScreen();
+    expect(screen.getByText("Contacts will appear here")).toBeOnTheScreen();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenView.test.ts
@@ -4,22 +4,34 @@ import { useAddressValidation } from "../useAddressValidation";
 import { useClipboardRecipient } from "../useClipboardRecipient";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
+import { useContactsFeature } from "@features/flow-contacts";
+import { useContacts } from "@features/platform-contacts";
 import {
   InvalidAddress,
   InvalidAddressBecauseDestinationIsAlsoSource,
 } from "@ledgerhq/ledger-wallet-framework/errors";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
-import { createMockAccount } from "./accounts";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
+import { createMockAccount, createMockCurrency } from "./accounts";
 
 jest.mock("../useAddressValidation");
 jest.mock("../useClipboardRecipient");
 jest.mock("../../../../context/SendFlowContext");
 jest.mock("@ledgerhq/live-common/account/index");
+jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
+jest.mock("@features/platform-contacts");
+jest.mock("@features/flow-contacts", () => ({
+  useContactsFeature: jest.fn(),
+}));
 
 const mockedUseAddressValidation = jest.mocked(useAddressValidation);
 const mockedUseClipboardRecipient = jest.mocked(useClipboardRecipient);
 const mockedUseSendFlowData = jest.mocked(useSendFlowData);
 const mockedGetMainAccount = jest.mocked(getMainAccount);
+const mockedSendFeatures = jest.mocked(sendFeatures);
+const mockedUseContacts = jest.mocked(useContacts);
+const mockedUseContactsFeature = jest.mocked(useContactsFeature);
 
 const mockAccount = createMockAccount({ id: "account_1" });
 
@@ -66,6 +78,13 @@ describe("useRecipientScreenView", () => {
       isLoading: false,
       validateAddress: jest.fn(),
     });
+    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
+    mockedUseContacts.mockReturnValue([]);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: false,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
   });
 
   it("shows initial state when no search value", () => {
@@ -79,7 +98,100 @@ describe("useRecipientScreenView", () => {
     );
 
     expect(result.current.showInitialState).toBe(true);
+    expect(result.current.showEmptyContactsState).toBe(false);
     expect(result.current.showSearchResults).toBe(false);
+  });
+
+  it("shows empty contacts state when address book is enabled and no contact matches the network", () => {
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([
+      mockContact({
+        id: "contact-sol",
+        name: "Alice",
+        addresses: [
+          mockContactAddress({
+            id: "address-sol",
+            currencyId: "solana",
+            label: "Solana",
+            address: "SolanaAddress123",
+          }),
+        ],
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.showInitialState).toBe(true);
+    expect(result.current.showEmptyContactsState).toBe(true);
+  });
+
+  it("does not show empty contacts state when address book is not supported", () => {
+    mockedSendFeatures.hasAddressBook.mockReturnValue(false);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: createMockAccount({
+          currency: createMockCurrency({ id: "tron", family: "tron" }),
+        }),
+        currency: createMockCurrency({ id: "tron", family: "tron" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.showEmptyContactsState).toBe(false);
+  });
+
+  it("does not show empty contacts state when a contact matches the network", () => {
+    mockedSendFeatures.hasAddressBook.mockReturnValue(true);
+    mockedUseContactsFeature.mockReturnValue({
+      isEnabled: true,
+      showNewBadge: false,
+      eligibleAddressFamilies: ["evm"],
+    });
+    mockedUseContacts.mockReturnValue([
+      mockContact({
+        id: "contact-eth",
+        name: "Alice",
+        addresses: [
+          mockContactAddress({
+            id: "address-eth",
+            currencyId: "ethereum",
+            label: "Ethereum",
+            address: "0x1234567890123456789012345678901234567890",
+          }),
+        ],
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useRecipientScreenView({
+        account: mockAccount,
+        currency: createMockCurrency({ id: "ethereum" }),
+        onAddressSelected: jest.fn(),
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.showInitialState).toBe(true);
+    expect(result.current.showEmptyContactsState).toBe(false);
   });
 
   it("shows search results when search value is provided", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -1,10 +1,14 @@
+import { useContactsFeature } from "@features/flow-contacts";
+import { useContacts } from "@features/platform-contacts";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
+import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import { useRecipientSearchState } from "@ledgerhq/live-common/flows/send/recipient/hooks/useRecipientSearchState";
+import { hasContactsOnNetwork } from "@ledgerhq/live-common/flows/send/recipient/utils/hasContactsOnNetwork";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
 import type { CryptoCurrency } from "@domain/entity-currency-crypto";
 import type { TokenCurrency } from "@domain/entity-currency-token";
 import type { Account, AccountLike } from "@ledgerhq/types-live";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useSendFlowData } from "../../../context/SendFlowContext";
 import { useAddressValidation } from "./useAddressValidation";
 import { useClipboardRecipient } from "./useClipboardRecipient";
@@ -27,8 +31,11 @@ export function useRecipientScreenView({
   recipientSupportsDomain,
 }: UseRecipientScreenViewProps) {
   const { recipientSearch } = useSendFlowData();
+  const contacts = useContacts();
+  const { isEnabled: isContactsFeatureEnabled } = useContactsFeature("mobile");
 
   const mainAccount = getMainAccount(account, parentAccount);
+  const hasAddressBook = sendFeatures.hasAddressBook(currency);
 
   const { result, isLoading } = useAddressValidation({
     searchValue: recipientSearch.value,
@@ -42,6 +49,13 @@ export function useRecipientScreenView({
 
   const hasSearchValue = recipientSearch.value.length > 0;
   const showInitialState = !hasSearchValue;
+  const showEmptyContactsState = useMemo(() => {
+    if (!showInitialState || !isContactsFeatureEnabled || !hasAddressBook) {
+      return false;
+    }
+
+    return !hasContactsOnNetwork(contacts, currency.id);
+  }, [contacts, currency.id, hasAddressBook, isContactsFeatureEnabled, showInitialState]);
 
   const { clipboardAddress } = useClipboardRecipient({
     enabled: showInitialState,
@@ -79,6 +93,7 @@ export function useRecipientScreenView({
     result,
     mainAccount,
     showInitialState,
+    showEmptyContactsState,
     clipboardAddress,
     handlePasteFromClipboard,
     handleAddressSelect,


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Display the "Contact will appear here" element in the recipient screen of LWD
Only if no contact having account in the chain we are sending to and that family is eligible to address book

<img width="432" height="969" alt="image" src="https://github.com/user-attachments/assets/3bc9e073-7670-4575-8e47-b2777b333d06" />


### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35767)** <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
