### PR TITLE
test(e2e-mobile): refactor wait for account discovery

### DIFF
--- a/e2e/mobile/jest.config.js
+++ b/e2e/mobile/jest.config.js
@@ -112,7 +112,7 @@ const config = {
   testMatch: ["<rootDir>/specs/**/*.spec.ts"],
   // CI shards exclude `.skip.spec.ts` (apps/ledger-live-mobile/scripts/shard-tests.mjs).
   testPathIgnorePatterns: ["\\.skip\\.spec\\.ts$"],
-  testTimeout: 300_000,
+  testTimeout: 60_000 * 6,
   reporters: [
     "detox/runners/jest/reporter",
     ["jest-allure2-reporter", jestAllure2ReporterOptions],

--- a/e2e/mobile/page/accounts/addAccount.drawer.ts
+++ b/e2e/mobile/page/accounts/addAccount.drawer.ts
@@ -1,5 +1,6 @@
+import { device } from "detox";
 import { Step } from "jest-allure2-reporter/api";
-import { delay, openDeeplink } from "../../helpers/commonHelpers";
+import { openDeeplink } from "../../helpers/commonHelpers";
 import CommonPage from "../common.page";
 import { retryUntilTimeout } from "../../utils/retry";
 import { checkForErrorModals } from "../../helpers/errorHelpers";
@@ -32,21 +33,24 @@ export default class AddAccountDrawer extends CommonPage {
 
   @Step("Wait for accounts discovery")
   async waitAccountsDiscovery() {
-    const DISCOVERY_TIMEOUT = 240000;
-    const ERROR_CHECK_INTERVAL = 2000;
+    const DISCOVERY_TIMEOUT = 240_000;
     const startTime = Date.now();
 
-    while (Date.now() - startTime < DISCOVERY_TIMEOUT) {
-      if (await IsIdVisible(this.continueButtonId, 1000)) {
-        return;
+    // disable sync to avoid Detox hanging during busy account discovery and UI animations
+    await device.disableSynchronization();
+    try {
+      while (Date.now() - startTime < DISCOVERY_TIMEOUT) {
+        if (await IsIdVisible(this.continueButtonId, 10_000)) {
+          return;
+        }
+        await checkForErrorModals(1_000, "Account discovery failed");
       }
-      await checkForErrorModals(1000, "Account discovery failed");
-      await delay(ERROR_CHECK_INTERVAL);
+      throw new Error(
+        `Account discovery timed out after ${DISCOVERY_TIMEOUT}ms. Expected button "${this.continueButtonId}" not found.`,
+      );
+    } finally {
+      await device.enableSynchronization();
     }
-
-    throw new Error(
-      `Account discovery timed out after ${DISCOVERY_TIMEOUT / 1000} seconds. Expected button "${this.continueButtonId}" not found.`,
-    );
   }
 
   @Step("Get number of accounts displayed by the blockchain scan")


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Improve account sync step reliability:
- account discovery triggers many network and UI updates

We can see on some reports that this process in particular can keep Detox waiting and potentially stall indefinitely.
Disable sync until success CTA is displayed.

- reduce load on detox 

Many calls with 1000ms timeouts potentially overwhelm Detox. 
Instead, set timeout for success CTA to 10sec to reduce intensity of Detox calls. 

Improve debugging:
- Increase overall Jest threshold to allow tests to throw relevant timeouts and errors.

The Jest threshold is the last defense and throws an empty error when triggered.
Prefer errors and timeouts from the test and from Detox for better debugging.
Account discovery step is allowing up to 4min (legit) - 5min for Jest is not enough.

Regression runs: https://github.com/LedgerHQ/ledger-live/actions/workflows/test-mobile-e2e-reusable.yml?query=branch%3Asupport%2FQAA-issue-103_e

### 🔗 Context

- **JIRA / GitHub issue**: https://github.com/LedgerHQ/qaa-flaky-tests/issues/103