### PR TITLE
ci(knip): disable github-actions plugin in root workspace

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,7 @@
     "unresolved": "off"
   },
   "ignoreExportsUsedInFile": true,
+  "github-actions": false,
   "project": ["src/**"],
   "ignore": [
     "**/__integrations__/*",


### PR DESCRIPTION
The github-actions plugin auto-enables whenever .github/workflows/*.yml exists in the cwd. With -W <package>, the root workspace is always included as an ancestor, so the plugin fires for all 72 unimported targets. A YAML syntax error in any workflow file (e.g. duplicate mapping keys) causes js-yaml to throw a fatal LoaderError, cascading into 72 unrelated package dead-code check failures.

Disabling the plugin has zero functional impact: binaries, devDependencies, unlisted, and unresolved are all off in the rules config, and the root project is src/** with no src/ at repo root.

Test run: https://github.com/LedgerHQ/ledger-live/actions/runs/31594068277