### PR TITLE
[LWDM] chore(auth): get Keycloak URL and LKRP credentials lazily

### DIFF
--- a/.changeset/calm-tools-authenticate.md
+++ b/.changeset/calm-tools-authenticate.md
@@ -1,7 +1,8 @@
 ---
+"@ledgerhq/ledger-auth": minor
 "@ledgerhq/ledger-key-ring-protocol": minor
 "@shared/auth": minor
 ---
 
-Load LKRP identity credentials on demand through a caller-provided callback and simplify auth
-provider factories to close over app-owned dependencies
+Load LKRP identity credentials on demand, allow AuthSDK to resolve the Keycloak URL lazily, and
+simplify auth feature gating around an app-owned provider

--- a/.changeset/calm-tools-authenticate.md
+++ b/.changeset/calm-tools-authenticate.md
@@ -1,0 +1,7 @@
+---
+"@ledgerhq/ledger-key-ring-protocol": minor
+"@shared/auth": minor
+---
+
+Load LKRP identity credentials on demand through a caller-provided callback and simplify auth
+provider factories to close over app-owned dependencies

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.test.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
+import { WalletAuthMissingBaseUrlError } from "@ledgerhq/ledger-auth";
 import { setAuthEnvironment, type AuthProvider } from "@shared/auth";
 import { setEnv } from "@shared/env";
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
@@ -86,29 +87,43 @@ describe("customCreateStore", () => {
       expect(endpoints.stagingKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should keep a stable auth provider facade when ledger auth is disabled at runtime", async () => {
+    it("should retry authentication after the environment becomes available", async () => {
+      endpoints.prodKeycloakAuth.mockReturnValue(
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockReturnValue(
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockReturnValue(
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
       const store = customCreateStore({ fetchRemoteFlags: null });
-      let injectedAuthProvider: AuthProvider | undefined;
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        injectedAuthProvider = extra.authProvider;
-      });
-
       store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
+
+      await expect(
+        dispatchThunk(store, (_dispatch, _getState, extra) =>
+          extra.authProvider.withToken({ queryFn }),
+        ),
+      ).rejects.toMatchObject({ name: WalletAuthMissingBaseUrlError.name });
+
       store.dispatch(setAuthEnvironment("PROD"));
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authProvider).toBe(injectedAuthProvider);
-      });
-
-      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: false } }));
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
 
       await dispatchThunk(store, (_dispatch, _getState, extra) =>
         extra.authProvider.withToken({ queryFn }),
       );
 
-      expect(queryFn).toHaveBeenCalledWith();
-      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+      expect(endpoints.prodKeycloakAuth).toHaveBeenCalledTimes(1);
     });
 
     it("should use the staging Keycloak URL for a staging Trustchain SDK", async () => {
@@ -188,49 +203,6 @@ describe("customCreateStore", () => {
           }),
         }),
       );
-    });
-
-    it("should authenticate without attestation when trustchain store only has credentials", async () => {
-      endpoints.prodKeycloakAuth.mockReturnValue(
-        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
-      );
-      endpoints.lkrpAuth.mockReturnValue(HttpResponse.json("auth-code-xyz"));
-      endpoints.lkrpToken.mockReturnValue(
-        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
-      );
-      endpoints.tokenExchange.mockReturnValue(
-        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
-      );
-
-      const store = customCreateStore({ fetchRemoteFlags: null });
-      store.dispatch(setAuthEnvironment("PROD"));
-      store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
-      store.dispatch(
-        importTrustchainStoreState({
-          trustchain: null,
-          memberCredentials: MEMBER_CREDENTIALS,
-        }),
-      );
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authProvider.withToken({ queryFn }),
-      );
-
-      expect(queryFn).toHaveBeenCalledWith(
-        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
-      );
-
-      const challengeRequest = await endpoints.lkrpAuth.mock.calls[0][0].request.json();
-      expect(challengeRequest).toEqual(
-        expect.objectContaining({
-          signature: expect.objectContaining({
-            credential: expect.objectContaining({
-              publicKey: MEMBER_CREDENTIALS.pubkey,
-            }),
-          }),
-        }),
-      );
-      expect(challengeRequest.signature).not.toHaveProperty("attestation");
     });
   });
 });

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -9,6 +9,7 @@ import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { getEnv } from "@shared/env";
 import { authApiExtra } from "@shared/auth";
 import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
+import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import {
   calApiExtra,
   cardApiExtra,
@@ -84,12 +85,7 @@ const customCreateStore = ({
               ...authApiExtra({
                 authFeatureId: "lwdAuth",
                 startListening: listenerMiddleware.startListening,
-                providerParams: {
-                  identityProvider: new LkrpIdentityProvider<State>({
-                    startListening: listenerMiddleware.startListening,
-                  }),
-                },
-                createAuthProvider: (environment, { identityProvider }) =>
+                createAuthProvider: environment =>
                   new AuthSDK(
                     {
                       clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
@@ -97,7 +93,11 @@ const customCreateStore = ({
                       keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
                       disablePkce: true,
                     },
-                    { provider: identityProvider },
+                    {
+                      provider: new LkrpIdentityProvider(
+                        (): TrustchainStore => store.getState().trustchain,
+                      ),
+                    },
                   ),
               }),
             },

--- a/apps/ledger-live-desktop/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-desktop/src/state-manager/configureStore.ts
@@ -1,13 +1,8 @@
-import {
-  configureStore,
-  createListenerMiddleware,
-  type Middleware,
-  type ThunkDispatch,
-} from "@reduxjs/toolkit";
+import { configureStore, type Middleware, type ThunkDispatch } from "@reduxjs/toolkit";
 import { UnknownAction } from "redux";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { getEnv } from "@shared/env";
-import { authApiExtra } from "@shared/auth";
+import { authApiExtra, authEnvironmentSelector } from "@shared/auth";
 import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
 import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import {
@@ -24,7 +19,11 @@ import reducers, { State } from "~/renderer/reducers";
 import { applyLldRTKApiMiddlewares } from "~/renderer/reducers/rtkQueryApi";
 import { createIdentitiesSyncMiddleware } from "@domain/api-push-devices";
 import { canPushDeviceIdsSelector, languageSelector } from "~/renderer/reducers/settings";
-import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
+import {
+  createFeatureFlagsMiddleware,
+  selectFeature,
+  type PartialFeatures,
+} from "@shared/feature-flags";
 import { fetchRemoteFlags as defaultFetchRemoteFlags } from "~/firebase/remoteConfig";
 import { sleepingListener } from "./sleepingListener";
 type Props = {
@@ -44,10 +43,6 @@ const customCreateStore = ({
   analyticsMiddleware,
   fetchRemoteFlags = defaultFetchRemoteFlags,
 }: Props) => {
-  // This listenerMiddleware is cross-scope as it is preferable to have one instance per store
-  // Source: https://github.com/reduxjs/redux-toolkit/discussions/3665
-  const listenerMiddleware = createListenerMiddleware<State>();
-
   const store = configureStore({
     reducer: reducers,
     preloadedState: state,
@@ -83,26 +78,28 @@ const customCreateStore = ({
                 ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
               }),
               ...authApiExtra({
-                authFeatureId: "lwdAuth",
-                startListening: listenerMiddleware.startListening,
-                createAuthProvider: environment =>
-                  new AuthSDK(
-                    {
-                      clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-                      keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
-                      keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-                      disablePkce: true,
+                isFeatureEnabled: (): boolean =>
+                  selectFeature(store.getState(), "lwdAuth").enabled ?? false,
+                authProvider: new AuthSDK(
+                  {
+                    clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                    keycloakBaseUrl(): string | null {
+                      const environment = authEnvironmentSelector(store.getState());
+                      return environment && getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`);
                     },
-                    {
-                      provider: new LkrpIdentityProvider(
-                        (): TrustchainStore => store.getState().trustchain,
-                      ),
-                    },
-                  ),
+                    keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                    disablePkce: true,
+                  },
+                  {
+                    provider: new LkrpIdentityProvider(
+                      (): TrustchainStore => store.getState().trustchain,
+                    ),
+                  },
+                ),
               }),
             },
           },
-        }).prepend(listenerMiddleware.middleware),
+        }),
       )
         .concat(logger)
         .concat(analyticsMiddleware ? [analyticsMiddleware] : [])

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.test.ts
@@ -1,6 +1,7 @@
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
+import { WalletAuthMissingBaseUrlError } from "@ledgerhq/ledger-auth";
 import { setAuthEnvironment, type AuthProvider } from "@shared/auth";
 import { importTrustchainStoreState } from "@ledgerhq/ledger-key-ring-protocol/store";
 import { CHALLENGE } from "@ledgerhq/ledger-key-ring-protocol/__mocks__/challenge";
@@ -126,29 +127,43 @@ describe("mobile store", () => {
       expect(endpoints.stagingKeycloakAuth).not.toHaveBeenCalled();
     });
 
-    it("should keep a stable auth provider facade when ledger auth is disabled at runtime", async () => {
+    it("should retry authentication after the environment becomes available", async () => {
+      endpoints.prodKeycloakAuth.mockImplementation(() =>
+        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
+      );
+      endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
+      endpoints.lkrpToken.mockImplementation(() =>
+        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+      );
+      endpoints.tokenExchange.mockImplementation(() =>
+        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+      );
+
       const { store } = require("./configureStore");
-      let injectedAuthProvider: AuthProvider | undefined;
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        injectedAuthProvider = extra.authProvider;
-      });
-
       store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
+
+      await expect(
+        dispatchThunk(store, (_dispatch, _getState, extra) =>
+          extra.authProvider.withToken({ queryFn }),
+        ),
+      ).rejects.toMatchObject({ name: WalletAuthMissingBaseUrlError.name });
+
       store.dispatch(setAuthEnvironment("PROD"));
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) => {
-        expect(extra.authProvider).toBe(injectedAuthProvider);
-      });
-
-      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: false } }));
+      store.dispatch(
+        importTrustchainStoreState({
+          trustchain: null,
+          memberCredentials: MEMBER_CREDENTIALS,
+        }),
+      );
 
       await dispatchThunk(store, (_dispatch, _getState, extra) =>
         extra.authProvider.withToken({ queryFn }),
       );
 
-      expect(queryFn).toHaveBeenCalledWith();
-      expect(endpoints.prodKeycloakAuth).not.toHaveBeenCalled();
+      expect(queryFn).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
+      );
+      expect(endpoints.prodKeycloakAuth).toHaveBeenCalledTimes(1);
     });
 
     it("should use the staging Keycloak URL for a staging Trustchain SDK", async () => {
@@ -236,52 +251,6 @@ describe("mobile store", () => {
           }),
         }),
       );
-    });
-
-    it("should authenticate without attestation when trustchain store only has credentials", async () => {
-      endpoints.prodKeycloakAuth.mockImplementation(() =>
-        HttpResponse.json({ tlv: CHALLENGE.tlv, json: CHALLENGE.json }),
-      );
-      endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json("auth-code-xyz"));
-      endpoints.lkrpToken.mockImplementation(() =>
-        HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
-      );
-      endpoints.tokenExchange.mockImplementation(() =>
-        HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
-      );
-
-      const { store } = require("./configureStore");
-      store.dispatch(setAuthEnvironment("PROD"));
-      store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
-      store.dispatch(
-        importTrustchainStoreState({
-          trustchain: null,
-          memberCredentials: MEMBER_CREDENTIALS,
-        }),
-      );
-
-      await dispatchThunk(store, async (_dispatch, _getState, extra) =>
-        extra.authProvider.withToken({
-          queryFn,
-          refreshAndRetryWhen: () => true,
-        }),
-      );
-
-      expect(queryFn).toHaveBeenCalledWith(
-        expect.objectContaining({ accessToken: KEYCLOAK_JWT, tokenType: "Bearer" }),
-      );
-
-      const challengeRequest = await endpoints.lkrpAuth.mock.calls.at(-1)?.[0].request.json();
-      expect(challengeRequest).toEqual(
-        expect.objectContaining({
-          signature: expect.objectContaining({
-            credential: expect.objectContaining({
-              publicKey: MEMBER_CREDENTIALS.pubkey,
-            }),
-          }),
-        }),
-      );
-      expect(challengeRequest.signature).not.toHaveProperty("attestation");
     });
   });
 });

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -1,7 +1,7 @@
 import Config from "react-native-config";
-import { configureStore, createListenerMiddleware, type StoreEnhancer } from "@reduxjs/toolkit";
+import { configureStore, type StoreEnhancer } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
-import { authApiExtra } from "@shared/auth";
+import { authApiExtra, authEnvironmentSelector } from "@shared/auth";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
 import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
@@ -29,14 +29,14 @@ import {
   swapApiExtra,
 } from "@shared/api-services";
 import { getCardSessionToken, refreshCardSession } from "@features/platform-card";
-import { createFeatureFlagsMiddleware, type PartialFeatures } from "@shared/feature-flags";
+import {
+  createFeatureFlagsMiddleware,
+  selectFeature,
+  type PartialFeatures,
+} from "@shared/feature-flags";
 import { fetchRemoteFlags } from "~/firebase/remoteConfig";
 import { sleepingListener } from "./sleepingListener";
 import { createPkcePairWithExpoCrypto } from "~/helpers/pkce";
-
-// This listenerMiddleware is cross-scope as it is preferable to have one instance per store
-// Source: https://github.com/reduxjs/redux-toolkit/discussions/3665
-const listenerMiddleware = createListenerMiddleware<State>();
 
 export const store = configureStore({
   reducer: reducers,
@@ -73,27 +73,29 @@ export const store = configureStore({
               ledgerClientVersion: getEnv("LEDGER_CLIENT_VERSION"),
             }),
             ...authApiExtra({
-              authFeatureId: "lwmAuth",
-              startListening: listenerMiddleware.startListening,
-              createAuthProvider: environment =>
-                new AuthSDK(
-                  {
-                    clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
-                    keycloakBaseUrl: getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`),
-                    keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
-                    disablePkce: true,
+              isFeatureEnabled: (): boolean =>
+                selectFeature(store.getState(), "lwmAuth").enabled ?? false,
+              authProvider: new AuthSDK(
+                {
+                  clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
+                  keycloakBaseUrl(): string | null {
+                    const environment = authEnvironmentSelector(store.getState());
+                    return environment && getEnv(`LEDGER_AUTH_KEYCLOAK_BASE_URL_${environment}`);
                   },
-                  {
-                    provider: new LkrpIdentityProvider(
-                      (): TrustchainStore => store.getState().trustchain,
-                    ),
-                    createPkcePair: createPkcePairWithExpoCrypto,
-                  },
-                ),
+                  keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
+                  disablePkce: true,
+                },
+                {
+                  provider: new LkrpIdentityProvider(
+                    (): TrustchainStore => store.getState().trustchain,
+                  ),
+                  createPkcePair: createPkcePairWithExpoCrypto,
+                },
+              ),
             }),
           },
         },
-      }).prepend(listenerMiddleware.middleware),
+      }),
     )
       .concat(rebootMiddleware)
       .concat(

--- a/apps/ledger-live-mobile/src/state-manager/configureStore.ts
+++ b/apps/ledger-live-mobile/src/state-manager/configureStore.ts
@@ -4,6 +4,7 @@ import { setupListeners } from "@reduxjs/toolkit/query";
 import { authApiExtra } from "@shared/auth";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
 import { LkrpIdentityProvider } from "@ledgerhq/ledger-key-ring-protocol";
+import type { TrustchainStore } from "@ledgerhq/ledger-key-ring-protocol/store";
 import NetInfo from "@react-native-community/netinfo";
 import { Platform } from "react-native";
 import VersionNumber from "react-native-version-number";
@@ -74,12 +75,7 @@ export const store = configureStore({
             ...authApiExtra({
               authFeatureId: "lwmAuth",
               startListening: listenerMiddleware.startListening,
-              providerParams: {
-                identityProvider: new LkrpIdentityProvider<State>({
-                  startListening: listenerMiddleware.startListening,
-                }),
-              },
-              createAuthProvider: (environment, { identityProvider }) =>
+              createAuthProvider: environment =>
                 new AuthSDK(
                   {
                     clientId: getEnv("LEDGER_AUTH_CLIENT_ID"),
@@ -87,7 +83,12 @@ export const store = configureStore({
                     keycloakRealm: getEnv("LEDGER_AUTH_KEYCLOAK_REALM"),
                     disablePkce: true,
                   },
-                  { provider: identityProvider, createPkcePair: createPkcePairWithExpoCrypto },
+                  {
+                    provider: new LkrpIdentityProvider(
+                      (): TrustchainStore => store.getState().trustchain,
+                    ),
+                    createPkcePair: createPkcePairWithExpoCrypto,
+                  },
                 ),
             }),
           },

--- a/libs/ledger-auth/README.md
+++ b/libs/ledger-auth/README.md
@@ -21,4 +21,9 @@
 
 ## Usage context
 
-Ledger Live Desktop and Mobile expose a stable `AuthProvider` through their Redux thunk extra argument. That facade lazily creates and caches `AuthSDK` when authentication is enabled and its environment is known.
+Ledger Wallet apps expose a stable `AuthProvider` backed by one `AuthSDK`
+through their Redux thunk extra argument.
+`AuthSDK` accepts either a static Keycloak base URL or a callback. The callback remains unevaluated
+until authentication needs a Keycloak endpoint and is resolved whenever the service derives one.
+It may return `null` while configuration is unavailable; authentication then rejects with
+`WalletAuthMissingBaseUrlError` and a later attempt resolves the callback again.

--- a/libs/ledger-auth/src/__tests__/authSDK.test.ts
+++ b/libs/ledger-auth/src/__tests__/authSDK.test.ts
@@ -1,4 +1,8 @@
-import { WalletAuthInvalidChallengeError, WalletAuthInvalidTokenError } from "../errors";
+import {
+  WalletAuthInvalidChallengeError,
+  WalletAuthInvalidTokenError,
+  WalletAuthMissingBaseUrlError,
+} from "../errors";
 import { AuthSDK } from "../authSDK";
 import type { AuthConfig, IdentityProvider, KeycloakService } from "../types";
 
@@ -8,15 +12,16 @@ function makeJwt(payload: Record<string, unknown>): string {
 }
 
 describe("AuthSDK", () => {
+  const KEYCLOAK_BASE_URL = "https://keycloak.test";
   const config: AuthConfig = {
     clientId: "ledger-keycloak",
-    keycloakBaseUrl: "https://keycloak.test",
+    keycloakBaseUrl: KEYCLOAK_BASE_URL,
     keycloakRealm: "ledger-bc-customers",
   };
 
   const keycloakService: jest.Mocked<KeycloakService> = {
-    baseUrl: config.keycloakBaseUrl,
-    realmBaseUrl: `${config.keycloakBaseUrl}/realms/${config.keycloakRealm}`,
+    baseUrl: KEYCLOAK_BASE_URL,
+    realmBaseUrl: `${KEYCLOAK_BASE_URL}/realms/${config.keycloakRealm}`,
     getChallenge: jest.fn(),
   };
 
@@ -37,6 +42,36 @@ describe("AuthSDK", () => {
       tokenType: "Bearer",
       accessToken: "keycloak-jwt",
     });
+  });
+
+  it("should retry authentication after the Keycloak URL becomes available", async () => {
+    const keycloakBaseUrl = jest
+      .fn<string | null, []>()
+      .mockReturnValueOnce(null)
+      .mockReturnValue(KEYCLOAK_BASE_URL);
+    const fetch = jest.fn<Promise<Response>, Parameters<typeof globalThis.fetch>>(async () =>
+      Response.json("challenge"),
+    );
+    const sdk = new AuthSDK(
+      { ...config, keycloakBaseUrl },
+      {
+        provider: identityProvider,
+        fetch,
+      },
+    );
+
+    await expect(sdk.withToken({ queryFn })).rejects.toBeInstanceOf(WalletAuthMissingBaseUrlError);
+    await expect(sdk.withToken({ queryFn })).resolves.toBeUndefined();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(String(fetch.mock.calls[0][0])).toContain(
+      `${KEYCLOAK_BASE_URL}/realms/${config.keycloakRealm}/protocol/openid-connect/auth`,
+    );
+    expect(identityProvider.authenticate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUri: `${KEYCLOAK_BASE_URL}/realms/${config.keycloakRealm}/broker/lkrp/endpoint`,
+      }),
+    );
   });
 
   it("retrieves a Keycloak JWT with PKCE by default", async () => {

--- a/libs/ledger-auth/src/errors.ts
+++ b/libs/ledger-auth/src/errors.ts
@@ -52,3 +52,11 @@ export class WalletAuthHttpError extends WalletAuthError {
     this.status = status;
   }
 }
+
+export class WalletAuthMissingBaseUrlError extends WalletAuthError {
+  override name = "WalletAuthMissingBaseUrlError";
+
+  constructor() {
+    super("Missing Keycloak base URL");
+  }
+}

--- a/libs/ledger-auth/src/keycloakService.ts
+++ b/libs/ledger-auth/src/keycloakService.ts
@@ -1,18 +1,30 @@
+import { WalletAuthMissingBaseUrlError } from "./errors";
 import { parseJsonResponse } from "./http";
-import type { ChallengeRequest, KeycloakService } from "./types";
+import type { AuthConfig, ChallengeRequest, KeycloakService } from "./types";
 
 export class HttpKeycloakService implements KeycloakService {
-  readonly baseUrl: string;
-  readonly realmBaseUrl: string;
-  private readonly openIdBaseUrl: string;
-
+  private getBaseUrl: () => string | null;
   readonly #fetch: typeof globalThis.fetch;
 
-  constructor(baseUrl: string, realm: string, fetch: typeof globalThis.fetch = globalThis.fetch) {
-    this.baseUrl = trimTrailingSlash(baseUrl);
-    this.realmBaseUrl = `${this.baseUrl}/realms/${realm}`;
-    this.openIdBaseUrl = `${this.realmBaseUrl}/protocol/openid-connect`;
+  constructor(
+    getBaseUrl: AuthConfig["keycloakBaseUrl"],
+    private readonly realm: string,
+    fetch: typeof globalThis.fetch = globalThis.fetch,
+  ) {
+    this.getBaseUrl = typeof getBaseUrl === "string" ? () => getBaseUrl : getBaseUrl;
     this.#fetch = fetch;
+  }
+
+  get baseUrl(): string {
+    const baseUrl = this.getBaseUrl();
+    if (!baseUrl) throw new WalletAuthMissingBaseUrlError();
+    return trimTrailingSlash(baseUrl);
+  }
+  get realmBaseUrl(): string {
+    return `${this.baseUrl}/realms/${this.realm}`;
+  }
+  get openIdBaseUrl(): string {
+    return `${this.realmBaseUrl}/protocol/openid-connect`;
   }
 
   async getChallenge(request: ChallengeRequest): Promise<unknown> {

--- a/libs/ledger-auth/src/types.ts
+++ b/libs/ledger-auth/src/types.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export type AuthConfig = {
   clientId: string;
-  keycloakBaseUrl: string;
+  keycloakBaseUrl: string | (() => string | null);
   keycloakRealm: string;
   disablePkce?: boolean;
 };

--- a/libs/ledger-key-ring-protocol/README.md
+++ b/libs/ledger-key-ring-protocol/README.md
@@ -10,6 +10,19 @@ Ledger Key Ring Protocol layer.
 > [`docs/ledger-sync`](../../docs/ledger-sync/README.md) — notably
 > [TrustchainSDK](../../docs/ledger-sync/02-trustchain-sdk.md).
 
+## Authentication identity provider
+
+`LkrpIdentityProvider` requires a callback that resolves the current trustchain
+credentials:
+
+```ts
+const provider = new LkrpIdentityProvider(() => store.getState().trustchain);
+```
+
+The callback may return the credentials directly or as a promise, allowing headless
+consumers to load secrets from external storage. It is called for every authentication;
+results are passed directly to challenge signing and are not retained by the provider.
+
 ## Testing the SDK with recorded scenarios
 
 The SDK is exercised end-to-end through **scenarios** that are recorded once against

--- a/libs/ledger-key-ring-protocol/package.json
+++ b/libs/ledger-key-ring-protocol/package.json
@@ -65,7 +65,6 @@
     "@ledgerhq/logs": "catalog:",
     "@ledgerhq/speculos-transport": "workspace:*",
     "@ledgerhq/types-devices": "workspace:^",
-    "@reduxjs/toolkit": "catalog:",
     "base64-js": "1",
     "isomorphic-ws": "catalog:",
     "rxjs": "catalog:",
@@ -73,6 +72,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@reduxjs/toolkit": "catalog:",
     "@shared/env": "workspace:*",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",

--- a/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
+++ b/libs/ledger-key-ring-protocol/scripts/keycloakAuth.ts
@@ -26,13 +26,7 @@ main()
   });
 
 async function main(): Promise<void> {
-  const provider = new LkrpIdentityProvider();
-
   const credentials = await readMemberCredentials();
-  provider.setTrustchainStore({
-    trustchain: credentials.trustchainId ? { rootId: credentials.trustchainId } : null,
-    memberCredentials: credentials,
-  });
 
   console.log("[CHECK] keycloak base url:", KEYCLOAK_BASE_URL);
   console.log("[CHECK] keycloak realm:", KEYCLOAK_REALM);
@@ -45,7 +39,10 @@ async function main(): Promise<void> {
       keycloakRealm: KEYCLOAK_REALM,
     },
     {
-      provider,
+      provider: new LkrpIdentityProvider(() => ({
+        trustchain: credentials.trustchainId ? { rootId: credentials.trustchainId } : null,
+        memberCredentials: credentials,
+      })),
       fetch: makeFetchCookie(fetch),
     },
   ).withToken({

--- a/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
+++ b/libs/ledger-key-ring-protocol/src/LKRPIdentityProvider.ts
@@ -6,7 +6,6 @@ import {
   type IdPAuthParams,
   type KeycloakToken,
 } from "@ledgerhq/ledger-auth";
-import type { TypedStartListening } from "@reduxjs/toolkit";
 import getApi, {
   type Challenge as ChallengeJson,
   type LKRPChallenge,
@@ -15,43 +14,25 @@ import getApi, {
 } from "./api";
 import type { MemberCredentials, Trustchain } from "./types";
 import { convertLiveCredentialsToKeyPair, credentialForPubKey, liveAuthentication } from "./utils";
-import { trustchainStoreActionTypePrefix, type TrustchainStore } from "./store";
 
-interface PartialTrustchainStore {
+export interface LkrpIdentityProviderStore {
   trustchain: Pick<Trustchain, "rootId"> | null;
   memberCredentials: MemberCredentials | null;
 }
 
-interface StateWithTrustchain {
-  trustchain: TrustchainStore;
-}
-
-export interface LkrpIdentityProviderOptions<State extends StateWithTrustchain> {
-  startListening?: TypedStartListening<State>;
-}
-
-export class LkrpIdentityProvider<
-  State extends StateWithTrustchain = StateWithTrustchain,
-> implements IdentityProvider {
+export class LkrpIdentityProvider implements IdentityProvider {
   readonly brokerId = "lkrp";
-  private trustchainStore: PartialTrustchainStore | undefined;
 
-  constructor({ startListening }: LkrpIdentityProviderOptions<State> = {}) {
-    startListening?.({
-      predicate: action => action.type.startsWith(trustchainStoreActionTypePrefix),
-      effect: (_action, listenerApi) => {
-        this.setTrustchainStore(listenerApi.getState().trustchain);
-      },
-    });
-  }
+  constructor(private readonly loadTrustchainStore: LoadTrustchainStore) {}
 
   async authenticate(request: IdPAuthParams): Promise<KeycloakToken> {
     const challenge = LkrpIdentityProvider.checkChallenge(request.challenge);
+    const trustchainStore = await this.loadTrustchainStore();
     const host = challenge.json.host;
     const api = getApi(`https://${host}`);
 
     const authorizationCode = await api.oidcPostChallengeResponse(
-      await this.signChallenge(challenge),
+      await this.signChallenge(challenge, trustchainStore),
     );
 
     const idPToken = await api.oidcExchangeAuthCode(
@@ -64,29 +45,28 @@ export class LkrpIdentityProvider<
     return api.oidcExchangeToken(idPToken, request.clientId);
   }
 
-  setTrustchainStore(store: PartialTrustchainStore | undefined): void {
-    this.trustchainStore = store;
-  }
-
-  private async signChallenge(challenge: LKRPChallenge): Promise<{
+  private async signChallenge(
+    challenge: LKRPChallenge,
+    trustchainStore: LkrpIdentityProviderStore | undefined,
+  ): Promise<{
     challenge: ChallengeJson;
     signature: WeakChallengeSignature;
   }> {
-    if (!this.trustchainStore?.memberCredentials) {
+    if (!trustchainStore?.memberCredentials) {
       throw new WalletAuthNoCredentialsError(this.brokerId);
     }
 
     const data = crypto.from_hex(challenge.tlv);
     const [parsed] = Challenge.fromBytes(data);
     const hash = crypto.hash(parsed.getUnsignedTLV());
-    const keypair = convertLiveCredentialsToKeyPair(this.trustchainStore.memberCredentials);
+    const keypair = convertLiveCredentialsToKeyPair(trustchainStore.memberCredentials);
     return {
       challenge: challenge.json,
       signature: {
-        credential: credentialForPubKey(this.trustchainStore.memberCredentials.pubkey),
+        credential: credentialForPubKey(trustchainStore.memberCredentials.pubkey),
         signature: crypto.to_hex(crypto.sign(hash, keypair)),
-        attestation: this.trustchainStore.trustchain?.rootId
-          ? crypto.to_hex(liveAuthentication(this.trustchainStore.trustchain.rootId))
+        attestation: trustchainStore.trustchain?.rootId
+          ? crypto.to_hex(liveAuthentication(trustchainStore.trustchain.rootId))
           : undefined,
       },
     };
@@ -100,3 +80,8 @@ export class LkrpIdentityProvider<
     }
   }
 }
+
+type LoadTrustchainStore = () =>
+  | Promise<LkrpIdentityProviderStore | undefined>
+  | LkrpIdentityProviderStore
+  | undefined;

--- a/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
+++ b/libs/ledger-key-ring-protocol/src/__tests__/LKRPIdentityProvider.integration.test.ts
@@ -1,6 +1,6 @@
 import { crypto } from "@ledgerhq/hw-ledger-key-ring-protocol";
 import { AuthSDK } from "@ledgerhq/ledger-auth";
-import { configureStore, createListenerMiddleware } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import type { Challenge as ChallengeJson, WeakChallengeSignature } from "../api";
@@ -61,7 +61,7 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
     server.resetHandlers();
   });
 
-  it("synchronizes credentials after Trustchain import actions", async () => {
+  it("should read current Redux credentials for every authentication", async () => {
     endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json(AUTHORIZATION_CODE));
     endpoints.lkrpToken.mockImplementation(() =>
       HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
@@ -70,10 +70,6 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
       HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
     );
 
-    const listenerMiddleware = createListenerMiddleware<{ trustchain: TrustchainStore }>();
-    const lkrpIdentityProvider = new LkrpIdentityProvider<{ trustchain: TrustchainStore }>({
-      startListening: listenerMiddleware.startListening,
-    });
     const store = configureStore({
       reducer: {
         trustchain: (
@@ -81,9 +77,8 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
           action: { type: string; payload?: { trustchain?: TrustchainStore } },
         ) => action.payload?.trustchain ?? state,
       },
-      middleware: getDefaultMiddleware =>
-        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
     });
+    const lkrpIdentityProvider = new LkrpIdentityProvider(() => store.getState().trustchain);
     const request = {
       challenge: { tlv: CHALLENGE.tlv, json: CHALLENGE.json },
       clientId: CLIENT_ID,
@@ -114,6 +109,47 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
       "signature.credential.publicKey",
       updatedMemberCredentials.pubkey,
     );
+  });
+
+  it("should load async headless credentials for every authentication", async () => {
+    endpoints.lkrpAuth.mockImplementation(() => HttpResponse.json(AUTHORIZATION_CODE));
+    endpoints.lkrpToken.mockImplementation(() =>
+      HttpResponse.json({ access_token: LKRP_TOKEN, token_type: "Bearer" }),
+    );
+    endpoints.tokenExchange.mockImplementation(() =>
+      HttpResponse.json({ access_token: KEYCLOAK_JWT, token_type: "Bearer" }),
+    );
+
+    const loadedMemberCredentials = initMemberCredentials();
+    const loadTrustchainStore = jest
+      .fn()
+      .mockResolvedValueOnce({
+        trustchain: { rootId: TRUSTCHAIN_ID },
+        memberCredentials: loadedMemberCredentials,
+      })
+      .mockResolvedValueOnce(undefined);
+    const lkrpIdentityProvider = new LkrpIdentityProvider(loadTrustchainStore);
+    const request = {
+      challenge: { tlv: CHALLENGE.tlv, json: CHALLENGE.json },
+      clientId: CLIENT_ID,
+      redirectUri: REDIRECT_URI,
+    };
+
+    await lkrpIdentityProvider.authenticate(request);
+    expect(await endpoints.lkrpAuth.mock.calls[0][0].request.json()).toEqual(
+      expect.objectContaining({
+        signature: expect.objectContaining({
+          credential: expect.objectContaining({ publicKey: loadedMemberCredentials.pubkey }),
+          attestation: EXPECTED_ATTESTATION,
+        }),
+      }),
+    );
+
+    await expect(lkrpIdentityProvider.authenticate(request)).rejects.toMatchObject({
+      name: "WalletAuthNoCredentialsError",
+    });
+    expect(loadTrustchainStore).toHaveBeenCalledTimes(2);
+    expect(endpoints.lkrpAuth).toHaveBeenCalledTimes(1);
   });
 
   it("retrieves a Keycloak JWT with PKCE", async () => {
@@ -275,12 +311,10 @@ describe("LkrpIdentityProvider (integration, MSW)", () => {
 });
 
 function createIdentityProvider(trustchainId: string | undefined): LkrpIdentityProvider {
-  const provider = new LkrpIdentityProvider();
-  provider.setTrustchainStore({
+  return new LkrpIdentityProvider(() => ({
     memberCredentials: MEMBER_CREDENTIALS,
     trustchain: trustchainId ? { rootId: trustchainId } : null,
-  });
-  return provider;
+  }));
 }
 
 function stringToArrayBuffer(value: string): ArrayBuffer {

--- a/libs/ledger-key-ring-protocol/src/index.ts
+++ b/libs/ledger-key-ring-protocol/src/index.ts
@@ -3,7 +3,7 @@ import { SDK } from "./sdk";
 import { MockSDK } from "./mockSdk";
 import { TrustchainSDKContext, TrustchainSDK, TrustchainLifecycle, WithDevice } from "./types";
 
-export { LkrpIdentityProvider } from "./LKRPIdentityProvider";
+export * from "./LKRPIdentityProvider";
 
 /**
  * Get an implementation of a TrustchainSDK

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10591,9 +10591,6 @@ importers:
       '@ledgerhq/types-devices':
         specifier: workspace:^
         version: link:../types-devices
-      '@reduxjs/toolkit':
-        specifier: 'catalog:'
-        version: 2.11.2
       base64-js:
         specifier: '1'
         version: 1.5.1
@@ -10610,6 +10607,9 @@ importers:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
+      '@reduxjs/toolkit':
+        specifier: 'catalog:'
+        version: 2.11.2
       '@shared/env':
         specifier: workspace:*
         version: link:../../shared/env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15186,9 +15186,6 @@ importers:
       '@reduxjs/toolkit':
         specifier: 'catalog:'
         version: 2.11.2
-      '@shared/feature-flags':
-        specifier: workspace:*
-        version: link:../feature-flags
       zod:
         specifier: 'catalog:'
         version: 4.3.6

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -70,8 +70,6 @@ Use `authApiExtra` to provide a stable `authProvider` through RTK Query's
 ([Redux thunk `extraArgument`](https://redux-toolkit.js.org/api/getDefaultMiddleware#customizing-the-included-middleware)):
 
 ```ts
-const listenerMiddleware = createListenerMiddleware<State>();
-
 const store = configureStore({
   reducer,
   middleware: getDefaultMiddleware =>
@@ -79,35 +77,32 @@ const store = configureStore({
       thunk: {
         extraArgument: {
           ...authApiExtra({
-            authFeatureId: "lwdAuth",
-            startListening: listenerMiddleware.startListening,
-            createAuthProvider: environment =>
-              new AuthSDK(getAuthConfig(environment), { provider: identityProvider }),
+            isFeatureEnabled: () => selectFeature(store.getState(), "lwdAuth").enabled,
+            authProvider: new AuthSDK(
+              {
+                ...authConfig,
+                keycloakBaseUrl: () => resolveKeycloakBaseUrl(store.getState()),
+              },
+              { provider: identityProvider },
+            ),
           }),
         },
       },
-    }).prepend(listenerMiddleware.middleware),
+    }),
 });
 ```
 
-The facade calls queries without a token while authentication is disabled. Once
-authentication is enabled and an environment is selected, it creates and caches
-the injected `AuthProvider`. `AuthSDK` from `@ledgerhq/ledger-auth` is one concrete
+The facade evaluates `isFeatureEnabled` for every request. It calls queries without a
+token while authentication is disabled and delegates to the same injected
+`AuthProvider` while enabled. Provider creation, feature selection, and environment
+availability remain app-owned. `AuthSDK` from `@ledgerhq/ledger-auth` is one concrete
 implementation behind this thunk contract.
-
-No initialization action is required: the integration reads the complete state
-whenever the auth environment or feature flags change, regardless of which action
-arrives first. Apps must publish the auth environment before starting authenticated
-queries.
-
-The typed `authFeatureId` selects either `lwdAuth` or `lwmAuth` from
-`@shared/feature-flags`; the Redux state must include its `featureFlags` slice.
 
 ## Scope
 
-This package owns the RTK Query adapter, auth environment state, and generic
-feature/environment lifecycle. Concrete provider construction, credentials, and
-platform cryptography remain in each app's composition root.
+This package owns the RTK Query adapter and auth environment state. Concrete provider
+construction, feature selection, credentials, and platform cryptography remain in each
+app's composition root.
 
 ## Validation
 

--- a/shared/auth/README.md
+++ b/shared/auth/README.md
@@ -79,11 +79,10 @@ const store = configureStore({
       thunk: {
         extraArgument: {
           ...authApiExtra({
-            startListening: listenerMiddleware.startListening,
             authFeatureId: "lwdAuth",
-            providerParams: { provider: identityProvider },
-            createAuthProvider: (environment, providerParams) =>
-              new AuthSDK(getAuthConfig(environment), providerParams),
+            startListening: listenerMiddleware.startListening,
+            createAuthProvider: environment =>
+              new AuthSDK(getAuthConfig(environment), { provider: identityProvider }),
           }),
         },
       },

--- a/shared/auth/package.json
+++ b/shared/auth/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "catalog:",
-    "@shared/feature-flags": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/shared/auth/src/api.test.ts
+++ b/shared/auth/src/api.test.ts
@@ -27,7 +27,6 @@ describe("authApiExtra", () => {
     const { authProvider } = authApiExtra({
       startListening: listenerMiddleware.startListening,
       authFeatureId: "lwdAuth",
-      providerParams: undefined,
       createAuthProvider,
     });
     const store = configureStore({
@@ -54,7 +53,6 @@ describe("authApiExtra", () => {
     const { authProvider } = authApiExtra({
       startListening: listenerMiddleware.startListening,
       authFeatureId: "lwdAuth",
-      providerParams: undefined,
       createAuthProvider,
     });
     const store = configureStore({
@@ -74,7 +72,7 @@ describe("authApiExtra", () => {
     store.dispatch(setAuthEnvironment("PROD"));
     await authProvider.withToken({ queryFn });
     expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(createAuthProvider).toHaveBeenCalledWith("PROD", undefined);
+    expect(createAuthProvider).toHaveBeenCalledWith("PROD");
     expect(queryFn).toHaveBeenCalledTimes(1);
     expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
 
@@ -97,7 +95,6 @@ describe("authApiExtra", () => {
     const { authProvider } = authApiExtra({
       startListening: listenerMiddleware.startListening,
       authFeatureId: "lwdAuth",
-      providerParams: undefined,
       createAuthProvider,
     });
     const store = configureStore({
@@ -114,7 +111,7 @@ describe("authApiExtra", () => {
 
     await authProvider.withToken({ queryFn });
     expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(createAuthProvider).toHaveBeenCalledWith("STAGING", undefined);
+    expect(createAuthProvider).toHaveBeenCalledWith("STAGING");
     expect(queryFn).toHaveBeenCalledTimes(1);
     expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
   });

--- a/shared/auth/src/api.test.ts
+++ b/shared/auth/src/api.test.ts
@@ -1,118 +1,62 @@
-import { configureStore, createListenerMiddleware } from "@reduxjs/toolkit";
-import { featureFlagsReducer, setOverride, type FeatureFlagsState } from "@shared/feature-flags";
-import { authEnvironmentReducer, setAuthEnvironment, type AuthEnvironmentState } from "./data";
 import { authApiExtra } from "./api";
-import { AuthProviderUnavailableError } from "./errors";
-import type { AuthProvider } from "./types";
-
-type State = {
-  authEnvironment: AuthEnvironmentState;
-  featureFlags: FeatureFlagsState;
-};
 
 const EXPECTED_TOKEN = { accessToken: "foo", tokenType: "Bearer" };
 
 describe("authApiExtra", () => {
-  const createAuthProvider = jest.fn(
-    (): AuthProvider => ({ withToken: ({ queryFn }) => queryFn(EXPECTED_TOKEN) }),
-  );
+  let authEnabled = false;
+  const isFeatureEnabled = jest.fn(() => authEnabled);
+  const withToken = jest.fn(({ queryFn }) => queryFn(EXPECTED_TOKEN));
   const queryFn = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    authEnabled = false;
   });
 
-  it("should bypass authentication for unrelated actions and the other platform flag", async () => {
-    const listenerMiddleware = createListenerMiddleware<State>();
+  it("should bypass authentication when the feature is disabled", async () => {
     const { authProvider } = authApiExtra({
-      startListening: listenerMiddleware.startListening,
-      authFeatureId: "lwdAuth",
-      createAuthProvider,
+      isFeatureEnabled,
+      authProvider: { withToken },
     });
-    const store = configureStore({
-      reducer: {
-        authEnvironment: authEnvironmentReducer,
-        featureFlags: featureFlagsReducer,
-      },
-      middleware: getDefaultMiddleware =>
-        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
-    });
-
-    store.dispatch(setAuthEnvironment("PROD"));
-    store.dispatch(setOverride({ key: "lwmAuth", value: { enabled: true } }));
-    store.dispatch({ type: "unrelated/action" });
 
     await authProvider.withToken({ queryFn });
-    expect(createAuthProvider).not.toHaveBeenCalled();
+
+    expect(isFeatureEnabled).toHaveBeenCalledTimes(1);
+    expect(withToken).not.toHaveBeenCalled();
     expect(queryFn).toHaveBeenCalledTimes(1);
     expect(queryFn).toHaveBeenNthCalledWith(1);
   });
 
-  it("should initialize, bypass, and reuse the provider as configuration changes", async () => {
-    const listenerMiddleware = createListenerMiddleware<State>();
+  it("should delegate authentication when the feature is enabled", async () => {
+    authEnabled = true;
     const { authProvider } = authApiExtra({
-      startListening: listenerMiddleware.startListening,
-      authFeatureId: "lwdAuth",
-      createAuthProvider,
-    });
-    const store = configureStore({
-      reducer: {
-        authEnvironment: authEnvironmentReducer,
-        featureFlags: featureFlagsReducer,
-      },
-      middleware: getDefaultMiddleware =>
-        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
+      isFeatureEnabled,
+      authProvider: { withToken },
     });
 
-    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
-    expect(() => authProvider.withToken({ queryFn })).toThrow(AuthProviderUnavailableError);
-    expect(createAuthProvider).not.toHaveBeenCalled();
-    expect(queryFn).not.toHaveBeenCalled();
-
-    store.dispatch(setAuthEnvironment("PROD"));
     await authProvider.withToken({ queryFn });
-    expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(createAuthProvider).toHaveBeenCalledWith("PROD");
-    expect(queryFn).toHaveBeenCalledTimes(1);
-    expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
 
-    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: false } }));
-    await authProvider.withToken({ queryFn });
-    expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(queryFn).toHaveBeenCalledTimes(2);
-    expect(queryFn).toHaveBeenNthCalledWith(2);
-
-    store.dispatch(setAuthEnvironment("STAGING"));
-    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
-    await authProvider.withToken({ queryFn });
-    expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(queryFn).toHaveBeenCalledTimes(3);
-    expect(queryFn).toHaveBeenNthCalledWith(3, EXPECTED_TOKEN);
+    expect(isFeatureEnabled).toHaveBeenCalledTimes(1);
+    expect(withToken).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledWith(EXPECTED_TOKEN);
   });
 
-  it("should create the provider when authentication is enabled after the environment is set", async () => {
-    const listenerMiddleware = createListenerMiddleware<State>();
+  it("should reevaluate the feature before every authentication", async () => {
     const { authProvider } = authApiExtra({
-      startListening: listenerMiddleware.startListening,
-      authFeatureId: "lwdAuth",
-      createAuthProvider,
+      isFeatureEnabled,
+      authProvider: { withToken },
     });
-    const store = configureStore({
-      reducer: {
-        authEnvironment: authEnvironmentReducer,
-        featureFlags: featureFlagsReducer,
-      },
-      middleware: getDefaultMiddleware =>
-        getDefaultMiddleware().prepend(listenerMiddleware.middleware),
-    });
-
-    store.dispatch(setAuthEnvironment("STAGING"));
-    store.dispatch(setOverride({ key: "lwdAuth", value: { enabled: true } }));
 
     await authProvider.withToken({ queryFn });
-    expect(createAuthProvider).toHaveBeenCalledTimes(1);
-    expect(createAuthProvider).toHaveBeenCalledWith("STAGING");
-    expect(queryFn).toHaveBeenCalledTimes(1);
-    expect(queryFn).toHaveBeenNthCalledWith(1, EXPECTED_TOKEN);
+    authEnabled = true;
+    await authProvider.withToken({ queryFn });
+    authEnabled = false;
+    await authProvider.withToken({ queryFn });
+
+    expect(isFeatureEnabled).toHaveBeenCalledTimes(3);
+    expect(withToken).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenNthCalledWith(1);
+    expect(queryFn).toHaveBeenNthCalledWith(2, EXPECTED_TOKEN);
+    expect(queryFn).toHaveBeenNthCalledWith(3);
   });
 });

--- a/shared/auth/src/api.ts
+++ b/shared/auth/src/api.ts
@@ -15,12 +15,11 @@ export interface AuthApiExtra {
 
 export type AuthFeatureId = Extract<FeatureId, "lwdAuth" | "lwmAuth">;
 
-export function authApiExtra<State extends StateWithAuthEnvironment, ProviderParams>({
+export function authApiExtra<State extends StateWithAuthEnvironment>({
   startListening,
   authFeatureId,
-  providerParams,
   createAuthProvider,
-}: AuthApiExtraOptions<State, ProviderParams>): AuthApiExtra {
+}: AuthApiExtraOptions<State>): AuthApiExtra {
   let authEnabled = false;
   let provider: AuthProvider | undefined;
 
@@ -33,7 +32,7 @@ export function authApiExtra<State extends StateWithAuthEnvironment, ProviderPar
       if (!authEnabled || provider) return;
       const environment = authEnvironmentSelector(state);
       if (environment) {
-        provider = createAuthProvider(environment, providerParams);
+        provider = createAuthProvider(environment);
       }
     },
   });
@@ -49,11 +48,10 @@ export function authApiExtra<State extends StateWithAuthEnvironment, ProviderPar
   };
 }
 
-export interface AuthApiExtraOptions<State extends StateWithAuthEnvironment, ProviderParams> {
+export interface AuthApiExtraOptions<State extends StateWithAuthEnvironment> {
   startListening: TypedStartListening<State>;
   authFeatureId: AuthFeatureId;
-  providerParams: ProviderParams;
-  createAuthProvider(environment: AuthEnvironment, providerParams: ProviderParams): AuthProvider;
+  createAuthProvider(environment: AuthEnvironment): AuthProvider;
 }
 
 interface StateWithAuthEnvironment extends WithFeatureFlags {

--- a/shared/auth/src/api.ts
+++ b/shared/auth/src/api.ts
@@ -1,59 +1,24 @@
-import type { TypedStartListening } from "@reduxjs/toolkit";
-import { selectFeature, type FeatureId, type WithFeatureFlags } from "@shared/feature-flags";
-import {
-  authEnvironmentSelector,
-  setAuthEnvironment,
-  type AuthEnvironment,
-  type AuthEnvironmentState,
-} from "./data";
 import type { AuthProvider } from "./types";
-import { AuthProviderUnavailableError } from "./errors";
 
 export interface AuthApiExtra {
   readonly authProvider: AuthProvider;
 }
 
-export type AuthFeatureId = Extract<FeatureId, "lwdAuth" | "lwmAuth">;
-
-export function authApiExtra<State extends StateWithAuthEnvironment>({
-  startListening,
-  authFeatureId,
-  createAuthProvider,
-}: AuthApiExtraOptions<State>): AuthApiExtra {
-  let authEnabled = false;
-  let provider: AuthProvider | undefined;
-
-  startListening({
-    predicate: action =>
-      action.type.startsWith("featureFlags/") || setAuthEnvironment.match(action),
-    effect(_action, listenerApi) {
-      const state = listenerApi.getState();
-      authEnabled = selectFeature(state, authFeatureId).enabled;
-      if (!authEnabled || provider) return;
-      const environment = authEnvironmentSelector(state);
-      if (environment) {
-        provider = createAuthProvider(environment);
-      }
-    },
-  });
-
+export function authApiExtra({
+  isFeatureEnabled,
+  authProvider,
+}: AuthApiExtraOptions): AuthApiExtra {
   return {
     authProvider: {
       withToken(options) {
-        if (!authEnabled) return options.queryFn();
-        if (!provider) throw new AuthProviderUnavailableError();
-        return provider.withToken(options);
+        if (!isFeatureEnabled()) return options.queryFn();
+        return authProvider.withToken(options);
       },
     },
   };
 }
 
-export interface AuthApiExtraOptions<State extends StateWithAuthEnvironment> {
-  startListening: TypedStartListening<State>;
-  authFeatureId: AuthFeatureId;
-  createAuthProvider(environment: AuthEnvironment): AuthProvider;
-}
-
-interface StateWithAuthEnvironment extends WithFeatureFlags {
-  authEnvironment: AuthEnvironmentState;
+export interface AuthApiExtraOptions {
+  isFeatureEnabled(): boolean;
+  authProvider: AuthProvider;
 }

--- a/shared/auth/src/errors.ts
+++ b/shared/auth/src/errors.ts
@@ -5,11 +5,3 @@ export class AuthProviderMissingError extends Error {
     super("Authenticated base query requires api.extra.authProvider");
   }
 }
-
-export class AuthProviderUnavailableError extends Error {
-  override name = "AuthProviderUnavailableError";
-
-  constructor() {
-    super("Authentication is enabled but no auth provider is available");
-  }
-}


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

This PR simplifies the authProvider integration by loading the Keycloak base URL (which depends on the LKRP environment), the remote config state of the feature, and the LKRP credentials lazily whenever the authentication is actually run. 

This makes the integration of the authProvider into wallet cli much simpler.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35626] <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

[LIVE-35626]: https://ledgerhq.atlassian.net/browse/LIVE-35626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ