### PR TITLE
[LWDM] fix(coin-evm): zero gas limit and fee headroom (LIVE-32644, LIVE-32650)

### DIFF
--- a/.changeset/evm-gas-limit-and-base-fee-headroom.md
+++ b/.changeset/evm-gas-limit-and-base-fee-headroom.md
@@ -1,0 +1,10 @@
+---
+"@ledgerhq/coin-evm": patch
+"@shared/env": patch
+---
+
+Fix EVM transactions being signed with a zero gas limit, and widen the EIP-1559 max fee headroom.
+
+When gas estimation failed, its `BigNumber(0)` fallback travelled back to the sign step, where it was read as a deliberate custom gas limit. That disabled re-estimation and produced a transaction the node rejected with `intrinsic gas too low`. A non-positive gas limit is no longer honoured as a custom value, so the estimation runs again, and crafting now fails rather than sending a zero gas limit to the device (LIVE-32644).
+
+`EIP1559_BASE_FEE_MULTIPLIER` goes from 1.27 to 1.6, so an estimated transaction stays includable for 4 blocks instead of 2 (the base fee grows by at most 12.5% per block). Max fees displayed on chains using the Ledger gas tracker will be higher, but the amount actually paid is unchanged: EIP-1559 charges the base fee plus the priority fee, and the max fee is only a ceiling (LIVE-32650).

--- a/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
+++ b/libs/coin-modules/coin-evm/src/api/index.integ.test.ts
@@ -228,18 +228,23 @@ describe.each([
     });
 
     it("crafts a transaction with the USDC asset", async () => {
-      const { transaction: result } = await module.craftTransaction({
-        type: `send-${mode}`,
-        intentType: "transaction",
-        amount: 10n,
-        sender: "0x9bcd841436ef4f85dacefb1aec772af71619024e",
-        recipient: "0x7b2c7232f9e38f30e2868f0e5bf311cd83554b5a",
-        data: { type: "buffer", value: Buffer.from([]) },
-        asset: {
-          type: "erc20",
-          assetReference: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      const { transaction: result } = await module.craftTransaction(
+        {
+          type: `send-${mode}`,
+          intentType: "transaction",
+          amount: 10n,
+          sender: "0x9bcd841436ef4f85dacefb1aec772af71619024e",
+          recipient: "0x7b2c7232f9e38f30e2868f0e5bf311cd83554b5a",
+          data: { type: "buffer", value: Buffer.from([]) },
+          asset: {
+            type: "erc20",
+            assetReference: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+          },
         },
-      });
+        // The sender holds no USDC, so estimating this transfer reverts on-chain. Pin the gas
+        // limit so the test covers the crafted payload rather than a live token balance.
+        { value: 0n, parameters: { gasLimit: 60000n } },
+      );
 
       expect(result).toMatch(/^0x[A-Fa-f0-9]+$/);
       expect(ethers.Transaction.from(result)).toMatchObject({

--- a/libs/coin-modules/coin-evm/src/logic/common.ts
+++ b/libs/coin-modules/coin-evm/src/logic/common.ts
@@ -175,9 +175,14 @@ export async function prepareUnsignedTxParams(
       new BigNumber(1))
     : new BigNumber(1);
 
+  const customGasLimit =
+    typeof customFeesParameters?.gasLimit === "bigint" && customFeesParameters.gasLimit > 0n
+      ? customFeesParameters.gasLimit
+      : null;
+
   const gasLimit =
-    typeof customFeesParameters?.gasLimit === "bigint"
-      ? BigNumber(customFeesParameters.gasLimit.toString())
+    customGasLimit !== null
+      ? BigNumber(customGasLimit.toString())
       : (
           await estimateGas(
             currency,

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.test.ts
@@ -37,6 +37,53 @@ describe("craftTransaction", () => {
     );
   });
 
+  describe("zero gas limit", () => {
+    const intent = {
+      intentType: "transaction",
+      type: "send-legacy",
+      recipient: "0x7b2c7232f9e38f30e2868f0e5bf311cd83554b5a",
+      amount: 10n,
+      asset: { type: "native" },
+    } as TransactionIntent<MemoNotSupported, BufferTxData>;
+
+    beforeEach(() => {
+      setCoinConfig(() => ({ info: { node: { type: "external" } } }) as unknown as EvmCoinConfig);
+      externalMocks.getTransactionCount.mockResolvedValue(18);
+      externalMocks.getFeeData.mockResolvedValue({
+        gasPrice: new BigNumber(8),
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        nextBaseFee: null,
+      });
+    });
+
+    it("re-estimates instead of trusting a zero gas limit coming back from a failed estimation", async () => {
+      externalMocks.getGasEstimation.mockResolvedValue(new BigNumber(2300));
+
+      const { transaction } = await craftTransaction(
+        { ethereumLikeInfo: { chainId: 42 } } as CryptoCurrency,
+        {
+          transactionIntent: intent,
+          customFees: { value: 0n, parameters: { gasPrice: 8n, gasLimit: 0n } },
+        },
+      );
+
+      expect(externalMocks.getGasEstimation).toHaveBeenCalled();
+      expect(ethers.Transaction.from(transaction).gasLimit).toBe(2300n);
+    });
+
+    it("refuses to craft a transaction when the gas estimation yields zero", async () => {
+      externalMocks.getGasEstimation.mockRejectedValue(new Error("node is down"));
+
+      await expect(
+        craftTransaction({ ethereumLikeInfo: { chainId: 42 } } as CryptoCurrency, {
+          transactionIntent: intent,
+          customFees: { value: 0n, parameters: { gasPrice: 8n } },
+        }),
+      ).rejects.toThrow("GasEstimationError");
+    });
+  });
+
   describe.each([
     [
       "legacy",

--- a/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
+++ b/libs/coin-modules/coin-evm/src/logic/craftTransaction.ts
@@ -8,6 +8,7 @@ import {
 } from "@ledgerhq/coin-module-framework/api/types";
 import { CryptoCurrency } from "@ledgerhq/ledger-wallet-framework/types";
 import { Transaction, TransactionLike } from "ethers";
+import { GasEstimationError } from "../errors";
 import { getNodeApi } from "../network/node";
 import { TransactionTypes } from "../types";
 import { prepareUnsignedTxParams } from "./common";
@@ -29,9 +30,14 @@ export async function craftTransaction(
     customFees?.parameters,
   );
 
-  // Some apps including, including Magic Eden, set the nonce to -1
+  // Never send a failed estimation to the device: the node rejects it as "intrinsic gas too low".
+  if (gasLimit.lte(0)) {
+    throw new GasEstimationError();
+  }
+
+  // Some apps, including Magic Eden, set the nonce to -1
   // instead of simply not providing it.
-  // In case of missing or nagative nonce, it must be re-computed.
+  // In case of missing or negative nonce, it must be re-computed.
   const nonce =
     typeof transactionIntent.sequence === "bigint" && transactionIntent.sequence >= 0n
       ? transactionIntent.sequence

--- a/shared/env/src/definitions/team-coin-integration/index.ts
+++ b/shared/env/src/definitions/team-coin-integration/index.ts
@@ -178,7 +178,7 @@ const teamCoinIntegration = {
     desc: "minimum priority fee percents allowed compared to network conditions allowed when EIP1559_MINIMUM_FEES_GATE is activated",
   },
   EIP1559_BASE_FEE_MULTIPLIER: {
-    def: 1.27,
+    def: 1.6,
     parser: floatParser,
     desc: "multiplier for the base fee that is composing the maxFeePerGas property",
   },


### PR DESCRIPTION
### 📝 Description

Two independent EVM fixes, one per commit.

**Zero gas limit (LIVE-32644)**

When gas estimation failed, its `BigNumber(0)` fallback was written onto the transaction and read back at sign time by `prepareUnsignedTxParams`, whose check was `typeof gasLimit === "bigint"`. Since `0n` is a bigint, it was taken for a deliberate custom gas limit: re-estimation was skipped and the transaction was signed with `gasLimit: 0`, which the node rejects with `intrinsic gas too low`. A Datadog payload confirms it (mainnet USDT transfer, `lld/4.15.0`, fees estimated correctly, `gasLimit: 0`).

Only a positive gas limit is honoured as a custom value now, and `craftTransaction` refuses to craft a non-positive one — `signSwapEvm` and `signApprovalEvm` call it directly without going through `validateIntent`, so that guard is their only gate.

Beyond blocking the invalid transaction, a transient failure is now retried on each validation cycle instead of being frozen: the zero used to stick to the transaction and disable re-estimation for good.

The `BigNumber(0)` fallback itself is kept — it is what lets `validateIntent` raise `FeeNotLoaded` and block the flow.

**Max fee headroom (LIVE-32650)**

`EIP1559_BASE_FEE_MULTIPLIER` goes from 1.27 to 1.6. The base fee grows by at most 12.5% per block, so 1.27 only covered ~2 blocks (~24s), less than a device signing round trip, while the RPC path already used 2.

The amount paid is unchanged (the network charges base fee + priority fee, the max fee is a ceiling), but `validateIntent` compares `maxFeePerGas × gasLimit` to the balance, so the balance required to send goes up: at 30 gwei / 21000 gas, 0.000821 → 0.001029 ETH. Users between those two values will now hit `NotEnoughGas`.

Unlike the first fix, this one has no Datadog occurrence backing it, hence the separate commit.

**Regression tests** — `craftTransaction.test.ts`: a zero gas limit passed as a custom fee triggers a real estimation, and crafting is refused when the estimation yields zero.

<img width="537" height="541" alt="Screenshot 2026-08-12 at 13 55 30" src="https://github.com/user-attachments/assets/3e3d4c83-dc91-4f74-85db-8d26718d10b2" />

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-32644](https://ledgerhq.atlassian.net/browse/LIVE-32644), [LIVE-32650](https://ledgerhq.atlassian.net/browse/LIVE-32650)

[LIVE-32644]: https://ledgerhq.atlassian.net/browse/LIVE-32644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ