### PR TITLE
[LWDM] feat(pay): add mobile stablecoin balance hero (LIVE-34895)

### DIFF
--- a/.changeset/LIVE-34898-mobile-pay-card-balance-hero.md
+++ b/.changeset/LIVE-34898-mobile-pay-card-balance-hero.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-balance": minor
+"live-mobile": patch
+"ledger-live-desktop": patch
+---
+
+Add the mobile Pay hero for the aggregated stablecoin balance. The `@features/flow-pay-card-balance` package gains props-only native empty and funded states, and both apps now share the portfolio aggregation through `aggregatePayCardBalance` (LIVE-34898). The hero is mounted at the top of the mobile Pay tab, which tracks `Page Pay` with the active `balance_filter` on view.

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -114,6 +114,7 @@
     "@domain/entity-wallet-sync": "workspace:^",
     "@features/flow-analytics-consent": "workspace:*",
     "@features/flow-pay-card-auth": "workspace:^",
+    "@features/flow-pay-card-balance": "workspace:^",
     "@features/flow-pay-card-feature-tour": "workspace:^",
     "@features/flow-contacts": "workspace:^",
     "@features/platform-contacts": "workspace:^",

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10012,6 +10012,10 @@
           "description": "Pay in USDC, USDT, BTC, ETH and more"
         }
       }
+    },
+    "balance": {
+      "emptyTitle": "Pay and get paid",
+      "emptyDescription": "Start by depositing stablecoin to your wallet"
     }
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabBalance.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabBalance.integration.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen, waitFor } from "@tests/test-renderer";
+import type { State } from "~/reducers/types";
+import { PayTabScreen } from "LLM/features/PayTab";
+
+const mockTrackScreen = jest.fn();
+const mockUseCategorizedAssetsFromPortfolio = jest.fn();
+
+jest.mock("LLM/hooks/useNavigationBarHeights", () => ({
+  useNavigationBarHeights: () => ({ top: 0 }),
+}));
+
+jest.mock("~/analytics", () => ({
+  TrackScreen: (props: Record<string, unknown>) => {
+    mockTrackScreen(props);
+    return null;
+  },
+  track: jest.fn(),
+}));
+
+jest.mock("@features/flow-pay-card-auth", () => {
+  const ReactModule = require("react");
+  const { View } = require("react-native");
+  return {
+    CardLogin: () => ReactModule.createElement(View, { testID: "card-login" }),
+  };
+});
+
+jest.mock("LLM/hooks/useCategorizedAssetsFromPortfolio", () => ({
+  useCategorizedAssetsFromPortfolio: () => mockUseCategorizedAssetsFromPortfolio(),
+}));
+
+const EMPTY_TITLE = "Pay and get paid";
+const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
+
+const tourSeen = (state: State): State => ({
+  ...state,
+  payCard: { ...state.payCard, hasSeenFeatureTour: true },
+});
+
+function mockPortfolio(overrides: Record<string, unknown> = {}) {
+  mockUseCategorizedAssetsFromPortfolio.mockReturnValue({
+    categorizedAssets: { cryptos: [], stocks: [], stablecoins: [] },
+    isLoadingStablecoinTickers: false,
+    isStablecoinTickersError: false,
+    ...overrides,
+  });
+}
+
+describe("PayTab balance hero integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPortfolio();
+  });
+
+  it("should render the empty hero when the user holds no stablecoins", async () => {
+    render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+    expect(screen.getByText(EMPTY_TITLE)).toBeVisible();
+    expect(screen.getByText(EMPTY_DESCRIPTION)).toBeVisible();
+    expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+  });
+
+  it("should render the aggregated stablecoin balance when the user holds stablecoins", async () => {
+    mockPortfolio({
+      categorizedAssets: {
+        cryptos: [],
+        stocks: [],
+        stablecoins: [{ currency: { id: "ethereum/erc20/usdc" }, value: 1000 }],
+      },
+    });
+
+    render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    expect(await screen.findByTestId("pay-card-balance-funded-state")).toBeVisible();
+    expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+  });
+
+  it("should track the Pay page with the active balance filter on view", async () => {
+    render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    await waitFor(() => {
+      expect(mockTrackScreen).toHaveBeenCalledWith(
+        expect.objectContaining({ category: "Pay", balance_filter: "all" }),
+      );
+    });
+  });
+
+  it("should still render the card login block below the hero", async () => {
+    render(<PayTabScreen />, { overrideInitialState: tourSeen });
+
+    expect(await screen.findByTestId("pay-card-balance-empty-state")).toBeVisible();
+    expect(screen.getByTestId("card-login")).toBeVisible();
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabFeatureTour.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabFeatureTour.integration.test.tsx
@@ -10,6 +10,20 @@ jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => null,
 }));
 
+// Feed an empty balance so this suite only asserts tour copy (hero has its own integration test).
+jest.mock("LLM/features/PayTab/hooks/usePayCardBalance", () => ({
+  usePayCardBalance: () => ({
+    status: "ready",
+    stableBalance: 0,
+    filter: "all",
+    formatCountervalue: () => ({}),
+  }),
+}));
+
+// Copy unique to the tour: the empty hero also renders "Pay and get paid".
+const FEATURE_TOUR_ROW = "Minimal volatility";
+const FEATURE_TOUR_CTA = "Got it";
+
 describe("PayTab feature tour integration", () => {
   it("should show the feature tour on first visit", async () => {
     render(<PayTabScreen />, {
@@ -21,7 +35,7 @@ describe("PayTab feature tour integration", () => {
 
     expect(screen.getByTestId("paytab-screen")).toBeVisible();
     await waitFor(() => {
-      expect(screen.getByText("Pay and get paid")).toBeVisible();
+      expect(screen.getByText(FEATURE_TOUR_ROW)).toBeVisible();
     });
   });
 
@@ -34,14 +48,14 @@ describe("PayTab feature tour integration", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("Pay and get paid")).toBeVisible();
+      expect(screen.getByText(FEATURE_TOUR_ROW)).toBeVisible();
     });
 
-    await user.press(screen.getByText("Got it"));
+    await user.press(screen.getByText(FEATURE_TOUR_CTA));
 
     await waitFor(() => {
       expect(store.getState().payCard.hasSeenFeatureTour).toBe(true);
-      expect(screen.queryByText("Pay and get paid")).toBeNull();
+      expect(screen.queryByText(FEATURE_TOUR_ROW)).toBeNull();
     });
   });
 
@@ -54,6 +68,6 @@ describe("PayTab feature tour integration", () => {
     });
 
     expect(screen.getByTestId("paytab-screen")).toBeVisible();
-    expect(screen.queryByText("Pay and get paid")).toBeNull();
+    expect(screen.queryByText(FEATURE_TOUR_ROW)).toBeNull();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -7,9 +7,9 @@ import {
   type PayCardBalanceData,
 } from "@features/flow-pay-card-balance";
 import { selectPayCardBalanceFilter } from "@domain/entity-pay-card";
-import { useSelector } from "LLD/hooks/redux";
-import { useCategorizedAssetsFromPortfolio } from "LLD/hooks/useCategorizedAssets";
-import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
+import { useSelector } from "~/context/hooks";
+import { counterValueCurrencySelector, localeSelector } from "~/reducers/settings";
 
 export function usePayCardBalance(): PayCardBalanceData {
   const locale = useSelector(localeSelector);

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/PayTabView.tsx
@@ -1,21 +1,37 @@
 import React from "react";
 import { CardLogin, type OpenHostedLogin } from "@features/flow-pay-card-auth";
 import { FeatureTour, type FeatureTourProps } from "@features/flow-pay-card-feature-tour";
+import {
+  PayCardBalance,
+  type PayCardBalanceData,
+  type PayCardBalanceLabels,
+} from "@features/flow-pay-card-balance";
 import { Box } from "@ledgerhq/lumen-ui-rnative";
+import { TrackScreen } from "~/analytics";
 
 type PayTabViewProps = {
   readonly top: number;
   readonly openHostedLogin: OpenHostedLogin;
   readonly featureTour: FeatureTourProps;
+  readonly balance: PayCardBalanceData;
+  readonly balanceLabels: PayCardBalanceLabels;
 };
 
-export function PayTabView({ top, openHostedLogin, featureTour }: PayTabViewProps) {
+export function PayTabView({
+  top,
+  openHostedLogin,
+  featureTour,
+  balance,
+  balanceLabels,
+}: PayTabViewProps) {
   return (
     <Box
       lx={{ flex: 1, backgroundColor: "canvas" }}
       style={{ paddingTop: top }}
       testID="paytab-screen"
     >
+      <TrackScreen category="Pay" balance_filter={balance.filter} />
+      <PayCardBalance {...balance} labels={balanceLabels} />
       <CardLogin openHostedLogin={openHostedLogin} />
       <FeatureTour {...featureTour} />
     </Box>

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
@@ -1,5 +1,6 @@
 import { Linking } from "react-native";
 import { renderHook } from "@tests/test-renderer";
+import type { PayCardBalanceData } from "@features/flow-pay-card-balance";
 import { track } from "~/analytics";
 import { usePayTabViewModel } from "./usePayTabViewModel";
 
@@ -9,6 +10,17 @@ jest.mock("LLM/hooks/useNavigationBarHeights", () => ({
 
 jest.mock("~/analytics", () => ({
   track: jest.fn(),
+}));
+
+const balance: PayCardBalanceData = {
+  status: "ready",
+  stableBalance: 0,
+  filter: "all",
+  formatCountervalue: jest.fn(),
+};
+
+jest.mock("LLM/features/PayTab/hooks/usePayCardBalance", () => ({
+  usePayCardBalance: () => balance,
 }));
 
 const mockedTrack = jest.mocked(track);
@@ -22,6 +34,14 @@ describe("usePayTabViewModel", () => {
     const { result } = renderHook(() => usePayTabViewModel());
 
     expect(result.current.top).toBe(24);
+  });
+
+  it("should expose the balance data and empty-state labels for the hero", () => {
+    const { result } = renderHook(() => usePayTabViewModel());
+
+    expect(result.current.balance).toBe(balance);
+    expect(result.current.balanceLabels.emptyTitle).toBeTruthy();
+    expect(result.current.balanceLabels.emptyDescription).toBeTruthy();
   });
 
   it("should open the hosted login URL", async () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -3,12 +3,24 @@ import { Linking } from "react-native";
 import { useTranslation } from "~/context/Locale";
 import type { OpenHostedLogin } from "@features/flow-pay-card-auth";
 import type { FeatureTourProps } from "@features/flow-pay-card-feature-tour";
+import type { PayCardBalanceLabels } from "@features/flow-pay-card-balance";
 import { useNavigationBarHeights } from "LLM/hooks/useNavigationBarHeights";
+import { usePayCardBalance } from "LLM/features/PayTab/hooks/usePayCardBalance";
 import { track } from "~/analytics";
 
 export function usePayTabViewModel() {
   const { top } = useNavigationBarHeights();
   const { t } = useTranslation();
+
+  const balance = usePayCardBalance();
+
+  const balanceLabels: PayCardBalanceLabels = useMemo(
+    () => ({
+      emptyTitle: t("payTab.balance.emptyTitle"),
+      emptyDescription: t("payTab.balance.emptyDescription"),
+    }),
+    [t],
+  );
 
   const openHostedLogin: OpenHostedLogin = useCallback(
     (loginUrl: string) => Linking.openURL(loginUrl),
@@ -43,5 +55,5 @@ export function usePayTabViewModel() {
     [t],
   );
 
-  return { top, openHostedLogin, featureTour };
+  return { top, openHostedLogin, featureTour, balance, balanceLabels };
 }

--- a/features/flow/pay-card-balance/README.md
+++ b/features/flow/pay-card-balance/README.md
@@ -2,7 +2,7 @@
 
 > [!CAUTION] > **Status: UNSTABLE** — In active development; API may change.
 
-Desktop Pay hero for the aggregated stablecoin balance. Renders two states:
+Shared Pay hero (Desktop and Mobile) for the aggregated stablecoin balance. Renders two states:
 
 - **funded** — the aggregated stable balance formatted as a countervalue. While `status` is
   `"loading"` this state renders its amount skeleton, so the empty placeholder never flashes before
@@ -28,19 +28,42 @@ The host passes the balance data (aggregated stable balance, `status`, `filter` 
 formatter) and the display `labels` directly, so the views stay props-only and platform navigation
 and data access remain at the app composition root.
 
+## Shared aggregation (`aggregatePayCardBalance`)
+
+Both apps derive the balance data from their own portfolio source, then feed it through the shared
+`aggregatePayCardBalance` helper so the filtering, summing and status mapping live in one place
+(LIVE-34898). Each app only writes a thin adapter that maps its `useCategorizedAssetsFromPortfolio`
+result into a `PayCardPortfolioPort`:
+
+```tsx
+import { aggregatePayCardBalance } from "@features/flow-pay-card-balance";
+
+return aggregatePayCardBalance({
+  stablecoins: categorizedAssets.stablecoins,
+  filter,
+  isLoading: isLoadingStablecoinTickers,
+  isError: isStablecoinTickersError,
+  formatCountervalue,
+});
+```
+
+`FormattedValue` is re-exported from `@ledgerhq/lumen-utils-shared` (the shared source used by both
+lumen `AmountDisplay` packages) so the contract stays platform-agnostic and tracks Lumen API changes.
+
 ## Platform resolution
 
-Only the view and state components carry a platform suffix. The container, view model, types and
-barrels are platform-agnostic and import without a suffix; TypeScript `moduleSuffixes`, the bundler
-and the jest preset resolve the right side.
+Only the view and state components carry a platform suffix (`.web` / `.native`). The container, view
+model, aggregation, types and barrels are platform-agnostic and import without a suffix; TypeScript
+`moduleSuffixes`, the bundlers (Rspack / Metro) and the jest preset resolve the right side.
 
-| Tooling          | How it resolves                                      |
-| ---------------- | ---------------------------------------------------- |
-| TypeScript (IDE) | Solution-style `tsconfig.json` → `tsconfig.web.json` |
-| Desktop (Rspack) | `.web` / unsuffixed                                  |
-| Jest             | Tests import `.web` files explicitly                 |
+| Tooling          | How it resolves                                                            |
+| ---------------- | ------------------------------------------------------------------------- |
+| TypeScript (IDE) | Solution-style `tsconfig.json` → `tsconfig.web.json` / `tsconfig.native.json` |
+| Desktop (Rspack) | `.web` / unsuffixed                                                        |
+| Mobile (Metro)   | `.native` / unsuffixed                                                     |
+| Jest             | Tests import `.web` / `.native` files explicitly                          |
 
-Each `.web` view also has a test importing it through its full `.web` filename. Dead-code analysis
+Each view also has a test importing it through its full platform filename. Dead-code analysis
 (knip) reads only the solution `tsconfig.json`, which declares no `moduleSuffixes`, so a suffixed
 file it can reach through no other path would be reported as dead.
 
@@ -51,26 +74,35 @@ Every `index.*` is a pure barrel (`export *` only); the components live in named
 
 ```text
 pay-card-balance/
-├── package.json                              # Package metadata and public exports
+├── package.json                                # Package metadata and public exports
 └── src/
     ├── components/
     │   └── PayCardBalance/
     │       ├── __tests__/
+    │       │   ├── aggregatePayCardBalance.web.test.ts
     │       │   ├── PayCardBalanceEmptyState.web.test.tsx
+    │       │   ├── PayCardBalanceEmptyState.native.test.tsx
     │       │   ├── PayCardBalanceFundedState.web.test.tsx
+    │       │   ├── PayCardBalanceFundedState.native.test.tsx
     │       │   ├── PayCardBalanceView.web.test.tsx
+    │       │   ├── PayCardBalanceView.native.test.tsx
     │       │   └── usePayCardBalanceViewModel.web.test.ts
-    │       ├── PayCardBalance.tsx             # Component container
-    │       ├── PayCardBalanceView.web.tsx     # Web presentational UI (state switch)
+    │       ├── PayCardBalance.tsx               # Component container (platform-agnostic)
+    │       ├── PayCardBalanceView.web.tsx       # Web presentational UI (state switch)
+    │       ├── PayCardBalanceView.native.tsx    # Native presentational UI (state switch)
     │       ├── PayCardBalanceEmptyState.web.tsx
+    │       ├── PayCardBalanceEmptyState.native.tsx
     │       ├── PayCardBalanceFundedState.web.tsx
-    │       ├── index.ts                       # Barrel
-    │       ├── types.ts                       # Component contracts
-    │       └── usePayCardBalanceViewModel.ts  # Shared state derivation
-    └── index.ts                              # Public API (barrel)
+    │       ├── PayCardBalanceFundedState.native.tsx
+    │       ├── aggregatePayCardBalance.ts       # Shared portfolio aggregation
+    │       ├── index.ts                         # Barrel
+    │       ├── types.ts                         # Component + port contracts
+    │       └── usePayCardBalanceViewModel.ts    # Shared state derivation
+    ├── index.ts                                 # Public API (barrel)
+    └── index.native.ts                          # Native public API (barrel)
 ```
 
 ## Tracking
 
 The hero itself does not emit analytics. The host is responsible for tracking `Page Pay` with the
-active `balance_filter` when the tab is viewed.
+active `balance_filter` when the tab is viewed (Desktop `TrackPage`, Mobile `TrackScreen`).

--- a/features/flow/pay-card-balance/package.json
+++ b/features/flow/pay-card-balance/package.json
@@ -4,9 +4,13 @@
   "private": true,
   "description": "Shared Pay Card balance hero (empty and funded states) for Ledger Wallet",
   "main": "src/index.ts",
+  "react-native": "src/index.native.ts",
   "types": "src/index.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "react-native": "./src/index.native.ts",
+      "default": "./src/index.ts"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -17,25 +21,28 @@
     "lint:ci": "oxlint src --quiet && pnpm lint:tailwind",
     "lint:fix": "oxfmt src && oxlint src --fix --quiet && pnpm lint:tailwind",
     "lint:tailwind": "eslint --no-eslintrc -c .eslintrc.tailwind.js --ext .ts,.tsx 'src/**/*.web.{ts,tsx}'",
-    "typecheck": "tsc --noEmit -p tsconfig.web.json",
+    "typecheck": "tsc --noEmit -p tsconfig.web.json && tsc --noEmit -p tsconfig.native.json",
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",
     "unimported": "pnpm knip --directory ../../.. -W features/flow/pay-card-balance"
   },
   "dependencies": {
-    "@domain/entity-pay-card": "workspace:^"
+    "@domain/entity-pay-card": "workspace:^",
+    "@ledgerhq/lumen-utils-shared": "catalog:"
   },
   "devDependencies": {
     "@support/jest-features-flow": "workspace:*",
     "@features/platform-style": "workspace:*",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
     "@swc/core": "catalog:",
     "@swc/jest": "catalog:",
     "@testing-library/dom": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
+    "@testing-library/react-native": "catalog:",
     "@types/jest": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
@@ -48,6 +55,8 @@
     "oxlint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-native": "catalog:",
+    "react-test-renderer": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:"
   },
@@ -60,10 +69,18 @@
   "peerDependencies": {
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
-    "react": "catalog:"
+    "@ledgerhq/lumen-ui-rnative": "catalog:",
+    "react": "catalog:",
+    "react-native": "catalog:"
   },
   "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    },
     "@ledgerhq/lumen-ui-react": {
+      "optional": true
+    },
+    "@ledgerhq/lumen-ui-rnative": {
       "optional": true
     },
     "@ledgerhq/lumen-design-core": {

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.native.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
+import type { PayCardBalanceLabels } from "./types";
+
+type PayCardBalanceEmptyStateProps = Readonly<{
+  labels: PayCardBalanceLabels;
+}>;
+
+export function PayCardBalanceEmptyState({ labels }: PayCardBalanceEmptyStateProps) {
+  return (
+    <Box
+      lx={{ alignItems: "center", justifyContent: "center", gap: "s16", paddingVertical: "s32" }}
+      testID="pay-card-balance-empty-state"
+    >
+      <Text typography="heading1SemiBold" lx={{ color: "base", textAlign: "center" }}>
+        {labels.emptyTitle}
+      </Text>
+      <Text typography="body2" lx={{ color: "muted", textAlign: "center" }}>
+        {labels.emptyDescription}
+      </Text>
+    </Box>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.native.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
+import { AmountDisplay, Box } from "@ledgerhq/lumen-ui-rnative";
 import type { FormattedValue } from "./types";
 
 type PayCardBalanceFundedStateProps = Readonly<{
@@ -14,13 +14,17 @@ export function PayCardBalanceFundedState({
   isLoading,
 }: PayCardBalanceFundedStateProps) {
   return (
-    <div className="flex items-end gap-12" data-testid="pay-card-balance-funded-state">
+    <Box
+      lx={{ alignItems: "center", justifyContent: "center", paddingVertical: "s32" }}
+      testID="pay-card-balance-funded-state"
+    >
       <AmountDisplay
         value={balance}
         formatter={formatCountervalue}
         loading={isLoading}
-        data-testid="pay-card-balance-amount"
+        size="md"
+        testID="pay-card-balance-amount"
       />
-    </div>
+    </Box>
   );
 }

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.native.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Box } from "@ledgerhq/lumen-ui-rnative";
+import type { PayCardBalanceViewProps } from "./types";
+import { PayCardBalanceEmptyState } from "./PayCardBalanceEmptyState";
+import { PayCardBalanceFundedState } from "./PayCardBalanceFundedState";
+
+export function PayCardBalanceView(props: PayCardBalanceViewProps) {
+  return (
+    <Box lx={{ paddingHorizontal: "s16" }} testID="pay-card-balance">
+      {props.displayMode === "funded" ? (
+        <PayCardBalanceFundedState
+          balance={props.balance}
+          formatCountervalue={props.formatCountervalue}
+          isLoading={props.isLoading}
+        />
+      ) : (
+        <PayCardBalanceEmptyState labels={props.labels} />
+      )}
+    </Box>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.native.test.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import { PayCardBalanceEmptyState } from "../PayCardBalanceEmptyState.native";
+
+describe("PayCardBalanceEmptyState (Native)", () => {
+  it("should render the empty title and description", () => {
+    render(
+      <PayCardBalanceEmptyState
+        labels={{
+          emptyTitle: "Pay and get paid",
+          emptyDescription: "Start by depositing stablecoin to your wallet",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("pay-card-balance-empty-state")).toBeTruthy();
+    expect(screen.getByText("Pay and get paid")).toBeTruthy();
+    expect(screen.getByText("Start by depositing stablecoin to your wallet")).toBeTruthy();
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.native.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import type { FormattedValue } from "../types";
+import { PayCardBalanceFundedState } from "../PayCardBalanceFundedState.native";
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(value),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+describe("PayCardBalanceFundedState (Native)", () => {
+  it("should render the funded balance", () => {
+    render(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+      />,
+    );
+
+    expect(screen.getByTestId("pay-card-balance-funded-state")).toBeTruthy();
+    expect(screen.getByTestId("pay-card-balance-amount")).toBeTruthy();
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+import type { FormattedValue, PayCardBalanceViewProps } from "../types";
+import { PayCardBalanceView } from "../PayCardBalanceView.native";
+
+const labels = {
+  emptyTitle: "Pay and get paid",
+  emptyDescription: "Start by depositing stablecoin to your wallet",
+};
+
+const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(value),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
+
+function renderView(props: PayCardBalanceViewProps) {
+  return render(<PayCardBalanceView {...props} />);
+}
+
+describe("PayCardBalanceView (Native)", () => {
+  it("should render the empty title and description when empty", () => {
+    renderView({ displayMode: "empty", labels });
+
+    expect(screen.getByText("Pay and get paid")).toBeVisible();
+    expect(screen.getByText("Start by depositing stablecoin to your wallet")).toBeVisible();
+  });
+
+  it("should not render a balance when empty", () => {
+    renderView({ displayMode: "empty", labels });
+
+    expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
+  });
+
+  it("should render the funded balance when funded", () => {
+    renderView({
+      displayMode: "funded",
+      balance: 1000,
+      formatCountervalue,
+      filter: "all",
+      isLoading: false,
+    });
+
+    expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
+    expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
@@ -1,0 +1,57 @@
+import { aggregatePayCardBalance } from "../aggregatePayCardBalance";
+import type { FormattedValue, PayCardPortfolioPort } from "../types";
+
+const formatCountervalue = (): FormattedValue => ({}) as unknown as FormattedValue;
+
+function buildPort(overrides: Partial<PayCardPortfolioPort> = {}): PayCardPortfolioPort {
+  return {
+    stablecoins: [],
+    filter: "all",
+    isLoading: false,
+    isError: false,
+    formatCountervalue,
+    ...overrides,
+  };
+}
+
+const usdc = { currency: { id: "ethereum/erc20/usdc" }, value: 1000 };
+const usdt = { currency: { id: "ethereum/erc20/usdt" }, value: 250.5 };
+
+describe("aggregatePayCardBalance", () => {
+  it("should sum every stablecoin countervalue when the filter is all", () => {
+    const data = aggregatePayCardBalance(buildPort({ stablecoins: [usdc, usdt] }));
+
+    expect(data.stableBalance).toBe(1250.5);
+    expect(data.status).toBe("ready");
+    expect(data.filter).toBe("all");
+  });
+
+  it("should sum only the matching stablecoin when the filter is a currencyId", () => {
+    const data = aggregatePayCardBalance(
+      buildPort({ stablecoins: [usdc, usdt], filter: "ethereum/erc20/usdc" }),
+    );
+
+    expect(data.stableBalance).toBe(1000);
+    expect(data.filter).toBe("ethereum/erc20/usdc");
+  });
+
+  it("should report loading while the portfolio is loading", () => {
+    const data = aggregatePayCardBalance(buildPort({ stablecoins: [usdc], isLoading: true }));
+
+    expect(data.status).toBe("loading");
+  });
+
+  it("should report error when the portfolio errors, regardless of loading", () => {
+    const data = aggregatePayCardBalance(
+      buildPort({ stablecoins: [usdc], isLoading: true, isError: true }),
+    );
+
+    expect(data.status).toBe("error");
+  });
+
+  it("should forward the countervalue formatter untouched", () => {
+    const data = aggregatePayCardBalance(buildPort());
+
+    expect(data.formatCountervalue).toBe(formatCountervalue);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/aggregatePayCardBalance.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/aggregatePayCardBalance.ts
@@ -1,0 +1,24 @@
+import type { PayCardBalanceData, PayCardBalanceStatus, PayCardPortfolioPort } from "./types";
+
+// Shared Pay hero aggregation (LIVE-34898): filters stablecoins by the active filter, sums their
+// countervalues and maps the loading/error flags to a single status.
+export function aggregatePayCardBalance({
+  stablecoins,
+  filter,
+  isLoading,
+  isError,
+  formatCountervalue,
+}: PayCardPortfolioPort): PayCardBalanceData {
+  const stableBalance = stablecoins
+    .filter(({ currency }) => filter === "all" || currency.id === filter)
+    .reduce((total, { value }) => total + value, 0);
+
+  let status: PayCardBalanceStatus = "ready";
+  if (isError) {
+    status = "error";
+  } else if (isLoading) {
+    status = "loading";
+  }
+
+  return { status, stableBalance, filter, formatCountervalue };
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/index.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/index.ts
@@ -1,2 +1,3 @@
 export * from "./PayCardBalance";
+export * from "./aggregatePayCardBalance";
 export * from "./types";

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
@@ -1,5 +1,8 @@
 import type { PayCardBalanceFilter } from "@domain/entity-pay-card";
-import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+import type { FormattedValue } from "@ledgerhq/lumen-utils-shared";
+
+// Shared by both platforms (`AmountDisplay`);
+export type { FormattedValue };
 
 export type PayCardBalanceStatus = "loading" | "error" | "ready";
 
@@ -8,16 +11,27 @@ export type PayCardBalanceLabels = Readonly<{
   emptyDescription: string;
 }>;
 
-/**
- * Everything the host feeds the hero. The desktop app derives it from the portfolio; LIVE-34898
- * will later provide a shared implementation.
- */
+// Host input for the hero, produced by {@link aggregatePayCardBalance} in both apps.
 export type PayCardBalanceData = Readonly<{
   status: PayCardBalanceStatus;
   /** Aggregated stablecoin countervalue, in the user's counter currency. */
   stableBalance: number;
   /** Active balance filter (`"all"` or a single stablecoin currencyId). */
   filter: PayCardBalanceFilter;
+  formatCountervalue: (value: number) => FormattedValue;
+}>;
+
+export type PayCardStablecoin = Readonly<{
+  currency: Readonly<{ id: string }>;
+  value: number;
+}>;
+
+// Platform-agnostic input for {@link aggregatePayCardBalance}
+export type PayCardPortfolioPort = Readonly<{
+  stablecoins: readonly PayCardStablecoin[];
+  filter: PayCardBalanceFilter;
+  isLoading: boolean;
+  isError: boolean;
   formatCountervalue: (value: number) => FormattedValue;
 }>;
 

--- a/features/flow/pay-card-balance/src/index.native.ts
+++ b/features/flow/pay-card-balance/src/index.native.ts
@@ -1,0 +1,1 @@
+export * from "./components/PayCardBalance";

--- a/features/flow/pay-card-balance/tsconfig.json
+++ b/features/flow/pay-card-balance/tsconfig.json
@@ -10,5 +10,8 @@
     "types": ["jest", "node", "@testing-library/jest-dom"]
   },
   "files": [],
-  "references": [{ "path": "./tsconfig.web.json" }]
+  "references": [
+    { "path": "./tsconfig.web.json" },
+    { "path": "./tsconfig.native.json" }
+  ]
 }

--- a/features/flow/pay-card-balance/tsconfig.native.json
+++ b/features/flow/pay-card-balance/tsconfig.native.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleSuffixes": [".native", ""]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "src/**/*.web.*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1737,6 +1737,9 @@ importers:
       '@features/flow-pay-card-auth':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-auth
+      '@features/flow-pay-card-balance':
+        specifier: workspace:^
+        version: link:../../features/flow/pay-card-balance
       '@features/flow-pay-card-feature-tour':
         specifier: workspace:^
         version: link:../../features/flow/pay-card-feature-tour
@@ -5679,6 +5682,9 @@ importers:
       '@domain/entity-pay-card':
         specifier: workspace:^
         version: link:../../../domain/entity/pay-card
+      '@ledgerhq/lumen-utils-shared':
+        specifier: 'catalog:'
+        version: 0.1.7(react@19.1.4)
     devDependencies:
       '@features/platform-style':
         specifier: workspace:*
@@ -5688,7 +5694,10 @@ importers:
         version: 0.1.24
       '@ledgerhq/lumen-ui-react':
         specifier: 'catalog:'
-        version: 0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative':
+        specifier: 'catalog:'
+        version: 0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@support/jest-features-flow':
         specifier: workspace:*
         version: link:../../../support/jest-features-flow
@@ -5707,6 +5716,9 @@ importers:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@testing-library/react-native':
+        specifier: 'catalog:'
+        version: 13.3.3(patch_hash=4f93e75372e62b6dc0f0b2635b62a322b37a3727637bd94a38df1ed8648e2e76)(jest@30.2.0(@types/node@24.12.0))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react-test-renderer@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/jest':
         specifier: 'catalog:'
         version: 30.0.0
@@ -5742,6 +5754,12 @@ importers:
         version: 19.1.4
       react-dom:
         specifier: 19.1.4
+        version: 19.1.4(react@19.1.4)
+      react-native:
+        specifier: 'catalog:'
+        version: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+      react-test-renderer:
+        specifier: 'catalog:'
         version: 19.1.4(react@19.1.4)
       tailwindcss:
         specifier: 'catalog:'
@@ -48598,17 +48616,6 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@ledgerhq/lumen-ui-react@0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
-    dependencies:
-      '@ledgerhq/lumen-design-core': 0.1.24
-      '@ledgerhq/lumen-utils-shared': 0.1.10(react@19.1.4)
-      i18next: 23.10.1
-      react: 19.1.4
-      react-dom: 19.1.4(react@19.1.4)
-      react-i18next: 14.1.3(i18next@23.10.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-    transitivePeerDependencies:
-      - react-native
-
   '@ledgerhq/lumen-ui-rnative-visualization@0.1.31(8558c8df326d011ff4ff124981e6a8bf)':
     dependencies:
       '@ledgerhq/lumen-design-core': 0.1.24
@@ -67585,7 +67592,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
-      metro: 0.83.3(metro-transform-worker@0.83.3)
+      metro: 0.83.3
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
@@ -67709,54 +67716,6 @@ snapshots:
       yargs: 17.7.2
     transitivePeerDependencies:
       - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro@0.83.3(metro-transform-worker@0.83.3):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.29.2
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      accepts: 1.3.8
-      chalk: 4.1.2
-      ci-info: 2.0.0
-      connect: 3.7.0
-      debug: 4.4.3
-      error-stack-parser: 2.1.4
-      flow-enums-runtime: 0.0.6
-      graceful-fs: 4.2.11
-      hermes-parser: 0.32.0
-      image-size: 1.1.1
-      invariant: 2.2.4
-      jest-worker: 29.7.0(metro@0.83.3)
-      jsc-safe-url: 0.2.4
-      lodash.throttle: 4.1.1
-      metro-babel-transformer: 0.83.3
-      metro-cache: 0.83.3
-      metro-cache-key: 0.83.3
-      metro-config: 0.83.3(metro-transform-worker@0.83.3)
-      metro-core: 0.83.3
-      metro-file-map: 0.83.3(metro@0.83.3)
-      metro-resolver: 0.83.3
-      metro-runtime: 0.83.3
-      metro-source-map: 0.83.3
-      metro-symbolicate: 0.83.3
-      metro-transform-plugins: 0.83.3
-      metro-transform-worker: 0.83.3
-      mime-types: 2.1.35
-      nullthrows: 1.1.1
-      serialize-error: 2.1.0
-      source-map: 0.5.7
-      throat: 5.0.0
-      ws: 7.5.10
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - metro-transform-worker
       - supports-color
       - utf-8-validate
 


### PR DESCRIPTION
### 📝 Description

Adds the mobile **Pay hero** that surfaces the user's aggregated stablecoin balance at the top of the Pay tab.

**Problem**: The mobile Pay tab had no balance hero — the aggregated stablecoin countervalue was only available on Desktop.

**Solution**:
- `@features/flow-pay-card-balance` gains **props-only** native views: `PayCardBalanceView.native` with `PayCardBalanceEmptyState.native` (placeholder title/description, no balance) and `PayCardBalanceFundedState.native` (formatted countervalue via lumen `AmountDisplay`). The package is now dual-platform (`.web` / `.native`) with a `tsconfig.native.json` and `index.native.ts` entry point.
- Portfolio derivation is shared through the new `aggregatePayCardBalance` (`PayCardPortfolioPort`), so Desktop and Mobile feed their own `useCategorizedAssetsFromPortfolio` into one aggregation that filters stablecoins, sums countervalues and maps loading/error to a single status. Desktop's `usePayCardBalance` was refactored onto it to remove duplication.
- The hero is mounted at the top of the mobile Pay tab via `usePayTabViewModel` + `PayTabView`, and the tab tracks `Page Pay` with the active `balance_filter` on view.

The filter pill + picker (LWM filter) is a separate, follow-up task blocked on this one.

Usage (native):

\`\`\`tsx
import { PayCardBalance } from "@features/flow-pay-card-balance";

<PayCardBalance {...balance} labels={balanceLabels} />
\`\`\`

### 🧪 Tests

- Shared unit tests for `aggregatePayCardBalance` (filter/sum/status).
- Native unit tests for the empty, funded and switch views.
- Mobile `PayTabBalance` integration test covering empty/funded states + analytics, mirroring Desktop.

### 📸 Screenshots


https://github.com/user-attachments/assets/bb449ecc-4b84-4b99-823a-eded1a1bded9



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34895](https://ledgerhq.atlassian.net/browse/LIVE-34895)
- Shared ViewModel / aggregation: LIVE-34898

[LIVE-34895]: https://ledgerhq.atlassian.net/browse/LIVE-34895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ