### PR TITLE
[LWDM] feat(zcash): add warning for unconfirmed spendable balance

### DIFF
--- a/.changeset/zcash-private-spendable-warning.md
+++ b/.changeset/zcash-private-spendable-warning.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"@ledgerhq/coin-zcash": minor
+---
+
+Show a warning in the send flow when the Zcash private balance is selected as source and funds were shielded in the last 15 minutes, explaining that recently shielded funds need confirmations and scanning before they are spendable

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/ZcashTransferFromSelector.tsx
@@ -10,12 +10,14 @@ import type { Transaction as ZcashTransaction } from "@ledgerhq/coin-zcash/types
 import {
   getPrivateBalance,
   getTransparentBalance,
+  hasRecentlyShieldedFunds,
 } from "@ledgerhq/coin-zcash/logic/account/balance";
 import { useSelector } from "LLD/hooks/redux";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Box from "~/renderer/components/Box/Box";
 import Text from "~/renderer/components/Text";
 import Label from "~/renderer/components/Label";
+import Alert from "~/renderer/components/Alert";
 import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
 import { useAccountUnit } from "~/renderer/hooks/useAccountUnit";
 
@@ -105,6 +107,10 @@ const ZcashTransferFromSelector = ({ account, transaction, onChange }: Props) =>
   // (not balance − private, which diverges across flag/module provenance).
   const privateBalance = getPrivateBalance(privateInfo);
   const transparentBalance = getTransparentBalance(zcashAccount.bitcoinResources?.utxos);
+  // Only warn while a freshly shielded note may still be maturing (until its
+  // transaction has enough confirmations); once everything is spendable the
+  // private balance no longer trails the total.
+  const showSpendableWarning = sender === "private" && hasRecentlyShieldedFunds(privateInfo);
 
   const formatConfig = { showCode: true, discreet, locale };
   const transparentLabel = formatCurrencyUnit(unit, transparentBalance, formatConfig);
@@ -165,6 +171,11 @@ const ZcashTransferFromSelector = ({ account, transaction, onChange }: Props) =>
           ) : null}
         </Card>
       </Box>
+      {showSpendableWarning ? (
+        <Alert type="warning" mt={3} data-testid="zcash-private-spendable-warning">
+          <Trans i18nKey="zcash.shielded.send.transferFrom.spendableWarning" />
+        </Alert>
+      ) : null}
     </Box>
   );
 };

--- a/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/families/bitcoin/__tests__/ZcashTransferFromSelector.test.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import BigNumber from "bignumber.js";
-import { DEFAULT_ZCASH_PRIVATE_INFO } from "@ledgerhq/coin-zcash/constants";
+import {
+  DEFAULT_ZCASH_PRIVATE_INFO,
+  ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+} from "@ledgerhq/coin-zcash/constants";
+import type { ShieldedTransaction } from "@ledgerhq/coin-zcash/network/types";
 import { render, screen, fireEvent, withFlagOverrides } from "tests/testSetup";
 import { createFixtureAccount } from "@ledgerhq/coin-bitcoin/fixtures/common.fixtures";
 import { CryptoCurrency } from "@domain/entity-currency-crypto";
@@ -184,6 +188,61 @@ describe("ZcashTransferFromSelector", () => {
     expect(screen.getByTestId("transfer-from-public")).toHaveTextContent(/0\.1 ZEC/);
     expect(screen.getByTestId("transfer-from-public")).not.toHaveTextContent(/0\.4 ZEC/);
     expect(screen.getByTestId("transfer-from-private")).toHaveTextContent(/0\.5 ZEC/);
+  });
+
+  const TIP = 1_000_000; // latest scanned block height
+  const outgoingShieldedTx = (blockHeight: number) =>
+    ({
+      blockHeight,
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "outgoing" }],
+      },
+    }) as unknown as ShieldedTransaction;
+  const recentShieldedTx = () => outgoingShieldedTx(TIP - 1);
+  const oldShieldedTx = () => outgoingShieldedTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS);
+
+  it(`shows the spendable-balance warning when Private is selected and funds were shielded within the last ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} blocks`, () => {
+    renderSelector(
+      buildAccount({
+        ufvk: "uview-test",
+        transactions: [recentShieldedTx()],
+        lastProcessedBlock: TIP,
+      }),
+      {
+        sender: "private",
+      } as Partial<Transaction>,
+    );
+    expect(screen.getByTestId("zcash-private-spendable-warning")).toBeVisible();
+  });
+
+  it(`hides the spendable-balance warning when the shielded transaction has ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS}+ confirmations`, () => {
+    renderSelector(
+      buildAccount({
+        ufvk: "uview-test",
+        transactions: [oldShieldedTx()],
+        lastProcessedBlock: TIP,
+      }),
+      {
+        sender: "private",
+      } as Partial<Transaction>,
+    );
+    expect(screen.queryByTestId("zcash-private-spendable-warning")).not.toBeInTheDocument();
+  });
+
+  it("hides the spendable-balance warning when Public is the selected source even with recent shielded funds", () => {
+    renderSelector(
+      buildAccount({
+        ufvk: "uview-test",
+        transactions: [recentShieldedTx()],
+        lastProcessedBlock: TIP,
+      }),
+      {
+        sender: "public",
+      } as Partial<Transaction>,
+    );
+    expect(screen.queryByTestId("zcash-private-spendable-warning")).not.toBeInTheDocument();
   });
 
   it("renders nothing when the zcashShielded feature flag is off", () => {

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -8952,7 +8952,8 @@
             "title": "Private balance",
             "subtitle": "Shielded",
             "unavailable": "Private balance unavailable"
-          }
+          },
+          "spendableWarning": "Spendable balance may be lower than total balance. Recently shielded funds need confirmations and full scanning (~15 minutes) before they can be spent."
         },
         "memo": {
           "label": "Memo (optional)",

--- a/libs/coin-modules/coin-zcash/src/constants.ts
+++ b/libs/coin-modules/coin-zcash/src/constants.ts
@@ -60,6 +60,11 @@ export const getZainoEndpoint = (): { grpcUrl: string; network: ZcashNetwork } =
 export const ZCASH_ACTIVATION_DATE = new Date("2022-05-31");
 export const ZCASH_ACTIVATION_DATE_STRING = "2022-05-31";
 export const ZCASH_OUTDATED_SYNC_INTERVAL_MINUTES = 2;
+// A freshly shielded note is scanned into the spendable (Ironwood) balance
+// before it can actually be spent: it first needs to gain confirmations. Until
+// the note's transaction has this many blocks mined on top of it, the spendable
+// balance can trail the total.
+export const ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS = 12;
 export const ZCASH_CHECK_OUTDATED_SYNC_INTERVAL = 5_000; // 5 seconds
 export const DEFAULT_ZCASH_PRIVATE_INFO: ZcashPrivateInfo = {
   orchardBalance: new BigNumber(0),

--- a/libs/coin-modules/coin-zcash/src/logic/account/balance.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/balance.ts
@@ -1,6 +1,8 @@
 import { BigNumber } from "bignumber.js";
 import type { BitcoinOutput } from "../../types/bridge";
 import type { ZcashPrivateInfo } from "../../network/types";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
+import { getTxType } from "../../bridge/operations";
 
 type PrivateBalances = Pick<
   ZcashPrivateInfo,
@@ -36,6 +38,33 @@ export function getTransparentBalance(
 export function getPrivateBalance(privateInfo: PrivateBalances | undefined | null): BigNumber {
   if (!privateInfo) return new BigNumber(0);
   return privateInfo.ironwoodBalance ?? new BigNumber(0);
+}
+
+/**
+ * Whether the account made an outgoing shielded transaction that has not yet
+ * gained {@link ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} confirmations.
+ *
+ * The change note of an outgoing shielded send is summed back into the spendable
+ * Ironwood balance as soon as it is scanned, but it cannot be spent again until
+ * its transaction has enough blocks mined on top of it. Confirmations are counted
+ * against the latest scanned block (`lastProcessedBlock`): an outgoing transaction
+ * is still maturing while `lastProcessedBlock - tx.blockHeight` is below the delay.
+ * Returns true when any such transaction exists, so the send flow can warn that
+ * the spendable balance may temporarily trail the total. Incoming transactions are
+ * ignored — they do not gate spendability the same way.
+ */
+export function hasRecentlyShieldedFunds(
+  privateInfo: Pick<ZcashPrivateInfo, "transactions" | "lastProcessedBlock"> | undefined | null,
+): boolean {
+  const transactions = privateInfo?.transactions;
+  const lastProcessedBlock = privateInfo?.lastProcessedBlock;
+  if (!transactions?.length || lastProcessedBlock === null || lastProcessedBlock === undefined)
+    return false;
+  return transactions.some(
+    tx =>
+      getTxType(tx).endsWith("_OUT") &&
+      lastProcessedBlock - tx.blockHeight < ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS,
+  );
 }
 
 /** Total balance shown to the user = transparent + private. */

--- a/libs/coin-modules/coin-zcash/src/logic/account/balance.unit.test.ts
+++ b/libs/coin-modules/coin-zcash/src/logic/account/balance.unit.test.ts
@@ -1,5 +1,12 @@
 import { BigNumber } from "bignumber.js";
-import { computeZcashBalance, getPrivateBalance, getTransparentBalance } from "./balance";
+import {
+  computeZcashBalance,
+  getPrivateBalance,
+  getTransparentBalance,
+  hasRecentlyShieldedFunds,
+} from "./balance";
+import type { ShieldedTransaction } from "../../network/types";
+import { ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS } from "../../constants";
 
 describe("getTransparentBalance", () => {
   it("returns 0 when there are no utxos", () => {
@@ -68,5 +75,85 @@ describe("computeZcashBalance", () => {
       ironwoodBalance: new BigNumber(0),
     };
     expect(computeZcashBalance(new BigNumber(10000), privateInfo)).toEqual(new BigNumber(10000));
+  });
+});
+
+describe("hasRecentlyShieldedFunds", () => {
+  const TIP = 1_000_000; // fixed latest scanned block height
+
+  // An outgoing shielded transaction: a net-negative Ironwood delta.
+  const outgoingTx = (blockHeight: number) =>
+    ({
+      blockHeight,
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "outgoing" }],
+      },
+    }) as unknown as ShieldedTransaction;
+
+  // An incoming shielded transaction: a net-positive Ironwood delta.
+  const incomingTx = (blockHeight: number) =>
+    ({
+      blockHeight,
+      decryptedData: {
+        orchard_outputs: [],
+        sapling_outputs: [],
+        ironwood_outputs: [{ amount: new BigNumber(5000), memo: "", transfer_type: "incoming" }],
+      },
+    }) as unknown as ShieldedTransaction;
+
+  it("returns false when privateInfo is missing or empty", () => {
+    expect(hasRecentlyShieldedFunds(undefined)).toBe(false);
+    expect(hasRecentlyShieldedFunds(null)).toBe(false);
+    expect(hasRecentlyShieldedFunds({ transactions: [], lastProcessedBlock: TIP })).toBe(false);
+  });
+
+  it("returns false when the latest scanned block is unknown", () => {
+    expect(
+      hasRecentlyShieldedFunds({ transactions: [outgoingTx(TIP)], lastProcessedBlock: null }),
+    ).toBe(false);
+  });
+
+  it(`returns true when an outgoing shielded transaction is within the last ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS} blocks`, () => {
+    expect(
+      hasRecentlyShieldedFunds({
+        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS + 1)],
+        lastProcessedBlock: TIP,
+      }),
+    ).toBe(true);
+  });
+
+  it(`returns false when all outgoing shielded transactions have ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS}+ confirmations`, () => {
+    expect(
+      hasRecentlyShieldedFunds({
+        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS)],
+        lastProcessedBlock: TIP,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores recent incoming transactions", () => {
+    expect(
+      hasRecentlyShieldedFunds({ transactions: [incomingTx(TIP - 1)], lastProcessedBlock: TIP }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one of several transactions is a recent outgoing tx", () => {
+    expect(
+      hasRecentlyShieldedFunds({
+        transactions: [outgoingTx(TIP - 20), outgoingTx(TIP - 1)],
+        lastProcessedBlock: TIP,
+      }),
+    ).toBe(true);
+  });
+
+  it(`treats an outgoing transaction just under the ${ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS}-block delay as recent`, () => {
+    expect(
+      hasRecentlyShieldedFunds({
+        transactions: [outgoingTx(TIP - ZCASH_SHIELDED_SPENDABILITY_DELAY_BLOCKS + 1)],
+        lastProcessedBlock: TIP,
+      }),
+    ).toBe(true);
   });
 });

--- a/libs/coin-modules/coin-zcash/src/network/engine.test.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.test.ts
@@ -17,6 +17,7 @@ const mockBuildIronwoodTransaction = jest.fn();
 const mockFinalizeTransaction = jest.fn();
 const mockBroadcastTransaction = jest.fn();
 const mockOrchardAddressFromUfvk = jest.fn<Promise<string>, [string]>();
+const mockTransactionDetails = jest.fn();
 
 // Mutable module object so individual tests can delete a PCZT method to
 // exercise the `getPcztModule` capability guard. `__esModule: true` makes the
@@ -32,6 +33,7 @@ const mockNativeModule: Record<string, unknown> = {
   finalizeTransaction: (...args: unknown[]) => mockFinalizeTransaction(...args),
   broadcastTransaction: (...args: unknown[]) => mockBroadcastTransaction(...args),
   orchardAddressFromUfvk: (...args: unknown[]) => mockOrchardAddressFromUfvk(...(args as [string])),
+  transactionDetails: (...args: unknown[]) => mockTransactionDetails(...args),
 };
 
 jest.mock("@ledgerhq/zcash-utils", () => mockNativeModule);
@@ -89,6 +91,7 @@ import {
   buildIronwoodTransactionJob,
   finalizeTransactionJob,
   broadcastTransactionJob,
+  transactionDetailsJob,
   deriveShieldedAddress,
   type StartSyncJobArgs,
 } from "./engine";
@@ -96,6 +99,7 @@ import type {
   BuildTransactionArgs,
   BuildIronwoodTransactionArgs,
   FinalizeTransactionArgs,
+  TransactionDetailsRequest,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -888,6 +892,81 @@ describe("broadcastTransactionJob", () => {
   });
 });
 
+// ── transactionDetailsJob ──────────────────────────────────────────────
+
+describe("transactionDetailsJob", () => {
+  const requests: TransactionDetailsRequest[] = [
+    {
+      txid: "aa".repeat(32),
+      height: 2_000_000,
+      prevouts: [{ txid: "bb".repeat(32), index: 0, value: "100000" }],
+    },
+    {
+      txid: "cc".repeat(32),
+      height: 2_000_001,
+      prevouts: [],
+    },
+  ];
+
+  it("delegates to native.transactionDetails with grpcUrl, requests, network and ufvk", async () => {
+    mockTransactionDetails.mockResolvedValue([]);
+
+    await transactionDetailsJob("https://grpc.example.com", requests, "mainnet", "uview1test");
+
+    expect(mockTransactionDetails).toHaveBeenCalledWith(
+      "https://grpc.example.com",
+      requests,
+      "mainnet",
+      "uview1test",
+    );
+  });
+
+  it("forwards an undefined ufvk when none is provided", async () => {
+    mockTransactionDetails.mockResolvedValue([]);
+
+    await transactionDetailsJob("https://grpc.example.com", requests, "mainnet");
+
+    expect(mockTransactionDetails).toHaveBeenCalledWith(
+      "https://grpc.example.com",
+      requests,
+      "mainnet",
+      undefined,
+    );
+  });
+
+  it("keeps an established fee and coerces a missing fee to null", async () => {
+    // First result carries a priced fee; second could not be priced (undefined)
+    // -> must surface as an explicit null rather than masquerading as zero.
+    mockTransactionDetails.mockResolvedValue([
+      { txid: "aa".repeat(32), fee: "1000", payees: ["u1payee"] },
+      { txid: "cc".repeat(32), fee: undefined, payees: [] },
+    ]);
+
+    const results = await transactionDetailsJob("url", requests, "mainnet", "uview1test");
+
+    expect(results).toEqual([
+      { txid: "aa".repeat(32), fee: "1000", payees: ["u1payee"] },
+      { txid: "cc".repeat(32), fee: null, payees: [] },
+    ]);
+  });
+
+  it("coerces a null fee to null", async () => {
+    mockTransactionDetails.mockResolvedValue([{ txid: "aa".repeat(32), fee: null, payees: [] }]);
+
+    const results = await transactionDetailsJob("url", requests, "mainnet");
+
+    expect(results[0].fee).toBeNull();
+  });
+
+  it("propagates errors from native.transactionDetails", async () => {
+    mockTransactionDetails.mockRejectedValue(new Error("gRPC unavailable"));
+
+    await expect(transactionDetailsJob("url", requests, "mainnet")).rejects.toThrow(
+      "gRPC unavailable",
+    );
+  });
+});
+
 describe("getPcztModule guard (via jobs)", () => {
   it("throws a descriptive error listing the missing PCZT method(s)", async () => {
     const original = mockNativeModule.finalizeTransaction;
@@ -945,6 +1024,39 @@ describe("mapNativeTx (Ironwood notes via startSyncJob)", () => {
     expect(iwOut.memo).toBe("iw-memo");
     expect(iwOut.transfer_type).toBe("incoming");
     expect(iwOut.nullifier).toBe("aa".repeat(32));
+  });
+
+  it("includes the recipient field on a shielded note when present", async () => {
+    mockGetChainTip.mockResolvedValue(200);
+    const tx = makeNativeTx({
+      orchardNotes: [
+        {
+          amount: 42_000n,
+          memo: "with-recipient",
+          transferType: "outgoing",
+          recipient: "ee".repeat(43),
+        },
+      ],
+      saplingNotes: [],
+    });
+    const stream = makeMockStream([tx]);
+    mockStartSync.mockResolvedValue(stream);
+
+    const onChunk = jest.fn();
+    await startSyncJob(
+      {
+        grpcUrl: "https://grpc.example.com",
+        network: "main",
+        viewingKey: "vk",
+        startBlockHeight: 100,
+        maxBatchSize: 500,
+      },
+      onChunk,
+      { isCancelled: () => false },
+    );
+
+    const orchardOut = onChunk.mock.calls[0][0].transactions[0].decryptedData.orchard_outputs[0];
+    expect(orchardOut.recipient).toBe("ee".repeat(43));
   });
 
   it("omits ironwood_outputs key when ironwoodNotes is absent or empty", async () => {

--- a/libs/coin-modules/coin-zcash/src/network/engine.ts
+++ b/libs/coin-modules/coin-zcash/src/network/engine.ts
@@ -259,6 +259,40 @@ export async function transactionDetailsJob(
 }
 
 /**
+ * Adds the nullifiers of incoming/internal notes to `target` so a later chunk
+ * can detect them as spent. Outgoing notes are skipped -- their nullifiers
+ * belong to the counterparty, not to us.
+ */
+function collectSpendableNullifiers(
+  notes: NativeTx["orchardNotes"] | undefined,
+  target: Set<string>,
+): void {
+  for (const note of notes ?? []) {
+    if (note.nullifier && note.transferType !== "outgoing") {
+      target.add(note.nullifier);
+    }
+  }
+}
+
+/**
+ * Maps a chunk's native transactions into `allTransactions` and grows
+ * `accumulatedNullifiers` with the Orchard/Ironwood notes discovered in them.
+ */
+function accumulateChunkTransactions(
+  transactions: NativeTx[],
+  allTransactions: ShieldedTransactionRaw[],
+  accumulatedNullifiers: Set<string>,
+): void {
+  for (const tx of transactions) {
+    allTransactions.push(mapNativeTx(tx));
+    // Collect nullifiers from incoming/internal notes discovered in this chunk
+    // so the next chunk can detect them as spent.
+    collectSpendableNullifiers(tx.orchardNotes, accumulatedNullifiers);
+    collectSpendableNullifiers(tx.ironwoodNotes, accumulatedNullifiers);
+  }
+}
+
+/**
  * Runs the shielded sync loop.
  *
  * Drives the native tonic gRPC stream in `maxBatchSize`-block chunks, emitting
@@ -349,21 +383,7 @@ export async function startSyncJob(
     }
 
     processedBlocks += blocksScanned;
-    for (const tx of transactions) {
-      allTransactions.push(mapNativeTx(tx));
-      // Collect nullifiers from incoming/internal Orchard and Ironwood notes
-      // discovered in this chunk so the next chunk can detect them as spent.
-      for (const note of tx.orchardNotes ?? []) {
-        if (note.nullifier && note.transferType !== "outgoing") {
-          accumulatedNullifiers.add(note.nullifier);
-        }
-      }
-      for (const note of tx.ironwoodNotes ?? []) {
-        if (note.nullifier && note.transferType !== "outgoing") {
-          accumulatedNullifiers.add(note.nullifier);
-        }
-      }
-    }
+    accumulateChunkTransactions(transactions, allTransactions, accumulatedNullifiers);
     allSpentKnownNullifiers.push(...spentKnownNullifiers);
 
     log(ZCASH_LOG_TYPE, "chunk done", {
@@ -384,8 +404,8 @@ export async function startSyncJob(
           txid: tx.txid,
           blockHeight: tx.blockHeight,
           fee: tx.fee,
-          orchardNotesCount: tx.orchardNotes?.length ?? 0,
-          saplingNotesCount: tx.saplingNotes?.length ?? 0,
+          orchardNotesCount: tx.orchardNotes.length,
+          saplingNotesCount: tx.saplingNotes.length,
           ironwoodNotesCount: tx.ironwoodNotes?.length ?? 0,
         })),
       );


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Show a warning in the send flow when the Zcash private balance is selected as source and funds were shielded in the last 15 minutes, explaining that recently shielded funds need confirmations and scanning before they are spendable

### 🔗 Context

- **JIRA / GitHub issue**: https://ledgerhq.atlassian.net/browse/LIVE-35612
