### PR TITLE
fix(coin-evm): zero gas limit and EIP-1559 fee headroom (LIVE-32644, LIVE-32650)

### DIFF
--- a/.changeset/evm-gas-limit-and-base-fee-headroom.md
+++ b/.changeset/evm-gas-limit-and-base-fee-headroom.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-evm": patch
+"@shared/env": patch
+---
+
+Fix EVM transactions being signed with a zero gas limit, and widen the EIP-1559 max fee headroom.
+
+When gas estimation failed, its `BigNumber(0)` fallback travelled back to the sign step, where it was read as a deliberate custom gas limit. That disabled re-estimation and produced a transaction the node rejected with `intrinsic gas too low`. A non-positive gas limit is no longer honoured as a custom value, so the estimation runs again, and crafting now fails rather than sending a zero gas limit to the device (LIVE-32644).
+
+`EIP1559_BASE_FEE_MULTIPLIER` goes from 1.27 to 1.6, so an estimated transaction stays includable for 4 blocks instead of 2 (the base fee grows by at most 12.5% per block). Max fees displayed on chains using the Ledger gas tracker will be higher, but the amount actually paid is unchanged: EIP-1559 charges the base fee plus the priority fee, and the max fee is only a ceiling (LIVE-32650).

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -7302,6 +7302,10 @@
     "GasPriceTooLow": {
       "title": "Gas price is lower than the network minimum"
     },
+    "GasEstimationError": {
+      "title": "Couldn't estimate the network fees",
+      "description": "Please try again in a moment. If it persists, check that the recipient and amount are correct."
+    },
     "PriorityFeeHigherThanMaxFee": {
       "title": "Max priority fee cannot be higher than max fee"
     },

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -1223,6 +1223,10 @@
     "GasPriceTooLow": {
       "title": "Gas price is lower than the network minimum"
     },
+    "GasEstimationError": {
+      "title": "Couldn't estimate the network fees",
+      "description": "Please try again in a moment. If it persists, check that the recipient and amount are correct."
+    },
     "PriorityFeeHigherThanMaxFee": {
       "title": "Max priority fee cannot be higher than max fee"
     },

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -175,9 +175,14 @@ export async function prepareUnsignedTxParams(
       new BigNumber(1))
     : new BigNumber(1);
 
+  const customGasLimit =
+    typeof customFeesParameters?.gasLimit === "bigint" && customFeesParameters.gasLimit > 0n
+      ? customFeesParameters.gasLimit
+      : null;
+
   const gasLimit =
-    typeof customFeesParameters?.gasLimit === "bigint"
-      ? BigNumber(customFeesParameters.gasLimit.toString())
+    customGasLimit !== null
+      ? BigNumber(customGasLimit.toString())
       : (
           await estimateGas(
             currency,

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
@@ -37,6 +37,53 @@ describe("craftTransaction", () => {
     );
   });
 
+  describe("zero gas limit", () => {
+    const intent = {
+      intentType: "transaction",
+      type: "send-legacy",
+      recipient: "0x7b2c7232f9e38f30e2868f0e5bf311cd83554b5a",
+      amount: 10n,
+      asset: { type: "native" },
+    } as TransactionIntent<MemoNotSupported, BufferTxData>;
+
+    beforeEach(() => {
+      setCoinConfig(() => ({ info: { node: { type: "external" } } }) as unknown as EvmCoinConfig);
+      externalMocks.getTransactionCount.mockResolvedValue(18);
+      externalMocks.getFeeData.mockResolvedValue({
+        gasPrice: new BigNumber(8),
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        nextBaseFee: null,
+      });
+    });
+
+    it("re-estimates instead of trusting a zero gas limit coming back from a failed estimation", async () => {
+      externalMocks.getGasEstimation.mockResolvedValue(new BigNumber(2300));
+
+      const { transaction } = await craftTransaction(
+        { ethereumLikeInfo: { chainId: 42 } } as CryptoCurrency,
+        {
+          transactionIntent: intent,
+          customFees: { value: 0n, parameters: { gasPrice: 8n, gasLimit: 0n } },
+        },
+      );
+
+      expect(externalMocks.getGasEstimation).toHaveBeenCalled();
+      expect(ethers.Transaction.from(transaction).gasLimit).toBe(2300n);
+    });
+
+    it("refuses to craft a transaction when the gas estimation yields zero", async () => {
+      externalMocks.getGasEstimation.mockRejectedValue(new Error("node is down"));
+
+      await expect(
+        craftTransaction({ ethereumLikeInfo: { chainId: 42 } } as CryptoCurrency, {
+          transactionIntent: intent,
+          customFees: { value: 0n, parameters: { gasPrice: 8n } },
+        }),
+      ).rejects.toThrow("GasEstimationError");
+    });
+  });
+
   describe.each([
     [
       "legacy",

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
@@ -8,6 +8,7 @@ import {
 } from "@ledgerhq/coin-module-framework/api/types";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { Transaction, TransactionLike } from "ethers";
+import { GasEstimationError } from "../errors";
 import { getNodeApi } from "../network/node";
 import { TransactionTypes } from "../types";
 import { prepareUnsignedTxParams } from "./common";
@@ -29,9 +30,14 @@ export async function craftTransaction(
     customFees?.parameters,
   );
 
-  // Some apps including, including Magic Eden, set the nonce to -1
+  // Never send a failed estimation to the device: the node rejects it as "intrinsic gas too low".
+  if (gasLimit.lte(0)) {
+    throw new GasEstimationError();
+  }
+
+  // Some apps, including Magic Eden, set the nonce to -1
   // instead of simply not providing it.
-  // In case of missing or nagative nonce, it must be re-computed.
+  // In case of missing or negative nonce, it must be re-computed.
   const nonce =
     typeof transactionIntent.sequence === "bigint" && transactionIntent.sequence >= 0n
       ? transactionIntent.sequence

--- a/shared/env/src/definitions/team-coin-integration/index.ts
+++ b/shared/env/src/definitions/team-coin-integration/index.ts
@@ -178,7 +178,7 @@ const teamCoinIntegration = {
     desc: "minimum priority fee percents allowed compared to network conditions allowed when EIP1559_MINIMUM_FEES_GATE is activated",
   },
   EIP1559_BASE_FEE_MULTIPLIER: {
-    def: 1.27,
+    def: 1.6,
     parser: floatParser,
     desc: "multiplier for the base fee that is composing the maxFeePerGas property",
   },


### PR DESCRIPTION
### 📝 Description

Two independent EVM fixes found while investigating broadcast failures on Datadog.

**1. Transactions signed with a zero gas limit (LIVE-32644)**

Previous behaviour: when gas estimation failed, `estimateGas` returned its `BigNumber(0)` fallback. That zero was propagated onto the transaction and read back at sign time by `prepareUnsignedTxParams`, whose presence check was `typeof customFeesParameters?.gasLimit === "bigint"` — and `0n` is a bigint. It was therefore treated as a deliberate custom gas limit, which **skipped re-estimation entirely**, and the transaction was signed with `gasLimit: 0`. The node rejected it with `intrinsic gas too low`.

A Datadog payload confirms it end to end (mainnet USDT transfer, `lld/4.15.0`):

```
nonce                1
to                   USDT, transfer()
maxFeePerGas         0.2389 gwei     ← fee estimation succeeded
maxPriorityFeePerGas 0.1057 gwei
gasLimit             0               ← only the gas estimation failed
```

The fix, in two layers:

- `prepareUnsignedTxParams` only honours a **positive** gas limit as a custom value, so a zero re-runs the estimation instead of disabling it. This is the root cause.
- `craftTransaction` refuses to craft when the resolved gas limit is not positive. This matters beyond the send flow: `signSwapEvm` and `signApprovalEvm` call `craftTransaction` **directly**, without going through `validateIntent`, so this guard is their only gate.

The `BigNumber(0)` fallback itself is intentionally left in place — it still lets `validateIntent` raise `FeeNotLoaded` and block the flow, which is the existing safety net. Only its ability to reach the device is removed.

Regression check: nothing in the monorepo relies on a zero gas limit being accepted. `sponsored` does not touch the gas limit, the CEX swap path deletes the field, the DEX path replaces a zero with a default, no chain config is concerned, and no test asserts a zero is propagated or signed.

**2. EIP-1559 max fee headroom (LIVE-32650)**

`EIP1559_BASE_FEE_MULTIPLIER` goes from 1.27 to 1.6. The Ledger gas tracker computes `maxFeePerGas = nextBaseFee × multiplier + priorityFee`; since the base fee grows by at most 12.5% per block, 1.27 only covered ~2 blocks (~24s), less than a device signing round trip. 1.6 covers 4 blocks. The RPC path already uses ×2, so chains on the Ledger explorer — including Ethereum mainnet — had the tightest margin of all.

Max fees displayed on those chains will be higher. **The amount actually paid is unchanged**: EIP-1559 charges base fee + priority fee, the max fee is only a ceiling. The visible effect is a slightly larger amount reserved on a send-max.

Automated checks preventing regression: two new tests in `craftTransaction.test.ts` cover re-estimation on a zero custom gas limit and the refusal to craft one.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32644](https://ledgerhq.atlassian.net/browse/LIVE-32644), [LIVE-32650](https://ledgerhq.atlassian.net/browse/LIVE-32650)


[LIVE-32644]: https://ledgerhq.atlassian.net/browse/LIVE-32644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ