### PR TITLE
[LWD] feat(analytics): simplify opt-in V2 gating (LIVE-35835)

### DIFF
--- a/.changeset/tidy-optin-v2-gate.md
+++ b/.changeset/tidy-optin-v2-gate.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Simplify Welcome analytics opt-in V2 gating to lwdAnalyticsOptInScreenV2 only

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/__tests__/useShouldUseAnalyticsOptInScreenV2.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/__tests__/useShouldUseAnalyticsOptInScreenV2.test.ts
@@ -16,14 +16,10 @@ const buildFeatureFlagsState = (overrides: Record<string, unknown>) => ({
 });
 
 describe("useShouldUseAnalyticsOptInScreenV2", () => {
-  it("should return true for onboarding variant B when the v2 flag is enabled", () => {
+  it("should return true for onboarding when the v2 flag is enabled", () => {
     const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
       initialState: {
         featureFlags: buildFeatureFlagsState({
-          lldAnalyticsOptInPrompt: {
-            enabled: true,
-            params: { variant: "B", entryPoints: ["Onboarding"] },
-          },
           lwdAnalyticsOptInScreenV2: { enabled: true },
         }),
       },
@@ -32,14 +28,10 @@ describe("useShouldUseAnalyticsOptInScreenV2", () => {
     expect(result.current).toBe(true);
   });
 
-  it("should return false for portfolio even when variant B and v2 flag are enabled", () => {
+  it("should return false for portfolio even when the v2 flag is enabled", () => {
     const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.portfolio), {
       initialState: {
         featureFlags: buildFeatureFlagsState({
-          lldAnalyticsOptInPrompt: {
-            enabled: true,
-            params: { variant: "B", entryPoints: ["Portfolio"] },
-          },
           lwdAnalyticsOptInScreenV2: { enabled: true },
         }),
       },
@@ -48,47 +40,11 @@ describe("useShouldUseAnalyticsOptInScreenV2", () => {
     expect(result.current).toBe(false);
   });
 
-  it("should return false for onboarding variant B when the v2 flag is disabled", () => {
+  it("should return false for onboarding when the v2 flag is disabled", () => {
     const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
       initialState: {
         featureFlags: buildFeatureFlagsState({
-          lldAnalyticsOptInPrompt: {
-            enabled: true,
-            params: { variant: "B", entryPoints: ["Onboarding"] },
-          },
           lwdAnalyticsOptInScreenV2: { enabled: false },
-        }),
-      },
-    });
-
-    expect(result.current).toBe(false);
-  });
-
-  it("should return false for onboarding variant A even when the v2 flag is enabled", () => {
-    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
-      initialState: {
-        featureFlags: buildFeatureFlagsState({
-          lldAnalyticsOptInPrompt: {
-            enabled: true,
-            params: { variant: "A", entryPoints: ["Onboarding"] },
-          },
-          lwdAnalyticsOptInScreenV2: { enabled: true },
-        }),
-      },
-    });
-
-    expect(result.current).toBe(false);
-  });
-
-  it("should return false for onboarding variant B when lldAnalyticsOptInPrompt is disabled", () => {
-    const { result } = renderHook(() => useShouldUseAnalyticsOptInScreenV2(EntryPoint.onboarding), {
-      initialState: {
-        featureFlags: buildFeatureFlagsState({
-          lldAnalyticsOptInPrompt: {
-            enabled: false,
-            params: { variant: "B", entryPoints: ["Onboarding"] },
-          },
-          lwdAnalyticsOptInScreenV2: { enabled: true },
         }),
       },
     });

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useCommonLogic.tsx
@@ -32,6 +32,7 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
   const isTrackingEnabled = useSelector(trackingEnabledSelector);
   const consentInfo = useSelector(analyticsConsentInfoSelector);
   const lldAnalyticsOptInPromptFlag = useFeature("lldAnalyticsOptInPrompt");
+  const lwdAnalyticsOptInScreenV2 = useFeature("lwdAnalyticsOptInScreenV2");
   const analyticsOptInFlag = useFeature("analyticsOptIn");
   const { currentPolicyVersion } = resolveAnalyticsOptInParams(analyticsOptInFlag);
   const policyVersion = currentPolicyVersion?.normalized ?? consentInfo.privacyPolicyVersion;
@@ -46,6 +47,8 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
   const variant = (lldAnalyticsOptInPromptFlag?.params?.variant ?? "A") as AnalyticsOptInVariant;
   const policyUrlKey = resolveAnalyticsOptInPolicyUrl(entryPoint, variant);
   const policyUrl = useLocalizedUrl(policyUrlKey);
+  const shouldUseScreenV2 =
+    entryPoint === EntryPoint.onboarding && Boolean(lwdAnalyticsOptInScreenV2?.enabled);
 
   const openAnalyticsOptInPrompt = useCallback(
     (routePath: string, callBack: () => void) => {
@@ -59,18 +62,24 @@ export const useAnalyticsOptInPrompt = ({ entryPoint }: Props) => {
     .map(s => s.toLowerCase())
     .includes(entryPoint.toLowerCase());
 
-  const isFlagEnabled = useMemo(
-    () =>
-      isEntryPointIncludedInFlagParams &&
-      lldAnalyticsOptInPromptFlag?.enabled &&
-      (!hasSeenAnalyticsOptInPrompt || entryPoint === EntryPoint.onboarding),
-    [
-      lldAnalyticsOptInPromptFlag,
-      hasSeenAnalyticsOptInPrompt,
-      entryPoint,
-      isEntryPointIncludedInFlagParams,
-    ],
-  );
+  const isFlagEnabled = useMemo(() => {
+    // V2 Welcome path: gated only by lwdAnalyticsOptInScreenV2 + unseen prompt.
+    if (shouldUseScreenV2) {
+      return !hasSeenAnalyticsOptInPrompt;
+    }
+
+    return (
+      Boolean(isEntryPointIncludedInFlagParams) &&
+      Boolean(lldAnalyticsOptInPromptFlag?.enabled) &&
+      (!hasSeenAnalyticsOptInPrompt || entryPoint === EntryPoint.onboarding)
+    );
+  }, [
+    shouldUseScreenV2,
+    hasSeenAnalyticsOptInPrompt,
+    isEntryPointIncludedInFlagParams,
+    lldAnalyticsOptInPromptFlag?.enabled,
+    entryPoint,
+  ]);
 
   const onSubmit = async () => {
     setIsAnalyticsOptInPromptOpened(false);

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useShouldUseAnalyticsOptInScreenV2.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInPrompt/hooks/useShouldUseAnalyticsOptInScreenV2.ts
@@ -1,14 +1,9 @@
 import { useFeature } from "@features/platform-feature-flags";
 import { EntryPoint } from "../types/AnalyticsOptInPromptNavigator";
 
+/** V2 Welcome screen is gated only by `lwdAnalyticsOptInScreenV2` (onboarding only). */
 export function useShouldUseAnalyticsOptInScreenV2(entryPoint: EntryPoint): boolean {
-  const lldAnalyticsOptInPrompt = useFeature("lldAnalyticsOptInPrompt");
   const lwdAnalyticsOptInScreenV2 = useFeature("lwdAnalyticsOptInScreenV2");
 
-  return (
-    entryPoint === EntryPoint.onboarding &&
-    Boolean(lldAnalyticsOptInPrompt?.enabled) &&
-    lldAnalyticsOptInPrompt?.params?.variant === "B" &&
-    Boolean(lwdAnalyticsOptInScreenV2?.enabled)
-  );
+  return entryPoint === EntryPoint.onboarding && Boolean(lwdAnalyticsOptInScreenV2?.enabled);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/__integrations__/AnalyticsOptInScreen.welcome.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/__integrations__/AnalyticsOptInScreen.welcome.integration.test.tsx
@@ -18,28 +18,21 @@ jest.mock("LLD/features/Onboarding/screens/Welcome/hooks/useVideoCarousel", () =
   }),
 }));
 
-const analyticsPromptEnabledOverrides = {
-  ...FEATURE_FLAGS_INITIAL_STATE.overrides,
-  lldAnalyticsOptInPrompt: {
-    enabled: true,
-    params: {
-      variant: "B",
-      entryPoints: ["Onboarding"],
-    },
-  },
-  lwdAnalyticsOptInScreenV2: {
-    enabled: true,
-  },
-};
-
-const featureFlagsState = {
+const buildFeatureFlagsState = (overrides: Record<string, unknown>) => ({
   ...FEATURE_FLAGS_INITIAL_STATE,
-  overrides: analyticsPromptEnabledOverrides,
+  overrides: {
+    ...FEATURE_FLAGS_INITIAL_STATE.overrides,
+    ...overrides,
+  },
   resolved: {
     ...FEATURE_FLAGS_DEFAULTS,
-    ...analyticsPromptEnabledOverrides,
+    ...overrides,
   },
-};
+});
+
+const v2EnabledFeatureFlags = buildFeatureFlagsState({
+  lwdAnalyticsOptInScreenV2: { enabled: true },
+});
 
 describe("AnalyticsOptInScreen on Welcome", () => {
   beforeEach(() => {
@@ -55,10 +48,10 @@ describe("AnalyticsOptInScreen on Welcome", () => {
     document.getElementById("modals")?.remove();
   });
 
-  it("should open the screen when user starts onboarding and accept continues flow", async () => {
+  it("should open the v2 screen when the v2 flag is enabled without lldAnalyticsOptInPrompt", async () => {
     const { user } = render(<Welcome />, {
       initialState: {
-        featureFlags: featureFlagsState,
+        featureFlags: v2EnabledFeatureFlags,
         settings: {
           ...INITIAL_STATE,
           hasSeenAnalyticsOptInPrompt: false,
@@ -80,17 +73,24 @@ describe("AnalyticsOptInScreen on Welcome", () => {
       "button_clicked",
       expect.objectContaining({
         button: "Accept all",
-        variant: "B",
         entryPoint: "Onboarding",
+        flow: "consent onboarding",
       }),
       true,
+    );
+    expect(track).not.toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        variant: expect.anything(),
+      }),
+      expect.anything(),
     );
   });
 
   it("should open preferences when user chooses Set preferences", async () => {
     const { user } = render(<Welcome />, {
       initialState: {
-        featureFlags: featureFlagsState,
+        featureFlags: v2EnabledFeatureFlags,
         settings: {
           ...INITIAL_STATE,
           hasSeenAnalyticsOptInPrompt: false,
@@ -109,7 +109,7 @@ describe("AnalyticsOptInScreen on Welcome", () => {
   it("should return to the main screen when user closes preferences", async () => {
     const { user } = render(<Welcome />, {
       initialState: {
-        featureFlags: featureFlagsState,
+        featureFlags: v2EnabledFeatureFlags,
         settings: {
           ...INITIAL_STATE,
           hasSeenAnalyticsOptInPrompt: false,
@@ -133,41 +133,27 @@ describe("AnalyticsOptInScreen on Welcome", () => {
       "button_clicked",
       expect.objectContaining({
         button: "Close",
-        variant: "B",
-        page: "Analytics opt-in screen B preferences",
+        page: "Analytics opt-in screen preferences",
       }),
       true,
     );
   });
 
-  it("should keep the legacy drawer for onboarding variant A when the v2 flag is enabled", async () => {
-    const variantAFeatureFlagsState = {
-      ...featureFlagsState,
-      overrides: {
-        ...featureFlagsState.overrides,
-        lldAnalyticsOptInPrompt: {
-          enabled: true,
-          params: {
-            variant: "A",
-            entryPoints: ["Onboarding"],
-          },
+  it("should keep the legacy drawer when the v2 flag is disabled and lldAnalyticsOptInPrompt is enabled", async () => {
+    const legacyFeatureFlags = buildFeatureFlagsState({
+      lldAnalyticsOptInPrompt: {
+        enabled: true,
+        params: {
+          variant: "A",
+          entryPoints: ["Onboarding"],
         },
       },
-      resolved: {
-        ...featureFlagsState.resolved,
-        lldAnalyticsOptInPrompt: {
-          enabled: true,
-          params: {
-            variant: "A",
-            entryPoints: ["Onboarding"],
-          },
-        },
-      },
-    };
+      lwdAnalyticsOptInScreenV2: { enabled: false },
+    });
 
     const { user } = render(<Welcome />, {
       initialState: {
-        featureFlags: variantAFeatureFlagsState,
+        featureFlags: legacyFeatureFlags,
         settings: {
           ...INITIAL_STATE,
           hasSeenAnalyticsOptInPrompt: false,
@@ -181,10 +167,27 @@ describe("AnalyticsOptInScreen on Welcome", () => {
     expect(screen.queryByTestId("analytics-opt-in-screen")).not.toBeInTheDocument();
   });
 
+  it("should not open the v2 screen when the prompt was already seen", async () => {
+    const { user } = render(<Welcome />, {
+      initialState: {
+        featureFlags: v2EnabledFeatureFlags,
+        settings: {
+          ...INITIAL_STATE,
+          hasSeenAnalyticsOptInPrompt: true,
+        },
+      },
+    });
+
+    await user.click(screen.getByTestId("v3-onboarding-get-started-button"));
+
+    expect(screen.queryByTestId("analytics-opt-in-screen")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("accept-analytics-button")).not.toBeInTheDocument();
+  });
+
   it("should refuse all and close the screen", async () => {
     const { user } = render(<Welcome />, {
       initialState: {
-        featureFlags: featureFlagsState,
+        featureFlags: v2EnabledFeatureFlags,
         settings: {
           ...INITIAL_STATE,
           hasSeenAnalyticsOptInPrompt: false,

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/analytics/trackAnalyticsOptInScreen.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/analytics/trackAnalyticsOptInScreen.ts
@@ -2,7 +2,6 @@ import { track } from "~/renderer/analytics/segment";
 import {
   ANALYTICS_OPT_IN_SCREEN_FLOW,
   ANALYTICS_OPT_IN_SCREEN_PAGES,
-  ANALYTICS_OPT_IN_SCREEN_VARIANT,
 } from "LLD/features/AnalyticsOptInScreenV2/types";
 
 type TrackPayload = {
@@ -27,7 +26,6 @@ export const trackAnalyticsOptInScreenClick = (
       ...basePayload(ANALYTICS_OPT_IN_SCREEN_PAGES[page]),
       button,
       flow: ANALYTICS_OPT_IN_SCREEN_FLOW,
-      variant: ANALYTICS_OPT_IN_SCREEN_VARIANT,
       entryPoint: "Onboarding",
     },
     shouldWeTrack,
@@ -46,7 +44,6 @@ export const trackAnalyticsOptInScreenToggle = (
       toggle,
       value,
       flow: ANALYTICS_OPT_IN_SCREEN_FLOW,
-      variant: ANALYTICS_OPT_IN_SCREEN_VARIANT,
       entryPoint: "Onboarding",
     },
     shouldWeTrack,

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/__tests__/useAnalyticsOptInScreenViewModel.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/hooks/__tests__/useAnalyticsOptInScreenViewModel.test.ts
@@ -63,11 +63,17 @@ describe("useAnalyticsOptInScreenViewModel", () => {
       "button_clicked",
       expect.objectContaining({
         button: "Accept all",
-        variant: "B",
         flow: "consent onboarding",
         entryPoint: "Onboarding",
       }),
       true,
+    );
+    expect(track).not.toHaveBeenCalledWith(
+      "button_clicked",
+      expect.objectContaining({
+        variant: expect.anything(),
+      }),
+      expect.anything(),
     );
   });
 
@@ -141,7 +147,6 @@ describe("useAnalyticsOptInScreenViewModel", () => {
       "button_clicked",
       expect.objectContaining({
         button: "Previous",
-        variant: "B",
       }),
       true,
     );
@@ -190,7 +195,6 @@ describe("useAnalyticsOptInScreenViewModel", () => {
       "button_clicked",
       expect.objectContaining({
         button: "Learn more link",
-        variant: "B",
       }),
       true,
     );

--- a/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/types.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/AnalyticsOptInScreenV2/types.ts
@@ -1,13 +1,10 @@
 export type AnalyticsOptInScreenStep = "main" | "preferences";
 
-/** Kept as "B" in analytics payloads until legacy variant A is removed. */
-export const ANALYTICS_OPT_IN_SCREEN_VARIANT = "B";
-
 export const ANALYTICS_OPT_IN_SCREEN_FLOW = "consent onboarding";
 
 export const ANALYTICS_OPT_IN_SCREEN_PAGES = {
-  main: "Analytics opt-in screen B main",
-  preferences: "Analytics opt-in screen B preferences",
+  main: "Analytics opt-in screen main",
+  preferences: "Analytics opt-in screen preferences",
 } as const;
 
 export type { AnalyticsOptInPromptHostProps as AnalyticsOptInScreenHostProps } from "LLD/features/AnalyticsOptInPrompt/types/AnalyticsOptInPromptNavigator";

--- a/shared/feature-flags/src/flags/team-engagement/lwdAnalyticsOptInScreenV2.ts
+++ b/shared/feature-flags/src/flags/team-engagement/lwdAnalyticsOptInScreenV2.ts
@@ -1,4 +1,4 @@
 import { flag } from "../../define";
 
-/** Rollout: internal QA → staged B traffic on Welcome onboarding only (with lldAnalyticsOptInPrompt variant B). */
+/** Rollout of the Welcome onboarding analytics opt-in screen (V2). Portfolio keeps the legacy drawer. */
 export const lwdAnalyticsOptInScreenV2 = flag();


### PR DESCRIPTION
### 📝 Description

Simplify which Desktop analytics consent UI is shown on Welcome.

**Problem**: The new Welcome opt-in screen (V2) required both `lldAnalyticsOptInPrompt` (enabled + variant B) and `lwdAnalyticsOptInScreenV2`. That dual-flag A/B setup made rollouts harder to reason about (see LIVE-35345).

**Solution**: Gate V2 with `lwdAnalyticsOptInScreenV2` only (onboarding). Legacy drawer behavior is unchanged when the V2 flag is off; Portfolio never gets V2. V2 tracking no longer sends variant B.

| `lwdAnalyticsOptInScreenV2` | Onboarding (Welcome) | Portfolio |
| --- | --- | --- |
| **ON** | V2 screen until `hasSeenAnalyticsOptInPrompt` | Unchanged (legacy via `lldAnalyticsOptInPrompt`) |
| **OFF** | Unchanged (legacy via `lldAnalyticsOptInPrompt`) | Unchanged (legacy via `lldAnalyticsOptInPrompt`) |

`lldAnalyticsOptInPrompt` is **not** removed — still used for legacy onboarding, Portfolio, and Settings.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35835](https://ledgerhq.atlassian.net/browse/LIVE-35835)
- **Related**: [LIVE-35345](https://ledgerhq.atlassian.net/browse/LIVE-35345)
- **ADR** (if any): N/A

[LIVE-35835]: https://ledgerhq.atlassian.net/browse/LIVE-35835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35345]: https://ledgerhq.atlassian.net/browse/LIVE-35345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ