### PR TITLE
[LWDM] fix(coin-zcash): carry the Ironwood bundle through to the signer

### DIFF
--- a/.changeset/zcash-ironwood-pczt-bundle.md
+++ b/.changeset/zcash-ironwood-pczt-bundle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/coin-zcash": patch
+---
+
+Carry the Ironwood bundle through to the device signer.

--- a/libs/coin-modules/coin-zcash/src/network/engine.test.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.test.ts
@@ -771,6 +771,51 @@ function makeRawPczt(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+/**
+ * The Ironwood section of a raw parsePczt() result: an Orchard-shaped bundle
+ * whose actions carry the extra PCZT v2 `notePlaintextVersion` byte.
+ */
+function makeRawIronwoodBundle() {
+  return {
+    actions: [
+      {
+        cvNet: new Uint8Array([0]),
+        nullifier: new Uint8Array([0]),
+        rk: new Uint8Array([0]),
+        spendRecipient: new Uint8Array([0]),
+        spendValue: "90000", // string -> bigint
+        spendRho: new Uint8Array([0]),
+        spendRseed: new Uint8Array([0]),
+        alpha: new Uint8Array([0]),
+        signingPath: "m/32'/133'/0'",
+        cmx: new Uint8Array([0]),
+        ephemeralKey: new Uint8Array([0]),
+        encCiphertext: new Uint8Array([0]),
+        outCiphertext: new Uint8Array([0]),
+        recipient: new Uint8Array([0]),
+        value: 40000n, // bigint -> bigint
+        rseed: new Uint8Array([0]),
+        rcv: new Uint8Array([0]),
+        notePlaintextVersion: 3,
+      },
+    ],
+    flags: 7,
+    valueBalance: "-50000", // string -> bigint
+    anchor: new Uint8Array([0xcd]),
+  };
+}
+
+/** A raw parsePczt() result for a V6 transaction carrying an Ironwood bundle. */
+function makeRawPcztV6(overrides: Partial<Record<string, unknown>> = {}) {
+  const base = makeRawPczt();
+  return {
+    ...base,
+    global: { ...base.global, txVersion: 6 },
+    ironwoodBundle: makeRawIronwoodBundle(),
+    ...overrides,
+  };
+}
+
 const buildArgs: Omit<BuildTransactionArgs, "requestId"> = {
   grpcUrl: "https://grpc.example.com",
   ufvk: "uview1test",
@@ -1001,7 +1046,7 @@ describe("buildIronwoodTransactionJob", () => {
 
   it("calls native.buildIronwoodTransaction, parsePczt, and returns the adapted result", async () => {
     mockBuildIronwoodTransaction.mockResolvedValue(nativeIwBuildResult);
-    mockParsePczt.mockReturnValue(makeRawPczt());
+    mockParsePczt.mockReturnValue(makeRawPcztV6());
 
     const result = await buildIronwoodTransactionJob(iwBuildArgs);
 
@@ -1018,13 +1063,45 @@ describe("buildIronwoodTransactionJob", () => {
 
   it("normalises the PCZT result via adaptPcztForSigner (same path as buildTransactionJob)", async () => {
     mockBuildIronwoodTransaction.mockResolvedValue(nativeIwBuildResult);
-    mockParsePczt.mockReturnValue(makeRawPczt());
+    mockParsePczt.mockReturnValue(makeRawPcztV6());
 
     const { pcztTransaction } = await buildIronwoodTransactionJob(iwBuildArgs);
 
     // Verify that adaptPcztForSigner ran (BigNumber normalisation is its signature)
     expect(pcztTransaction.transparentInputs[0].value).toBe(100000n);
     expect(pcztTransaction.orchardBundle?.valueBalance).toBe(-20000n);
+  });
+
+  // The signer refuses to send a V6 transaction whose `ironwoodBundle` is null,
+  // and does so before any APDU, so the bundle surviving the build -> parse ->
+  // adapt round trip is the whole point of this job.
+  it("carries the Ironwood bundle through to the signer, normalised", async () => {
+    mockBuildIronwoodTransaction.mockResolvedValue(nativeIwBuildResult);
+    mockParsePczt.mockReturnValue(makeRawPcztV6());
+
+    const { pcztTransaction } = await buildIronwoodTransactionJob(iwBuildArgs);
+
+    expect(pcztTransaction.global.txVersion).toBe(6);
+    const ironwood = pcztTransaction.ironwoodBundle;
+    expect(ironwood).not.toBeNull();
+    expect(ironwood?.valueBalance).toBe(-50000n);
+    expect(ironwood?.flags).toBe(7);
+    expect(ironwood?.actions).toHaveLength(1);
+    expect(ironwood?.actions[0].spendValue).toBe(90000n);
+    expect(ironwood?.actions[0].value).toBe(40000n);
+    // The byte that distinguishes an Ironwood action from an Orchard one.
+    expect(ironwood?.actions[0].notePlaintextVersion).toBe(3);
+  });
+
+  it("throws a diagnosable error when the native addon drops the Ironwood bundle", async () => {
+    mockBuildIronwoodTransaction.mockResolvedValue(nativeIwBuildResult);
+    // A pre-Ironwood @ledgerhq/zcash-utils: parsePczt returns no Ironwood section
+    // even though the builder reported two Ironwood actions.
+    mockParsePczt.mockReturnValue(makeRawPczt());
+
+    await expect(buildIronwoodTransactionJob(iwBuildArgs)).rejects.toThrow(
+      /parsePczt dropped the Ironwood bundle.*zcash-utils is too old/s,
+    );
   });
 
   it("propagates errors from native.buildIronwoodTransaction", async () => {

--- a/libs/coin-modules/coin-zcash/src/network/engine.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.ts
@@ -48,6 +48,38 @@ type NativeTx = NonNullable<Awaited<ReturnType<NativeStream["next"]>>>;
  */
 type NativePcztTransaction = ReturnType<NativeModule["parsePczt"]>;
 
+type NativeOrchardAction = NonNullable<NativePcztTransaction["orchardBundle"]>["actions"][number];
+
+/**
+ * The Ironwood section of a parsed PCZT, as the native addon returns it.
+ *
+ * Declared here rather than read off `NativePcztTransaction` because
+ * `@ledgerhq/zcash-utils` only started returning `ironwoodBundle` from
+ * `parsePczt()` in the release that added Ironwood support to its parser; the
+ * catalog pin in `pnpm-workspace.yaml` may still predate it. Structurally it is
+ * an Orchard bundle whose actions each carry the extra PCZT v2
+ * `notePlaintextVersion` byte -- see `PcztIronwoodBundle` in
+ * `@ledgerhq/device-signer-kit-zcash`, which this is normalised into.
+ */
+type NativeIronwoodBundle = {
+  actions: (NativeOrchardAction & { notePlaintextVersion: number })[];
+  flags: number;
+  valueBalance: string;
+  anchor: Uint8Array;
+};
+
+/**
+ * Reads the Ironwood section off a `parsePczt()` result.
+ *
+ * Returns `undefined` both when the transaction genuinely has no Ironwood
+ * actions and when the native addon predates Ironwood parsing;
+ * `buildIronwoodTransactionJob` distinguishes the two, since only the latter is
+ * a misconfiguration.
+ */
+function nativeIronwoodBundle(raw: NativePcztTransaction): NativeIronwoodBundle | undefined {
+  return (raw as { ironwoodBundle?: NativeIronwoodBundle | null }).ironwoodBundle ?? undefined;
+}
+
 /** PCZT methods that must be present on the native addon at runtime. */
 const PCZT_METHODS = [
   "parsePczt",
@@ -164,7 +196,26 @@ function adaptPcztForSigner(raw: NativePcztTransaction): PcztTransaction {
           })),
         }
       : null,
+    // V6 only. The signer rejects a V5 transaction that carries an Ironwood
+    // bundle just as firmly as a V6 one that does not, so an absent section
+    // must map to `null` rather than be omitted or defaulted.
+    ironwoodBundle: adaptIronwoodBundle(nativeIronwoodBundle(raw)),
   };
+}
+
+/** Normalises the Ironwood bundle exactly as `adaptPcztForSigner` does the Orchard one. */
+function adaptIronwoodBundle(raw: NativeIronwoodBundle | undefined) {
+  return raw
+    ? {
+        ...raw,
+        valueBalance: BigInt(raw.valueBalance),
+        actions: raw.actions.map(action => ({
+          ...action,
+          spendValue: BigInt(action.spendValue),
+          value: BigInt(action.value),
+        })),
+      }
+    : null;
 }
 
 /**
@@ -204,9 +255,24 @@ export async function buildIronwoodTransactionJob(
   const native = await getPcztModule();
   const built = await native.buildIronwoodTransaction(args);
   const rawPczt = native.parsePczt(built.pcztHex); // synchronous NAPI call — no await
+  const pcztTransaction = adaptPcztForSigner(rawPczt);
+
+  // The builder just produced Ironwood actions, so the parse must hand them
+  // back. If it does not, the native addon predates Ironwood parsing: the
+  // signer would reject the V6 transaction for a null Ironwood bundle, and the
+  // error it raises names neither this module nor the version mismatch. Fail
+  // here instead, where the cause is known.
+  if (built.nActionsIronwood > 0 && pcztTransaction.ironwoodBundle === null) {
+    throw new Error(
+      `parsePczt dropped the Ironwood bundle of a V6 PCZT with ${built.nActionsIronwood} ` +
+        "action(s): @ledgerhq/zcash-utils is too old to parse the Ironwood pool. " +
+        "Bump the @ledgerhq/zcash-utils catalog entry in pnpm-workspace.yaml.",
+    );
+  }
+
   return {
     pcztHex: built.pcztHex,
-    pcztTransaction: adaptPcztForSigner(rawPczt),
+    pcztTransaction,
     feeZat: built.feeZat,
     anchorHeight: built.anchorHeight,
     nActionsIronwood: built.nActionsIronwood,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ catalogs:
       specifier: 2.3.3
       version: 2.3.3
     '@ledgerhq/zcash-utils':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 2.1.0
+      version: 2.1.0
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
@@ -1113,7 +1113,7 @@ importers:
         version: link:../../libs/wallet-pnl
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.1.0
       '@lottiefiles/dotlottie-react':
         specifier: 0.17.13
         version: 0.17.13(react@19.1.4)
@@ -8767,7 +8767,7 @@ importers:
         version: link:../../wallet-btc
       '@ledgerhq/zcash-utils':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.1.0
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -20236,8 +20236,8 @@ packages:
   '@ledgerhq/wallet-api-simulator@2.3.3':
     resolution: {integrity: sha512-gtSepkiGXvwIyvMC0DhNNYfZKt2BXFZ7IeFIY7h3Edz9ya5LxaRWWe3Zczo5Ex2CHgH2ALfXew+tZOod9Hd6Rg==}
 
-  '@ledgerhq/zcash-utils@2.0.0':
-    resolution: {integrity: sha512-2dA3L12vxTtIE5QRz4M5rPLFe+ZKeJLVZI3RU2WW+4MYr2k/W99pfUZZfh0/q+HpqzcldmlYDrvu3/HoylMlLg==}
+  '@ledgerhq/zcash-utils@2.1.0':
+    resolution: {integrity: sha512-qUMiG+uOwTVv8c5aXghBM1Coi0n1WTiVvq5bUlG+1qqeLbDZJBb4t1uZD6xrC09COX2DHoeD+VaJz8M8aPA5Aw==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -48808,7 +48808,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@ledgerhq/zcash-utils@2.0.0': {}
+  '@ledgerhq/zcash-utils@2.1.0': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -67515,7 +67515,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -67639,54 +67639,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,7 +51,7 @@ catalog:
   "@ledgerhq/wallet-api-core": 2.0.0
   "@ledgerhq/wallet-api-server": 3.4.3
   "@ledgerhq/wallet-api-simulator": 2.3.3
-  "@ledgerhq/zcash-utils": 2.0.0
+  "@ledgerhq/zcash-utils": 2.1.0
   # React Native
   react-native: 0.81.6
   "@react-native/assets-registry": 0.81.6


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

`buildIronwoodTransactionJob` re-parses the V6 PCZT it just built to produce the
structured object the signer consumes, but `adaptPcztForSigner` only mapped the
Orchard section. The signer rejects a V6 transaction whose `ironwoodBundle` is
null before sending a single APDU, so every Ironwood send failed with a bare
`InvalidArgumentError` and no indication of the cause.

The adapter now maps `ironwoodBundle` alongside `orchardBundle`, applying the
same bigint normalisation, and the job fails with an explicit error when the
native addon reports Ironwood actions the parse did not return — which is what a
`@ledgerhq/zcash-utils` older than the Ironwood-aware parser does.

Requires a `@ledgerhq/zcash-utils` release whose `parsePczt` returns
`ironwoodBundle`; until the catalog entry in `pnpm-workspace.yaml` is bumped to
it, Ironwood sends fail with that explicit error instead of the signer's opaque
one.

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35805
