### PR TITLE
[LWDM] feat(pay-tab): wire stable balance filter in LWD (LIVE-35846)

### DIFF
--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   renderWithMockedCounterValuesProvider,
+  fireEvent,
   screen,
   waitFor,
   render,
@@ -8,13 +9,19 @@ import {
 } from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { server } from "tests/server";
-import { trackPage } from "~/renderer/analytics/segment";
+import { track, trackPage } from "~/renderer/analytics/segment";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC } from "LLD/features/__mocks__/accounts.mock";
 import { payCardInitialState } from "@domain/entity-pay-card";
 import PayTab from "LLD/features/PayTab";
+import { usePayStablecoins, type PayStablecoins } from "../hooks/usePayStablecoins";
+import { USDC, USDT, makeItem } from "../hooks/__tests__/fixtures";
 
 const mockNavigate = jest.fn();
+
+jest.mock("../hooks/usePayStablecoins", () => ({
+  usePayStablecoins: jest.fn(),
+}));
 
 jest.mock("react-router", () => ({
   ...jest.requireActual("react-router"),
@@ -23,6 +30,8 @@ jest.mock("react-router", () => ({
 
 const mockedUseNavigate = jest.mocked(useNavigate);
 const mockedTrackPage = jest.mocked(trackPage);
+const mockedTrack = jest.mocked(track);
+const mockedUsePayStablecoins = jest.mocked(usePayStablecoins);
 
 const EMPTY_TITLE = "Pay and get paid";
 const EMPTY_DESCRIPTION = "Start by depositing stablecoin to your wallet";
@@ -30,6 +39,31 @@ const FEATURE_TOUR_ROW = "Minimal volatility";
 
 const onboardedState = { settings: { ...AFTER_ONBOARDING_STATE, counterValue: "USD" } };
 const tourSeenState = { payCard: { ...payCardInitialState, hasSeenFeatureTour: true } };
+const fundedState = {
+  ...onboardedState,
+  ...tourSeenState,
+  accounts: [BTC_ACCOUNT, ETH_ACCOUNT_WITH_USDC],
+};
+
+const defaultPayStablecoins: PayStablecoins = {
+  stablecoins: [],
+  defaultStablecoins: [USDC, USDT],
+  isLoading: false,
+  isError: false,
+};
+
+function mockPayStablecoins(overrides: Partial<PayStablecoins> = {}) {
+  mockedUsePayStablecoins.mockReturnValue({
+    ...defaultPayStablecoins,
+    ...overrides,
+  });
+}
+
+function mockFundedPayStablecoins() {
+  mockPayStablecoins({
+    stablecoins: [makeItem(USDC.id, USDC.ticker, USDC.name, 1000)],
+  });
+}
 
 jest.mock("@features/flow-pay-card-auth", () => ({
   CardLogin: () => <button type="button">Login</button>,
@@ -39,9 +73,10 @@ jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
 
-describe("PayTab integration", () => {
+describe("PayTab", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPayStablecoins();
     mockedUseNavigate.mockReturnValue(mockNavigate);
   });
 
@@ -92,6 +127,8 @@ describe("PayTab integration", () => {
   });
 
   it("should render the aggregated stablecoin balance when the user holds USDC", async () => {
+    mockFundedPayStablecoins();
+
     const { container } = renderWithMockedCounterValuesProvider(<PayTab />, {
       initialState: {
         ...onboardedState,
@@ -103,7 +140,6 @@ describe("PayTab integration", () => {
     await waitFor(() => {
       expect(within(container).getByTestId("pay-card-balance-funded-state")).toBeVisible();
     });
-    expect(within(container).queryByTestId("pay-card-balance-empty-state")).not.toBeInTheDocument();
   });
 
   it("should track the Pay page with the active balance filter on view", () => {
@@ -127,5 +163,55 @@ describe("PayTab integration", () => {
     });
 
     expect(await screen.findByRole("button", { name: "Login" })).toBeVisible();
+  });
+
+  it("should open the balance filter dialog from the hero pill and track the interaction", async () => {
+    mockFundedPayStablecoins();
+
+    renderWithMockedCounterValuesProvider(<PayTab />, {
+      initialState: fundedState,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pay-card-balance-filter-pill")).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByTestId("pay-card-balance-filter-pill"));
+
+    const dialog = await screen.findByTestId("pay-card-balance-filter-dialog");
+    expect(dialog).toHaveTextContent("USD Coin");
+    expect(dialog).toHaveTextContent("Tether USD");
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", { button: "balance_filter" });
+  });
+
+  it("should persist the selected stablecoin, update the hero pill and track the confirmation", async () => {
+    mockFundedPayStablecoins();
+
+    const { store } = renderWithMockedCounterValuesProvider(<PayTab />, {
+      initialState: fundedState,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pay-card-balance-filter-pill")).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByTestId("pay-card-balance-filter-pill"));
+
+    fireEvent.click(await screen.findByTestId("pay-card-balance-filter-option-usdc"));
+    fireEvent.click(screen.getByTestId("pay-card-balance-filter-confirm"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("pay-card-balance-filter-dialog")).not.toBeInTheDocument();
+    });
+
+    expect(store.getState().payCard.balanceFilter).toBe(USDC.id);
+
+    const pill = screen.getByTestId("pay-card-balance-filter-pill");
+    expect(within(pill).getByText("USDC")).toBeVisible();
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", {
+      button: "confirm_balance_filter",
+      asset: "USDC",
+    });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/buildBalanceFilterOptions.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/buildBalanceFilterOptions.test.ts
@@ -1,0 +1,63 @@
+import type { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { buildBalanceFilterOptions } from "../buildBalanceFilterOptions";
+import type { DefaultStablecoin } from "../usePayStablecoins";
+import { USDC, USDT, USD_UNIT, makeItem } from "./fixtures";
+
+function build(stablecoins: CategorizedAssetItem[], defaults: DefaultStablecoin[] = [USDC, USDT]) {
+  return buildBalanceFilterOptions({
+    stablecoins,
+    defaultStablecoins: defaults,
+    allLabel: "All stablecoins",
+    locale: "en",
+    counterValueUnit: USD_UNIT,
+  });
+}
+
+describe("buildBalanceFilterOptions", () => {
+  it("should always offer USDC and USDT at zero when nothing is held", () => {
+    const options = build([]);
+
+    expect(options.map(o => o.id)).toEqual(["all", USDC.id, USDT.id]);
+    expect(options[0]).toMatchObject({ id: "all", title: "All stablecoins", countervalue: 0 });
+    expect(options[1]).toMatchObject({
+      id: USDC.id,
+      ticker: "USDC",
+      ledgerId: USDC.id,
+      countervalue: 0,
+    });
+    expect(options[1].cryptoAmountLabel).toContain("USDC");
+    expect(options[2]).toMatchObject({ id: USDT.id, ticker: "USDT", countervalue: 0 });
+  });
+
+  it("should merge held balances into the default rows", () => {
+    const options = build([makeItem("ethereum/erc20/usd__coin", "USDC", "USD Coin", 1000)]);
+
+    expect(options[0].countervalue).toBe(1000);
+    expect(options[1]).toMatchObject({ id: USDC.id, ticker: "USDC", countervalue: 1000 });
+    expect(options[2].countervalue).toBe(0);
+  });
+
+  it("should keep the canonical default id even when USDC is held on another chain", () => {
+    const options = build([makeItem("polygon/erc20/usd__coin", "USDC", "USD Coin", 500)]);
+
+    expect(options[1]).toMatchObject({ id: USDC.id, ledgerId: USDC.id, countervalue: 500 });
+  });
+
+  it("should list other held stablecoins after the defaults, ordered by countervalue", () => {
+    const options = build([
+      makeItem("ethereum/erc20/dai", "DAI", "Dai", 500),
+      makeItem("ethereum/erc20/frax", "FRAX", "Frax", 800),
+    ]);
+
+    expect(options.map(o => o.ticker)).toEqual([undefined, "USDC", "USDT", "FRAX", "DAI"]);
+  });
+
+  it("should total every held stablecoin in the all option", () => {
+    const options = build([
+      makeItem("ethereum/erc20/usd__coin", "USDC", "USD Coin", 1000),
+      makeItem("ethereum/erc20/dai", "DAI", "Dai", 250),
+    ]);
+
+    expect(options[0]).toMatchObject({ id: "all", countervalue: 1250 });
+  });
+});

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/fixtures.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/fixtures.ts
@@ -1,0 +1,35 @@
+import { makeToken } from "@ledgerhq/asset-aggregation/assetCategorization/__tests__/fixtures";
+import type { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import type { Unit } from "@domain/entity-currency-unit";
+import type { DefaultStablecoin } from "../usePayStablecoins";
+
+export const USD_UNIT: Unit = { name: "US Dollar", code: "USD", magnitude: 2 };
+
+export const USDC: DefaultStablecoin = {
+  id: "ethereum/erc20/usd__coin",
+  ticker: "USDC",
+  name: "USD Coin",
+  magnitude: 6,
+};
+
+export const USDT: DefaultStablecoin = {
+  id: "ethereum/erc20/usd_tether__erc20_",
+  ticker: "USDT",
+  name: "Tether USD",
+  magnitude: 6,
+};
+
+export function makeItem(
+  id: string,
+  ticker: string,
+  name: string,
+  value: number,
+): CategorizedAssetItem {
+  return {
+    currency: makeToken(id, ticker, name, 6),
+    balance: value * 1_000_000,
+    value,
+    distribution: 0,
+    accounts: [],
+  };
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayCardBalance.test.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/__tests__/usePayCardBalance.test.ts
@@ -1,28 +1,24 @@
-import { renderHook } from "tests/testSetup";
-import {
-  createMockCategorizedAssets,
-  STABLECOIN_ASSET,
-} from "@ledgerhq/asset-aggregation/mocks/categorizedAssets.mock";
+import { act, renderHook, waitFor } from "tests/testSetup";
+import { track } from "~/renderer/analytics/segment";
 import { AFTER_ONBOARDING_STATE } from "~/renderer/reducers/settings";
 import { usePayCardBalance } from "../usePayCardBalance";
+import type { PayStablecoins } from "../usePayStablecoins";
+import { usePayStablecoins } from "../usePayStablecoins";
+import { USDC, USDT, makeItem } from "./fixtures";
 
-const mockUseCategorizedAssetsFromPortfolio = jest.fn();
+jest.mock("../usePayStablecoins", () => ({ usePayStablecoins: jest.fn() }));
 
-jest.mock("LLD/hooks/useCategorizedAssets", () => ({
-  useCategorizedAssetsFromPortfolio: (...args: unknown[]) =>
-    mockUseCategorizedAssetsFromPortfolio(...args),
-}));
+const mockedUsePayStablecoins = jest.mocked(usePayStablecoins);
+const mockedTrack = jest.mocked(track);
 
 const initialState = { settings: { ...AFTER_ONBOARDING_STATE, counterValue: "USD" } };
 
-function mockPortfolioResult(overrides: Record<string, unknown> = {}) {
-  mockUseCategorizedAssetsFromPortfolio.mockReturnValue({
-    categorizedAssets: createMockCategorizedAssets(),
-    isLoadingStablecoinTickers: false,
-    isStablecoinTickersError: false,
-    stablecoinTickers: [],
-    isLoadingStocks: false,
-    isStocksError: false,
+function mockStablecoins(overrides: Partial<PayStablecoins> = {}) {
+  mockedUsePayStablecoins.mockReturnValue({
+    stablecoins: [],
+    defaultStablecoins: [USDC, USDT],
+    isLoading: false,
+    isError: false,
     ...overrides,
   });
 }
@@ -30,63 +26,50 @@ function mockPortfolioResult(overrides: Record<string, unknown> = {}) {
 describe("usePayCardBalance", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockPortfolioResult();
+    mockStablecoins();
   });
 
-  it("should sum the stablecoin countervalues when filter is all", () => {
-    mockPortfolioResult({
-      categorizedAssets: {
-        cryptos: [],
-        stocks: [],
-        stablecoins: [
-          { ...STABLECOIN_ASSET, value: 1000 },
-          { ...STABLECOIN_ASSET, value: 250.5 },
-        ],
-      },
+  it("should sum every stablecoin countervalue when the filter is all", () => {
+    mockStablecoins({
+      stablecoins: [
+        makeItem("ethereum/erc20/usd__coin", "USDC", "USDC", 1000),
+        makeItem("ethereum/erc20/usd_tether__erc20_", "USDT", "USDT", 250.5),
+      ],
     });
 
     const { result } = renderHook(() => usePayCardBalance(), { initialState });
 
     expect(result.current.stableBalance).toBe(1250.5);
     expect(result.current.status).toBe("ready");
+    expect(result.current.hasBalance).toBe(true);
   });
 
-  it("should sum only the matching stablecoin when filter is a currencyId", () => {
-    const usdt = {
-      ...STABLECOIN_ASSET,
-      currency: { ...STABLECOIN_ASSET.currency, id: "ethereum/erc20/usdt" },
-      value: 250.5,
-    };
-
-    mockPortfolioResult({
-      categorizedAssets: {
-        cryptos: [],
-        stocks: [],
-        stablecoins: [{ ...STABLECOIN_ASSET, value: 1000 }, usdt],
-      },
+  it("should sum only the matching ticker when a coin filter is active", () => {
+    mockStablecoins({
+      stablecoins: [
+        makeItem("ethereum/erc20/usd__coin", "USDC", "USDC", 1000),
+        makeItem("ethereum/erc20/usd_tether__erc20_", "USDT", "USDT", 250.5),
+      ],
     });
 
     const { result } = renderHook(() => usePayCardBalance(), {
-      initialState: {
-        ...initialState,
-        payCard: { balanceFilter: "ethereum/erc20/usdc" },
-      },
+      initialState: { ...initialState, payCard: { balanceFilter: USDC.id } },
     });
 
     expect(result.current.stableBalance).toBe(1000);
-    expect(result.current.filter).toBe("ethereum/erc20/usdc");
+    expect(result.current.filter).toBe(USDC.id);
   });
 
-  it("should report loading while stablecoin tickers load", () => {
-    mockPortfolioResult({ isLoadingStablecoinTickers: true });
+  it("should report loading while stablecoins load", () => {
+    mockStablecoins({ isLoading: true });
 
     const { result } = renderHook(() => usePayCardBalance(), { initialState });
 
     expect(result.current.status).toBe("loading");
   });
 
-  it("should report error when the stablecoin tickers fail", () => {
-    mockPortfolioResult({ isStablecoinTickersError: true });
+  it("should report error when stablecoins fail", () => {
+    mockStablecoins({ isError: true });
 
     const { result } = renderHook(() => usePayCardBalance(), { initialState });
 
@@ -99,11 +82,43 @@ describe("usePayCardBalance", () => {
     expect(result.current.filter).toBe("all");
   });
 
-  it("should format a countervalue in the counter currency", () => {
+  it("should report no balance when the user holds no stablecoins", () => {
     const { result } = renderHook(() => usePayCardBalance(), { initialState });
 
-    const formatted = result.current.formatCountervalue(1000);
+    expect(result.current.hasBalance).toBe(false);
+  });
 
-    expect(formatted).toBeDefined();
+  it("should always expose the all option first, followed by the defaults", () => {
+    const { result } = renderHook(() => usePayCardBalance(), { initialState });
+
+    expect(result.current.filterOptions[0].id).toBe("all");
+    expect(result.current.filterOptions.map(o => o.id)).toEqual(
+      expect.arrayContaining([USDC.id, USDT.id]),
+    );
+  });
+
+  it("should heal a stale persisted filter back to all", async () => {
+    const { result, store } = renderHook(() => usePayCardBalance(), {
+      initialState: { ...initialState, payCard: { balanceFilter: "ethereum/erc20/gone" } },
+    });
+
+    expect(result.current.filter).toBe("all");
+    await waitFor(() => expect(store.getState().payCard.balanceFilter).toBe("all"));
+  });
+
+  it("should persist the confirmed filter", async () => {
+    const { result, store } = renderHook(() => usePayCardBalance(), { initialState });
+
+    act(() => result.current.onConfirmFilter(USDC.id));
+
+    await waitFor(() => expect(store.getState().payCard.balanceFilter).toBe(USDC.id));
+  });
+
+  it("should forward tracking events to analytics", () => {
+    const { result } = renderHook(() => usePayCardBalance(), { initialState });
+
+    act(() => result.current.onTrackEvent?.("button_clicked", { button: "balance_filter" }));
+
+    expect(mockedTrack).toHaveBeenCalledWith("button_clicked", { button: "balance_filter" });
   });
 });

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/buildBalanceFilterOptions.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/buildBalanceFilterOptions.ts
@@ -1,0 +1,97 @@
+import BigNumber from "bignumber.js";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/currencies/index";
+import type { Unit } from "@domain/entity-currency-unit";
+import { PAY_CARD_BALANCE_FILTER_ALL } from "@domain/entity-pay-card";
+import type { PayCardBalanceFilterOption } from "@features/flow-pay-card-balance";
+import type { CategorizedAssetItem } from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import type { DefaultStablecoin } from "./usePayStablecoins";
+
+function formatCrypto(unit: Unit, balance: number, locale: string): string {
+  return formatCurrencyUnit(unit, new BigNumber(balance), { locale, showCode: true });
+}
+
+function assetOption(
+  id: string,
+  item: CategorizedAssetItem,
+  locale: string,
+  formatFiat: (value: number) => string,
+  override?: Pick<DefaultStablecoin, "name" | "ticker">,
+): PayCardBalanceFilterOption {
+  return {
+    id,
+    title: override?.name ?? item.currency.name,
+    ticker: override?.ticker ?? item.currency.ticker,
+    ledgerId: id,
+    countervalue: item.value,
+    countervalueLabel: formatFiat(item.value),
+    cryptoAmountLabel: formatCrypto(item.currency.units[0], item.balance, locale),
+  };
+}
+
+export function buildBalanceFilterOptions({
+  stablecoins,
+  defaultStablecoins,
+  allLabel,
+  locale,
+  counterValueUnit,
+}: Readonly<{
+  stablecoins: readonly CategorizedAssetItem[];
+  defaultStablecoins: readonly DefaultStablecoin[];
+  allLabel: string;
+  locale: string;
+  counterValueUnit: Unit;
+}>): PayCardBalanceFilterOption[] {
+  const formatFiat = (value: number): string =>
+    formatCurrencyUnit(counterValueUnit, new BigNumber(value), { locale, showCode: true });
+
+  const byTicker = new Map<string, CategorizedAssetItem>();
+  for (const item of stablecoins) {
+    byTicker.set(item.currency.ticker.toUpperCase(), item);
+  }
+
+  const unfilteredTotal = stablecoins.reduce((total, { value }) => total + value, 0);
+
+  const options: PayCardBalanceFilterOption[] = [
+    {
+      id: PAY_CARD_BALANCE_FILTER_ALL,
+      title: allLabel,
+      countervalue: unfilteredTotal,
+      countervalueLabel: formatFiat(unfilteredTotal),
+    },
+  ];
+
+  const defaultTickers = new Set(defaultStablecoins.map(coin => coin.ticker.toUpperCase()));
+  for (const coin of defaultStablecoins) {
+    const held = byTicker.get(coin.ticker.toUpperCase());
+    if (held) {
+      options.push(assetOption(coin.id, held, locale, formatFiat, coin));
+    } else {
+      const unit: Unit = { name: coin.name, code: coin.ticker, magnitude: coin.magnitude };
+      options.push({
+        id: coin.id,
+        title: coin.name,
+        ticker: coin.ticker,
+        ledgerId: coin.id,
+        countervalue: 0,
+        countervalueLabel: formatFiat(0),
+        cryptoAmountLabel: formatCrypto(unit, 0, locale),
+      });
+    }
+  }
+
+  const others = stablecoins
+    .filter(item => !defaultTickers.has(item.currency.ticker.toUpperCase()))
+    .sort((a, b) => b.value - a.value || a.currency.ticker.localeCompare(b.currency.ticker));
+  for (const item of others) {
+    options.push(assetOption(item.currency.id, item, locale, formatFiat));
+  }
+
+  return options;
+}
+
+export function tickerForFilter(
+  filter: string,
+  options: readonly PayCardBalanceFilterOption[],
+): string | undefined {
+  return options.find(option => option.id === filter)?.ticker;
+}

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -1,15 +1,12 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import BigNumber from "bignumber.js";
 import { useTranslation } from "react-i18next";
-import {
-  formatCurrencyUnit,
-  formatCurrencyUnitFragment,
-} from "@ledgerhq/live-common/currencies/index";
+import { formatCurrencyUnitFragment } from "@ledgerhq/live-common/currencies/index";
 import {
   aggregatePayCardBalance,
+  resolveSelection,
   type FormattedValue,
   type PayCardBalanceData,
-  type PayCardBalanceFilterOption,
 } from "@features/flow-pay-card-balance";
 import {
   PAY_CARD_BALANCE_FILTER_ALL,
@@ -18,8 +15,10 @@ import {
   type PayCardBalanceFilter,
 } from "@domain/entity-pay-card";
 import { useDispatch, useSelector } from "LLD/hooks/redux";
-import { useCategorizedAssetsFromPortfolio } from "LLD/hooks/useCategorizedAssets";
 import { counterValueCurrencySelector, localeSelector } from "~/renderer/reducers/settings";
+import { track } from "~/renderer/analytics/segment";
+import { buildBalanceFilterOptions, tickerForFilter } from "./buildBalanceFilterOptions";
+import { usePayStablecoins } from "./usePayStablecoins";
 
 export function usePayCardBalance(): PayCardBalanceData {
   const dispatch = useDispatch();
@@ -28,8 +27,50 @@ export function usePayCardBalance(): PayCardBalanceData {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
   const filter = useSelector(selectPayCardBalanceFilter);
 
-  const { categorizedAssets, isLoadingStablecoinTickers, isStablecoinTickersError } =
-    useCategorizedAssetsFromPortfolio();
+  const { stablecoins, defaultStablecoins, isLoading, isError } = usePayStablecoins();
+
+  const filterOptions = useMemo(
+    () =>
+      buildBalanceFilterOptions({
+        stablecoins,
+        defaultStablecoins,
+        allLabel: t("payTab.balance.filter.allStablecoins"),
+        locale,
+        counterValueUnit: counterValueCurrency.units[0],
+      }),
+    [stablecoins, defaultStablecoins, t, locale, counterValueCurrency],
+  );
+
+  const effectiveFilter = useMemo(
+    () =>
+      resolveSelection(
+        filter,
+        filterOptions.map(option => option.id),
+      ),
+    [filter, filterOptions],
+  );
+
+  // Heal a stale persisted selection once data is ready.
+  useEffect(() => {
+    if (!isLoading && !isError && effectiveFilter !== filter) {
+      dispatch(setPayCardBalanceFilter(PAY_CARD_BALANCE_FILTER_ALL));
+    }
+  }, [isLoading, isError, effectiveFilter, filter, dispatch]);
+
+  // Defaults (USDC/USDT) are keyed by market id; held rows may use a different currencyId.
+  // Match by ticker so the filtered total stays correct across those ids.
+  const stablecoinsForAggregate = useMemo(() => {
+    if (effectiveFilter === PAY_CARD_BALANCE_FILTER_ALL) {
+      return stablecoins;
+    }
+    const ticker = tickerForFilter(effectiveFilter, filterOptions);
+    if (ticker == null) {
+      return stablecoins.filter(({ currency }) => currency.id === effectiveFilter);
+    }
+    return stablecoins.filter(
+      ({ currency }) => currency.ticker.toUpperCase() === ticker.toUpperCase(),
+    );
+  }, [stablecoins, effectiveFilter, filterOptions]);
 
   const unit = counterValueCurrency.units[0];
 
@@ -42,30 +83,6 @@ export function usePayCardBalance(): PayCardBalanceData {
     [unit, locale],
   );
 
-  // "all" plus one row per held stablecoin, so a currencyId filter resolves instead of falling back to "all".
-  const filterOptions = useMemo<PayCardBalanceFilterOption[]>(
-    () => [
-      {
-        id: PAY_CARD_BALANCE_FILTER_ALL,
-        title: t("payTab.balance.filter.allStablecoins"),
-        countervalue: 0,
-        countervalueLabel: "",
-      },
-      ...categorizedAssets.stablecoins.map(({ currency, value }) => ({
-        id: currency.id,
-        title: currency.name,
-        ticker: currency.ticker,
-        ledgerId: currency.id,
-        countervalue: value,
-        countervalueLabel: formatCurrencyUnit(unit, new BigNumber(value), {
-          locale,
-          showCode: true,
-        }),
-      })),
-    ],
-    [categorizedAssets.stablecoins, t, unit, locale],
-  );
-
   const onConfirmFilter = useCallback(
     (next: PayCardBalanceFilter) => {
       dispatch(setPayCardBalanceFilter(next));
@@ -73,25 +90,39 @@ export function usePayCardBalance(): PayCardBalanceData {
     [dispatch],
   );
 
-  return useMemo(
-    () =>
-      aggregatePayCardBalance({
-        stablecoins: categorizedAssets.stablecoins,
-        filter,
-        isLoading: isLoadingStablecoinTickers,
-        isError: isStablecoinTickersError,
-        filterOptions,
-        formatCountervalue,
-        onConfirmFilter,
-      }),
-    [
-      categorizedAssets.stablecoins,
-      filter,
-      isLoadingStablecoinTickers,
-      isStablecoinTickersError,
+  const onTrackEvent = useCallback((event: string, params: Record<string, unknown>) => {
+    track(event, params);
+  }, []);
+
+  return useMemo(() => {
+    const aggregate = aggregatePayCardBalance({
+      // Pre-filtered by ticker/id; aggregate with "all" so it sums the prepared list.
+      stablecoins: stablecoinsForAggregate,
+      filter: PAY_CARD_BALANCE_FILTER_ALL,
+      isLoading,
+      isError,
       filterOptions,
       formatCountervalue,
       onConfirmFilter,
-    ],
-  );
+      onTrackEvent,
+    });
+
+    return {
+      ...aggregate,
+      // Keep the resolved selection for the UI (not the "all" forced into aggregate).
+      filter: effectiveFilter,
+      // Funded vs empty depends on any held stablecoin, not the active filter slice.
+      hasBalance: stablecoins.some(({ value }) => value > 0),
+    };
+  }, [
+    stablecoinsForAggregate,
+    isLoading,
+    isError,
+    formatCountervalue,
+    effectiveFilter,
+    stablecoins,
+    filterOptions,
+    onConfirmFilter,
+    onTrackEvent,
+  ]);
 }

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/hooks/usePayStablecoins.ts
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import { useDistribution } from "~/renderer/actions/general";
+import {
+  useStablecoinTickers,
+  selectTopAssetsByCategory,
+} from "@features/platform-aggregated-assets";
+import {
+  useGetAssetsDataInfiniteQuery,
+  AssetCategory,
+  mergeAssetsDataPages,
+} from "@domain/api-aggregated-assets";
+import {
+  useCategorizedAssets,
+  type CategorizedAssetItem,
+} from "@ledgerhq/asset-aggregation/assetCategorization/index";
+import { useSelector } from "LLD/hooks/redux";
+import {
+  blacklistedTokenIdsSelector,
+  hideEmptyTokenAccountsSelector,
+} from "~/renderer/reducers/settings";
+
+const STABLECOIN_CATEGORIES = [AssetCategory.Stablecoins];
+
+// Always-offered rows, taken from the top of the market-cap-ordered stablecoins (USDC/USDT).
+const DEFAULT_STABLECOIN_COUNT = 2;
+
+export type DefaultStablecoin = Readonly<{
+  id: string;
+  ticker: string;
+  name: string;
+  magnitude: number;
+}>;
+
+export type PayStablecoins = Readonly<{
+  stablecoins: CategorizedAssetItem[];
+  defaultStablecoins: DefaultStablecoin[];
+  isLoading: boolean;
+  isError: boolean;
+}>;
+
+export function usePayStablecoins(): PayStablecoins {
+  const hideEmptyTokenAccount = useSelector(hideEmptyTokenAccountsSelector);
+  const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
+
+  // Force cross-chain asset grouping so each stablecoin is a single aggregated item,
+  // independent of the aggregatedAssets wallet flag.
+  const distribution = useDistribution({
+    showEmptyAccounts: true,
+    hideEmptyTokenAccount,
+    groupBy: "asset",
+  });
+
+  const {
+    tickers: stablecoinTickers,
+    isLoading: isLoadingStablecoinTickers,
+    isError: isStablecoinTickersError,
+  } = useStablecoinTickers("lld", __APP_VERSION__);
+
+  const {
+    data: stablecoinAssets,
+    isLoading: isLoadingStablecoinAssets,
+    isError: isStablecoinAssetsError,
+  } = useGetAssetsDataInfiniteQuery({
+    categories: STABLECOIN_CATEGORIES,
+    product: "lld",
+    version: __APP_VERSION__,
+  });
+
+  const categorized = useCategorizedAssets(distribution, stablecoinTickers);
+
+  const stablecoins = useMemo(() => {
+    const blacklist = new Set(blacklistedTokenIds ?? []);
+    return categorized.stablecoins.filter(({ currency }) => !blacklist.has(currency.id));
+  }, [categorized.stablecoins, blacklistedTokenIds]);
+
+  const defaultStablecoins = useMemo<DefaultStablecoin[]>(() => {
+    const merged = mergeAssetsDataPages(stablecoinAssets?.pages);
+    if (!merged) return [];
+    const { stablecoins: top } = selectTopAssetsByCategory(merged, stablecoinTickers, {
+      maxCryptos: 0,
+      maxStablecoins: DEFAULT_STABLECOIN_COUNT,
+    });
+    return top.map(({ currency }) => ({
+      id: currency.id,
+      ticker: currency.ticker,
+      name: currency.name,
+      magnitude: currency.units[0]?.magnitude ?? 0,
+    }));
+  }, [stablecoinAssets, stablecoinTickers]);
+
+  return {
+    stablecoins,
+    defaultStablecoins,
+    isLoading: isLoadingStablecoinTickers || isLoadingStablecoinAssets || distribution.isLoading,
+    isError: isStablecoinTickersError || isStablecoinAssetsError,
+  };
+}

--- a/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/PayTab/hooks/usePayCardBalance.ts
@@ -53,8 +53,8 @@ export function usePayCardBalance(): PayCardBalanceData {
   const onConfirmFilter = useCallback((_next: PayCardBalanceFilter) => {}, []);
 
   return useMemo(
-    () =>
-      aggregatePayCardBalance({
+    () => ({
+      ...aggregatePayCardBalance({
         stablecoins: categorizedAssets.stablecoins,
         filter,
         isLoading: isLoadingStablecoinTickers,
@@ -63,6 +63,9 @@ export function usePayCardBalance(): PayCardBalanceData {
         formatCountervalue,
         onConfirmFilter,
       }),
+      filterOptions,
+      onConfirmFilter,
+    }),
     [
       categorizedAssets.stablecoins,
       filter,

--- a/features/flow/pay-card-balance/package.json
+++ b/features/flow/pay-card-balance/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "@domain/entity-pay-card": "workspace:^",
-    "@ledgerhq/lumen-utils-shared": "catalog:"
+    "@ledgerhq/lumen-utils-shared": "catalog:",
+    "@ledgerhq/crypto-icons": "catalog:"
   },
   "devDependencies": {
     "@support/jest-features-flow": "workspace:*",
     "@features/platform-style": "workspace:*",
-    "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/lumen-design-core": "catalog:",
     "@ledgerhq/lumen-ui-react": "catalog:",
     "@ledgerhq/lumen-ui-rnative": "catalog:",

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceEmptyState.native.test.tsx
@@ -1,17 +1,11 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
 import { PayCardBalanceEmptyState } from "../PayCardBalanceEmptyState.native";
+import { emptyLabels } from "./fixtures";
 
 describe("PayCardBalanceEmptyState (Native)", () => {
   it("should render the empty title and description", () => {
-    render(
-      <PayCardBalanceEmptyState
-        labels={{
-          emptyTitle: "Pay and get paid",
-          emptyDescription: "Start by depositing stablecoin to your wallet",
-        }}
-      />,
-    );
+    render(<PayCardBalanceEmptyState labels={emptyLabels} />);
 
     expect(screen.getByTestId("pay-card-balance-empty-state")).toBeTruthy();
     expect(screen.getByText("Pay and get paid")).toBeTruthy();

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/PayCardBalanceView.native.test.tsx
@@ -1,16 +1,24 @@
 import React from "react";
 import { render, screen } from "@testing-library/react-native";
-import type { FormattedValue, PayCardBalanceViewProps } from "../types";
+import type { PayCardBalanceViewProps } from "../types";
 import { PayCardBalanceView } from "../PayCardBalanceView.native";
-import { labels } from "./fixtures";
+import { emptyLabels, filterLabels, formatCountervalue, options } from "./fixtures";
 
-const formatCountervalue = (value: number): FormattedValue => ({
-  integerPart: String(value),
-  decimalPart: "00",
-  currencyText: "$",
-  decimalSeparator: ".",
-  currencyPosition: "start",
-});
+function fundedProps(): PayCardBalanceViewProps {
+  return {
+    displayMode: "funded",
+    balance: 1000,
+    formatCountervalue,
+    isLoading: false,
+    labels: filterLabels,
+    filter: "all",
+    options,
+    isFilterOpen: false,
+    onOpenFilter: jest.fn(),
+    onCloseFilter: jest.fn(),
+    onConfirmFilter: jest.fn(),
+  };
+}
 
 function renderView(props: PayCardBalanceViewProps) {
   return render(<PayCardBalanceView {...props} />);
@@ -18,32 +26,20 @@ function renderView(props: PayCardBalanceViewProps) {
 
 describe("PayCardBalanceView (Native)", () => {
   it("should render the empty title and description when empty", () => {
-    renderView({ displayMode: "empty", labels });
+    renderView({ displayMode: "empty", labels: emptyLabels });
 
     expect(screen.getByText("Pay and get paid")).toBeVisible();
     expect(screen.getByText("Start by depositing stablecoin to your wallet")).toBeVisible();
   });
 
   it("should not render a balance when empty", () => {
-    renderView({ displayMode: "empty", labels });
+    renderView({ displayMode: "empty", labels: emptyLabels });
 
     expect(screen.queryByTestId("pay-card-balance-funded-state")).toBeNull();
   });
 
   it("should render the funded balance when funded", () => {
-    renderView({
-      displayMode: "funded",
-      balance: 1000,
-      formatCountervalue,
-      filter: "all",
-      options: [],
-      isFilterOpen: false,
-      onOpenFilter: jest.fn(),
-      onCloseFilter: jest.fn(),
-      onConfirmFilter: jest.fn(),
-      isLoading: false,
-      labels,
-    });
+    renderView(fundedProps());
 
     expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
     expect(screen.queryByTestId("pay-card-balance-empty-state")).toBeNull();

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/aggregatePayCardBalance.web.test.ts
@@ -37,7 +37,7 @@ const filterOptionsWithStablecoins = [
 function buildPort(overrides: Partial<PayCardPortfolioPort> = {}): PayCardPortfolioPort {
   return {
     stablecoins: [],
-    filter: "all",
+    filter: PAY_CARD_BALANCE_FILTER_ALL,
     isLoading: false,
     isError: false,
     filterOptions,

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/fixtures.tsx
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/__tests__/fixtures.tsx
@@ -1,9 +1,17 @@
-import type { FormattedValue } from "@ledgerhq/lumen-ui-react";
-import type { PayCardBalanceFilterOption, PayCardBalanceLabels } from "../types";
+import type {
+  FormattedValue,
+  PayCardBalanceEmptyLabels,
+  PayCardBalanceFilterLabels,
+  PayCardBalanceFilterOption,
+  PayCardBalanceLabels,
+} from "../types";
 
-export const labels: PayCardBalanceLabels = {
+export const emptyLabels: PayCardBalanceEmptyLabels = {
   emptyTitle: "Pay and get paid",
   emptyDescription: "Start by depositing stablecoin to your wallet",
+};
+
+export const filterLabels: PayCardBalanceFilterLabels = {
   allStablecoins: "All stablecoins",
   filterDialogTitle: "Filter balance",
   filterDialogDescription: "Select a stablecoin to filter your balance",
@@ -11,14 +19,18 @@ export const labels: PayCardBalanceLabels = {
   confirm: "Confirm",
 };
 
-export const formatCountervalue = (value: number): FormattedValue =>
-  ({
-    integerPart: String(value),
-    decimalPart: "00",
-    currencyText: "$",
-    decimalSeparator: ".",
-    currencyPosition: "start",
-  }) as unknown as FormattedValue;
+export const labels: PayCardBalanceLabels = {
+  ...emptyLabels,
+  ...filterLabels,
+};
+
+export const formatCountervalue = (value: number): FormattedValue => ({
+  integerPart: String(value),
+  decimalPart: "00",
+  currencyText: "$",
+  decimalSeparator: ".",
+  currencyPosition: "start",
+});
 
 export const USDC_ID = "ethereum/erc20/usd__coin";
 export const USDT_ID = "ethereum/erc20/usd_tether__erc20_";

--- a/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
+++ b/features/flow/pay-card-balance/src/components/PayCardBalance/types.ts
@@ -36,26 +36,12 @@ export type PayCardBalanceFilterOption = Readonly<{
   cryptoAmountLabel?: string;
 }>;
 
-/** Host props for `PayCardBalance`, produced via {@link aggregatePayCardBalance}. */
-export type PayCardBalanceData = Readonly<{
-  status: PayCardBalanceStatus;
-  stableBalance: number;
-  filter: PayCardBalanceFilter;
-  /** Whether the user holds any stablecoin balance. Drives funded vs empty. */
-  hasBalance: boolean;
-  /** First entry is always the "all" option. */
-  filterOptions: readonly PayCardBalanceFilterOption[];
-  formatCountervalue: (value: number) => FormattedValue;
-  onConfirmFilter: (filter: PayCardBalanceFilter) => void;
-  onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
-}>;
-
 export type PayCardStablecoin = Readonly<{
   currency: Readonly<{ id: string }>;
   value: number;
 }>;
 
-// Platform-agnostic input for {@link aggregatePayCardBalance}
+/** Platform-agnostic input for {@link aggregatePayCardBalance}. */
 export type PayCardPortfolioPort = Readonly<{
   stablecoins: readonly PayCardStablecoin[];
   filter: PayCardBalanceFilter;
@@ -67,6 +53,25 @@ export type PayCardPortfolioPort = Readonly<{
   onConfirmFilter: (filter: PayCardBalanceFilter) => void;
   onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
 }>;
+
+/** Result of {@link aggregatePayCardBalance}: filtered total + status. */
+export type PayCardBalanceAggregate = Readonly<{
+  status: PayCardBalanceStatus;
+  stableBalance: number;
+  filter: PayCardBalanceFilter;
+  /** Whether the user holds any stablecoin balance. Drives funded vs empty. */
+  hasBalance: boolean;
+  formatCountervalue: (value: number) => FormattedValue;
+}>;
+
+/** Full host props for `PayCardBalance` (= aggregate + filter UI wiring). */
+export type PayCardBalanceData = PayCardBalanceAggregate &
+  Readonly<{
+    /** First entry is always the "all" option. */
+    filterOptions: readonly PayCardBalanceFilterOption[];
+    onConfirmFilter: (filter: PayCardBalanceFilter) => void;
+    onTrackEvent?: (event: string, params: Record<string, unknown>) => void;
+  }>;
 
 export type PayCardBalanceProps = PayCardBalanceData &
   Readonly<{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2352,7 +2352,7 @@ importers:
         version: 18.0.1
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6
+        version: 0.81.6(@babel/core@7.28.5)
       '@react-native/codegen':
         specifier: 'catalog:'
         version: 0.81.6(@babel/core@7.28.5)
@@ -5682,6 +5682,9 @@ importers:
       '@domain/entity-pay-card':
         specifier: workspace:^
         version: link:../../../domain/entity/pay-card
+      '@ledgerhq/crypto-icons':
+        specifier: 'catalog:'
+        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-react@0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-utils-shared':
         specifier: 'catalog:'
         version: 0.1.7(react@19.1.4)
@@ -5689,9 +5692,6 @@ importers:
       '@features/platform-style':
         specifier: workspace:*
         version: link:../../platform/style
-      '@ledgerhq/crypto-icons':
-        specifier: 'catalog:'
-        version: 2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-react@0.1.51(@ledgerhq/lumen-design-core@0.1.24)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(@ledgerhq/lumen-ui-rnative@0.1.54(@ledgerhq/lumen-design-core@0.1.24)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4))(react-dom@19.1.4(react@19.1.4))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
       '@ledgerhq/lumen-design-core':
         specifier: 'catalog:'
         version: 0.1.24
@@ -14384,7 +14384,7 @@ importers:
         version: 0.81.6
       '@react-native/babel-preset':
         specifier: 'catalog:'
-        version: 0.81.6
+        version: 0.81.6(@babel/core@7.28.5)
       '@rsbuild/core':
         specifier: 'catalog:'
         version: 2.0.9
@@ -14408,7 +14408,7 @@ importers:
         version: 10.4.4(@storybook/react@10.4.1(@types/react@19.0.14)(@typescript/typescript6@6.0.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4))(react@19.1.4)(storybook@10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@storybook/addon-react-native-web':
         specifier: 'catalog:'
-        version: 0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@storybook/jest':
         specifier: 'catalog:'
         version: 0.2.3
@@ -22329,6 +22329,8 @@ packages:
   '@react-native/babel-preset@0.81.6':
     resolution: {integrity: sha512-RtIr82ccPoyMLmIC3/vCG96MzRmIT+IzQkjCgTS5b93uAxiER9BS7+d1l7+zD00VanClt6CTBM4K4n6RCnAykg==}
     engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      '@babel/core': '*'
 
   '@react-native/codegen@0.77.3':
     resolution: {integrity: sha512-Q6ZJCE7h6Z3v3DiEZUnqzHbgwF3ZILN+ACTx6qu/x2X1cL96AatKwdX92e0+7J9RFg6gdoFYJgRrW8Q6VnWZsQ==}
@@ -42110,6 +42112,16 @@ snapshots:
       regexpu-core: 6.2.0
       semver: 6.3.1
 
+  '@babel/helper-define-polyfill-provider@0.6.5':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42184,6 +42196,14 @@ snapshots:
       '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
+
+  '@babel/helper-remap-async-to-generator@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-wrap-function': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42332,6 +42352,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-export-default-from@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-proposal-export-default-from@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42418,9 +42442,17 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-syntax-dynamic-import@7.8.3':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-export-default-from@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-export-default-from@7.25.9(@babel/core@7.28.5)':
@@ -42431,6 +42463,10 @@ snapshots:
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-syntax-flow@7.27.1':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.28.5)':
@@ -42575,6 +42611,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-async-generator-functions@7.28.0':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42590,6 +42634,14 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-async-to-generator@7.27.1':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-remap-async-to-generator': 7.27.1
     transitivePeerDependencies:
       - supports-color
 
@@ -42610,6 +42662,10 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-block-scoping@7.28.5':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
@@ -42681,6 +42737,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/template': 7.28.6
 
+  '@babel/plugin-transform-computed-properties@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/template': 7.28.6
+
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42691,6 +42752,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-destructuring@7.28.5':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -42744,11 +42812,23 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-flow-strip-types@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-flow': 7.27.1
+
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.28.5)
+
+  '@babel/plugin-transform-for-of@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42761,6 +42841,14 @@ snapshots:
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-function-name@7.27.1':
+    dependencies:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/traverse': 7.29.0
@@ -42786,9 +42874,17 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-literals@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-logical-assignment-operators@7.28.5':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
@@ -42842,6 +42938,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.27.1':
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42862,6 +42963,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-numeric-separator@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42873,6 +42978,16 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
+
+  '@babel/plugin-transform-object-rest-spread@7.28.4':
+    dependencies:
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5
+      '@babel/plugin-transform-parameters': 7.27.7
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
@@ -42892,6 +43007,10 @@ snapshots:
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-optional-catch-binding@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42918,10 +43037,21 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-parameters@7.27.7':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-private-methods@7.27.1':
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -42936,6 +43066,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-property-in-object@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -42959,6 +43097,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-react-display-name@7.28.0':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -42971,9 +43113,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.25.9':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-react-jsx-source@7.25.9':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-react-jsx-source@7.25.9(@babel/core@7.28.5)':
@@ -42988,6 +43138,16 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx@7.27.1':
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.27.1
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -43009,6 +43169,10 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-regenerator@7.28.4':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43024,6 +43188,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-runtime@7.25.9':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-plugin-utils': 7.27.1
+      babel-plugin-polyfill-corejs2: 0.4.14
+      babel-plugin-polyfill-corejs3: 0.10.6
+      babel-plugin-polyfill-regenerator: 0.6.5
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-runtime@7.25.9(@babel/core@7.28.5)':
     dependencies:
@@ -43054,6 +43229,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-spread@7.27.1':
+    dependencies:
+      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -43065,6 +43247,10 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.27.1
+
+  '@babel/plugin-transform-sticky-regex@7.27.1':
+    dependencies:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
@@ -51329,6 +51515,55 @@ snapshots:
 
   '@react-native/babel-preset@0.81.6':
     dependencies:
+      '@babel/plugin-proposal-export-default-from': 7.25.9
+      '@babel/plugin-syntax-dynamic-import': 7.8.3
+      '@babel/plugin-syntax-export-default-from': 7.25.9
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3
+      '@babel/plugin-transform-arrow-functions': 7.27.1
+      '@babel/plugin-transform-async-generator-functions': 7.28.0
+      '@babel/plugin-transform-async-to-generator': 7.27.1
+      '@babel/plugin-transform-block-scoping': 7.28.5
+      '@babel/plugin-transform-class-properties': 7.27.1
+      '@babel/plugin-transform-classes': 7.28.4
+      '@babel/plugin-transform-computed-properties': 7.27.1
+      '@babel/plugin-transform-destructuring': 7.28.5
+      '@babel/plugin-transform-flow-strip-types': 7.27.1
+      '@babel/plugin-transform-for-of': 7.27.1
+      '@babel/plugin-transform-function-name': 7.27.1
+      '@babel/plugin-transform-literals': 7.27.1
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.5
+      '@babel/plugin-transform-modules-commonjs': 7.27.1
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.27.1
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.27.1
+      '@babel/plugin-transform-numeric-separator': 7.27.1
+      '@babel/plugin-transform-object-rest-spread': 7.28.4
+      '@babel/plugin-transform-optional-catch-binding': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.5
+      '@babel/plugin-transform-parameters': 7.27.7
+      '@babel/plugin-transform-private-methods': 7.27.1
+      '@babel/plugin-transform-private-property-in-object': 7.27.1
+      '@babel/plugin-transform-react-display-name': 7.28.0
+      '@babel/plugin-transform-react-jsx': 7.27.1
+      '@babel/plugin-transform-react-jsx-self': 7.25.9
+      '@babel/plugin-transform-react-jsx-source': 7.25.9
+      '@babel/plugin-transform-regenerator': 7.28.4
+      '@babel/plugin-transform-runtime': 7.25.9
+      '@babel/plugin-transform-shorthand-properties': 7.27.1
+      '@babel/plugin-transform-spread': 7.27.1
+      '@babel/plugin-transform-sticky-regex': 7.27.1
+      '@babel/plugin-transform-typescript': 7.28.5
+      '@babel/plugin-transform-unicode-regex': 7.27.1
+      '@babel/template': 7.28.6
+      '@react-native/babel-plugin-codegen': 0.81.6
+      babel-plugin-syntax-hermes-parser: 0.29.1
+      babel-plugin-transform-flow-enums: 0.0.2
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/babel-preset@0.81.6(@babel/core@7.28.5)':
+    dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-proposal-export-default-from': 7.25.9(@babel/core@7.28.5)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
@@ -54758,11 +54993,11 @@ snapshots:
       react-native: 0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@15.1.0(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(metro-transform-worker@0.81.5)(metro@0.81.5)(react@19.1.4)
       storybook: 10.4.1(@testing-library/dom@10.4.1)(@types/react@19.0.14)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
 
-  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6)(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@storybook/addon-react-native-web@0.0.29(@react-native/babel-preset@0.81.6(@babel/core@7.28.5))(babel-plugin-react-native-web@0.19.10)(metro-react-native-babel-preset@0.77.0(@babel/core@7.28.5))(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       babel-plugin-react-native-web: 0.19.10
     optionalDependencies:
-      '@react-native/babel-preset': 0.81.6
+      '@react-native/babel-preset': 0.81.6(@babel/core@7.28.5)
       metro-react-native-babel-preset: 0.77.0(@babel/core@7.28.5)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -58326,12 +58561,27 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.8
 
+  babel-plugin-polyfill-corejs2@0.4.14:
+    dependencies:
+      '@babel/compat-data': 7.28.5
+      '@babel/helper-define-polyfill-provider': 0.6.5
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.5):
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.10.6:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.5
+      core-js-compat: 3.43.0
     transitivePeerDependencies:
       - supports-color
 
@@ -58348,6 +58598,12 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.5)
       core-js-compat: 3.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.5:
+    dependencies:
+      '@babel/helper-define-polyfill-provider': 0.6.5
     transitivePeerDependencies:
       - supports-color
 
@@ -58396,6 +58652,12 @@ snapshots:
       hermes-parser: 0.29.1
 
   babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0: {}
+
+  babel-plugin-transform-flow-enums@0.0.2:
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.27.1
+    transitivePeerDependencies:
+      - '@babel/core'
 
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.28.5):
     dependencies:


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Wires the stable balance filter into Ledger Wallet Desktop PayTab on top of the flow UI (#20735):

- Build filter options: USDC + USDT always, plus other held stablecoins
- Pass `filter` / `filterOptions` / `onConfirmFilter` into `PayCardBalance`
- Persist selection via `setPayCardBalanceFilter` (hero total + pill update)
- i18n labels for the filter dialog
- PayTab integration coverage

**Stacked on:** #20735 ([LIVE-34900](https://ledgerhq.atlassian.net/browse/LIVE-34900)) — retarget base to `develop` after that PR merges.





https://github.com/user-attachments/assets/f7a84d92-e6d8-4a97-a903-35ae8c7c044e



### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35846](https://ledgerhq.atlassian.net/browse/LIVE-35846)
- **ADR** (if any): N/A

### 🧪 How to test

> ⚠️ Automated checks must pass before making your PR "Ready for review".

- [ ] Unit tests for `buildBalanceFilterOptions`, `usePayCardBalance`, and PayTab integration
- [ ] Pay tab with stablecoins shows filter pill and correct total
- [ ] Confirming a coin filter updates the hero total and pill label/icon
- [ ] Persisted filter restores after reload; falls back to All when invalid

### ✅ Checklist

- [x] **Self-review** completed
- [x] **Automated tests** cover this change (unit/integration)
- [ ] **Manual QA** performed (or not needed; explain why)
- [ ] **Visual QA** (screenshots/video) for UI changes
- [x] **Documentation** updated if needed (N/A)
- [ ] **Changeset** added if a published package is affected (N/A)

[LIVE-34900]: https://ledgerhq.atlassian.net/browse/LIVE-34900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-35846]: https://ledgerhq.atlassian.net/browse/LIVE-35846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ