### PR TITLE
[LWDM] feat(pay-card-balance): add stable balance filter picker UI (LIVE-34900)

### DIFF
--- a/.changeset/bright-filters-select.md
+++ b/.changeset/bright-filters-select.md
@@ -1,0 +1,7 @@
+---
+"@features/flow-pay-card-balance": minor
+"ledger-live-desktop": patch
+"live-mobile": patch
+---
+
+Add a stablecoin balance filter picker to the Pay card hero.

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -1,17 +1,29 @@
 import { useCallback, useMemo } from "react";
 import BigNumber from "bignumber.js";
-import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
+import { useTranslation } from "react-i18next";
+import {
+  formatCurrencyUnit,
+  formatCurrencyUnitFragment,
+} from "@ledgerhq/live-common/currencies/index";
 import {
   aggregatePayCardBalance,
   type FormattedValue,
   type PayCardBalanceData,
+  type PayCardBalanceFilterOption,
 } from "@features/flow-pay-card-balance";
-import { selectPayCardBalanceFilter } from "@domain/entity-pay-card";
-import { useSelector } from "LLD/hooks/redux";
+import {
+  PAY_CARD_BALANCE_FILTER_ALL,
+  selectPayCardBalanceFilter,
+  setPayCardBalanceFilter,
+  type PayCardBalanceFilter,
+} from "@domain/entity-pay-card";
+import { useDispatch, useSelector } from "LLD/hooks/redux";
 import { useCategorizedAssetsFromPortfolio } from "LLD/hooks/useCategorizedAssets";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
 
 export function usePayCardBalance(): PayCardBalanceData {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
   const locale = useSelector(localeSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filter = useSelector(selectPayCardBalanceFilter);
@@ -30,6 +42,37 @@ export function usePayCardBalance(): PayCardBalanceData {
     [unit, locale],
   );
 
+  // "all" plus one row per held stablecoin, so a currencyId filter resolves instead of falling back to "all".
+  const filterOptions = useMemo<PayCardBalanceFilterOption[]>(
+    () => [
+      {
+        id: PAY_CARD_BALANCE_FILTER_ALL,
+        title: t("payTab.balance.filter.allStablecoins"),
+        countervalue: 0,
+        countervalueLabel: "",
+      },
+      ...categorizedAssets.stablecoins.map(({ currency, value }) => ({
+        id: currency.id,
+        title: currency.name,
+        ticker: currency.ticker,
+        ledgerId: currency.id,
+        countervalue: value,
+        countervalueLabel: formatCurrencyUnit(unit, new BigNumber(value), {
+          locale,
+          showCode: true,
+        }),
+      })),
+    ],
+    [categorizedAssets.stablecoins, t, unit, locale],
+  );
+
+  const onConfirmFilter = useCallback(
+    (next: PayCardBalanceFilter) => {
+      dispatch(setPayCardBalanceFilter(next));
+    },
+    [dispatch],
+  );
+
   return useMemo(
     () =>
       aggregatePayCardBalance({
@@ -37,14 +80,18 @@ export function usePayCardBalance(): PayCardBalanceData {
         filter,
         isLoading: isLoadingStablecoinTickers,
         isError: isStablecoinTickersError,
+        filterOptions,
         formatCountervalue,
+        onConfirmFilter,
       }),
     [
       categorizedAssets.stablecoins,
       filter,
       isLoadingStablecoinTickers,
       isStablecoinTickersError,
+      filterOptions,
       formatCountervalue,
+      onConfirmFilter,
     ],
   );
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/index.tsx
@@ -25,6 +25,11 @@ const PayTab = () => {
         labels={{
           emptyTitle: t("payTab.balance.emptyTitle"),
           emptyDescription: t("payTab.balance.emptyDescription"),
+          allStablecoins: t("payTab.balance.filter.allStablecoins"),
+          filterDialogTitle: t("payTab.balance.filter.dialogTitle"),
+          filterDialogDescription: t("payTab.balance.filter.dialogDescription"),
+          filterDialogBanner: t("payTab.balance.filter.dialogBanner"),
+          confirm: t("payTab.balance.filter.confirm"),
         }}
       />
       <CardLogin openHostedLogin={openHostedLogin} />

--- a/apps/ledger-live-desktop/static/i18n/en/app.json
+++ b/apps/ledger-live-desktop/static/i18n/en/app.json
@@ -890,7 +890,14 @@
     },
     "balance": {
       "emptyTitle": "Pay and get paid",
-      "emptyDescription": "Start by depositing stablecoin to your wallet"
+      "emptyDescription": "Start by depositing stablecoin to your wallet",
+      "filter": {
+        "allStablecoins": "All stablecoins",
+        "dialogTitle": "Filter balance",
+        "dialogDescription": "Use stablecoin to pay worldwide with low fees and minimal volatility.",
+        "dialogBanner": "Manage all other assets in your home",
+        "confirm": "Confirm"
+      }
     }
   },
   "lend": {

--- a/apps/ledger-live-mobile/src/locales/en/common.json
+++ b/apps/ledger-live-mobile/src/locales/en/common.json
@@ -10015,7 +10015,14 @@
     },
     "balance": {
       "emptyTitle": "Pay and get paid",
-      "emptyDescription": "Start by depositing stablecoin to your wallet"
+      "emptyDescription": "Start by depositing stablecoin to your wallet",
+      "filter": {
+        "allStablecoins": "All stablecoins",
+        "dialogTitle": "Filter balance",
+        "dialogDescription": "Use stablecoin to pay worldwide with low fees and minimal volatility.",
+        "dialogBanner": "Manage all other assets in your home",
+        "confirm": "Confirm"
+      }
     }
   },
   "syncIndicator": {

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabFeatureTour.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/__integrations__/PayTabFeatureTour.integration.test.tsx
@@ -16,7 +16,10 @@ jest.mock("LLM/features/PayTab/hooks/usePayCardBalance", () => ({
     status: "ready",
     stableBalance: 0,
     filter: "all",
+    hasBalance: false,
+    filterOptions: [],
     formatCountervalue: () => ({}),
+    onConfirmFilter: () => {},
   }),
 }));
 

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -6,12 +6,18 @@ import {
   type FormattedValue,
   type PayCardBalanceData,
 } from "@features/flow-pay-card-balance";
-import { selectPayCardBalanceFilter } from "@domain/entity-pay-card";
+import {
+  PAY_CARD_BALANCE_FILTER_ALL,
+  selectPayCardBalanceFilter,
+  type PayCardBalanceFilter,
+} from "@domain/entity-pay-card";
 import { useCategorizedAssetsFromPortfolio } from "LLM/hooks/useCategorizedAssetsFromPortfolio";
 import { useSelector } from "~/context/hooks";
+import { useTranslation } from "~/context/Locale";
 import { counterValueCurrencySelector, localeSelector } from "~/reducers/settings";
 
 export function usePayCardBalance(): PayCardBalanceData {
+  const { t } = useTranslation();
   const locale = useSelector(localeSelector);
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filter = useSelector(selectPayCardBalanceFilter);
@@ -30,6 +36,22 @@ export function usePayCardBalance(): PayCardBalanceData {
     [unit, locale],
   );
 
+  // Full filter options / confirm wiring lands with the LWD/LWM filter tasks.
+  const filterOptions = useMemo(
+    () =>
+      [
+        {
+          id: PAY_CARD_BALANCE_FILTER_ALL,
+          title: t("payTab.balance.filter.allStablecoins"),
+          countervalue: 0,
+          countervalueLabel: "",
+        },
+      ] as const,
+    [t],
+  );
+
+  const onConfirmFilter = useCallback((_next: PayCardBalanceFilter) => {}, []);
+
   return useMemo(
     () =>
       aggregatePayCardBalance({
@@ -37,14 +59,18 @@ export function usePayCardBalance(): PayCardBalanceData {
         filter,
         isLoading: isLoadingStablecoinTickers,
         isError: isStablecoinTickersError,
+        filterOptions,
         formatCountervalue,
+        onConfirmFilter,
       }),
     [
       categorizedAssets.stablecoins,
       filter,
       isLoadingStablecoinTickers,
       isStablecoinTickersError,
+      filterOptions,
       formatCountervalue,
+      onConfirmFilter,
     ],
   );
 }

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.test.ts
@@ -16,7 +16,10 @@ const balance: PayCardBalanceData = {
   status: "ready",
   stableBalance: 0,
   filter: "all",
+  hasBalance: false,
+  filterOptions: [],
   formatCountervalue: jest.fn(),
+  onConfirmFilter: jest.fn(),
 };
 
 jest.mock("LLM/features/PayTab/hooks/usePayCardBalance", () => ({

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/screens/PayTab/usePayTabViewModel.ts
@@ -18,6 +18,11 @@ export function usePayTabViewModel() {
     () => ({
       emptyTitle: t("payTab.balance.emptyTitle"),
       emptyDescription: t("payTab.balance.emptyDescription"),
+      allStablecoins: t("payTab.balance.filter.allStablecoins"),
+      filterDialogTitle: t("payTab.balance.filter.dialogTitle"),
+      filterDialogDescription: t("payTab.balance.filter.dialogDescription"),
+      filterDialogBanner: t("payTab.balance.filter.dialogBanner"),
+      confirm: t("payTab.balance.filter.confirm"),
     }),
     [t],
   );

--- a/features/flow/pay-card-balance/package.json
+++ b/features/flow/pay-card-balance/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@support/jest-features-flow": "workspace:*",
     "@features/platform-style": "workspace:*",
+    "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterDialog.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterDialog.web.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import type { PayCardBalanceFilter } from "@domain/entity-pay-card";
+import { BalanceFilterDialogView } from "./BalanceFilterDialogView";
+import { useBalanceFilterDialogViewModel } from "./useBalanceFilterDialogViewModel";
+import type { PayCardBalanceFilterLabels, PayCardBalanceFilterOption } from "./types";
+
+export type BalanceFilterDialogProps = Readonly<{
+  isOpen: boolean;
+  filter: PayCardBalanceFilter;
+  options: readonly PayCardBalanceFilterOption[];
+  labels: PayCardBalanceFilterLabels;
+  onClose: () => void;
+  onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
+}>;
+
+export function BalanceFilterDialog({
+  isOpen,
+  filter,
+  options,
+  labels,
+  onClose,
+  onConfirmFilter,
+  onTrackEvent,
+}: BalanceFilterDialogProps) {
+  const { draftFilter, onSelectDraft, onConfirm } = useBalanceFilterDialogViewModel({
+    isOpen,
+    activeFilter: filter,
+    options,
+    onConfirmFilter,
+    onClose,
+    onTrackEvent,
+  });
+
+  return (
+    <BalanceFilterDialogView
+      isOpen={isOpen}
+      draftFilter={draftFilter}
+      options={options}
+      labels={labels}
+      onClose={onClose}
+      onSelectDraft={onSelectDraft}
+      onConfirm={onConfirm}
+    />
+  );
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterDialogView.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterDialogView.web.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback } from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import {
+  Banner,
+  Button,
+  Card,
+  CardContent,
+  CardContentDescription,
+  CardContentTitle,
+  CardHeader,
+  CardLeading,
+  CardTrailing,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  Spot,
+} from "@ledgerhq/lumen-ui-react";
+import { Bundle } from "@ledgerhq/lumen-ui-react/symbols";
+import type { PayCardBalanceFilter } from "@domain/entity-pay-card";
+import type { PayCardBalanceFilterLabels, PayCardBalanceFilterOption } from "./types";
+
+export type BalanceFilterDialogViewProps = Readonly<{
+  isOpen: boolean;
+  draftFilter: PayCardBalanceFilter;
+  options: readonly PayCardBalanceFilterOption[];
+  labels: PayCardBalanceFilterLabels;
+  onClose: () => void;
+  onSelectDraft: (filter: PayCardBalanceFilter) => void;
+  onConfirm: () => void;
+}>;
+
+export function BalanceFilterDialogView({
+  isOpen,
+  draftFilter,
+  options,
+  labels,
+  onClose,
+  onSelectDraft,
+  onConfirm,
+}: BalanceFilterDialogViewProps) {
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader
+          density="expanded"
+          title={labels.filterDialogTitle}
+          description={labels.filterDialogDescription}
+          onClose={onClose}
+        />
+        <DialogBody className="flex flex-col gap-16">
+          <div className="flex flex-col gap-8" data-testid="pay-card-balance-filter-dialog">
+            {options.map(option => {
+              const selected = option.id === draftFilter;
+              const rowKey = option.ticker?.toLowerCase() ?? "all";
+              return (
+                <Card
+                  key={option.id}
+                  type="interactive"
+                  outlined={selected}
+                  onClick={() => onSelectDraft(option.id)}
+                  data-testid={`pay-card-balance-filter-option-${rowKey}`}
+                >
+                  <CardHeader>
+                    <CardLeading>
+                      {option.ledgerId != null ? (
+                        <CryptoIcon
+                          ledgerId={option.ledgerId}
+                          ticker={option.ticker ?? ""}
+                          size={48}
+                        />
+                      ) : (
+                        <Spot appearance="icon" icon={Bundle} size={48} />
+                      )}
+                      <CardContent>
+                        <CardContentTitle>{option.title}</CardContentTitle>
+                        {option.ticker != null ? (
+                          <CardContentDescription>{option.ticker}</CardContentDescription>
+                        ) : null}
+                      </CardContent>
+                    </CardLeading>
+                    <CardTrailing>
+                      <div className="flex flex-col items-end gap-4">
+                        <span className="body-2-semi-bold">{option.countervalueLabel}</span>
+                        {option.cryptoAmountLabel != null ? (
+                          <span className="body-3 text-muted">{option.cryptoAmountLabel}</span>
+                        ) : null}
+                      </div>
+                    </CardTrailing>
+                  </CardHeader>
+                </Card>
+              );
+            })}
+          </div>
+          <Banner appearance="info" title={labels.filterDialogBanner} />
+          <Button
+            appearance="base"
+            size="lg"
+            className="w-full"
+            onClick={onConfirm}
+            data-testid="pay-card-balance-filter-confirm"
+          >
+            {labels.confirm}
+          </Button>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterPill.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/BalanceFilterPill.web.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { CryptoIcon } from "@ledgerhq/crypto-icons";
+import { MediaButton } from "@ledgerhq/lumen-ui-react";
+import type { PayCardBalanceFilterOption } from "./types";
+
+type BalanceFilterPillProps = Readonly<{
+  allStablecoinsLabel: string;
+  selectedOption?: PayCardBalanceFilterOption;
+  onClick: () => void;
+}>;
+
+export function BalanceFilterPill({
+  allStablecoinsLabel,
+  selectedOption,
+  onClick,
+}: BalanceFilterPillProps) {
+  const label = selectedOption?.ticker ?? selectedOption?.title ?? allStablecoinsLabel;
+
+  const leadingContent =
+    selectedOption?.ledgerId != null ? (
+      <CryptoIcon
+        ledgerId={selectedOption.ledgerId}
+        ticker={selectedOption.ticker ?? ""}
+        size={24}
+      />
+    ) : undefined;
+
+  return (
+    <MediaButton
+      size="sm"
+      appearance="no-background"
+      leadingContent={leadingContent}
+      leadingContentShape="rounded"
+      className="shrink-0"
+      onClick={onClick}
+      data-testid="pay-card-balance-filter-pill"
+    >
+      {label}
+    </MediaButton>
+  );
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.native.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.native.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { Box, Text } from "@ledgerhq/lumen-ui-rnative";
-import type { PayCardBalanceLabels } from "./types";
+import type { PayCardBalanceEmptyLabels } from "./types";
 
 type PayCardBalanceEmptyStateProps = Readonly<{
-  labels: PayCardBalanceLabels;
+  labels: PayCardBalanceEmptyLabels;
 }>;
 
 export function PayCardBalanceEmptyState({ labels }: PayCardBalanceEmptyStateProps) {

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceEmptyState.web.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import type { PayCardBalanceLabels } from "./types";
+import type { PayCardBalanceEmptyLabels } from "./types";
 
 type PayCardBalanceEmptyStateProps = Readonly<{
-  labels: PayCardBalanceLabels;
+  labels: PayCardBalanceEmptyLabels;
 }>;
 
 export function PayCardBalanceEmptyState({ labels }: PayCardBalanceEmptyStateProps) {

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceFundedState.web.tsx
@@ -1,17 +1,24 @@
 import React from "react";
 import { AmountDisplay } from "@ledgerhq/lumen-ui-react";
-import type { FormattedValue } from "./types";
+import type { FormattedValue, PayCardBalanceFilterOption } from "./types";
+import { BalanceFilterPill } from "./BalanceFilterPill";
 
 type PayCardBalanceFundedStateProps = Readonly<{
   balance: number;
   formatCountervalue: (value: number) => FormattedValue;
   isLoading: boolean;
+  allStablecoinsLabel: string;
+  selectedOption?: PayCardBalanceFilterOption;
+  onOpenFilter: () => void;
 }>;
 
 export function PayCardBalanceFundedState({
   balance,
   formatCountervalue,
   isLoading,
+  allStablecoinsLabel,
+  selectedOption,
+  onOpenFilter,
 }: PayCardBalanceFundedStateProps) {
   return (
     <div className="flex items-end gap-12" data-testid="pay-card-balance-funded-state">
@@ -20,6 +27,11 @@ export function PayCardBalanceFundedState({
         formatter={formatCountervalue}
         loading={isLoading}
         data-testid="pay-card-balance-amount"
+      />
+      <BalanceFilterPill
+        allStablecoinsLabel={allStablecoinsLabel}
+        selectedOption={selectedOption}
+        onClick={onOpenFilter}
       />
     </div>
   );

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/PayCardBalanceView.web.tsx
@@ -3,16 +3,31 @@ import { Divider } from "@ledgerhq/lumen-ui-react";
 import type { PayCardBalanceViewProps } from "./types";
 import { PayCardBalanceEmptyState } from "./PayCardBalanceEmptyState";
 import { PayCardBalanceFundedState } from "./PayCardBalanceFundedState";
+import { BalanceFilterDialog } from "./BalanceFilterDialog";
 
 export function PayCardBalanceView(props: PayCardBalanceViewProps) {
   return (
     <div className="flex flex-col gap-24" data-testid="pay-card-balance">
       {props.displayMode === "funded" ? (
-        <PayCardBalanceFundedState
-          balance={props.balance}
-          formatCountervalue={props.formatCountervalue}
-          isLoading={props.isLoading}
-        />
+        <>
+          <PayCardBalanceFundedState
+            balance={props.balance}
+            formatCountervalue={props.formatCountervalue}
+            isLoading={props.isLoading}
+            allStablecoinsLabel={props.labels.allStablecoins}
+            selectedOption={props.selectedOption}
+            onOpenFilter={props.onOpenFilter}
+          />
+          <BalanceFilterDialog
+            isOpen={props.isFilterOpen}
+            filter={props.filter}
+            options={props.options}
+            labels={props.labels}
+            onClose={props.onCloseFilter}
+            onConfirmFilter={props.onConfirmFilter}
+            onTrackEvent={props.onTrackEvent}
+          />
+        </>
       ) : (
         <PayCardBalanceEmptyState labels={props.labels} />
       )}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterDialog.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterDialog.web.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { BalanceFilterDialog } from "../BalanceFilterDialog.web";
+import type { BalanceFilterDialogProps } from "../BalanceFilterDialog.web";
+import { USDT_ID, labels, options } from "./fixtures";
+import { renderWithStyle } from "./renderWithStyle.web";
+
+function buildProps(overrides: Partial<BalanceFilterDialogProps> = {}): BalanceFilterDialogProps {
+  return {
+    isOpen: true,
+    filter: "all",
+    options,
+    labels,
+    onClose: jest.fn(),
+    onConfirmFilter: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderDialog(props: BalanceFilterDialogProps) {
+  return renderWithStyle(<BalanceFilterDialog {...props} />);
+}
+
+describe("BalanceFilterDialog (Web)", () => {
+  it("should confirm the selected filter and close when confirming", async () => {
+    const onClose = jest.fn();
+    const onConfirmFilter = jest.fn();
+    renderDialog(buildProps({ onClose, onConfirmFilter }));
+
+    await screen.getByTestId("pay-card-balance-filter-option-usdt").click();
+    await screen.getByTestId("pay-card-balance-filter-confirm").click();
+
+    expect(onConfirmFilter).toHaveBeenCalledWith(USDT_ID);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterDialogView.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterDialogView.web.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { BalanceFilterDialogView } from "../BalanceFilterDialogView.web";
+import type { BalanceFilterDialogViewProps } from "../BalanceFilterDialogView.web";
+import { USDC_ID, labels, options } from "./fixtures";
+import { renderWithStyle } from "./renderWithStyle.web";
+
+function buildProps(
+  overrides: Partial<BalanceFilterDialogViewProps> = {},
+): BalanceFilterDialogViewProps {
+  return {
+    isOpen: true,
+    draftFilter: "all",
+    options,
+    labels,
+    onClose: jest.fn(),
+    onSelectDraft: jest.fn(),
+    onConfirm: jest.fn(),
+    ...overrides,
+  };
+}
+
+function renderView(props: BalanceFilterDialogViewProps) {
+  return renderWithStyle(<BalanceFilterDialogView {...props} />);
+}
+
+describe("BalanceFilterDialogView (Web)", () => {
+  it("should render nothing when closed", () => {
+    renderView(buildProps({ isOpen: false }));
+
+    expect(screen.queryByTestId("pay-card-balance-filter-dialog")).not.toBeInTheDocument();
+  });
+
+  it("should render one row per option with tickers and crypto amounts", () => {
+    renderView(buildProps());
+
+    expect(screen.getByTestId("pay-card-balance-filter-dialog")).toBeVisible();
+    expect(screen.getByText("All stablecoins")).toBeVisible();
+    expect(screen.getByText("USD Coin")).toBeVisible();
+    expect(screen.getByText("USDC")).toBeVisible();
+    expect(screen.getByText("1,000.00 USDC")).toBeVisible();
+    expect(screen.getByText("Tether USD")).toBeVisible();
+  });
+
+  it("should select an option when its row is pressed", async () => {
+    const onSelectDraft = jest.fn();
+    renderView(buildProps({ onSelectDraft }));
+
+    await screen.getByTestId("pay-card-balance-filter-option-usdc").click();
+
+    expect(onSelectDraft).toHaveBeenCalledWith(USDC_ID);
+  });
+
+  it("should confirm when the confirm button is pressed", async () => {
+    const onConfirm = jest.fn();
+    renderView(buildProps({ onConfirm }));
+
+    await screen.getByTestId("pay-card-balance-filter-confirm").click();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterPill.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/BalanceFilterPill.web.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { BalanceFilterPill } from "../BalanceFilterPill.web";
+import { usdcOption } from "./fixtures";
+import { renderWithStyle } from "./renderWithStyle.web";
+
+describe("BalanceFilterPill (Web)", () => {
+  it("should render the all-stablecoins label when nothing is selected", () => {
+    renderWithStyle(
+      <BalanceFilterPill allStablecoinsLabel="All stablecoins" onClick={jest.fn()} />,
+    );
+
+    expect(screen.getByTestId("pay-card-balance-filter-pill")).toBeVisible();
+    expect(screen.getByText("All stablecoins")).toBeVisible();
+  });
+
+  it("should render the selected ticker when an option is selected", () => {
+    renderWithStyle(
+      <BalanceFilterPill
+        allStablecoinsLabel="All stablecoins"
+        selectedOption={usdcOption}
+        onClick={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("USDC")).toBeVisible();
+    expect(screen.queryByText("All stablecoins")).not.toBeInTheDocument();
+  });
+
+  it("should call onClick when pressed", async () => {
+    const onClick = jest.fn();
+    renderWithStyle(<BalanceFilterPill allStablecoinsLabel="All stablecoins" onClick={onClick} />);
+
+    await screen.getByTestId("pay-card-balance-filter-pill").click();
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.web.test.tsx
@@ -1,19 +1,17 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { StyleProvider } from "@features/platform-style";
+import { screen } from "@testing-library/react";
 import { PayCardBalanceEmptyState } from "../PayCardBalanceEmptyState.web";
+import { renderWithStyle } from "./renderWithStyle.web";
 
 describe("PayCardBalanceEmptyState (Web)", () => {
   it("should render the empty title and description", () => {
-    render(
-      <StyleProvider colorScheme="dark">
-        <PayCardBalanceEmptyState
-          labels={{
-            emptyTitle: "Pay and get paid",
-            emptyDescription: "Start by depositing stablecoin to your wallet",
-          }}
-        />
-      </StyleProvider>,
+    renderWithStyle(
+      <PayCardBalanceEmptyState
+        labels={{
+          emptyTitle: "Pay and get paid",
+          emptyDescription: "Start by depositing stablecoin to your wallet",
+        }}
+      />,
     );
 
     expect(screen.getByTestId("pay-card-balance-empty-state")).toBeVisible();

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceFundedState.web.test.tsx
@@ -1,31 +1,55 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { StyleProvider } from "@features/platform-style";
-import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+import { screen } from "@testing-library/react";
 import { PayCardBalanceFundedState } from "../PayCardBalanceFundedState.web";
-
-const formatCountervalue = (value: number): FormattedValue =>
-  ({
-    integerPart: String(value),
-    decimalPart: "00",
-    currencyText: "$",
-    decimalSeparator: ".",
-    currencyPosition: "start",
-  }) as unknown as FormattedValue;
+import { formatCountervalue, usdcOption } from "./fixtures";
+import { renderWithStyle } from "./renderWithStyle.web";
 
 describe("PayCardBalanceFundedState (Web)", () => {
-  it("should render the funded balance", () => {
-    render(
-      <StyleProvider colorScheme="dark">
-        <PayCardBalanceFundedState
-          balance={1000}
-          formatCountervalue={formatCountervalue}
-          isLoading={false}
-        />
-      </StyleProvider>,
+  it("should render the funded balance and the filter pill", () => {
+    renderWithStyle(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+        allStablecoinsLabel="All stablecoins"
+        onOpenFilter={jest.fn()}
+      />,
     );
 
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
     expect(screen.getByTestId("pay-card-balance-amount")).toBeVisible();
+    expect(screen.getByTestId("pay-card-balance-filter-pill")).toBeVisible();
+  });
+
+  it("should render the selected coin ticker on the pill", () => {
+    renderWithStyle(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+        allStablecoinsLabel="All stablecoins"
+        selectedOption={usdcOption}
+        onOpenFilter={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("USDC")).toBeVisible();
+  });
+
+  it("should open the filter when the pill is pressed", async () => {
+    const onOpenFilter = jest.fn();
+    renderWithStyle(
+      <PayCardBalanceFundedState
+        balance={1000}
+        formatCountervalue={formatCountervalue}
+        isLoading={false}
+        allStablecoinsLabel="All stablecoins"
+        onOpenFilter={onOpenFilter}
+      />,
+    );
+
+    await screen.getByTestId("pay-card-balance-filter-pill").click();
+
+    expect(onOpenFilter).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import type { FormattedValue, PayCardBalanceViewProps } from "../types";
 import { PayCardBalanceView } from "../PayCardBalanceView.native";
-
-const labels = {
-  emptyTitle: "Pay and get paid",
-  emptyDescription: "Start by depositing stablecoin to your wallet",
-};
+import { labels } from "./fixtures";
 
 const formatCountervalue = (value: number): FormattedValue => ({
   integerPart: String(value),
@@ -40,7 +36,13 @@ describe("PayCardBalanceView (Native)", () => {
       balance: 1000,
       formatCountervalue,
       filter: "all",
+      options: [],
+      isFilterOpen: false,
+      onOpenFilter: jest.fn(),
+      onCloseFilter: jest.fn(),
+      onConfirmFilter: jest.fn(),
       isLoading: false,
+      labels,
     });
 
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.web.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.web.test.tsx
@@ -1,30 +1,29 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { StyleProvider } from "@features/platform-style";
-import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+import { screen } from "@testing-library/react";
 import { PayCardBalanceView } from "../PayCardBalanceView.web";
 import type { PayCardBalanceViewProps } from "../types";
+import { formatCountervalue, labels, options } from "./fixtures";
+import { renderWithStyle } from "./renderWithStyle.web";
 
-const labels = {
-  emptyTitle: "Pay and get paid",
-  emptyDescription: "Start by depositing stablecoin to your wallet",
-};
-
-const formatCountervalue = (value: number): FormattedValue =>
-  ({
-    integerPart: String(value),
-    decimalPart: "00",
-    currencyText: "$",
-    decimalSeparator: ".",
-    currencyPosition: "start",
-  }) as unknown as FormattedValue;
+function fundedProps(overrides: Partial<PayCardBalanceViewProps> = {}): PayCardBalanceViewProps {
+  return {
+    displayMode: "funded",
+    balance: 1000,
+    formatCountervalue,
+    isLoading: false,
+    labels,
+    filter: "all",
+    options,
+    isFilterOpen: false,
+    onOpenFilter: jest.fn(),
+    onCloseFilter: jest.fn(),
+    onConfirmFilter: jest.fn(),
+    ...overrides,
+  } as PayCardBalanceViewProps;
+}
 
 function renderView(props: PayCardBalanceViewProps) {
-  return render(
-    <StyleProvider colorScheme="dark">
-      <PayCardBalanceView {...props} />
-    </StyleProvider>,
-  );
+  return renderWithStyle(<PayCardBalanceView {...props} />);
 }
 
 describe("PayCardBalanceView (Web)", () => {
@@ -41,16 +40,23 @@ describe("PayCardBalanceView (Web)", () => {
     expect(screen.queryByTestId("pay-card-balance-funded-state")).not.toBeInTheDocument();
   });
 
-  it("should render the funded balance when funded", () => {
-    renderView({
-      displayMode: "funded",
-      balance: 1000,
-      formatCountervalue,
-      filter: "all",
-      isLoading: false,
-    });
+  it("should render the funded balance and pill when funded", () => {
+    renderView(fundedProps());
 
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
+    expect(screen.getByTestId("pay-card-balance-filter-pill")).toBeVisible();
     expect(screen.queryByTestId("pay-card-balance-empty-state")).not.toBeInTheDocument();
+  });
+
+  it("should not render the dialog contents while the filter is closed", () => {
+    renderView(fundedProps({ isFilterOpen: false }));
+
+    expect(screen.queryByTestId("pay-card-balance-filter-dialog")).not.toBeInTheDocument();
+  });
+
+  it("should render the dialog contents when the filter is open", () => {
+    renderView(fundedProps({ isFilterOpen: true }));
+
+    expect(screen.getByTestId("pay-card-balance-filter-dialog")).toBeVisible();
   });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
@@ -1,7 +1,38 @@
+import { PAY_CARD_BALANCE_FILTER_ALL } from "@domain/entity-pay-card";
 import { aggregatePayCardBalance } from "../aggregatePayCardBalance";
 import type { FormattedValue, PayCardPortfolioPort } from "../types";
 
 const formatCountervalue = (): FormattedValue => ({}) as unknown as FormattedValue;
+const onConfirmFilter = jest.fn();
+const filterOptions = [
+  {
+    id: PAY_CARD_BALANCE_FILTER_ALL,
+    title: "All stablecoins",
+    countervalue: 0,
+    countervalueLabel: "$0.00",
+  },
+] as const;
+const filterOptionsWithStablecoins = [
+  ...filterOptions,
+  {
+    id: "ethereum/erc20/usdc",
+    title: "USD Coin",
+    ticker: "USDC",
+    ledgerId: "ethereum/erc20/usdc",
+    countervalue: 1000,
+    countervalueLabel: "$1,000.00",
+    cryptoAmountLabel: "1,000.00 USDC",
+  },
+  {
+    id: "ethereum/erc20/usdt",
+    title: "Tether USD",
+    ticker: "USDT",
+    ledgerId: "ethereum/erc20/usdt",
+    countervalue: 250.5,
+    countervalueLabel: "$250.50",
+    cryptoAmountLabel: "250.50 USDT",
+  },
+] as const;
 
 function buildPort(overrides: Partial<PayCardPortfolioPort> = {}): PayCardPortfolioPort {
   return {
@@ -9,7 +40,9 @@ function buildPort(overrides: Partial<PayCardPortfolioPort> = {}): PayCardPortfo
     filter: "all",
     isLoading: false,
     isError: false,
+    filterOptions,
     formatCountervalue,
+    onConfirmFilter,
     ...overrides,
   };
 }
@@ -28,11 +61,28 @@ describe("aggregatePayCardBalance", () => {
 
   it("should sum only the matching stablecoin when the filter is a currencyId", () => {
     const data = aggregatePayCardBalance(
-      buildPort({ stablecoins: [usdc, usdt], filter: "ethereum/erc20/usdc" }),
+      buildPort({
+        stablecoins: [usdc, usdt],
+        filter: "ethereum/erc20/usdc",
+        filterOptions: filterOptionsWithStablecoins,
+      }),
     );
 
     expect(data.stableBalance).toBe(1000);
     expect(data.filter).toBe("ethereum/erc20/usdc");
+  });
+
+  it("should fall back to all when the persisted filter is no longer available", () => {
+    const data = aggregatePayCardBalance(
+      buildPort({
+        stablecoins: [usdc, usdt],
+        filter: "ethereum/erc20/dai",
+        filterOptions: filterOptionsWithStablecoins,
+      }),
+    );
+
+    expect(data.stableBalance).toBe(1250.5);
+    expect(data.filter).toBe(PAY_CARD_BALANCE_FILTER_ALL);
   });
 
   it("should report loading while the portfolio is loading", () => {
@@ -53,5 +103,18 @@ describe("aggregatePayCardBalance", () => {
     const data = aggregatePayCardBalance(buildPort());
 
     expect(data.formatCountervalue).toBe(formatCountervalue);
+  });
+
+  it("should report hasBalance when any stablecoin has a positive value", () => {
+    const data = aggregatePayCardBalance(buildPort({ stablecoins: [usdc] }));
+
+    expect(data.hasBalance).toBe(true);
+  });
+
+  it("should forward filterOptions and onConfirmFilter", () => {
+    const data = aggregatePayCardBalance(buildPort());
+
+    expect(data.filterOptions).toBe(filterOptions);
+    expect(data.onConfirmFilter).toBe(onConfirmFilter);
   });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/fixtures.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/fixtures.tsx
@@ -1,0 +1,53 @@
+import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+import type { PayCardBalanceFilterOption, PayCardBalanceLabels } from "../types";
+
+export const labels: PayCardBalanceLabels = {
+  emptyTitle: "Pay and get paid",
+  emptyDescription: "Start by depositing stablecoin to your wallet",
+  allStablecoins: "All stablecoins",
+  filterDialogTitle: "Filter balance",
+  filterDialogDescription: "Select a stablecoin to filter your balance",
+  filterDialogBanner: "USDC and USDT are always shown",
+  confirm: "Confirm",
+};
+
+export const formatCountervalue = (value: number): FormattedValue =>
+  ({
+    integerPart: String(value),
+    decimalPart: "00",
+    currencyText: "$",
+    decimalSeparator: ".",
+    currencyPosition: "start",
+  }) as unknown as FormattedValue;
+
+export const USDC_ID = "ethereum/erc20/usd__coin";
+export const USDT_ID = "ethereum/erc20/usd_tether__erc20_";
+
+export const allOption: PayCardBalanceFilterOption = {
+  id: "all",
+  title: "All stablecoins",
+  countervalue: 1250,
+  countervalueLabel: "$1,250.00",
+};
+
+export const usdcOption: PayCardBalanceFilterOption = {
+  id: USDC_ID,
+  title: "USD Coin",
+  ticker: "USDC",
+  ledgerId: USDC_ID,
+  countervalue: 1000,
+  countervalueLabel: "$1,000.00",
+  cryptoAmountLabel: "1,000.00 USDC",
+};
+
+export const usdtOption: PayCardBalanceFilterOption = {
+  id: USDT_ID,
+  title: "Tether USD",
+  ticker: "USDT",
+  ledgerId: USDT_ID,
+  countervalue: 250,
+  countervalueLabel: "$250.00",
+  cryptoAmountLabel: "250.00 USDT",
+};
+
+export const options: PayCardBalanceFilterOption[] = [allOption, usdcOption, usdtOption];

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/renderWithStyle.web.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/renderWithStyle.web.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { StyleProvider } from "@features/platform-style";
+
+export function renderWithStyle(ui: React.ReactElement) {
+  return render(<StyleProvider colorScheme="dark">{ui}</StyleProvider>);
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/resolveSelection.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/resolveSelection.test.ts
@@ -1,0 +1,20 @@
+import { resolveSelection } from "../resolveSelection";
+import { USDC_ID, USDT_ID } from "./fixtures";
+
+describe("resolveSelection", () => {
+  it("should keep 'all' as-is", () => {
+    expect(resolveSelection("all", [USDC_ID, USDT_ID])).toBe("all");
+  });
+
+  it("should keep the persisted filter when it is still a listed option", () => {
+    expect(resolveSelection(USDC_ID, ["all", USDC_ID, USDT_ID])).toBe(USDC_ID);
+  });
+
+  it("should fall back to 'all' when the persisted filter is no longer listed", () => {
+    expect(resolveSelection(USDC_ID, ["all", USDT_ID])).toBe("all");
+  });
+
+  it("should fall back to 'all' when there are no options", () => {
+    expect(resolveSelection(USDC_ID, [])).toBe("all");
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/useBalanceFilterDialogViewModel.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/useBalanceFilterDialogViewModel.web.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from "@testing-library/react";
+import { useBalanceFilterDialogViewModel } from "../useBalanceFilterDialogViewModel";
+import type { BalanceFilterDialogViewModelParams } from "../types";
+import { USDC_ID, USDT_ID, options } from "./fixtures";
+
+function buildParams(
+  overrides: Partial<BalanceFilterDialogViewModelParams> = {},
+): BalanceFilterDialogViewModelParams {
+  return {
+    isOpen: true,
+    activeFilter: "all",
+    options,
+    onConfirmFilter: jest.fn(),
+    onClose: jest.fn(),
+    onTrackEvent: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("useBalanceFilterDialogViewModel", () => {
+  it("should seed the draft from the active filter", () => {
+    const { result } = renderHook(() =>
+      useBalanceFilterDialogViewModel(buildParams({ activeFilter: USDC_ID })),
+    );
+
+    expect(result.current.draftFilter).toBe(USDC_ID);
+  });
+
+  it("should update the draft when an option is selected", () => {
+    const { result } = renderHook(() => useBalanceFilterDialogViewModel(buildParams()));
+
+    act(() => result.current.onSelectDraft(USDT_ID));
+
+    expect(result.current.draftFilter).toBe(USDT_ID);
+  });
+
+  it("should re-seed the draft when the dialog re-opens", () => {
+    const { result, rerender } = renderHook(props => useBalanceFilterDialogViewModel(props), {
+      initialProps: buildParams({ isOpen: false, activeFilter: USDC_ID }),
+    });
+
+    rerender(buildParams({ isOpen: true, activeFilter: USDT_ID }));
+
+    expect(result.current.draftFilter).toBe(USDT_ID);
+  });
+
+  it("should persist the draft, track the ticker and close on confirm", () => {
+    const onConfirmFilter = jest.fn();
+    const onClose = jest.fn();
+    const onTrackEvent = jest.fn();
+    const { result } = renderHook(() =>
+      useBalanceFilterDialogViewModel(
+        buildParams({ activeFilter: USDC_ID, onConfirmFilter, onClose, onTrackEvent }),
+      ),
+    );
+
+    act(() => result.current.onConfirm());
+
+    expect(onConfirmFilter).toHaveBeenCalledWith(USDC_ID);
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "confirm_balance_filter",
+      asset: "USDC",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("should track 'all' as the asset when confirming the all option", () => {
+    const onTrackEvent = jest.fn();
+    const { result } = renderHook(() =>
+      useBalanceFilterDialogViewModel(buildParams({ activeFilter: "all", onTrackEvent })),
+    );
+
+    act(() => result.current.onConfirm());
+
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", {
+      button: "confirm_balance_filter",
+      asset: "all",
+    });
+  });
+});

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/usePayCardBalanceViewModel.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/usePayCardBalanceViewModel.web.test.ts
@@ -1,38 +1,34 @@
-import { renderHook } from "@testing-library/react";
-import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
+import { act, renderHook } from "@testing-library/react";
 import { usePayCardBalanceViewModel } from "../usePayCardBalanceViewModel";
 import type { PayCardBalanceProps } from "../types";
-
-const labels = {
-  emptyTitle: "Pay and get paid",
-  emptyDescription: "Start by depositing stablecoin to your wallet",
-};
-
-const formatCountervalue = (): FormattedValue => ({}) as unknown as FormattedValue;
+import { USDC_ID, formatCountervalue, labels, options } from "./fixtures";
 
 function buildProps(overrides: Partial<PayCardBalanceProps> = {}): PayCardBalanceProps {
   return {
     status: "ready",
     stableBalance: 0,
     filter: "all",
+    hasBalance: false,
+    filterOptions: options,
     formatCountervalue,
+    onConfirmFilter: jest.fn(),
     labels,
     ...overrides,
   };
 }
 
 describe("usePayCardBalanceViewModel", () => {
-  it("should be empty when the stable balance is zero", () => {
+  it("should be empty when the user has no balance", () => {
     const { result } = renderHook(() =>
-      usePayCardBalanceViewModel(buildProps({ stableBalance: 0 })),
+      usePayCardBalanceViewModel(buildProps({ hasBalance: false })),
     );
 
     expect(result.current.displayMode).toBe("empty");
   });
 
-  it("should be funded when the stable balance is positive and ready", () => {
+  it("should be funded when the user has balance and is ready", () => {
     const { result } = renderHook(() =>
-      usePayCardBalanceViewModel(buildProps({ status: "ready", stableBalance: 1250.5 })),
+      usePayCardBalanceViewModel(buildProps({ hasBalance: true, stableBalance: 1250.5 })),
     );
 
     expect(result.current).toMatchObject({
@@ -43,9 +39,9 @@ describe("usePayCardBalanceViewModel", () => {
     });
   });
 
-  it("should be funded and loading while the balance loads", () => {
+  it("should be funded and loading while data loads", () => {
     const { result } = renderHook(() =>
-      usePayCardBalanceViewModel(buildProps({ status: "loading", stableBalance: 0 })),
+      usePayCardBalanceViewModel(buildProps({ status: "loading", hasBalance: false })),
     );
 
     expect(result.current).toMatchObject({ displayMode: "funded", isLoading: true });
@@ -53,9 +49,49 @@ describe("usePayCardBalanceViewModel", () => {
 
   it("should be empty on error", () => {
     const { result } = renderHook(() =>
-      usePayCardBalanceViewModel(buildProps({ status: "error", stableBalance: 1250.5 })),
+      usePayCardBalanceViewModel(buildProps({ status: "error", hasBalance: true })),
     );
 
     expect(result.current.displayMode).toBe("empty");
+  });
+
+  it("should expose the selected option for a valid filter", () => {
+    const { result } = renderHook(() =>
+      usePayCardBalanceViewModel(buildProps({ hasBalance: true, filter: USDC_ID })),
+    );
+
+    expect(result.current).toMatchObject({
+      displayMode: "funded",
+      filter: USDC_ID,
+      selectedOption: { id: USDC_ID, ticker: "USDC" },
+    });
+  });
+
+  it("should open the filter and track the open event", () => {
+    const onTrackEvent = jest.fn();
+    const { result } = renderHook(() =>
+      usePayCardBalanceViewModel(buildProps({ hasBalance: true, onTrackEvent })),
+    );
+
+    if (result.current.displayMode !== "funded") throw new Error("expected funded");
+    expect(result.current.isFilterOpen).toBe(false);
+
+    act(() => result.current.displayMode === "funded" && result.current.onOpenFilter());
+
+    if (result.current.displayMode !== "funded") throw new Error("expected funded");
+    expect(result.current.isFilterOpen).toBe(true);
+    expect(onTrackEvent).toHaveBeenCalledWith("button_clicked", { button: "balance_filter" });
+  });
+
+  it("should close the filter", () => {
+    const { result } = renderHook(() =>
+      usePayCardBalanceViewModel(buildProps({ hasBalance: true })),
+    );
+
+    act(() => result.current.displayMode === "funded" && result.current.onOpenFilter());
+    act(() => result.current.displayMode === "funded" && result.current.onCloseFilter());
+
+    if (result.current.displayMode !== "funded") throw new Error("expected funded");
+    expect(result.current.isFilterOpen).toBe(false);
   });
 });

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/aggregatePayCardBalance.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/aggregatePayCardBalance.ts
@@ -1,17 +1,29 @@
+import { PAY_CARD_BALANCE_FILTER_ALL } from "@domain/entity-pay-card";
+import { resolveSelection } from "./resolveSelection";
 import type { PayCardBalanceData, PayCardBalanceStatus, PayCardPortfolioPort } from "./types";
 
-// Shared Pay hero aggregation (LIVE-34898): filters stablecoins by the active filter, sums their
+// Filters stablecoins by the active filter, sums their
 // countervalues and maps the loading/error flags to a single status.
 export function aggregatePayCardBalance({
   stablecoins,
   filter,
   isLoading,
   isError,
+  filterOptions,
   formatCountervalue,
+  onConfirmFilter,
+  onTrackEvent,
 }: PayCardPortfolioPort): PayCardBalanceData {
+  const optionIds = filterOptions.map(option => option.id);
+  const effectiveFilter = resolveSelection(filter, optionIds);
   const stableBalance = stablecoins
-    .filter(({ currency }) => filter === "all" || currency.id === filter)
+    .filter(
+      ({ currency }) =>
+        effectiveFilter === PAY_CARD_BALANCE_FILTER_ALL || currency.id === effectiveFilter,
+    )
     .reduce((total, { value }) => total + value, 0);
+
+  const hasBalance = stablecoins.some(({ value }) => value > 0);
 
   let status: PayCardBalanceStatus = "ready";
   if (isError) {
@@ -20,5 +32,14 @@ export function aggregatePayCardBalance({
     status = "loading";
   }
 
-  return { status, stableBalance, filter, formatCountervalue };
+  return {
+    status,
+    stableBalance,
+    filter: effectiveFilter,
+    hasBalance,
+    filterOptions,
+    formatCountervalue,
+    onConfirmFilter,
+    onTrackEvent,
+  };
 }

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/index.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/index.ts
@@ -1,3 +1,4 @@
 export * from "./PayCardBalance";
 export * from "./aggregatePayCardBalance";
+export * from "./resolveSelection";
 export * from "./types";

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/resolveSelection.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/resolveSelection.ts
@@ -1,0 +1,11 @@
+import { PAY_CARD_BALANCE_FILTER_ALL, type PayCardBalanceFilter } from "@domain/entity-pay-card";
+
+export function resolveSelection(
+  persisted: PayCardBalanceFilter,
+  optionIds: readonly PayCardBalanceFilter[],
+): PayCardBalanceFilter {
+  if (persisted === PAY_CARD_BALANCE_FILTER_ALL) {
+    return PAY_CARD_BALANCE_FILTER_ALL;
+  }
+  return optionIds.includes(persisted) ? persisted : PAY_CARD_BALANCE_FILTER_ALL;
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
@@ -6,19 +6,48 @@ export type { FormattedValue };
 
 export type PayCardBalanceStatus = "loading" | "error" | "ready";
 
-export type PayCardBalanceLabels = Readonly<{
+export type PayCardBalanceEmptyLabels = Readonly<{
   emptyTitle: string;
   emptyDescription: string;
 }>;
 
-// Host input for the hero, produced by {@link aggregatePayCardBalance} in both apps.
+export type PayCardBalanceFilterLabels = Readonly<{
+  allStablecoins: string;
+  filterDialogTitle: string;
+  filterDialogDescription: string;
+  filterDialogBanner: string;
+  confirm: string;
+}>;
+
+export type PayCardBalanceLabels = PayCardBalanceEmptyLabels & PayCardBalanceFilterLabels;
+
+/** A selectable row in the filter dialog. `id` is `"all"` or a stablecoin currencyId. */
+export type PayCardBalanceFilterOption = Readonly<{
+  id: PayCardBalanceFilter;
+  title: string;
+  /** Absent for the "all" row. */
+  ticker?: string;
+  /** Ledger currency id for the crypto icon. Absent for the "all" row. */
+  ledgerId?: string;
+  countervalue: number;
+  /** Preformatted fiat countervalue, e.g. "$1,000.00". */
+  countervalueLabel: string;
+  /** Preformatted crypto amount, e.g. "1,000.00 USDC". Absent for the "all" row. */
+  cryptoAmountLabel?: string;
+}>;
+
+/** Host props for `PayCardBalance`, produced via {@link aggregatePayCardBalance}. */
 export type PayCardBalanceData = Readonly<{
   status: PayCardBalanceStatus;
-  /** Aggregated stablecoin countervalue, in the user's counter currency. */
   stableBalance: number;
-  /** Active balance filter (`"all"` or a single stablecoin currencyId). */
   filter: PayCardBalanceFilter;
+  /** Whether the user holds any stablecoin balance. Drives funded vs empty. */
+  hasBalance: boolean;
+  /** First entry is always the "all" option. */
+  filterOptions: readonly PayCardBalanceFilterOption[];
   formatCountervalue: (value: number) => FormattedValue;
+  onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
 }>;
 
 export type PayCardStablecoin = Readonly<{
@@ -32,7 +61,11 @@ export type PayCardPortfolioPort = Readonly<{
   filter: PayCardBalanceFilter;
   isLoading: boolean;
   isError: boolean;
+  /** First entry is always the "all" option. */
+  filterOptions: readonly PayCardBalanceFilterOption[];
   formatCountervalue: (value: number) => FormattedValue;
+  onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
 }>;
 
 export type PayCardBalanceProps = PayCardBalanceData &
@@ -43,12 +76,37 @@ export type PayCardBalanceProps = PayCardBalanceData &
 export type PayCardBalanceViewProps =
   | Readonly<{
       displayMode: "empty";
-      labels: PayCardBalanceLabels;
+      labels: PayCardBalanceEmptyLabels;
     }>
   | Readonly<{
       displayMode: "funded";
       balance: number;
       formatCountervalue: (value: number) => FormattedValue;
-      filter: PayCardBalanceFilter;
       isLoading: boolean;
+      labels: PayCardBalanceFilterLabels;
+      filter: PayCardBalanceFilter;
+      options: readonly PayCardBalanceFilterOption[];
+      /** Applied option, or `undefined` when "all" is active. */
+      selectedOption?: PayCardBalanceFilterOption;
+      isFilterOpen: boolean;
+      onOpenFilter: () => void;
+      onCloseFilter: () => void;
+      onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+      onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
     }>;
+
+export type BalanceFilterDialogViewModelParams = Readonly<{
+  isOpen: boolean;
+  /** Active (resolved) filter, used to seed the draft when the dialog opens. */
+  activeFilter: PayCardBalanceFilter;
+  options: readonly PayCardBalanceFilterOption[];
+  onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+  onClose: () => void;
+  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
+}>;
+
+export type BalanceFilterDialogViewModel = Readonly<{
+  draftFilter: PayCardBalanceFilter;
+  onSelectDraft: (filter: PayCardBalanceFilter) => void;
+  onConfirm: () => void;
+}>;

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/useBalanceFilterDialogViewModel.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/useBalanceFilterDialogViewModel.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from "react";
+import { PAY_CARD_BALANCE_FILTER_ALL, type PayCardBalanceFilter } from "@domain/entity-pay-card";
+import type { BalanceFilterDialogViewModel, BalanceFilterDialogViewModelParams } from "./types";
+
+export function useBalanceFilterDialogViewModel({
+  isOpen,
+  activeFilter,
+  options,
+  onConfirmFilter,
+  onClose,
+  onTrackEvent,
+}: BalanceFilterDialogViewModelParams): BalanceFilterDialogViewModel {
+  const [draftFilter, setDraftFilter] = useState<PayCardBalanceFilter>(activeFilter);
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraftFilter(activeFilter);
+    }
+  }, [isOpen, activeFilter]);
+
+  const onSelectDraft = useCallback((next: PayCardBalanceFilter) => {
+    setDraftFilter(next);
+  }, []);
+
+  const onConfirm = useCallback(() => {
+    onConfirmFilter(draftFilter);
+    const asset =
+      draftFilter === PAY_CARD_BALANCE_FILTER_ALL
+        ? PAY_CARD_BALANCE_FILTER_ALL
+        : (options.find(option => option.id === draftFilter)?.ticker ?? draftFilter);
+    onTrackEvent?.("button_clicked", { button: "confirm_balance_filter", asset });
+    onClose();
+  }, [draftFilter, options, onConfirmFilter, onClose, onTrackEvent]);
+
+  return { draftFilter, onSelectDraft, onConfirm };
+}

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/usePayCardBalanceViewModel.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/usePayCardBalanceViewModel.ts
@@ -1,14 +1,43 @@
+import { useCallback, useMemo, useState } from "react";
+import { PAY_CARD_BALANCE_FILTER_ALL } from "@domain/entity-pay-card";
+import { resolveSelection } from "./resolveSelection";
 import type { PayCardBalanceProps, PayCardBalanceViewProps } from "./types";
 
 export function usePayCardBalanceViewModel({
   status,
   stableBalance,
   filter,
+  hasBalance,
+  filterOptions,
   formatCountervalue,
+  onConfirmFilter,
+  onTrackEvent,
   labels,
 }: PayCardBalanceProps): PayCardBalanceViewProps {
   const isLoading = status === "loading";
-  const isFunded = isLoading || (status === "ready" && stableBalance > 0);
+  const isFunded = isLoading || (status === "ready" && hasBalance);
+
+  const optionIds = useMemo(() => filterOptions.map(option => option.id), [filterOptions]);
+  const effectiveFilter = resolveSelection(filter, optionIds);
+
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+
+  const onOpenFilter = useCallback(() => {
+    setIsFilterOpen(true);
+    onTrackEvent?.("button_clicked", { button: "balance_filter" });
+  }, [onTrackEvent]);
+
+  const onCloseFilter = useCallback(() => {
+    setIsFilterOpen(false);
+  }, []);
+
+  const selectedOption = useMemo(
+    () =>
+      effectiveFilter === PAY_CARD_BALANCE_FILTER_ALL
+        ? undefined
+        : filterOptions.find(option => option.id === effectiveFilter),
+    [effectiveFilter, filterOptions],
+  );
 
   if (!isFunded) {
     return { displayMode: "empty", labels };
@@ -18,7 +47,15 @@ export function usePayCardBalanceViewModel({
     displayMode: "funded",
     balance: stableBalance,
     formatCountervalue,
-    filter,
     isLoading,
+    labels,
+    filter: effectiveFilter,
+    options: filterOptions,
+    selectedOption,
+    isFilterOpen,
+    onOpenFilter,
+    onCloseFilter,
+    onConfirmFilter,
+    onTrackEvent,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2358,7 +2358,7 @@ importers:
         version: 18.0.1
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6(@babel/core@7.28.5)
+        version: 0.81.6
       '@react-native/codegen':
         specifier: 'catalog:'
         version: 0.81.6(@babel/core@7.28.5)
@@ -5735,6 +5735,9 @@ importers:
       '@features/platform-style':
         specifier: workspace:*
         version: link:../../platform/style
+      '@ledgerhq/crypto-icons':
+        specifier: 'catalog:'
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-react@0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
         version: 0.1.24
@@ -14427,7 +14430,7 @@ importers:
         version: 0.81.6
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6(@babel/core@7.28.5)
+        version: 0.81.6
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.0.9
@@ -14451,7 +14454,7 @@ importers:
         version: 10.4.4(@storybook/react@10.4.1(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/addon-react-native-web':
         specifier: 'catalog:'
-        version: 0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@storybook/jest':
         specifier: 'catalog:'
         version: 0.2.3
@@ -22372,8 +22375,6 @@ packages:
   '@react-native/babel-preset@0.81.6':
     resolution: {integrity: sha512-RtIr82ccPoyMLmIC3/vCG96MzRmIT+IzQkjCgTS5b93uAxiER9BS7+d1l7+zD00VanClt6CTBM4K4n6RCnAykg==}
     engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
 
   '@react-native/codegen@0.77.3':
     resolution: {integrity: sha512-Q6ZJCE7h6Z3v3DiEZUnqzHbgwF3ZILN+ACTx6qu/x2X1cL96AatKwdX92e0+7J9RFg6gdoFYJgRrW8Q6VnWZsQ==}
@@ -42155,16 +42156,6 @@ snapshots:
       regexpu-core: 6.2.0
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.5':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3
-      lodash.debounce: 4.0.8
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42239,14 +42230,6 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
-
-  '@babel/helper-remap-async-to-generator@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42395,10 +42378,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.25.9':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42485,17 +42464,9 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-export-default-from@7.25.9':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.28.5)':
@@ -42506,10 +42477,6 @@ snapshots:
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-flow@7.27.1':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5)':
@@ -42654,14 +42621,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-async-generator-functions@7.28.0':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42677,14 +42636,6 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-to-generator@7.27.1':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-remap-async-to-generator': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -42705,10 +42656,6 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-block-scoping@7.28.5':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
@@ -42780,11 +42727,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.28.6
 
-  '@babel/plugin-transform-computed-properties@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.28.6
-
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42795,13 +42737,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-destructuring@7.28.5':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -42855,23 +42790,11 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-flow': 7.27.1
-
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
-
-  '@babel/plugin-transform-for-of@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42884,14 +42807,6 @@ snapshots:
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-function-name@7.27.1':
-    dependencies:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.29.0
@@ -42917,17 +42832,9 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-literals@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-logical-assignment-operators@7.28.5':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
@@ -42981,11 +42888,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
-    dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43006,10 +42908,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-numeric-separator@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43021,16 +42919,6 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-
-  '@babel/plugin-transform-object-rest-spread@7.28.4':
-    dependencies:
-      '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5
-      '@babel/plugin-transform-parameters': 7.27.7
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
@@ -43050,10 +42938,6 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/plugin-transform-optional-catch-binding@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -43080,21 +42964,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-parameters@7.27.7':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-private-methods@7.27.1':
-    dependencies:
-      '@babel/helper-create-class-features-plugin': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -43109,14 +42982,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -43140,10 +43005,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-display-name@7.28.0':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43156,17 +43017,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.25.9':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx-source@7.25.9':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.28.5)':
@@ -43181,16 +43034,6 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-react-jsx@7.27.1':
-    dependencies:
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -43212,10 +43055,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-regenerator@7.28.4':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43231,17 +43070,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-runtime@7.25.9':
-    dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      babel-plugin-polyfill-corejs2: 0.4.14
-      babel-plugin-polyfill-corejs3: 0.10.6
-      babel-plugin-polyfill-regenerator: 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-runtime@7.25.9(@babel/core@7.28.5)':
     dependencies:
@@ -43272,13 +43100,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-spread@7.27.1':
-    dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43290,10 +43111,6 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-sticky-regex@7.27.1':
-    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
@@ -48360,6 +48177,16 @@ snapshots:
       react-dom: 19.1.4(react@19.1.4)
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
 
+  '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-react@0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
+    dependencies:
+      react: 19.1.4
+    optionalDependencies:
+      '@ledgerhq/lumen-design-core': 0.1.24
+      '@ledgerhq/lumen-ui-react': 0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/lumen-ui-rnative': 0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      react-dom: 19.1.4(react@19.1.4)
+      react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4)
+
   '@ledgerhq/crypto-icons@2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-rnative@0.1.54(db3cee34e4c141f05cf3fa5e40e0d3fc))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)':
     dependencies:
       react: 19.1.4
@@ -51547,55 +51374,6 @@ snapshots:
       - supports-color
 
   '@react-native/babel-preset@0.81.6':
-    dependencies:
-      '@babel/plugin-proposal-export-default-from': 7.25.9
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-      '@babel/plugin-syntax-export-default-from': 7.25.9
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-      '@babel/plugin-transform-arrow-functions': 7.27.1
-      '@babel/plugin-transform-async-generator-functions': 7.28.0
-      '@babel/plugin-transform-async-to-generator': 7.27.1
-      '@babel/plugin-transform-block-scoping': 7.28.5
-      '@babel/plugin-transform-class-properties': 7.27.1
-      '@babel/plugin-transform-classes': 7.28.4
-      '@babel/plugin-transform-computed-properties': 7.27.1
-      '@babel/plugin-transform-destructuring': 7.28.5
-      '@babel/plugin-transform-flow-strip-types': 7.27.1
-      '@babel/plugin-transform-for-of': 7.27.1
-      '@babel/plugin-transform-function-name': 7.27.1
-      '@babel/plugin-transform-literals': 7.27.1
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.5
-      '@babel/plugin-transform-modules-commonjs': 7.27.1
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1
-      '@babel/plugin-transform-numeric-separator': 7.27.1
-      '@babel/plugin-transform-object-rest-spread': 7.28.4
-      '@babel/plugin-transform-optional-catch-binding': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.5
-      '@babel/plugin-transform-parameters': 7.27.7
-      '@babel/plugin-transform-private-methods': 7.27.1
-      '@babel/plugin-transform-private-property-in-object': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0
-      '@babel/plugin-transform-react-jsx': 7.27.1
-      '@babel/plugin-transform-react-jsx-self': 7.25.9
-      '@babel/plugin-transform-react-jsx-source': 7.25.9
-      '@babel/plugin-transform-regenerator': 7.28.4
-      '@babel/plugin-transform-runtime': 7.25.9
-      '@babel/plugin-transform-shorthand-properties': 7.27.1
-      '@babel/plugin-transform-spread': 7.27.1
-      '@babel/plugin-transform-sticky-regex': 7.27.1
-      '@babel/plugin-transform-typescript': 7.28.5
-      '@babel/plugin-transform-unicode-regex': 7.27.1
-      '@babel/template': 7.28.6
-      '@react-native/babel-plugin-codegen': 0.81.6
-      babel-plugin-syntax-hermes-parser: 0.29.1
-      babel-plugin-transform-flow-enums: 0.0.2
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@react-native/babel-preset@0.81.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.28.5)
@@ -55026,11 +54804,11 @@ snapshots:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
 
-  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       babel-plugin-react-native-web: 0.19.10
     optionalDependencies:
-      '@react-native/babel-preset': 0.81.6(@babel/core@7.28.5)
+      '@react-native/babel-preset': 0.81.6
       metro-react-native-babel-preset: 0.77.0(@babel/core@7.28.5)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -58594,27 +58372,12 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.8
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    dependencies:
-      '@babel/compat-data': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-corejs3@0.10.6:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
-      core-js-compat: 3.43.0
     transitivePeerDependencies:
       - supports-color
 
@@ -58631,12 +58394,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       core-js-compat: 3.43.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.5:
-    dependencies:
-      '@babel/helper-define-polyfill-provider': 0.6.5
     transitivePeerDependencies:
       - supports-color
 
@@ -58685,12 +58442,6 @@ snapshots:
       hermes-parser: 0.29.1
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
-
-  babel-plugin-transform-flow-enums@0.0.2:
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.27.1
-    transitivePeerDependencies:
-      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.28.5):
     dependencies:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Adds the stable balance filter picker UI in `@features/flow-pay-card-balance`:

- "All stablecoins" pill under the funded hero
- Single-select filter dialog (All or one coin) with Confirm
- `resolveSelection` fallback to All when the persisted currency is no longer in the list
- Tracking hooks: `balance_filter` on open, `confirm_balance_filter` on confirm

LWD data wiring lives in the stacked follow-up: #20736 ([LIVE-35846](https://ledgerhq.atlassian.net/browse/LIVE-35846)).

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-34900](https://ledgerhq.atlassian.net/browse/LIVE-34900)
- **ADR** (if any): N/A

### 🧪 How to test

> ⚠️ Automated checks must pass before making your PR "Ready for review".

- [ ] Unit tests for filter pill, dialog view, dialog VM, `resolveSelection`, and PayCardBalance VMs
- [ ] Funded state shows the All stablecoins pill and opens the filter dialog
- [ ] Confirming a draft selection closes the dialog and calls `onConfirmFilter`
- [ ] Invalid persisted filter falls back to All

### ✅ Checklist

- [x] **Self-review** completed
- [x] **Automated tests** cover this change (unit/integration)
- [ ] **Manual QA** performed (or not needed; explain why)
- [ ] **Visual QA** (screenshots/video) for UI changes
- [x] **Documentation** updated if needed (N/A)
- [ ] **Changeset** added if a published package is affected (N/A for private flow package)

[LIVE-35846]: https://ledgerhq.atlassian.net/browse/LIVE-35846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-34900]: https://ledgerhq.atlassian.net/browse/LIVE-34900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ