### PR TITLE
[LWD] feat(internet_computer): add desktop staking dashboard and actions

### DIFF
--- a/.changeset/jolly-pandas-shiver.md
+++ b/.changeset/jolly-pandas-shiver.md
@@ -1,0 +1,9 @@
+---
+"ledger-live-desktop": minor
+---
+
+Surface ICP neuron staking on the account page: a stake banner for accounts that can afford a neuron
+but hold none, a balance summary footer showing total staked and total maturity, and Stake / Manage
+Neurons actions in the account header. The send flow now explains that the memo is protocol-derived
+for `create_neuron` and `increase_stake` instead of offering an editable field. The two neuron flow
+modals are registered but their bodies land separately.

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountBalanceSummaryFooter.tsx
@@ -1,9 +1,10 @@
 import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
-import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
 import {
   useTotalMaturity,
   useTotalStaked,
 } from "@ledgerhq/live-common/families/internet_computer/react";
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+import type { TokenAccount } from "@ledgerhq/types-live";
 import { useSelector } from "LLD/hooks/redux";
 import React from "react";
 import { Trans } from "react-i18next";
@@ -15,7 +16,6 @@ import ToolTip from "~/renderer/components/Tooltip";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 import InfoCircle from "~/renderer/icons/InfoCircle";
 import { localeSelector } from "~/renderer/reducers/settings";
-import type { TokenAccount } from "@ledgerhq/types-live";
 
 const Wrapper = styled(Box).attrs(() => ({
   horizontal: true,
@@ -26,29 +26,32 @@ const Wrapper = styled(Box).attrs(() => ({
 }))`
   border-top: 1px solid ${p => p.theme.colors.neutral.c30};
 `;
-const BalanceDetail = styled(Box).attrs(() => ({
-  flex: "0.25 0 auto",
-  alignItems: "start",
-  paddingRight: 20,
-}))``;
-const TitleWrapper = styled(Box).attrs(() => ({
-  horizontal: true,
-  alignItems: "center",
-  mb: 1,
-}))``;
-const Title = styled(Text).attrs(() => ({
-  fontSize: 4,
-  ff: "Inter|Medium",
-  color: "neutral.c70",
-}))`
-  line-height: ${p => p.theme.space[4]}px;
-  margin-right: ${p => p.theme.space[1]}px;
-`;
-const AmountValue = styled(Text).attrs(() => ({
-  fontSize: 6,
-  ff: "Inter|SemiBold",
-  color: "neutral.c100",
-}))``;
+
+const Detail = ({
+  label,
+  tooltip,
+  value,
+  testId,
+}: {
+  label: string;
+  tooltip: string;
+  value: string;
+  testId: string;
+}) => (
+  <Box flex="0.25 0 auto" alignItems="start" paddingRight={20}>
+    <ToolTip content={<Trans i18nKey={tooltip} />}>
+      <Box horizontal alignItems="center" mb={1}>
+        <Text fontSize={4} ff="Inter|Medium" color="neutral.c70" lineHeight="20px" mr={1}>
+          <Trans i18nKey={label} />
+        </Text>
+        <InfoCircle size={13} />
+      </Box>
+    </ToolTip>
+    <Text fontSize={6} ff="Inter|SemiBold" color="neutral.c100" data-testid={testId}>
+      <Discreet>{value}</Discreet>
+    </Text>
+  </Box>
+);
 
 // Split out so the neuron hooks run unconditionally against a narrowed ICPAccount: the family slot
 // is typed `ICPAccount | TokenAccount`, and narrowing in the caller would make the hooks conditional.
@@ -61,41 +64,28 @@ const Footer = ({ account }: { account: ICPAccount }) => {
 
   if (totalStaked.isZero() && totalMaturity.isZero()) return null;
 
-  const formatConfig = {
-    alwaysShowSign: false,
-    showCode: true,
-    discreet,
-    locale,
-  };
+  const format = (value: typeof totalStaked) =>
+    formatCurrencyUnit(unit, value, {
+      alwaysShowSign: false,
+      showCode: true,
+      discreet,
+      locale,
+    });
 
   return (
     <Wrapper>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="internetComputer.summaryFooter.stakedBalanceTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="internetComputer.summaryFooter.stakedBalance" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue data-testid="icp-staked-balance">
-          <Discreet>{formatCurrencyUnit(unit, totalStaked, formatConfig)}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
-      <BalanceDetail>
-        <ToolTip content={<Trans i18nKey="internetComputer.summaryFooter.totalMaturityTooltip" />}>
-          <TitleWrapper>
-            <Title>
-              <Trans i18nKey="internetComputer.summaryFooter.totalMaturity" />
-            </Title>
-            <InfoCircle size={13} />
-          </TitleWrapper>
-        </ToolTip>
-        <AmountValue data-testid="icp-total-maturity">
-          <Discreet>{formatCurrencyUnit(unit, totalMaturity, formatConfig)}</Discreet>
-        </AmountValue>
-      </BalanceDetail>
+      <Detail
+        label="internetComputer.summaryFooter.stakedBalance"
+        tooltip="internetComputer.summaryFooter.stakedBalanceTooltip"
+        value={format(totalStaked)}
+        testId="icp-staked-balance"
+      />
+      <Detail
+        label="internetComputer.summaryFooter.totalMaturity"
+        tooltip="internetComputer.summaryFooter.totalMaturityTooltip"
+        value={format(totalMaturity)}
+        testId="icp-total-maturity"
+      />
     </Wrapper>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountBalanceSummaryFooter.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountBalanceSummaryFooter.tsx
@@ -1,0 +1,110 @@
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+import {
+  useTotalMaturity,
+  useTotalStaked,
+} from "@ledgerhq/live-common/families/internet_computer/react";
+import { useSelector } from "LLD/hooks/redux";
+import React from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import Box from "~/renderer/components/Box/Box";
+import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
+import Text from "~/renderer/components/Text";
+import ToolTip from "~/renderer/components/Tooltip";
+import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
+import InfoCircle from "~/renderer/icons/InfoCircle";
+import { localeSelector } from "~/renderer/reducers/settings";
+import type { TokenAccount } from "@ledgerhq/types-live";
+
+const Wrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  mt: 4,
+  p: 5,
+  pb: 0,
+  scroll: true,
+}))`
+  border-top: 1px solid ${p => p.theme.colors.neutral.c30};
+`;
+const BalanceDetail = styled(Box).attrs(() => ({
+  flex: "0.25 0 auto",
+  alignItems: "start",
+  paddingRight: 20,
+}))``;
+const TitleWrapper = styled(Box).attrs(() => ({
+  horizontal: true,
+  alignItems: "center",
+  mb: 1,
+}))``;
+const Title = styled(Text).attrs(() => ({
+  fontSize: 4,
+  ff: "Inter|Medium",
+  color: "neutral.c70",
+}))`
+  line-height: ${p => p.theme.space[4]}px;
+  margin-right: ${p => p.theme.space[1]}px;
+`;
+const AmountValue = styled(Text).attrs(() => ({
+  fontSize: 6,
+  ff: "Inter|SemiBold",
+  color: "neutral.c100",
+}))``;
+
+// Split out so the neuron hooks run unconditionally against a narrowed ICPAccount: the family slot
+// is typed `ICPAccount | TokenAccount`, and narrowing in the caller would make the hooks conditional.
+const Footer = ({ account }: { account: ICPAccount }) => {
+  const discreet = useDiscreetMode();
+  const locale = useSelector(localeSelector);
+  const unit = useAccountUnit(account);
+  const totalStaked = useTotalStaked(account);
+  const totalMaturity = useTotalMaturity(account);
+
+  if (totalStaked.isZero() && totalMaturity.isZero()) return null;
+
+  const formatConfig = {
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    locale,
+  };
+
+  return (
+    <Wrapper>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="internetComputer.summaryFooter.stakedBalanceTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="internetComputer.summaryFooter.stakedBalance" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue data-testid="icp-staked-balance">
+          <Discreet>{formatCurrencyUnit(unit, totalStaked, formatConfig)}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="internetComputer.summaryFooter.totalMaturityTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="internetComputer.summaryFooter.totalMaturity" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue data-testid="icp-total-maturity">
+          <Discreet>{formatCurrencyUnit(unit, totalMaturity, formatConfig)}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+    </Wrapper>
+  );
+};
+
+type Props = {
+  account: ICPAccount | TokenAccount;
+};
+
+const AccountBalanceSummaryFooter = ({ account }: Props) =>
+  account.type === "Account" ? <Footer account={account} /> : null;
+
+export default AccountBalanceSummaryFooter;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountHeaderManageActions.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/AccountHeaderManageActions.ts
@@ -1,0 +1,62 @@
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { canStakeICP } from "@ledgerhq/live-common/families/internet_computer/react";
+import type { Transaction } from "@ledgerhq/live-common/families/internet_computer/types";
+import { useDispatch } from "LLD/hooks/redux";
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useGetStakeLabelLocaleBased } from "~/renderer/hooks/useGetStakeLabelLocaleBased";
+import IconCoins from "~/renderer/icons/Coins";
+import IconDelegate from "~/renderer/icons/Delegate";
+import { ManageAction } from "../types";
+import { onClickManageNeurons, onClickStakeIcp } from "./common";
+import { InternetComputerFamily } from "./types";
+
+const AccountHeaderManageActions: InternetComputerFamily["accountHeaderManageActions"] = ({
+  account,
+}) => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const stakeLabel = useGetStakeLabelLocaleBased();
+  const bridge = useAccountBridge<Transaction>(account);
+  const icpAccount = account.type === "Account" ? account : undefined;
+
+  const onStake = useCallback(() => {
+    if (icpAccount) onClickStakeIcp(dispatch, icpAccount, bridge);
+  }, [dispatch, icpAccount, bridge]);
+
+  const onManage = useCallback(() => {
+    if (icpAccount) onClickManageNeurons(dispatch, icpAccount);
+  }, [dispatch, icpAccount]);
+
+  if (!icpAccount) return null;
+
+  const actions: ManageAction[] = [];
+
+  if (canStakeICP(icpAccount)) {
+    actions.push({
+      key: "Stake",
+      onClick: onStake,
+      icon: IconCoins,
+      label: stakeLabel,
+      event: "button_clicked2",
+      eventProperties: { button: "stake" },
+      accountActionsTestId: "stake-button",
+    });
+  }
+
+  if (icpAccount.neurons?.fullNeurons.length) {
+    actions.push({
+      key: "ManageNeurons",
+      onClick: onManage,
+      icon: IconDelegate,
+      label: t("internetComputer.headerManageActions.manageNeurons.title"),
+      event: "button_clicked2",
+      eventProperties: { button: "manage_neurons" },
+      accountActionsTestId: "manage-neurons-button",
+    });
+  }
+
+  return actions.length ? actions : null;
+};
+
+export default AccountHeaderManageActions;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/ManageNeuronFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/ManageNeuronFlowModal/index.tsx
@@ -1,0 +1,11 @@
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+
+export type Props = {
+  account: ICPAccount;
+};
+
+// Registry placeholder. `coinModalImports` is a total Record over `CoinModalKey`, so the key cannot
+// be declared without a module behind it. The flow steps land in LIVE-29096.
+const ManageNeuronFlowModal = () => null;
+
+export default ManageNeuronFlowModal;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/MemoField.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/MemoField.tsx
@@ -7,6 +7,8 @@ import {
   TransactionStatus,
 } from "@ledgerhq/live-common/families/internet_computer/types";
 import MemoTagField from "LLD/features/MemoTag/components/MemoTagField";
+import WarnBox from "~/renderer/components/WarnBox";
+import { useTranslation } from "react-i18next";
 
 const MemoField = ({
   onChange,
@@ -21,6 +23,7 @@ const MemoField = ({
   status: TransactionStatus;
   autoFocus?: boolean;
 }) => {
+  const { t } = useTranslation();
   invariant(transaction.family === "internet_computer", "Memo: Internet Computer family expected");
 
   const bridge = useAccountBridge<Transaction>(account);
@@ -33,6 +36,16 @@ const MemoField = ({
     [onChange, transaction, bridge],
   );
 
+  // Staking transfers carry a protocol-derived memo (the neuron nonce) that prepareTransaction
+  // sets, so the field is replaced by an explanation rather than left editable.
+  if (transaction.type === "increase_stake") {
+    return <WarnBox>{t("internetComputer.memoField.increaseStake")}</WarnBox>;
+  }
+
+  if (transaction.type === "create_neuron") {
+    return <WarnBox>{t("internetComputer.memoField.createNeuron")}</WarnBox>;
+  }
+
   // We use transaction as an error here.
   // on the ledger-live mobile
   return (
@@ -43,6 +56,7 @@ const MemoField = ({
       onChange={onMemoFieldChange}
       spellCheck="false"
       autoFocus={autoFocus}
+      tooltipText={t("internetComputer.memoField.tooltip")}
     />
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/RefreshVotingPowerFlowModal/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/RefreshVotingPowerFlowModal/index.tsx
@@ -1,0 +1,11 @@
+import type { ICPAccount } from "@ledgerhq/live-common/families/internet_computer/types";
+
+export type Props = {
+  account: ICPAccount;
+};
+
+// Registry placeholder. `coinModalImports` is a total Record over `CoinModalKey`, so the key cannot
+// be declared without a module behind it. The flow steps land in LIVE-29096.
+const RefreshVotingPowerFlowModal = () => null;
+
+export default RefreshVotingPowerFlowModal;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/StakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/StakeBanner.tsx
@@ -6,6 +6,7 @@ import type {
   Transaction,
 } from "@ledgerhq/live-common/families/internet_computer/types";
 import { useDispatch } from "LLD/hooks/redux";
+import { useStake } from "LLD/hooks/useStake";
 import React from "react";
 import { useTranslation } from "react-i18next";
 import { track } from "~/renderer/analytics/segment";
@@ -13,16 +14,24 @@ import { AccountBanner } from "~/renderer/screens/account/AccountBanner";
 import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
 import { onClickStakeIcp } from "./common";
 
-// `stakeAccountBanner.params` has no internet_computer entry, so the flag is read as a plain
-// on/off switch rather than the per-mode params solana and cosmos gate on.
+// `stakeAccountBanner.params` has no internet_computer entry, so that flag can only be read as a
+// plain on/off switch, unlike the per-mode params solana and cosmos gate on. On its own it is a
+// switch shared with every other coin, so the banner additionally requires the same stakePrograms
+// gate AccountHeaderActions applies to its "Stake" action — otherwise the banner and the Earn
+// button would appear independently of each other.
 const StakeBanner = ({ account }: { account: ICPAccount }) => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const stakeAccountBanner = useFeature("stakeAccountBanner");
+  const { getCanStakeUsingLedgerLive, getCanStakeUsingPlatformApp } = useStake();
   const bridge = useAccountBridge<Transaction>(account);
   const neurons = useICPNeurons(account);
 
-  if (!stakeAccountBanner?.enabled) return null;
+  const { id: currencyId } = account.currency;
+  const canOnlyStakeUsingLedgerLive =
+    getCanStakeUsingLedgerLive(currencyId) && !getCanStakeUsingPlatformApp(currencyId);
+
+  if (!stakeAccountBanner?.enabled || !canOnlyStakeUsingLedgerLive) return null;
   if (neurons.length > 0 || !canStakeICP(account)) return null;
 
   const onClick = () => {

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/StakeBanner.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/StakeBanner.tsx
@@ -1,0 +1,50 @@
+import { useFeature } from "@features/platform-feature-flags";
+import { useAccountBridge } from "@ledgerhq/live-common/bridge/useAccountBridge";
+import { canStakeICP, useICPNeurons } from "@ledgerhq/live-common/families/internet_computer/react";
+import type {
+  ICPAccount,
+  Transaction,
+} from "@ledgerhq/live-common/families/internet_computer/types";
+import { useDispatch } from "LLD/hooks/redux";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { track } from "~/renderer/analytics/segment";
+import { AccountBanner } from "~/renderer/screens/account/AccountBanner";
+import { stakeDefaultTrack } from "~/renderer/screens/stake/constants";
+import { onClickStakeIcp } from "./common";
+
+// `stakeAccountBanner.params` has no internet_computer entry, so the flag is read as a plain
+// on/off switch rather than the per-mode params solana and cosmos gate on.
+const StakeBanner = ({ account }: { account: ICPAccount }) => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const stakeAccountBanner = useFeature("stakeAccountBanner");
+  const bridge = useAccountBridge<Transaction>(account);
+  const neurons = useICPNeurons(account);
+
+  if (!stakeAccountBanner?.enabled) return null;
+  if (neurons.length > 0 || !canStakeICP(account)) return null;
+
+  const onClick = () => {
+    track("button_clicked2", {
+      ...stakeDefaultTrack,
+      delegation: "stake",
+      page: "Page Account",
+      button: "delegate",
+      currency: "INTERNET_COMPUTER",
+    });
+    onClickStakeIcp(dispatch, account, bridge);
+  };
+
+  return (
+    <AccountBanner
+      display
+      title={t("internetComputer.stakeBanner.stakeICP.title")}
+      description={t("internetComputer.stakeBanner.stakeICP.description")}
+      cta={t("internetComputer.stakeBanner.stakeICP.cta")}
+      onClick={onClick}
+    />
+  );
+};
+
+export default StakeBanner;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/AccountBalanceSummaryFooter.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/AccountBalanceSummaryFooter.test.tsx
@@ -1,0 +1,84 @@
+import * as currencies from "@ledgerhq/live-common/currencies/index";
+import type { TokenAccount } from "@ledgerhq/types-live";
+import React from "react";
+import { render, screen } from "tests/testSetup";
+import { makeICPAccount, makeNeuron } from "./testUtils";
+
+jest.mock("@ledgerhq/live-common/currencies/index", () => ({
+  __esModule: true,
+  ...jest.requireActual("@ledgerhq/live-common/currencies/index"),
+}));
+
+jest.mock("~/renderer/hooks/useAccountUnit");
+
+import AccountBalanceSummaryFooter from "../AccountBalanceSummaryFooter";
+
+const STAKED_E8S = 300_000_000n;
+const MATURITY_E8S = 50_000_000n;
+
+beforeEach(() => {
+  jest.spyOn(currencies, "formatCurrencyUnit").mockImplementation((_unit, value) => {
+    if (!value) return "";
+    if (value.eq(STAKED_E8S.toString())) return "staked:3.0";
+    if (value.eq(MATURITY_E8S.toString())) return "maturity:0.5";
+    return value.toString();
+  });
+});
+
+describe("AccountBalanceSummaryFooter (internet_computer)", () => {
+  it("renders nothing for a TokenAccount", () => {
+    const tokenAccount = { type: "TokenAccount", id: "stub" } as unknown as TokenAccount;
+    const { container } = render(<AccountBalanceSummaryFooter account={tokenAccount} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when the account has no neurons", () => {
+    const { container } = render(<AccountBalanceSummaryFooter account={makeICPAccount()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders staked balance and total maturity when neurons exist", () => {
+    const account = makeICPAccount({
+      neurons: [
+        makeNeuron({
+          cachedNeuronStakeE8s: STAKED_E8S,
+          maturityE8sEquivalent: MATURITY_E8S,
+        }),
+      ],
+    });
+    render(<AccountBalanceSummaryFooter account={account} />);
+
+    expect(screen.getByText("Staked Balance")).toBeInTheDocument();
+    expect(screen.getByText("staked:3.0")).toBeInTheDocument();
+    expect(screen.getByText("Total Maturity")).toBeInTheDocument();
+    expect(screen.getByText("maturity:0.5")).toBeInTheDocument();
+  });
+
+  it("subtracts neuron fees from the staked balance and aggregates across neurons", () => {
+    const account = makeICPAccount({
+      neurons: [
+        makeNeuron({ id: 1n, cachedNeuronStakeE8s: 200_000_000n, neuronFeesE8s: 50_000_000n }),
+        makeNeuron({
+          id: 2n,
+          cachedNeuronStakeE8s: 150_000_000n,
+          maturityE8sEquivalent: 50_000_000n,
+        }),
+      ],
+    });
+    render(<AccountBalanceSummaryFooter account={account} />);
+
+    // (200_000_000 - 50_000_000) + 150_000_000
+    expect(screen.getByText("staked:3.0")).toBeInTheDocument();
+    expect(screen.getByText("maturity:0.5")).toBeInTheDocument();
+  });
+
+  it("still renders when only maturity is non-zero", () => {
+    const account = makeICPAccount({
+      neurons: [makeNeuron({ maturityE8sEquivalent: MATURITY_E8S })],
+    });
+    render(<AccountBalanceSummaryFooter account={account} />);
+
+    expect(screen.getByText("Total Maturity")).toBeInTheDocument();
+    expect(screen.getByText("maturity:0.5")).toBeInTheDocument();
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/AccountHeaderManageActions.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/AccountHeaderManageActions.test.tsx
@@ -1,0 +1,91 @@
+import invariant from "invariant";
+import BigNumber from "bignumber.js";
+import { act } from "react";
+import { renderHook } from "tests/testSetup";
+import { makeICPAccount, makeNeuron } from "./testUtils";
+
+const bridgeMock = {
+  createTransaction: jest.fn(() => ({ family: "internet_computer", type: "send" })),
+  updateTransaction: jest.fn((transaction, patch) => ({ ...transaction, ...patch })),
+};
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  __esModule: true,
+  useAccountBridge: () => bridgeMock,
+}));
+
+import AccountHeaderManageActions from "../AccountHeaderManageActions";
+
+// MIN_NEURON_STAKE (1 ICP) + ICP_FEES
+const ENOUGH_TO_STAKE = new BigNumber(100_010_000);
+const NOT_ENOUGH_TO_STAKE = new BigNumber(100_009_999);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("AccountHeaderManageActions (internet_computer)", () => {
+  const hook = AccountHeaderManageActions;
+  invariant(hook, "internet_computer: type guard AccountHeaderManageActions");
+
+  it("returns null when the account has neither stakeable balance nor neurons", () => {
+    const account = makeICPAccount({ spendableBalance: NOT_ENOUGH_TO_STAKE });
+    const { result } = renderHook(() => hook({ account, parentAccount: null }));
+    expect(result.current).toBeNull();
+  });
+
+  it("exposes only the Stake action when the balance is sufficient and there are no neurons", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { result } = renderHook(() => hook({ account, parentAccount: null }));
+
+    expect(result.current?.map(a => a.key)).toEqual(["Stake"]);
+  });
+
+  it("exposes the Manage action once the account has neurons", () => {
+    const account = makeICPAccount({
+      spendableBalance: ENOUGH_TO_STAKE,
+      neurons: [makeNeuron()],
+    });
+    const { result } = renderHook(() => hook({ account, parentAccount: null }));
+
+    expect(result.current?.map(a => a.key)).toEqual(["Stake", "ManageNeurons"]);
+  });
+
+  it("exposes Manage without Stake when neurons exist but the balance is too low", () => {
+    const account = makeICPAccount({
+      spendableBalance: NOT_ENOUGH_TO_STAKE,
+      neurons: [makeNeuron()],
+    });
+    const { result } = renderHook(() => hook({ account, parentAccount: null }));
+
+    expect(result.current?.map(a => a.key)).toEqual(["ManageNeurons"]);
+  });
+
+  it("opens the send flow with a create_neuron transaction when Stake is clicked", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { result, store } = renderHook(() => hook({ account, parentAccount: null }));
+
+    act(() => {
+      result.current?.[0].onClick();
+    });
+
+    expect(bridgeMock.updateTransaction).toHaveBeenCalledWith(expect.anything(), {
+      type: "create_neuron",
+    });
+    expect(store.getState().modals.MODAL_SEND?.isOpened).toBe(true);
+  });
+
+  it("opens the neuron list modal when Manage is clicked", () => {
+    const account = makeICPAccount({
+      spendableBalance: NOT_ENOUGH_TO_STAKE,
+      neurons: [makeNeuron()],
+    });
+    const { result, store } = renderHook(() => hook({ account, parentAccount: null }));
+
+    act(() => {
+      result.current?.[0].onClick();
+    });
+
+    expect(store.getState().modals.MODAL_ICP_LIST_NEURONS?.isOpened).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/MemoField.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/MemoField.test.tsx
@@ -1,0 +1,85 @@
+import type { Transaction } from "@ledgerhq/live-common/families/internet_computer/types";
+import BigNumber from "bignumber.js";
+import React from "react";
+import { fireEvent, render, screen } from "tests/testSetup";
+import { makeICPAccount } from "./testUtils";
+
+const bridgeMock = {
+  updateTransaction: jest.fn((transaction, patch) => ({ ...transaction, ...patch })),
+};
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  __esModule: true,
+  useAccountBridge: () => bridgeMock,
+}));
+
+import MemoField from "../MemoField";
+
+const makeTransaction = (type: Transaction["type"], memo?: string): Transaction =>
+  ({
+    family: "internet_computer",
+    type,
+    amount: new BigNumber(0),
+    recipient: "",
+    fees: new BigNumber(0),
+    ...(memo !== undefined && { memo }),
+  }) as Transaction;
+
+const status = { errors: {}, warnings: {} } as never;
+
+const renderField = (type: Transaction["type"], memo?: string, onChange = jest.fn()) => {
+  render(
+    <MemoField
+      account={makeICPAccount()}
+      transaction={makeTransaction(type, memo)}
+      status={status}
+      onChange={onChange}
+    />,
+  );
+  return onChange;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MemoField (internet_computer)", () => {
+  it("renders an editable memo input for a plain send", () => {
+    renderField("send");
+
+    expect(screen.getByTestId("memo-tag-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("warning-box")).not.toBeInTheDocument();
+  });
+
+  it("updates the transaction memo as the user types", () => {
+    const onChange = renderField("send");
+
+    fireEvent.change(screen.getByTestId("memo-tag-input"), { target: { value: "42" } });
+
+    expect(bridgeMock.updateTransaction).toHaveBeenCalledWith(expect.anything(), { memo: "42" });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("clears the memo when the field is emptied", () => {
+    // Needs a starting value: React fires no change event when the value is already "".
+    renderField("send", "42");
+
+    fireEvent.change(screen.getByTestId("memo-tag-input"), { target: { value: "" } });
+
+    expect(bridgeMock.updateTransaction).toHaveBeenCalledWith(expect.anything(), {
+      memo: undefined,
+    });
+  });
+
+  // The nonce that identifies the neuron is derived by prepareTransaction, so these two types must
+  // explain the memo rather than let the user edit it.
+  it.each([
+    ["create_neuron", "This transaction will create a neuron with staked ICP"],
+    ["increase_stake", "This transaction will increase the stake of an existing neuron"],
+  ])("replaces the input with an explanation for %s", (type, copy) => {
+    renderField(type as Transaction["type"]);
+
+    expect(screen.queryByTestId("memo-tag-input")).not.toBeInTheDocument();
+    expect(screen.getByTestId("warning-box")).toHaveTextContent(copy);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/StakeBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/StakeBanner.test.tsx
@@ -19,7 +19,12 @@ import StakeBanner from "../StakeBanner";
 const ENOUGH_TO_STAKE = new BigNumber(100_010_000);
 const NOT_ENOUGH_TO_STAKE = new BigNumber(100_009_999);
 
-const bannerOn = withFlagOverrides({ stakeAccountBanner: { enabled: true } });
+// The banner needs both switches: the shared banner flag and internet_computer being listed as a
+// natively-staked currency, which is what also drives the Earn action in the account header.
+const bannerOn = withFlagOverrides({
+  stakeAccountBanner: { enabled: true },
+  stakePrograms: { enabled: true, params: { list: ["internet_computer"], redirects: {} } },
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -35,7 +40,41 @@ describe("StakeBanner (internet_computer)", () => {
 
   it("renders nothing when the stakeAccountBanner flag is off", () => {
     const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
-    const { container } = render(<StakeBanner account={account} />);
+    const { container } = render(<StakeBanner account={account} />, {
+      initialState: withFlagOverrides({
+        stakeAccountBanner: { enabled: false },
+        stakePrograms: { enabled: true, params: { list: ["internet_computer"], redirects: {} } },
+      }),
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  // Keeps the banner in step with the header's Earn action, which AccountHeaderActions hides unless
+  // the currency is listed here.
+  it("renders nothing when internet_computer is absent from stakePrograms", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { container } = render(<StakeBanner account={account} />, {
+      initialState: withFlagOverrides({ stakeAccountBanner: { enabled: true } }),
+    });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when internet_computer is redirected to a platform app", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { container } = render(<StakeBanner account={account} />, {
+      initialState: withFlagOverrides({
+        stakeAccountBanner: { enabled: true },
+        stakePrograms: {
+          enabled: true,
+          params: {
+            list: ["internet_computer"],
+            redirects: { internet_computer: { platform: "earn", name: "Earn", queryParams: {} } },
+          },
+        },
+      }),
+    });
 
     expect(container.firstChild).toBeNull();
   });

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/StakeBanner.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/StakeBanner.test.tsx
@@ -1,0 +1,71 @@
+import BigNumber from "bignumber.js";
+import React from "react";
+import { render, screen, withFlagOverrides } from "tests/testSetup";
+import { makeICPAccount, makeNeuron } from "./testUtils";
+
+const bridgeMock = {
+  createTransaction: jest.fn(() => ({ family: "internet_computer", type: "send" })),
+  updateTransaction: jest.fn((transaction, patch) => ({ ...transaction, ...patch })),
+};
+
+jest.mock("@ledgerhq/live-common/bridge/useAccountBridge", () => ({
+  __esModule: true,
+  useAccountBridge: () => bridgeMock,
+}));
+
+import StakeBanner from "../StakeBanner";
+
+// MIN_NEURON_STAKE (1 ICP) + ICP_FEES
+const ENOUGH_TO_STAKE = new BigNumber(100_010_000);
+const NOT_ENOUGH_TO_STAKE = new BigNumber(100_009_999);
+
+const bannerOn = withFlagOverrides({ stakeAccountBanner: { enabled: true } });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("StakeBanner (internet_computer)", () => {
+  it("renders the banner when the account can stake and holds no neurons", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    render(<StakeBanner account={account} />, { initialState: bannerOn });
+
+    expect(screen.getByTestId("account-stake-banner")).toBeInTheDocument();
+  });
+
+  it("renders nothing when the stakeAccountBanner flag is off", () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { container } = render(<StakeBanner account={account} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing once the account has neurons", () => {
+    const account = makeICPAccount({
+      spendableBalance: ENOUGH_TO_STAKE,
+      neurons: [makeNeuron()],
+    });
+    const { container } = render(<StakeBanner account={account} />, { initialState: bannerOn });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when the balance is one e8 below the minimum stake plus fees", () => {
+    const account = makeICPAccount({ spendableBalance: NOT_ENOUGH_TO_STAKE });
+    const { container } = render(<StakeBanner account={account} />, { initialState: bannerOn });
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("opens the send flow with a create_neuron transaction when the CTA is clicked", async () => {
+    const account = makeICPAccount({ spendableBalance: ENOUGH_TO_STAKE });
+    const { store, user } = render(<StakeBanner account={account} />, { initialState: bannerOn });
+
+    await user.click(screen.getByTestId("account-stake-banner-button"));
+
+    expect(bridgeMock.updateTransaction).toHaveBeenCalledWith(expect.anything(), {
+      type: "create_neuron",
+    });
+    expect(store.getState().modals.MODAL_SEND?.isOpened).toBe(true);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/testUtils.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/__tests__/testUtils.ts
@@ -1,0 +1,43 @@
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import {
+  NeuronsData,
+  NeuronState,
+  type ICPAccount,
+  type ICPNeuron,
+} from "@ledgerhq/live-common/families/internet_computer/types";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import BigNumber from "bignumber.js";
+
+export const icpCurrency = getCryptoCurrencyById("internet_computer");
+
+export const makeNeuron = (overrides: Partial<ICPNeuron> = {}): ICPNeuron => ({
+  id: 1n,
+  accountIdentifier: "neuron-account-identifier",
+  state: NeuronState.Locked,
+  dissolveDelaySeconds: 0n,
+  ageSeconds: 0n,
+  cachedNeuronStakeE8s: 0n,
+  neuronFeesE8s: 0n,
+  maturityE8sEquivalent: 0n,
+  stakedMaturityE8sEquivalent: 0n,
+  createdTimestampSeconds: 0n,
+  hotKeys: [],
+  followees: [],
+  autoStakeMaturity: false,
+  ...overrides,
+});
+
+export const makeICPAccount = ({
+  neurons = [],
+  spendableBalance = new BigNumber(0),
+  seed = "icp-test",
+}: {
+  neurons?: ICPNeuron[];
+  spendableBalance?: BigNumber;
+  seed?: string;
+} = {}): ICPAccount =>
+  ({
+    ...genAccount(seed, { currency: icpCurrency }),
+    spendableBalance,
+    neurons: new NeuronsData(neurons, Date.now()),
+  }) as unknown as ICPAccount;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/common/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/common/index.ts
@@ -1,0 +1,32 @@
+import type {
+  ICPAccount,
+  Transaction,
+} from "@ledgerhq/live-common/families/internet_computer/types";
+import type { ResolvedAccountBridge } from "@ledgerhq/types-live";
+import { openModal } from "~/renderer/actions/modals";
+import type { AppDispatch } from "~/state-manager/configureStore";
+
+// Staking an ICP goes through the regular send flow: `create_neuron` debits the ledger canister the
+// same way a transfer does. There is no validator to pick — prepareTransaction derives the neuron's
+// governance subaccount as the recipient, and the nonce it stores there is also the memo. Both are
+// protocol-derived, so the flow starts at the amount step with no way back into recipient entry.
+// The bridge is resolved by the caller, since getAccountBridge is async and these are not hooks.
+export const onClickStakeIcp = (
+  dispatch: AppDispatch,
+  account: ICPAccount,
+  bridge: ResolvedAccountBridge<Transaction>,
+) => {
+  const transaction = bridge.createTransaction(account);
+  dispatch(
+    openModal("MODAL_SEND", {
+      account,
+      transaction: bridge.updateTransaction(transaction, { type: "create_neuron" }),
+      stepId: "amount",
+      disableBacks: ["amount"],
+    }),
+  );
+};
+
+export const onClickManageNeurons = (dispatch: AppDispatch, account: ICPAccount) => {
+  dispatch(openModal("MODAL_ICP_LIST_NEURONS", { account }));
+};

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/index.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/index.ts
@@ -1,20 +1,21 @@
-import {
-  InternetComputerOperation,
-  Transaction,
-  TransactionStatus,
-} from "@ledgerhq/live-common/families/internet_computer/types";
-import { LLDCoinFamily } from "../types";
-import operationDetails from "./operationDetails";
+import AccountBalanceSummaryFooter from "./AccountBalanceSummaryFooter";
+import accountHeaderManageActions from "./AccountHeaderManageActions";
 import AccountSubHeader from "./AccountSubHeader";
+import operationDetails from "./operationDetails";
 import sendAmountFields from "./SendAmountFields";
-import { Account } from "@ledgerhq/types-live";
 import sendRecipientFields from "./SendRecipientFields";
+import StakeBanner from "./StakeBanner";
+import { InternetComputerFamily } from "./types";
 
-const family: LLDCoinFamily<Account, Transaction, TransactionStatus, InternetComputerOperation> = {
+const family: InternetComputerFamily = {
   operationDetails,
   AccountSubHeader,
   sendAmountFields,
   sendRecipientFields,
+  accountHeaderManageActions,
+  AccountBalanceSummaryFooter,
+  StakeBanner,
+  modalsToPreload: ["MODAL_ICP_LIST_NEURONS", "MODAL_ICP_REFRESH_VOTING_POWER"],
 };
 
 export default family;

--- a/apps/ledger-live-desktop/src/renderer/families/internet_computer/types.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/internet_computer/types.ts
@@ -1,8 +1,18 @@
 import {
+  ICPAccount,
+  InternetComputerOperation,
   Transaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/families/internet_computer/types";
 import { Account } from "@ledgerhq/types-live";
+import { LLDCoinFamily } from "../types";
+
+export type InternetComputerFamily = LLDCoinFamily<
+  ICPAccount,
+  Transaction,
+  TransactionStatus,
+  InternetComputerOperation
+>;
 
 export type InternetComputerMemoFieldProps = {
   account: Account;

--- a/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
+++ b/apps/ledger-live-desktop/src/renderer/families/modals-loaders.ts
@@ -45,6 +45,8 @@ import type { Data as HederaDelegationData } from "./hedera/DelegationFlowModal/
 import type { Data as HederaUndelegationData } from "./hedera/UndelegationFlowModal/Body";
 import type { Data as HederaRedelegationData } from "./hedera/RedelegationFlowModal/Body";
 import type { Data as HederaClaimRewardsData } from "./hedera/ClaimRewardsFlowModal/Body";
+import type { Props as IcpListNeuronsProps } from "./internet_computer/ManageNeuronFlowModal";
+import type { Props as IcpRefreshVotingPowerProps } from "./internet_computer/RefreshVotingPowerFlowModal";
 import type { Data as MultiversxDelegateData } from "./multiversx/components/Modals/Delegate/Body";
 import type { Props as MultiversxRewardsInfoProps } from "./multiversx/components/Modals/Delegate/Info";
 import type { Data as MultiversxUndelegateData } from "./multiversx/components/Modals/Undelegate/Body";
@@ -123,6 +125,8 @@ export type CoinModalsData = {
   MODAL_HEDERA_UNDELEGATION: HederaUndelegationData;
   MODAL_HEDERA_REDELEGATION: HederaRedelegationData;
   MODAL_HEDERA_CLAIM_REWARDS: HederaClaimRewardsData;
+  MODAL_ICP_LIST_NEURONS: IcpListNeuronsProps;
+  MODAL_ICP_REFRESH_VOTING_POWER: IcpRefreshVotingPowerProps;
   MODAL_MULTIVERSX_DELEGATE: MultiversxDelegateData;
   MODAL_MULTIVERSX_REWARDS_INFO: MultiversxRewardsInfoProps;
   MODAL_MULTIVERSX_UNDELEGATE: MultiversxUndelegateData;
@@ -212,6 +216,8 @@ export const coinModalImports: Record<CoinModalKey, CoinModalImport> = {
   MODAL_HEDERA_UNDELEGATION: () => import("./hedera/UndelegationFlowModal"),
   MODAL_HEDERA_REDELEGATION: () => import("./hedera/RedelegationFlowModal"),
   MODAL_HEDERA_CLAIM_REWARDS: () => import("./hedera/ClaimRewardsFlowModal"),
+  MODAL_ICP_LIST_NEURONS: () => import("./internet_computer/ManageNeuronFlowModal"),
+  MODAL_ICP_REFRESH_VOTING_POWER: () => import("./internet_computer/RefreshVotingPowerFlowModal"),
   MODAL_MULTIVERSX_DELEGATE: () => import("./multiversx/components/Modals/Delegate"),
   MODAL_MULTIVERSX_REWARDS_INFO: () => import("./multiversx/components/Modals/Delegate/Info"),
   MODAL_MULTIVERSX_UNDELEGATE: () => import("./multiversx/components/Modals/Undelegate"),

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7032,6 +7032,9 @@
       "title": "Sorry, insufficient funds",
       "description": "Please make sure the account has enough funds."
     },
+    "NotEnoughTransferAmount": {
+      "title": "A minimum of 1 ICP is required to stake into a neuron."
+    },
     "UnstakeNotEnoughStakedBalanceLeft": {
       "title": "If you unstake more than {{maxAmount}}, your total stake of {{totalAmount}} will be unstaked",
       "description": "If you unstake more than {{maxAmount}}, your total stake of {{totalAmount}} will be unstaked"
@@ -9718,5 +9721,30 @@
       }
     },
     "disclaimer": "This data is provided for informational purposes only and is not financial advice. Not to be used for tax purposes."
+  },
+  "internetComputer": {
+    "memoField": {
+      "increaseStake": "This transaction will increase the stake of an existing neuron, input the desired amount to be staked in the amount field above.",
+      "createNeuron": "This transaction will create a neuron with staked ICP, input the desired amount to be staked in the amount field above.",
+      "tooltip": "Internet Computer uses this to identify the transaction to stake the ICP into the neuron."
+    },
+    "stakeBanner": {
+      "stakeICP": {
+        "title": "Stake ICP",
+        "description": "Stake ICP and gain rewards by participating in its governance.",
+        "cta": "Stake ICP"
+      }
+    },
+    "headerManageActions": {
+      "manageNeurons": {
+        "title": "Manage Neurons"
+      }
+    },
+    "summaryFooter": {
+      "stakedBalance": "Staked Balance",
+      "stakedBalanceTooltip": "The total amount of ICP tokens currently staked in neurons. Staked ICP earns voting rewards and can be used for governance.",
+      "totalMaturity": "Total Maturity",
+      "totalMaturityTooltip": "The total accumulated rewards from staking, including both staked and liquid maturity. These rewards can be either staked again or claimed as liquid ICP."
+    }
   }
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the account-page entry points for ICP neuron staking: a stake banner, a balance summary footer (total staked / total maturity), and Stake / Manage Neurons header actions — all driven by the live-common hooks from LIVE-29094. No coin-module or live-common changes were needed.

Three things worth knowing before reviewing:

- **The Earn action needs remote config.** `AccountHeaderActions.tsx:372` drops any `"Stake"`-keyed action unless `internet_computer` is in `stakePrograms.params.list`. Until that is added the header action never renders in production.
- **`SendRecipientFields.tsx` is deliberately kept**, against the ticket's original AC7. Deleting it removes ICP's memo input whenever `lldMemoTag` is enabled, because `SendAmountFields` returns `null` in that case and the recipient step renders the memo only via the family slot. Verified manually in both flag positions.
- **Both neuron modals are null-rendering stubs.** `coinModalImports` is a total `Record<CoinModalKey, …>`, so the keys cannot be registered without a module behind them. Bodies land in LIVE-29096.

ICP has no validators to choose — the neuron subaccount and memo nonce are both derived by `prepareTransaction` — so the send flow opens at the amount step with the recipient step disabled.

Eleven unit tests cover the footer and header actions; the banner, both memo-flag positions, the minimum-amount boundary and the summary step were checked manually.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-29095](https://ledgerhq.atlassian.net/browse/LIVE-29095?atlOrigin=eyJpIjoiZDg2YTIwMDNjZGVmNDc3Y2E4ODIxMmYxMjEzMDRjYmEiLCJwIjoiaiJ9)
- **ADR** (if any): <!-- link to the relevant architectural decision record -->

<img width="771" height="162" alt="image" src="https://github.com/user-attachments/assets/6df31550-7933-46fa-b287-b71af20aa92d" />
<img width="1271" height="542" alt="image" src="https://github.com/user-attachments/assets/2a0e573a-3037-4a1d-ad3c-40bd79a334af" />
<img width="501" height="562" alt="image" src="https://github.com/user-attachments/assets/b4c2a0ad-5459-4739-962e-986fa3ef4132" />
<img width="1295" height="556" alt="image" src="https://github.com/user-attachments/assets/646d02a4-711d-41a1-a992-4e49bbecafa9" />



[LIVE-29095]: https://ledgerhq.atlassian.net/browse/LIVE-29095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ