### PR TITLE
[LWDM] fix(swap): cap hyperevm gas limit (LIVE-35253)

### DIFF
--- a/.changeset/swift-swaps-cap.md
+++ b/.changeset/swift-swaps-cap.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+Cap HyperEVM DEX swap gas limits

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.test.ts
@@ -1,10 +1,27 @@
 import { TransportStatusError } from "@ledgerhq/hw-transport/errors";
 import { ErrorStatus } from "@ledgerhq/hw-app-exchange/ReturnCode";
+import BigNumber from "bignumber.js";
 import { CompleteExchangeError } from "../error";
 import {
   enrichSwapDeserializationError,
+  getBufferedDexGasLimit,
   shouldForceZeroAmountForDexSwap,
 } from "./completeExchange";
+
+describe("getBufferedDexGasLimit", () => {
+  it.each([
+    ["caps HyperEVM at 2.9M", "hyperevm", 3_000_000, "2900000"],
+    ["keeps a buffered HyperEVM value below the cap", "hyperevm", 2_000_000, "2600000"],
+    ["does not cap other EVM currencies", "ethereum", 3_000_000, "3900000"],
+  ])("%s", (_case, fromCurrencyId, gasLimit, expected) => {
+    expect(
+      getBufferedDexGasLimit({
+        gasLimit: new BigNumber(gasLimit),
+        fromCurrencyId,
+      }).toFixed(),
+    ).toBe(expected);
+  });
+});
 
 describe("shouldForceZeroAmountForDexSwap", () => {
   const base = {

--- a/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
+++ b/libs/ledger-live-common/src/exchange/swap/completeExchange.ts
@@ -35,8 +35,25 @@ import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 
 const COMPLETE_EXCHANGE_LOG = "SWAP-CompleteExchange";
 const LIFI_GAS_LIMIT_BUFFER_MULTIPLIER = 1.3;
+const HYPEREVM_GAS_LIMIT_CAP = new BigNumber(2_900_000);
 
 const ARC_CURRENCY_IDS = new Set(["arc", "arc_testnet"]);
+
+export function getBufferedDexGasLimit({
+  gasLimit,
+  fromCurrencyId,
+}: {
+  gasLimit: BigNumber;
+  fromCurrencyId: string;
+}): BigNumber {
+  const bufferedGasLimit = gasLimit
+    .times(LIFI_GAS_LIMIT_BUFFER_MULTIPLIER)
+    .integerValue(BigNumber.ROUND_UP);
+
+  return fromCurrencyId === "hyperevm"
+    ? BigNumber.minimum(bufferedGasLimit, HYPEREVM_GAS_LIMIT_CAP)
+    : bufferedGasLimit;
+}
 
 export function shouldForceZeroAmountForDexSwap({
   isDex,
@@ -199,9 +216,10 @@ const completeExchange = (
           transaction.gasLimit &&
           BigNumber.isBigNumber(transaction.gasLimit)
         ) {
-          const gasLimit = transaction.gasLimit
-            .times(LIFI_GAS_LIMIT_BUFFER_MULTIPLIER)
-            .integerValue(BigNumber.ROUND_UP);
+          const gasLimit = getBufferedDexGasLimit({
+            gasLimit: transaction.gasLimit,
+            fromCurrencyId: mainRefundCurrency.id,
+          });
           const transactionFixed = {
             ...transaction,
             fees: undefined, // to be recalculated


### PR DESCRIPTION
## Summary
- Cap the buffered DEX gas limit at 2.9M for HyperEVM accounts.
- Add focused coverage and a changeset for `@ledgerhq/live-common`.
- Jira: [LIVE-35253](https://ledgerhq.atlassian.net/browse/LIVE-35253)

## Test plan
- [x] `pnpm common jest src/exchange/swap/completeExchange.test.ts --runInBand`
- [x] `pnpm common lint`
- [x] `pnpm common format:check`
- [x] `pnpm common typecheck`
- [x] `pnpm common build`
- [x] `pnpm commitlint --from origin/develop --to HEAD`

Made with [Cursor](https://cursor.com)

[LIVE-35253]: https://ledgerhq.atlassian.net/browse/LIVE-35253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ