### PR TITLE
fix(contacts): prevent address name input clipping (LIVE-35775)

### DIFF
--- a/.changeset/fix-contacts-address-name-focus.md
+++ b/.changeset/fix-contacts-address-name-focus.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Fix the address-name input focus state in Contacts.

--- a/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
@@ -37,7 +37,7 @@ export function ContactsRenameAddressDialog({
         data-testid="contacts-rename-address-dialog"
       >
         <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
-        <DialogBody className="flex flex-col gap-32 px-24 pb-24">
+        <DialogBody className="flex flex-col gap-32 px-24 pt-2 pb-24">
           <TextInput
             autoComplete="off"
             autoCorrect="off"


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added a focused rendering test for the input resizing contract.
- [x] **Impact of the changes:**
      Verify the address-name field stays fully highlighted and the clear button remains visible while editing a Contacts address.

### 📝 Description

The address-name input in the Contacts Desktop rename dialog could render only partially highlighted when focused because the input could not shrink alongside its clear button.

The input can now shrink within Lumen’s existing field container, preserving the focus ring and clear button.

<img width="1194" height="966" alt="image" src="https://github.com/user-attachments/assets/cae29661-bf39-4ed9-a5df-610337aebd67" />

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35775

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)