### PR TITLE
[LWM] feat(contacts): wire Mobile Contacts tracking (LIVE-33968)

### DIFF
--- a/.changeset/llm-contacts-tracking-wiring.md
+++ b/.changeset/llm-contacts-tracking-wiring.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": minor
+---
+
+Wire Mobile Contacts scenario entry points to the shared analytics contract.

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/constants.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/constants.ts
@@ -1,0 +1,1 @@
+export const CONTACTS_ANALYTICS_PLATFORM = "llm" as const;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/contactsCurrencyAnalyticsDependencies.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/contactsCurrencyAnalyticsDependencies.ts
@@ -1,0 +1,6 @@
+import type { ResolveContactsCurrencyAnalyticsDependencies } from "@features/platform-contacts";
+import { getCryptoAssetsStore } from "@ledgerhq/ledger-wallet-framework/cryptoAssetsStore";
+
+export const contactsCurrencyAnalyticsDependencies: ResolveContactsCurrencyAnalyticsDependencies = {
+  findTokenById: currencyId => getCryptoAssetsStore().findTokenById(currencyId),
+};

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/createContactsAnalyticsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/createContactsAnalyticsAdapter.ts
@@ -1,0 +1,27 @@
+import type { ContactsAnalyticsAdapter } from "@features/flow-contacts";
+import { screen, track } from "~/analytics";
+import { CONTACTS_ANALYTICS_PLATFORM } from "./constants";
+import { mapContactsPageEventToScreenCategory } from "./mapContactsPageEventToScreenCategory";
+
+export function createContactsAnalyticsAdapter(): ContactsAnalyticsAdapter {
+  return {
+    track: ({ name, properties }) => {
+      track(name, {
+        ...properties,
+        platform: CONTACTS_ANALYTICS_PLATFORM,
+      });
+    },
+    trackPage: ({ page, properties }) => {
+      void screen(
+        mapContactsPageEventToScreenCategory(page),
+        undefined,
+        {
+          ...properties,
+          platform: CONTACTS_ANALYTICS_PLATFORM,
+        },
+        true,
+        true,
+      );
+    },
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/index.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/index.ts
@@ -1,0 +1,6 @@
+export { contactsCurrencyAnalyticsDependencies } from "./contactsCurrencyAnalyticsDependencies";
+export { CONTACTS_ANALYTICS_PLATFORM } from "./constants";
+export { createContactsAnalyticsAdapter } from "./createContactsAnalyticsAdapter";
+export { mapContactsPageEventToScreenCategory } from "./mapContactsPageEventToScreenCategory";
+export { resolveContactsCurrencyAnalytics } from "@features/platform-contacts";
+export { useContactsAnalytics } from "./useContactsAnalytics";

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.test.ts
@@ -1,0 +1,15 @@
+import { CONTACTS_PAGE_EVENTS } from "@features/flow-contacts";
+import { mapContactsPageEventToScreenCategory } from "./mapContactsPageEventToScreenCategory";
+
+describe("mapContactsPageEventToScreenCategory", () => {
+  it("should strip the Page prefix from contacts page events", () => {
+    expect(mapContactsPageEventToScreenCategory(CONTACTS_PAGE_EVENTS.CONTACTS)).toBe("Contacts");
+    expect(mapContactsPageEventToScreenCategory(CONTACTS_PAGE_EVENTS.ADD_CONTACT)).toBe(
+      "Add Contact",
+    );
+  });
+
+  it("should return the page name unchanged when it has no Page prefix", () => {
+    expect(mapContactsPageEventToScreenCategory("Contacts" as never)).toBe("Contacts");
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.ts
@@ -1,0 +1,7 @@
+import type { ContactsPageEventName } from "@features/flow-contacts";
+
+const PAGE_EVENT_PREFIX = "Page ";
+
+export function mapContactsPageEventToScreenCategory(page: ContactsPageEventName): string {
+  return page.startsWith(PAGE_EVENT_PREFIX) ? page.slice(PAGE_EVENT_PREFIX.length) : page;
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/analytics/useContactsAnalytics.ts
@@ -1,0 +1,25 @@
+import { useMemo } from "react";
+import {
+  createContactsAnalyticsHelper,
+  type ContactsAnalyticsHelper,
+  useContactsFeature,
+} from "@features/flow-contacts";
+import { buildContactsGlobalProperties, useContacts } from "@features/platform-contacts";
+import { createContactsAnalyticsAdapter } from "./createContactsAnalyticsAdapter";
+
+export function useContactsAnalytics(): ContactsAnalyticsHelper {
+  const contacts = useContacts();
+  const { isEnabled } = useContactsFeature("mobile");
+  const adapter = useMemo(() => createContactsAnalyticsAdapter(), []);
+
+  return useMemo(
+    () =>
+      createContactsAnalyticsHelper(adapter, () =>
+        buildContactsGlobalProperties({
+          ffAddressBookEnabled: isEnabled,
+          contacts,
+        }),
+      ),
+    [adapter, contacts, isEnabled],
+  );
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsButton/__tests__/useContactsButtonViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsButton/__tests__/useContactsButtonViewModel.test.ts
@@ -2,10 +2,19 @@ import { renderHook, withFlagOverrides } from "@tests/test-renderer";
 import { useContactsButtonViewModel } from "../useContactsButtonViewModel";
 
 const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual<typeof import("@react-navigation/native")>("@react-navigation/native"),
   useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock("../../../analytics/useContactsAnalytics", () => ({
+  useContactsAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    trackPage: jest.fn(),
+    getGlobalProperties: jest.fn(),
+  }),
 }));
 
 describe("useContactsButtonViewModel", () => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsButton/useContactsButtonViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/components/ContactsButton/useContactsButtonViewModel.ts
@@ -3,12 +3,14 @@ import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTranslation } from "~/context/Locale";
 import { ScreenName } from "~/const";
-import { track } from "~/analytics";
-import { useContactsFeature } from "@features/flow-contacts";
 import {
-  MY_WALLET_TRACKING_BUTTON,
-  MY_WALLET_TRACKING_PAGE_NAME,
-} from "LLM/features/MyWallet/constants";
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
+  useContactsFeature,
+} from "@features/flow-contacts";
+import { useContactsAnalytics } from "../../analytics/useContactsAnalytics";
 
 export type ContactsButtonViewModel = {
   isEnabled: boolean;
@@ -23,14 +25,16 @@ export function useContactsButtonViewModel(): ContactsButtonViewModel {
     useNavigation<NativeStackNavigationProp<{ [key: string]: object | undefined }>>();
   const { t } = useTranslation();
   const { isEnabled, showNewBadge } = useContactsFeature("mobile");
+  const analytics = useContactsAnalytics();
 
   const handleClick = useCallback(() => {
-    track("button_clicked", {
-      button: MY_WALLET_TRACKING_BUTTON.contacts,
-      page: MY_WALLET_TRACKING_PAGE_NAME,
+    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.ENTRY,
+      button: CONTACTS_TRACKING_BUTTON.contacts,
+      page: CONTACTS_PAGE_PROPERTY.MY_WALLET,
     });
     navigation.navigate(ScreenName.MyWalletContacts);
-  }, [navigation]);
+  }, [analytics, navigation]);
 
   return {
     isEnabled,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.test.tsx
@@ -12,6 +12,14 @@ jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
   useOpenSendFlow: () => ({ handleOpenSendFlow: jest.fn() }),
 }));
 
+jest.mock("../analytics/useContactsAnalytics", () => ({
+  useContactsAnalytics: () => ({
+    trackEvent: jest.fn(),
+    trackPage: jest.fn(),
+    getGlobalProperties: jest.fn(),
+  }),
+}));
+
 function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>["contacts"]) {
   const store = configureStore({
     reducer: { contacts: contactsSlice.reducer },
@@ -24,6 +32,18 @@ function makeWrapper(contacts: ReturnType<typeof contactsSlice.getInitialState>[
 }
 
 describe("useContactAddressDetailActionsAdapter", () => {
+  it("should return inactive actions when no address is selected", () => {
+    const Wrapper = makeWrapper([mockMeContact()]);
+    const { result } = renderHook(
+      () => useContactAddressDetailActionsAdapter(undefined, undefined, jest.fn()),
+      { wrapper: Wrapper },
+    );
+
+    expect(result.current.addressDetailDialog.canEdit).toBe(false);
+    expect(result.current.addressDetailDialog.canDelete).toBe(false);
+    expect(result.current.deleteSheet.isOpen).toBe(false);
+  });
+
   it("should reopen the same address after cancelling the rename drawer", () => {
     const contact = mockContactWithAddress();
     const address = contact.addresses[0]!;

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/hooks/useContactAddressDetailActionsAdapter.ts
@@ -11,11 +11,14 @@ import {
   resolveContactAddressDetailActionsLabels,
   useContactAddressDetailActionsFlowBindings,
   useContactsAddressDetailActionsPorts,
+  CONTACTS_TRACKING_BUTTON,
+  trackContactAddressDetailQuickAction,
 } from "@features/flow-contacts";
 import { useOpenSendFlow } from "LLM/features/Send/hooks/useOpenSendFlow";
 import { useCallback, useMemo } from "react";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
+import { useContactsAnalytics } from "../analytics/useContactsAnalytics";
 
 export type ContactAddressDetailActionsFlowProps = Readonly<{
   addressDetailDialog: Pick<
@@ -44,8 +47,10 @@ export function useContactAddressDetailActionsAdapter(
   contactId: ContactId | undefined,
   addressId: ContactAddressId | undefined,
   onCloseAddressDetail: () => void,
+  asset?: string,
 ): ContactAddressDetailActionsFlowProps {
   const { t } = useTranslation();
+  const analytics = useContactsAnalytics();
   const ports = useContactsAddressDetailActionsPorts();
   const { handleOpenSendFlow } = useOpenSendFlow({
     sourceScreenName: ScreenName.MyWalletContactDetail,
@@ -59,15 +64,27 @@ export function useContactAddressDetailActionsAdapter(
       }),
     [t],
   );
+  const trackQuickAction = useCallback(
+    (
+      button:
+        | typeof CONTACTS_TRACKING_BUTTON.send
+        | typeof CONTACTS_TRACKING_BUTTON.edit
+        | typeof CONTACTS_TRACKING_BUTTON.delete,
+    ) => {
+      trackContactAddressDetailQuickAction(analytics, button, asset);
+    },
+    [analytics, asset],
+  );
   const onSend = useCallback(
     (intent: ContactAddressDetailSendIntent) => {
+      trackQuickAction(CONTACTS_TRACKING_BUTTON.send);
       handleOpenSendFlow({
         currencyIds: [intent.currencyId],
         recipient: intent.address,
       });
       onCloseAddressDetail();
     },
-    [handleOpenSendFlow, onCloseAddressDetail],
+    [handleOpenSendFlow, onCloseAddressDetail, trackQuickAction],
   );
   const { flow, renameViewModel } = useContactAddressDetailActionsFlowBindings({
     contactId: contactId ?? ContactIdSchema.parse("contact-me"),
@@ -81,6 +98,14 @@ export function useContactAddressDetailActionsAdapter(
     closeRenameViewModel();
     onCloseAddressDetail();
   }, [closeRenameViewModel, onCloseAddressDetail]);
+  const onEdit = useCallback(() => {
+    trackQuickAction(CONTACTS_TRACKING_BUTTON.edit);
+    flow.onEditPress();
+  }, [flow, trackQuickAction]);
+  const onDelete = useCallback(() => {
+    trackQuickAction(CONTACTS_TRACKING_BUTTON.delete);
+    flow.onDeletePress();
+  }, [flow, trackQuickAction]);
 
   if (!isSelectionActive) {
     return mapUiStateToFlowProps(createInactiveContactAddressDetailActionsUiState(labels));
@@ -92,6 +117,11 @@ export function useContactAddressDetailActionsAdapter(
 
   return {
     ...uiState,
+    addressDetailDialog: {
+      ...uiState.addressDetailDialog,
+      onEdit,
+      onDelete,
+    },
     renameSheet: {
       ...uiState.renameSheet,
       onClose: onCloseRename,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -5,13 +5,19 @@ import {
   type ContactsEditSignerMismatchDrawerProps,
   type ContactsRenameContactDrawerProps,
   type ContactDetailActionsLabels,
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
   createContactDetailEditDeleteUiState,
   resolveContactDetailEditDeleteLabels,
+  useContactDetailEditDeleteAnalytics,
   useContactDetailEditDeleteFlowBindings,
   useContactsEditDeletePorts,
 } from "@features/flow-contacts";
 import { useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "~/context/Locale";
+import { useContactsAnalytics } from "../../../analytics/useContactsAnalytics";
 
 export type ContactDetailEditDeleteFlowProps = Readonly<{
   actionsMenu: Readonly<{
@@ -35,6 +41,7 @@ export function useContactDetailEditDeleteAdapter(
   onDeleteSuccess: () => void,
 ): ContactDetailEditDeleteFlowProps {
   const { t } = useTranslation();
+  const analytics = useContactsAnalytics();
   const ports = useContactsEditDeletePorts();
   const { flow, renameViewModel } = useContactDetailEditDeleteFlowBindings({
     contactId,
@@ -54,11 +61,25 @@ export function useContactDetailEditDeleteAdapter(
     () => createContactDetailEditDeleteUiState(flow, renameViewModel, labels),
     [flow, labels, renameViewModel],
   );
+  const { onEdit } = useContactDetailEditDeleteAnalytics(
+    analytics,
+    {
+      onEditPress: flow.onEditPress,
+      onDeletePress: flow.onDeletePress,
+      openDelete: flow.openDelete,
+    },
+    uiState.signerMismatch.isOpen,
+  );
   const pendingDeleteRef = useRef(false);
   const onDelete = useCallback(() => {
+    analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+      button: CONTACTS_TRACKING_BUTTON.deleteContact,
+      page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+    });
     pendingDeleteRef.current = true;
     flow.onDeletePress();
-  }, [flow]);
+  }, [analytics, flow]);
   const onActionsMenuHidden = useCallback(() => {
     if (!pendingDeleteRef.current) {
       return;
@@ -74,7 +95,7 @@ export function useContactDetailEditDeleteAdapter(
       isOpen: flow.isActionsMenuOpen,
       canDelete: flow.canDelete,
       labels: labels.actions,
-      onEdit: flow.onEditPress,
+      onEdit,
       onDelete,
       onClose: flow.onCloseActionsMenu,
       onHidden: onActionsMenuHidden,

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ContactDetailView } from "@features/flow-contacts";
-import { TrackScreen } from "~/analytics";
 import { ContactsAddAddressFlowDrawer } from "./components/ContactsAddAddressFlowDrawer";
 import { ContactAddressDetailActionsSheets } from "./components/ContactAddressDetailActionsSheets";
 import { ContactAddressDetailDialogSheet } from "./components/ContactAddressDetailDialogSheet";
@@ -21,7 +20,6 @@ export function ContactDetailScreen(): React.JSX.Element | null {
 
   return (
     <>
-      <TrackScreen category="Contacts" />
       <ContactDetailView {...viewModel.pageProps} />
       {viewModel.addAddressFlowState.status !== "closed" ? (
         <ContactsAddAddressFlowDrawer {...viewModel.addAddressFlowProps} />

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.test.ts
@@ -1,0 +1,68 @@
+import { useNavigation, useRoute } from "@react-navigation/native";
+import { mockMeContact } from "@domain/entity-contact/schema.mock";
+import { renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import { useContactDetailScreenViewModel } from "./useContactDetailScreenViewModel";
+
+const mockGoBack = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual<typeof import("@react-navigation/native")>("@react-navigation/native"),
+  useRoute: jest.fn(),
+  useNavigation: jest.fn(),
+}));
+
+jest.mock("../../hooks/useContactsAddressValidationAdapter", () => ({
+  useContactsAddressValidationAdapter: () => ({
+    validateAddress: async ({ address }: { address: string }) => ({
+      status: "valid",
+      resolvedAddress: address,
+      isDomain: false,
+    }),
+  }),
+}));
+
+jest.mock("LLM/features/Send/hooks/useOpenSendFlow", () => ({
+  useOpenSendFlow: () => ({ handleOpenSendFlow: jest.fn() }),
+}));
+
+jest.mock("../../analytics/useContactsAnalytics", () => ({
+  useContactsAnalytics: () => ({
+    trackEvent: jest.fn(),
+    trackPage: jest.fn(),
+    getGlobalProperties: jest.fn(),
+  }),
+}));
+
+const mockedUseRoute = jest.mocked(useRoute);
+const mockedUseNavigation = jest.mocked(useNavigation);
+
+describe("useContactDetailScreenViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should redirect when contacts are disabled", () => {
+    mockedUseRoute.mockReturnValue({
+      key: ScreenName.MyWalletContactDetail,
+      name: ScreenName.MyWalletContactDetail,
+      params: { contactId: mockMeContact().id },
+    });
+    mockedUseNavigation.mockReturnValue({
+      navigate: jest.fn(),
+      goBack: mockGoBack,
+      replace: mockReplace,
+      canGoBack: jest.fn(() => true),
+    } as never);
+
+    const { result } = renderHook(() => useContactDetailScreenViewModel(), {
+      overrideInitialState: withFlagOverrides({
+        lwmContacts: { enabled: false, params: { newBadge: false } },
+      }),
+    });
+
+    expect(result.current.status).toBe("redirecting");
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/useContactDetailScreenViewModel.ts
@@ -16,10 +16,23 @@ import {
   useContactDetailSharedState,
   useContactAddressDetailDialog,
   useContactsFeature,
+  useContactsMeContact,
   useEmptyContactDetail,
   usePopulatedContactDetail,
+  CONTACTS_EVENT_SOURCE,
+  CONTACTS_FLOW,
+  CONTACTS_PAGE_EVENTS,
+  CONTACTS_PAGE_PROPERTY,
+  CONTACTS_TRACK_EVENTS,
+  CONTACTS_TRACKING_BUTTON,
+  trackContactsAddAddressClick,
 } from "@features/flow-contacts";
 import { createMockContactDeviceIntentsPort } from "@features/platform-contacts";
+import {
+  resolveContactsCurrencyAnalytics,
+  useContactsAnalytics,
+  contactsCurrencyAnalyticsDependencies,
+} from "../../analytics";
 import type { BaseNavigationComposite } from "~/components/RootNavigator/types/helpers";
 import { NavigatorName, ScreenName } from "~/const";
 import { useDispatch } from "~/context/hooks";
@@ -54,6 +67,10 @@ type NavigationProp = BaseNavigationComposite<
 export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel {
   const dispatch = useDispatch();
   const hasCompletedMockConfirmation = useRef(false);
+  const trackedContactDetailId = useRef<string | undefined>(undefined);
+  const trackedAddressDetailId = useRef<string | undefined>(undefined);
+  const analytics = useContactsAnalytics();
+  const meContact = useContactsMeContact();
   const navigation = useNavigation<NavigationProp>();
   const route =
     useRoute<RouteProp<MyWalletNavigatorStackParamList, typeof ScreenName.MyWalletContactDetail>>();
@@ -106,31 +123,57 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
 
     hasCompletedMockConfirmation.current = true;
 
-    const signedAddress = await deviceIntents.registerExternalAddress({
-      contact,
-      currencyId: addAddressFlowState.selectedCurrencyId,
-      label: addAddressFlowState.addressLabel.label,
-      address: addAddressFlowState.addressEntry.resolvedAddress,
-    });
-    const address = contactAddress({
-      id: `address-${uuid()}`,
-      currencyId: addAddressFlowState.selectedCurrencyId,
-      label: addAddressFlowState.addressLabel.label,
-      address: addAddressFlowState.addressEntry.resolvedAddress,
-      device: signedAddress.addressDeviceContext,
-    });
+    try {
+      const signedAddress = await deviceIntents.registerExternalAddress({
+        contact,
+        currencyId: addAddressFlowState.selectedCurrencyId,
+        label: addAddressFlowState.addressLabel.label,
+        address: addAddressFlowState.addressEntry.resolvedAddress,
+      });
+      const address = contactAddress({
+        id: `address-${uuid()}`,
+        currencyId: addAddressFlowState.selectedCurrencyId,
+        label: addAddressFlowState.addressLabel.label,
+        address: addAddressFlowState.addressEntry.resolvedAddress,
+        device: signedAddress.addressDeviceContext,
+      });
 
-    dispatch(
-      addAddress({
-        contactId: addAddressFlowState.selectedContactId,
-        address,
-        deviceCredentials: signedAddress.deviceCredentials,
-      }),
-    );
-    completeMockConfirmation();
-    closeAddAddress();
+      dispatch(
+        addAddress({
+          contactId: addAddressFlowState.selectedContactId,
+          address,
+          deviceCredentials: signedAddress.deviceCredentials,
+        }),
+      );
+      completeMockConfirmation();
+      closeAddAddress();
+
+      try {
+        const { network, asset } = await resolveContactsCurrencyAnalytics(
+          addAddressFlowState.selectedCurrencyId,
+          contactsCurrencyAnalyticsDependencies,
+        );
+        const inputMethod = addAddressFlowState.addressEntry.inputMethod ?? "manual";
+
+        analytics.trackEvent(CONTACTS_TRACK_EVENTS.ADDRESS_ADDED, {
+          source: CONTACTS_EVENT_SOURCE.ADD_ADDRESS,
+          network,
+          asset,
+          inputMethod,
+          isEns: inputMethod === "ens",
+          flow: CONTACTS_FLOW.CONTACTS,
+        });
+      } catch {
+        // Analytics enrichment is best-effort and must not affect the user flow.
+      }
+    } catch (error) {
+      hasCompletedMockConfirmation.current = false;
+      console.warn("Failed to complete add-address confirmation", error);
+      closeAddAddress();
+    }
   }, [
     addAddressFlowState,
+    analytics,
     closeAddAddress,
     completeMockConfirmation,
     contact,
@@ -142,8 +185,10 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   }, [completeMockAddressConfirmation]);
   const onAddAddress = useCallback(() => {
     if (!contact || eligibleNetworkIds.length === 0) return;
+
+    trackContactsAddAddressClick(analytics, contact.id, meContact.id);
     startAddAddress(contact);
-  }, [contact, eligibleNetworkIds.length, startAddAddress]);
+  }, [analytics, contact, eligibleNetworkIds.length, meContact.id, startAddAddress]);
   const onCurrencySelected = useCallback<ContactsAddAddressFlowDrawerProps["onCurrencySelected"]>(
     selection => {
       if (addAddressFlowState.status === "selectingCurrency") {
@@ -179,6 +224,30 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       },
     });
   }, [navigation, updateAddress]);
+  const onContinueFromName = useCallback(() => {
+    if (addAddressFlowState.status === "namingAddress") {
+      const currencyId = addAddressFlowState.selectedCurrencyId;
+      const inputMethod = addAddressFlowState.addressEntry.inputMethod ?? "manual";
+
+      void resolveContactsCurrencyAnalytics(currencyId, contactsCurrencyAnalyticsDependencies)
+        .then(({ network, asset }) => {
+          analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
+            source: CONTACTS_EVENT_SOURCE.ADD_ADDRESS,
+            button: CONTACTS_TRACKING_BUTTON.saveAddress,
+            page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
+            network,
+            asset,
+            inputMethod,
+            flow: CONTACTS_FLOW.CONTACTS,
+          });
+        })
+        .catch(() => {
+          // Analytics enrichment is best-effort and must not affect the user flow.
+        });
+    }
+
+    continueFromName();
+  }, [addAddressFlowState, analytics, continueFromName]);
   const labels = useMemo<ContactDetailLabels>(
     () => ({
       addAddress: t("contacts.addAddress"),
@@ -215,11 +284,13 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
   const onDeleteSuccess = useCallback(() => {
     navigation.navigate(ScreenName.MyWalletContacts);
   }, [navigation]);
+  const addressDetailAsset = selection?.network.networkTicker;
   const editDeleteFlow = useContactDetailEditDeleteAdapter(route.params.contactId, onDeleteSuccess);
   const addressDetailActions = useContactAddressDetailActionsAdapter(
     route.params.contactId,
     selection?.row?.addressId,
     onCloseAddressDetail,
+    addressDetailAsset,
   );
   const onCloseAddressDetailSheet = useCallback(() => {
     if (
@@ -240,6 +311,50 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
     onCloseAddressDetail,
   ]);
   const shouldRedirect = !isEnabled || !contact;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      return;
+    }
+
+    const contactId = route.params.contactId;
+
+    if (trackedContactDetailId.current === contactId) {
+      return;
+    }
+
+    trackedContactDetailId.current = contactId;
+    analytics.trackPage(CONTACTS_PAGE_EVENTS.CONTACT_DETAIL, {
+      source: CONTACTS_EVENT_SOURCE.CONTACT_DETAIL,
+      isSelf: contactId === meContact.id,
+    });
+  }, [analytics, meContact.id, route.params.contactId, shouldRedirect]);
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      return;
+    }
+
+    const addressKey =
+      isOpen && selection ? `${selection.row.addressId}:${selection.network.networkId}` : undefined;
+
+    if (addressKey === undefined || trackedAddressDetailId.current === addressKey) {
+      return;
+    }
+
+    trackedAddressDetailId.current = addressKey;
+    analytics.trackPage(CONTACTS_PAGE_EVENTS.ADDRESS_DETAIL, {
+      source: CONTACTS_EVENT_SOURCE.ADDRESS_DETAIL,
+      network: selection!.network.networkName,
+      asset: selection!.network.networkTicker,
+    });
+  }, [analytics, isOpen, selection, shouldRedirect]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      trackedAddressDetailId.current = undefined;
+    }
+  }, [isOpen]);
 
   useLayoutEffect(() => {
     if (shouldRedirect) {
@@ -281,7 +396,7 @@ export function useContactDetailScreenViewModel(): ContactDetailScreenViewModel 
       onAddressConfirm: confirmAddress,
       onBack: goBackAddAddress,
       onClose: closeAddAddress,
-      onContinueFromName: continueFromName,
+      onContinueFromName,
       onCurrencySelected,
       onQrCodeClick,
     },

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.test.tsx
@@ -2,15 +2,21 @@ import { mockMeContact } from "@domain/entity-contact/schema.mock";
 import { act, renderHook } from "@tests/test-renderer";
 import { useContactsAddContactDrawerAdapter } from "./useContactsAddContactDrawerAdapter";
 
+function renderAdapter() {
+  const onSaveSuccess = jest.fn();
+  const rendered = renderHook(() => useContactsAddContactDrawerAdapter(onSaveSuccess), {
+    overrideInitialState: state => ({
+      ...state,
+      contacts: { contacts: [mockMeContact()] },
+    }),
+  });
+
+  return { ...rendered, onSaveSuccess };
+}
+
 describe("useContactsAddContactDrawerAdapter", () => {
   it("should add a valid contact, reset the draft, and close the drawer", async () => {
-    const onSaveSuccess = jest.fn();
-    const { result, store } = renderHook(() => useContactsAddContactDrawerAdapter(onSaveSuccess), {
-      overrideInitialState: state => ({
-        ...state,
-        contacts: { contacts: [mockMeContact()] },
-      }),
-    });
+    const { result, store, onSaveSuccess } = renderAdapter();
 
     expect(result.current.isOpen).toBe(false);
     expect(result.current.isConfirmEnabled).toBe(false);

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsAddContactDrawerAdapter.ts
@@ -8,18 +8,19 @@ import {
 } from "@domain/entity-contact";
 import {
   type ContactCreationPort,
-  type ContactsAddContactDrawerLabels,
   type ContactsAddContactDrawerProps,
-  useAddContactDrawerViewModel,
-} from "@features/flow-contacts-add-contact";
+  useAddContactAppAdapter,
+} from "@features/flow-contacts";
 import { useDispatch } from "~/context/hooks";
 import { useTranslation } from "~/context/Locale";
+import { useContactsAnalytics } from "../../../analytics/useContactsAnalytics";
 
 export function useContactsAddContactDrawerAdapter(
   onSaveSuccess: () => void,
 ): ContactsAddContactDrawerProps {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const analytics = useContactsAnalytics();
   const contactCreation = useMemo<ContactCreationPort>(
     () => ({
       createContact: async ({ name }) => {
@@ -37,11 +38,7 @@ export function useContactsAddContactDrawerAdapter(
     }),
     [dispatch],
   );
-  const drawerViewModel = useAddContactDrawerViewModel({
-    contactCreation,
-    onSaveSuccess,
-  });
-  const labels = useMemo<ContactsAddContactDrawerLabels>(
+  const labels = useMemo(
     () => ({
       title: t("contacts.addContact"),
       namePlaceholder: t("contacts.addContactDrawer.namePlaceholder"),
@@ -55,8 +52,10 @@ export function useContactsAddContactDrawerAdapter(
     [t],
   );
 
-  return {
-    ...drawerViewModel,
+  return useAddContactAppAdapter({
+    analytics,
+    contactCreation,
+    onSaveSuccess,
     labels,
-  };
+  });
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.test.ts
@@ -1,0 +1,50 @@
+import { mockMeContact } from "@domain/entity-contact/schema.mock";
+import { act, renderHook, withFlagOverrides } from "@tests/test-renderer";
+import { ScreenName } from "~/const";
+import { useContactsPageViewModel } from "./useContactsPageViewModel";
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual<typeof import("@react-navigation/native")>("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate, goBack: mockGoBack }),
+}));
+
+function renderViewModel(patchState?: Parameters<typeof withFlagOverrides>[1]) {
+  return renderHook(() => useContactsPageViewModel(), {
+    overrideInitialState: withFlagOverrides({}, patchState),
+  });
+}
+
+describe("useContactsPageViewModel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should navigate to the contact detail screen when a contact is opened", () => {
+    const me = mockMeContact();
+    const { result } = renderViewModel(state => ({
+      ...state,
+      contacts: { contacts: [me] },
+    }));
+
+    act(() => {
+      result.current.onOpenContact(me.id);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(ScreenName.MyWalletContactDetail, {
+      contactId: me.id,
+    });
+  });
+
+  it("should close the feature introduction by going back", () => {
+    const { result } = renderViewModel();
+
+    act(() => {
+      result.current.featureIntroduction.onClose();
+    });
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/hooks/useContactsPageViewModel.ts
@@ -2,6 +2,11 @@ import {
   type ContactsListViewLabels,
   type ContactsViewNativeProps,
   useContactsSearchViewModel,
+  useContactsMeContact,
+  useContactsListPageAnalytics,
+  trackContactsLedgerSyncActivate,
+  trackContactsLedgerSyncDismiss,
+  trackContactsListContactOpen,
 } from "@features/flow-contacts";
 import {
   CONTACTS_FEATURE_INTRODUCTION_HIGHLIGHTS,
@@ -16,12 +21,15 @@ import { USER_AVATAR_URL } from "LLM/components/UserAvatar/constants";
 import type { MyWalletNavigatorStackParamList } from "LLM/features/MyWallet/types";
 import { ScreenName } from "~/const";
 import { useTranslation } from "~/context/Locale";
+import { useContactsAnalytics } from "../../../analytics/useContactsAnalytics";
 import { useContactsFeatureIntroductionPreference } from "../../../hooks/useContactsFeatureIntroductionPreference";
 import type { ContactsPageViewModel } from "../types";
 
 export function useContactsPageViewModel(): ContactsPageViewModel {
   const { t } = useTranslation();
   const navigation = useNavigation<NativeStackNavigationProp<MyWalletNavigatorStackParamList>>();
+  const analytics = useContactsAnalytics();
+  const meContact = useContactsMeContact();
   const labels = useMemo<ContactsListViewLabels>(
     () => ({
       title: t("contacts.title"),
@@ -57,15 +65,18 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
   const onSearchQueryChange = useCallback((query: string) => setSearchQuery(query), []);
   const onOpenContact = useCallback<ContactsViewNativeProps["onOpenContact"]>(
     contactId => {
+      trackContactsListContactOpen(analytics, contactId, meContact.id);
       navigation.navigate(ScreenName.MyWalletContactDetail, { contactId });
     },
-    [navigation],
+    [analytics, meContact.id, navigation],
   );
-  const onDismissLedgerSyncIntroduction = useCallback(
-    () => setIsLedgerSyncIntroductionDismissed(true),
-    [],
-  );
-  const onActivateIntroduction = useCallback(() => undefined, []);
+  const onDismissLedgerSyncIntroduction = useCallback(() => {
+    trackContactsLedgerSyncDismiss(analytics);
+    setIsLedgerSyncIntroductionDismissed(true);
+  }, [analytics]);
+  const onActivateIntroduction = useCallback(() => {
+    trackContactsLedgerSyncActivate(analytics);
+  }, [analytics]);
   const onCompleteFeatureIntroduction = useCallback(() => {
     featureIntroductionState.dismiss();
   }, [featureIntroductionState]);
@@ -83,6 +94,14 @@ export function useContactsPageViewModel(): ContactsPageViewModel {
     isFeatureIntroductionRequested: featureIntroductionState.isRequested,
     ledgerSyncStatus,
     isLedgerSyncIntroductionDismissed,
+  });
+  const searchHasResults = !("status" in viewModel && viewModel.status === "no-results");
+
+  useContactsListPageAnalytics({
+    analytics,
+    searchQuery,
+    searchHasResults,
+    isLedgerSyncIntroductionOpen,
   });
 
   return {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactsPage/index.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useLayoutEffect } from "react";
 import { useNavigation } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useContactsFeature } from "@features/flow-contacts";
-import { TrackScreen } from "~/analytics";
 import { ContactsPageContent } from "./components/ContactsPageContent";
 import { useContactsAddContactDrawerAdapter } from "./hooks/useContactsAddContactDrawerAdapter";
 import { useContactsPageNavigationViewModel } from "./hooks/useContactsPageNavigationViewModel";
@@ -44,10 +43,5 @@ export function ContactsScreen() {
     return <ContactsScreenRedirect />;
   }
 
-  return (
-    <>
-      <TrackScreen category="Contacts" />
-      <ContactsScreenContent />
-    </>
-  );
+  return <ContactsScreenContent />;
 }


### PR DESCRIPTION
## Summary

Wire Ledger Wallet Mobile Contacts scenario entry points to the shared Contacts analytics contract from `@features/flow-contacts`, using global properties from `@features/platform-contacts`.

- Add Mobile Contacts analytics adapters (`platform: "llm"`) via `useContactsAnalytics` / `createContactsAnalyticsHelper`
- Cover entry, list, search, Ledger Sync gate, Add contact, contact detail, Add address (including QR via `inputMethod: "qr_code"`), address detail, and quick actions
- Remove conflicting legacy `<TrackScreen category="Contacts" />` usage from Contacts screens

## Stack

1. #20682 — shared analytics contract (merged)
2. #20731 — Desktop wiring (merged)
3. **#20759 — shared tracking hooks + Desktop dedupe** ← base branch
4. **This PR — Mobile wiring**

## Test plan

- [x] Mobile Contacts unit tests (adapters + view models)
- [ ] Manual smoke on Contacts list, detail, add contact, add address flows