### PR TITLE
[LWM] fix(mobile): prevent transient contact name errors (LIVE-35827)

### DIFF
--- a/.changeset/quiet-names-settle.md
+++ b/.changeset/quiet-names-settle.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts-add-contact": minor
+---
+
+Prevent transient duplicate name errors after adding a contact

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/components/ContactsAddContactDrawerSheet/ContactsAddContactDrawerSheet.test.tsx
@@ -112,6 +112,12 @@ describe("ContactsAddContactDrawerSheet", () => {
     expect(screen.getByRole("button", { name: "Confirm name" })).toBeDisabled();
   });
 
+  it("should make the name input non-editable while saving", () => {
+    render(<ContactsAddContactDrawerSheet {...createViewModel({ isSaving: true })} />);
+
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveProp("editable", false);
+  });
+
   it("should expose the edited name, enable confirmation, and close the drawer", async () => {
     const onClose = jest.fn();
     const onDraftNameChange = jest.fn();

--- a/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.native.tsx
@@ -7,6 +7,7 @@ type ContactNameInputProps = Readonly<{
   value: string;
   placeholder: string;
   errorMessage?: string;
+  isEditable?: boolean;
   onChangeText: (name: string) => void;
 }>;
 
@@ -14,6 +15,7 @@ export function ContactNameInput({
   value,
   placeholder,
   errorMessage,
+  isEditable = true,
   onChangeText,
 }: ContactNameInputProps): React.JSX.Element {
   const isAtNameLengthLimit = value.length === CONTACT_NAME_MAX_LENGTH;
@@ -27,6 +29,7 @@ export function ContactNameInput({
         value={value}
         onChangeText={onChangeText}
         maxLength={CONTACT_NAME_MAX_LENGTH}
+        editable={isEditable}
         status={errorMessage ? "error" : undefined}
       />
       <Box

--- a/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactNameInput/ContactNameInput.web.tsx
@@ -6,6 +6,7 @@ type ContactNameInputProps = Readonly<{
   value: string;
   placeholder: string;
   errorMessage?: string;
+  isEditable?: boolean;
   onChange: (value: string) => void;
 }>;
 
@@ -13,6 +14,7 @@ export function ContactNameInput({
   value,
   placeholder,
   errorMessage,
+  isEditable = true,
   onChange,
 }: ContactNameInputProps): React.ReactNode {
   return (
@@ -25,6 +27,7 @@ export function ContactNameInput({
       maxCount={CONTACT_NAME_MAX_LENGTH}
       helperText={errorMessage}
       status={errorMessage ? "error" : undefined}
+      readOnly={!isEditable}
       className="mt-2"
     />
   );

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -25,7 +25,7 @@ export type ContactsContactNameDrawerContentProps = Readonly<{
   invalidNameError: ContactNameValidationErrorName | null;
   bottomInset?: number;
   keyboardInset?: number;
-  isInputEditable?: boolean;
+  isEditable?: boolean;
   labels: ContactsContactNameDrawerLabels;
   confirmLabel: string;
   confirmTestID?: string;
@@ -41,7 +41,7 @@ export function ContactsContactNameDrawerContent({
   invalidNameError,
   bottomInset = 0,
   keyboardInset = 0,
-  isInputEditable = true,
+  isEditable = true,
   labels,
   confirmLabel,
   confirmTestID,
@@ -64,7 +64,7 @@ export function ContactsContactNameDrawerContent({
               value={draftName}
               placeholder={labels.namePlaceholder}
               errorMessage={nameValidationError}
-              isEditable={isInputEditable}
+              isEditable={isEditable}
               onChangeText={onDraftNameChange}
             />
             <Banner appearance="info" description={labels.namingDisclaimer} />

--- a/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/components/ContactsContactNameDrawer/ContactsContactNameDrawerContent.native.tsx
@@ -25,6 +25,7 @@ export type ContactsContactNameDrawerContentProps = Readonly<{
   invalidNameError: ContactNameValidationErrorName | null;
   bottomInset?: number;
   keyboardInset?: number;
+  isInputEditable?: boolean;
   labels: ContactsContactNameDrawerLabels;
   confirmLabel: string;
   confirmTestID?: string;
@@ -40,6 +41,7 @@ export function ContactsContactNameDrawerContent({
   invalidNameError,
   bottomInset = 0,
   keyboardInset = 0,
+  isInputEditable = true,
   labels,
   confirmLabel,
   confirmTestID,
@@ -62,6 +64,7 @@ export function ContactsContactNameDrawerContent({
               value={draftName}
               placeholder={labels.namePlaceholder}
               errorMessage={nameValidationError}
+              isEditable={isInputEditable}
               onChangeText={onDraftNameChange}
             />
             <Banner appearance="info" description={labels.namingDisclaimer} />

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.test.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.test.tsx
@@ -70,4 +70,19 @@ describe("ContactsAddContactDialog", () => {
 
     expect(onDraftNameChange).toHaveBeenCalledWith("Ada1");
   });
+
+  it("should make the draft name read-only while saving", () => {
+    render(
+      <ContactsAddContactDialog
+        {...createViewModel({
+          draftName: "Ada",
+          isSaving: true,
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveAttribute(
+      "readonly",
+    );
+  });
 });

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.test.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.test.tsx
@@ -81,8 +81,6 @@ describe("ContactsAddContactDialog", () => {
       />,
     );
 
-    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveAttribute(
-      "readonly",
-    );
+    expect(screen.getByTestId("contacts-add-contact-name-input")).toHaveAttribute("readonly");
   });
 });

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDialog.web.tsx
@@ -39,6 +39,7 @@ export function ContactsAddContactDialog({
             value={draftName}
             placeholder={labels.namePlaceholder}
             errorMessage={nameValidationError}
+            isEditable={!isSaving}
             onChange={onDraftNameChange}
           />
           <ContactsAddContactNamingDisclaimer

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDrawer.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDrawer.native.tsx
@@ -23,6 +23,7 @@ export function ContactsAddContactDrawer({
       invalidNameError={invalidNameError}
       bottomInset={bottomInset}
       keyboardInset={keyboardInset}
+      isInputEditable={!isSaving}
       labels={labels}
       confirmLabel={labels.confirmName}
       onDraftNameChange={onDraftNameChange}

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDrawer.native.tsx
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/ContactsAddContactDrawer.native.tsx
@@ -23,7 +23,7 @@ export function ContactsAddContactDrawer({
       invalidNameError={invalidNameError}
       bottomInset={bottomInset}
       keyboardInset={keyboardInset}
-      isInputEditable={!isSaving}
+      isEditable={!isSaving}
       labels={labels}
       confirmLabel={labels.confirmName}
       onDraftNameChange={onDraftNameChange}

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.ts
@@ -17,8 +17,12 @@ export function useAddContactDrawerViewModel({
     setDraftName("");
   }, [setDraftName]);
   const onDraftNameChange = useCallback(
-    (name: string) => setDraftName(name.slice(0, CONTACT_NAME_MAX_LENGTH)),
-    [setDraftName],
+    (name: string) => {
+      if (!isSaving) {
+        setDraftName(name.slice(0, CONTACT_NAME_MAX_LENGTH));
+      }
+    },
+    [isSaving, setDraftName],
   );
   const onConfirm = useCallback(async () => {
     if (!isSaveEnabled || isSaving) {

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.ts
@@ -44,7 +44,7 @@ export function useAddContactDrawerViewModel({
     isSaving,
     draftName,
     avatarInitial,
-    invalidNameError,
+    invalidNameError: isSaving ? null : invalidNameError,
     onOpen,
     onClose,
     onDraftNameChange,

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { contact, INVALID_CONTACT_NAME_ERROR_NAME } from "@domain/entity-contact";
+import { mockContact, mockMeContact } from "@domain/entity-contact/schema.mock";
 import { useContacts } from "@features/platform-contacts";
 import type { ContactCreationPort } from "./model/ports";
 import { useAddContactDrawerViewModel } from "./useAddContactDrawerViewModel";
@@ -92,5 +93,46 @@ describe("useAddContactDrawerViewModel", () => {
 
     expect(contactCreation.createContact).toHaveBeenCalledWith({ name: "a".repeat(32) });
     expect(onSaveSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not expose a duplicate error while saving a newly created contact", async () => {
+    let contacts = [mockMeContact()];
+    const createdContact = mockContact({ id: "contact-ada", name: "Ada" });
+    let resolveCreation: (contact: typeof createdContact) => void;
+    const creation = new Promise<typeof createdContact>(resolve => {
+      resolveCreation = resolve;
+    });
+    const contactCreation: ContactCreationPort = {
+      createContact: jest.fn(async () => {
+        contacts = [...contacts, createdContact];
+        return creation;
+      }),
+    };
+    mockedUseContacts.mockImplementation(() => contacts);
+    const { result, rerender } = renderHook(() =>
+      useAddContactDrawerViewModel({ contactCreation, onSaveSuccess: jest.fn() }),
+    );
+
+    act(() => {
+      result.current.onOpen();
+      result.current.onDraftNameChange("Ada");
+    });
+
+    act(() => {
+      void result.current.onConfirm();
+    });
+    rerender();
+
+    expect(result.current).toMatchObject({
+      isSaving: true,
+      invalidNameError: null,
+    });
+
+    await act(async () => {
+      resolveCreation(createdContact);
+      await creation;
+    });
+
+    expect(result.current.isOpen).toBe(false);
   });
 });

--- a/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
+++ b/features/flow/flow-contacts-add-contact/src/screens/AddContact/useAddContactDrawerViewModel.web.test.ts
@@ -128,6 +128,12 @@ describe("useAddContactDrawerViewModel", () => {
       invalidNameError: null,
     });
 
+    act(() => {
+      result.current.onDraftNameChange("Ada1");
+    });
+
+    expect(result.current.draftName).toBe("Ada");
+
     await act(async () => {
       resolveCreation(createdContact);
       await creation;


### PR DESCRIPTION
### 📝 Description

#### Previous behaviour

After creating a valid contact, the drawer could briefly display a duplicate-name error because the new contact reached the store before the drawer closed.

#### Fix

Do not expose validation errors while the already-valid name is being saved. The name input is read-only during this short saving state, and the ViewModel also ignores draft updates while saving. Duplicate names remain blocked before submission.

#### Regression coverage

Added coverage for the store update during a pending creation, attempts to update the draft while saving, and the read-only state on Web and Native.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35827](https://ledgerhq.atlassian.net/browse/LIVE-35827)
- **ADR** (if any): N/A


[LIVE-35827]: https://ledgerhq.atlassian.net/browse/LIVE-35827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ