### PR TITLE
fix(contacts): move ENS disclaimer below name (LIVE-35829)

### DIFF
--- a/.changeset/move-ens-disclaimer.md
+++ b/.changeset/move-ens-disclaimer.md
@@ -1,0 +1,5 @@
+---
+"@features/flow-contacts": minor
+---
+
+Move the ENS resolution disclaimer below the address name field.

--- a/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
+++ b/features/flow/contacts/src/steps/AddAddress/ContactsAddAddressEntryView.web.tsx
@@ -38,13 +38,6 @@ export function ContactsAddAddressEntryView({
         status={inputStatus}
         value={value}
       />
-      {showEnsDisclaimer ? (
-        <Banner
-          appearance="info"
-          data-testid="contacts-add-address-ens-disclaimer"
-          description={labels.ensDisclaimer}
-        />
-      ) : null}
       {addressLabel && nameLabels && onAddressLabelChange ? (
         <TextInput
           autoComplete="off"
@@ -65,6 +58,13 @@ export function ContactsAddAddressEntryView({
             />
           }
           value={addressLabel.value}
+        />
+      ) : null}
+      {showEnsDisclaimer ? (
+        <Banner
+          appearance="info"
+          data-testid="contacts-add-address-ens-disclaimer"
+          description={labels.ensDisclaimer}
         />
       ) : null}
       {sanctionedAddressBanner ? <SanctionedAddressBanner {...sanctionedAddressBanner} /> : null}


### PR DESCRIPTION
### ✅ Checklist

- [x] `npx changeset` was attached.
- [ ] **Covered by automatic tests.** No test was added for this localized layout ordering change.
- [x] **Impact of the changes:**
      On Desktop, resolve an ENS name and verify the address input, its validation state, and Address name field stay consecutive; verify the ENS resolution banner appears directly below the name field.

### 📝 Description

The Desktop Contacts Add address form displayed the ENS resolution disclaimer between the validated address field and the Address name field.

This PR moves the existing disclaimer below the Address name field. Its condition, copy, visual style, and test identifier are unchanged.

### ❓ Context

- **JIRA or GitHub link**: https://ledgerhq.atlassian.net/browse/LIVE-35829

---

### 🧐 Checklist for the PR Reviewers

- **The code aligns with the requirements** described in the linked JIRA or GitHub issue.
- **The PR description clearly documents the changes** made and explains any technical trade-offs or design decisions.
- **There are no undocumented trade-offs**, technical debt, or maintainability issues.
- **The PR has been tested** thoroughly, and any potential edge cases have been considered and handled.
- **Any new dependencies** have been justified and documented.
- **Performance** considerations have been taken into account. (changes have been profiled or benchmarked if necessary)