### PR TITLE
[LWDM] fix(dust-filter): use historical price in dust filter (LIVE-35220)

### DIFF
--- a/.changeset/old-dust-settle.md
+++ b/.changeset/old-dust-settle.md
@@ -1,0 +1,5 @@
+---
+"@ledgerhq/live-common": minor
+---
+
+Fix dust filter to evaluate transaction fiat value at the time of the transaction (historical price) instead of the current market price

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/__tests__/smallValueOperationsThreshold.test.ts
@@ -222,9 +222,9 @@ describe("smallValueOperationsThreshold", () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const regularAccount = { type: "Account", currency: mockNativeCurrency } as AccountLike;
 
-    const buildOp = (type: string, value: BigNumber): Operation =>
+    const buildOp = (type: string, value: BigNumber, date?: Date): Operation =>
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      ({ type, value }) as Operation;
+      ({ type, value, date }) as Operation;
 
     const mockSmallValueCalculations = (
       operationCurrency: CryptoCurrency | TokenCurrency,
@@ -424,6 +424,27 @@ describe("smallValueOperationsThreshold", () => {
       });
 
       expect(result).toBe(true);
+    });
+
+    it("should forward operation.date to calculate so the historical price is used", () => {
+      const txDate = new Date("2021-01-01T00:00:00Z");
+      mockSmallValueCalculations(mockNativeCurrency, 49);
+
+      isSmallValueOperation({
+        operation: buildOp("IN", new BigNumber(1_000_000), txDate),
+        account: regularAccount,
+        countervaluesState: mockCountervaluesState,
+        userCounterValueCurrency: EUR,
+      });
+
+      expect(mockCalculate).toHaveBeenCalledWith(
+        mockCountervaluesState,
+        expect.objectContaining({
+          from: mockNativeCurrency,
+          to: EUR,
+          date: txDate,
+        }),
+      );
     });
 
     it("should return false when the converted threshold is zero", () => {

--- a/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
+++ b/libs/ledger-live-common/src/hideSmallValueTokenOperations/smallValueOperationsThreshold.ts
@@ -225,6 +225,7 @@ export function isSmallValueOperation({
     to: userCounterValueCurrency,
     value: operation.value.toNumber(),
     disableRounding: true,
+    date: operation.date,
   });
 
   if (typeof rawOpFiatValue !== "number" || !Number.isFinite(rawOpFiatValue)) return false;


### PR DESCRIPTION
### 📝 Description

The dust filter in `isSmallValueOperation` was calling `calculate()` without passing a `date`, which always resolves to the **latest** market price (`map.get("latest")`). This means a transaction received years ago as dust (e.g. 5000 satoshis when BTC was worth \$0.50) would not be filtered today because its *current* value exceeds the \$0.01 threshold — even though the UI displays the historical fiat value at the time of the transaction.

**Fix**: pass `operation.date` to `calculate()` so the dust evaluation uses the same historical exchange rate the UI already shows as the transaction's fiat value.

```ts
// before
const rawOpFiatValue = calculate(countervaluesState, {
  from: operationCurrency,
  to: userCounterValueCurrency,
  value: operation.value.toNumber(),
  disableRounding: true,
});

// after
const rawOpFiatValue = calculate(countervaluesState, {
  from: operationCurrency,
  to: userCounterValueCurrency,
  value: operation.value.toNumber(),
  disableRounding: true,
  date: operation.date,
});
```

A test was added to assert that `operation.date` is forwarded to `calculate`.


https://github.com/user-attachments/assets/1a0f20af-bf05-4d03-b3eb-eb8e6cd758b1



https://github.com/user-attachments/assets/86aaeb7f-a2c9-4fcd-8ce5-b907c1739ffa



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35220](https://ledgerhq.atlassian.net/browse/LIVE-35220)

[LIVE-35220]: https://ledgerhq.atlassian.net/browse/LIVE-35220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ