### PR TITLE
[LWD] fix(portfolio): show one Braze banner on narrow placement width

### DIFF
--- a/.changeset/calm-banners-shrink.md
+++ b/.changeset/calm-banners-shrink.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Show only one portfolio Braze banner when the placement area is too narrow for two readable columns, using CSS container queries instead of JS width measurement.

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/__integrations__/PortfolioContentCards.test.tsx
@@ -8,6 +8,7 @@ import { track } from "~/renderer/analytics/segment";
 import { ContentCardEvent } from "@ledgerhq/live-common/braze/contentCardExtras";
 import { LocationContentCard } from "~/types/dynamicContent";
 import { CONTENT_BANNER_ACTION_CARD_CLOSE_LABEL } from "../components/ContentBannerActionCard/types";
+import { BRAZE_PLACEMENT_GRID_CLASS_NAME } from "../utils/brazePlacementLayout";
 
 let mockShouldDisplayBrazePlacement = false;
 
@@ -126,14 +127,14 @@ function asClassicBrazeCard(
   return Object.assign(Object.create(ClassicCard.prototype), { id, extras });
 }
 
+const desktopCardsForTopCarousel = Cards.map(asClassicBrazeCard);
+const desktopCardsForBrazeGrid = CardsForBrazeGrid.map(asClassicBrazeCard);
+const desktopCardsWithBottomPlacements = [...Cards, ...BottomCards].map(asClassicBrazeCard);
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockShouldDisplayBrazePlacement = false;
 });
-
-const desktopCardsForTopCarousel = Cards.map(asClassicBrazeCard);
-const desktopCardsForBrazeGrid = CardsForBrazeGrid.map(asClassicBrazeCard);
-const desktopCardsWithBottomPlacements = [...Cards, ...BottomCards].map(asClassicBrazeCard);
 
 describe("PortfolioContentCards", () => {
   test("render slides", async () => {
@@ -353,6 +354,32 @@ describe("PortfolioContentCards", () => {
     expect(screen.getByText("Foo")).toBeVisible();
     expect(screen.queryByText("Bar")).toBeNull();
     expect(screen.queryByTestId("carousel-arrow-next")).not.toBeInTheDocument();
+  });
+
+  test("uses container-query classes to hide extra Braze banners on narrow placement width", async () => {
+    mockShouldDisplayBrazePlacement = true;
+
+    render(<PortfolioContentCards />, {
+      initialState: {
+        dynamicContent: {
+          desktopCards: desktopCardsForBrazeGrid,
+          portfolioCards: CardsForBrazeGrid,
+        },
+        settings: {
+          shareAnalytics: true,
+          sharePersonalizedRecommandations: true,
+          lastAnalyticsConsentDate: new Date().toISOString(),
+          privacyPolicyVersion: 1,
+        },
+      },
+    });
+
+    expect(await screen.findByText("Foo")).toBeVisible();
+    // JSDOM does not evaluate CSS container queries; assert the responsive grid contract instead.
+    expect(screen.getByTestId("portfolio-braze-placement-grid")).toHaveClass(
+      ...BRAZE_PLACEMENT_GRID_CLASS_NAME.split(" "),
+    );
+    expect(screen.getByText("Bar")).toBeInTheDocument();
   });
 
   test("classic path stacks leadingSlide above Braze carousel without truncating Braze cards", async () => {

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -7,50 +7,22 @@ import React, {
   type ReactNode,
 } from "react";
 import { useNavigate } from "react-router";
-import styled from "styled-components";
 
 import { Carousel } from "@ledgerhq/react-ui";
 import { track } from "~/renderer/analytics/segment";
 import { openURL } from "~/renderer/linking";
 import type { PortfolioContentCard as PortfolioCardType } from "~/types/dynamicContent";
 import type { CarouselActions } from "../../types";
+import {
+  BRAZE_PLACEMENT_CONTAINER_CLASS_NAME,
+  BRAZE_PLACEMENT_GRID_CLASS_NAME,
+} from "../../utils/brazePlacementLayout";
 import { ContentBannerActionCard } from "../ContentBannerActionCard";
 import LogContentCardWrapper from "../LogContentCardWrapper";
 import Slide from "./Slide";
 import { usePortfolioContentCardsViewModel } from "./usePortfolioContentCardsViewModel";
 
 export default PortfolioContentCards;
-
-const CarouselWrapper = styled.div`
-  & > div > div > button {
-    translate: 0 -50%;
-    margin: 0 -12px;
-    background-color: ${({ theme }) => theme.colors.neutral.c00};
-  }
-`;
-
-/** 2 columns, max 2 cards (Braze placement portfolio) */
-const BrazePlacementGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-  width: 100%;
-  & > * {
-    min-width: 0;
-  }
-`;
-
-const LeadingGridCell = styled.div`
-  min-width: 0;
-  width: 100%;
-`;
-
-const StackedLeading = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: 100%;
-`;
 
 type BrazeSlideProps = {
   card: PortfolioCardType;
@@ -121,7 +93,9 @@ type PortfolioContentCardsProps = Readonly<{
 
 function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
   const { layout, brazeCarouselEntries, positionOffset, logSlideClick, dismissCard } =
-    usePortfolioContentCardsViewModel({ hasLeadingSlide: Boolean(leadingSlide) });
+    usePortfolioContentCardsViewModel({
+      hasLeadingSlide: Boolean(leadingSlide),
+    });
 
   const handlePrevButton = () => trackSlide("prev");
   const handleNextButton = () => trackSlide("next");
@@ -143,7 +117,7 @@ function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
 
   // Carousel requires ReactElement[] (uses children.length / .map) — not a Fragment.
   const renderCarousel = (slides: ReactElement[]) => (
-    <CarouselWrapper>
+    <div className="[&>div>div>button]:-mx-12 [&>div>div>button]:translate-y-[-50%] [&>div>div>button]:bg-base">
       <Carousel
         initialDelay={2500}
         autoPlay={6000}
@@ -152,7 +126,7 @@ function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
       >
         {slides}
       </Carousel>
-    </CarouselWrapper>
+    </div>
   );
 
   if (layout === "empty") return null;
@@ -163,32 +137,37 @@ function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
 
   if (layout === "braze-grid") {
     return (
-      <BrazePlacementGrid>
-        {leadingSlide ? (
-          <LeadingGridCell key="portfolio-upsell-leading">
-            {leadingSlideForGrid(leadingSlide)}
-          </LeadingGridCell>
-        ) : null}
-        {brazeCarouselEntries.map(({ card, portfolioIndex }, displayIndex) => (
-          <PortfolioBrazePlacementSlide
-            key={card.id}
-            card={card}
-            index={portfolioIndex}
-            displayedPosition={displayIndex + positionOffset}
-            logSlideClick={logSlideClick}
-            dismissCard={dismissCard}
-          />
-        ))}
-      </BrazePlacementGrid>
+      <div className={BRAZE_PLACEMENT_CONTAINER_CLASS_NAME}>
+        <div
+          className={BRAZE_PLACEMENT_GRID_CLASS_NAME}
+          data-testid="portfolio-braze-placement-grid"
+        >
+          {leadingSlide ? (
+            <div className="min-w-0 w-full" key="portfolio-upsell-leading">
+              {leadingSlideForGrid(leadingSlide)}
+            </div>
+          ) : null}
+          {brazeCarouselEntries.map(({ card, portfolioIndex }, displayIndex) => (
+            <PortfolioBrazePlacementSlide
+              key={card.id}
+              card={card}
+              index={portfolioIndex}
+              displayedPosition={displayIndex + positionOffset}
+              logSlideClick={logSlideClick}
+              dismissCard={dismissCard}
+            />
+          ))}
+        </div>
+      </div>
     );
   }
 
   if (layout === "stacked-leading") {
     return (
-      <StackedLeading>
+      <div className="flex w-full flex-col gap-16">
         {leadingSlide}
         {renderCarousel(brazeSlides)}
-      </StackedLeading>
+      </div>
     );
   }
 

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/index.tsx
@@ -117,7 +117,7 @@ function PortfolioContentCards({ leadingSlide }: PortfolioContentCardsProps) {
 
   // Carousel requires ReactElement[] (uses children.length / .map) — not a Fragment.
   const renderCarousel = (slides: ReactElement[]) => (
-    <div className="[&>div>div>button]:-mx-12 [&>div>div>button]:translate-y-[-50%] [&>div>div>button]:bg-base">
+    <div className="[&_[data-testid=carousel-arrow-prev]]:-ml-12 [&_[data-testid=carousel-arrow-next]]:-mr-12 [&_[data-testid^=carousel-arrow]]:bg-base">
       <Carousel
         initialDelay={2500}
         autoPlay={6000}

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/components/PortfolioContentCards/usePortfolioContentCardsViewModel.ts
@@ -3,9 +3,9 @@ import { useWalletFeaturesConfig } from "@features/platform-feature-flags";
 import type { PortfolioContentCard } from "~/types/dynamicContent";
 import { usePortfolioCarouselCards } from "../../hooks/usePortfolioCarouselCards";
 import type { CarouselActions } from "../../types";
+import { MAX_DESKTOP_BRAZE_PLACEMENT_CARDS } from "../../utils/constants";
 
-/** Desktop Braze placement grid: max 2 cards in the row (LN upsell counts as one when present). */
-export const MAX_DESKTOP_BRAZE_PLACEMENT_CARDS = 2;
+export { MAX_DESKTOP_BRAZE_PLACEMENT_CARDS } from "../../utils/constants";
 
 export type BrazeCarouselEntry = {
   card: PortfolioContentCard;

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/__tests__/brazePlacementLayout.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/__tests__/brazePlacementLayout.test.ts
@@ -1,0 +1,32 @@
+import {
+  BRAZE_PLACEMENT_CONTAINER_CLASS_NAME,
+  BRAZE_PLACEMENT_GRID_CLASS_NAME,
+  BRAZE_PLACEMENT_NARROW_MAX_CONTAINER_WIDTH,
+  BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH,
+  MIN_BRAZE_BANNER_WIDTH,
+} from "../brazePlacementLayout";
+
+describe("brazePlacementLayout", () => {
+  it("should derive the two-column breakpoint from the minimum banner width and grid gap", () => {
+    expect(BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH).toBe(
+      MIN_BRAZE_BANNER_WIDTH * 2 + 16 + 1,
+    );
+    expect(BRAZE_PLACEMENT_NARROW_MAX_CONTAINER_WIDTH).toBe(
+      BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH - 1,
+    );
+  });
+
+  it("should keep the container query context on a parent wrapper", () => {
+    expect(BRAZE_PLACEMENT_CONTAINER_CLASS_NAME).toBe("@container w-full");
+  });
+
+  it("should expose container-query grid classes aligned with the breakpoints", () => {
+    expect(BRAZE_PLACEMENT_GRID_CLASS_NAME).not.toContain("@container");
+    expect(BRAZE_PLACEMENT_GRID_CLASS_NAME).toContain(
+      `@min-[${BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH}px]:grid-cols-2`,
+    );
+    expect(BRAZE_PLACEMENT_GRID_CLASS_NAME).toContain(
+      `@max-[${BRAZE_PLACEMENT_NARROW_MAX_CONTAINER_WIDTH}px]:[&>:nth-child(n+2)]:hidden`,
+    );
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/brazePlacementLayout.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/brazePlacementLayout.ts
@@ -1,0 +1,23 @@
+/** Minimum readable banner width in the Braze placement grid (px). */
+export const MIN_BRAZE_BANNER_WIDTH = 343;
+
+/** Gap between banners in the Braze placement grid (px). Must match Tailwind `gap-16`. */
+export const BRAZE_PLACEMENT_GRID_GAP = 16;
+
+/** Container width above which two side-by-side banners stay wider than {@link MIN_BRAZE_BANNER_WIDTH}. */
+export const BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH =
+  MIN_BRAZE_BANNER_WIDTH * 2 + BRAZE_PLACEMENT_GRID_GAP + 1;
+
+/** Last container width (px) that keeps a single-column Braze placement grid. */
+export const BRAZE_PLACEMENT_NARROW_MAX_CONTAINER_WIDTH =
+  BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH - 1;
+
+/** Query context for the portfolio Braze placement row. Must wrap {@link BRAZE_PLACEMENT_GRID_CLASS_NAME}. */
+export const BRAZE_PLACEMENT_CONTAINER_CLASS_NAME = "@container w-full";
+
+/**
+ * Tailwind container-query grid for portfolio Braze placements.
+ * Breakpoints must stay in sync with {@link BRAZE_PLACEMENT_TWO_COLUMN_MIN_CONTAINER_WIDTH}.
+ */
+export const BRAZE_PLACEMENT_GRID_CLASS_NAME =
+  "grid w-full grid-cols-1 gap-16 [&>*]:min-w-0 @min-[703px]:grid-cols-2 @max-[702px]:[&>:nth-child(n+2)]:hidden";

--- a/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/constants/index.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/DynamicContent/utils/constants/index.ts
@@ -2,3 +2,6 @@ export const OFFLINE_SEEN_DELAY = 2e3;
 
 /** Category id Braze uses for the always-on hardware carousel on the portfolio page. */
 export const ALWAYS_ON_CATEGORY_ID = "alwayson";
+
+/** Desktop Braze placement grid: max 2 cards in the row (LN upsell counts as one when present). */
+export const MAX_DESKTOP_BRAZE_PLACEMENT_CARDS = 2;


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Limit desktop portfolio Braze placement to one banner when the container is too narrow for two readable columns (≤702px, ~343px per banner).
Measure container width with ResizeObserver (callback ref + useLayoutEffect) and derive card count / column layout from shared layout utils.
Replace styled-components with Tailwind in PortfolioContentCards; add unit and integration tests.

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

https://github.com/user-attachments/assets/c04cfce1-d7db-4b62-a8bb-b1b3be0a62bb


### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-29795]<!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->


[LIVE-29795]: https://ledgerhq.atlassian.net/browse/LIVE-29795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ