### PR TITLE
feat(aggregated-assets): validate and brand the response (LIVE-35232)

### DIFF
--- a/.changeset/quiet-rates-validated.md
+++ b/.changeset/quiet-rates-validated.md
@@ -1,0 +1,7 @@
+---
+"@domain/api-aggregated-assets": patch
+"@domain/entity-interest-rate": patch
+"@domain/entity-currency": patch
+---
+
+Validate the DADA response per item, dropping malformed entries instead of trusting the payload, and brand an interest rate's currencyId and fetchAt so an id or timestamp cannot be confused with a plain string

--- a/domain/api/aggregated-assets/package.json
+++ b/domain/api/aggregated-assets/package.json
@@ -40,7 +40,9 @@
     "@domain/entity-interest-rate": "workspace:*",
     "@reduxjs/toolkit": "catalog:",
     "@shared/api-services": "workspace:*",
-    "@shared/env": "workspace:*"
+    "@shared/env": "workspace:*",
+    "@shared/schema-primitives": "workspace:*",
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/domain/api/aggregated-assets/src/internals/requests.test.ts
+++ b/domain/api/aggregated-assets/src/internals/requests.test.ts
@@ -45,12 +45,19 @@ describe("resolveBaseUrl", () => {
 
 describe("fetchAssetsPage", () => {
   let baseQuery: jest.Mock;
+  let warn: jest.SpyInstance;
 
   const request = () =>
     baseQuery.mock.calls[0][0] as { url: string; params: Record<string, unknown> };
 
   beforeEach(() => {
     baseQuery = jest.fn().mockResolvedValue({ data: emptyRaw });
+    warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  /* In afterEach, so a failing assertion cannot leak the spy into the next test. */
+  afterEach(() => {
+    warn.mockRestore();
   });
 
   it("targets the /assets path on the resolved base url", async () => {
@@ -81,6 +88,24 @@ describe("fetchAssetsPage", () => {
 
     expect(result.cryptoOrTokenCurrencies).toEqual({});
     expect(result.currenciesOrder).toEqual(emptyRaw.currenciesOrder);
+  });
+
+  /* The chunked endpoint merges pages from here, so validation has to cover this path too. */
+  it("drops an invalid asset rather than carrying it into a merged chunk", async () => {
+    baseQuery.mockResolvedValue({
+      data: {
+        ...emptyRaw,
+        cryptoAssets: {
+          btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} },
+          broken: { id: 42 },
+        },
+      },
+    });
+
+    const result = await fetchAssetsPage(baseQuery, params());
+
+    expect(Object.keys(result.cryptoAssets)).toEqual(["btc"]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("cryptoAssets=1"));
   });
 
   /*

--- a/domain/api/aggregated-assets/src/internals/requests.ts
+++ b/domain/api/aggregated-assets/src/internals/requests.ts
@@ -10,6 +10,7 @@ import type { AssetsData, GetAssetsDataParams } from "../types";
 import { convertApiAssets } from "../transforms";
 import { buildAssetsQueryParams } from "../requests";
 import { assertDadaApiHost } from "./utils";
+import { validateAssetsResponse } from "./validate";
 
 type DadaQueryResult = QueryReturnValue<unknown, FetchBaseQueryError, FetchBaseQueryMeta>;
 
@@ -45,6 +46,6 @@ export async function fetchAssetsPage(
 
   if (result.error) throw result.error;
 
-  const raw = result.data as RawApiResponse;
+  const raw = validateAssetsResponse(result.data as RawApiResponse);
   return { ...raw, cryptoOrTokenCurrencies: convertApiAssets(raw.cryptoOrTokenCurrencies) };
 }

--- a/domain/api/aggregated-assets/src/internals/validate.test.ts
+++ b/domain/api/aggregated-assets/src/internals/validate.test.ts
@@ -1,0 +1,168 @@
+import { validateAssetsResponse } from "./validate";
+import type { RawApiResponse } from "../schema";
+
+const asset = (id: string) => ({ id, ticker: id.toUpperCase(), name: id, assetsIds: {} });
+const rate = (currencyId: string) => ({
+  currencyId,
+  rate: 0.04,
+  type: "APY",
+  fetchAt: "2026-01-01T00:00:00.000Z",
+});
+
+function response(overrides: Partial<RawApiResponse> = {}): RawApiResponse {
+  return {
+    cryptoAssets: { btc: asset("btc") },
+    networks: { ethereum: { id: "ethereum", name: "Ethereum" } },
+    cryptoOrTokenCurrencies: {},
+    interestRates: { ethereum: rate("ethereum") },
+    markets: {},
+    currenciesOrder: { key: "marketCap", order: "desc", metaCurrencyIds: ["btc"] },
+    ...overrides,
+  } as RawApiResponse;
+}
+
+let warn: jest.SpyInstance;
+
+beforeEach(() => {
+  warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warn.mockRestore();
+});
+
+describe("validateAssetsResponse", () => {
+  it("returns a well-formed response unchanged and warns about nothing", () => {
+    const input = response();
+
+    expect(validateAssetsResponse(input)).toEqual(input);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps the valid siblings when one asset is malformed", () => {
+    const result = validateAssetsResponse(
+      response({
+        cryptoAssets: {
+          btc: asset("btc"),
+          broken: { id: 42, ticker: "BAD" },
+          eth: asset("eth"),
+        } as unknown as RawApiResponse["cryptoAssets"],
+      }),
+    );
+
+    expect(Object.keys(result.cryptoAssets)).toEqual(["btc", "eth"]);
+  });
+
+  it("returns an empty collection rather than failing when every item is invalid", () => {
+    const result = validateAssetsResponse(
+      response({
+        interestRates: { a: { rate: "nope" }, b: {} } as unknown as RawApiResponse["interestRates"],
+      }),
+    );
+
+    expect(result.interestRates).toEqual({});
+    expect(result.cryptoAssets).not.toEqual({});
+  });
+
+  /* DADA adds fields; zod's default object mode would strip them back out. */
+  it("preserves fields it does not model", () => {
+    const result = validateAssetsResponse(
+      response({
+        cryptoAssets: {
+          btc: { ...asset("btc"), marketCap: 123, nested: { a: 1 } },
+        } as unknown as RawApiResponse["cryptoAssets"],
+      }),
+    );
+
+    expect(result.cryptoAssets.btc).toMatchObject({ marketCap: 123, nested: { a: 1 } });
+  });
+
+  it("drops an unusable network without touching the others", () => {
+    const result = validateAssetsResponse(
+      response({
+        networks: {
+          ethereum: { id: "ethereum", name: "Ethereum" },
+          bad: { name: "no id" },
+        } as unknown as RawApiResponse["networks"],
+      }),
+    );
+
+    expect(Object.keys(result.networks)).toEqual(["ethereum"]);
+  });
+
+  it("falls back to no server ordering when currenciesOrder is unusable", () => {
+    const result = validateAssetsResponse(
+      response({
+        currenciesOrder: { key: "marketCap" } as unknown as RawApiResponse["currenciesOrder"],
+      }),
+    );
+
+    expect(result.currenciesOrder).toEqual({ key: "", order: "", metaCurrencyIds: [] });
+  });
+
+  it("reports how many items each collection lost", () => {
+    validateAssetsResponse(
+      response({
+        cryptoAssets: {
+          ok: asset("ok"),
+          bad: {},
+          alsoBad: {},
+        } as unknown as RawApiResponse["cryptoAssets"],
+        networks: { bad: {} } as unknown as RawApiResponse["networks"],
+      }),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0] as [string];
+    expect(message).toContain("dropped 3");
+    expect(message).toContain("cryptoAssets=2");
+    expect(message).toContain("networks=1");
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["a number", 1234],
+    ["not a date", "nope"],
+  ])("keeps a rate whose fetchAt is %s, since nothing reads it", (_label, fetchAt) => {
+    const result = validateAssetsResponse(
+      response({
+        interestRates: {
+          ethereum: { currencyId: "ethereum", rate: 0.04, type: "APY", fetchAt },
+        } as unknown as RawApiResponse["interestRates"],
+      }),
+    );
+
+    expect(result.interestRates.ethereum).toMatchObject({ rate: 0.04, type: "APY" });
+  });
+
+  it("still drops a rate whose value is unusable", () => {
+    const result = validateAssetsResponse(
+      response({
+        interestRates: {
+          ethereum: { currencyId: "ethereum", rate: "4%", type: "APY" },
+        } as unknown as RawApiResponse["interestRates"],
+      }),
+    );
+
+    expect(result.interestRates).toEqual({});
+  });
+
+  /* Merging pushes into metaCurrencyIds, so a shared fallback would accumulate across responses. */
+  it("returns a fresh ordering fallback for each response", () => {
+    const broken = { currenciesOrder: {} as RawApiResponse["currenciesOrder"] };
+
+    const first = validateAssetsResponse(response(broken));
+    first.currenciesOrder.metaCurrencyIds.push("leaked");
+    const second = validateAssetsResponse(response(broken));
+
+    expect(second.currenciesOrder.metaCurrencyIds).toEqual([]);
+  });
+
+  it("tolerates a collection missing from the response", () => {
+    const { cryptoAssets: _omitted, ...withoutAssets } = response();
+
+    const result = validateAssetsResponse(withoutAssets as RawApiResponse);
+
+    expect(result.cryptoAssets).toEqual({});
+  });
+});

--- a/domain/api/aggregated-assets/src/internals/validate.ts
+++ b/domain/api/aggregated-assets/src/internals/validate.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { CryptoAssetMetaSchema } from "@domain/entity-aggregated-asset";
+import { InterestRateSchema } from "@domain/entity-interest-rate";
+import { DateTimeIsoSchema } from "@shared/schema-primitives";
+import type { RawApiResponse } from "../schema";
+
+/*
+ * `loose` on every schema: DADA is a live aggregator and adds fields. Zod's default object mode
+ * strips what it does not model, which would delete a new field between the wire and the consumer.
+ * Validation here checks the fields we rely on and passes the rest through untouched.
+ */
+const AssetSchema = CryptoAssetMetaSchema.loose();
+
+/*
+ * `fetchAt` never costs a rate: nothing reads it, so an unparseable timestamp is discarded on its
+ * own rather than taking a usable APY with it. The entity types it optional for the same reason.
+ */
+const RateSchema = InterestRateSchema.loose().extend({
+  fetchAt: DateTimeIsoSchema.optional().catch(undefined),
+});
+const NetworkSchema = z.looseObject({ id: z.string(), name: z.string() });
+const OrderSchema = z.looseObject({
+  key: z.string(),
+  order: z.string(),
+  metaCurrencyIds: z.array(z.string()),
+});
+
+/**
+ * No server ordering, rather than a throw, when `currenciesOrder` is unusable.
+ *
+ * A function, not a constant: callers merge pages by pushing into `metaCurrencyIds`, so a shared
+ * instance would accumulate ids across unrelated responses.
+ */
+const noOrder = () => ({ key: "", order: "", metaCurrencyIds: [] });
+
+function keepValidEntries<T>(
+  collection: Record<string, unknown> | undefined,
+  schema: z.ZodType<T>,
+): { valid: Record<string, T>; dropped: number } {
+  const valid: Record<string, T> = {};
+  let dropped = 0;
+
+  for (const [key, item] of Object.entries(collection ?? {})) {
+    const parsed = schema.safeParse(item);
+    if (parsed.success) valid[key] = parsed.data;
+    else dropped += 1;
+  }
+
+  return { valid, dropped };
+}
+
+/**
+ * Drops the entries of a DADA response that do not match their entity, keeping the rest.
+ *
+ * Never rejects the whole response: one unmodelled asset would otherwise blank out Market,
+ * Portfolio and the asset selector at once. Drops are counted and warned about, because silent
+ * data loss here looks identical to DADA simply not carrying an asset.
+ *
+ * `markets` and `cryptoOrTokenCurrencies` are untouched — the first has no entity to validate
+ * against yet, the second is converted by `convertApiAssets` whose leniency is load-bearing.
+ */
+export function validateAssetsResponse(raw: RawApiResponse): RawApiResponse {
+  const cryptoAssets = keepValidEntries(raw.cryptoAssets, AssetSchema);
+  const interestRates = keepValidEntries(raw.interestRates, RateSchema);
+  const networks = keepValidEntries(raw.networks, NetworkSchema);
+
+  const parsedOrder = OrderSchema.safeParse(raw.currenciesOrder);
+
+  const dropped = {
+    cryptoAssets: cryptoAssets.dropped,
+    interestRates: interestRates.dropped,
+    networks: networks.dropped,
+    currenciesOrder: parsedOrder.success ? 0 : 1,
+  };
+
+  const total = Object.values(dropped).reduce((sum, count) => sum + count, 0);
+  if (total > 0) {
+    const detail = Object.entries(dropped)
+      .filter(([, count]) => count > 0)
+      .map(([collection, count]) => `${collection}=${count}`)
+      .join(" ");
+    console.warn(`DADA response: dropped ${total} invalid item(s) — ${detail}`);
+  }
+
+  return {
+    ...raw,
+    cryptoAssets: cryptoAssets.valid,
+    interestRates: interestRates.valid,
+    networks: networks.valid,
+    currenciesOrder: parsedOrder.success ? parsedOrder.data : noOrder(),
+  };
+}

--- a/domain/api/aggregated-assets/src/pagination.test.ts
+++ b/domain/api/aggregated-assets/src/pagination.test.ts
@@ -1,3 +1,4 @@
+import { InterestRateSchema } from "@domain/entity-interest-rate";
 import { mergeAssetsDataPages } from "./pagination";
 import type { AssetsDataWithPagination } from "./types";
 
@@ -38,7 +39,12 @@ describe("mergeAssetsDataPages", () => {
           cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
           networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } },
           interestRates: {
-            btc: { currencyId: "btc", rate: 1, type: "APY", fetchAt: "2026-01-01" },
+            btc: InterestRateSchema.parse({
+              currencyId: "btc",
+              rate: 1,
+              type: "APY",
+              fetchAt: "2026-01-01T00:00:00.000Z",
+            }),
           },
           markets: { btc: { price: 1 } },
         }),
@@ -46,7 +52,12 @@ describe("mergeAssetsDataPages", () => {
           cryptoAssets: { eth: { id: "eth", ticker: "ETH", name: "Ether", assetsIds: {} } },
           networks: { ethereum: { id: "ethereum", name: "Ethereum" } },
           interestRates: {
-            eth: { currencyId: "eth", rate: 2, type: "APR", fetchAt: "2026-01-01" },
+            eth: InterestRateSchema.parse({
+              currencyId: "eth",
+              rate: 2,
+              type: "APR",
+              fetchAt: "2026-01-01T00:00:00.000Z",
+            }),
           },
           markets: { eth: { price: 2 } },
         }),

--- a/domain/api/aggregated-assets/src/transforms.test.ts
+++ b/domain/api/aggregated-assets/src/transforms.test.ts
@@ -1,3 +1,4 @@
+import { InterestRateSchema } from "@domain/entity-interest-rate";
 import { configureStore } from "@reduxjs/toolkit";
 import { assetsDataApi } from "./api";
 import type { RawApiResponse } from "./schema";
@@ -111,7 +112,12 @@ describe("transformAssetsResponse, via getAssetData", () => {
       cryptoAssets: { btc: { id: "btc", ticker: "BTC", name: "Bitcoin", assetsIds: {} } },
       networks: { bitcoin: { id: "bitcoin", name: "Bitcoin" } },
       interestRates: {
-        bitcoin: { currencyId: "bitcoin", rate: 4.2, type: "APY", fetchAt: "2026-07-31" },
+        bitcoin: InterestRateSchema.parse({
+          currencyId: "bitcoin",
+          rate: 4.2,
+          type: "APY",
+          fetchAt: "2026-07-31T00:00:00.000Z",
+        }),
       },
       markets: { bitcoin: { price: 65000 } },
     });

--- a/domain/api/aggregated-assets/src/transforms.ts
+++ b/domain/api/aggregated-assets/src/transforms.ts
@@ -3,6 +3,7 @@ import { CryptoCurrencySchema, findCryptoCurrencyById } from "@domain/entity-cur
 import type { CryptoOrTokenCurrency } from "@domain/entity-currency";
 import { convertApiToken } from "@domain/api-currency-token";
 import type { ApiAsset, RawApiResponse } from "./schema";
+import { validateAssetsResponse } from "./internals/validate";
 import type { AssetsDataWithPagination } from "./types";
 
 /**
@@ -46,7 +47,9 @@ export function convertApiAssets(
           symbol: asset.symbol,
           disableCountervalue: asset.disableCountervalue,
           supportsSegwit: asset.hasSegwit,
-          ...(asset.chainId ? { ethereumLikeInfo: { chainId: parseInt(asset.chainId, 10) } } : {}),
+          ...(asset.chainId
+            ? { ethereumLikeInfo: { chainId: Number.parseInt(asset.chainId, 10) } }
+            : {}),
         });
       }
     }
@@ -58,12 +61,13 @@ export function transformAssetsResponse(
   response: RawApiResponse,
   meta?: FetchBaseQueryMeta,
 ): AssetsDataWithPagination {
-  const enrichedCryptoOrTokenCurrencies = convertApiAssets(response.cryptoOrTokenCurrencies);
+  const validated = validateAssetsResponse(response);
+  const enrichedCryptoOrTokenCurrencies = convertApiAssets(validated.cryptoOrTokenCurrencies);
 
   const nextCursor = meta?.response?.headers.get("x-ledger-next") || undefined;
 
   return {
-    ...response,
+    ...validated,
     cryptoOrTokenCurrencies: enrichedCryptoOrTokenCurrencies,
     pagination: {
       nextCursor,

--- a/domain/entity/aggregated-asset/src/schema.ts
+++ b/domain/entity/aggregated-asset/src/schema.ts
@@ -13,6 +13,12 @@ export const CryptoAssetMetaSchema = z.object({
   ticker: z.string(),
   /** Asset display name */
   name: z.string(),
-  /** Map of network IDs to their corresponding asset IDs */
+  /**
+   * Network id to the currency id representing this asset there.
+   *
+   * Ids stay unbranded for now: branding the values costs 23 fixture sites across three packages
+   * and 31 more in the apps, for no production change, since every caller only reads them and a
+   * branded string is already assignable to string. Worth doing on its own, not inside another task.
+   */
   assetsIds: z.record(z.string(), z.string()),
 });

--- a/domain/entity/currency/src/schema.ts
+++ b/domain/entity/currency/src/schema.ts
@@ -1,7 +1,21 @@
 import { z } from "zod";
-import { CryptoCurrencySchema } from "@domain/entity-currency-crypto";
-import { TokenCurrencySchema } from "@domain/entity-currency-token";
+import { CryptoCurrencyIdSchema, CryptoCurrencySchema } from "@domain/entity-currency-crypto";
+import { TokenCurrencyIdSchema, TokenCurrencySchema } from "@domain/entity-currency-token";
 import { FiatCurrencySchema } from "@domain/entity-currency-fiat";
+
+/**
+ * The id of a crypto or a token currency — `"ethereum"` or `"ethereum/erc20/usd_tether"`.
+ *
+ * Lives here rather than beside each consumer because callers that key data by currency accept
+ * both kinds, and asserting only the crypto form would reject every token id.
+ */
+export const CryptoOrTokenCurrencyIdSchema = z.union([
+  CryptoCurrencyIdSchema,
+  TokenCurrencyIdSchema,
+]);
+
+/** A crypto or token currency id, inferred from {@link CryptoOrTokenCurrencyIdSchema}. */
+export type CryptoOrTokenCurrencyId = z.infer<typeof CryptoOrTokenCurrencyIdSchema>;
 
 /**
  * Discriminated union of {@link CryptoCurrency} and {@link TokenCurrency}.

--- a/domain/entity/interest-rate/package.json
+++ b/domain/entity/interest-rate/package.json
@@ -18,6 +18,8 @@
     "unimported": "pnpm knip --directory ../../.. -W domain/entity/interest-rate"
   },
   "dependencies": {
+    "@domain/entity-currency": "workspace:*",
+    "@shared/schema-primitives": "workspace:*",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/domain/entity/interest-rate/src/schema.test.ts
+++ b/domain/entity/interest-rate/src/schema.test.ts
@@ -17,10 +17,16 @@ describe("InterestRateSchema", () => {
   });
 
   it("throws when a required field is missing", () => {
-    for (const key of ["currencyId", "rate", "type", "fetchAt"] as const) {
+    for (const key of ["currencyId", "rate", "type"] as const) {
       const { [key]: _omitted, ...rest } = valid;
       expect(() => InterestRateSchema.parse(rest)).toThrow();
     }
+  });
+
+  /* Nothing reads fetchAt, so its absence must not cost an otherwise usable rate. */
+  it("accepts a rate with no fetchAt", () => {
+    const { fetchAt: _omitted, ...rest } = valid;
+    expect(() => InterestRateSchema.parse(rest)).not.toThrow();
   });
 
   it("throws when rate is not a number", () => {
@@ -31,8 +37,17 @@ describe("InterestRateSchema", () => {
     expect(() => InterestRateSchema.parse({ ...valid, type: "STAKING" })).not.toThrow();
   });
 
-  it("does not validate the fetchAt format", () => {
-    expect(() => InterestRateSchema.parse({ ...valid, fetchAt: "not-a-date" })).not.toThrow();
+  it.each(["not-a-date", "2026-07-31", "2026-07-31T00:00:00"])(
+    "rejects %p as fetchAt, which needs an offset",
+    fetchAt => {
+      expect(() => InterestRateSchema.parse({ ...valid, fetchAt })).toThrow();
+    },
+  );
+
+  it("accepts a token id, not just a crypto one", () => {
+    expect(
+      InterestRateSchema.parse({ ...valid, currencyId: "ethereum/erc20/usd_tether" }),
+    ).toMatchObject({ currencyId: "ethereum/erc20/usd_tether" });
   });
 });
 

--- a/domain/entity/interest-rate/src/schema.ts
+++ b/domain/entity/interest-rate/src/schema.ts
@@ -1,4 +1,6 @@
 import { z } from "zod";
+import { CryptoOrTokenCurrencyIdSchema } from "@domain/entity-currency";
+import { DateTimeIsoSchema } from "@shared/schema-primitives";
 
 /**
  * The rate kinds the apps understand.
@@ -17,12 +19,17 @@ export const ApySchema = z.object({
 
 /** An interest rate attached to one currency. */
 export const InterestRateSchema = z.object({
-  /** Currency identifier */
-  currencyId: z.string(),
+  /** Crypto or token id: DADA keys rates by both, so the crypto form alone would reject tokens. */
+  currencyId: CryptoOrTokenCurrencyIdSchema,
   /** Interest rate value */
   rate: z.number(),
   /** Type of rate (NRR, APR, APY, etc.) — intentionally wider than ApyType, see above */
   type: z.string(),
-  /** Timestamp when the rate was fetched */
-  fetchAt: z.string(),
+  /**
+   * When the rate was read, as an ISO datetime with offset.
+   *
+   * Optional because nothing reads it: DADA omitting it, or sending a date without a time, must
+   * not cost an otherwise usable rate.
+   */
+  fetchAt: DateTimeIsoSchema.optional(),
 });

--- a/features/platform/aggregated-assets/src/selectors/interestRateSelectors.test.ts
+++ b/features/platform/aggregated-assets/src/selectors/interestRateSelectors.test.ts
@@ -1,13 +1,13 @@
 import { selectInterestRateByCurrency } from "./interestRateSelectors";
 import type { ApiState } from "./selectorUtils";
-import type { InterestRate } from "@domain/entity-interest-rate";
+import { InterestRateSchema } from "@domain/entity-interest-rate";
 
-const bitcoinRate: InterestRate = {
+const bitcoinRate = InterestRateSchema.parse({
   currencyId: "bitcoin",
   rate: 4.2,
   type: "APY",
   fetchAt: "2026-07-31T00:00:00.000Z",
-};
+});
 
 function stateWith(pages: Record<string, unknown>[]): ApiState {
   return { assetsDataApi: { queries: { a: { data: { pages } } } } } as ApiState;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3820,6 +3820,12 @@ importers:
       '@shared/env':
         specifier: workspace:*
         version: link:../../../shared/env
+      '@shared/schema-primitives':
+        specifier: workspace:*
+        version: link:../../../shared/schema-primitives
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -4484,6 +4490,12 @@ importers:
 
   domain/entity/interest-rate:
     dependencies:
+      '@domain/entity-currency':
+        specifier: workspace:*
+        version: link:../currency
+      '@shared/schema-primitives':
+        specifier: workspace:*
+        version: link:../../../shared/schema-primitives
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
### 📝 Description

**Problem.** Nothing checked the DADA payload at runtime. `RawApiResponse` simply *asserted* that `cryptoAssets` was `Record<string, CryptoAssetMeta>` and `interestRates` was `Record<string, InterestRate>`, and `transformAssetsResponse` spread both straight through — so malformed data reached every consumer wearing a type it had never been checked against. Separately, `currencyId` and `fetchAt` were plain `z.string()`, so nothing distinguished a currency id from a timestamp at a call boundary.

**Solution.** Validate per entry at the api boundary, and brand the two interest-rate fields.

| Collection | Validated against | Invalid entry |
| --- | --- | --- |
| `cryptoAssets` | `CryptoAssetMetaSchema` | dropped |
| `interestRates` | `InterestRateSchema` | dropped |
| `networks` | api wire schema | dropped |
| `currenciesOrder` | api wire schema | falls back to no server ordering |

**Never a whole-response `parse`.** One unmodelled asset would otherwise blank out Market, Portfolio and the asset selector at once. Drops are counted per collection and reported in a single `console.warn` per response — aggregated rather than per item so a bad page cannot flood the log, and `warn` not `error` because this is expected and recoverable (`console.error` reaches Datadog as an error event).

### 🔍 Three decisions that needed evidence, not assumption

**1. Every schema is `loose()`.** I probed zod 4.3.6 before writing anything: `z.object()` **strips** unknown keys by default. Validating with the entity schemas as-is would have silently deleted any field DADA adds between the wire and the consumer — turning validation into data loss. `.loose()` checks the fields we rely on and passes the rest through. A test pins it.

**2. `fetchAt` never costs a rate.** The ticket claimed zero production reads; I verified it — every occurrence in the repo is a mock or handler *assigning* it, never reading. So it is branded **and optional**: DADA omitting a timestamp, or sending a date without a time, must not discard an APY the UI does display. The boundary coerces a bad value instead of dropping the rate.

**3. `assetsIds` stays unbranded — measured, not assumed.** I implemented the value branding and typechecked it:

- **0** production errors — every caller only *reads*, and a branded string is already assignable to `string`
- **23** fixture errors across `domain/api`, `features/platform` and `libs/asset-aggregation`
- **31** further `assetsIds:` literal sites in the two apps (103 repo-wide)

Entirely fixture cost, no production gain today. Reverted, with the numbers recorded next to the field so it reads as a decision rather than an omission. This is the *"materially harder, budget for it separately"* case the ticket flagged — it deserves its own change.

### 🏛️ Where the id union lives

`currencyId` cannot be `CryptoCurrencyIdSchema` alone: DADA keys rates by both `ethereum` and `ethereum/erc20/usd_tether`, so that would reject every token id.

The union goes in **`@domain/entity-currency`**, which already owns the crypto-or-token concept, rather than as a local copy inside interest-rate. Note `@domain/entity-contact` already declares its own `ContactCurrencyIdSchema` with the identical shape — a local copy here would have made it the second. Contact can adopt the shared one whenever its owners like; not touched here.

### 🧪 Tests

**All 168 pre-existing `domain/api` tests pass unmodified**, including the LIVE-35224 characterization suite — the hard constraint on this ticket.

Two of the interest-rate entity's **own** schema tests did change, because this PR inverts what they pinned: *"throws when a required field is missing"* (which listed `fetchAt`) and *"does not validate the fetchAt format"*. They now assert the new contract — a rate with no `fetchAt` is accepted, and `"2026-07-31"` / `"2026-07-31T00:00:00"` are rejected for lacking an offset. These are the entity's schema tests, not characterization tests.

New coverage: valid response untouched, one invalid item among valid siblings, an entirely invalid collection, unmodelled fields preserved, `currenciesOrder` fallback, per-collection drop counts, `fetchAt` tolerated in three broken shapes, and the drop path **through the chunked endpoint** (which merges pages and so needed its own case).

### ✅ Verification

- `@domain/api-aggregated-assets` **181 tests** (from 168) · `@domain/entity-interest-rate` **27** (from 23) · `@domain/entity-currency` 7 · `@domain/entity-aggregated-asset` 5 · `@features/platform-aggregated-assets` 129 · `libs/asset-aggregation` 74 · live-common `portfolio`/`modularDrawer`/`ModularDrawer`/`market` **297**
- Every touched package: `tsc` **exit 0, 0 own-source errors**
- **Desktop and mobile typecheck ✅ All Good** — branding an entity rippled into zero app files
- `enforce-boundaries` 0 · `enforce-package-structure:test` 0 · structure validator ok · knip 0 on all three touched packages · `oxfmt --check` clean
- `pnpm install --frozen-lockfile` succeeds; lockfile diff is **12 insertions, 0 deletions** — exactly the four new workspace links

> [!NOTE]
> Plain `pnpm install` wanted to collapse a `metro@0.83.3(metro-transform-worker@0.83.3)` peer variant, 49 unrelated deletions in the React Native bundler graph. The lockfile here carries only the four dependency entries; the churn was reverted and `--frozen-lockfile` re-verified.

**Pre-existing and unrelated**, confirmed to contain zero branding errors: `libs/asset-detail` `tsc` reports 105 errors, all in unbuilt sibling libs and none in its own source; `libs/ledger-live-common` reports 5 `TS2307` on `@ledgerhq/live-common/families/evm/types`, because its build output is absent (`lib-es/families/evm/types.d.ts` does not exist).

### 📖 Reviewing this

Three commits. The first two are one change split for readability and are coupled — the boundary coercion in commit 1 only makes sense with the brand from commit 2:

1. `validate the response per item` — the validation module and its wiring into both response paths
2. `brand currencyId and fetchAt` — the entity change, plus the measured `assetsIds` decision
3. `add changeset`

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35232](https://ledgerhq.atlassian.net/browse/LIVE-35232) (epic: [LIVE-35223](https://ledgerhq.atlassian.net/browse/LIVE-35223))
- **ADR**: [DADA DDD compliant](https://ledgerhq.atlassian.net/wiki/spaces/WXP/pages/7382761502/DADA+DDD+compliant)
- **Not in this PR, still on the ticket**: the two layer-ownership fixes folded into LIVE-35232 (moving the DADA-agnostic `errors.ts` to `@shared/api-services`, and taking the RTK hooks out of `domain/api`). They touch both apps, so they land separately rather than entangling a Market/Portfolio regression with validation changes.
- **Unblocks**: LIVE-35233 — `cryptoOrTokenCurrencies`, the leniency-preserving one


[LIVE-35232]: https://ledgerhq.atlassian.net/browse/LIVE-35232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ