### PR TITLE
[LWD] test(pay): refactor PayTab integration tests

### DIFF
--- a/.changeset/refactor-paytab-integration-tests.md
+++ b/.changeset/refactor-paytab-integration-tests.md
@@ -1,0 +1,5 @@
+---
+"ledger-live-desktop": patch
+---
+
+Refactor PayTab integration tests: merge describe blocks and use scoped within queries

--- a/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
+++ b/apps/ledger-live-desktop/src/mvvm/features/PayTab/__integrations__/PayTab.integration.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { renderWithMockedCounterValuesProvider, screen, waitFor, render } from "tests/testSetup";
+import {
+  renderWithMockedCounterValuesProvider,
+  screen,
+  waitFor,
+  render,
+  within,
+} from "tests/testSetup";
 import { useNavigate } from "react-router";
 import { server } from "tests/server";
 import { trackPage } from "~/renderer/analytics/segment";
@@ -33,7 +39,16 @@ jest.mock("~/renderer/linking", () => ({
   openURL: jest.fn(),
 }));
 
-describe("PayTab feature tour integration", () => {
+describe("PayTab integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigate.mockReturnValue(mockNavigate);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
   it("should show the feature tour on first visit", () => {
     render(<PayTab />, {
       initialState: { payCard: { ...payCardInitialState, hasSeenFeatureTour: false } },
@@ -66,17 +81,6 @@ describe("PayTab feature tour integration", () => {
     expect(screen.queryByText(FEATURE_TOUR_ROW)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Got it" })).not.toBeInTheDocument();
   });
-});
-
-describe("PayTab feature integration", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockedUseNavigate.mockReturnValue(mockNavigate);
-  });
-
-  afterEach(() => {
-    server.resetHandlers();
-  });
 
   it("should render the empty hero when the user holds no stablecoins", async () => {
     renderWithMockedCounterValuesProvider(<PayTab />, {
@@ -88,7 +92,7 @@ describe("PayTab feature integration", () => {
   });
 
   it("should render the aggregated stablecoin balance when the user holds USDC", async () => {
-    renderWithMockedCounterValuesProvider(<PayTab />, {
+    const { container } = renderWithMockedCounterValuesProvider(<PayTab />, {
       initialState: {
         ...onboardedState,
         ...tourSeenState,
@@ -97,9 +101,9 @@ describe("PayTab feature integration", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("pay-card-balance-funded-state")).toBeVisible();
+      expect(within(container).getByTestId("pay-card-balance-funded-state")).toBeVisible();
     });
-    expect(screen.queryByText(EMPTY_TITLE)).not.toBeInTheDocument();
+    expect(within(container).queryByTestId("pay-card-balance-empty-state")).not.toBeInTheDocument();
   });
 
   it("should track the Pay page with the active balance filter on view", () => {


### PR DESCRIPTION
### 📝 Description

Refactors the PayTab integration test suite for clarity and correctness:

- Merges the two separate `describe` blocks (`PayTab feature tour integration` and `PayTab feature integration`) into a single `PayTab integration` block so lifecycle hooks (`beforeEach`/`afterEach`) apply uniformly to all tests.
- Adds the `within` import from `tests/testSetup`.
- Replaces global `screen` queries with scoped `within(container)` queries for better test isolation and accuracy.

### 🔗 Context

- **JIRA / GitHub issue**: N/A