### PR TITLE
[LWDM] fix(coin-ton): support transactions with more than one output message

### DIFF
--- a/.changeset/ton-multi-output-operations.md
+++ b/.changeset/ton-multi-output-operations.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-ton": patch
+---
+
+Fix TON (GRAM) account import/sync failing with `[ton] txn with > 1 output not expected` when the account history contains transactions with more than one outgoing message. Such transactions (e.g. wallet v4/v5 batch sends, or a main transfer plus a small secondary message) are now aggregated into a single OUT operation whose value is the sum of the account's outgoing messages and whose recipients list every destination, instead of throwing and aborting the whole account synchronization.

--- a/libs/coin-modules/coin-ton/src/__tests__/unit/txn.unit.test.ts
+++ b/libs/coin-modules/coin-ton/src/__tests__/unit/txn.unit.test.ts
@@ -143,6 +143,175 @@ describe("Transaction functions", () => {
         },
       ]);
     });
+
+    it("should aggregate a multi-output OUT ton transaction into a single ledger operation", () => {
+      // Regression for LIVE-35577: a TON transaction can carry more than one outgoing
+      // message (e.g. a main transfer plus a small secondary message). These must be
+      // aggregated into a single OUT operation instead of throwing.
+      const base = tonTransactionResponse.transactions[0];
+      const mainRecipient = "0:9220C181A6CFEACD11B7B8F62138DF1BB9CC82B6ED2661D2F5FAEE204B3EFB20";
+      const secondaryRecipient =
+        "0:D49106E94D5220B7BBFAEBE253151FB7F9E5D1173FF857AE85F947E7EAF3A0D0";
+      const addressBook = {
+        [mainRecipient]: { user_friendly: "EQCSIMGBps_qzRG3uPYhON8bucyCtu0mYdL1-u4gSz77IK7z" },
+        [secondaryRecipient]: {
+          user_friendly: "EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0KzT",
+        },
+      };
+      const transactions: TonTransaction[] = [{ ...base, in_msg: null, out_msgs: [] }];
+      if (base.in_msg) {
+        transactions[0].out_msgs = [
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: mainRecipient,
+            value: "37300000000",
+            hash: "outMsgHashMain",
+          },
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: secondaryRecipient,
+            value: "323750000",
+            hash: "outMsgHashSecondary",
+          },
+        ];
+      }
+      const { now, lt, hash, total_fees, mc_block_seqno } = transactions[0];
+
+      const finalOperation = flatMap(
+        transactions,
+        mapTxToOps(mockAccountId, mockAddress, addressBook),
+      );
+
+      expect(finalOperation).toEqual([
+        {
+          id: encodeOperationId(mockAccountId, hash, "OUT"),
+          hash: "outMsgHashMain",
+          type: "OUT",
+          // 37300000000 + 323750000
+          value: BigNumber("37623750000"),
+          fee: BigNumber(total_fees),
+          blockHeight: mc_block_seqno,
+          blockHash: null,
+          hasFailed: true,
+          accountId: mockAccountId,
+          senders: [transactions[0].account],
+          recipients: [
+            "EQCSIMGBps_qzRG3uPYhON8bucyCtu0mYdL1-u4gSz77IK7z",
+            "EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0KzT",
+          ],
+          date: new Date(now * 1000), // now is defined in seconds
+          extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
+        },
+      ]);
+    });
+
+    it("should ignore zero-value out messages when building the OUT operation", () => {
+      // The value-bearing message may not be the first one; the OUT operation must be
+      // built from the actual value-carrying messages, not blindly from out_msgs[0].
+      const base = tonTransactionResponse.transactions[0];
+      const valueRecipient = "0:D49106E94D5220B7BBFAEBE253151FB7F9E5D1173FF857AE85F947E7EAF3A0D0";
+      const addressBook = {
+        [valueRecipient]: { user_friendly: "EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0KzT" },
+      };
+      const transactions: TonTransaction[] = [{ ...base, in_msg: null, out_msgs: [] }];
+      if (base.in_msg) {
+        transactions[0].out_msgs = [
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: "0:0000000000000000000000000000000000000000000000000000000000000000",
+            value: "0",
+            hash: "zeroValueHash",
+          },
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: valueRecipient,
+            value: "5000000",
+            hash: "valueHash",
+          },
+        ];
+      }
+      const { now, lt, hash, total_fees, mc_block_seqno } = transactions[0];
+
+      const finalOperation = flatMap(
+        transactions,
+        mapTxToOps(mockAccountId, mockAddress, addressBook),
+      );
+
+      expect(finalOperation).toEqual([
+        {
+          id: encodeOperationId(mockAccountId, hash, "OUT"),
+          hash: "valueHash",
+          type: "OUT",
+          value: BigNumber("5000000"),
+          fee: BigNumber(total_fees),
+          blockHeight: mc_block_seqno,
+          blockHash: null,
+          hasFailed: true,
+          accountId: mockAccountId,
+          senders: [transactions[0].account],
+          recipients: ["EQDUkQbpTVIgt7v66-JTFR-3-eXRFz_4V66F-Ufn6vOg0KzT"],
+          date: new Date(now * 1000), // now is defined in seconds
+          extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
+        },
+      ]);
+    });
+
+    it("should deduplicate recipients when several outputs target the same destination", () => {
+      const base = tonTransactionResponse.transactions[0];
+      const recipient = "0:9220C181A6CFEACD11B7B8F62138DF1BB9CC82B6ED2661D2F5FAEE204B3EFB20";
+      const addressBook = {
+        [recipient]: { user_friendly: "EQCSIMGBps_qzRG3uPYhON8bucyCtu0mYdL1-u4gSz77IK7z" },
+      };
+      const transactions: TonTransaction[] = [{ ...base, in_msg: null, out_msgs: [] }];
+      if (base.in_msg) {
+        transactions[0].out_msgs = [
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: recipient,
+            value: "1000000",
+            hash: "h1",
+          },
+          {
+            ...base.in_msg,
+            source: base.account,
+            destination: recipient,
+            value: "2000000",
+            hash: "h2",
+          },
+        ];
+      }
+      const { now, lt, hash, total_fees, mc_block_seqno } = transactions[0];
+
+      const finalOperation = flatMap(
+        transactions,
+        mapTxToOps(mockAccountId, mockAddress, addressBook),
+      );
+
+      expect(finalOperation).toEqual([
+        {
+          id: encodeOperationId(mockAccountId, hash, "OUT"),
+          hash: "h1",
+          type: "OUT",
+          // 1000000 + 2000000, summed across both messages
+          value: BigNumber("3000000"),
+          fee: BigNumber(total_fees),
+          blockHeight: mc_block_seqno,
+          blockHash: null,
+          hasFailed: true,
+          accountId: mockAccountId,
+          senders: [transactions[0].account],
+          // both outputs target the same destination -> a single recipient
+          recipients: ["EQCSIMGBps_qzRG3uPYhON8bucyCtu0mYdL1-u4gSz77IK7z"],
+          date: new Date(now * 1000), // now is defined in seconds
+          extra: { comment: { isEncrypted: false, text: "" }, explorerHash: hash, lt },
+        },
+      ]);
+    });
   });
 
   describe("mapJettonToOps", () => {

--- a/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
+++ b/libs/coin-modules/coin-ton/src/bridge/bridgeHelpers/txn.ts
@@ -84,8 +84,6 @@ export function mapTxToOps(
   return (tx: TonTransaction): TonOperation[] => {
     const ops: TonOperation[] = [];
 
-    if (tx.out_msgs.length > 1) throw Error(`[ton] txn with > 1 output not expected ${tx}`);
-
     const accountAddr = Address.parse(tx.account).toString({ urlSafe: true, bounceable: false });
 
     if (accountAddr !== addr) throw Error(`[ton] unexpected address ${accountAddr} ${addr}`);
@@ -98,13 +96,20 @@ export function mapTxToOps(
       tx.in_msg.value !== "0" &&
       tx.account === tx.in_msg.destination;
 
-    const isSending =
-      tx.out_msgs.length !== 0 &&
-      tx.out_msgs[0].source &&
-      tx.out_msgs[0].source !== "" &&
-      tx.out_msgs[0].value &&
-      tx.out_msgs[0].value !== "0" &&
-      tx.account === tx.out_msgs[0].source;
+    // A single TON transaction can emit several outgoing messages (e.g. wallet v4/v5
+    // batch sends, or a main transfer alongside a small secondary message). Collect
+    // every value-bearing message originating from this account and aggregate them
+    // into one OUT operation rather than assuming a single output.
+    const outMsgsFromAccount = tx.out_msgs.filter(
+      msg =>
+        msg.source &&
+        msg.source !== "" &&
+        msg.value &&
+        msg.value !== "0" &&
+        tx.account === msg.source,
+    );
+
+    const isSending = outMsgsFromAccount.length > 0;
 
     const date = new Date(tx.now * 1000); // now is defined in seconds
     const hash = tx.in_msg?.hash ?? tx.hash; // this is the hash we know in signature time
@@ -170,27 +175,40 @@ export function mapTxToOps(
     }
 
     if (isSending) {
+      const outValue = outMsgsFromAccount.reduce(
+        (sum, msg) => sum.plus(BigNumber(msg.value ?? 0)),
+        BigNumber(0),
+      );
+      // Dedupe: a batch send may target the same destination in several messages.
+      const recipients = [
+        ...new Set(
+          outMsgsFromAccount.flatMap(msg => getFriendlyAddress(addressBook, msg.destination)),
+        ),
+      ];
+      // The aggregated op sums every out message, but its hash and comment represent
+      // the first (primary) out message of the batch.
+      const [firstOutMsg] = outMsgsFromAccount;
       ops.push({
         id: encodeOperationId(accountId, hash, "OUT"),
-        hash: tx.out_msgs[0].hash,
+        hash: firstOutMsg.hash,
         type: "OUT",
-        value: BigNumber(tx.out_msgs[0].value ?? 0),
+        value: outValue,
         fee: BigNumber(tx.total_fees),
         blockHeight: tx.mc_block_seqno ?? 1,
         blockHash: null,
         hasFailed,
         accountId,
         senders: [accountAddr],
-        recipients: getFriendlyAddress(addressBook, tx.out_msgs[0].destination),
+        recipients,
         date,
         extra: {
           lt: tx.lt,
           explorerHash: tx.hash,
           comment: {
-            isEncrypted: tx.out_msgs[0].message_content?.decoded?.type === "binary_comment",
+            isEncrypted: firstOutMsg.message_content?.decoded?.type === "binary_comment",
             text:
-              tx.out_msgs[0].message_content?.decoded?.type === "text_comment"
-                ? tx.out_msgs[0].message_content.decoded.comment
+              firstOutMsg.message_content?.decoded?.type === "text_comment"
+                ? firstOutMsg.message_content.decoded.comment
                 : "",
           },
         },


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->
Adding or syncing a TON (GRAM) account whose history contains a transaction with
more than one outgoing message failed with:

`[ton] txn with > 1 output not expected`

Because the error was thrown inside the sync mapper, a single such transaction
anywhere in history aborted the **whole** account synchronization, so the account
could not be added at all (desktop and mobile). Works in other wallets (TonKeeper),
so the on-chain data is valid — our importer was too strict.

Fixes **LIVE-35577**.

## 🔎 Root cause

`coin-ton`'s `mapTxToOps` (bridge/bridgeHelpers/txn.ts) assumed a TON transaction has
at most one outgoing message and `throw`ew otherwise, only ever reading `out_msgs[0]`.
On TON a transaction routinely emits multiple `out_msgs` (wallet v4/v5 batch sends, a
main transfer plus a small secondary message, forwards/bounces).

Reproduced on the reported account against Ledger's indexer (`ton.coin.ledger.com`):
two transactions with `out_msgs.length == 2` (older than the recent history, which is
why they were easy to miss).

## 🛠 Changes

- Remove the `out_msgs.length > 1` throw.
- Aggregate every value-bearing message originating from the account into a **single
  OUT operation**: `value` = sum of the outputs, `recipients` = all (deduplicated)
  destinations, `fee` = `total_fees`; `hash`/comment taken from the primary message.
- Fix a latent bug where OUT detection inspected only `out_msgs[0]` (a zero-value first
  message could hide/under-value the send).
- Unit tests: multi-output aggregation, value-bearing message not first, duplicate-
  destination dedupe.
- Changeset (patch, `@ledgerhq/coin-ton`).

**Backward compatible:** single-output transactions map to identical operations
(same id/hash/value/recipients); multi-output transactions previously threw, so there
is no persisted state to diverge from. Account balance is API-sourced (not derived from
operations), so summing `value` is display-only.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 --> [LIVE-35577](https://ledgerhq.atlassian.net/browse/LIVE-35577)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
