### PR TITLE
fix(mobile): keep add address actions above keyboard (LIVE-35828)

### DIFF
--- a/.changeset/bright-addresses-rise.md
+++ b/.changeset/bright-addresses-rise.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Keep mobile Add Address actions anchored above the keyboard

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.test.tsx
@@ -64,6 +64,28 @@ describe("ContactsAddAddressName", () => {
     expect(onContinue).toHaveBeenCalledTimes(1);
   });
 
+  it("should keep the continuation above the keyboard inset", () => {
+    render(
+      <ContactsAddAddressName
+        addressLabel={{
+          status: "valid",
+          value: "Ethereum",
+          label: ContactAddressLabelSchema.parse("Ethereum"),
+          validationError: null,
+        }}
+        labels={labels}
+        bottomOffset={320}
+        onChangeText={jest.fn()}
+        onContinue={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-address-name-screen")).toHaveStyle({
+      bottom: 0,
+      paddingBottom: 352,
+    });
+  });
+
   it.each([
     {
       name: "invalid characters",

--- a/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/AddressName/ContactsAddAddressName.native.tsx
@@ -26,7 +26,7 @@ export function ContactsAddAddressName({
   return (
     <BottomSheetView
       testID="contacts-add-address-name-screen"
-      style={{ bottom: bottomOffset, paddingBottom: 32 }}
+      style={{ bottom: 0, paddingBottom: 32 + bottomOffset }}
     >
       <BottomSheetHeader density="expanded" title={labels.title} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntry.native.test.tsx
@@ -74,7 +74,7 @@ describe("ContactsAddAddressEntry", () => {
     expect(onChangeText).toHaveBeenCalledWith("0", "manual");
   });
 
-  it("should keep the confirmation above the keyboard offset", () => {
+  it("should keep the confirmation above the keyboard inset", () => {
     renderEntry(
       {
         status: "empty",
@@ -86,8 +86,8 @@ describe("ContactsAddAddressEntry", () => {
     );
 
     expect(screen.getByTestId("contacts-add-address-entry-screen")).toHaveStyle({
-      bottom: 320,
-      paddingBottom: 32,
+      bottom: 0,
+      paddingBottom: 352,
     });
   });
 

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.native.tsx
@@ -27,7 +27,7 @@ export function ContactsAddAddressEntryView({
   return (
     <BottomSheetView
       testID="contacts-add-address-entry-screen"
-      style={{ bottom: bottomOffset, paddingBottom: bottomPadding }}
+      style={{ bottom: 0, paddingBottom: bottomPadding + bottomOffset }}
     >
       <BottomSheetHeader density="expanded" title={labels.title} />
       <Box style={{ flex: 1 }} lx={{ justifyContent: "space-between", gap: "s16" }}>


### PR DESCRIPTION
### 📝 Description

#### Previous behaviour

The Confirm address and Continue actions could be partially obscured by the keyboard in the Mobile Add Address flow.

#### Fix

Reserve the keyboard inset in the content padding for both address steps instead of translating the content with an absolute bottom offset. This keeps the fixed drawer stable and the primary action above the keyboard.

<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-08-12 at 15 59 28" src="https://github.com/user-attachments/assets/3eda15ec-0f2c-43d9-9cd0-d6a47e931b1d" />
<img width="350" height="750" alt="Simulator Screenshot - iOS Simulator - 2026-08-12 at 15 59 44" src="https://github.com/user-attachments/assets/65b796f9-7b72-4e23-9a4e-4468a7cd1470" />
<img width="434" height="888" alt="image" src="https://github.com/user-attachments/assets/a14f7f2d-ea1f-45e9-a7da-63b4886bb36d" />

#### Regression coverage

Added native component tests covering the address and address-name primary actions with a keyboard inset.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35828](https://ledgerhq.atlassian.net/browse/LIVE-35828)
- **ADR** (if any): N/A


[LIVE-35828]: https://ledgerhq.atlassian.net/browse/LIVE-35828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ