### PR TITLE
[LWD] fix(receive): guard confirm address against concurrent calls

### DIFF
--- a/.changeset/receive-confirm-address-in-flight-guard.md
+++ b/.changeset/receive-confirm-address-in-flight-guard.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Fix the receive flow reporting a verification error (visible on Polkadot) while the address confirmation succeeded on the device: re-renders no longer start a concurrent `confirmAddress` call, and a late result can no longer overwrite a successful verification.

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/index.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/index.tsx
@@ -74,27 +74,34 @@ const ReceiveModal = (props: GlobalModalData["MODAL_RECEIVE"]) => {
     setState(prevState => ({ ...prevState, stepId: newStepId }));
   }, []);
 
-  const setIsAddressVerified = (newIsAddressVerified: State["isAddressVerified"]) => {
+  const setIsAddressVerified = useCallback((newIsAddressVerified: State["isAddressVerified"]) => {
     setState(prevState => ({ ...prevState, isAddressVerified: newIsAddressVerified }));
-  };
+  }, []);
 
-  const setVerifyAddressError = (newVerifyAddressError: State["verifyAddressError"]) => {
-    setState(prevState => ({ ...prevState, verifyAddressError: newVerifyAddressError }));
-  };
+  const setVerifyAddressError = useCallback(
+    (newVerifyAddressError: State["verifyAddressError"]) => {
+      setState(prevState => ({ ...prevState, verifyAddressError: newVerifyAddressError }));
+    },
+    [],
+  );
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     setStepId(initialState.stepId);
     setIsAddressVerified(initialState.isAddressVerified);
     setVerifyAddressError(initialState.verifyAddressError);
-  };
+  }, [initialState, setStepId, setIsAddressVerified, setVerifyAddressError]);
 
-  const handleChangeAddressVerified = (isAddressVerified?: boolean | null, err?: Error | null) => {
-    if (err && err.name !== "UserRefusedAddress") {
-      logger.critical(err);
-    }
-    setIsAddressVerified(isAddressVerified);
-    setVerifyAddressError(err);
-  };
+  // kept stable: a new identity on every render re-triggers the address verification
+  const handleChangeAddressVerified = useCallback(
+    (isAddressVerified?: boolean | null, err?: Error | null) => {
+      if (err && err.name !== "UserRefusedAddress") {
+        logger.critical(err);
+      }
+      setIsAddressVerified(isAddressVerified);
+      setVerifyAddressError(err);
+    },
+    [setIsAddressVerified, setVerifyAddressError],
+  );
 
   // Making sure at least one account exists, if not, redirecting to the add account modal
   const accounts = useSelector(accountsSelector);

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { Subject } from "rxjs";
+import { render, waitFor, act } from "tests/testSetup";
+import { genAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
+import { Device } from "@ledgerhq/live-common/hw/actions/types";
+import StepReceiveFunds from "./StepReceiveFunds";
+import { StepProps } from "../Body";
+
+jest.mock("@ledgerhq/live-common/bridge/index", () => ({
+  getAccountBridge: jest.fn(),
+}));
+
+// Avoid the families registry lazy-loading (and suspending) real coin UIs.
+jest.mock("~/renderer/families", () => ({
+  useLLDCoinFamily: () => ({}),
+}));
+
+const mockedGetAccountBridge = jest.mocked(getAccountBridge);
+
+const account = genAccount("step-receive-funds-account", { currency: undefined });
+
+const makeDevice = (): Device =>
+  ({
+    deviceId: "device-1",
+    modelId: "nanoX",
+    wired: false,
+  }) as Device;
+
+const makeProps = (overrides: Partial<StepProps>): StepProps =>
+  ({
+    t: ((k: string) => k) as unknown as StepProps["t"],
+    transitionTo: jest.fn(),
+    device: makeDevice(),
+    account,
+    parentAccount: null,
+    token: null,
+    receiveTokenMode: false,
+    closeModal: jest.fn(),
+    isAddressVerified: null,
+    verifyAddressError: null,
+    onRetry: jest.fn(),
+    onSkipConfirm: jest.fn(),
+    onResetSkip: jest.fn(),
+    onChangeToken: jest.fn(),
+    onChangeAccount: jest.fn(),
+    onChangeAddressVerified: jest.fn(),
+    onClose: jest.fn(),
+    currencyName: account.currency.name,
+    ...overrides,
+  }) as StepProps;
+
+describe("StepReceiveFunds auto-trigger regression", () => {
+  let receiveSubject: Subject<unknown>;
+  let receive: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    receiveSubject = new Subject();
+    receive = jest.fn(() => receiveSubject);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    mockedGetAccountBridge.mockReturnValue({ receive } as unknown as ReturnType<
+      typeof getAccountBridge
+    >);
+  });
+
+  it("should call bridge.receive only once when re-rendered with new callback/device identities while verification is pending", async () => {
+    const { rerender } = render(<StepReceiveFunds {...makeProps({})} />);
+
+    await waitFor(() => expect(receive).toHaveBeenCalledTimes(1));
+
+    for (let i = 0; i < 3; i++) {
+      rerender(
+        <StepReceiveFunds
+          {...makeProps({
+            onChangeAddressVerified: jest.fn(),
+            device: makeDevice(),
+          })}
+        />,
+      );
+      // let any pending effect/promise chain flush
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(receive).toHaveBeenCalledTimes(1);
+  });
+
+  it("should report success exactly once when the verification completes", async () => {
+    const onChangeAddressVerified = jest.fn();
+    render(<StepReceiveFunds {...makeProps({ onChangeAddressVerified })} />);
+
+    await waitFor(() => expect(receive).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      receiveSubject.next({ address: account.freshAddress });
+      receiveSubject.complete();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(onChangeAddressVerified).toHaveBeenCalledWith(true));
+    expect(onChangeAddressVerified).not.toHaveBeenCalledWith(false, expect.anything());
+    expect(onChangeAddressVerified).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
+++ b/apps/ledger-live-desktop/src/renderer/modals/Receive/steps/StepReceiveFunds.tsx
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect, useCallback, useRef, useState } from "react";
 import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
 import { getAccountBridge } from "@ledgerhq/live-common/bridge/index";
 import { getMainAccount } from "@ledgerhq/live-common/account/index";
@@ -215,13 +215,18 @@ const StepReceiveFunds = (props: StepProps) => {
   const [modalVisible, setModalVisible] = useState(false);
   const hideQRCodeModal = useCallback(() => setModalVisible(false), [setModalVisible]);
   const showQRCodeModal = useCallback(() => setModalVisible(true), [setModalVisible]);
+  // `isAddressVerified` stays `null` for the whole device confirmation, so without this latch a
+  // re-render would start a concurrent verification and break the ongoing one.
+  const isConfirmingRef = useRef(false);
+
   const confirmAddress = useCallback(async () => {
+    if (isConfirmingRef.current) return;
+    isConfirmingRef.current = true;
     try {
       if (getEnv("MOCK")) {
-        setTimeout(() => {
-          onChangeAddressVerified(true);
-          transitionTo("receive");
-        }, 3000);
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        onChangeAddressVerified(true);
+        transitionTo("receive");
       } else {
         if (!device) {
           throw new DisconnectedDevice();
@@ -240,6 +245,8 @@ const StepReceiveFunds = (props: StepProps) => {
     } catch (err) {
       onChangeAddressVerified(false, err as Error);
       hideQRCodeModal();
+    } finally {
+      isConfirmingRef.current = false;
     }
   }, [device, mainAccount, transitionTo, onChangeAddressVerified, hideQRCodeModal]);
 


### PR DESCRIPTION
### 📝 Description

**Previous behaviour**: on the receive flow, an address verification error was displayed even though the confirmation on the device completed normally. Reproduced consistently on Polkadot.

**Root cause**: in `StepReceiveFunds.tsx`, the auto-trigger effect

```ts
useEffect(() => {
  if (isAddressVerified === null) confirmAddress();
}, [specific?.useCustomConfirmAddress, isAddressVerified, confirmAddress]);
```

depends on `confirmAddress`, which is recreated on every render (its deps include `device`, `mainAccount` and `onChangeAddressVerified` — the latter being a non-memoized function in `modals/Receive/index.tsx`). Since `isAddressVerified` stays `null` for the whole duration of the device confirmation, every re-render started a **concurrent** `bridge.receive(..., { verify: true })` call. `withDevice` does not serialize device access, so the second call tore down the in-flight APDU exchange, and its `catch` overwrote the success with an error. Polkadot was the loudest reporter because its address confirmation is a long, multi-screen device flow.

**Fix**:

- `steps/StepReceiveFunds.tsx`: an `isConfirmingRef` latch makes `confirmAddress` return early when a verification is already running, and releases it in a `finally`.
- `modals/Receive/index.tsx`: `handleChangeAddressVerified`, `setIsAddressVerified`, `setVerifyAddressError` and `handleReset` are now `useCallback`-stable, removing the main source of re-triggering.

**Regression check**: `StepReceiveFunds.test.tsx` asserts that `bridge.receive` is called only once despite repeated re-renders with fresh callback/device identities while the verification is pending, and that a completed verification reports success exactly once. Removing the latch makes the first test fail with 4 calls instead of 1.

**Known related issue, out of scope**: `families/concordium/StepReceiveFunds/index.tsx` duplicates the same unguarded effect and has the same bug.

### 🧪 QA focus

- Receive on a Polkadot account with a real device: confirm the address → no error.
- User rejection on the device (`UserRefusedAddress`) → error screen + retry still work.
- Non-regression on the other receive paths (BTC/EVM, token accounts, staking step after receive).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35825](https://ledgerhq.atlassian.net/browse/LIVE-35825)
- Reported on Slack: https://ledger.slack.com/archives/C02KVKX8GCF/p1786524984729949

[LIVE-35825]: https://ledgerhq.atlassian.net/browse/LIVE-35825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ