### PR TITLE
[LWDM] fix(contacts): allow reopening delete contact confirmation

### DIFF
--- a/.changeset/fix-mobile-contacts-reopen-delete-modal.md
+++ b/.changeset/fix-mobile-contacts-reopen-delete-modal.md
@@ -1,0 +1,5 @@
+---
+"live-mobile": patch
+---
+
+Fixed reopening the delete contact confirmation sheet after cancelling it by opening delete only after the actions menu sheet has fully dismissed.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/screens/Contacts/useContactDetailEditDeleteAdapter.ts
@@ -65,6 +65,7 @@ export function useContactDetailEditDeleteAdapter(
       page: CONTACTS_PAGE_PROPERTY.CONTACT_DETAIL,
     });
     flow.onDeletePress();
+    flow.openDelete();
   }, [analytics, flow]);
 
   useEffect(() => {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/__integrations__/Contacts.integration.test.tsx
@@ -1026,6 +1026,36 @@ describe("Contacts integration", () => {
     });
   });
 
+  it("should reopen the delete contact confirmation after canceling it", async () => {
+    const contacts = [mockMeContact(), mockContact({ id: "contact-ada", name: "Ada" })];
+    const { user } = render(<MyWalletNavigator />, {
+      overrideInitialState: withContactsPageReadyState(
+        { lwmContacts: { enabled: true, params: { newBadge: false } } },
+        state => ({ ...state, contacts: { contacts } }),
+      ),
+    });
+
+    await user.press(screen.getByTestId("my-wallet-contacts-button"));
+    await user.press(await screen.findByTestId("contacts-saved-contact-contact-ada"));
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-delete-action"));
+
+    expect(await screen.findByTestId("contacts-delete-contact-confirm")).toBeVisible();
+
+    await user.press(screen.getByText("Cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("contacts-delete-contact-confirm")).toBeNull();
+    });
+
+    await user.press(await screen.findByTestId("contacts-detail-actions-trigger"));
+    await user.press(await screen.findByTestId("contacts-detail-delete-action"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("contacts-delete-contact-confirm")).toBeVisible();
+    });
+  });
+
   it("should delete a saved contact and navigate back to the contacts list", async () => {
     const contacts = [mockMeContact(), mockContact({ id: "contact-ada", name: "Ada" })];
     const { user } = render(<MyWalletNavigator />, {

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/components/ContactDetailEditDeleteSheets/index.tsx
@@ -28,7 +28,11 @@ export function ContactDetailEditDeleteSheets({
   const keyboardInset = shouldUseKeyboardAvoidance(Platform.OS, Platform.Version)
     ? keyboardHeight
     : 0;
-  const { onClose: onCloseActionsMenuFromMenu, ...actionsMenuProps } = actionsMenu;
+  const {
+    onClose: onCloseActionsMenuFromMenu,
+    onHidden: onActionsMenuHidden,
+    ...actionsMenuProps
+  } = actionsMenu;
   const onCloseActionsMenu = useCallback(() => {
     onCloseActionsMenuFromMenu();
   }, [onCloseActionsMenuFromMenu]);
@@ -47,6 +51,7 @@ export function ContactDetailEditDeleteSheets({
       <QueuedBottomSheet
         isRequestingToBeOpened={actionsMenu.isOpen}
         onClose={onCloseActionsMenu}
+        onModalHide={onActionsMenuHidden}
         testID="contacts-detail-actions-sheet"
         enableDynamicSizing
       >

--- a/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/Contacts/screens/ContactDetail/hooks/useContactDetailEditDeleteAdapter.ts
@@ -10,7 +10,7 @@ import {
   useContactDetailEditDeleteFlowBindings,
   useContactsEditDeletePorts,
 } from "@features/flow-contacts";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "~/context/Locale";
 
 export type ContactDetailEditDeleteFlowProps = Readonly<{
@@ -21,6 +21,7 @@ export type ContactDetailEditDeleteFlowProps = Readonly<{
     onEdit: () => void;
     onDelete: () => void;
     onClose: () => void;
+    onHidden: () => void;
   }>;
   renameDrawer: ContactsRenameContactDrawerProps;
   deleteDrawer: ContactsDeleteContactDrawerProps;
@@ -53,6 +54,19 @@ export function useContactDetailEditDeleteAdapter(
     () => createContactDetailEditDeleteUiState(flow, renameViewModel, labels),
     [flow, labels, renameViewModel],
   );
+  const pendingDeleteRef = useRef(false);
+  const onDelete = useCallback(() => {
+    pendingDeleteRef.current = true;
+    flow.onDeletePress();
+  }, [flow]);
+  const onActionsMenuHidden = useCallback(() => {
+    if (!pendingDeleteRef.current) {
+      return;
+    }
+
+    pendingDeleteRef.current = false;
+    flow.openDelete();
+  }, [flow]);
 
   return {
     onOpenActionsMenu: flow.onOpenActionsMenu,
@@ -61,8 +75,9 @@ export function useContactDetailEditDeleteAdapter(
       canDelete: flow.canDelete,
       labels: labels.actions,
       onEdit: flow.onEditPress,
-      onDelete: flow.onDeletePress,
+      onDelete,
       onClose: flow.onCloseActionsMenu,
+      onHidden: onActionsMenuHidden,
     },
     renameDrawer: uiState.rename,
     deleteDrawer: uiState.delete,

--- a/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.ts
@@ -119,8 +119,7 @@ export function useContactDetailEditDeleteFlowViewModel({
 
   const onDeletePress = useCallback(() => {
     setIsActionsMenuOpen(false);
-    openDelete();
-  }, [openDelete]);
+  }, []);
 
   const onOpenActionsMenu = useCallback(() => {
     setIsActionsMenuOpen(true);

--- a/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/editDelete/useContactDetailEditDeleteFlowViewModel.web.test.tsx
@@ -239,8 +239,10 @@ describe("useContactDetailEditDeleteFlowViewModel", () => {
 
     act(() => {
       result.current.onDeletePress();
+      result.current.openDelete();
     });
 
+    expect(result.current.isActionsMenuOpen).toBe(false);
     expect(result.current.deleteLifecycle).toEqual({ status: "open", contactId: contact.id });
 
     await act(async () => {


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

<!-- A clear and concise description of what this PR does and why it is needed. -->
<!-- For bug fixes: describe the previous behaviour, the fix and the automated check that prevents future regression. -->
<!-- For features: describe the problem solved and the approach taken. -->
<!-- For libraries: include a usage code sample. -->
<!-- When possible, attach screenshots or recordings to help reviewers validate the changes. -->

- Fixes a mobile bug where the delete contact confirmation sheet would not reopen after the user cancelled it and tapped Delete again from the contact detail actions menu.
- Defers opening the delete confirmation until the actions menu bottom sheet has fully dismissed, using `onModalHide` and a pending-delete flag in the mobile adapter, so `QueuedBottomSheet` no longer conflicts when transitioning between sheets.
- Keeps desktop behavior unchanged by calling `openDelete()` immediately after `onDeletePress()` in the desktop adapter, since it does not use the queued sheet pattern.


https://github.com/user-attachments/assets/bc97a5bd-fb32-4988-b72e-f6c6e5f545d8



### 🔗 Context

[LIVE-35790](https://ledgerhq.atlassian.net/browse/LIVE-35790)


[LIVE-35790]: https://ledgerhq.atlassian.net/browse/LIVE-35790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ