### PR TITLE
feat(platform-contacts): add shared Contacts analytics contract

### DIFF
--- a/.changeset/contacts-analytics-contract.md
+++ b/.changeset/contacts-analytics-contract.md
@@ -1,0 +1,6 @@
+---
+"@features/platform-contacts": minor
+"@features/flow-contacts": minor
+---
+
+Add shared Contacts analytics global properties in platform-contacts and the typed tracking contract helper in flow-contacts.

--- a/features/flow/contacts/README.md
+++ b/features/flow/contacts/README.md
@@ -23,9 +23,13 @@ Shared Contacts flow package for Desktop and Mobile.
 - Shared UI components (`.web.tsx` / `.native.tsx`)
 - Contact detail composition; Platform Contacts owns the reusable Contact avatar, including the
   app-owned "Me" profile image
+- Contacts analytics contract: typed event/page names, payloads, and
+  `createContactsAnalyticsHelper()` for apps to inject their `track` functions
 - Compatibility exports for `@features/flow-contacts-add-contact`
 
-App layers own routing, screen composition, i18n, and analytics.
+App layers own routing, screen composition, i18n, and analytics adapters (`track` /
+`trackPage`). Flow-specific tracking contracts and helpers live in this package; shared global
+analytics properties come from `@features/platform-contacts`.
 
 For Add Address, the Flow resolves ordered production network IDs from
 `eligibleAddressFamilies` and sends only those IDs to MAD. The consuming adapter filters MAD content
@@ -101,6 +105,7 @@ src/
 │   ├── ContactsButton/                  # My Wallet entry (web + native)
 ├── hooks/                               # Contacts flow-only hooks
 ├── utils/                               # Contacts flow-only utilities
+├── analytics/                           # Typed tracking contract + helper
 ├── jest.native.ts                       # Mobile Jest entry (re-exports ./index.native)
 ├── featureFlags.ts
 ├── index.ts                             # Web public API

--- a/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
+++ b/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
@@ -1,0 +1,191 @@
+/**
+ * Contacts analytics contract aligned with the
+ * [Contacts Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7271088138/Contacts+-+Tracking+Plan).
+ *
+ * P2 secured account-name tracking is intentionally excluded from Contacts: payloads must never
+ * include contact names, address labels, account names, raw blockchain addresses, or raw search
+ * queries. For `search_query`, send `queryLength` and `hasResults` instead of the tracking plan's
+ * `$query` placeholder to avoid leaking names or address fragments.
+ */
+
+import type { ContactsGlobalProperties } from "@features/platform-contacts";
+
+export const CONTACTS_EVENT_SOURCE = {
+  ENTRY: "entry",
+  LIST: "list",
+  SEARCH: "search",
+  LEDGER_SYNC_GATE: "ledger_sync_gate",
+  ADD_CONTACT: "add_contact",
+  PICTURE: "picture",
+  CONTACT_DETAIL: "contact_detail",
+  ADD_ADDRESS: "add_address",
+  ADDRESS_DETAIL: "address_detail",
+  QUICK_ACTION: "quick_action",
+} as const;
+
+export type ContactsEventSource =
+  (typeof CONTACTS_EVENT_SOURCE)[keyof typeof CONTACTS_EVENT_SOURCE];
+
+/** track() event names used by Contacts. */
+export const CONTACTS_TRACK_EVENTS = {
+  BUTTON_CLICKED: "button_clicked",
+  SEARCH_QUERY: "search_query",
+  ERROR_DISPLAYED: "error_displayed",
+  CONTACT_ADDED: "contact_added",
+  ADDRESS_ADDED: "address_added",
+} as const;
+
+export type ContactsTrackEventName =
+  (typeof CONTACTS_TRACK_EVENTS)[keyof typeof CONTACTS_TRACK_EVENTS];
+
+/** trackPage() / screen page names used by Contacts. */
+export const CONTACTS_PAGE_EVENTS = {
+  CONTACTS: "Page Contacts",
+  ACTIVATE_LEDGER_SYNC: "Page Activate Ledger Sync",
+  ADD_CONTACT: "Page Add Contact",
+  CONTACT_DETAIL: "Page Contact detail",
+  ADDRESS_DETAIL: "Page Contacts Address detail",
+} as const;
+
+export type ContactsPageEventName =
+  (typeof CONTACTS_PAGE_EVENTS)[keyof typeof CONTACTS_PAGE_EVENTS];
+
+/** `page` property values attached to track events. */
+export const CONTACTS_PAGE_PROPERTY = {
+  MY_WALLET: "My Wallet",
+  CONTACTS: "contacts",
+  CONTACT_DETAIL: "contact detail",
+  CONTACT_DETAIL_SNAKE: "contact_detail",
+  ADD_CONTACT: "add contact",
+  LEDGER_SYNC_GATE: "ledger sync gate",
+  ADDRESS_DETAIL: "address detail",
+} as const;
+
+export type ContactsPageProperty =
+  (typeof CONTACTS_PAGE_PROPERTY)[keyof typeof CONTACTS_PAGE_PROPERTY];
+
+export const CONTACTS_TRACKING_BUTTON = {
+  contacts: "contacts",
+  addContact: "add contact",
+  contact: "contact",
+  activateLedgerSync: "activate ledger sync",
+  dismiss: "dismiss",
+  contactPicture: "contact picture",
+  saveContact: "save contact",
+  editContact: "edit contact",
+  deleteContact: "delete contact",
+  addAddress: "add address",
+  disabledNetworkTooltip: "disabled network tooltip",
+  saveAddress: "save address",
+  send: "send",
+  edit: "edit",
+  delete: "delete",
+} as const;
+
+export type ContactsTrackingButton =
+  (typeof CONTACTS_TRACKING_BUTTON)[keyof typeof CONTACTS_TRACKING_BUTTON];
+
+export const CONTACTS_FLOW = {
+  CONTACTS: "contacts",
+  SEND: "send",
+} as const;
+
+export type ContactsFlow = (typeof CONTACTS_FLOW)[keyof typeof CONTACTS_FLOW];
+
+export type ContactsPictureAction = "add" | "change" | "delete";
+
+export type ContactsAddressInputMethod = "paste" | "qr_code" | "manual" | "ens";
+
+export type ContactsAddAddressType = "me" | "other";
+
+export type ContactsAddContactErrorType = "invalid name" | "invalid picture";
+
+export type ContactsContactDetailErrorType = "signer_mismatch";
+
+type WithGlobalProperties<T> = T & ContactsGlobalProperties;
+
+export type ContactsTrackEventInputParams = {
+  [CONTACTS_TRACK_EVENTS.BUTTON_CLICKED]: Readonly<{
+    source: ContactsEventSource;
+    button: ContactsTrackingButton | (string & {});
+    page: ContactsPageProperty | (string & {});
+    flow?: ContactsFlow | (string & {});
+    action?: ContactsPictureAction;
+    hasPicture?: boolean;
+    myContact?: boolean;
+    type?: ContactsAddAddressType;
+    asset?: string;
+    network?: string;
+    inputMethod?: ContactsAddressInputMethod;
+  }>;
+  [CONTACTS_TRACK_EVENTS.SEARCH_QUERY]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.SEARCH;
+    page: typeof CONTACTS_PAGE_PROPERTY.CONTACTS;
+    queryLength: number;
+    hasResults: boolean;
+  }>;
+  [CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED]: Readonly<{
+    source: ContactsEventSource;
+    page: ContactsPageProperty | (string & {});
+    errorType: ContactsAddContactErrorType | ContactsContactDetailErrorType | (string & {});
+  }>;
+  [CONTACTS_TRACK_EVENTS.CONTACT_ADDED]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.ADD_CONTACT;
+    hasCustomPicture: boolean;
+    flow: ContactsFlow | (string & {});
+    page: ContactsPageProperty | (string & {});
+  }>;
+  [CONTACTS_TRACK_EVENTS.ADDRESS_ADDED]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.ADD_ADDRESS;
+    network: string;
+    asset: string;
+    inputMethod: ContactsAddressInputMethod | (string & {});
+    isEns: boolean;
+    flow: ContactsFlow | (string & {});
+  }>;
+};
+
+export type ContactsPageEventInputParams = {
+  [CONTACTS_PAGE_EVENTS.CONTACTS]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.LIST;
+    page: typeof CONTACTS_PAGE_PROPERTY.CONTACTS;
+  }>;
+  [CONTACTS_PAGE_EVENTS.ACTIVATE_LEDGER_SYNC]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE;
+    flow: typeof CONTACTS_FLOW.CONTACTS;
+    previousPage: string;
+  }>;
+  [CONTACTS_PAGE_EVENTS.ADD_CONTACT]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.ADD_CONTACT;
+    flow: ContactsFlow | (string & {});
+  }>;
+  [CONTACTS_PAGE_EVENTS.CONTACT_DETAIL]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.CONTACT_DETAIL;
+    isSelf: boolean;
+  }>;
+  [CONTACTS_PAGE_EVENTS.ADDRESS_DETAIL]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.ADDRESS_DETAIL;
+    network: string;
+    asset: string;
+  }>;
+};
+
+export type ContactsTrackEventParams = {
+  [T in ContactsTrackEventName]: WithGlobalProperties<ContactsTrackEventInputParams[T]>;
+};
+
+export type ContactsPageEventParams = {
+  [T in ContactsPageEventName]: WithGlobalProperties<ContactsPageEventInputParams[T]>;
+};
+
+export type ContactsTrackEventPayload<T extends ContactsTrackEventName = ContactsTrackEventName> =
+  Readonly<{
+    name: T;
+    properties: ContactsTrackEventParams[T];
+  }>;
+
+export type ContactsPageEventPayload<T extends ContactsPageEventName = ContactsPageEventName> =
+  Readonly<{
+    page: T;
+    properties: ContactsPageEventParams[T];
+  }>;

--- a/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.ts
+++ b/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.ts
@@ -1,0 +1,62 @@
+import type { ContactsGlobalProperties } from "@features/platform-contacts";
+import type {
+  ContactsPageEventInputParams,
+  ContactsPageEventName,
+  ContactsPageEventParams,
+  ContactsPageEventPayload,
+  ContactsTrackEventInputParams,
+  ContactsTrackEventName,
+  ContactsTrackEventParams,
+  ContactsTrackEventPayload,
+} from "./contactsAnalytics.types";
+
+export type ContactsAnalyticsAdapter = Readonly<{
+  track: <T extends ContactsTrackEventName>(payload: ContactsTrackEventPayload<T>) => void;
+  trackPage: <T extends ContactsPageEventName>(payload: ContactsPageEventPayload<T>) => void;
+}>;
+
+export type ContactsAnalyticsHelper = Readonly<{
+  trackEvent: <T extends ContactsTrackEventName>(
+    eventName: T,
+    params: ContactsTrackEventInputParams[T],
+  ) => void;
+  trackPage: <T extends ContactsPageEventName>(
+    pageName: T,
+    params: ContactsPageEventInputParams[T],
+  ) => void;
+  getGlobalProperties: () => ContactsGlobalProperties;
+}>;
+
+export function createContactsAnalyticsHelper(
+  adapter: ContactsAnalyticsAdapter,
+  getGlobalProperties: () => ContactsGlobalProperties,
+): ContactsAnalyticsHelper {
+  return {
+    getGlobalProperties,
+    trackEvent(eventName, params) {
+      adapter.track({
+        name: eventName,
+        properties: {
+          ...getGlobalProperties(),
+          ...params,
+        } as ContactsTrackEventParams[typeof eventName],
+      });
+    },
+    trackPage(pageName, params) {
+      adapter.trackPage({
+        page: pageName,
+        properties: {
+          ...getGlobalProperties(),
+          ...params,
+        } as ContactsPageEventParams[typeof pageName],
+      });
+    },
+  };
+}
+
+export function createNoopContactsAnalyticsAdapter(): ContactsAnalyticsAdapter {
+  return {
+    track: () => undefined,
+    trackPage: () => undefined,
+  };
+}

--- a/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
+++ b/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
@@ -1,0 +1,224 @@
+import {
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
+  type ContactsPageEventPayload,
+  type ContactsTrackEventPayload,
+} from "./contactsAnalytics.types";
+import {
+  createContactsAnalyticsHelper,
+  createNoopContactsAnalyticsAdapter,
+} from "./createContactsAnalyticsHelper";
+
+const globalProperties = {
+  ffAddressBookEnabled: true,
+  contactsCount: 2,
+  externalAddressesSavedCount: 1,
+  myAddressesSavedCount: 1,
+} as const;
+
+describe("createContactsAnalyticsHelper", () => {
+  it("merges global properties with track event params before dispatching", () => {
+    const track = jest.fn();
+    const trackPage = jest.fn();
+    const helper = createContactsAnalyticsHelper({ track, trackPage }, () => globalProperties);
+
+    helper.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.ENTRY,
+      button: CONTACTS_TRACKING_BUTTON.contacts,
+      page: CONTACTS_PAGE_PROPERTY.MY_WALLET,
+    });
+
+    expect(track).toHaveBeenCalledWith({
+      name: CONTACTS_TRACK_EVENTS.BUTTON_CLICKED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.ENTRY,
+        button: CONTACTS_TRACKING_BUTTON.contacts,
+        page: CONTACTS_PAGE_PROPERTY.MY_WALLET,
+      },
+    });
+  });
+
+  it("merges global properties with page event params before dispatching", () => {
+    const track = jest.fn();
+    const trackPage = jest.fn();
+    const helper = createContactsAnalyticsHelper({ track, trackPage }, () => globalProperties);
+
+    helper.trackPage(CONTACTS_PAGE_EVENTS.CONTACT_DETAIL, {
+      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+      isSelf: false,
+    });
+
+    expect(trackPage).toHaveBeenCalledWith({
+      page: CONTACTS_PAGE_EVENTS.CONTACT_DETAIL,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+        isSelf: false,
+      },
+    });
+  });
+
+  it("reads the latest global properties on each dispatch", () => {
+    let contactsCount = 1;
+    const track = jest.fn();
+    const trackPage = jest.fn();
+    const helper = createContactsAnalyticsHelper({ track, trackPage }, () => ({
+      ...globalProperties,
+      contactsCount,
+    }));
+
+    helper.trackPage(CONTACTS_PAGE_EVENTS.CONTACTS, {
+      source: CONTACTS_EVENT_SOURCE.LIST,
+      page: CONTACTS_PAGE_PROPERTY.CONTACTS,
+    });
+
+    contactsCount = 4;
+    helper.trackPage(CONTACTS_PAGE_EVENTS.CONTACTS, {
+      source: CONTACTS_EVENT_SOURCE.LIST,
+      page: CONTACTS_PAGE_PROPERTY.CONTACTS,
+    });
+
+    expect(trackPage).toHaveBeenNthCalledWith(1, {
+      page: CONTACTS_PAGE_EVENTS.CONTACTS,
+      properties: expect.objectContaining({ contactsCount: 1 }),
+    });
+    expect(trackPage).toHaveBeenNthCalledWith(2, {
+      page: CONTACTS_PAGE_EVENTS.CONTACTS,
+      properties: expect.objectContaining({ contactsCount: 4 }),
+    });
+  });
+
+  it("exposes a noop adapter for tests", () => {
+    expect(() =>
+      createNoopContactsAnalyticsAdapter().track({
+        name: CONTACTS_TRACK_EVENTS.CONTACT_ADDED,
+        properties: {
+          ...globalProperties,
+          source: CONTACTS_EVENT_SOURCE.ADD_CONTACT,
+          hasCustomPicture: false,
+          flow: CONTACTS_FLOW.CONTACTS,
+          page: CONTACTS_PAGE_PROPERTY.ADD_CONTACT,
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("Contacts analytics payload shapes", () => {
+  it("accepts typed payloads for each tracking-plan source", () => {
+    const entryClick: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.BUTTON_CLICKED> = {
+      name: CONTACTS_TRACK_EVENTS.BUTTON_CLICKED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.ENTRY,
+        button: CONTACTS_TRACKING_BUTTON.contacts,
+        page: CONTACTS_PAGE_PROPERTY.MY_WALLET,
+      },
+    };
+
+    const searchQuery: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.SEARCH_QUERY> = {
+      name: CONTACTS_TRACK_EVENTS.SEARCH_QUERY,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.SEARCH,
+        page: CONTACTS_PAGE_PROPERTY.CONTACTS,
+        queryLength: 3,
+        hasResults: true,
+      },
+    };
+
+    const ledgerSyncClick: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.BUTTON_CLICKED> =
+      {
+        name: CONTACTS_TRACK_EVENTS.BUTTON_CLICKED,
+        properties: {
+          ...globalProperties,
+          source: CONTACTS_EVENT_SOURCE.LEDGER_SYNC_GATE,
+          button: CONTACTS_TRACKING_BUTTON.activateLedgerSync,
+          page: CONTACTS_PAGE_PROPERTY.LEDGER_SYNC_GATE,
+        },
+      };
+
+    const contactAdded: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.CONTACT_ADDED> = {
+      name: CONTACTS_TRACK_EVENTS.CONTACT_ADDED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.ADD_CONTACT,
+        hasCustomPicture: true,
+        flow: CONTACTS_FLOW.CONTACTS,
+        page: CONTACTS_PAGE_PROPERTY.ADD_CONTACT,
+      },
+    };
+
+    const addContactError: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED> =
+      {
+        name: CONTACTS_TRACK_EVENTS.ERROR_DISPLAYED,
+        properties: {
+          ...globalProperties,
+          source: CONTACTS_EVENT_SOURCE.ADD_CONTACT,
+          page: CONTACTS_PAGE_PROPERTY.ADD_CONTACT,
+          errorType: "invalid name",
+        },
+      };
+
+    const contactDetailPage: ContactsPageEventPayload<typeof CONTACTS_PAGE_EVENTS.CONTACT_DETAIL> =
+      {
+        page: CONTACTS_PAGE_EVENTS.CONTACT_DETAIL,
+        properties: {
+          ...globalProperties,
+          source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+          isSelf: true,
+        },
+      };
+
+    const addressAdded: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.ADDRESS_ADDED> = {
+      name: CONTACTS_TRACK_EVENTS.ADDRESS_ADDED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.ADD_ADDRESS,
+        network: "ethereum",
+        asset: "ETH",
+        inputMethod: "manual",
+        isEns: false,
+        flow: CONTACTS_FLOW.CONTACTS,
+      },
+    };
+
+    const quickAction: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.BUTTON_CLICKED> = {
+      name: CONTACTS_TRACK_EVENTS.BUTTON_CLICKED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.QUICK_ACTION,
+        button: CONTACTS_TRACKING_BUTTON.send,
+        page: CONTACTS_PAGE_PROPERTY.ADDRESS_DETAIL,
+        asset: "ETH",
+      },
+    };
+
+    const payloads = [
+      entryClick,
+      searchQuery,
+      ledgerSyncClick,
+      contactAdded,
+      addContactError,
+      contactDetailPage,
+      addressAdded,
+      quickAction,
+    ];
+
+    for (const payload of payloads) {
+      const properties = "properties" in payload ? payload.properties : undefined;
+      expect(properties?.ffAddressBookEnabled).toBe(true);
+      expect(properties?.source).toBeDefined();
+      expect(Object.keys(properties ?? {})).not.toContain("contact_name");
+      expect(Object.keys(properties ?? {})).not.toContain("address_label");
+      expect(Object.keys(properties ?? {})).not.toContain("account_name");
+      expect(Object.keys(properties ?? {})).not.toContain("address");
+      expect(Object.keys(properties ?? {})).not.toContain("query");
+    }
+  });
+});

--- a/features/flow/contacts/src/analytics/index.ts
+++ b/features/flow/contacts/src/analytics/index.ts
@@ -1,0 +1,2 @@
+export * from "./contactsAnalytics.types";
+export * from "./createContactsAnalyticsHelper";

--- a/features/flow/contacts/src/index.native.ts
+++ b/features/flow/contacts/src/index.native.ts
@@ -1,6 +1,7 @@
 export * from "./contactsListFacade.native";
 export * from "./contactsViewFacade.native";
 export * from "./addContactFacade";
+export * from "./analytics";
 export * from "./steps/EditContact";
 export * from "./steps/EditContact/native";
 export * from "./steps/EditAddress";

--- a/features/flow/contacts/src/index.ts
+++ b/features/flow/contacts/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./contactsListFacade";
 export * from "./contactsViewFacade";
 export * from "./addContactFacade";
+export * from "./analytics";
 export * from "./steps/EditContact";
 export * from "./steps/EditContact/web";
 export * from "./steps/EditAddress";

--- a/features/platform/contacts/README.md
+++ b/features/platform/contacts/README.md
@@ -4,8 +4,8 @@
 >
 > **Status: UNSTABLE** — In active development as part of the DDD migration.
 
-Contacts domain selectors, display helpers, React hooks, and Device Intent ports shared by flow
-packages.
+Contacts domain selectors, display helpers, React hooks, Device Intent ports, and shared
+analytics building blocks used by flow packages.
 
 ## Exports
 
@@ -19,3 +19,5 @@ packages.
   resolves the React Native implementation.
 - `ContactDeviceIntentsPort`: defines the typed boundary for Contacts device interactions.
 - `createMockContactDeviceIntentsPort()`: returns temporary typed device results for Contacts flows.
+- Contacts analytics building blocks: `ContactsGlobalProperties` and
+  `buildContactsGlobalProperties()` for shared global event properties.

--- a/features/platform/contacts/src/analytics/buildContactsGlobalProperties.ts
+++ b/features/platform/contacts/src/analytics/buildContactsGlobalProperties.ts
@@ -1,0 +1,25 @@
+import type { Contact } from "@domain/entity-contact";
+import type { ContactsGlobalProperties } from "./contactsGlobalProperties";
+
+export type BuildContactsGlobalPropertiesInput = Readonly<{
+  ffAddressBookEnabled: boolean;
+  contacts: readonly Contact[];
+}>;
+
+export function buildContactsGlobalProperties(
+  input: BuildContactsGlobalPropertiesInput,
+): ContactsGlobalProperties {
+  const meContact = input.contacts.find(contact => contact.isMe);
+  const savedContacts = input.contacts.filter(contact => !contact.isMe);
+  const externalAddressesSavedCount = savedContacts.reduce(
+    (count, contact) => count + contact.addresses.length,
+    0,
+  );
+
+  return {
+    ffAddressBookEnabled: input.ffAddressBookEnabled,
+    contactsCount: savedContacts.length,
+    externalAddressesSavedCount,
+    myAddressesSavedCount: meContact?.addresses.length ?? 0,
+  };
+}

--- a/features/platform/contacts/src/analytics/buildContactsGlobalProperties.web.test.ts
+++ b/features/platform/contacts/src/analytics/buildContactsGlobalProperties.web.test.ts
@@ -1,0 +1,57 @@
+import {
+  mockContactWithAddress,
+  mockMeContact,
+  mockMeContactWithAddresses,
+  mockPopulatedContacts,
+} from "@domain/entity-contact/schema.mock";
+import { buildContactsGlobalProperties } from "./buildContactsGlobalProperties";
+
+describe("buildContactsGlobalProperties", () => {
+  it("counts saved contacts and splits external addresses between other contacts and Me", () => {
+    const contacts = mockPopulatedContacts();
+
+    expect(
+      buildContactsGlobalProperties({
+        ffAddressBookEnabled: true,
+        contacts,
+      }),
+    ).toEqual({
+      ffAddressBookEnabled: true,
+      contactsCount: 5,
+      externalAddressesSavedCount: 3,
+      myAddressesSavedCount: 3,
+    });
+  });
+
+  it("returns zero counts when only Me is present without addresses", () => {
+    expect(
+      buildContactsGlobalProperties({
+        ffAddressBookEnabled: false,
+        contacts: [mockMeContact()],
+      }),
+    ).toEqual({
+      ffAddressBookEnabled: false,
+      contactsCount: 0,
+      externalAddressesSavedCount: 0,
+      myAddressesSavedCount: 0,
+    });
+  });
+
+  it("excludes Me addresses from externalAddressesSavedCount", () => {
+    const contacts = [
+      mockMeContactWithAddresses(),
+      mockContactWithAddress({ id: "contact-ben", name: "Ben" }),
+    ];
+
+    expect(
+      buildContactsGlobalProperties({
+        ffAddressBookEnabled: true,
+        contacts,
+      }),
+    ).toMatchObject({
+      contactsCount: 1,
+      externalAddressesSavedCount: 1,
+      myAddressesSavedCount: 3,
+    });
+  });
+});

--- a/features/platform/contacts/src/analytics/contactsGlobalProperties.ts
+++ b/features/platform/contacts/src/analytics/contactsGlobalProperties.ts
@@ -1,0 +1,6 @@
+export type ContactsGlobalProperties = Readonly<{
+  ffAddressBookEnabled: boolean;
+  contactsCount: number;
+  externalAddressesSavedCount: number;
+  myAddressesSavedCount: number;
+}>;

--- a/features/platform/contacts/src/analytics/index.ts
+++ b/features/platform/contacts/src/analytics/index.ts
@@ -1,0 +1,2 @@
+export * from "./contactsGlobalProperties";
+export * from "./buildContactsGlobalProperties";

--- a/features/platform/contacts/src/index.native.ts
+++ b/features/platform/contacts/src/index.native.ts
@@ -1,4 +1,5 @@
 export * from "./useContacts";
+export * from "./analytics";
 export * from "./utils/getContactInitial";
 export * from "./hooks/useContactsMeContact";
 export * from "./utils/getContactAvatarColorClass";

--- a/features/platform/contacts/src/index.ts
+++ b/features/platform/contacts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./useContacts";
+export * from "./analytics";
 export * from "./utils/getContactInitial";
 export * from "./hooks/useContactsMeContact";
 export * from "./utils/getContactAvatarColorClass";


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

Define the shared Contacts analytics contract in `@features/platform-contacts` so Desktop and Mobile scenario tasks can dispatch tracking through one typed helper with injected Segment adapters.

- Centralize event names, page names, button/page property constants, and typed payloads aligned with the [Contacts Tracking Plan](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7271088138/Contacts+-+Tracking+Plan)
- Centralize global user properties: `ffAddressBookEnabled`, `contactsCount`, `externalAddressesSavedCount`, `myAddressesSavedCount`
- Cover all Contacts event sources: entry, list, search, Ledger Sync gate, Add contact, picture, contact detail, Add address, address detail, and quick action
- Add `buildContactsGlobalProperties()` and `createContactsAnalyticsHelper()` with `trackEvent()` / `trackPage()` and an injectable `ContactsAnalyticsAdapter`
- Exclude P2 secured account-name tracking: no contact names, address labels, account names, raw addresses, or raw search queries in payloads (`search_query` uses `queryLength` + `hasResults` instead of `$query`)

## Out of scope

No app-layer wiring yet — scenario tickets will inject Desktop/Mobile `track()` / `trackPage()` adapters and call the helper from ViewModels.

### 🔗 Context

[LIVE-33966](https://ledgerhq.atlassian.net/browse/LIVE-33966)


[LIVE-33966]: https://ledgerhq.atlassian.net/browse/LIVE-33966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ