### PR TITLE
[LWD] fix(drawer): don't restore focus after a completed exchange

### DIFF
--- a/.changeset/nasty-adults-cross.md
+++ b/.changeset/nasty-adults-cross.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": minor
+---
+
+fix(drawer): don't restore focus to a detached webview on close

--- a/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/LiveAppDrawer.tsx
@@ -289,8 +289,14 @@ export const LiveAppDrawer = () => {
             message: "User closed the drawer",
           });
         }
+        // A completed exchange tears down the swap <webview> that had focus before the
+        // drawer opened, so restoring focus to it on close crashes (focus-trap calls
+        // WebViewElement.focus() on a detached guest). Only restore focus when the drawer
+        // is dismissed before completing, where the webview is still alive. Set the flag
+        // before dispatching the close so SideDrawer never reads a stale value on the close
+        // render (mirrors onCloseExchangeComplete's ordering).
+        setShouldRestoreDrawerFocusOnClose(!exchangeCompleted);
         dispatch(closePlatformAppDrawer());
-        setShouldRestoreDrawerFocusOnClose(true);
         // Reset state for next time
         setExchangeCompleted(false);
       }}

--- a/apps/ledger-live-desktop/src/renderer/components/__tests__/LiveAppDrawer.test.tsx
+++ b/apps/ledger-live-desktop/src/renderer/components/__tests__/LiveAppDrawer.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, screen, act } from "tests/testSetup";
+
+// Capture the props SideDrawer receives on every render so we can inspect the value at
+// the moment the drawer closes — LiveAppDrawer resets shouldRestoreFocusOnClose back to
+// true on the following render, so the final value is not the meaningful one.
+type SideDrawerSnapshot = { isOpen: boolean; shouldRestoreFocusOnClose: boolean };
+const mockSnapshots: SideDrawerSnapshot[] = [];
+let mockLastProps: { onRequestClose?: () => void } = {};
+
+jest.mock("~/renderer/components/SideDrawer", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  SideDrawer: (props: any) => {
+    mockSnapshots.push({
+      isOpen: props.isOpen,
+      shouldRestoreFocusOnClose: props.shouldRestoreFocusOnClose,
+    });
+    mockLastProps = props;
+    return props.isOpen ? <div>{props.children}</div> : null;
+  },
+}));
+
+// Stub the exchange-complete body: it only needs to pass isCompleteExchangeData and let
+// the test flip LiveAppDrawer into its "completed" state by invoking data.onResult.
+jest.mock("~/renderer/modals/Platform/Exchange/CompleteExchange/Body", () => ({
+  __esModule: true,
+  isCompleteExchangeData: () => true,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: ({ data }: any) => (
+    <button type="button" onClick={() => data.onResult({ id: "op-1" })}>
+      complete
+    </button>
+  ),
+}));
+
+// Avoid real account-sync side effects when onResult fires.
+jest.mock("~/renderer/hooks/useSyncAccountsById", () => ({
+  useSyncAccountsById: () => jest.fn(),
+}));
+
+import { LiveAppDrawer } from "~/renderer/components/LiveAppDrawer";
+
+const openCompletedExchangeState = {
+  UI: {
+    informationCenter: { isOpen: false, tabId: "announcement" },
+    platformAppDrawer: {
+      isOpen: true,
+      payload: {
+        type: "EXCHANGE_COMPLETE",
+        title: "swap.title",
+        data: {
+          exchange: { fromAccount: { type: "Account", id: "acc-1" } },
+          onResult: jest.fn(),
+          onCancel: jest.fn(),
+        },
+      },
+    },
+    isMemoTagBoxVisible: false,
+    forceAutoFocusOnMemoField: false,
+  },
+};
+
+describe("LiveAppDrawer", () => {
+  beforeEach(() => {
+    mockSnapshots.length = 0;
+    mockLastProps = {};
+  });
+
+  it("does not restore focus on close once the exchange has completed", async () => {
+    // Regression: closing the swap broadcast-success screen restored focus to the swap
+    // <webview>, whose Electron guest had been torn down, crashing with
+    // "Cannot read properties of null (reading 'focus')". A completed exchange must close
+    // without restoring focus.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const { user } = render(<LiveAppDrawer />, {
+      initialState: openCompletedExchangeState as never,
+    });
+
+    // Before completion, focus is still restored on close (webview is alive).
+    expect(mockSnapshots.at(-1)?.shouldRestoreFocusOnClose).toBe(true);
+
+    // Broadcast success -> LiveAppDrawer marks the exchange completed.
+    await user.click(screen.getByRole("button", { name: "complete" }));
+
+    // Close via the header / backdrop / Escape path.
+    act(() => {
+      mockLastProps.onRequestClose?.();
+    });
+
+    // The value SideDrawer sees at the close render (isOpen -> false) must be false, so
+    // its focus-trap deactivates without returning focus to the detached webview.
+    const closeSnapshot = mockSnapshots.find(snapshot => !snapshot.isOpen);
+    expect(closeSnapshot?.shouldRestoreFocusOnClose).toBe(false);
+  });
+});


### PR DESCRIPTION
### 📝 Description

**Previous behaviour:** closing the swap transaction broadcast-success screen (X button, backdrop, or Escape) threw an uncaught `Cannot read properties of null (reading 'focus')`. The swap live app runs in an Electron `<webview>` that holds focus before the exchange-complete drawer opens; on close, `focus-trap` restored focus to that webview, but after a completed exchange its Electron guest is torn down, so `WebViewElement.focus()` dereferenced a null ref. The `shouldRestoreFocusOnClose: false` opt-out added in LIVE-29447 only covered the "View Details" button — the generic close paths reset it back to `true`.

**Fix:** `LiveAppDrawer` keys `shouldRestoreFocusOnClose` on `exchangeCompleted`, so a completed exchange closes without restoring focus. Cancelled exchanges and every other drawer keep restoring focus as before.

**Regression check:** new `LiveAppDrawer.test.tsx` asserts a completed exchange closes with `shouldRestoreFocusOnClose === false` (red before the fix, green after); `oxfmt`, `oxlint`, and `typecheck` are clean.

### 🔗 Context

- **JIRA / GitHub issue**: [LIVE-35890](https://ledgerhq.atlassian.net/browse/LIVE-35890)
- **ADR** (if any): n/a

[LIVE-35890]: https://ledgerhq.atlassian.net/browse/LIVE-35890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ