### PR TITLE
[LWDM] refactor(types-devices): remove redundant type exports

### DIFF
--- a/.changeset/clear-owls-migrate.md
+++ b/.changeset/clear-owls-migrate.md
@@ -1,0 +1,11 @@
+---
+"@ledgerhq/types-devices": major
+---
+Remove redundant device and transport exports.
+
+| Removed exports                                            | Migration guidelines                                                                                                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Transport`, `Observer`, `DescriptorEvent`, `Subscription` | For LedgerJS usage, import the corresponding types from `@ledgerhq/hw-transport`. Note that LedgerJS is deprecated; migrate to Device Management Kit when possible. |
+| `BluetoothInfos`                                           | Import `BluetoothInfos` from `@ledgerhq/devices`, where it remains available. No migration is required when using Device Management Kit.                            |
+| `DevicesWithTouchScreen`                                   | No replacement is planned yet.                                                                                                                                      |
+| `ChargingModes`, `BatteryStatusFlags`                      | No replacement is planned yet. Battery-related operations are supported by Device Management Kit.                                                                   |

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.test.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.test.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from "electron";
-import { DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceModelId } from "@ledgerhq/devices";
 import IPCTransport from "./IPCTransport";
 
 jest.mock("electron", () => ({
@@ -21,9 +21,14 @@ jest.mock("@ledgerhq/logs", () => {
   };
 });
 
-jest.mock("@ledgerhq/devices", () => ({
-  getDeviceModel: jest.fn(() => ({ id: DeviceModelId.nanoS })),
-}));
+jest.mock("@ledgerhq/devices", () => {
+  const actual = jest.requireActual("@ledgerhq/devices");
+
+  return {
+    ...actual,
+    getDeviceModel: jest.fn(() => ({ id: actual.DeviceModelId.nanoS })),
+  };
+});
 
 const mockInvoke = jest.mocked(ipcRenderer.invoke);
 

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -5,9 +5,8 @@
 import { ipcRenderer } from "electron";
 import Transport, { type DescriptorEvent, TransportError } from "@ledgerhq/hw-transport";
 import { log, trace, TraceContext } from "@ledgerhq/logs";
-import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Observer } from "rxjs";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { v4 as uuid } from "uuid";
 // No longer need transport channels - using direct invoke
 

--- a/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
+++ b/apps/ledger-live-desktop/src/renderer/IPCTransport.ts
@@ -3,9 +3,9 @@
  * WebHID devices use DeviceManagementKit directly in renderer
  */
 import { ipcRenderer } from "electron";
-import Transport, { TransportError } from "@ledgerhq/hw-transport";
+import Transport, { type DescriptorEvent, TransportError } from "@ledgerhq/hw-transport";
 import { log, trace, TraceContext } from "@ledgerhq/logs";
-import { DescriptorEvent, DeviceModelId } from "@ledgerhq/types-devices";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import { Observer } from "rxjs";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { v4 as uuid } from "uuid";

--- a/apps/ledger-live-mobile/package.json
+++ b/apps/ledger-live-mobile/package.json
@@ -145,6 +145,7 @@
     "@ledgerhq/context-module": "catalog:",
     "@ledgerhq/crypto-icons": "catalog:",
     "@ledgerhq/device-intent": "workspace:^",
+    "@ledgerhq/device-core": "workspace:^",
     "@ledgerhq/device-management-kit": "catalog:",
     "@ledgerhq/device-signer-kit-ethereum": "catalog:",
     "@ledgerhq/device-transport-kit-react-native-hid": "catalog:",

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/Debug/useLargeScreenUpsellDebugViewModel.ts
@@ -3,7 +3,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useFeature } from "@features/platform-feature-flags";
 import type { Features } from "@shared/feature-flags";
 import { setOverride } from "@shared/feature-flags";
-import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
+import { DevicesWithTouchScreen } from "@ledgerhq/device-core";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import {
   isCooldownElapsed,
   shouldThrottle,

--- a/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
+++ b/apps/ledger-live-mobile/src/mvvm/features/LargeScreenUpsell/hooks/useLargeScreenUpsellEligibility.ts
@@ -1,7 +1,8 @@
 import { resolveOnboardingDateForUpsell } from "@ledgerhq/live-common/postOnboarding/logic/legacyOnboardingDate";
 import { isCooldownElapsed } from "@ledgerhq/live-common/postOnboarding/logic/upsellFrequency";
 import { onboardingDateSelector } from "@ledgerhq/live-common/postOnboarding/reducer";
-import { DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
+import { DevicesWithTouchScreen } from "@ledgerhq/device-core";
+import { DeviceModelId } from "@ledgerhq/types-devices";
 import { useFeature } from "@features/platform-feature-flags";
 import { useSelector } from "~/context/hooks";
 import { knownDeviceModelIdsSelector } from "~/reducers/settings";

--- a/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
+++ b/apps/ledger-live-mobile/src/screens/BleDevicePairingFlow/index.tsx
@@ -1,4 +1,5 @@
-import { Device, DeviceModelId, DevicesWithTouchScreen } from "@ledgerhq/types-devices";
+import { DevicesWithTouchScreen } from "@ledgerhq/device-core";
+import { DeviceModelId, type Device } from "@ledgerhq/types-devices";
 import { DiscoveredDevice } from "@ledgerhq/device-management-kit";
 import React, { useCallback } from "react";
 import { Flex } from "@ledgerhq/native-ui";

--- a/libs/device-core/src/capabilities/devicesWithTouchScreen.test.ts
+++ b/libs/device-core/src/capabilities/devicesWithTouchScreen.test.ts
@@ -1,0 +1,12 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+import { DevicesWithTouchScreen } from "./devicesWithTouchScreen";
+
+describe("DevicesWithTouchScreen", () => {
+  it("includes only touchscreen device models", () => {
+    expect(DevicesWithTouchScreen).toEqual([
+      DeviceModelId.stax,
+      DeviceModelId.europa,
+      DeviceModelId.apex,
+    ]);
+  });
+});

--- a/libs/device-core/src/capabilities/devicesWithTouchScreen.ts
+++ b/libs/device-core/src/capabilities/devicesWithTouchScreen.ts
@@ -1,0 +1,10 @@
+import { DeviceModelId } from "@ledgerhq/devices";
+
+/**
+ * Device models equipped with a touchscreen.
+ */
+export const DevicesWithTouchScreen = [
+  DeviceModelId.stax,
+  DeviceModelId.europa,
+  DeviceModelId.apex,
+] as const;

--- a/libs/device-core/src/index.ts
+++ b/libs/device-core/src/index.ts
@@ -38,6 +38,7 @@ export {
 export { isEditDeviceNameSupported } from "./capabilities/isEditDeviceNameSupported";
 export { isSyncOnboardingSupported } from "./capabilities/isSyncOnboardingSupported";
 export { supportedDeviceModelIds } from "./capabilities/isCustomLockScreenSupported";
+export { DevicesWithTouchScreen } from "./capabilities/devicesWithTouchScreen";
 export { getDeviceHasBattery } from "./capabilities/getDeviceHasBattery";
 export { isCharonSupported } from "./commands/use-cases/isCharonSupported";
 // src/customLockScreen/

--- a/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/actions/getBatteryStatuses.ts
@@ -1,10 +1,9 @@
-import { BatteryStatusFlags } from "@ledgerhq/types-devices";
 import { DeviceId } from "@ledgerhq/types-live";
 import { Observable } from "rxjs";
 import { scan } from "rxjs/operators";
 import { FullActionState, initialSharedActionState, sharedReducer } from "./core";
 import { getBatteryStatusTask, GetBatteryStatusesTaskError } from "../tasks/getBatteryStatuses";
-import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { BatteryStatusTypes, type BatteryStatusFlags } from "../../hw/getBatteryStatus";
 
 export type GetBatteryStatusesActionArgs = {
   deviceId: DeviceId;

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.test.ts
@@ -1,6 +1,5 @@
 import Transport from "@ledgerhq/hw-transport";
-import { ChargingModes } from "@ledgerhq/types-devices";
-import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { BatteryStatusTypes, ChargingModes } from "../../hw/getBatteryStatus";
 import { getBatteryStatus } from "./getBatteryStatus";
 import { firstValueFrom } from "rxjs";
 

--- a/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/deviceSDK/commands/getBatteryStatus.ts
@@ -1,10 +1,14 @@
 import Transport from "@ledgerhq/hw-transport";
-import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
 import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { UnresponsiveCmdEvent } from "./core";
 import { Observable, from, of } from "rxjs";
 import { switchMap } from "rxjs/operators";
-import { BatteryStatusTypes, FlagMasks } from "../../hw/getBatteryStatus";
+import {
+  BatteryStatusTypes,
+  ChargingModes,
+  FlagMasks,
+  type BatteryStatusFlags,
+} from "../../hw/getBatteryStatus";
 
 export type GetBatteryStatusCmdEvent =
   | { type: "data"; batteryStatus: BatteryStatusFlags | number }

--- a/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/hooks/useBatteryStatuses.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { log } from "@ledgerhq/logs";
-import { BatteryStatusFlags } from "@ledgerhq/types-devices";
 import {
   getBatteryStatusesAction,
   GetBatteryStatusesActionState,
   initialState,
 } from "../actions/getBatteryStatuses";
-import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
+import { BatteryStatusTypes, type BatteryStatusFlags } from "../../hw/getBatteryStatus";
 import { useEnv } from "@features/platform-env";
 
 export type UseBatteryStatusesArgs = {

--- a/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
+++ b/libs/ledger-live-common/src/deviceSDK/tasks/getBatteryStatuses.ts
@@ -6,8 +6,7 @@ import { catchError, filter, map, switchMap } from "rxjs/operators";
 import { SharedTaskEvent, retryOnErrorsCommandWrapper, sharedLogicTaskWrapper } from "./core";
 import { quitApp } from "../commands/quitApp";
 import { withTransport } from "../transports/core";
-import { BatteryStatusTypes } from "../../hw/getBatteryStatus";
-import { BatteryStatusFlags } from "@ledgerhq/types-devices";
+import { BatteryStatusTypes, type BatteryStatusFlags } from "../../hw/getBatteryStatus";
 import getBatteryStatus from "../commands/getBatteryStatus";
 
 export type GetBatteryStatusesTaskArgs = {

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.test.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.test.ts
@@ -1,5 +1,4 @@
-import getBatteryStatus, { BatteryStatusTypes } from "./getBatteryStatus";
-import { ChargingModes } from "@ledgerhq/types-devices";
+import getBatteryStatus, { BatteryStatusTypes, ChargingModes } from "./getBatteryStatus";
 
 const mockTransportGenerator = out => ({ send: () => out });
 describe("getBatteryStatus", () => {

--- a/libs/ledger-live-common/src/hw/getBatteryStatus.ts
+++ b/libs/ledger-live-common/src/hw/getBatteryStatus.ts
@@ -1,9 +1,21 @@
 import Transport from "@ledgerhq/hw-transport";
-import { BatteryStatusFlags, ChargingModes } from "@ledgerhq/types-devices";
 import { TransportStatusError, StatusCodes } from "@ledgerhq/hw-transport/errors";
 import { LocalTracer } from "@ledgerhq/logs";
 
 import { LOG_TYPE } from ".";
+
+export enum ChargingModes {
+  NONE = 0x00,
+  USB = 0x01,
+  QI = 0x02,
+}
+
+export interface BatteryStatusFlags {
+  charging: ChargingModes;
+  issueCharging: boolean;
+  issueTemperature: boolean;
+  issueBattery: boolean;
+}
 
 export enum BatteryStatusTypes {
   BATTERY_PERCENTAGE = 0x00,

--- a/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
+++ b/libs/live-dmk-desktop/src/transport/DeviceManagementKitTransport.ts
@@ -5,10 +5,9 @@ import {
   type DeviceSessionState,
   DiscoveredDevice,
 } from "@ledgerhq/device-management-kit";
-import Transport from "@ledgerhq/hw-transport";
+import Transport, { type DescriptorEvent } from "@ledgerhq/hw-transport";
 import { dmkToLedgerDeviceIdMap, activeDeviceSessionSubject } from "@ledgerhq/live-dmk-shared";
 import { LocalTracer } from "@ledgerhq/logs";
-import { DescriptorEvent } from "@ledgerhq/types-devices";
 import { firstValueFrom, Observer, startWith, pairwise, map, Subscription } from "rxjs";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
 

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.test.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.test.ts
@@ -1,6 +1,7 @@
 import { BlePlxManager } from "./BlePlxManager";
 import { DeviceManagementKitBLETransport, tracer } from "./DeviceManagementKitBLETransport";
 import { Observable, Subject, Subscription } from "rxjs";
+import { DeviceModelId, getDeviceModel } from "@ledgerhq/devices";
 import { State } from "react-native-ble-plx";
 import { getDeviceManagementKit } from "../hooks";
 import {
@@ -305,9 +306,7 @@ describe("DeviceManagementKitBLETransport", () => {
             model: "flex",
           },
         },
-        deviceModel: {
-          id: "europa",
-        },
+        deviceModel: getDeviceModel(DeviceModelId.europa),
       });
     });
     it("should call stopDiscovering if unsubscribed", async () => {

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -28,7 +28,6 @@ import {
   Subscription,
 } from "rxjs";
 import { first, filter, tap, timeout, retry, map } from "rxjs/operators";
-import type { DeviceModel } from "@ledgerhq/types-devices";
 import { HwTransportError } from "@ledgerhq/hw-transport/errors";
 import { PairingFailed, PeerRemovedPairing, isPeerRemovedPairingError } from "../errors";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";
@@ -289,9 +288,7 @@ export class DeviceManagementKitBLETransport extends Transport {
             type: "add",
             descriptor: "",
             device: device,
-            deviceModel: {
-              id,
-            } as DeviceModel,
+            deviceModel: getDeviceModel(id),
           });
         }
       },

--- a/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
+++ b/libs/live-dmk-mobile/src/transport/DeviceManagementKitBLETransport.ts
@@ -1,4 +1,8 @@
-import Transport from "@ledgerhq/hw-transport";
+import Transport, {
+  type DescriptorEvent,
+  type Observer as TransportObserver,
+  type Subscription as TransportSubscription,
+} from "@ledgerhq/hw-transport";
 import {
   DeviceId,
   DeviceManagementKit,
@@ -24,11 +28,7 @@ import {
   Subscription,
 } from "rxjs";
 import { first, filter, tap, timeout, retry, map } from "rxjs/operators";
-import { DescriptorEvent, DeviceModel } from "@ledgerhq/types-devices";
-import type {
-  Observer as TransportObserver,
-  Subscription as TransportSubscription,
-} from "@ledgerhq/hw-transport";
+import type { DeviceModel } from "@ledgerhq/types-devices";
 import { HwTransportError } from "@ledgerhq/hw-transport/errors";
 import { PairingFailed, PeerRemovedPairing, isPeerRemovedPairingError } from "../errors";
 import { getDeviceManagementKit } from "../hooks/useDeviceManagementKit";

--- a/libs/types-devices/README.md
+++ b/libs/types-devices/README.md
@@ -14,104 +14,19 @@ Ledger types for devices and transport.
 #### Table of Contents
 
 *   [DeviceModelId](#devicemodelid)
-*   [DevicesWithTouchScreen](#deviceswithtouchscreen)
 *   [DeviceModel](#devicemodel)
-*   [ChargingModes](#chargingmodes)
-*   [BatteryStatusFlags](#batterystatusflags)
-*   [BluetoothInfos](#bluetoothinfos)
-*   [Subscription](#subscription)
-    *   [Properties](#properties)
 *   [Device](#device)
-*   [Observer](#observer)
-*   [send](#send)
-    *   [Parameters](#parameters)
-*   [on](#on)
-*   [off](#off)
-*   [setExchangeTimeout](#setexchangetimeout)
-*   [setExchangeUnresponsiveTimeout](#setexchangeunresponsivetimeout)
 
 ### DeviceModelId
 
 DeviceModelId is a unique identifier to identify the model of a Ledger hardware wallet.
 
-### DevicesWithTouchScreen
-
-DevicesWithTouchScreen is a list of DeviceModelId of whom the Ledger device can present a QR code.
-
-Type: [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[DeviceModelId](#devicemodelid)>
-
 ### DeviceModel
 
 a DeviceModel contains all the information of a specific Ledger hardware wallet model.
-
-### ChargingModes
-
-### BatteryStatusFlags
-
-Series of flags to represent the health status of the Ledger hardware wallet battery.
-
-### BluetoothInfos
-
-### Subscription
-
-represent an ongoing job that can be stopped with .unsubscribe()
-
-Type: {unsubscribe: function (): void}
-
-#### Properties
-
-*   `unsubscribe` **function (): void**&#x20;
 
 ### Device
 
 data about the device. not yet typed
 
 Type: any
-
-### Observer
-
-Type: Readonly<{next: function (event: Ev): any, error: function (e: any): any, complete: function (): any}>
-
-### send
-
-wrapper on top of exchange to simplify work of the implementation.
-
-Type: function (cla: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), ins: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), p1: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), p2: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), data: [Buffer](https://nodejs.org/api/buffer.html), statusList: [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>): [Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)<[Buffer](https://nodejs.org/api/buffer.html)>
-
-#### Parameters
-
-*   `cla` &#x20;
-*   `ins` &#x20;
-*   `p1` &#x20;
-*   `p2` &#x20;
-*   `data` &#x20;
-*   `statusList`  is a list of accepted status code (shorts). \[0x9000] by default
-
-Returns **any** a Promise of response buffer
-
-### on
-
-Listen to an event on an instance of transport.
-Transport implementation can have specific events. Here is the common events:
-
-*   `"disconnect"` : triggered if Transport is disconnected
-
-Type: function (eventName: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), cb: function (...args: [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)\<any>): any): void
-
-### off
-
-Stop listening to an event on an instance of transport.
-
-Type: function (eventName: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), cb: function (...args: [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)\<any>): any): void
-
-### setExchangeTimeout
-
-Set a timeout (in milliseconds) for the exchange call. Only some transport might implement it. (e.g. U2F)
-
-Type: function (exchangeTimeout: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)): void
-
-### setExchangeUnresponsiveTimeout
-
-Define the delay before emitting "unresponsive" on an exchange that does not respond
-
-Type: function (unresponsiveTimeout: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)): void

--- a/libs/types-devices/src/index.ts
+++ b/libs/types-devices/src/index.ts
@@ -12,15 +12,6 @@ export enum DeviceModelId {
 }
 
 /**
- * DevicesWithTouchScreen is a list of DeviceModelId of whom the Ledger device can present a QR code.
- */
-export const DevicesWithTouchScreen: DeviceModelId[] = [
-  DeviceModelId.stax,
-  DeviceModelId.europa,
-  DeviceModelId.apex,
-];
-
-/**
  * a DeviceModel contains all the information of a specific Ledger hardware wallet model.
  */
 export interface DeviceModel {
@@ -41,122 +32,6 @@ export interface DeviceModel {
 }
 
 /**
- *
- */
-export enum ChargingModes {
-  NONE = 0x00,
-  USB = 0x01,
-  QI = 0x02,
-}
-
-/**
- * Series of flags to represent the health status of the Ledger hardware wallet battery.
- */
-export interface BatteryStatusFlags {
-  charging: ChargingModes;
-  issueCharging: boolean;
-  issueTemperature: boolean;
-  issueBattery: boolean;
-}
-
-/**
- *
- */
-export interface BluetoothInfos {
-  deviceModel: DeviceModel;
-  serviceUuid: string;
-  writeUuid: string;
-  writeCmdUuid: string;
-  notifyUuid: string;
-}
-/**
- * represent an ongoing job that can be stopped with .unsubscribe()
- */
-export type Subscription = {
-  unsubscribe: () => void;
-};
-
-/**
  * data about the device. not yet typed
  */
 export type Device = any; // Should be a union type of all possible Device object's shape
-
-export interface DescriptorEvent<Descriptor> {
-  type: "add" | "remove";
-  descriptor: Descriptor;
-  deviceModel?: DeviceModel | null | undefined;
-  device?: Device;
-}
-
-/**
- */
-export type Observer<Ev> = Readonly<{
-  next: (event: Ev) => unknown;
-  error: (e: any) => unknown;
-  complete: () => unknown;
-}>;
-
-export interface Transport {
-  deviceModel: DeviceModel | null | undefined;
-
-  exchange: (apdu: Buffer) => Promise<Buffer>;
-  close: () => Promise<void>;
-  setScrambleKey: (key: string) => void;
-
-  /**
-   * wrapper on top of exchange to simplify work of the implementation.
-   * @param cla
-   * @param ins
-   * @param p1
-   * @param p2
-   * @param data
-   * @param statusList is a list of accepted status code (shorts). [0x9000] by default
-   * @return a Promise of response buffer
-   */
-  send: (
-    cla: number,
-    ins: number,
-    p1: number,
-    p2: number,
-    data?: Buffer,
-    statusList?: Array<number>,
-  ) => Promise<Buffer>;
-
-  /**
-   * Listen to an event on an instance of transport.
-   * Transport implementation can have specific events. Here is the common events:
-   * * `"disconnect"` : triggered if Transport is disconnected
-   */
-  on: (eventName: string, cb: (...args: Array<any>) => any) => void;
-
-  /**
-   * Stop listening to an event on an instance of transport.
-   */
-  off: (eventName: string, cb: (...args: Array<any>) => any) => void;
-  emit: (event: string, ...args: any) => void;
-
-  /**
-   * Set a timeout (in milliseconds) for the exchange call. Only some transport might implement it. (e.g. U2F)
-   */
-  setExchangeTimeout: (exchangeTimeout: number) => void;
-
-  /**
-   * Define the delay before emitting "unresponsive" on an exchange that does not respond
-   */
-  setExchangeUnresponsiveTimeout: (unresponsiveTimeout: number) => void;
-
-  exchangeAtomicImpl: (f: () => Promise<Buffer | void>) => Promise<Buffer | void>;
-
-  decorateAppAPIMethods: (
-    self: Record<string, any>,
-    methods: Array<string>,
-    scrambleKey: string,
-  ) => void;
-
-  decorateAppAPIMethod: <R, A extends any[]>(
-    methodName: string,
-    f: (...args: A) => Promise<R>,
-    ctx: any,
-    scrambleKey: string,
-  ) => (...args: A) => Promise<R>;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1812,6 +1812,9 @@ importers:
       '@ledgerhq/crypto-icons':
         specifier: 'catalog:'
         version: 2.0.4(@ledgerhq/lumen-design-core@0.1.24)(@ledgerhq/lumen-ui-rnative@0.1.54(db3cee34e4c141f05cf3fa5e40e0d3fc))(react-native@0.81.6(patch_hash=fbb22f6ab81c7336a446f504c4aef2f23fc558838854399c868c5590e29ac9f1)(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(@typescript/typescript6@6.0.2))(@types/react@19.0.14)(react@19.1.4))(react@19.1.4)
+      '@ledgerhq/device-core':
+        specifier: workspace:^
+        version: link:../../libs/device-core
       '@ledgerhq/device-intent':
         specifier: workspace:^
         version: link:../../libs/device-intent


### PR DESCRIPTION
### 📝 Description

This PR cleans up redundant and unused `@ledgerhq/types-devices` exports as a step toward eventually removing the package.

`@ledherhq/types-devices` is not compatible with the new monorepo architecture (domain/features/etc.).

This audit shows for each type where it was used, internally or externally (publicly on github), and for each a decision that was taken in this PR.

### Usage audit

| Export | Ledger Live usage (before decision) | External repos | Decision | Changeset note |
| --- | --- | --- | --- | --- |
| `DeviceModelId` | 298 files: Mobile (139), Desktop (86), Wallet CLI (6), E2E (2), shared libraries (65). | - RabbyHub/rabby-mobile<br>- cryptoflashi/production (stale; hybrid workspace/npm)<br>- helium/wallet-app<br>- thomson0313/solana-wallet-app (stale) | **Pending**<br>Widely used runtime enum; choose a canonical owner before migration. | — |
| `DevicesWithTouchScreen` | 3 files: Mobile large-screen-upsell eligibility/debug and BLE pairing. | - cryptoflashi/production (stale) | **Moved to `device-core` (breaking public API)**<br>Runtime capability, not a shared type; this short-term cleanup shrinks `types-devices` ahead of its removal. | `DevicesWithTouchScreen` was removed from the public package; no replacement is planned yet. |
| `DeviceModel` | 4 files: common hardware wrapper; Mobile language prompt and byte-size UI; DMK mobile BLE transport. | - cryptoflashi/production (stale; hybrid workspace/npm) | **Pending**<br>Duplicates the `devices` interface, but needs a compatibility plan. | — |
| `ChargingModes` | 4 battery implementation/test files in `ledger-live-common`. | - cryptoflashi/production (stale; hybrid workspace/npm) | **Moved to `live-common` (breaking public API)**<br>Battery-domain enum used only by Live Common locally. | `ChargingModes` was removed from the public package; no replacement is planned yet. Battery-related operations are supported by Device Management Kit. |
| `BatteryStatusFlags` | 5 battery action, command, task, hook, and hardware files in `ledger-live-common`. | - cryptoflashi/production (stale; hybrid workspace/npm) | **Moved to `live-common` (breaking public API)**<br>Battery response shape belongs with its parsing and consumers. | `BatteryStatusFlags` was removed from the public package; no replacement is planned yet. Battery-related operations are supported by Device Management Kit. |
| `BluetoothInfos` | None. | None. | **Dropped (breaking public API)**<br>Duplicates `devices`; no public-code consumer found. | Import `BluetoothInfos` from `@ledgerhq/devices`, where it remains available. No migration is required when using Device Management Kit. |
| `Subscription` | None. | None. | **Dropped (breaking public API)**<br>Use `rxjs` or `hw-transport` subscriptions instead. | `Subscription` was removed. For LedgerJS usage, import it from `@ledgerhq/hw-transport`; LedgerJS is deprecated, so migrate to Device Management Kit when possible. |
| `Device` | 59 files: Desktop/Mobile analytics, navigation, device-action, family-flow, BLE pairing; DMK mobile. | - cryptoflashi/production (stale; hybrid workspace/npm) | **Pending**<br>It is `any`; replace it with domain-specific shapes incrementally. | — |
| `DescriptorEvent` | 3 files: Desktop `IPCTransport`, DMK Desktop transport, and DMK Mobile BLE transport. | - cryptoflashi/production (stale; hybrid workspace/npm) | **Drop from `types-devices`; use `hw-transport` (breaking public API)**<br>`hw-transport` is the canonical transport contract. | `DescriptorEvent` was removed. For LedgerJS usage, import it from `@ledgerhq/hw-transport`; LedgerJS is deprecated, so migrate to Device Management Kit when possible. |
| `Observer` | None. | None. | **Dropped (breaking public API)**<br>Use `rxjs` or `hw-transport` observer contracts instead. | `Observer` was removed. For LedgerJS usage, import it from `@ledgerhq/hw-transport`; LedgerJS is deprecated, so migrate to Device Management Kit when possible. |
| `Transport` | None. | None. | **Dropped (breaking public API)**<br>`hw-transport` owns the actual transport implementation and API. | `Transport` was removed. For LedgerJS usage, import it from `@ledgerhq/hw-transport`; LedgerJS is deprecated, so migrate to Device Management Kit when possible. |

### 🔗 Context

- **JIRA / GitHub issue**: N/A