### PR TITLE
ci(push): add missing test swimlanes to push workflow

### DIFF
--- a/.github/workflows/build-and-test-push.yml
+++ b/.github/workflows/build-and-test-push.yml
@@ -74,6 +74,38 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/test-features-reusable.yml@develop
     secrets: inherit
 
+  test-shared:
+    name: "Test Shared"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-shared-reusable.yml@develop
+    secrets: inherit
+
+  test-domain:
+    name: "Test Domain"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-domain-reusable.yml@develop
+    secrets: inherit
+
+  test-devtools:
+    name: "Test DevTools"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-devtools-reusable.yml@develop
+    secrets: inherit
+
+  test-support:
+    name: "Test Support"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-support-reusable.yml@develop
+    secrets: inherit
+
   test-design-system:
     name: "Test UI Libs"
     permissions:
@@ -109,6 +141,27 @@ jobs:
     uses: LedgerHQ/ledger-live/.github/workflows/build-wallet-cli-reusable.yml@develop
     secrets: inherit
 
+  test-additional:
+    name: "Test Additional"
+    uses: LedgerHQ/ledger-live/.github/workflows/test-additional.yml@develop
+    secrets: inherit
+
+  test-mobile-e2e-lint:
+    name: "Mobile E2E Lint & Typecheck"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-mobile-e2e-lint-reusable.yml@develop
+    secrets: inherit
+
+  test-desktop-e2e-lint:
+    name: "Desktop E2E Lint & Typecheck"
+    permissions:
+      id-token: write
+      contents: read
+    uses: LedgerHQ/ledger-live/.github/workflows/test-desktop-e2e-lint-reusable.yml@develop
+    secrets: inherit
+
   # Final Check required
   ok:
     name: "OK"
@@ -120,10 +173,17 @@ jobs:
       - build-test-mobile
       - test-libraries
       - test-features
+      - test-shared
+      - test-domain
+      - test-devtools
+      - test-support
       - test-design-system
       - build-web-tools
       - test-cli
       - build-wallet-cli
+      - test-additional
+      - test-mobile-e2e-lint
+      - test-desktop-e2e-lint
     runs-on: ubuntu-22.04
     if: always() && !cancelled()
     steps:


### PR DESCRIPTION
## What

Adds 7 test jobs to `build-and-test-push.yml` that were already present in the PR workflow but absent from the push workflow:

- `test-shared` — coverage & codechecks for `shared/**`
- `test-domain` — coverage & codechecks for `domain/**`
- `test-devtools` — coverage & codechecks for `devtools/**`
- `test-support` — coverage & codechecks for `support/**`
- `test-additional` — changeset validation
- `test-mobile-e2e-lint` — lint & typecheck for mobile E2E tests
- `test-desktop-e2e-lint` — lint & typecheck for desktop E2E tests

All 7 are added to the `ok` gate.

## Why

The push workflow runs on every merge to `develop`, `main`, `release`, and `hotfix`. It is the canonical record of repo health after code lands.

The PR workflow gates these jobs on `determine-affected` — they only run when the relevant paths change. That's intentional for PR throughput. But the push workflow had no equivalent safety net at all: **a regression in `shared`, `domain`, `devtools`, `support`, or the E2E test suites could merge and go undetected until the next PR that happened to touch those paths.**

Concretely, the gaps were:

| Missing job | Risk |
|---|---|
| `test-shared` / `test-domain` / `test-devtools` / `test-support` | Test failures and coverage regressions in these packages are invisible post-merge |
| `test-mobile-e2e-lint` / `test-desktop-e2e-lint` | Lint/typecheck regressions in E2E suites accumulate silently on `develop` |
| `test-additional` | Changeset hygiene not enforced at merge time |

## Compute impact

Jobs are cheap in practice. Sampled from real CI runs:

| Job | Runner | Observed avg |
|---|---|---|
| `test-shared` | self-hosted 8CPU/32RAM | ~1m 32s |
| `test-domain` | self-hosted 8CPU/32RAM | ~2m 13s |
| `test-devtools` | self-hosted 8CPU/32RAM | ~1m 58s |
| `test-support` | self-hosted 8CPU/32RAM | ~2m |
| `test-additional` | ubuntu-24.04 | ~51s |
| `test-mobile-e2e-lint` | ubuntu-22.04 | ~2m 19s |
| `test-desktop-e2e-lint` | ubuntu-22.04 | ~2m 30s |

All jobs run in parallel with no dependencies on each other or on the existing jobs. They complete well within the existing push critical path (~30–45 min), so wall-clock run time is unchanged. Total additional runner-time per push is ~8 min self-hosted and ~6 min GH-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)