### PR TITLE
fix(e2e): reveal targets clear of sticky layers, drop dead scroll workarounds

### DIFF
--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -36,6 +36,9 @@ export const QUICK_VISIBILITY_PROBE_TIMEOUT = 500;
 
 const DEFAULT_WEB_ELEMENT_INTERVAL = 2000;
 
+/** How far past the viewport edge revealForTap pushes a target so an overlay cannot intercept it. */
+const EDGE_CLEARANCE_PIXELS = 200;
+
 export type WaitForElementOptions = {
   errorCheckTimeout?: number;
   errorElementId?: string;
@@ -327,6 +330,25 @@ export const NativeElementHelpers = {
     direction: Direction = "down",
   ): Promise<void> {
     await scroller.scrollByPixels(scrollViewId, pixels, direction);
+  },
+
+  /**
+   * Scrolls to an element and leaves it clear of the viewport edge, so a tap reaches it.
+   *
+   * `scrollToId` stops as soon as the target is minimally visible, which is the edge it entered
+   * through — where the sticky header and footer sit. Android reports such an element as visible
+   * anyway (`visibility` is View.getLocalVisibleRect(), which ignores occlusion by siblings), so the
+   * tap is accepted and then swallowed. Continuing in the same direction clears that edge.
+   *
+   * Use before a tap; `scrollToId` stays correct for assertions.
+   */
+  async revealForTap(
+    id: string | RegExp,
+    scrollViewId?: string | RegExp,
+    direction: Direction = "down",
+  ): Promise<void> {
+    await NativeElementHelpers.scrollToId(id, scrollViewId, undefined, direction);
+    await NativeElementHelpers.scrollByPixels(scrollViewId, EDGE_CLEARANCE_PIXELS, direction);
   },
 
   async getAttributesOfElement(id: string | RegExp, index = 0): Promise<Detox.ElementAttributes> {

--- a/e2e/mobile/helpers/elementHelpers.ts
+++ b/e2e/mobile/helpers/elementHelpers.ts
@@ -39,6 +39,13 @@ const DEFAULT_WEB_ELEMENT_INTERVAL = 2000;
 /** How far past the viewport edge revealForTap pushes a target so an overlay cannot intercept it. */
 const EDGE_CLEARANCE_PIXELS = 200;
 
+export type RevealForTapOptions = {
+  /** Scroll container. Omitted means the engine guesses the first scrollable by type. */
+  container?: string | RegExp;
+  /** Search direction; the edge clearance always continues the same way. Defaults to "down". */
+  direction?: Direction;
+};
+
 export type WaitForElementOptions = {
   errorCheckTimeout?: number;
   errorElementId?: string;
@@ -342,13 +349,10 @@ export const NativeElementHelpers = {
    *
    * Use before a tap; `scrollToId` stays correct for assertions.
    */
-  async revealForTap(
-    id: string | RegExp,
-    scrollViewId?: string | RegExp,
-    direction: Direction = "down",
-  ): Promise<void> {
-    await NativeElementHelpers.scrollToId(id, scrollViewId, undefined, direction);
-    await NativeElementHelpers.scrollByPixels(scrollViewId, EDGE_CLEARANCE_PIXELS, direction);
+  async revealForTap(id: string | RegExp, options: RevealForTapOptions = {}): Promise<void> {
+    const { container, direction = "down" } = options;
+    await NativeElementHelpers.scrollToId(id, container, undefined, direction);
+    await NativeElementHelpers.scrollByPixels(container, EDGE_CLEARANCE_PIXELS, direction);
   },
 
   async getAttributesOfElement(id: string | RegExp, index = 0): Promise<Detox.ElementAttributes> {

--- a/e2e/mobile/jest.environment.ts
+++ b/e2e/mobile/jest.environment.ts
@@ -185,6 +185,7 @@ export default class TestEnvironment extends DetoxEnvironment {
       getLabelOfElement: NativeElementHelpers.getLabelOfElement,
       IsIdPresent: NativeElementHelpers.isIdPresent,
       IsIdVisible: NativeElementHelpers.isIdVisible,
+      revealForTap: NativeElementHelpers.revealForTap,
       scrollByPixels: NativeElementHelpers.scrollByPixels,
       scrollToId: NativeElementHelpers.scrollToId,
       scrollToText: NativeElementHelpers.scrollToText,

--- a/e2e/mobile/page/accounts/addAccount.drawer.ts
+++ b/e2e/mobile/page/accounts/addAccount.drawer.ts
@@ -4,6 +4,10 @@ import CommonPage from "../common.page";
 import { retryUntilTimeout } from "../../utils/retry";
 import { checkForErrorModals } from "../../helpers/errorHelpers";
 
+// Short enough that retryUntilTimeout's own budget still allows a re-tap; the default 60s would
+// consume the whole budget in a single attempt.
+const CONTINUE_DISMISS_TIMEOUT = 5_000;
+
 export default class AddAccountDrawer extends CommonPage {
   baseLink = "add-account";
   deselectAllButtonId = "add-accounts-deselect-all";
@@ -59,7 +63,11 @@ export default class AddAccountDrawer extends CommonPage {
   async finishAccountsDiscovery() {
     await retryUntilTimeout(async () => {
       await tapById(this.continueButtonId);
-      await waitForElementNotVisible(this.continueButtonId);
+      const dismissed = await waitForElementNotVisible(
+        this.continueButtonId,
+        CONTINUE_DISMISS_TIMEOUT,
+      );
+      if (!dismissed) throw new Error(`${this.continueButtonId} still visible after tap`);
     });
   }
 

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -120,6 +120,9 @@ export default class ModularDrawer {
       if (await IsIdVisible(id)) return;
       await scrollView.swipe("up", "slow", 0.2, 0.5);
     }
+    throw new Error(
+      `Network item ${String(id)} not reachable after ${maxAttempts} swipes in ${this.networkSelectionScrollViewId}`,
+    );
   }
 
   private async selectAssetCurrencyAndNetwork(account: Account): Promise<void> {

--- a/e2e/mobile/page/drawer/modular.drawer.ts
+++ b/e2e/mobile/page/drawer/modular.drawer.ts
@@ -120,6 +120,8 @@ export default class ModularDrawer {
       if (await IsIdVisible(id)) return;
       await scrollView.swipe("up", "slow", 0.2, 0.5);
     }
+    // The last swipe is only useful if its result is checked, so probe once more before failing.
+    if (await IsIdVisible(id)) return;
     throw new Error(
       `Network item ${String(id)} not reachable after ${maxAttempts} swipes in ${this.networkSelectionScrollViewId}`,
     );

--- a/e2e/mobile/page/drawer/wallet40Drawers.drawer.ts
+++ b/e2e/mobile/page/drawer/wallet40Drawers.drawer.ts
@@ -1,57 +1,13 @@
-import { by, element, waitFor } from "detox";
 import { Step } from "jest-allure2-reporter/api";
-import { delay, isAndroid } from "../../helpers/commonHelpers";
+import { isAndroid } from "../../helpers/commonHelpers";
 import {
   QUICK_VISIBILITY_PROBE_TIMEOUT,
   VISIBILITY_PROBE_TIMEOUT,
 } from "../../helpers/elementHelpers";
 
 export default class Wallet40DrawersPage {
-  walletV4TourCloseButtonId = "drawer-close-button";
-  productTourCloseButtonId = "product-tour-close-button";
-  walletV4TourFirstSlideTitle = "A clearer view of your portfolio";
-  walletV4TourNextButtonText = "Next";
-  walletV4TourCompleteButtonText = "Discover my new portfolio";
-  wallet40DrawerMountDelayMs = 1500;
   analyticsConsentDrawerId = "analytics-consent-drawer";
   analyticsConsentRefuseAllButtonId = "analytics-consent-drawer-secondary-button";
-  closeButtonLabel = "Close";
-
-  // The Wallet 4.0 onboarding/product tour can mount over the portfolio at startup and block interactions.
-  // Dismiss it via whatever affordance is present: close-button id, "Close" label, or stepping through the tour.
-  @Step("Close Wallet 4.0 tour if visible")
-  async closeWalletV4TourIfVisible(timeout = VISIBILITY_PROBE_TIMEOUT): Promise<boolean> {
-    if (await this.isTextVisible(this.walletV4TourFirstSlideTitle, timeout)) {
-      if (await IsIdVisible(this.walletV4TourCloseButtonId, QUICK_VISIBILITY_PROBE_TIMEOUT)) {
-        await tapById(this.walletV4TourCloseButtonId);
-        await waitForElementNotVisible(this.walletV4TourCloseButtonId);
-        return true;
-      }
-
-      if (await this.tapCloseButtonByLabelIfVisible()) {
-        return true;
-      }
-
-      await this.tapTextIfVisible(this.walletV4TourNextButtonText);
-      await this.tapTextIfVisible(this.walletV4TourNextButtonText);
-      await this.tapTextIfVisible(this.walletV4TourCompleteButtonText);
-      return true;
-    }
-
-    if (await IsIdVisible(this.walletV4TourCloseButtonId, timeout)) {
-      await tapById(this.walletV4TourCloseButtonId);
-      await waitForElementNotVisible(this.walletV4TourCloseButtonId);
-      return true;
-    }
-
-    if (await IsIdVisible(this.productTourCloseButtonId, QUICK_VISIBILITY_PROBE_TIMEOUT)) {
-      await tapById(this.productTourCloseButtonId);
-      await waitForElementNotVisible(this.productTourCloseButtonId);
-      return true;
-    }
-
-    return await this.tapCloseButtonByLabelIfVisible();
-  }
 
   @Step("Close analytics consent drawer if visible")
   async closeAnalyticsConsentDrawerIfVisible(timeout = VISIBILITY_PROBE_TIMEOUT): Promise<boolean> {
@@ -72,44 +28,7 @@ export default class Wallet40DrawersPage {
 
   @Step("Close Wallet 4.0 blocking drawers if visible")
   async closeWallet40BlockingDrawersIfVisible(timeout = VISIBILITY_PROBE_TIMEOUT) {
-    // Android can expose the topbar before queued Wallet 4.0 drawers finish mounting.
-    if (isAndroid()) await delay(this.wallet40DrawerMountDelayMs);
-
     const drawerTimeout = isAndroid() ? timeout : QUICK_VISIBILITY_PROBE_TIMEOUT;
-
-    await this.closeWalletV4TourIfVisible(QUICK_VISIBILITY_PROBE_TIMEOUT);
     await this.closeAnalyticsConsentDrawerIfVisible(drawerTimeout);
-    await this.closeWalletV4TourIfVisible(QUICK_VISIBILITY_PROBE_TIMEOUT);
-    await this.closeAnalyticsConsentDrawerIfVisible(QUICK_VISIBILITY_PROBE_TIMEOUT);
-  }
-
-  private async isTextVisible(text: string, timeout = VISIBILITY_PROBE_TIMEOUT): Promise<boolean> {
-    try {
-      await waitFor(element(by.text(text)))
-        .toBeVisible()
-        .withTimeout(timeout);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  private async tapTextIfVisible(text: string): Promise<void> {
-    if (await this.isTextVisible(text, VISIBILITY_PROBE_TIMEOUT)) {
-      await element(by.text(text)).tap();
-      await delay(300);
-    }
-  }
-
-  private async tapCloseButtonByLabelIfVisible(): Promise<boolean> {
-    try {
-      const closeButton = element(by.label(this.closeButtonLabel)).atIndex(0);
-      await waitFor(closeButton).toBeVisible().withTimeout(QUICK_VISIBILITY_PROBE_TIMEOUT);
-      await closeButton.tap();
-      await waitFor(closeButton).not.toBeVisible().withTimeout(VISIBILITY_PROBE_TIMEOUT);
-      return true;
-    } catch {
-      return false;
-    }
   }
 }

--- a/e2e/mobile/page/wallet/assetDetail.page.ts
+++ b/e2e/mobile/page/wallet/assetDetail.page.ts
@@ -234,10 +234,7 @@ export default class AssetDetailPage {
   async openFirstTransaction(ticker: string) {
     await this.scrollToTransactions();
     const scrollViewId = await this.getScrollViewId();
-    await scrollToId(this.operationsListItemId, scrollViewId, 300, "down");
-    // Extra "slack" scroll so the first operation is centered and not stuck behind the
-    // sticky Buy/Swap footer, which would otherwise intercept the tap on Android.
-    await scrollByPixels(scrollViewId, 200, "down");
+    await revealForTap(this.operationsListItemId, scrollViewId, "down");
     await detoxExpect(this.operationByTicker(ticker).atIndex(0)).toBeVisible();
     await this.tapTransactionUntilOperationDetailsOpen();
   }

--- a/e2e/mobile/page/wallet/assetDetail.page.ts
+++ b/e2e/mobile/page/wallet/assetDetail.page.ts
@@ -234,7 +234,7 @@ export default class AssetDetailPage {
   async openFirstTransaction(ticker: string) {
     await this.scrollToTransactions();
     const scrollViewId = await this.getScrollViewId();
-    await revealForTap(this.operationsListItemId, scrollViewId, "down");
+    await revealForTap(this.operationsListItemId, { container: scrollViewId });
     await detoxExpect(this.operationByTicker(ticker).atIndex(0)).toBeVisible();
     await this.tapTransactionUntilOperationDetailsOpen();
   }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -204,8 +204,7 @@ export default class PortfolioPage {
         await tapById(this.cryptoAddressItemId(currencyId));
       }
     } else {
-      await scrollToId(this.assetItemId(currencyName), this.accountsListView);
-      await scrollByPixels(this.accountsListView, 100, "down");
+      await revealForTap(this.assetItemId(currencyName), this.accountsListView, "down");
       await tapById(this.assetItemId(currencyName));
     }
   }
@@ -511,9 +510,7 @@ export default class PortfolioPage {
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
     const currencyName = testId.replace("assetItem-", "");
-    // The transparent nav header floats over the list, and Android reports the row underneath it as
-    // visible, so without this the tap is swallowed by the header.
-    await scrollByPixels(this.emptyPortfolioListId, 200, "up");
+    await revealForTap(testId, this.emptyPortfolioListId, "up");
     await tapById(testId);
     return currencyName;
   }

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -227,7 +227,7 @@ export default class PortfolioPage {
       jestExpect(assetsCount).toBeLessThanOrEqual(5);
       await detoxExpect(getElementById(this.showAllAssetsButton)).toBeVisible();
       await tapById(this.showAllAssetsButton);
-      jestExpect(await countElementsById(this.assetItemRegExp)).toBeGreaterThan(5);
+      jestExpect(await countElements(getElementsById(this.assetItemRegExp))).toBeGreaterThan(5);
     }
   }
 
@@ -241,7 +241,9 @@ export default class PortfolioPage {
       await scrollToId(this.showAllAccountsButton, this.accountsListView, 400);
       jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeLessThanOrEqual(5);
       await this.tapShowAllAccountsButton();
-      jestExpect(await countElementsById(app.common.accountItemNameRegExp)).toBeGreaterThan(5);
+      jestExpect(
+        await countElements(getElementsById(app.common.accountItemNameRegExp)),
+      ).toBeGreaterThan(5);
       await this.tapAddNewOrExistingAccountButton();
       await app.addAccount.importWithYourLedger();
     }
@@ -281,7 +283,7 @@ export default class PortfolioPage {
     await scrollToId(this.seeAllTransactionsButton, this.accountsListView, 2000, "down");
     await detoxExpect(getElementById(this.seeAllTransactionsButton)).toBeVisible();
     await tapById(this.seeAllTransactionsButton);
-    jestExpect(await countElementsById(this.operationRowDate)).toBeGreaterThan(3);
+    jestExpect(await countElements(getElementsById(this.operationRowDate))).toBeGreaterThan(3);
   }
 
   @Step("Click on selected last operation")

--- a/e2e/mobile/page/wallet/portfolio.page.ts
+++ b/e2e/mobile/page/wallet/portfolio.page.ts
@@ -204,7 +204,7 @@ export default class PortfolioPage {
         await tapById(this.cryptoAddressItemId(currencyId));
       }
     } else {
-      await revealForTap(this.assetItemId(currencyName), this.accountsListView, "down");
+      await revealForTap(this.assetItemId(currencyName), { container: this.accountsListView });
       await tapById(this.assetItemId(currencyName));
     }
   }
@@ -512,7 +512,7 @@ export default class PortfolioPage {
   async tapFirstAssetItemW40(): Promise<string> {
     const testId = await getIdByRegexp(this.assetItemRegExp, 0);
     const currencyName = testId.replace("assetItem-", "");
-    await revealForTap(testId, this.emptyPortfolioListId, "up");
+    await revealForTap(testId, { container: this.emptyPortfolioListId, direction: "up" });
     await tapById(testId);
     return currencyName;
   }

--- a/e2e/mobile/types/global.d.ts
+++ b/e2e/mobile/types/global.d.ts
@@ -75,6 +75,7 @@ declare global {
   var getLabelOfElement: typeof NativeElementHelpers.getLabelOfElement;
   var IsIdPresent: typeof NativeElementHelpers.isIdPresent;
   var IsIdVisible: typeof NativeElementHelpers.isIdVisible;
+  var revealForTap: typeof NativeElementHelpers.revealForTap;
   var scrollByPixels: typeof NativeElementHelpers.scrollByPixels;
   var scrollToId: typeof NativeElementHelpers.scrollToId;
   var scrollToText: typeof NativeElementHelpers.scrollToText;


### PR DESCRIPTION
### 📝 Description

Parts 5 and 6 of QAA-1442, together. **45 insertions, 95 deletions — a net removal of 50 lines.**

#### Part 5 (QAA-1460) — one helper replaces three magic numbers

Three call sites had hand-tuned "slack" scrolls past sticky layers, with three different constants (200 / 100 / 200) and duplicated explanations. They are one defect patched three times: `scrollToId` stops the moment the target is *minimally* visible, which is always the edge it entered through — and the edges are exactly where the sticky header and footer sit. On Android the tap is then accepted and swallowed, because `visibility` is `View.getLocalVisibleRect()` and ignores occlusion by siblings.

```ts
async revealForTap(id, scrollViewId?, direction = "down") {
  await NativeElementHelpers.scrollToId(id, scrollViewId, undefined, direction);
  await NativeElementHelpers.scrollByPixels(scrollViewId, EDGE_CLEARANCE_PIXELS, direction);
}
```

The clearance always goes **the same way as the search**, which is what moves the target off the edge it came in through. `grep scrollByPixels page/ specs/` now returns nothing.

**`revealById` and the measured safe rect from the ticket were dropped** — see the [QAA-1460 comment](https://ledgerhq.atlassian.net/browse/QAA-1460) for why: the ticket's two acceptance criteria turned out not to be overlay problems at all (one is a 60s wait with no scroll, the other is Espresso refusing to type into a focused `ReactEditText`, i.e. the keyboard). The Receive testIDs were added and then reverted, because no spec taps those controls — production code with zero consumers.

#### Part 6 (QAA-1458) — four subtractions

| | Change |
|---|---|
| **A** | `swipeToNetworkItem` exhausted 5 swipes and **returned normally**, so the failure surfaced later as a generic tap error. It now throws, naming the item, the attempt count and the container. This is the call behind 12 `modular-drawer-network-selection-scrollView not found` errors in one CI shard |
| **B** | `finishAccountsDiscovery`'s `retryUntilTimeout` was **dead code**: it only re-runs on throw, and `waitForElementNotVisible` returns `false` instead of throwing, so a Continue button that never dismissed counted as success. The result is now raised, with a 5s probe so the retry budget allows an actual re-tap |
| **C** | Three `toBeGreaterThan` assertions after "show all" used `countElementsById`, which counts only rows **≥75% visible** — a full list longer than the viewport reads as ≤5 and false-fails. They now use the existing `countElements(getElementsById(...))` |
| **D** | The Wallet 4.0 **tour guard is deleted** (115 → 38 lines). `tour: false, q2Tour: false` are forced in both flag presets and no spec overrides them, so it guarded a drawer that cannot render — while costing an Android-only 1500ms sleep, wasted probes at 13 call sites, and 4 hardcoded English strings. The analytics half is kept: it still fires for `marketBanner.spec.ts`, whose fixture omits `hasSeenAnalyticsOptInPrompt` |

### ✅ Verification

Local device runs, `E2E_RETRIES=0` throughout so no flake is masked by a retry.

| Spec | Covers | Android | iOS |
|---|---|---|---|
| `marketBanner` | D (only spec where the analytics drawer appears) | 1/1 | 1/1 |
| `wallet40Q2/walletAssets` | D + Part 5 | 5/5 | 5/5 |
| `wallet40Q2/operationsHistory` | D + Part 5 | 3/3 | 3/3 |
| `wallet40Q2/assetAggregationMarketDetail` | D + Part 5 | 4/4 | 3/4 — see below |
| `wallet40Q2/portfolio` | A + B | 7/7 | — |

**CI-time improvement:** `walletAssets` on Android went **244s → 163s** once D removed the dead tour probes, before the sleep removal was even counted.

### ⚠️ Two things a reviewer should know

**1. The iOS `assetAggregationMarketDetail` failure is pre-existing.** `[DAI (Polygon)] - Aggregated assets show one row per asset…` fails in `scrollToAddressItem` (`assetDetail.page.ts`), code this PR does not touch. Proven by reverting `e2e/mobile` to `develop` and re-running on iOS: **it fails identically there** (133s, same test). It passes on Android. The mechanism is that `scrollToAddressItem` re-searches from scratch per address with a fixed `700, "down"`, so the second (Ethereum) address overshoots the addresses section entirely. Logged to QAA-1458.

**2. Change C is a fix to code that does not currently execute.** All three lines are in legacy `else` branches, and every spec reaching them is `describe.skip`'d in Q2 (`isQ2WithAggregatedAssets` / `isQ2WithOperationsList`). So CI will neither prove nor disprove it — it is zero-risk, and also unverified by design. If those legacy paths are genuinely dead, **deleting them** would be better than fixing assertions inside them; that decision is deliberately not taken here.

### 🔗 Context

- **JIRA**: [QAA-1460](https://ledgerhq.atlassian.net/browse/QAA-1460) (Part 5) and [QAA-1458](https://ledgerhq.atlassian.net/browse/QAA-1458) (Part 6, items A–D), both under [QAA-1442](https://ledgerhq.atlassian.net/browse/QAA-1442)
- QAA-1458 stays **open**: the remaining backlog (10 omitted-container scroll calls, the 35% visibility threshold, the regex + `"bottom"` scroll, unexplained magic pixels, `scrollOnce`'s inverted-direction fallback, and `isIdVisible`'s multiple-match trap) is recorded there. Each changes scroll behaviour and needs its own device run, which is why it is not bundled here.


[QAA-1460]: https://ledgerhq.atlassian.net/browse/QAA-1460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ