### PR TITLE
fix(llc): normalize address / xpub before computing A4 account version

### DIFF
--- a/.changeset/giant-eels-hang.md
+++ b/.changeset/giant-eels-hang.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": patch
+---
+
+fix(llc): normalize hex-encoded before computing A4 account versions

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountId.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountId.test.ts
@@ -1,45 +1,4 @@
-import { deriveA4AccountId, normalizeAccountKey } from "./accountId";
-
-describe("normalizeAccountKey", () => {
-  it("lowercases EVM 0x address", () => {
-    expect(normalizeAccountKey("0x742d35Cc6634C0532925a3b844Bc454e4438f44e")).toEqual(
-      "0x742d35cc6634c0532925a3b844bc454e4438f44e",
-    );
-  });
-
-  it.each<[string, string, string]>([
-    [
-      "bitcoin",
-      "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz",
-      "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz",
-    ],
-    [
-      "canton",
-      "BobCorp::12208fceed3e5e2ae59cb00f00d7b3a0cc7f1f1c53d44c5c22cd7424f1b79b4d66d::1",
-      "BobCorp::12208fceed3e5e2ae59cb00f00d7b3a0cc7f1f1c53d44c5c22cd7424f1b79b4d66d::1",
-    ],
-    [
-      "cardano",
-      "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae",
-      "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgs68faae",
-    ],
-    ["ripple", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"],
-    [
-      "solana",
-      "EkmJ7PEGdPhUH1MSHcjLnz5MN8aJMGrxvfDz5kJKsmYT",
-      "EkmJ7PEGdPhUH1MSHcjLnz5MN8aJMGrxvfDz5kJKsmYT",
-    ],
-    [
-      "stellar",
-      "GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V",
-      "GBOVKZBEM2YYLOCDCUXJ4IMRKHN4LCJAE7WEAEA2KF562XFAGDBOB64V",
-    ],
-    ["tezos", "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb", "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"],
-    ["tron", "TJmV3QHMiDHpFSs9v5BKxJaVxpAV3q6QnF", "TJmV3QHMiDHpFSs9v5BKxJaVxpAV3q6QnF"],
-  ])("keeps %s address verbatim", (_, input, expected) => {
-    expect(normalizeAccountKey(input)).toEqual(expected);
-  });
-});
+import { deriveA4AccountId } from "./accountId";
 
 describe("deriveA4AccountId", () => {
   it("returns known digest for ethereum address (EVM, lowercased before hashing)", () => {

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountId.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountId.ts
@@ -1,9 +1,6 @@
 import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
-
-export function normalizeAccountKey(xpubOrAddress: string): string {
-  return /^0x[0-9a-fA-F]+$/.test(xpubOrAddress) ? xpubOrAddress.toLowerCase() : xpubOrAddress;
-}
+import { normalizeAccountKey } from "./utils";
 
 export function deriveA4AccountId(xpubOrAddress: string): string {
   const textEncoder = new TextEncoder();

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountVersion.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountVersion.test.ts
@@ -68,4 +68,16 @@ describe("computeA4AccountVersion", () => {
     computeA4AccountVersion(addrs);
     expect(addrs).toEqual(["zzz", "aaa"]);
   });
+
+  it("EVM gold pair: checksummed and lowercase produce the same version", () => {
+    const checksummed = "0x742d35Cc6634C0532925a3b844Bc454e4438f44e";
+    const lowercase = "0x742d35cc6634c0532925a3b844bc454e4438f44e";
+    expect(computeA4AccountVersion([checksummed])).toBe(computeA4AccountVersion([lowercase]));
+  });
+
+  it("EVM gold pair: known digest for single checksummed address", () => {
+    expect(computeA4AccountVersion(["0x742d35Cc6634C0532925a3b844Bc454e4438f44e"])).toBe(
+      "ff8b25f1cdd03142b2300762c03b74ac6f8dffa401adf341971ed5b624da38b8",
+    );
+  });
 });

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountVersion.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/accountVersion.ts
@@ -1,7 +1,8 @@
 import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
+import { normalizeAccountKey } from "./utils";
 
 export function computeA4AccountVersion(addresses: string[]): string {
-  const payload = [...addresses].sort().join("|");
+  const payload = addresses.map(normalizeAccountKey).sort().join("|");
   return bytesToHex(sha256(new TextEncoder().encode(payload)));
 }

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.test.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.test.ts
@@ -1,5 +1,5 @@
 import { getEnv } from "@shared/env";
-import { toA4Network, resolveA4BaseUrl } from "./utils";
+import { toA4Network, resolveA4BaseUrl, normalizeAccountKey } from "./utils";
 
 jest.mock("@shared/env");
 
@@ -13,6 +13,32 @@ describe("resolveA4BaseUrl", () => {
   ] as const)("returns env var for %s", (env, key, url) => {
     mockGetEnv.mockImplementation(k => (k === key ? url : ""));
     expect(resolveA4BaseUrl(env)).toEqual(url);
+  });
+});
+
+describe("normalizeAccountKey", () => {
+  it("lowercases EVM 0x address (gold pair: checksummed → lowercase)", () => {
+    expect(normalizeAccountKey("0x742d35Cc6634C0532925a3b844Bc454e4438f44e")).toEqual(
+      "0x742d35cc6634c0532925a3b844bc454e4438f44e",
+    );
+  });
+
+  it("is a no-op for already-lowercase EVM address", () => {
+    expect(normalizeAccountKey("0x742d35cc6634c0532925a3b844bc454e4438f44e")).toEqual(
+      "0x742d35cc6634c0532925a3b844bc454e4438f44e",
+    );
+  });
+
+  it.each([
+    [
+      "bitcoin xpub",
+      "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz",
+    ],
+    ["ripple", "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh"],
+    ["solana", "EkmJ7PEGdPhUH1MSHcjLnz5MN8aJMGrxvfDz5kJKsmYT"],
+    ["tron", "TJmV3QHMiDHpFSs9v5BKxJaVxpAV3q6QnF"],
+  ])("keeps %s address verbatim", (_, input) => {
+    expect(normalizeAccountKey(input)).toEqual(input);
   });
 });
 

--- a/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.ts
+++ b/libs/ledger-live-common/src/bridge/generic-coin-framework/a4/client/utils.ts
@@ -2,6 +2,10 @@ import { getEnv } from "@shared/env";
 import { A4_SUPPORTED_NETWORKS } from "../config";
 import type { A4Environment } from "../config";
 
+export function normalizeAccountKey(xpubOrAddress: string): string {
+  return /^0x[0-9a-fA-F]+$/.test(xpubOrAddress) ? xpubOrAddress.toLowerCase() : xpubOrAddress;
+}
+
 const A4_SUPPORTED_NETWORK_SET: ReadonlySet<string> = new Set(A4_SUPPORTED_NETWORKS);
 
 function remapCurrencyId(currencyId: string): string {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Addresses and public keys are not normalizerd when computing A4 account versions. It creates a mismatch with A4 account identifiers that do use the normalization.

### 🔗 Context

- **JIRA / GitHub issue**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
