### PR TITLE
[LWM] fix(send): persist summary field edits back to the amount step

### DIFF
--- a/.changeset/tender-fans-act.md
+++ b/.changeset/tender-fans-act.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Keep memo, tag and comment edits made from the send summary when navigating back to the recipient or amount step, instead of reverting them.

--- a/apps/ledger-live-mobile/src/helpers/navigationHelpers.test.ts
+++ b/apps/ledger-live-mobile/src/helpers/navigationHelpers.test.ts
@@ -1,0 +1,129 @@
+import { CommonActions } from "@react-navigation/native";
+import { NavigatorName, ScreenName } from "~/const";
+import { popToScreen } from "./navigationHelpers";
+
+const transaction = { family: "generic", memo: "123" };
+
+const navigatorKey = "sendfunds-stack-key";
+const recipientStep = { name: ScreenName.SendSelectRecipient, key: "recipient-key" };
+const amountStep = { name: ScreenName.SendAmountCoin, key: "amount-key" };
+const summaryStep = { name: ScreenName.SendSummary, key: "summary-key" };
+const editStep = { name: ScreenName.XrpEditTag, key: "edit-key" };
+
+type Step = { name: string; key?: string; state?: StackState };
+type StackState = { key?: string; routes: Step[] };
+
+// Production registers the edit screen as a sibling of the SendFunds navigator, so its state is the
+// base stack and the steps live one level down.
+const baseStackWith = (steps: Step[]): StackState => ({
+  key: "base-key",
+  routes: [
+    {
+      name: NavigatorName.SendFunds,
+      key: "sendfunds-route-key",
+      state: { key: navigatorKey, routes: [...steps, summaryStep] },
+    },
+    editStep,
+  ],
+});
+
+// A flow registering its edit screen inside its own stack reaches the steps directly.
+const sendStackWith = (steps: Step[]): StackState => ({
+  key: navigatorKey,
+  routes: [...steps, summaryStep, editStep],
+});
+
+const makeNavigation = (state: StackState) => ({
+  popTo: jest.fn(),
+  dispatch: jest.fn(),
+  getState: () => state,
+});
+
+const setParamsOn = (sourceKey: string) => ({
+  ...CommonActions.setParams({ transaction }),
+  source: sourceKey,
+  target: navigatorKey,
+});
+
+describe("popToScreen", () => {
+  it("pops to the summary's navigator with the wrapped screen params", () => {
+    const navigation = makeNavigation(baseStackWith([recipientStep, amountStep]));
+    const params = { accountId: "js:2:ripple:rTest:", transaction };
+
+    popToScreen(navigation, ScreenName.SendSummary, params);
+
+    expect(navigation.popTo).toHaveBeenCalledTimes(1);
+    expect(navigation.popTo).toHaveBeenCalledWith(NavigatorName.SendFunds, {
+      screen: ScreenName.SendSummary,
+      params,
+    });
+  });
+
+  it("mirrors the edited transaction onto every step keeping its own copy", () => {
+    const navigation = makeNavigation(sendStackWith([recipientStep, amountStep]));
+
+    popToScreen(navigation, ScreenName.SendSummary, { transaction });
+
+    expect(navigation.dispatch).toHaveBeenCalledTimes(2);
+    expect(navigation.dispatch).toHaveBeenCalledWith(setParamsOn("recipient-key"));
+    expect(navigation.dispatch).toHaveBeenCalledWith(setParamsOn("amount-key"));
+  });
+
+  it("mirrors the edited transaction onto steps nested inside the send navigator", () => {
+    const navigation = makeNavigation(baseStackWith([recipientStep, amountStep]));
+
+    popToScreen(navigation, ScreenName.SendSummary, { transaction });
+
+    expect(navigation.dispatch).toHaveBeenCalledTimes(2);
+    expect(navigation.dispatch).toHaveBeenCalledWith(setParamsOn("recipient-key"));
+    expect(navigation.dispatch).toHaveBeenCalledWith(setParamsOn("amount-key"));
+  });
+
+  it("skips the amount step when the recipient went straight to the summary", () => {
+    const navigation = makeNavigation(sendStackWith([recipientStep]));
+
+    popToScreen(navigation, ScreenName.SendSummary, { transaction });
+
+    expect(navigation.dispatch).toHaveBeenCalledTimes(1);
+    expect(navigation.dispatch).toHaveBeenCalledWith(setParamsOn("recipient-key"));
+  });
+
+  it("still pops when no earlier step is in the stack", () => {
+    const navigation = makeNavigation(baseStackWith([]));
+
+    popToScreen(navigation, ScreenName.SendSummary, { transaction });
+
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+    expect(navigation.popTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("still pops when the stack has no key yet", () => {
+    const navigation = makeNavigation({ routes: [recipientStep, amountStep, summaryStep] });
+
+    popToScreen(navigation, ScreenName.SendSummary, { transaction });
+
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+    expect(navigation.popTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("still pops when the params carry no transaction", () => {
+    const navigation = makeNavigation(sendStackWith([recipientStep, amountStep]));
+
+    popToScreen(navigation, ScreenName.SendSummary, { accountId: "js:2:ripple:rTest:" });
+
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+    expect(navigation.popTo).toHaveBeenCalledTimes(1);
+  });
+
+  it("still pops for summaries outside the send flow", () => {
+    const navigation = makeNavigation(sendStackWith([recipientStep, amountStep]));
+
+    popToScreen(navigation, ScreenName.SwapForm, { transaction });
+
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+    expect(navigation.popTo).toHaveBeenCalledWith(NavigatorName.Swap, {
+      screen: ScreenName.SwapForm,
+      params: { transaction },
+    });
+  });
+});

--- a/apps/ledger-live-mobile/src/helpers/navigationHelpers.ts
+++ b/apps/ledger-live-mobile/src/helpers/navigationHelpers.ts
@@ -1,3 +1,4 @@
+import { CommonActions, type NavigationAction } from "@react-navigation/native";
 import { NavigatorName, ScreenName } from "~/const";
 
 const screenToNavigatorMap = {
@@ -9,15 +10,69 @@ const screenToNavigatorMap = {
 type ScreenToNavigatorMap = typeof screenToNavigatorMap;
 type MappedScreen = keyof ScreenToNavigatorMap;
 
+type NavigationState = {
+  key?: string;
+  routes: ReadonlyArray<{ name: string; key?: string; state?: NavigationState }>;
+};
+
+type StackNavigation = {
+  getState: () => NavigationState;
+  dispatch: (action: NavigationAction) => void;
+};
+
+const stepsKeepingTransactionCopy = new Set<string>([
+  ScreenName.SendSelectRecipient,
+  ScreenName.SendAmountCoin,
+]);
+
+// BaseNavigator registers family edit screens as siblings of the flow navigator, so the state we
+// get back from one is the base stack and the steps live one level down.
+const findStepStack = (
+  state: NavigationState | undefined,
+  navigatorName: string,
+): NavigationState | undefined => {
+  if (!state) return undefined;
+  if (state.routes.some(route => stepsKeepingTransactionCopy.has(route.name))) return state;
+  return findStepStack(
+    state.routes.find(route => route.name === navigatorName)?.state,
+    navigatorName,
+  );
+};
+
+const syncTransactionToEarlierSteps = (
+  navigation: StackNavigation,
+  navigatorName: string,
+  transaction: unknown,
+): void => {
+  const stack = findStepStack(navigation.getState(), navigatorName);
+  const target = stack?.key;
+  if (!target) return;
+
+  for (const route of stack.routes) {
+    if (!route.key || !stepsKeepingTransactionCopy.has(route.name)) continue;
+
+    navigation.dispatch({
+      ...CommonActions.setParams({ transaction }),
+      source: route.key,
+      target,
+    });
+  }
+};
+
 export const popToScreen = <T extends MappedScreen>(
-  navigation: { popTo: (navigator: ScreenToNavigatorMap[T], params: unknown) => void },
+  navigation: StackNavigation & {
+    popTo: (navigator: ScreenToNavigatorMap[T], params: unknown) => void;
+  },
   screen: T,
   params: unknown,
 ): void => {
   const navigator = screenToNavigatorMap[screen];
+  const transaction = (params as { transaction?: unknown } | undefined)?.transaction;
 
-  navigation.popTo(navigator, {
-    screen,
-    params,
-  });
+  // Mirror before popping: once popTo runs, the dispatch no longer reaches the earlier steps.
+  if (screen === ScreenName.SendSummary && transaction) {
+    syncTransactionToEarlierSteps(navigation, navigator, transaction);
+  }
+
+  navigation.popTo(navigator, { screen, params });
 };

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.test.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.test.ts
@@ -1,0 +1,71 @@
+import { useRoute } from "@react-navigation/native";
+import { renderHook } from "@tests/test-renderer";
+import type { Transaction } from "@ledgerhq/live-common/generated/types";
+import { useTransactionChangeFromNavigation } from "./screenTransactionHooks";
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: jest.fn(),
+}));
+
+const mockUseRoute = jest.mocked(useRoute);
+const transaction = { family: "generic", memo: "123" } as unknown as Transaction;
+
+const routeWith = (params: { transaction?: Transaction }) =>
+  mockUseRoute.mockReturnValue({
+    key: "amount-key",
+    name: "SendAmountCoin",
+    params,
+  } as never);
+
+describe("useTransactionChangeFromNavigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adopts a transaction already present in the route params on mount", () => {
+    const setTransaction = jest.fn();
+    routeWith({ transaction });
+
+    renderHook(() => useTransactionChangeFromNavigation(setTransaction));
+
+    expect(setTransaction).toHaveBeenCalledTimes(1);
+    expect(setTransaction).toHaveBeenCalledWith(transaction);
+  });
+
+  it("ignores route params carrying no transaction", () => {
+    const setTransaction = jest.fn();
+    routeWith({});
+
+    renderHook(() => useTransactionChangeFromNavigation(setTransaction));
+
+    expect(setTransaction).not.toHaveBeenCalled();
+  });
+
+  it("ignores an unchanged transaction when the setter identity changes", () => {
+    const firstSetter = jest.fn();
+    const secondSetter = jest.fn();
+    routeWith({ transaction });
+
+    let setTransaction = firstSetter;
+    const { rerender } = renderHook(() => useTransactionChangeFromNavigation(setTransaction));
+    setTransaction = secondSetter;
+    rerender({});
+
+    expect(firstSetter).toHaveBeenCalledTimes(1);
+    expect(secondSetter).not.toHaveBeenCalled();
+  });
+
+  it("adopts a transaction mirrored onto the params after mount", () => {
+    const setTransaction = jest.fn();
+    routeWith({ transaction });
+    const { rerender } = renderHook(() => useTransactionChangeFromNavigation(setTransaction));
+
+    const editedTransaction = { ...transaction, memo: "456" } as Transaction;
+    routeWith({ transaction: editedTransaction });
+    rerender({});
+
+    expect(setTransaction).toHaveBeenCalledTimes(2);
+    expect(setTransaction).toHaveBeenLastCalledWith(editedTransaction);
+  });
+});

--- a/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
+++ b/apps/ledger-live-mobile/src/logic/screenTransactionHooks.ts
@@ -4,7 +4,7 @@ import { concatMap, filter } from "rxjs/operators";
 import { useState, useCallback, useEffect, useRef } from "react";
 import { InteractionManager, Platform } from "react-native";
 import { log } from "@ledgerhq/logs";
-import { useRoute, useNavigation } from "@react-navigation/native";
+import { useRoute, useNavigation, type RouteProp } from "@react-navigation/native";
 import type {
   Account,
   AccountLike,
@@ -117,8 +117,10 @@ const completeSignedTxBroadcast = ({
   });
 };
 
+type TransactionParamList = Record<string, { transaction?: Transaction } | undefined>;
+
 export const useTransactionChangeFromNavigation = (setTransaction: (_: Transaction) => void) => {
-  const route = useRoute<Route>();
+  const route = useRoute<RouteProp<TransactionParamList>>();
   const navigationTransaction = route.params?.transaction;
   // Start at `undefined` so the first time `navigationTransaction` is set we
   // dispatch — including the case where the screen mounts (or remounts via

--- a/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/02-SelectRecipient.test.tsx
@@ -133,6 +133,44 @@ describe("SendSelectRecipient", () => {
 
 const mockGetCustomSendFlow = jest.mocked(getCustomSendFlow);
 
+const accountState = (state: Parameters<typeof Object>[0]) => ({
+  ...state,
+  accounts: {
+    active: [
+      {
+        id: "parentId",
+        type: "Account",
+        currency: { units: [], family: "aleo", id: "aleo" },
+        subAccounts: [],
+        operations: [],
+        operationsCount: 0,
+        balance: { gt: () => true },
+        spendableBalance: { gt: () => true },
+      } as unknown as Account,
+    ],
+  },
+});
+
+const mockBridgeTransaction = (overrides: Record<string, unknown> = {}) =>
+  jest.spyOn(useBridgeTransactionModule, "default").mockReturnValue({
+    transaction: { recipient: "aleo1abc", family: "aleo" },
+    status: { errors: {}, warnings: {} },
+    ...overrides,
+  } as unknown as useBridgeTransactionModule.Result);
+
+const renderRecipient = (params: Record<string, unknown> = {}) =>
+  render(
+    <SendSelectRecipient
+      route={
+        { params: { accountId: "parentId", ...params } } as unknown as RouteProp<
+          SendFundsNavigatorStackParamList,
+          ScreenName.SendSelectRecipient
+        >
+      }
+    />,
+    { overrideInitialState: accountState },
+  );
+
 describe("SendSelectRecipient — custom send flow", () => {
   const mockNavigateAfterRecipient = jest.fn();
 
@@ -142,24 +180,6 @@ describe("SendSelectRecipient — custom send flow", () => {
     mockGetCustomSendFlow.mockReturnValue(null);
   });
 
-  const accountState = (state: Parameters<typeof Object>[0]) => ({
-    ...state,
-    accounts: {
-      active: [
-        {
-          id: "parentId",
-          type: "Account",
-          currency: { units: [], family: "aleo", id: "aleo" },
-          subAccounts: [],
-          operations: [],
-          operationsCount: 0,
-          balance: { gt: () => true },
-          spendableBalance: { gt: () => true },
-        } as unknown as Account,
-      ],
-    },
-  });
-
   it("calls navigateAfterRecipient and returns early when it returns true", async () => {
     mockNavigateAfterRecipient.mockReturnValue(true);
     mockGetCustomSendFlow.mockReturnValue({
@@ -167,24 +187,9 @@ describe("SendSelectRecipient — custom send flow", () => {
       navigateAfterRecipient: mockNavigateAfterRecipient,
     });
 
-    jest.spyOn(useBridgeTransactionModule, "default").mockReturnValue({
-      transaction: { recipient: "aleo1abc", family: "aleo" },
-      status: { errors: {}, warnings: {} },
-    } as unknown as useBridgeTransactionModule.Result);
+    mockBridgeTransaction();
 
-    const { user } = render(
-      <SendSelectRecipient
-        route={
-          {
-            params: { accountId: "parentId" },
-          } as unknown as RouteProp<
-            SendFundsNavigatorStackParamList,
-            ScreenName.SendSelectRecipient
-          >
-        }
-      />,
-      { overrideInitialState: accountState },
-    );
+    const { user } = renderRecipient();
 
     await user.press(screen.getByTestId("enabled-recipient-continue-button"));
 
@@ -199,28 +204,27 @@ describe("SendSelectRecipient — custom send flow", () => {
       navigateAfterRecipient: mockNavigateAfterRecipient,
     });
 
-    jest.spyOn(useBridgeTransactionModule, "default").mockReturnValue({
-      transaction: { recipient: "aleo1abc", family: "aleo" },
-      status: { errors: {}, warnings: {} },
-    } as unknown as useBridgeTransactionModule.Result);
+    mockBridgeTransaction();
 
-    const { user } = render(
-      <SendSelectRecipient
-        route={
-          {
-            params: { accountId: "parentId" },
-          } as unknown as RouteProp<
-            SendFundsNavigatorStackParamList,
-            ScreenName.SendSelectRecipient
-          >
-        }
-      />,
-      { overrideInitialState: accountState },
-    );
+    const { user } = renderRecipient();
 
     await user.press(screen.getByTestId("enabled-recipient-continue-button"));
 
     expect(mockNavigateAfterRecipient).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(ScreenName.SendAmountCoin, expect.anything());
+  });
+});
+
+describe("SendSelectRecipient — transaction mirrored from a later step", () => {
+  it("adopts the transaction pushed onto its route params", () => {
+    const setTransaction = jest.fn();
+    const editedTransaction = { recipient: "aleo1abc", family: "aleo", memo: "123" };
+
+    mockBridgeTransaction({ setTransaction });
+
+    renderRecipient({ transaction: editedTransaction });
+
+    expect(setTransaction).toHaveBeenCalledTimes(1);
+    expect(setTransaction).toHaveBeenCalledWith(editedTransaction);
   });
 });

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.test.tsx
@@ -33,6 +33,10 @@ jest.mock("@ledgerhq/live-common/bridge/useBridgeTransaction", () => ({
   default: jest.fn(),
 }));
 
+jest.mock("~/logic/screenTransactionHooks", () => ({
+  useTransactionChangeFromNavigation: jest.fn(),
+}));
+
 jest.mock("~/screens/SendFunds/utils/customSendFlow", () => ({
   getCustomSendFlow: jest.fn(() => null),
 }));

--- a/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/03a-AmountCoin.tsx
@@ -12,6 +12,7 @@ import useBridgeTransaction from "@ledgerhq/live-common/bridge/useBridgeTransact
 import { useDebounce } from "@ledgerhq/live-common/hooks/useDebounce";
 import { getAccountCurrency, getMainAccount } from "@ledgerhq/live-common/account/helpers";
 import { getCustomSendFlow } from "~/screens/SendFunds/utils/customSendFlow";
+import { useTransactionChangeFromNavigation } from "~/logic/screenTransactionHooks";
 import { ScreenName } from "~/const";
 import { useAccountScreen } from "LLM/hooks/useAccountScreen";
 import { TrackScreen } from "~/analytics";
@@ -76,6 +77,7 @@ function SendAmountCoinContent({ navigation, route, account, parentAccount }: Co
       parentAccount,
     }),
   );
+  useTransactionChangeFromNavigation(setTransaction);
   const debouncedTransaction = useDebounce(transaction, 500);
   useEffect(() => {
     let cancelled = false;

--- a/apps/ledger-live-mobile/src/screens/SendFunds/__integrations__/summaryEditRevertRealScreens.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/screens/SendFunds/__integrations__/summaryEditRevertRealScreens.integration.test.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { Pressable, Text } from "react-native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useNavigation, useNavigationState } from "@react-navigation/native";
+import { setEnv } from "@shared/env";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { act, renderWithReactQuery, screen, withFlagOverrides } from "@tests/test-renderer";
+import { bridgeSuspenseScreenLayout } from "~/navigation/navigatorConfig";
+import type { State } from "~/reducers/types";
+import { NavigatorName, ScreenName } from "~/const";
+import SendSelectRecipient from "../02-SelectRecipient";
+import SendAmountCoin from "../03a-AmountCoin";
+import SendSummary from "../04-Summary";
+import { component as XrpEditTag } from "~/families/xrp/ScreenEditTag";
+
+const currency = getCryptoCurrencyById("ripple");
+const account = genAccount("send-xrp-account", { currency });
+const recipientAccount = genAccount("recipient-xrp-account", { currency });
+const RECIPIENT = recipientAccount.freshAddress;
+
+const RootStack = createNativeStackNavigator();
+const BaseStack = createNativeStackNavigator();
+const SendStack = createNativeStackNavigator();
+
+function GoBack({ testID }: { testID: string }) {
+  const navigation = useNavigation();
+  return (
+    <Pressable testID={testID} onPress={() => navigation.goBack()}>
+      <Text>back</Text>
+    </Pressable>
+  );
+}
+
+const withGoBack =
+  <P extends object>(Component: React.ComponentType<P>, testID: string, probe = false) =>
+  (props: P) => (
+    <>
+      <Component {...props} />
+      <GoBack testID={testID} />
+      {probe && <StackProbe />}
+    </>
+  );
+
+function StackProbe() {
+  const names = useNavigationState(state => state.routes.map(r => r.name).join(","));
+  return <Text testID="stack-probe">{names}</Text>;
+}
+
+function SendFundsNested() {
+  return (
+    <SendStack.Navigator
+      screenOptions={{ headerShown: false }}
+      screenLayout={bridgeSuspenseScreenLayout}
+      initialRouteName={ScreenName.SendSelectRecipient}
+    >
+      <SendStack.Screen
+        name={ScreenName.SendSelectRecipient}
+        component={SendSelectRecipient as never}
+      />
+      <SendStack.Screen
+        name={ScreenName.SendAmountCoin}
+        component={withGoBack(SendAmountCoin, "amount-go-back") as never}
+      />
+      <SendStack.Screen
+        name={ScreenName.SendSummary}
+        component={withGoBack(SendSummary, "summary-go-back", true) as never}
+        initialParams={{
+          currentNavigation: ScreenName.SendSummary,
+          nextNavigation: ScreenName.SendSelectDevice,
+        }}
+      />
+    </SendStack.Navigator>
+  );
+}
+
+// Mirrors production: the edit screen is a sibling of the send navigator, not one of its steps, so
+// editing pushes it onto the base stack and popToScreen returns from above the steps.
+function BaseNested() {
+  return (
+    <BaseStack.Navigator screenOptions={{ headerShown: false }}>
+      <BaseStack.Screen name={NavigatorName.SendFunds} component={SendFundsNested} />
+      <BaseStack.Screen name={ScreenName.XrpEditTag} component={XrpEditTag as never} />
+    </BaseStack.Navigator>
+  );
+}
+
+function Harness() {
+  return (
+    <RootStack.Navigator screenOptions={{ headerShown: false }}>
+      <RootStack.Screen name={NavigatorName.Base} component={BaseNested} />
+    </RootStack.Navigator>
+  );
+}
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(1000);
+  });
+}
+
+function renderFlow() {
+  return renderWithReactQuery(<Harness />, {
+    overrideInitialState: withFlagOverrides({ llmMemoTag: { enabled: true } }, (state: State) => ({
+      ...state,
+      accounts: { ...state.accounts, active: [account] },
+    })),
+    navigationInitialState: {
+      index: 0,
+      routes: [
+        {
+          name: NavigatorName.Base,
+          state: {
+            index: 0,
+            routes: [
+              {
+                name: NavigatorName.SendFunds,
+                state: {
+                  index: 0,
+                  routes: [
+                    {
+                      name: ScreenName.SendSelectRecipient,
+                      params: { accountId: account.id },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  });
+}
+
+describe("send summary edit revert — real screens (integration)", () => {
+  beforeAll(() => {
+    setEnv("MOCK", "1");
+  });
+
+  afterAll(() => {
+    setEnv("MOCK", "");
+  });
+
+  type User = ReturnType<typeof renderFlow>["user"];
+
+  async function driveToEditedSummary(user: User): Promise<void> {
+    await user.paste(await screen.findByTestId("recipient-input"), RECIPIENT);
+    await flush();
+    await user.paste(await screen.findByTestId("memo-tag-input"), "1234");
+    await flush();
+    await user.press(await screen.findByTestId("enabled-recipient-continue-button"));
+
+    await user.paste(await screen.findByTestId("amount-input"), "1");
+    await flush();
+    await user.press(await screen.findByTestId("enabled-amount-continue-button"));
+
+    expect(await screen.findByTestId("summary-memo-tag")).toHaveTextContent("1234");
+
+    await user.press(await screen.findByText("Edit"));
+    await user.paste(await screen.findByDisplayValue("1234"), "5678");
+    await flush();
+    await user.press(await screen.findByText("Validate tag"));
+    await flush();
+
+    expect(await screen.findByTestId("summary-memo-tag")).toHaveTextContent("5678");
+  }
+
+  it("returns to the summary leaving the steps below it intact", async () => {
+    const { user } = renderFlow();
+
+    await driveToEditedSummary(user);
+
+    expect(screen.getByTestId("stack-probe")).toHaveTextContent(
+      `${ScreenName.SendSelectRecipient},${ScreenName.SendAmountCoin},${ScreenName.SendSummary}`,
+    );
+  });
+
+  it("keeps the edited tag when the amount step is revisited", async () => {
+    const { user } = renderFlow();
+
+    await driveToEditedSummary(user);
+
+    await user.press(await screen.findByTestId("summary-go-back"));
+    await flush();
+    await user.press(await screen.findByTestId("enabled-amount-continue-button"));
+    await flush();
+
+    expect(await screen.findByTestId("summary-memo-tag")).toHaveTextContent("5678");
+  });
+
+  it("keeps the edited tag as far back as the recipient step", async () => {
+    const { user } = renderFlow();
+
+    await driveToEditedSummary(user);
+
+    await user.press(await screen.findByTestId("summary-go-back"));
+    await flush();
+    await user.press(await screen.findByTestId("amount-go-back"));
+    await flush();
+
+    await user.press(await screen.findByTestId("enabled-recipient-continue-button"));
+    await flush();
+    await user.press(await screen.findByTestId("enabled-amount-continue-button"));
+    await flush();
+
+    expect(await screen.findByTestId("summary-memo-tag")).toHaveTextContent("5678");
+  });
+});


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Fix send flow reverting memo, tag and comment edits made from the summary step when navigating back.

### 🔗 Context

https://ledgerhq.atlassian.net/browse/LIVE-35403
