### PR TITLE
fix(contacts): truncate detail contact names (LIVE-35776)

### DIFF
--- a/.changeset/fix-contacts-name-truncation.md
+++ b/.changeset/fix-contacts-name-truncation.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Truncate long contact names in the Contacts detail pane.

--- a/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/ContactDetailView.web.test.tsx
@@ -61,6 +61,24 @@ describe("ContactDetailView", () => {
     ).toBeInTheDocument();
   });
 
+  it("should truncate a long saved contact name within the detail header", () => {
+    const name = "Z".repeat(64);
+
+    render(
+      <ContactDetailView
+        {...defaultProps}
+        contact={mockContact({ id: "contact-long-name", name })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-detail-name")).toHaveTextContent(name);
+    expect(screen.getByTestId("contacts-detail-name")).toHaveClass(
+      "min-w-0",
+      "max-w-full",
+      "truncate",
+    );
+  });
+
   it("should render populated address rows when provided", () => {
     const contact = mockContact({
       id: "contact-benoit",

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
@@ -4,6 +4,7 @@ import { Plus } from "@ledgerhq/lumen-ui-react/symbols";
 import { resolveMeContactDisplayName } from "@features/platform-contacts";
 import type { ContactDetailViewProps } from "../types";
 import { ContactDetailAvatar } from "./ContactDetailAvatar.web";
+import { ContactDetailName } from "./ContactDetailName.web";
 
 type ContactDetailHeaderProps = Pick<
   ContactDetailViewProps,
@@ -29,12 +30,7 @@ export function ContactDetailHeader({
       <div className="flex w-full min-w-0 flex-col items-center gap-16">
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
         <div className="flex w-full min-w-0 flex-col items-center gap-4">
-          <h2
-            className="heading-3-semi-bold min-w-0 max-w-full truncate text-base"
-            data-testid="contacts-detail-name"
-          >
-            {displayName}
-          </h2>
+          <ContactDetailName name={displayName} />
           <p className="body-2 text-muted">{labels.formatAddressCount(contact.addresses.length)}</p>
         </div>
       </div>

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailHeader.web.tsx
@@ -26,10 +26,13 @@ export function ContactDetailHeader({
 
   return (
     <div className="flex flex-col items-center gap-24 pt-24">
-      <div className="flex flex-col items-center gap-16">
+      <div className="flex w-full min-w-0 flex-col items-center gap-16">
         <ContactDetailAvatar contact={contact} meAvatarSrc={meAvatarSrc} />
-        <div className="flex flex-col items-center gap-4">
-          <h2 className="heading-3-semi-bold text-base" data-testid="contacts-detail-name">
+        <div className="flex w-full min-w-0 flex-col items-center gap-4">
+          <h2
+            className="heading-3-semi-bold min-w-0 max-w-full truncate text-base"
+            data-testid="contacts-detail-name"
+          >
             {displayName}
           </h2>
           <p className="body-2 text-muted">{labels.formatAddressCount(contact.addresses.length)}</p>

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { ContactDetailName } from "./ContactDetailName.web";
+
+type TooltipProps = Readonly<{
+  children: React.ReactNode;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}>;
+
+let onTooltipOpenChange: TooltipProps["onOpenChange"] | undefined;
+
+jest.mock("@ledgerhq/lumen-ui-react", () => ({
+  Tooltip: ({ children, onOpenChange, open }: TooltipProps) => {
+    onTooltipOpenChange = onOpenChange;
+    return (
+      <div data-testid="contacts-detail-name-tooltip" data-open={String(open)}>
+        {children}
+      </div>
+    );
+  },
+  TooltipTrigger: ({ children }: Readonly<{ children: React.ReactNode }>) => <>{children}</>,
+  TooltipContent: ({ children }: Readonly<{ children: React.ReactNode }>) => <>{children}</>,
+}));
+
+function setTextMetrics(element: HTMLElement, scrollWidth: number, clientWidth: number) {
+  Object.defineProperty(element, "scrollWidth", { configurable: true, value: scrollWidth });
+  Object.defineProperty(element, "clientWidth", { configurable: true, value: clientWidth });
+}
+
+describe("ContactDetailName", () => {
+  beforeEach(() => {
+    onTooltipOpenChange = undefined;
+  });
+
+  it("should show the full name in a tooltip only when the title is truncated", () => {
+    const name = "Z".repeat(64);
+    render(<ContactDetailName name={name} />);
+
+    const title = screen.getByTestId("contacts-detail-name");
+    const tooltip = screen.getByTestId("contacts-detail-name-tooltip");
+
+    expect(title).toHaveTextContent(name);
+    expect(title).toHaveClass("min-w-0", "max-w-full", "truncate");
+
+    setTextMetrics(title, 100, 100);
+    act(() => onTooltipOpenChange!(true));
+    expect(tooltip).toHaveAttribute("data-open", "false");
+
+    setTextMetrics(title, 200, 100);
+    act(() => onTooltipOpenChange!(true));
+    expect(tooltip).toHaveAttribute("data-open", "true");
+
+    act(() => onTooltipOpenChange!(false));
+    expect(tooltip).toHaveAttribute("data-open", "false");
+  });
+});

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.test.tsx
@@ -1,57 +1,40 @@
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ContactDetailName } from "./ContactDetailName.web";
-
-type TooltipProps = Readonly<{
-  children: React.ReactNode;
-  onOpenChange: (open: boolean) => void;
-  open: boolean;
-}>;
-
-let onTooltipOpenChange: TooltipProps["onOpenChange"] | undefined;
-
-jest.mock("@ledgerhq/lumen-ui-react", () => ({
-  Tooltip: ({ children, onOpenChange, open }: TooltipProps) => {
-    onTooltipOpenChange = onOpenChange;
-    return (
-      <div data-testid="contacts-detail-name-tooltip" data-open={String(open)}>
-        {children}
-      </div>
-    );
-  },
-  TooltipTrigger: ({ children }: Readonly<{ children: React.ReactNode }>) => <>{children}</>,
-  TooltipContent: ({ children }: Readonly<{ children: React.ReactNode }>) => <>{children}</>,
-}));
 
 function setTextMetrics(element: HTMLElement, scrollWidth: number, clientWidth: number) {
   Object.defineProperty(element, "scrollWidth", { configurable: true, value: scrollWidth });
   Object.defineProperty(element, "clientWidth", { configurable: true, value: clientWidth });
 }
 
-describe("ContactDetailName", () => {
-  beforeEach(() => {
-    onTooltipOpenChange = undefined;
-  });
+function getTooltipContainer(): HTMLElement {
+  const tooltipContainer = screen.getByTestId("contacts-detail-name").parentElement;
+  if (tooltipContainer === null) {
+    throw new Error("The Tooltip mock should render a container");
+  }
+  return tooltipContainer;
+}
 
+describe("ContactDetailName", () => {
   it("should show the full name in a tooltip only when the title is truncated", () => {
     const name = "Z".repeat(64);
     render(<ContactDetailName name={name} />);
 
     const title = screen.getByTestId("contacts-detail-name");
-    const tooltip = screen.getByTestId("contacts-detail-name-tooltip");
+    const tooltip = getTooltipContainer();
 
     expect(title).toHaveTextContent(name);
     expect(title).toHaveClass("min-w-0", "max-w-full", "truncate");
 
     setTextMetrics(title, 100, 100);
-    act(() => onTooltipOpenChange!(true));
+    fireEvent.mouseEnter(tooltip);
     expect(tooltip).toHaveAttribute("data-open", "false");
 
     setTextMetrics(title, 200, 100);
-    act(() => onTooltipOpenChange!(true));
+    fireEvent.mouseEnter(tooltip);
     expect(tooltip).toHaveAttribute("data-open", "true");
 
-    act(() => onTooltipOpenChange!(false));
+    fireEvent.mouseLeave(tooltip);
     expect(tooltip).toHaveAttribute("data-open", "false");
   });
 });

--- a/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.tsx
+++ b/features/flow/contacts/src/steps/Detail/components/ContactDetailName.web.tsx
@@ -1,0 +1,36 @@
+import React, { useCallback, useRef, useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@ledgerhq/lumen-ui-react";
+
+type ContactDetailNameProps = Readonly<{
+  name: string;
+}>;
+
+export function ContactDetailName({ name }: ContactDetailNameProps): React.JSX.Element {
+  const nameRef = useRef<HTMLHeadingElement>(null);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
+  const handleTooltipOpenChange = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setIsTooltipOpen(false);
+      return;
+    }
+
+    const element = nameRef.current;
+    setIsTooltipOpen(element !== null && element.scrollWidth > element.clientWidth);
+  }, []);
+
+  return (
+    <Tooltip open={isTooltipOpen} onOpenChange={handleTooltipOpenChange}>
+      <TooltipTrigger asChild>
+        <h2
+          ref={nameRef}
+          className="heading-3-semi-bold min-w-0 max-w-full truncate text-base"
+          data-testid="contacts-detail-name"
+        >
+          {name}
+        </h2>
+      </TooltipTrigger>
+      <TooltipContent>{name}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/support/jest-features-flow/mocks/passthrough-web.js
+++ b/support/jest-features-flow/mocks/passthrough-web.js
@@ -1,11 +1,26 @@
 const React = require("react");
+const TooltipOpenContext = React.createContext();
 
 function InteractiveIcon({ icon: _icon, iconType: _iconType, size: _size, ...props }) {
   return React.createElement("button", { type: "button", ...props });
 }
 
-function Tooltip({ children }) {
-  return React.createElement(React.Fragment, undefined, children);
+function Tooltip({ children, onOpenChange, open }) {
+  return React.createElement(
+    TooltipOpenContext.Provider,
+    { value: open },
+    React.createElement(
+      "div",
+      {
+        "data-open": String(open),
+        onMouseEnter: () => onOpenChange?.(true),
+        onMouseLeave: () => onOpenChange?.(false),
+        onFocus: () => onOpenChange?.(true),
+        onBlur: () => onOpenChange?.(false),
+      },
+      children,
+    ),
+  );
 }
 
 function TooltipTrigger({ children }) {
@@ -13,6 +28,8 @@ function TooltipTrigger({ children }) {
 }
 
 function TooltipContent({ children, ...props }) {
+  if (React.useContext(TooltipOpenContext) === false) return null;
+
   return React.createElement("div", { ...props, role: "tooltip" }, children);
 }
 


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [x] **Covered by automatic tests.** Added unit coverage for overflow-only tooltip behavior and extended the Contact Detail view test with a long contact name.
- [x] **Impact of the changes:**
      Verify a 32-character contact name is truncated inside the Contacts detail pane after the Desktop window is narrowed, and its full name appears on hover.

### 📝 Description

Long contact names could overflow the Contacts detail pane when the Desktop window became narrow.

The detail header now constrains the title width, applies a single-line ellipsis, and shows the complete name in a Lumen tooltip only when the title overflows.

<img width="536" height="543" alt="image" src="https://github.com/user-attachments/assets/ec58a9aa-db5e-40d3-a8ff-c64bf8a8e2f6" />


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35776

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)