### PR TITLE
fix(aggregated-assets): stop the walk on a repeated cursor (LIVE-35503)

### DIFF
--- a/.changeset/tidy-walks-bounded.md
+++ b/.changeset/tidy-walks-bounded.md
@@ -1,0 +1,5 @@
+---
+"@domain/api-aggregated-assets": patch
+---
+
+Stop the DADA category pagination walk when the server repeats a cursor, so a proxy echoing `x-ledger-next` can no longer leave the Stocks or Stablecoins query loading forever

--- a/domain/api/aggregated-assets/src/internals/collectAllByCategory.test.ts
+++ b/domain/api/aggregated-assets/src/internals/collectAllByCategory.test.ts
@@ -155,4 +155,15 @@ describe("collectAllByCategory", () => {
     expect(result.error).toMatchObject({ error: expect.stringContaining("evil.example.com") });
     expect(baseQuery).not.toHaveBeenCalled();
   });
+
+  it("stops and keeps what it collected when the server repeats a cursor", async () => {
+    baseQuery
+      .mockResolvedValueOnce(page(rawWith(["aaplx"]), "stuck"))
+      .mockResolvedValue(page(rawWith(["teslax"]), "stuck"));
+
+    const result = await collectAllByCategory(queryArg, baseQuery, tickersOf);
+
+    expect(result).toEqual({ data: ["AAPLX", "TESLAX"] });
+    expect(baseQuery).toHaveBeenCalledTimes(2);
+  });
 });

--- a/domain/api/aggregated-assets/src/internals/collectAllByCategory.ts
+++ b/domain/api/aggregated-assets/src/internals/collectAllByCategory.ts
@@ -8,20 +8,18 @@ import type { GetAssetsByCategoryParams } from "../types";
 import { resolveBaseUrl, type DadaBaseQuery } from "./requests";
 
 /**
- * Walks every page of a category and collects one projection per asset.
+ * Collects one projection per asset across every page of a category.
  *
- * Internal: both public category accessors share it, nothing outside this package should call it.
- * TODO(LIVE-35503): the walk is unbounded and only stops when the server clears the cursor.
+ * Ends on a repeated cursor, which is what a proxy echoing `x-ledger-next` produces. Deliberately
+ * still unbounded if the server keeps minting new ones: Cloudflare fronts DADA, so a page cap was
+ * judged not worth the ceiling it would put on how large a category may grow.
  */
 export async function collectAllByCategory(
   queryArg: GetAssetsByCategoryParams,
   baseQuery: DadaBaseQuery,
   extract: (data: RawApiResponse) => string[],
 ): Promise<QueryReturnValue<string[], FetchBaseQueryError, FetchBaseQueryMeta>> {
-  /*
-   * The host guard throws, and a rejected queryFn surfaces in RTK as an unhandled error. Convert it
-   * so no path out of this endpoint can throw — LIVE-35232 depends on that.
-   */
+  /* The host guard throws, and a rejected queryFn surfaces in RTK as an unhandled error. */
   let baseUrl: string;
   try {
     baseUrl = resolveBaseUrl(queryArg);
@@ -52,7 +50,13 @@ export async function collectAllByCategory(
     if (result.error) return { error: result.error };
 
     collected.push(...extract(result.data as RawApiResponse));
-    cursor = result.meta?.response?.headers.get("x-ledger-next") || undefined;
+
+    const nextCursor = result.meta?.response?.headers.get("x-ledger-next") || undefined;
+
+    /* Same cursor back means no further pages, so this is success rather than an error. */
+    if (nextCursor !== undefined && nextCursor === cursor) return { data: collected };
+
+    cursor = nextCursor;
   } while (cursor);
 
   return { data: collected };


### PR DESCRIPTION
### 📝 Description

**Problem.** `collectAllByCategory` walks pages in a `do…while (cursor)` whose only exit is the server clearing `x-ledger-next`. Running inside an RTK `queryFn`, a walk that never ends never settles the query: `useStablecoinTickers` and `useStockAssetIds` stay `isLoading` for the lifetime of the app while issuing back-to-back requests, and the entry is cached for a day. The user sees a permanent spinner with no error state to recover from.

Pre-existing, not introduced by the migration — byte-identical on develop before LIVE-35226 relocated it. Raised by @ysitbon on [#20345](https://github.com/LedgerHQ/ledger-live/pull/20345) (*"on dirait qu'il y a une boucle"*).

**Solution.** One extra exit, seven lines:

```ts
const nextCursor = result.meta?.response?.headers.get("x-ledger-next") || undefined;

/* A server handing back the cursor it was given has no further pages; keep what was collected. */
if (nextCursor !== undefined && nextCursor === cursor) return { data: collected };

cursor = nextCursor;
```

A cursor returned unchanged means the server has no further pages, so this resolves as **success with what was collected** rather than an error — nothing is broken from the caller's point of view. It covers the one non-termination case with a concrete mechanism behind it: a proxy or CDN echoing the `x-ledger-next` header.

### ✂️ Two of the ticket's suggestions were implemented, reviewed, and then removed

I first built all three guards the ticket proposed. On review we cut two, and the reasoning is worth recording because both look like obvious wins on paper:

| Suggestion | Outcome |
| --- | --- |
| Stop on a repeated cursor | **kept** |
| Page cap (`MAX_PAGES`) for a server minting new cursors forever | **removed** — Cloudflare fronts DADA, so the residual risk was judged too low to price in, and the cap's number was arbitrary: at `pageSize: 100` any value doubles as a ceiling on how large a category may legitimately grow, which is a cliff you only discover when it fires |
| Thread RTK's `AbortSignal` into the walk | **removed** — the base query already refuses an aborted request, so the walk already stops on abort. The in-loop check saved exactly one round-trip RTK would have rejected anyway |

**The walk is therefore still unbounded if the server never repeats itself.** That is a deliberate, accepted risk, and the docstring says so in place of the old `TODO(LIVE-35503)` — so the next reader doesn't mistake it for an oversight and re-add what was just decided against.

### 🔍 Two claims I made while arguing for the guards, corrected

Both were load-bearing in my own case for keeping them, and both were wrong:

1. **"Without the cap the whole process wedges."** That was an artifact of the test double. The mock returned `Promise.resolve(...)` — a microtask — so the loop never yielded and starved jest's own timers. A real request is network I/O, which *does* yield, so the app would stay responsive. The true production symptom is endless background requests plus a query that never settles, not a freeze.
2. **"Aborting doesn't stop the walk."** My probe did run unbounded, but because `abort()` never got a turn to execute — the same starvation. Aborting already stopped the walk, via the base query, before this PR.

### ✅ Verification

- **domain/api: 169 tests** (develop's 168 + 1) · `tsc` exit 0, 0 errors
- The **10 pre-existing `collectAllByCategory` tests are untouched** — extended, not replaced, as the ticket required
- The one new test is mutation-checked: remove the guard and it spins forever rather than passing, so it is genuinely load-bearing
- `@features/platform-aggregated-assets` 129 tests, `tsc` exit 0
- `enforce-boundaries` 0 · `enforce-package-structure:test` 0 · structure validator `✓ package structure ok` · knip 0 · `oxfmt --check` clean

Desktop and mobile typecheck were **not** re-run for the trimmed version: the diff is seven lines inside one `internals/` file with no signature or public-API change, so there is no surface for them to catch. They passed on the earlier, larger version of this branch.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35503](https://ledgerhq.atlassian.net/browse/LIVE-35503) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **ADR**: [DADA DDD compliant](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7382761502/DADA+DDD+compliant)
- Targets `develop` — [#20678](https://github.com/LedgerHQ/ledger-live/pull/20678) (LIVE-35301) is merged, so this is no longer stacked
- **Remaining in the epic**: LIVE-35232 and LIVE-35233 (zod validation)


[LIVE-35503]: https://ledgerhq.atlassian.net/browse/LIVE-35503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ