### PR TITLE
[LWDM] feat(lwdm): add the contact avatar component in the new send flow

### DIFF
--- a/.changeset/angry-tips-cheer.md
+++ b/.changeset/angry-tips-cheer.md
@@ -1,0 +1,6 @@
+---
+"ledger-live-desktop": minor
+"live-mobile": minor
+---
+
+feat(lwdm): add the contact avatar component in the new send flow

--- a/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -1,3 +1,5 @@
+import { ContactIdSchema } from "@domain/entity-contact";
+import { ContactAvatar } from "@features/platform-contacts";
 import type { MatchedContact } from "@ledgerhq/live-common/flows/send/recipient/types";
 import {
   Button,
@@ -28,16 +30,6 @@ type RecipientCardProps = Readonly<{
   onSend: () => void;
   onAddContact: () => void;
 }>;
-
-function getContactInitials(name: string): string {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map(part => part[0])
-    .join("")
-    .toUpperCase();
-}
 
 export function RecipientCard({
   recipient,
@@ -70,12 +62,13 @@ export function RecipientCard({
       <CardHeader className={showActions ? undefined : "pb-16"}>
         <CardLeading>
           {contact ? (
-            <div
-              className="body-1-semi-bold flex size-48 shrink-0 items-center justify-center rounded-full bg-accent text-on-accent"
-              aria-hidden
-            >
-              {getContactInitials(contact.contactName)}
-            </div>
+            <ContactAvatar
+              contactId={ContactIdSchema.parse(contact.contactId)}
+              name={contact.contactName}
+              size="md"
+              ariaHidden
+              testId="send-recipient-card-avatar"
+            />
           ) : (
             <Spot appearance="icon" icon={Wallet} />
           )}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/constants.ts
@@ -35,7 +35,7 @@ export const SEND_STEP_CONFIGS: Record<SendFlowStep, SendStepConfig> = {
       title: "",
     },
   },
-  // Desktop only for now (absent from SEND_FLOW_STEP_ORDER). Kept to satisfy the
+  // Not registered yet (absent from SEND_FLOW_STEP_ORDER). Kept to satisfy the
   // Record<SendFlowStep, SendStepConfig> contract.
   [SEND_FLOW_STEP.ADD_CONTACT]: {
     id: SEND_FLOW_STEP.ADD_CONTACT,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/AddressMatchedSection.tsx
@@ -1,7 +1,3 @@
-import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
-import { getRecipientMatchPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientMatchPresentation";
-import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
-import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
 import {
   Banner,
   BottomSheet,
@@ -15,156 +11,91 @@ import {
   Text,
   useBottomSheetRef,
 } from "@ledgerhq/lumen-ui-rnative";
-import { useFeature } from "@features/platform-feature-flags";
 import React, { useCallback } from "react";
 import { Keyboard } from "react-native";
 import { useTranslation } from "~/context/Locale";
+import type { AddressMatchedSectionViewModel } from "../hooks/useAddressMatchedSectionViewModel";
 import { AccountRowWithBalance } from "./AccountRowWithBalance";
 import { AddressListItem } from "./AddressListItem";
-import { useFormatRelativeDate } from "../hooks/useFormatRelativeDate";
+import { RecipientCard } from "./RecipientCard";
 
 type AddressMatchedSectionProps = Readonly<{
-  searchResult: AddressSearchResult;
-  searchValue: string;
-  onSelect: (address: string, ensName?: string) => void;
-  isSanctioned?: boolean;
-  isAddressComplete?: boolean;
-  hasBridgeError?: boolean;
+  viewModel: AddressMatchedSectionViewModel;
 }>;
 
-export function AddressMatchedSection({
-  searchResult,
-  searchValue,
-  onSelect,
-  isSanctioned = false,
-  isAddressComplete = false,
-  hasBridgeError = false,
-}: AddressMatchedSectionProps) {
+export function AddressMatchedSection({ viewModel }: AddressMatchedSectionProps) {
   const { t } = useTranslation();
-  const formatRelativeDate = useFormatRelativeDate();
-  const isFirstInteractionBannerEnabled =
-    useFeature("newSendFlowFirstInteractionBanner")?.enabled ?? false;
   const helpSheetRef = useBottomSheetRef();
   const openHelpSheet = useCallback(() => {
     Keyboard.dismiss();
     helpSheetRef.current?.present();
   }, [helpSheetRef]);
 
-  const presentation = getRecipientMatchPresentation({
-    searchResult,
-    searchValue,
-    isSanctioned,
-    isAddressComplete,
-    hasBridgeError,
-  });
-
-  if (!presentation) {
+  if (!viewModel.isVisible || !viewModel.suggestion) {
     return null;
   }
 
-  const formattedAddress = formatAddress(
-    presentation.kind === "recipient-card" ? presentation.recipientAddress : presentation.address,
-    SEND_ADDRESS_FORMAT_OPTIONS,
-  );
+  const { suggestion } = viewModel;
 
   return (
     <Box lx={{ flexDirection: "column" }}>
-      <Subheader lx={{ marginBottom: "s12", marginHorizontal: "s8" }}>
-        <SubheaderRow>
-          <SubheaderTitle>{t("send.newSendFlow.addressMatched")}</SubheaderTitle>
-        </SubheaderRow>
-      </Subheader>
+      {viewModel.showHeader && (
+        <Subheader lx={{ marginBottom: "s12", marginHorizontal: "s8" }}>
+          <SubheaderRow>
+            <SubheaderTitle>{viewModel.addressMatchedLabel}</SubheaderTitle>
+          </SubheaderRow>
+        </Subheader>
+      )}
       <Box lx={{ flexDirection: "column" }}>
-        {/* Show all matched Ledger accounts */}
-        {presentation.kind === "matched-ledger-account" &&
-          presentation.matchedAccounts.map(({ account }) => (
+        {suggestion.kind === "recipient-card" ? (
+          <RecipientCard
+            recipient={suggestion.recipient}
+            description={suggestion.description}
+            contact={suggestion.contact}
+            isReady={suggestion.isReady}
+            showActions={suggestion.showActions}
+            addContactLabel={suggestion.addContactLabel}
+            sendLabel={suggestion.sendLabel}
+            onSend={suggestion.onSend}
+          />
+        ) : suggestion.kind === "matched-ledger-accounts" ? (
+          suggestion.matchedAccounts.map(({ account }) => (
             <AccountRowWithBalance
               key={account.id}
               account={account}
-              onSelect={() => onSelect(account.freshAddress)}
+              onSelect={() => suggestion.onSelect(account.freshAddress)}
               showSendTo
-              disabled={presentation.isDisabled}
+              disabled={suggestion.isDisabled}
               testID="new-send-flow-address-confirm"
             />
-          ))}
-
-        {/* Show ENS result if available and no matched accounts */}
-        {presentation.kind === "matched-ens" && (
+          ))
+        ) : (
           <AddressListItem
-            address={presentation.address}
-            name={`${presentation.ensName} (${formattedAddress})`}
-            description={formattedAddress}
-            onSelect={() => onSelect(presentation.address, presentation.ensName)}
+            address={suggestion.address}
+            name={suggestion.name}
+            description={suggestion.description}
+            onSelect={suggestion.onSelect}
             showSendTo
-            disabled={presentation.isDisabled}
+            isLedgerAccount={suggestion.isLedgerAccount}
+            disabled={suggestion.disabled}
+            hideDescription={suggestion.hideDescription}
             testID="new-send-flow-address-confirm"
           />
         )}
-
-        {/* Show recent match if available and no matched accounts or ENS */}
-        {presentation.kind === "matched-recent-address" && (
-          <AddressListItem
-            address={presentation.matchedRecentAddress.address}
-            name={formatAddress(
-              presentation.matchedRecentAddress.address,
-              SEND_ADDRESS_FORMAT_OPTIONS,
-            )}
-            description={t("send.newSendFlow.alreadyUsed", {
-              date: formatRelativeDate(presentation.matchedRecentAddress.lastUsedAt),
-            })}
-            onSelect={() =>
-              onSelect(
-                presentation.matchedRecentAddress.address,
-                presentation.matchedRecentAddress.ensName,
-              )
+      </Box>
+      {viewModel.showFirstInteractionWarning && (
+        <Box lx={{ flexDirection: "column", marginVertical: "s16", marginHorizontal: "s8" }}>
+          <Banner
+            appearance="info"
+            description={t("send.newSendFlow.firstInteraction.description")}
+            primaryAction={
+              <Button appearance="gray" size="sm" onPress={openHelpSheet}>
+                {t("send.newSendFlow.firstInteraction.learnMore")}
+              </Button>
             }
-            showSendTo
-            disabled={presentation.isDisabled}
-            testID="new-send-flow-address-confirm"
           />
-        )}
-
-        {/* Show valid address without match (new address) */}
-        {presentation.kind === "valid-address" && (
-          <AddressListItem
-            address={presentation.address}
-            name={formattedAddress}
-            description={t("send.newSendFlow.notInRecentHistory")}
-            onSelect={() => onSelect(presentation.address)}
-            showSendTo
-            disabled={false}
-            testID="new-send-flow-address-confirm"
-          />
-        )}
-
-        {/* Show disabled address if sanctioned or has bridge error (even if no match) */}
-        {presentation.kind === "disabled-address" && (
-          <AddressListItem
-            address={presentation.address}
-            name={formattedAddress}
-            description={formattedAddress}
-            showSendTo
-            disabled={true}
-          />
-        )}
-      </Box>
-      <Box lx={{ flexDirection: "column", marginVertical: "s16", marginHorizontal: "s8" }}>
-        {isFirstInteractionBannerEnabled &&
-          searchResult.isFirstInteraction &&
-          !isSanctioned &&
-          !hasBridgeError &&
-          isAddressComplete && (
-            <Banner
-              appearance="info"
-              description={t("send.newSendFlow.firstInteraction.description")}
-              primaryAction={
-                <Button appearance="gray" size="sm" onPress={openHelpSheet}>
-                  {t("send.newSendFlow.firstInteraction.learnMore")}
-                </Button>
-              }
-            />
-          )}
-      </Box>
+        </Box>
+      )}
       <BottomSheet ref={helpSheetRef} enableDynamicSizing snapPoints={null}>
         <BottomSheetView>
           <BottomSheetHeader />

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientCard.tsx
@@ -1,0 +1,100 @@
+import { ContactIdSchema } from "@domain/entity-contact";
+import { ContactAvatar } from "@features/platform-contacts/native";
+import type { MatchedContact } from "@ledgerhq/live-common/flows/send/recipient/types";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  Spot,
+} from "@ledgerhq/lumen-ui-rnative";
+import { Wallet } from "@ledgerhq/lumen-ui-rnative/symbols";
+import React from "react";
+
+type RecipientCardProps = Readonly<{
+  recipient: string;
+  description?: string;
+  contact?: MatchedContact;
+  isReady: boolean;
+  showActions: boolean;
+  addContactLabel: string;
+  sendLabel: string;
+  onSend: () => void;
+}>;
+
+export function RecipientCard({
+  recipient,
+  description,
+  contact,
+  isReady,
+  showActions,
+  addContactLabel,
+  sendLabel,
+  onSend,
+}: RecipientCardProps) {
+  return (
+    <Card type="info" testID="send-recipient-card" lx={{ marginHorizontal: "s8" }}>
+      <CardHeader lx={showActions ? undefined : { paddingBottom: "s16" }}>
+        <CardLeading>
+          {contact ? (
+            <ContactAvatar
+              contactId={ContactIdSchema.parse(contact.contactId)}
+              name={contact.contactName}
+              size="md"
+              testID="send-recipient-card-avatar"
+            />
+          ) : (
+            <Spot appearance="icon" icon={Wallet} />
+          )}
+          <CardContent>
+            <CardContentTitle typography="body2SemiBold" numberOfLines={contact ? 1 : undefined}>
+              {contact?.contactName ?? recipient}
+            </CardContentTitle>
+            {(contact?.addressLabel ?? description) && (
+              <CardContentDescription typography="body3">
+                {contact?.addressLabel ?? description}
+              </CardContentDescription>
+            )}
+          </CardContent>
+        </CardLeading>
+      </CardHeader>
+
+      {showActions && (
+        <Box
+          lx={{
+            flexDirection: "row",
+            gap: "s8",
+            paddingHorizontal: "s16",
+            paddingBottom: "s16",
+          }}
+        >
+          {!contact && (
+            <Button
+              appearance="gray"
+              size="sm"
+              onPress={() => undefined}
+              testID="send-recipient-card-add-contact"
+              lx={{ flex: 1 }}
+            >
+              {addContactLabel}
+            </Button>
+          )}
+          <Button
+            appearance="base"
+            size="sm"
+            onPress={onSend}
+            disabled={!isReady}
+            testID="send-recipient-card-send"
+            lx={{ flex: 1 }}
+          >
+            {sendLabel}
+          </Button>
+        </Box>
+      )}
+    </Card>
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/RecipientScreenView.tsx
@@ -23,14 +23,12 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     showMatched,
     shouldShowErrorBanner,
     keyboardBehavior,
-    handleMatchedAddress,
+    addressMatchedSectionViewModel,
   } = viewModel;
   const {
     isLoading,
     showInitialState,
     showEmptyContactsState,
-    result,
-    searchValue,
     showBridgeSenderError,
     bridgeSenderError,
     showSanctionedBanner,
@@ -39,7 +37,6 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
     showAddressValidationError,
     bridgeRecipientError,
     bridgeRecipientWarning,
-    isAddressComplete,
     addressValidationErrorType,
     clipboardAddress,
     handlePasteFromClipboard,
@@ -65,16 +62,7 @@ export const RecipientScreenView = ({ viewModel }: RecipientScreenViewProps) => 
 
           {showMemo && <MemoControls vm={memo} />}
 
-          {showMatched && (
-            <AddressMatchedSection
-              searchResult={result}
-              searchValue={searchValue}
-              onSelect={handleMatchedAddress}
-              isSanctioned={showSanctionedBanner}
-              isAddressComplete={isAddressComplete}
-              hasBridgeError={showBridgeRecipientError}
-            />
-          )}
+          {showMatched && <AddressMatchedSection viewModel={addressMatchedSectionViewModel} />}
 
           {showAddressValidationError && (
             <AddressValidationError error={addressValidationErrorType} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/components/__tests__/AddressMatchedSection.test.tsx
@@ -1,7 +1,8 @@
 import type { AddressSearchResult } from "@ledgerhq/live-common/flows/send/recipient/types";
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
 import { AddressMatchedSection } from "../AddressMatchedSection";
+import { useAddressMatchedSectionViewModel } from "../../hooks/useAddressMatchedSectionViewModel";
 
 jest.mock("@features/platform-feature-flags", () => ({
   useFeature: () => ({ enabled: false }),
@@ -18,9 +19,18 @@ jest.mock("~/context/hooks", () => ({
   useSelector: () => "en",
 }));
 
+jest.mock("@features/platform-contacts/native", () => ({
+  ContactAvatar: ({ name, testID }: { name: string; testID?: string }) => {
+    const RN = jest.requireActual<typeof import("react-native")>("react-native");
+    return <RN.Text testID={testID}>{name}</RN.Text>;
+  },
+}));
+
 jest.mock("@ledgerhq/lumen-ui-rnative", () => {
   const RN = jest.requireActual<typeof import("react-native")>("react-native");
-  const Container = ({ children }: { children: React.ReactNode }) => <RN.View>{children}</RN.View>;
+  const Container = ({ children, testID }: { children?: React.ReactNode; testID?: string }) => (
+    <RN.View testID={testID}>{children}</RN.View>
+  );
   const Label = ({ children }: { children: React.ReactNode }) => <RN.Text>{children}</RN.Text>;
 
   return {
@@ -29,11 +39,27 @@ jest.mock("@ledgerhq/lumen-ui-rnative", () => {
     BottomSheetHeader: () => null,
     BottomSheetView: Container,
     Box: Container,
-    Button: ({ children, onPress }: { children: React.ReactNode; onPress: () => void }) => (
-      <RN.Pressable onPress={onPress}>
+    Button: ({
+      children,
+      onPress,
+      testID,
+      disabled,
+    }: {
+      children: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+      disabled?: boolean;
+    }) => (
+      <RN.Pressable onPress={onPress} testID={testID} disabled={disabled}>
         <RN.Text>{children}</RN.Text>
       </RN.Pressable>
     ),
+    Card: Container,
+    CardContent: Container,
+    CardContentDescription: Label,
+    CardContentTitle: Label,
+    CardHeader: Container,
+    CardLeading: Container,
     ListItem: ({
       children,
       onPress,
@@ -87,17 +113,75 @@ const searchResult: AddressSearchResult = {
   hasBridgeValidationResult: true,
 };
 
+function AddressMatchedSectionContainer({
+  result,
+  isContactsFeatureEnabled = false,
+  onSelect = jest.fn(),
+}: Readonly<{
+  result: AddressSearchResult;
+  isContactsFeatureEnabled?: boolean;
+  onSelect?: (address: string, ensName?: string) => void;
+}>) {
+  const viewModel = useAddressMatchedSectionViewModel({
+    searchResult: result,
+    searchValue: address,
+    onSelect,
+    isAddressComplete: true,
+    isContactsFeatureEnabled,
+  });
+
+  return <AddressMatchedSection viewModel={viewModel} />;
+}
+
 describe("AddressMatchedSection", () => {
   it("shows a valid unmatched address selected by the shared presentation", () => {
+    render(<AddressMatchedSectionContainer result={searchResult} />);
+
+    expect(screen.getByTestId("new-send-flow-address-confirm")).toBeVisible();
+  });
+
+  it("shows the recipient card with contact avatar when contacts are enabled", () => {
+    const onSelect = jest.fn();
     render(
-      <AddressMatchedSection
-        searchResult={searchResult}
-        searchValue={address}
-        onSelect={jest.fn()}
-        isAddressComplete
+      <AddressMatchedSectionContainer
+        result={{
+          ...searchResult,
+          status: "ens_resolved",
+          resolvedAddress: address,
+          ensName: "vitalik.eth",
+          matchedContact: {
+            contactId: "contact-remi",
+            contactName: "Remi",
+            addressId: "address-remi-ethereum",
+            addressLabel: "Ethereum Network",
+            address,
+          },
+        }}
+        isContactsFeatureEnabled
+        onSelect={onSelect}
       />,
     );
 
-    expect(screen.getByTestId("new-send-flow-address-confirm")).toBeVisible();
+    expect(screen.getByTestId("send-recipient-card")).toBeVisible();
+    expect(screen.getByTestId("send-recipient-card-avatar")).toHaveTextContent("Remi");
+
+    fireEvent.press(screen.getByTestId("send-recipient-card-send"));
+    expect(onSelect).toHaveBeenCalledWith(address, "vitalik.eth");
+  });
+
+  it("keeps add contact enabled as a no-op on the recipient card", () => {
+    render(
+      <AddressMatchedSectionContainer
+        result={{
+          ...searchResult,
+          status: "valid",
+          resolvedAddress: address,
+        }}
+        isContactsFeatureEnabled
+      />,
+    );
+
+    expect(screen.getByTestId("send-recipient-card-add-contact")).toBeEnabled();
+    expect(screen.getByTestId("send-recipient-card-send")).toBeEnabled();
   });
 });

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useAddressValidation.test.ts
@@ -10,8 +10,11 @@ import {
   getAccountCurrency,
 } from "@ledgerhq/live-common/account/index";
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
+import { findMatchedContact } from "@ledgerhq/live-common/flows/send/recipient/utils/findMatchedContact";
 import { genTokenAccount } from "@ledgerhq/ledger-wallet-framework/mocks/account";
+import { mockContact, mockContactAddress } from "@domain/entity-contact/schema.mock";
 import { useFormattedAccountBalance } from "LLM/hooks/useFormattedAccountBalance";
+import { accountsSelector } from "~/reducers/accounts";
 import { useMaybeAccountName, useBatchMaybeAccountName } from "~/reducers/wallet";
 import { sendFeatures } from "@ledgerhq/live-common/bridge/descriptor/send/features";
 import type { Transaction } from "@ledgerhq/live-common/generated/types";
@@ -23,6 +26,7 @@ jest.mock("@ledgerhq/domain-service/hooks/index");
 jest.mock("@ledgerhq/ledger-wallet-framework/sanction/index");
 jest.mock("@ledgerhq/live-common/account/index");
 jest.mock("@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation");
+jest.mock("@ledgerhq/live-common/flows/send/recipient/utils/findMatchedContact");
 jest.mock("LLM/hooks/useFormattedAccountBalance");
 jest.mock("@ledgerhq/live-common/bridge/descriptor/send/features");
 
@@ -33,6 +37,7 @@ const mockedGetRecentAddressesStore = jest.mocked(getRecentAddressesStore);
 const mockedGetMainAccount = jest.mocked(getMainAccount);
 const mockedGetAccountCurrency = jest.mocked(getAccountCurrency);
 const mockedUseBridgeRecipientValidation = jest.mocked(useBridgeRecipientValidation);
+const mockedFindMatchedContact = jest.mocked(findMatchedContact);
 const mockedUseFormattedAccountBalance = jest.mocked(useFormattedAccountBalance);
 const mockedUseMaybeAccountName = jest.mocked(useMaybeAccountName);
 const mockedUseBatchMaybeAccountName = jest.mocked(useBatchMaybeAccountName);
@@ -83,6 +88,7 @@ describe("useAddressValidation", () => {
     mockedUseMaybeAccountName.mockReturnValue("My Account");
     mockedUseBatchMaybeAccountName.mockReturnValue([]);
     mockedSendFeatures.getSelfTransferPolicy.mockReturnValue("impossible");
+    mockedFindMatchedContact.mockReturnValue(undefined);
   });
 
   it("returns idle status for empty search", () => {
@@ -287,6 +293,60 @@ describe("useAddressValidation", () => {
 
     expect(result.current.result.matchedRecentAddress).toBeDefined();
     expect(result.current.result.matchedRecentAddress?.address).toBe("recent_matching_address");
+  });
+
+  it("matches a saved contact by resolved address", () => {
+    const contactAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const remiContact = mockContact({
+      id: "contact-remi",
+      name: "Remi",
+      addresses: [
+        mockContactAddress({
+          id: "address-remi-ethereum",
+          currencyId: "ethereum",
+          label: "Ethereum Network",
+          address: contactAddress,
+        }),
+      ],
+    });
+    const matchedContact = {
+      contactId: "contact-remi",
+      contactName: "Remi",
+      addressId: "address-remi-ethereum",
+      addressLabel: "Ethereum Network",
+      address: contactAddress,
+    };
+
+    mockedUseSelector.mockImplementation(selector =>
+      selector === accountsSelector ? [mockEthereumAccount] : [remiContact],
+    );
+    mockedFindMatchedContact.mockReturnValue(matchedContact);
+
+    mockedUseDomain.mockReturnValue({
+      status: "loaded",
+      resolutions: [
+        { domain: "vitalik.eth", address: contactAddress, registry: "ens", type: "forward" },
+      ],
+      updatedAt: Date.now(),
+    });
+
+    const { result } = renderHook(() =>
+      useAddressValidation({
+        searchValue: "vitalik.eth",
+        currency: mockEthereumAccount.currency,
+        account: mockEthereumAccount,
+        recipientSupportsDomain: true,
+      }),
+    );
+
+    expect(result.current.result.matchedContact).toEqual(matchedContact);
+    expect(result.current.result.ensName).toBe("vitalik.eth");
+    expect(mockedFindMatchedContact).toHaveBeenCalledWith(
+      [remiContact],
+      "vitalik.eth",
+      "ethereum",
+      contactAddress,
+    );
   });
 
   it("excludes current account from matches when self-transfer is impossible", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/__tests__/useRecipientScreenContentViewModel.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react-native";
 import { track } from "~/analytics";
 import { useMemoViewModel } from "../../../../components/Memo/hooks/useMemoViewModel";
 import { useSendFlowData } from "../../../../context/SendFlowContext";
+import { useAddressMatchedSectionViewModel } from "../useAddressMatchedSectionViewModel";
 import { useRecipientScreenView } from "../useRecipientScreenView";
 import { createMockAccount } from "./accounts";
 import { useRecipientScreenContentViewModel } from "../useRecipientScreenContentViewModel";
@@ -10,6 +11,7 @@ jest.mock("~/analytics");
 jest.mock("../../../../components/Memo/hooks/useMemoViewModel");
 jest.mock("../../../../context/SendFlowContext");
 jest.mock("../useRecipientScreenView");
+jest.mock("../useAddressMatchedSectionViewModel");
 jest.mock("@ledgerhq/ledger-wallet-framework/tracking/send", () => ({
   getSendFlowTrackingProperties: jest.fn(() => ({ currency: "bitcoin" })),
 }));
@@ -21,6 +23,7 @@ const mockedTrack = jest.mocked(track);
 const mockedUseMemoViewModel = jest.mocked(useMemoViewModel);
 const mockedUseSendFlowData = jest.mocked(useSendFlowData);
 const mockedUseRecipientScreenView = jest.mocked(useRecipientScreenView);
+const mockedUseAddressMatchedSectionViewModel = jest.mocked(useAddressMatchedSectionViewModel);
 
 const account = createMockAccount({ id: "account_1" });
 const handleAddressSelect = jest.fn();
@@ -38,6 +41,7 @@ const recipientViewModel = {
     bridgeWarnings: {},
     hasBridgeValidationResult: true,
     matchedAccounts: [],
+    matchedContact: undefined,
     isLedgerAccount: false,
     isFirstInteraction: false,
   },
@@ -56,12 +60,21 @@ const recipientViewModel = {
   addressValidationErrorType: null,
   clipboardAddress: null,
   handlePasteFromClipboard: jest.fn(),
+  isContactsFeatureEnabled: true,
 } as never;
 
 const memoViewModel = {
   hasFilledMemo: true,
   memoError: undefined,
 } as never;
+
+const addressMatchedSectionViewModel = {
+  isVisible: true,
+  showHeader: false,
+  addressMatchedLabel: "Address matched",
+  suggestion: null,
+  showFirstInteractionWarning: false,
+};
 
 describe("useRecipientScreenContentViewModel", () => {
   beforeEach(() => {
@@ -71,6 +84,9 @@ describe("useRecipientScreenContentViewModel", () => {
     } as never);
     mockedUseRecipientScreenView.mockReturnValue(recipientViewModel);
     mockedUseMemoViewModel.mockReturnValue(memoViewModel);
+    mockedUseAddressMatchedSectionViewModel.mockReturnValue(
+      addressMatchedSectionViewModel as never,
+    );
   });
 
   function renderViewModel() {
@@ -91,6 +107,7 @@ describe("useRecipientScreenContentViewModel", () => {
     expect(result.current.showMemo).toBe(true);
     expect(result.current.showMatched).toBe(true);
     expect(result.current.keyboardBehavior).toBe("padding");
+    expect(result.current.addressMatchedSectionViewModel).toEqual(addressMatchedSectionViewModel);
     expect(mockedTrack).toHaveBeenCalledTimes(2);
     expect(mockedTrack).toHaveBeenNthCalledWith(
       1,
@@ -109,10 +126,11 @@ describe("useRecipientScreenContentViewModel", () => {
   });
 
   it("tracks and forwards matched-address selection", () => {
-    const { result } = renderViewModel();
+    renderViewModel();
+    const { onSelect } = mockedUseAddressMatchedSectionViewModel.mock.calls[0][0];
 
     act(() => {
-      result.current.handleMatchedAddress("destination", "name.eth");
+      onSelect("destination", "name.eth");
     });
 
     expect(mockedTrack).toHaveBeenCalledWith(

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressMatchedSectionViewModel.ts
@@ -1,0 +1,257 @@
+import { getRecipientMatchPresentation } from "@ledgerhq/live-common/flows/send/recipient/utils/getRecipientMatchPresentation";
+import type {
+  AddressSearchResult,
+  MatchedAccount,
+  MatchedContact,
+  RecentAddress,
+} from "@ledgerhq/live-common/flows/send/recipient/types";
+import { SEND_ADDRESS_FORMAT_OPTIONS } from "@ledgerhq/live-common/flows/send/utils";
+import { formatAddress } from "@ledgerhq/live-common/utils/addressUtils";
+import { useFeature } from "@features/platform-feature-flags";
+import { useTranslation } from "~/context/Locale";
+import { useFormatRelativeDate } from "./useFormatRelativeDate";
+
+type UseAddressMatchedSectionViewModelProps = Readonly<{
+  searchResult: AddressSearchResult;
+  searchValue: string;
+  onSelect: (address: string, ensName?: string) => void;
+  isSanctioned?: boolean;
+  isAddressComplete?: boolean;
+  hasBridgeError?: boolean;
+  isContactsFeatureEnabled?: boolean;
+}>;
+
+type AddressListItemSuggestion = Readonly<{
+  kind: "address-list-item";
+  address: string;
+  name?: string;
+  description?: string;
+  onSelect?: () => void;
+  isLedgerAccount?: boolean;
+  disabled?: boolean;
+  hideDescription?: boolean;
+}>;
+
+type MatchedLedgerAccountsSuggestion = Readonly<{
+  kind: "matched-ledger-accounts";
+  address: string;
+  matchedAccounts: readonly MatchedAccount[];
+  matchedRecentAddress: RecentAddress | undefined;
+  isDisabled: boolean;
+  onSelect: (address: string) => void;
+}>;
+
+type RecipientCardSuggestion = Readonly<{
+  kind: "recipient-card";
+  recipient: string;
+  description?: string;
+  contact?: MatchedContact;
+  isReady: boolean;
+  showActions: boolean;
+  addContactLabel: string;
+  sendLabel: string;
+  onSend: () => void;
+}>;
+
+export type AddressMatchedSectionViewModel = Readonly<{
+  isVisible: boolean;
+  showHeader: boolean;
+  addressMatchedLabel: string;
+  suggestion:
+    | AddressListItemSuggestion
+    | MatchedLedgerAccountsSuggestion
+    | RecipientCardSuggestion
+    | null;
+  showFirstInteractionWarning: boolean;
+}>;
+
+export function useAddressMatchedSectionViewModel({
+  searchResult,
+  searchValue,
+  onSelect,
+  isSanctioned = false,
+  isAddressComplete = false,
+  hasBridgeError = false,
+  isContactsFeatureEnabled = false,
+}: UseAddressMatchedSectionViewModelProps): AddressMatchedSectionViewModel {
+  const { t } = useTranslation();
+  const formatRelativeDate = useFormatRelativeDate();
+  const isFirstInteractionBannerEnabled =
+    useFeature("newSendFlowFirstInteractionBanner")?.enabled ?? false;
+  const addressMatchedLabel = t("send.newSendFlow.addressMatched");
+  const recipientAddress = searchResult.resolvedAddress ?? searchValue;
+  const shouldShowErrorRecipientCard =
+    isContactsFeatureEnabled && isAddressComplete && (hasBridgeError || isSanctioned);
+
+  if (shouldShowErrorRecipientCard) {
+    return {
+      isVisible: true,
+      showHeader: false,
+      addressMatchedLabel,
+      suggestion: {
+        kind: "recipient-card",
+        recipient: recipientAddress,
+        contact: undefined,
+        isReady: false,
+        showActions: false,
+        addContactLabel: t("contacts.addContact"),
+        sendLabel: t("contacts.addressDetail.send"),
+        onSend: () => onSelect(recipientAddress, searchResult.ensName),
+      },
+      showFirstInteractionWarning: false,
+    };
+  }
+
+  const presentation = getRecipientMatchPresentation({
+    searchResult,
+    searchValue,
+    isSanctioned,
+    isAddressComplete,
+    hasBridgeError,
+    isContactsFeatureEnabled,
+  });
+
+  if (!presentation) {
+    return {
+      isVisible: false,
+      showHeader: false,
+      addressMatchedLabel,
+      suggestion: null,
+      showFirstInteractionWarning: false,
+    };
+  }
+
+  const formattedAddress = formatAddress(
+    presentation.kind === "recipient-card" ? presentation.recipientAddress : presentation.address,
+    SEND_ADDRESS_FORMAT_OPTIONS,
+  );
+  const getAlreadyUsedDescription = (lastUsedAt?: Date): string | undefined => {
+    if (!lastUsedAt) {
+      return undefined;
+    }
+
+    return t("send.newSendFlow.alreadyUsed", {
+      date: formatRelativeDate(lastUsedAt),
+    });
+  };
+
+  const showFirstInteractionWarning =
+    isFirstInteractionBannerEnabled &&
+    searchResult.isFirstInteraction &&
+    !isSanctioned &&
+    !hasBridgeError &&
+    isAddressComplete;
+
+  switch (presentation.kind) {
+    case "recipient-card":
+      return {
+        isVisible: true,
+        showHeader: false,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "recipient-card",
+          recipient: presentation.ensName ?? presentation.recipientAddress,
+          description: presentation.ensName
+            ? presentation.recipientAddress
+            : getAlreadyUsedDescription(presentation.matchedRecentAddress?.lastUsedAt),
+          contact: presentation.matchedContact,
+          isReady: presentation.isReady,
+          showActions: !hasBridgeError,
+          addContactLabel: t("contacts.addContact"),
+          sendLabel: t("contacts.addressDetail.send"),
+          onSend: () => onSelect(presentation.recipientAddress, presentation.ensName),
+        },
+        showFirstInteractionWarning,
+      };
+    case "matched-contact":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "address-list-item",
+          address: presentation.address,
+          name: presentation.matchedContact.contactName,
+          description: formattedAddress,
+          onSelect: () => onSelect(presentation.address, presentation.ensName),
+          disabled: presentation.isDisabled,
+        },
+        showFirstInteractionWarning,
+      };
+    case "matched-ens":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "address-list-item",
+          address: presentation.address,
+          name: `${presentation.ensName} (${formattedAddress})`,
+          description: formattedAddress,
+          onSelect: () => onSelect(presentation.address, presentation.ensName),
+          disabled: presentation.isDisabled,
+        },
+        showFirstInteractionWarning,
+      };
+    case "matched-ledger-account":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "matched-ledger-accounts",
+          address: presentation.address,
+          matchedAccounts: presentation.matchedAccounts,
+          matchedRecentAddress: presentation.matchedRecentAddress,
+          isDisabled: presentation.isDisabled,
+          onSelect: (address: string) =>
+            onSelect(address, presentation.matchedRecentAddress?.ensName),
+        },
+        showFirstInteractionWarning,
+      };
+    case "matched-recent-address":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "address-list-item",
+          address: presentation.address,
+          description:
+            getAlreadyUsedDescription(presentation.matchedRecentAddress.lastUsedAt) ??
+            formattedAddress,
+          onSelect: () => onSelect(presentation.address, presentation.matchedRecentAddress.ensName),
+          disabled: presentation.isDisabled,
+        },
+        showFirstInteractionWarning,
+      };
+    case "valid-address":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "address-list-item",
+          address: presentation.address,
+          name: formattedAddress,
+          description: t("send.newSendFlow.notInRecentHistory"),
+          onSelect: () => onSelect(presentation.address),
+        },
+        showFirstInteractionWarning,
+      };
+    case "disabled-address":
+      return {
+        isVisible: true,
+        showHeader: true,
+        addressMatchedLabel,
+        suggestion: {
+          kind: "address-list-item",
+          address: presentation.address,
+          name: formattedAddress,
+          description: formattedAddress,
+          disabled: true,
+        },
+        showFirstInteractionWarning,
+      };
+  }
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useAddressValidation.ts
@@ -1,3 +1,4 @@
+import { selectContacts } from "@domain/entity-contact";
 import { isAddressSanctioned } from "@ledgerhq/ledger-wallet-framework/sanction/index";
 import { useDomain } from "@ledgerhq/domain-service/hooks/index";
 import { isLoaded } from "@ledgerhq/domain-service/hooks/logic";
@@ -19,6 +20,7 @@ import { accountsSelector } from "~/reducers/accounts";
 import { useBatchMaybeAccountName, useMaybeAccountName } from "~/reducers/wallet";
 
 import { useBridgeRecipientValidation } from "@ledgerhq/live-common/flows/send/recipient/hooks/useBridgeRecipientValidation";
+import { findMatchedContact } from "@ledgerhq/live-common/flows/send/recipient/utils/findMatchedContact";
 import type {
   AddressSearchResult,
   AddressValidationError,
@@ -76,6 +78,7 @@ export function useAddressValidation({
   const validationTriggeredRef = useRef<boolean>(false);
 
   const allAccounts = useSelector(accountsSelector);
+  const contacts = useSelector(selectContacts);
 
   const domainServiceResponse = useDomain(recipientSupportsDomain ? searchValue : "", "ens");
   const domainIsLoading = recipientSupportsDomain && isDomainLoading(domainServiceResponse);
@@ -113,6 +116,10 @@ export function useAddressValidation({
     ),
     debounceMs,
   });
+
+  const hasInvalidBridgeRecipient =
+    bridgeValidation.errors.recipient?.name === "InvalidAddress" && !ensResolution;
+  const canMatchValidatedRecipient = Boolean(searchValue) && !hasInvalidBridgeRecipient;
 
   const userAccountsForCurrency = useMemo(() => {
     const selfTransferPolicy = sendFeatures.getSelfTransferPolicy(currency);
@@ -200,6 +207,14 @@ export function useAddressValidation({
 
   const matchedLedgerAccount = currentAccountMatch ?? matchedLedgerAccounts[0];
 
+  const matchedContact = useMemo(() => {
+    if (!canMatchValidatedRecipient || !sanctionCurrency) {
+      return undefined;
+    }
+
+    return findMatchedContact(contacts, searchValue, sanctionCurrency.id, ensResolution?.address);
+  }, [canMatchValidatedRecipient, sanctionCurrency, contacts, searchValue, ensResolution?.address]);
+
   const { formattedBalance, formattedCounterValue } =
     useFormattedAccountBalance(matchedLedgerAccount);
   const accountName = useMaybeAccountName(matchedLedgerAccount);
@@ -281,7 +296,8 @@ export function useAddressValidation({
         ]
       : matchedLedgerAccounts;
 
-    const isFirstInteraction = !matchedRecentAddress && allMatchedAccounts.length === 0;
+    const isFirstInteraction =
+      !matchedRecentAddress && allMatchedAccounts.length === 0 && !matchedContact;
 
     const matchedAccounts: MatchedAccount[] = allMatchedAccounts.map(acc => ({
       account: acc,
@@ -316,7 +332,7 @@ export function useAddressValidation({
       isFirstInteraction,
       matchedRecentAddress,
       matchedAccounts,
-      matchedContact: undefined,
+      matchedContact,
       bridgeErrors: filteredBridgeErrors,
       bridgeWarnings: bridgeValidation.warnings,
       isBridgeLoading: bridgeValidation.isLoading && bridgeValidation.status === null,
@@ -329,6 +345,7 @@ export function useAddressValidation({
     matchedLedgerAccounts,
     currentAccountMatch,
     matchedRecentAddress,
+    matchedContact,
     formattedBalance,
     formattedCounterValue,
     accountName,

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenContentViewModel.ts
@@ -10,6 +10,7 @@ import { getSendFlowTrackingProperties } from "@ledgerhq/ledger-wallet-framework
 import { shouldUseKeyboardAvoidance } from "~/logic/keyboardVisible";
 import { useMemoViewModel } from "../../../components/Memo/hooks/useMemoViewModel";
 import { useSendFlowData } from "../../../context/SendFlowContext";
+import { useAddressMatchedSectionViewModel } from "./useAddressMatchedSectionViewModel";
 import { useRecipientScreenView } from "./useRecipientScreenView";
 
 export type UseRecipientScreenContentViewModelProps = Readonly<{
@@ -80,6 +81,16 @@ export function useRecipientScreenContentViewModel({
     [trackingProperties, handleAddressSelect],
   );
 
+  const addressMatchedSectionViewModel = useAddressMatchedSectionViewModel({
+    searchResult: recipient.result,
+    searchValue: recipient.searchValue,
+    onSelect: handleMatchedAddress,
+    isSanctioned: recipient.showSanctionedBanner,
+    isAddressComplete: recipient.isAddressComplete,
+    hasBridgeError: recipient.showBridgeRecipientError,
+    isContactsFeatureEnabled: recipient.isContactsFeatureEnabled,
+  });
+
   useEffect(() => {
     if (showMemo) {
       track("send_modal", { ...trackingProperties, name: "step memo" });
@@ -117,7 +128,7 @@ export function useRecipientScreenContentViewModel({
     showMatched,
     shouldShowErrorBanner,
     keyboardBehavior,
-    handleMatchedAddress,
+    addressMatchedSectionViewModel,
   };
 }
 

--- a/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Send/screens/Recipient/hooks/useRecipientScreenView.ts
@@ -97,6 +97,7 @@ export function useRecipientScreenView({
     clipboardAddress,
     handlePasteFromClipboard,
     handleAddressSelect,
+    isContactsFeatureEnabled,
     ...searchState,
   };
 }


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Integrates the shared `ContactAvatar` into the new Send flow recipient card on desktop and mobile, replacing the initials placeholder on desktop. On mobile, adds a `RecipientCard` component and refactors `AddressMatchedSection` via a dedicated view model.

### 🔗 Context

- **[JIRA / GitHub issue](https://ledgerhq.atlassian.net/browse/LIVE-35807)**: <!-- e.g. [LLD-1234] or #456 -->
- **ADR** (if any): <!-- link to the relevant architectural decision record -->
