### PR TITLE
[LWM] fix(contacts): prevent network search crash (LIVE-35788)

### DIFF
--- a/.changeset/stable-network-search.md
+++ b/.changeset/stable-network-search.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Fix the Contacts network search drawer crash

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -722,6 +722,29 @@ describe("Contacts integration", () => {
     });
   });
 
+  it("should keep the currency selector usable when searching for a network", async () => {
+    const { user } = render(<ContactDetailAddressEntryTestApp />, {
+      navigationInitialState: contactDetailNavigationState,
+      overrideInitialState: withContactsPageReadyState({
+        lwmContacts: {
+          enabled: true,
+          params: { newBadge: false, eligibleAddressFamilies: ["evm"] },
+        },
+      }),
+    });
+
+    await user.press(screen.getByTestId("contacts-detail-add-address"));
+
+    const searchInput = await screen.findByTestId("modular-drawer-search-input");
+    await user.press(searchInput);
+    await user.type(searchInput, "ethereum");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("modular-drawer-search-input")).toBeVisible();
+      expect(screen.getByText(/ethereum/i)).toBeVisible();
+    });
+  });
+
   it("should return to currency selection without removing the contact detail route", async () => {
     const { user } = render(<ContactDetailAddressEntryTestApp />, {
       navigationInitialState: contactDetailNavigationState,

--- a/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/ModularDrawer/screens/AssetSelection/index.tsx
@@ -65,12 +65,12 @@ const AssetSelection = ({
   const source = useSelector(modularDrawerSourceSelector);
 
   const { trackModularDrawerEvent } = useModularDrawerAnalytics();
-  const { collapse, snapToIndex } = useBottomSheet();
+  const { collapse, expand } = useBottomSheet();
   const listRef = useRef<FlatList>(null);
 
   const expandToFullHeight = () => {
     if (formattedAssets.length > 0) {
-      snapToIndex(1);
+      expand();
       listRef.current?.scrollToIndex({ index: 0 });
     }
   };


### PR DESCRIPTION
### ✅ Checklist

- [x] npx changeset was attached.
- [x] **Covered by automatic tests.** Added a Contacts integration regression covering search input focus and filtering inside the embedded currency selector.
- [x] **Impact of the changes:**
      QA should add a contact address on iOS, tap the asset/network search input, and confirm the drawer remains open and search results filter correctly.

### 📝 Description

Opening the asset/network search input while adding a contact address on mobile could crash the app. The embedded Contacts drawer has one snap point, while asset selection attempted to move to a fixed second snap-point index.

The asset selector now uses the bottom sheet maximum configured snap point. This preserves expansion in the standard ModularDrawer and safely supports the single-point Contacts drawer. A Contacts integration test covers opening and searching within the real embedded selector.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35788

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)
