### PR TITLE
[LWM] fix(mobile): reopen cancelled contact address edit (LIVE-35789)

### DIFF
--- a/.changeset/fix-mobile-contacts-reopen-address-edit.md
+++ b/.changeset/fix-mobile-contacts-reopen-address-edit.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed reopening an address after cancelling its edit drawer in Contacts.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -12,10 +12,6 @@ jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
   useOpenSendFlow: () => ({ handleOpenSendFlow: jest.fn() }),
 }));
 
-jest.mock("~/context/Locale", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
 function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
   const store = configureStore({
     reducer: { contacts: contactsSlice.reducer },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -1,0 +1,78 @@
+import React, { type ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { act, renderHook } from "@testing-library/react-native";
+import { Provider } from "react-redux";
+import { contactsSlice } from "@domain/entity-contact";
+import { mockContactWithAddress, mockMeContact } from "@domain/entity-contact/schema.mock";
+import { getCryptoCurrencyById } from "@domain/entity-currency-crypto";
+import { useContactAddressDetailDialog, usePopulatedContactDetail } from "@features/flow-contacts";
+import { useContactAddressDetailActionsAdapter } from "./useContactAddressDetailActionsAdapter";
+
+jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
+  useOpenSendFlow: () => ({ handleOpenSendFlow: jest.fn() }),
+}));
+
+jest.mock("~/context/Locale", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
+  const store = configureStore({
+    reducer: { contacts: contactsSlice.reducer },
+    preloadedState: { contacts: { contacts } },
+  });
+
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+describe("useContactAddressDetailActionsAdapter", () => {
+  it("should reopen the same address after cancelling the rename drawer", () => {
+    const contact = mockContactWithAddress();
+    const address = contact.addresses[0]!;
+    const Wrapper = makeWrapper([mockMeContact(), contact]);
+    const { result } = renderHook(
+      () => {
+        const populatedContactDetail = usePopulatedContactDetail(contact.id, {
+          resolveNetworkId: () => getCryptoCurrencyById("ethereum").id,
+        });
+        const addressDetail = useContactAddressDetailDialog(populatedContactDetail);
+        const actions = useContactAddressDetailActionsAdapter(
+          contact.id,
+          addressDetail.selection?.row.addressId,
+          addressDetail.onClose,
+        );
+
+        return { addressDetail, actions };
+      },
+      { wrapper: Wrapper },
+    );
+
+    act(() => {
+      result.current.addressDetail.onAddressRowPress({
+        type: "open-address-detail",
+        contactId: contact.id,
+        addressId: address.id,
+      });
+    });
+
+    expect(result.current.addressDetail.isOpen).toBe(true);
+
+    act(() => {
+      result.current.actions.renameSheet.onClose();
+    });
+
+    expect(result.current.addressDetail.isOpen).toBe(false);
+
+    act(() => {
+      result.current.addressDetail.onAddressRowPress({
+        type: "open-address-detail",
+        contactId: contact.id,
+        addressId: address.id,
+      });
+    });
+
+    expect(result.current.addressDetail.isOpen).toBe(true);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -76,12 +76,25 @@ export function useContactAddressDetailActionsAdapter(
     onSend,
     onCloseAddressDetail,
   });
+  const { onClose: closeRenameViewModel } = renameViewModel;
+  const onCloseRename = useCallback(() => {
+    closeRenameViewModel();
+    onCloseAddressDetail();
+  }, [closeRenameViewModel, onCloseAddressDetail]);
 
   if (!isSelectionActive) {
     return mapUiStateToFlowProps(createInactiveContactAddressDetailActionsUiState(labels));
   }
 
-  return mapUiStateToFlowProps(
+  const uiState = mapUiStateToFlowProps(
     createActiveContactAddressDetailActionsUiState(flow, renameViewModel, labels),
   );
+
+  return {
+    ...uiState,
+    renameSheet: {
+      ...uiState.renameSheet,
+      onClose: onCloseRename,
+    },
+  };
 }


### PR DESCRIPTION
### ✅ Checklist

- [x] Changeset attached.
- [x] **Covered by automatic tests.** A Mobile regression test cancels the rename drawer and reopens the same address.
- [x] **Impact of the changes:**
      Contacts address editing can be reopened after cancellation on Mobile.

### 📝 Description

Cancelling an address rename drawer on Mobile left the previous address selection active while its detail sheet had already been dismissed. Pressing the same address again therefore did not trigger a new state change.

The Mobile Contacts adapter now clears the address detail when the rename drawer closes. The same list item can then reopen normally.

https://github.com/user-attachments/assets/1bbb5cbd-64d7-4cfe-9f63-0e94e57a8ddc


### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35789

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)