### PR TITLE
[LWD] feat(contacts): allow editing of contact address value (LIVE-35836)

### DIFF
--- a/.changeset/contacts-edit-address-value.md
+++ b/.changeset/contacts-edit-address-value.md
@@ -1,0 +1,6 @@
+---
+"@features/flow-contacts": minor
+"@features/platform-contacts": patch
+---
+
+Allow editing the saved wallet address in Contacts Edit Address flow, with the same validation as Add Address.

--- a/apps/ledger-live-desktop/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.ts
+++ b/apps/ledger-live-desktop/src/mvvm/features/Contacts/analytics/mapContactsPageEventToScreenCategory.ts
@@ -6,6 +6,7 @@ const CONTACTS_PAGE_EVENT_TO_SCREEN_CATEGORY = {
   [CONTACTS_PAGE_EVENTS.ADD_CONTACT]: { category: "Add Contact" },
   [CONTACTS_PAGE_EVENTS.CONTACT_DETAIL]: { category: "Contact detail" },
   [CONTACTS_PAGE_EVENTS.ADDRESS_DETAIL]: { category: "Contacts Address detail" },
+  [CONTACTS_PAGE_EVENTS.EDIT_ADDRESS]: { category: "Edit address" },
 } as const satisfies Record<ContactsPageEventName, Readonly<{ category: string; name?: string }>>;
 
 export function mapContactsPageEventToScreenCategory(page: ContactsPageEventName): Readonly<{

--- a/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
+++ b/features/flow/contacts/src/analytics/contactsAnalytics.types.ts
@@ -19,6 +19,7 @@ export const CONTACTS_EVENT_SOURCE = {
   PICTURE: "picture",
   CONTACT_DETAIL: "contact_detail",
   ADD_ADDRESS: "add_address",
+  EDIT_ADDRESS: "edit_address",
   ADDRESS_DETAIL: "address_detail",
   QUICK_ACTION: "quick_action",
 } as const;
@@ -33,6 +34,7 @@ export const CONTACTS_TRACK_EVENTS = {
   ERROR_DISPLAYED: "error_displayed",
   CONTACT_ADDED: "contact_added",
   ADDRESS_ADDED: "address_added",
+  ADDRESS_EDITED: "address_edited",
 } as const;
 
 export type ContactsTrackEventName =
@@ -45,6 +47,7 @@ export const CONTACTS_PAGE_EVENTS = {
   ADD_CONTACT: "Page Add Contact",
   CONTACT_DETAIL: "Page Contact detail",
   ADDRESS_DETAIL: "Page Contacts Address detail",
+  EDIT_ADDRESS: "Page Edit address",
 } as const;
 
 export type ContactsPageEventName =
@@ -59,6 +62,7 @@ export const CONTACTS_PAGE_PROPERTY = {
   ADD_CONTACT: "add contact",
   LEDGER_SYNC_GATE: "ledger sync gate",
   ADDRESS_DETAIL: "address detail",
+  EDIT_ADDRESS: "edit address",
 } as const;
 
 export type ContactsPageProperty =
@@ -77,6 +81,7 @@ export const CONTACTS_TRACKING_BUTTON = {
   addAddress: "add address",
   disabledNetworkTooltip: "disabled network tooltip",
   saveAddress: "save address",
+  applyChanges: "apply changes",
   send: "send",
   edit: "edit",
   delete: "delete",
@@ -143,6 +148,14 @@ export type ContactsTrackEventInputParams = {
     isEns: boolean;
     flow: ContactsFlow | (string & {});
   }>;
+  [CONTACTS_TRACK_EVENTS.ADDRESS_EDITED]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.EDIT_ADDRESS;
+    network: string;
+    asset: string;
+    inputMethod: ContactsAddressInputMethod | (string & {});
+    isEns: boolean;
+    flow: ContactsFlow | (string & {});
+  }>;
 };
 
 export type ContactsPageEventInputParams = {
@@ -165,6 +178,11 @@ export type ContactsPageEventInputParams = {
   }>;
   [CONTACTS_PAGE_EVENTS.ADDRESS_DETAIL]: Readonly<{
     source: typeof CONTACTS_EVENT_SOURCE.ADDRESS_DETAIL;
+    network: string;
+    asset: string;
+  }>;
+  [CONTACTS_PAGE_EVENTS.EDIT_ADDRESS]: Readonly<{
+    source: typeof CONTACTS_EVENT_SOURCE.EDIT_ADDRESS;
     network: string;
     asset: string;
   }>;

--- a/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
+++ b/features/flow/contacts/src/analytics/createContactsAnalyticsHelper.web.test.ts
@@ -199,6 +199,44 @@ describe("Contacts analytics payload shapes", () => {
       },
     };
 
+    const addressEdited: ContactsTrackEventPayload<typeof CONTACTS_TRACK_EVENTS.ADDRESS_EDITED> = {
+      name: CONTACTS_TRACK_EVENTS.ADDRESS_EDITED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        network: "ethereum",
+        asset: "ETH",
+        inputMethod: "manual",
+        isEns: false,
+        flow: CONTACTS_FLOW.CONTACTS,
+      },
+    };
+
+    const editAddressPage: ContactsPageEventPayload<typeof CONTACTS_PAGE_EVENTS.EDIT_ADDRESS> = {
+      page: CONTACTS_PAGE_EVENTS.EDIT_ADDRESS,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        network: "ethereum",
+        asset: "ETH",
+      },
+    };
+
+    const applyChangesClick: ContactsTrackEventPayload<
+      typeof CONTACTS_TRACK_EVENTS.BUTTON_CLICKED
+    > = {
+      name: CONTACTS_TRACK_EVENTS.BUTTON_CLICKED,
+      properties: {
+        ...globalProperties,
+        source: CONTACTS_EVENT_SOURCE.EDIT_ADDRESS,
+        button: CONTACTS_TRACKING_BUTTON.applyChanges,
+        page: CONTACTS_PAGE_PROPERTY.EDIT_ADDRESS,
+        network: "ethereum",
+        asset: "ETH",
+        flow: CONTACTS_FLOW.CONTACTS,
+      },
+    };
+
     const payloads = [
       entryClick,
       searchQuery,
@@ -207,6 +245,9 @@ describe("Contacts analytics payload shapes", () => {
       addContactError,
       contactDetailPage,
       addressAdded,
+      addressEdited,
+      editAddressPage,
+      applyChangesClick,
       quickAction,
     ];
 

--- a/features/flow/contacts/src/analytics/trackContactsEvents.ts
+++ b/features/flow/contacts/src/analytics/trackContactsEvents.ts
@@ -54,11 +54,13 @@ export function trackContactAddressDetailQuickAction(
   analytics: ContactsAnalyticsHelper,
   button: ContactsTrackingButton,
   asset?: string,
+  network?: string,
 ): void {
   analytics.trackEvent(CONTACTS_TRACK_EVENTS.BUTTON_CLICKED, {
     source: CONTACTS_EVENT_SOURCE.QUICK_ACTION,
     button,
     page: CONTACTS_PAGE_PROPERTY.ADDRESS_DETAIL,
     ...(asset ? { asset } : {}),
+    ...(network ? { network } : {}),
   });
 }

--- a/features/flow/contacts/src/steps/AddAddress/model/addressEntryState.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressEntryState.ts
@@ -1,0 +1,87 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import type {
+  ContactsAddressValidationPort,
+  ContactsAddressValidationResult,
+} from "./addressValidation/types";
+import type { AddAddressEntryState, AddAddressInputSource } from "../types";
+
+export const EMPTY_ADDRESS_ENTRY_STATE = {
+  status: "empty",
+  value: "",
+  resolvedAddress: null,
+  inputMethod: null,
+} as const satisfies AddAddressEntryState;
+
+export function createValidatingAddressEntryState(
+  value: string,
+  inputMethod: AddAddressInputSource,
+): AddAddressEntryState {
+  return {
+    status: "validating",
+    value,
+    resolvedAddress: null,
+    inputMethod,
+  };
+}
+
+export function resolveAddressEntryState(
+  value: string,
+  inputMethod: AddAddressInputSource,
+  result: ContactsAddressValidationResult,
+): AddAddressEntryState {
+  switch (result.status) {
+    case "valid":
+      return {
+        status: "valid",
+        value,
+        resolvedAddress: result.resolvedAddress,
+        inputMethod: result.isDomain ? "ens" : inputMethod,
+      };
+    case "invalid_format":
+    case "domain_not_found":
+    case "sanctioned":
+      return {
+        status: "invalid",
+        value,
+        resolvedAddress: null,
+        inputMethod:
+          result.status === "domain_not_found" ||
+          ((result.status === "invalid_format" || result.status === "sanctioned") &&
+            result.isDomain)
+            ? "ens"
+            : inputMethod,
+        error: result.status,
+      };
+    case "unavailable":
+      return {
+        status: "unavailable",
+        value,
+        resolvedAddress: null,
+        inputMethod,
+      };
+  }
+}
+
+export function applyAddressEntryIfCurrent(
+  currentEntry: AddAddressEntryState,
+  nextEntry: AddAddressEntryState,
+  expectedValue: string,
+): AddAddressEntryState {
+  if (currentEntry.value !== expectedValue) {
+    return currentEntry;
+  }
+
+  return nextEntry;
+}
+
+export async function requestAddressValidation(
+  addressValidation: ContactsAddressValidationPort,
+  currencyId: ContactAddress["currencyId"],
+  address: string,
+): Promise<ContactsAddressValidationResult> {
+  try {
+    return await addressValidation.validateAddress({ currencyId, address });
+  } catch {
+    return { status: "unavailable" };
+  }
+}

--- a/features/flow/contacts/src/steps/AddAddress/model/addressEntryState.web.test.ts
+++ b/features/flow/contacts/src/steps/AddAddress/model/addressEntryState.web.test.ts
@@ -1,0 +1,67 @@
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import {
+  applyAddressEntryIfCurrent,
+  createValidatingAddressEntryState,
+  EMPTY_ADDRESS_ENTRY_STATE,
+  resolveAddressEntryState,
+} from "./addressEntryState";
+
+describe("addressEntryState", () => {
+  const resolvedAddress = ContactAddressValueSchema.parse(
+    "0x1234567890123456789012345678901234567890",
+  );
+
+  it("should map valid validation results to entry state", () => {
+    expect(
+      resolveAddressEntryState("ens.eth", "manual", {
+        status: "valid",
+        resolvedAddress,
+        isDomain: true,
+      }),
+    ).toEqual({
+      status: "valid",
+      value: "ens.eth",
+      resolvedAddress,
+      inputMethod: "ens",
+    });
+  });
+
+  it("should map invalid validation results and preserve ens input method", () => {
+    expect(
+      resolveAddressEntryState("bad.eth", "paste", {
+        status: "domain_not_found",
+      }),
+    ).toEqual({
+      status: "invalid",
+      value: "bad.eth",
+      resolvedAddress: null,
+      inputMethod: "ens",
+      error: "domain_not_found",
+    });
+  });
+
+  it("should create validating and empty entry states", () => {
+    expect(createValidatingAddressEntryState("0xabc", "manual")).toEqual({
+      status: "validating",
+      value: "0xabc",
+      resolvedAddress: null,
+      inputMethod: "manual",
+    });
+    expect(EMPTY_ADDRESS_ENTRY_STATE).toMatchObject({
+      status: "empty",
+      value: "",
+    });
+  });
+
+  it("should ignore stale entry updates", () => {
+    const current = createValidatingAddressEntryState("0xabc", "manual");
+    const next = resolveAddressEntryState("0xabc", "manual", {
+      status: "valid",
+      resolvedAddress,
+      isDomain: false,
+    });
+
+    expect(applyAddressEntryIfCurrent(current, next, "0xabc")).toEqual(next);
+    expect(applyAddressEntryIfCurrent(current, next, "0xstale")).toEqual(current);
+  });
+});

--- a/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
+++ b/features/flow/contacts/src/steps/AddAddress/useAddAddressFlowViewModel.ts
@@ -7,7 +7,13 @@ import {
   type ContactAddressLabel,
   type ContactId,
 } from "@domain/entity-contact";
-import type { ContactsAddressValidationPort, ContactsAddressValidationResult } from "./model/ports";
+import type { ContactsAddressValidationPort } from "./model/ports";
+import {
+  createValidatingAddressEntryState,
+  EMPTY_ADDRESS_ENTRY_STATE,
+  requestAddressValidation,
+  resolveAddressEntryState,
+} from "./model/addressEntryState";
 import { wait } from "../../utils/wait";
 import type {
   AddAddressContact,
@@ -22,13 +28,6 @@ import type {
 const CLOSED_ADD_ADDRESS_FLOW_STATE = {
   status: "closed",
 } as const satisfies AddAddressFlowState;
-
-const EMPTY_ADD_ADDRESS_ENTRY_STATE = {
-  status: "empty",
-  value: "",
-  resolvedAddress: null,
-  inputMethod: null,
-} as const satisfies AddAddressEntryState;
 
 const UNAVAILABLE_ADDRESS_VALIDATION: ContactsAddressValidationPort = {
   validateAddress: async () => ({ status: "unavailable" }),
@@ -73,68 +72,6 @@ function createAddressLabelState(
 
 function limitAddressLabelLength(value: string): string {
   return value.slice(0, CONTACT_ADDRESS_LABEL_MAX_LENGTH);
-}
-
-function resolveAddressEntryState(
-  value: string,
-  inputMethod: AddAddressInputSource,
-  result: ContactsAddressValidationResult,
-): AddAddressEntryState {
-  switch (result.status) {
-    case "valid":
-      return {
-        status: "valid",
-        value,
-        resolvedAddress: result.resolvedAddress,
-        inputMethod: result.isDomain ? "ens" : inputMethod,
-      };
-    case "invalid_format":
-    case "domain_not_found":
-    case "sanctioned":
-      return {
-        status: "invalid",
-        value,
-        resolvedAddress: null,
-        inputMethod:
-          result.status === "domain_not_found" ||
-          ((result.status === "invalid_format" || result.status === "sanctioned") &&
-            result.isDomain)
-            ? "ens"
-            : inputMethod,
-        error: result.status,
-      };
-    case "unavailable":
-      return {
-        status: "unavailable",
-        value,
-        resolvedAddress: null,
-        inputMethod,
-      };
-  }
-}
-
-function createValidatingAddressEntryState(
-  value: string,
-  inputMethod: AddAddressInputSource,
-): AddAddressEntryState {
-  return {
-    status: "validating",
-    value,
-    resolvedAddress: null,
-    inputMethod,
-  };
-}
-
-async function requestAddressValidation(
-  addressValidation: ContactsAddressValidationPort,
-  currencyId: ContactAddress["currencyId"],
-  address: string,
-): Promise<ContactsAddressValidationResult> {
-  try {
-    return await addressValidation.validateAddress({ currencyId, address });
-  } catch {
-    return { status: "unavailable" };
-  }
 }
 
 function applyAddressEntryState(
@@ -189,7 +126,7 @@ export function useAddAddressFlowViewModel({
           selectedContactId,
           existingAddressLabels: currentState.existingAddressLabels,
           selectedCurrencyId: selection.currencyId,
-          addressEntry: EMPTY_ADD_ADDRESS_ENTRY_STATE,
+          addressEntry: EMPTY_ADDRESS_ENTRY_STATE,
           addressLabel: createAddressLabelState(
             limitAddressLabelLength(selection.assetDisplayName),
             currentState.existingAddressLabels,
@@ -212,7 +149,7 @@ export function useAddAddressFlowViewModel({
 
       if (normalizedAddress.length === 0) {
         setState(currentState =>
-          applyAddressEntryState(currentState, selectedCurrencyId, EMPTY_ADD_ADDRESS_ENTRY_STATE),
+          applyAddressEntryState(currentState, selectedCurrencyId, EMPTY_ADDRESS_ENTRY_STATE),
         );
         return;
       }

--- a/features/flow/contacts/src/steps/Detail/createContactAddressDetailActionsPorts.ts
+++ b/features/flow/contacts/src/steps/Detail/createContactAddressDetailActionsPorts.ts
@@ -25,7 +25,7 @@ export function createContactAddressDetailActionsPorts({
 }: ContactAddressDetailActionsPortsDeps): ContactAddressDetailActionsDataPorts {
   return {
     edit: {
-      renameAddressLabel: async ({ contactId, addressId, label }) => {
+      updateAddress: async ({ contactId, addressId, label, address }) => {
         const currentAddress = selectContactAddressById(getState(), contactId, addressId);
 
         if (currentAddress === undefined) {
@@ -40,6 +40,7 @@ export function createContactAddressDetailActionsPorts({
           contact: currentContact,
           address: currentAddress,
           label: parsedLabel,
+          updatedAddress: address,
         });
 
         dispatch(
@@ -48,6 +49,7 @@ export function createContactAddressDetailActionsPorts({
             address: {
               ...currentAddress,
               label: parsedLabel,
+              address,
               device,
             },
           }),

--- a/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/addressDetailActionsController.web.test.ts
@@ -8,7 +8,7 @@ function createPorts(
 ): ContactAddressDetailActionsPorts {
   return {
     edit: {
-      renameAddressLabel: jest.fn(),
+      updateAddress: jest.fn(),
     },
     deletion: {
       deleteAddress: jest.fn().mockResolvedValue(undefined),

--- a/features/flow/contacts/src/steps/Detail/model/mapContactAddressDetailActionsUiState.ts
+++ b/features/flow/contacts/src/steps/Detail/model/mapContactAddressDetailActionsUiState.ts
@@ -5,6 +5,7 @@ import type {
   ContactsRenameAddressDialogProps,
   RenameAddressDialogViewModel,
 } from "../../EditAddress/types";
+import { EMPTY_EDIT_ADDRESS_ENTRY_STATE } from "../../EditAddress/model/addressEntryValidation";
 import type { UseContactAddressDetailActionsFlowViewModelResult } from "../useContactAddressDetailActionsFlowViewModel";
 import type { ContactAddressDetailActionsLabels } from "./resolveContactAddressDetailActionsLabels";
 
@@ -44,11 +45,13 @@ export function createInactiveContactAddressDetailActionsUiState(
       isSaving: false,
       draftLabel: "",
       invalidLabelError: null,
+      addressEntry: EMPTY_EDIT_ADDRESS_ENTRY_STATE,
       isConfirmEnabled: false,
       labels: labels.rename,
       onOpen: () => undefined,
       onClose: () => undefined,
       onDraftLabelChange: () => undefined,
+      onAddressChange: () => undefined,
       onConfirm: async () => undefined,
     },
     signer: {

--- a/features/flow/contacts/src/steps/Detail/model/ports.ts
+++ b/features/flow/contacts/src/steps/Detail/model/ports.ts
@@ -3,6 +3,7 @@ import type {
   ContactAddress,
   ContactAddressId,
   ContactAddressLabel,
+  ContactAddressValue,
   ContactId,
   ContactInput,
 } from "@domain/entity-contact";
@@ -46,14 +47,15 @@ export type ContactAddressDeletionPort = Readonly<{
   deleteAddress(input: ContactAddressDeletionInput): Promise<void>;
 }>;
 
-export type ContactAddressRenameInput = Readonly<{
+export type ContactAddressUpdateInput = Readonly<{
   contactId: ContactId;
   addressId: ContactAddressId;
   label: ContactAddressLabel;
+  address: ContactAddressValue;
 }>;
 
 export type ContactAddressEditPort = Readonly<{
-  renameAddressLabel(input: ContactAddressRenameInput): Promise<ContactAddress>;
+  updateAddress(input: ContactAddressUpdateInput): Promise<ContactAddress>;
 }>;
 
 export type ContactAddressDetailActionsDataPorts = Readonly<{

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.ts
@@ -38,6 +38,16 @@ export function resolveContactAddressDetailActionsLabels({
         [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: t("contacts.addAddressName.duplicateLabel"),
         [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: t(addressLabelTooLongKey),
       },
+      addressValidation: {
+        addressPlaceholder: t("contacts.addAddressEntry.addressPlaceholder"),
+        validatingAddress: t("contacts.addAddressEntry.validatingAddress"),
+        validAddress: t("contacts.addAddressEntry.validAddress"),
+        invalidAddress: t("contacts.addAddressEntry.invalidAddress"),
+        domainNotFound: t("contacts.addAddressEntry.domainNotFound"),
+        sanctionedAddress: t("contacts.addAddressEntry.sanctionedAddress"),
+        validationUnavailable: t("contacts.addAddressEntry.validationUnavailable"),
+        ensDisclaimer: t("contacts.addAddressEntry.ensDisclaimer"),
+      },
     },
     ...resolveContactEditSignerActionLabels(t),
   };

--- a/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.web.test.ts
+++ b/features/flow/contacts/src/steps/Detail/model/resolveContactAddressDetailActionsLabels.web.test.ts
@@ -17,6 +17,9 @@ describe("resolveContactAddressDetailActionsLabels", () => {
       [DUPLICATE_CONTACT_ADDRESS_LABEL_ERROR_NAME]: "contacts.addAddressName.duplicateLabel",
       [CONTACT_ADDRESS_LABEL_TOO_LONG_ERROR_NAME]: "contacts.addAddressName.tooLongLabel",
     });
+    expect(labels.rename.addressValidation.addressPlaceholder).toBe(
+      "contacts.addAddressEntry.addressPlaceholder",
+    );
     expect(labels.signer.title).toBe("contacts.editSigner.title");
     expect(labels.signerMismatch.title).toBe("contacts.editSignerMismatch.title");
   });

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.ts
@@ -7,6 +7,8 @@ import {
 import { ContactAddressIdSchema } from "@domain/entity-contact";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
+import type { ContactsAddressValidationPort } from "../AddAddress/model/addressValidation/types";
+import type { ContactAddressEditSavePayload } from "../EditAddress/types";
 import { useRenameAddressDialogViewModel } from "../EditAddress/useRenameAddressDialogViewModel";
 import type { ContactAddressDetailActionsPorts } from "./model/ports";
 import { useContactAddressDetailActionsFlowViewModel } from "./useContactAddressDetailActionsFlowViewModel";
@@ -20,18 +22,24 @@ export type UseContactAddressDetailActionsFlowBindingsOptions = Readonly<{
   contactId: ContactId;
   addressId: ContactAddressId | undefined;
   ports: ContactAddressDetailActionsPorts;
+  addressValidation?: ContactsAddressValidationPort;
+  manualValidationDebounceMs?: number;
   onSend?: (intent: ContactAddressDetailSendIntent) => void;
   onDeleteSuccess?: () => void;
   onCloseAddressDetail?: () => void;
+  onEditAddressSaved?: (payload: ContactAddressEditSavePayload) => void;
 }>;
 
 export function useContactAddressDetailActionsFlowBindings({
   contactId,
   addressId,
   ports,
+  addressValidation,
+  manualValidationDebounceMs,
   onSend,
   onDeleteSuccess,
   onCloseAddressDetail,
+  onEditAddressSaved,
 }: UseContactAddressDetailActionsFlowBindingsOptions) {
   const flow = useContactAddressDetailActionsFlowViewModel({
     contactId,
@@ -57,11 +65,18 @@ export function useContactAddressDetailActionsFlowBindings({
     contactId,
     addressId: resolvedAddressId,
     currentLabel: contactAddress?.label ?? "",
+    currentAddress: contactAddress?.address,
+    currencyId: contactAddress?.currencyId,
     existingLabels,
     editPort: ports.edit,
+    addressValidation,
+    manualValidationDebounceMs,
     isRequestedOpen: flow.editUiState === "edit-open",
     onCloseRequest: flow.onEditClose,
-    onSaveSuccess: () => onCloseAddressDetail?.(),
+    onSaveSuccess: payload => {
+      onEditAddressSaved?.(payload);
+      onCloseAddressDetail?.();
+    },
   });
 
   return { flow, renameViewModel };

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowBindings.web.test.tsx
@@ -17,7 +17,7 @@ function createPorts(
 ): ContactAddressDetailActionsPorts {
   return {
     edit: {
-      renameAddressLabel: jest.fn(),
+      updateAddress: jest.fn(),
     },
     deletion: {
       deleteAddress: jest.fn().mockResolvedValue(undefined),

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsFlowViewModel.web.test.tsx
@@ -24,7 +24,7 @@ function createPorts(
 ): ContactAddressDetailActionsPorts {
   return {
     edit: {
-      renameAddressLabel: jest.fn().mockResolvedValue(mockContactAddress()),
+      updateAddress: jest.fn().mockResolvedValue(mockContactAddress()),
     },
     deletion: {
       deleteAddress: jest.fn().mockResolvedValue(undefined),

--- a/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
+++ b/features/flow/contacts/src/steps/Detail/useContactAddressDetailActionsViewModel.web.test.tsx
@@ -13,7 +13,7 @@ function createPorts(
 ): ContactAddressDetailActionsPorts {
   return {
     edit: {
-      renameAddressLabel: jest.fn(),
+      updateAddress: jest.fn(),
     },
     deletion: {
       deleteAddress: jest.fn().mockResolvedValue(undefined),

--- a/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
+++ b/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDialog.web.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import {
+  AddressInput,
+  Banner,
   Button,
   Dialog,
   DialogBody,
@@ -9,6 +11,7 @@ import {
 } from "@ledgerhq/lumen-ui-react";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import type { ContactsRenameAddressDialogProps } from "./types";
+import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
 
 export function ContactsRenameAddressDialog({
   isOpen,
@@ -16,13 +19,20 @@ export function ContactsRenameAddressDialog({
   isSaving,
   draftLabel,
   invalidLabelError,
+  addressEntry,
   labels,
   onClose,
   onDraftLabelChange,
+  onAddressChange,
   onConfirm,
 }: ContactsRenameAddressDialogProps): React.ReactNode {
   const labelValidationError =
     invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+  const addressInput = useEditAddressDialogPresentation({
+    addressEntry,
+    labels: labels.addressValidation,
+    onAddressChange,
+  });
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -38,6 +48,26 @@ export function ContactsRenameAddressDialog({
       >
         <DialogHeader density="expanded" title={labels.title} onClose={onClose} />
         <DialogBody className="flex flex-col gap-32 px-24 pt-2 pb-24">
+          <AddressInput
+            autoComplete="off"
+            autoCorrect="off"
+            data-testid="contacts-edit-address-input"
+            helperText={addressInput.helperText}
+            onChange={addressInput.onChange}
+            onPaste={addressInput.onPaste}
+            placeholder={labels.addressValidation.addressPlaceholder}
+            prefix=""
+            spellCheck={false}
+            status={addressInput.inputStatus}
+            value={addressInput.value}
+          />
+          {addressInput.showEnsDisclaimer ? (
+            <Banner
+              appearance="info"
+              data-testid="contacts-edit-address-ens-disclaimer"
+              description={labels.addressValidation.ensDisclaimer}
+            />
+          ) : null}
           <TextInput
             autoComplete="off"
             autoCorrect="off"

--- a/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDrawer.native.tsx
+++ b/features/flow/contacts/src/steps/EditAddress/ContactsRenameAddressDrawer.native.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import {
+  AddressInput,
+  Banner,
   BottomSheetHeader,
   BottomSheetView,
   Box,
@@ -7,7 +9,9 @@ import {
   TextInput,
 } from "@ledgerhq/lumen-ui-rnative";
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
+import { CONTACTS_NATIVE_ADDRESS_INPUT_PROPS } from "../../model/addressInputFieldProps.native";
 import type { ContactsRenameAddressDrawerProps } from "./types";
+import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
 
 export function ContactsRenameAddressDialog({
   isOpen,
@@ -18,10 +22,17 @@ export function ContactsRenameAddressDialog({
   bottomInset = 0,
   labels,
   onDraftLabelChange,
+  onAddressChange,
   onConfirm,
+  addressEntry,
 }: ContactsRenameAddressDrawerProps): React.JSX.Element {
   const labelValidationError =
     invalidLabelError === null ? undefined : labels.labelValidationErrors[invalidLabelError];
+  const addressInput = useEditAddressAddressEntryPresentation({
+    addressEntry,
+    labels: labels.addressValidation,
+    onAddressChange,
+  });
 
   return (
     <BottomSheetView style={{ paddingBottom: bottomInset + 24 }}>
@@ -29,9 +40,25 @@ export function ContactsRenameAddressDialog({
         <Box lx={{ gap: "s24" }}>
           <BottomSheetHeader density="expanded" title={labels.title} />
           <Box lx={{ gap: "s24", paddingHorizontal: "s16" }}>
+            <AddressInput
+              testID="contacts-edit-address-input"
+              prefix=""
+              value={addressInput.value}
+              placeholder={labels.addressValidation.addressPlaceholder}
+              onChangeText={addressInput.onChangeText}
+              status={addressInput.inputStatus}
+              helperText={addressInput.helperText}
+              {...CONTACTS_NATIVE_ADDRESS_INPUT_PROPS}
+            />
+            {addressInput.showEnsDisclaimer ? (
+              <Banner
+                testID="contacts-edit-address-ens-disclaimer"
+                appearance="info"
+                description={labels.addressValidation.ensDisclaimer}
+              />
+            ) : null}
             <TextInput
-              autoComplete="off"
-              autoCorrect={false}
+              {...CONTACTS_NATIVE_ADDRESS_INPUT_PROPS}
               helperText={labelValidationError}
               label={labels.inputLabel}
               maxLength={CONTACT_ADDRESS_LABEL_MAX_LENGTH}

--- a/features/flow/contacts/src/steps/EditAddress/model/addressEntryValidation.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/addressEntryValidation.ts
@@ -1,0 +1,33 @@
+import type { ContactAddress } from "@domain/entity-contact";
+import {
+  applyAddressEntryIfCurrent,
+  createValidatingAddressEntryState,
+  EMPTY_ADDRESS_ENTRY_STATE,
+  requestAddressValidation,
+  resolveAddressEntryState,
+} from "../../AddAddress/model/addressEntryState";
+import type { AddAddressEntryState } from "../../AddAddress/types";
+
+export {
+  applyAddressEntryIfCurrent as applyAddressEntryState,
+  createValidatingAddressEntryState,
+  requestAddressValidation,
+  resolveAddressEntryState,
+};
+
+export const EMPTY_EDIT_ADDRESS_ENTRY_STATE = EMPTY_ADDRESS_ENTRY_STATE;
+
+export function createInitialEditAddressEntryState(
+  currentAddress: ContactAddress["address"],
+): AddAddressEntryState {
+  return {
+    status: "valid",
+    value: currentAddress,
+    resolvedAddress: currentAddress,
+    inputMethod: "manual",
+  };
+}
+
+export function addressesMatch(value: string, currentAddress: ContactAddress["address"]): boolean {
+  return value.trim().toLowerCase() === currentAddress.toLowerCase();
+}

--- a/features/flow/contacts/src/steps/EditAddress/model/controller.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/controller.ts
@@ -1,4 +1,4 @@
-import { parseContactAddressLabel } from "@domain/entity-contact";
+import { ContactError, parseContactAddressLabel } from "@domain/entity-contact";
 import type { ContactAddressEditPort } from "../../Detail/model/ports";
 import { createRenameAddressViewModel } from "./viewModel";
 import type { RenameAddressController } from "../types";
@@ -8,10 +8,19 @@ export function createRenameAddressController(
 ): RenameAddressController {
   return {
     getViewModel: createRenameAddressViewModel,
-    save: async (contactId, addressId, draftLabel, existingLabels) => {
+    save: async (contactId, addressId, draftLabel, addressEntry, existingLabels) => {
+      if (addressEntry.status !== "valid") {
+        throw new ContactError("Cannot save an address that has not been validated");
+      }
+
       const label = parseContactAddressLabel(draftLabel, existingLabels);
 
-      return editPort.renameAddressLabel({ contactId, addressId, label });
+      return editPort.updateAddress({
+        contactId,
+        addressId,
+        label,
+        address: addressEntry.resolvedAddress,
+      });
     },
   };
 }

--- a/features/flow/contacts/src/steps/EditAddress/model/viewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/viewModel.ts
@@ -1,19 +1,29 @@
 import { getContactAddressLabelValidationError } from "@domain/entity-contact";
-import type { ContactAddressLabel } from "@domain/entity-contact";
+import type { ContactAddress, ContactAddressLabel } from "@domain/entity-contact";
+import type { AddAddressEntryState } from "../../AddAddress/types";
 import type { RenameAddressViewModel } from "../types";
 
 export function createRenameAddressViewModel(
   draftLabel: string,
   currentLabel: string,
+  currentAddress: ContactAddress["address"] | undefined,
+  addressEntry: AddAddressEntryState,
   existingLabels: readonly ContactAddressLabel[],
 ): RenameAddressViewModel {
   const trimmedDraftLabel = draftLabel.trim();
   const invalidLabelError = getContactAddressLabelValidationError(draftLabel, existingLabels);
-  const hasChanged = trimmedDraftLabel !== currentLabel.trim();
+  const labelValid = trimmedDraftLabel.length > 0 && invalidLabelError === null;
+  const addressValid = addressEntry.status === "valid";
+  const labelChanged = trimmedDraftLabel !== currentLabel.trim();
+  const addressChanged =
+    currentAddress !== undefined &&
+    addressEntry.status === "valid" &&
+    addressEntry.resolvedAddress !== currentAddress;
+  const hasChanged = labelChanged || addressChanged;
 
   return {
     draftLabel,
     invalidLabelError,
-    isConfirmEnabled: hasChanged && trimmedDraftLabel.length > 0 && invalidLabelError === null,
+    isConfirmEnabled: hasChanged && labelValid && addressValid,
   };
 }

--- a/features/flow/contacts/src/steps/EditAddress/model/viewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/model/viewModel.web.test.ts
@@ -1,29 +1,94 @@
-import { ContactAddressLabelSchema } from "@domain/entity-contact";
+import { ContactAddressLabelSchema, ContactAddressValueSchema } from "@domain/entity-contact";
+import { createInitialEditAddressEntryState } from "./addressEntryValidation";
 import { createRenameAddressViewModel } from "./viewModel";
 
 describe("createRenameAddressViewModel", () => {
   const currentLabel = "Ethereum";
+  const currentAddress = ContactAddressValueSchema.parse(
+    "0x1234567890123456789012345678901234567890",
+  );
   const existingLabels = [ContactAddressLabelSchema.parse("Polygon")];
+  const validAddressEntry = createInitialEditAddressEntryState(currentAddress);
 
   it("should enable confirm when the label changed and is valid", () => {
-    expect(createRenameAddressViewModel("Main ETH", currentLabel, existingLabels)).toEqual({
+    expect(
+      createRenameAddressViewModel(
+        "Main ETH",
+        currentLabel,
+        currentAddress,
+        validAddressEntry,
+        existingLabels,
+      ),
+    ).toEqual({
       draftLabel: "Main ETH",
       invalidLabelError: null,
       isConfirmEnabled: true,
     });
   });
 
-  it("should disable confirm when the label is unchanged", () => {
-    expect(createRenameAddressViewModel(currentLabel, currentLabel, existingLabels)).toEqual({
+  it("should enable confirm when the address changed and is valid", () => {
+    const updatedAddressEntry = createInitialEditAddressEntryState(
+      ContactAddressValueSchema.parse("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+    );
+
+    expect(
+      createRenameAddressViewModel(
+        currentLabel,
+        currentLabel,
+        currentAddress,
+        updatedAddressEntry,
+        existingLabels,
+      ),
+    ).toEqual({
+      draftLabel: currentLabel,
+      invalidLabelError: null,
+      isConfirmEnabled: true,
+    });
+  });
+
+  it("should disable confirm when the label and address are unchanged", () => {
+    expect(
+      createRenameAddressViewModel(
+        currentLabel,
+        currentLabel,
+        currentAddress,
+        validAddressEntry,
+        existingLabels,
+      ),
+    ).toEqual({
       draftLabel: currentLabel,
       invalidLabelError: null,
       isConfirmEnabled: false,
     });
   });
 
+  it("should disable confirm when the address is invalid", () => {
+    expect(
+      createRenameAddressViewModel(
+        currentLabel,
+        currentLabel,
+        currentAddress,
+        {
+          status: "invalid",
+          value: "invalid-address",
+          resolvedAddress: null,
+          inputMethod: "manual",
+          error: "invalid_format",
+        },
+        existingLabels,
+      ).isConfirmEnabled,
+    ).toBe(false);
+  });
+
   it("should expose duplicate label validation errors", () => {
     expect(
-      createRenameAddressViewModel("Polygon", currentLabel, existingLabels).invalidLabelError,
+      createRenameAddressViewModel(
+        "Polygon",
+        currentLabel,
+        currentAddress,
+        validAddressEntry,
+        existingLabels,
+      ).invalidLabelError,
     ).toBe("DuplicateContactAddressLabelError");
   });
 });

--- a/features/flow/contacts/src/steps/EditAddress/types.ts
+++ b/features/flow/contacts/src/steps/EditAddress/types.ts
@@ -5,7 +5,19 @@ import type {
   ContactAddressLabelValidationErrorName,
   ContactId,
 } from "@domain/entity-contact";
+import type {
+  AddAddressEntryState,
+  AddAddressInputMethod,
+  AddAddressInputSource,
+} from "../AddAddress/types";
 import type { ContactAddressEditPort } from "../Detail/model/ports";
+
+export type ContactAddressEditSavePayload = Readonly<{
+  currencyId: ContactAddress["currencyId"] | undefined;
+  inputMethod: AddAddressInputMethod | null;
+  labelChanged: boolean;
+  addressChanged: boolean;
+}>;
 
 export type RenameAddressViewModel = Readonly<{
   draftLabel: string;
@@ -17,9 +29,11 @@ export type RenameAddressDialogViewModel = RenameAddressViewModel &
   Readonly<{
     isOpen: boolean;
     isSaving: boolean;
+    addressEntry: AddAddressEntryState;
     onOpen: () => void;
     onClose: () => void;
     onDraftLabelChange: (label: string) => void;
+    onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
     onConfirm: () => Promise<void>;
   }>;
 
@@ -27,9 +41,30 @@ export type UseRenameAddressDialogViewModelOptions = Readonly<{
   contactId: ContactId;
   addressId: ContactAddressId;
   currentLabel: string;
+  currentAddress: ContactAddress["address"] | undefined;
+  currencyId: ContactAddress["currencyId"] | undefined;
   existingLabels: readonly ContactAddressLabel[];
   editPort: ContactAddressEditPort;
-  onSaveSuccess: () => void;
+  onSaveSuccess?: (payload: ContactAddressEditSavePayload) => void;
+}>;
+
+export type ContactsEditAddressValidationLabels = Readonly<{
+  addressPlaceholder: string;
+  validatingAddress: string;
+  validAddress: string;
+  invalidAddress: string;
+  domainNotFound: string;
+  sanctionedAddress: string;
+  validationUnavailable: string;
+  ensDisclaimer: string;
+}>;
+
+export type EditAddressAddressEntryPresentation = Readonly<{
+  value: string;
+  inputStatus?: "error" | "success";
+  helperText?: string;
+  showEnsDisclaimer: boolean;
+  onChangeText: (value: string) => void;
 }>;
 
 export type ContactsRenameAddressLabels = Readonly<{
@@ -37,6 +72,7 @@ export type ContactsRenameAddressLabels = Readonly<{
   inputLabel: string;
   applyChanges: string;
   labelValidationErrors: Readonly<Record<ContactAddressLabelValidationErrorName, string>>;
+  addressValidation: ContactsEditAddressValidationLabels;
 }>;
 
 export type ContactsRenameAddressDialogProps = RenameAddressDialogViewModel &
@@ -50,22 +86,19 @@ export type ContactsRenameAddressDrawerProps = RenameAddressDialogViewModel &
     labels: ContactsRenameAddressLabels;
   }>;
 
-export type RenameAddressSaveInput = Readonly<{
-  contactId: ContactId;
-  addressId: ContactAddressId;
-  label: ContactAddressLabel;
-}>;
-
 export type RenameAddressController = Readonly<{
   getViewModel: (
     draftLabel: string,
     currentLabel: string,
+    currentAddress: ContactAddress["address"] | undefined,
+    addressEntry: AddAddressEntryState,
     existingLabels: readonly ContactAddressLabel[],
   ) => RenameAddressViewModel;
   save: (
     contactId: ContactId,
     addressId: ContactAddressId,
     draftLabel: string,
+    addressEntry: AddAddressEntryState,
     existingLabels: readonly ContactAddressLabel[],
   ) => Promise<ContactAddress>;
 }>;

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntry.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntry.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ContactAddress } from "@domain/entity-contact";
+import type { AddAddressEntryState, AddAddressInputSource } from "../AddAddress/types";
+import type { ContactsAddressValidationPort } from "../AddAddress/model/addressValidation/types";
+import { wait } from "../../utils/wait";
+import {
+  addressesMatch,
+  applyAddressEntryState,
+  createInitialEditAddressEntryState,
+  createValidatingAddressEntryState,
+  EMPTY_EDIT_ADDRESS_ENTRY_STATE,
+  requestAddressValidation,
+  resolveAddressEntryState,
+} from "./model/addressEntryValidation";
+
+const UNAVAILABLE_ADDRESS_VALIDATION: ContactsAddressValidationPort = {
+  validateAddress: async () => ({ status: "unavailable" }),
+};
+
+export type UseEditAddressAddressEntryOptions = Readonly<{
+  addressValidation?: ContactsAddressValidationPort;
+  currencyId: ContactAddress["currencyId"] | undefined;
+  currentAddress: ContactAddress["address"] | undefined;
+  isActive: boolean;
+  manualValidationDebounceMs?: number;
+}>;
+
+export type UseEditAddressAddressEntryResult = Readonly<{
+  addressEntry: AddAddressEntryState;
+  onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
+}>;
+
+export function useEditAddressAddressEntry({
+  addressValidation = UNAVAILABLE_ADDRESS_VALIDATION,
+  currencyId,
+  currentAddress,
+  isActive,
+  manualValidationDebounceMs = 0,
+}: UseEditAddressAddressEntryOptions): UseEditAddressAddressEntryResult {
+  const [addressEntry, setAddressEntry] = useState<AddAddressEntryState>(() =>
+    currentAddress === undefined
+      ? EMPTY_EDIT_ADDRESS_ENTRY_STATE
+      : createInitialEditAddressEntryState(currentAddress),
+  );
+  const validationRequestId = useRef(0);
+  const wasActiveRef = useRef(false);
+  const hasInitializedRef = useRef(currentAddress !== undefined);
+
+  useEffect(() => {
+    const didOpen = isActive && !wasActiveRef.current;
+
+    if (didOpen) {
+      hasInitializedRef.current = false;
+      setAddressEntry(
+        currentAddress !== undefined
+          ? createInitialEditAddressEntryState(currentAddress)
+          : EMPTY_EDIT_ADDRESS_ENTRY_STATE,
+      );
+      validationRequestId.current += 1;
+      if (currentAddress !== undefined) {
+        hasInitializedRef.current = true;
+      }
+    } else if (isActive && !hasInitializedRef.current && currentAddress !== undefined) {
+      setAddressEntry(createInitialEditAddressEntryState(currentAddress));
+      validationRequestId.current += 1;
+      hasInitializedRef.current = true;
+    }
+
+    if (!isActive) {
+      hasInitializedRef.current = false;
+    }
+
+    wasActiveRef.current = isActive;
+  }, [currentAddress, isActive]);
+
+  useEffect(
+    () => () => {
+      validationRequestId.current += 1;
+    },
+    [],
+  );
+
+  const onAddressChange = useCallback(
+    (value: string, inputMethod: AddAddressInputSource) => {
+      const normalizedAddress = value.trim();
+      const requestId = validationRequestId.current + 1;
+      validationRequestId.current = requestId;
+
+      if (normalizedAddress.length === 0) {
+        setAddressEntry(EMPTY_EDIT_ADDRESS_ENTRY_STATE);
+        return;
+      }
+
+      if (currentAddress !== undefined && addressesMatch(normalizedAddress, currentAddress)) {
+        setAddressEntry(createInitialEditAddressEntryState(currentAddress));
+        return;
+      }
+
+      if (currencyId === undefined) {
+        setAddressEntry({
+          status: "unavailable",
+          value,
+          resolvedAddress: null,
+          inputMethod,
+        });
+        return;
+      }
+
+      setAddressEntry(createValidatingAddressEntryState(value, inputMethod));
+
+      void (async () => {
+        if (inputMethod === "manual" && manualValidationDebounceMs > 0) {
+          await wait(manualValidationDebounceMs);
+          if (validationRequestId.current !== requestId) {
+            return;
+          }
+        }
+
+        const validationResult = await requestAddressValidation(
+          addressValidation,
+          currencyId,
+          normalizedAddress,
+        );
+
+        if (validationRequestId.current !== requestId) {
+          return;
+        }
+
+        setAddressEntry(currentEntry =>
+          applyAddressEntryState(
+            currentEntry,
+            resolveAddressEntryState(value, inputMethod, validationResult),
+            value,
+          ),
+        );
+      })();
+    },
+    [addressValidation, currencyId, currentAddress, manualValidationDebounceMs],
+  );
+
+  return { addressEntry, onAddressChange };
+}

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntry.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntry.web.test.ts
@@ -1,0 +1,187 @@
+import { act, renderHook } from "@testing-library/react";
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { mockContactAddress } from "@domain/entity-contact/schema.mock";
+import type { ContactsAddressValidationPort } from "../AddAddress/model/addressValidation/types";
+import { useEditAddressAddressEntry } from "./useEditAddressAddressEntry";
+
+describe("useEditAddressAddressEntry", () => {
+  const mockAddress = mockContactAddress();
+  const currentAddress = mockAddress.address;
+  const currencyId = mockAddress.currencyId;
+  const validAddress = ContactAddressValueSchema.parse(
+    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+  );
+
+  function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(res => {
+      resolve = res;
+    });
+
+    return { promise, resolve };
+  }
+
+  function createValidationPort(
+    validateAddress: ContactsAddressValidationPort["validateAddress"],
+  ): ContactsAddressValidationPort {
+    return { validateAddress };
+  }
+
+  it("should recover to valid after an invalid address edit", async () => {
+    const validateAddress = jest
+      .fn<
+        ReturnType<ContactsAddressValidationPort["validateAddress"]>,
+        Parameters<ContactsAddressValidationPort["validateAddress"]>
+      >()
+      .mockResolvedValueOnce({ status: "invalid_format", isDomain: false })
+      .mockResolvedValueOnce({ status: "valid", resolvedAddress: validAddress, isDomain: false });
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntry({
+        addressValidation: createValidationPort(validateAddress),
+        currencyId,
+        currentAddress,
+        isActive: true,
+      }),
+    );
+
+    await act(async () => {
+      result.current.onAddressChange("invalid-address", "manual");
+    });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "invalid",
+      value: "invalid-address",
+    });
+
+    await act(async () => {
+      result.current.onAddressChange(validAddress, "manual");
+      await Promise.resolve();
+    });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "valid",
+      value: validAddress,
+      resolvedAddress: validAddress,
+    });
+  });
+
+  it("should ignore stale validation results for outdated input values", async () => {
+    const deferredValidation =
+      createDeferred<Awaited<ReturnType<ContactsAddressValidationPort["validateAddress"]>>>();
+    const validateAddress = jest
+      .fn<
+        ReturnType<ContactsAddressValidationPort["validateAddress"]>,
+        Parameters<ContactsAddressValidationPort["validateAddress"]>
+      >()
+      .mockReturnValueOnce(deferredValidation.promise)
+      .mockResolvedValueOnce({ status: "valid", resolvedAddress: validAddress, isDomain: false });
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntry({
+        addressValidation: createValidationPort(validateAddress),
+        currencyId,
+        currentAddress,
+        isActive: true,
+      }),
+    );
+
+    act(() => {
+      result.current.onAddressChange("invalid-address", "manual");
+    });
+
+    act(() => {
+      result.current.onAddressChange(validAddress, "manual");
+    });
+
+    await act(async () => {
+      deferredValidation.resolve({ status: "invalid_format", isDomain: false });
+      await Promise.resolve();
+    });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "valid",
+      value: validAddress,
+      resolvedAddress: validAddress,
+    });
+  });
+
+  it("should restore the initial valid state when the saved address is re-entered", async () => {
+    const validateAddress = jest
+      .fn<
+        ReturnType<ContactsAddressValidationPort["validateAddress"]>,
+        Parameters<ContactsAddressValidationPort["validateAddress"]>
+      >()
+      .mockResolvedValue({ status: "invalid_format", isDomain: false });
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntry({
+        addressValidation: createValidationPort(validateAddress),
+        currencyId,
+        currentAddress,
+        isActive: true,
+      }),
+    );
+
+    await act(async () => {
+      result.current.onAddressChange("invalid-address", "manual");
+    });
+
+    await act(async () => {
+      result.current.onAddressChange(currentAddress, "manual");
+    });
+
+    expect(validateAddress).toHaveBeenCalledTimes(1);
+    expect(validateAddress).toHaveBeenCalledWith({
+      currencyId,
+      address: "invalid-address",
+    });
+    expect(result.current.addressEntry).toMatchObject({
+      status: "valid",
+      value: currentAddress,
+      resolvedAddress: currentAddress,
+    });
+  });
+
+  it("should keep the input editable when currencyId is missing", () => {
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntry({
+        currencyId: undefined,
+        currentAddress,
+        isActive: true,
+      }),
+    );
+
+    act(() => {
+      result.current.onAddressChange("0xpending", "manual");
+    });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "unavailable",
+      value: "0xpending",
+      inputMethod: "manual",
+    });
+  });
+
+  it("should initialize when currentAddress becomes available after open", () => {
+    const { result, rerender } = renderHook(
+      ({ currentAddress: nextAddress }) =>
+        useEditAddressAddressEntry({
+          currencyId,
+          currentAddress: nextAddress,
+          isActive: true,
+        }),
+      { initialProps: { currentAddress: undefined as typeof currentAddress | undefined } },
+    );
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "empty",
+      value: "",
+    });
+
+    rerender({ currentAddress });
+
+    expect(result.current.addressEntry).toMatchObject({
+      status: "valid",
+      value: currentAddress,
+      resolvedAddress: currentAddress,
+    });
+  });
+});

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntryPresentation.native.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntryPresentation.native.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
+import { useEditAddressAddressEntryPresentation } from "./useEditAddressAddressEntryPresentation.native";
+
+const labels = {
+  addressPlaceholder: "Address",
+  validatingAddress: "Validating",
+  validAddress: "Valid",
+  invalidAddress: "Invalid",
+  domainNotFound: "Domain not found",
+  sanctionedAddress: "Sanctioned",
+  validationUnavailable: "Unavailable",
+  ensDisclaimer: "ENS disclaimer",
+};
+
+describe("useEditAddressAddressEntryPresentation", () => {
+  it("should expose validation presentation for a valid address entry", () => {
+    const currentAddress = createInitialEditAddressEntryState(
+      ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
+    );
+    const onAddressChange = jest.fn();
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntryPresentation({
+        addressEntry: currentAddress,
+        labels,
+        onAddressChange,
+      }),
+    );
+
+    expect(result.current).toMatchObject({
+      value: currentAddress.value,
+      inputStatus: "success",
+      helperText: "Valid",
+      showEnsDisclaimer: false,
+    });
+  });
+
+  it("should classify multi-character native edits as paste", () => {
+    const currentAddress = createInitialEditAddressEntryState(
+      ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
+    );
+    const onAddressChange = jest.fn();
+    const { result } = renderHook(() =>
+      useEditAddressAddressEntryPresentation({
+        addressEntry: currentAddress,
+        labels,
+        onAddressChange,
+      }),
+    );
+
+    act(() => {
+      result.current.onChangeText("0x1234567890123456789012345678901234567891");
+    });
+
+    expect(onAddressChange).toHaveBeenCalledWith(
+      "0x1234567890123456789012345678901234567891",
+      "manual",
+    );
+
+    act(() => {
+      result.current.onChangeText("0xpasted1234567890123456789012345678901234567890");
+    });
+
+    expect(onAddressChange).toHaveBeenLastCalledWith(
+      "0xpasted1234567890123456789012345678901234567890",
+      "paste",
+    );
+  });
+});

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntryPresentation.native.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressAddressEntryPresentation.native.ts
@@ -1,0 +1,37 @@
+import { useCallback, useMemo } from "react";
+import { resolveAddressInputPresentation } from "../AddAddress/model/addressInputPresentation";
+import type { AddAddressEntryState, AddAddressInputSource } from "../AddAddress/types";
+import { classifyNativeAddressInputMethod } from "../../utils/classifyNativeAddressInputMethod";
+import type {
+  ContactsEditAddressValidationLabels,
+  EditAddressAddressEntryPresentation,
+} from "./types";
+
+export function useEditAddressAddressEntryPresentation({
+  addressEntry,
+  labels,
+  onAddressChange,
+}: Readonly<{
+  addressEntry: AddAddressEntryState;
+  labels: ContactsEditAddressValidationLabels;
+  onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
+}>): EditAddressAddressEntryPresentation {
+  const presentation = useMemo(
+    () => resolveAddressInputPresentation(addressEntry, labels),
+    [addressEntry, labels],
+  );
+  const onChangeText = useCallback(
+    (value: string) => {
+      onAddressChange(value, classifyNativeAddressInputMethod(addressEntry.value, value));
+    },
+    [addressEntry.value, onAddressChange],
+  );
+
+  return {
+    value: addressEntry.value,
+    inputStatus: presentation.inputStatus,
+    helperText: presentation.helperText,
+    showEnsDisclaimer: presentation.showEnsDisclaimer,
+    onChangeText,
+  };
+}

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressDialogPresentation.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressDialogPresentation.web.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ClipboardEvent } from "react";
+import { ContactAddressValueSchema } from "@domain/entity-contact";
+import { createInitialEditAddressEntryState } from "./model/addressEntryValidation";
+import { useEditAddressDialogPresentation } from "./useEditAddressDialogPresentation.web";
+
+const labels = {
+  addressPlaceholder: "Address",
+  validatingAddress: "Validating",
+  validAddress: "Valid",
+  invalidAddress: "Invalid",
+  domainNotFound: "Domain not found",
+  sanctionedAddress: "Sanctioned",
+  validationUnavailable: "Unavailable",
+  ensDisclaimer: "ENS disclaimer",
+};
+
+describe("useEditAddressDialogPresentation", () => {
+  it("should expose validation presentation for a valid address entry", () => {
+    const addressEntry = createInitialEditAddressEntryState(
+      ContactAddressValueSchema.parse("0x1234567890123456789012345678901234567890"),
+    );
+    const onAddressChange = jest.fn();
+    const { result } = renderHook(() =>
+      useEditAddressDialogPresentation({
+        addressEntry,
+        labels,
+        onAddressChange,
+      }),
+    );
+
+    expect(result.current).toMatchObject({
+      value: addressEntry.value,
+      inputStatus: "success",
+      helperText: "Valid",
+      showEnsDisclaimer: false,
+    });
+  });
+
+  it("should prevent default paste and forward the pasted value", () => {
+    const addressEntry = {
+      status: "valid" as const,
+      value: "0x12",
+      resolvedAddress: ContactAddressValueSchema.parse(
+        "0x1234567890123456789012345678901234567890",
+      ),
+      inputMethod: "manual" as const,
+    };
+    const onAddressChange = jest.fn();
+    const preventDefault = jest.fn();
+    const { result } = renderHook(() =>
+      useEditAddressDialogPresentation({
+        addressEntry,
+        labels,
+        onAddressChange,
+      }),
+    );
+
+    act(() => {
+      result.current.onPaste({
+        currentTarget: { selectionStart: 4, selectionEnd: 4 },
+        clipboardData: { getData: () => "34" },
+        preventDefault,
+      } as unknown as ClipboardEvent<HTMLInputElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onAddressChange).toHaveBeenCalledWith("0x1234", "paste");
+  });
+});

--- a/features/flow/contacts/src/steps/EditAddress/useEditAddressDialogPresentation.web.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useEditAddressDialogPresentation.web.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, type ChangeEvent, type ClipboardEvent } from "react";
+import { resolveAddressInputPresentation } from "../AddAddress/model/addressInputPresentation";
+import type { AddAddressEntryState, AddAddressInputSource } from "../AddAddress/types";
+import { getPastedValue } from "../../utils/getPastedValue.web";
+import type { ContactsEditAddressValidationLabels } from "./types";
+
+export function useEditAddressDialogPresentation({
+  addressEntry,
+  labels,
+  onAddressChange,
+}: Readonly<{
+  addressEntry: AddAddressEntryState;
+  labels: ContactsEditAddressValidationLabels;
+  onAddressChange: (value: string, inputMethod: AddAddressInputSource) => void;
+}>) {
+  const presentation = useMemo(
+    () => resolveAddressInputPresentation(addressEntry, labels),
+    [addressEntry, labels],
+  );
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => onAddressChange(event.target.value, "manual"),
+    [onAddressChange],
+  );
+  const onPaste = useCallback(
+    (event: ClipboardEvent<HTMLInputElement>) => {
+      event.preventDefault();
+      onAddressChange(getPastedValue(addressEntry.value, event), "paste");
+    },
+    [addressEntry.value, onAddressChange],
+  );
+
+  return {
+    value: addressEntry.value,
+    ...presentation,
+    onChange,
+    onPaste,
+  };
+}

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.ts
@@ -1,29 +1,51 @@
 import { CONTACT_ADDRESS_LABEL_MAX_LENGTH } from "@domain/entity-contact";
 import { useCallback, useEffect, useState } from "react";
+import type { ContactsAddressValidationPort } from "../AddAddress/model/addressValidation/types";
+import { useEditAddressAddressEntry } from "./useEditAddressAddressEntry";
 import { useRenameAddressViewModel } from "./useRenameAddressViewModel";
 import type { RenameAddressDialogViewModel, UseRenameAddressDialogViewModelOptions } from "./types";
+
+export type UseRenameAddressDialogViewModelOptionsWithValidation =
+  UseRenameAddressDialogViewModelOptions &
+    Readonly<{
+      addressValidation?: ContactsAddressValidationPort;
+      manualValidationDebounceMs?: number;
+    }>;
 
 export function useRenameAddressDialogViewModel({
   contactId,
   addressId,
   currentLabel,
+  currentAddress,
+  currencyId,
   existingLabels,
   editPort,
+  addressValidation,
+  manualValidationDebounceMs,
   isRequestedOpen,
   onCloseRequest,
   onSaveSuccess,
-}: UseRenameAddressDialogViewModelOptions &
+}: UseRenameAddressDialogViewModelOptionsWithValidation &
   Readonly<{
     isRequestedOpen: boolean;
     onCloseRequest: () => void;
   }>): RenameAddressDialogViewModel {
   const [draftLabel, setDraftLabel] = useState(currentLabel);
   const [isSaving, setIsSaving] = useState(false);
+  const { addressEntry, onAddressChange } = useEditAddressAddressEntry({
+    addressValidation,
+    currencyId,
+    currentAddress,
+    isActive: isRequestedOpen,
+    manualValidationDebounceMs,
+  });
   const { invalidLabelError, isConfirmEnabled, save } = useRenameAddressViewModel(
     contactId,
     addressId,
     currentLabel,
+    currentAddress,
     draftLabel,
+    addressEntry,
     existingLabels,
     editPort,
   );
@@ -53,24 +75,46 @@ export function useRenameAddressDialogViewModel({
 
     try {
       await save();
-      onSaveSuccess();
+      const addressChanged =
+        addressEntry.status === "valid" &&
+        currentAddress !== undefined &&
+        addressEntry.resolvedAddress !== currentAddress;
+      onSaveSuccess?.({
+        currencyId,
+        inputMethod: addressChanged ? addressEntry.inputMethod : null,
+        labelChanged: draftLabel.trim() !== currentLabel.trim(),
+        addressChanged,
+      });
       onCloseRequest();
     } catch {
       return;
     } finally {
       setIsSaving(false);
     }
-  }, [isConfirmEnabled, isSaving, onCloseRequest, onSaveSuccess, save]);
+  }, [
+    addressEntry,
+    currencyId,
+    currentAddress,
+    currentLabel,
+    draftLabel,
+    isConfirmEnabled,
+    isSaving,
+    onCloseRequest,
+    onSaveSuccess,
+    save,
+  ]);
 
   return {
     isOpen: isRequestedOpen,
     isSaving,
     draftLabel,
     invalidLabelError,
+    addressEntry,
     isConfirmEnabled: isConfirmEnabled && !isSaving,
     onOpen: () => undefined,
     onClose,
     onDraftLabelChange,
+    onAddressChange,
     onConfirm,
   };
 }

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressDialogViewModel.web.test.ts
@@ -10,7 +10,7 @@ describe("useRenameAddressDialogViewModel", () => {
 
   function createEditPort(overrides: Partial<ContactAddressEditPort> = {}): ContactAddressEditPort {
     return {
-      renameAddressLabel: jest.fn().mockResolvedValue(
+      updateAddress: jest.fn().mockResolvedValue(
         contactAddress({
           ...address,
           label: "Main ETH",
@@ -29,6 +29,8 @@ describe("useRenameAddressDialogViewModel", () => {
           contactId: contact.id,
           addressId: address.id,
           currentLabel: address.label,
+          currentAddress: address.address,
+          currencyId: address.currencyId,
           existingLabels: [],
           editPort: createEditPort(),
           isRequestedOpen,
@@ -45,12 +47,13 @@ describe("useRenameAddressDialogViewModel", () => {
 
     rerender({ isRequestedOpen: true });
     expect(result.current.draftLabel).toBe(address.label);
+    expect(result.current.addressEntry.value).toBe(address.address);
   });
 
   it("should save, notify success, and close when confirm succeeds", async () => {
     const onCloseRequest = jest.fn();
     const onSaveSuccess = jest.fn();
-    const renameAddressLabel = jest.fn().mockResolvedValue(
+    const updateAddress = jest.fn().mockResolvedValue(
       contactAddress({
         ...address,
         label: "Main ETH",
@@ -61,8 +64,10 @@ describe("useRenameAddressDialogViewModel", () => {
         contactId: contact.id,
         addressId: address.id,
         currentLabel: address.label,
+        currentAddress: address.address,
+        currencyId: address.currencyId,
         existingLabels: [],
-        editPort: createEditPort({ renameAddressLabel }),
+        editPort: createEditPort({ updateAddress }),
         isRequestedOpen: true,
         onCloseRequest,
         onSaveSuccess,
@@ -77,13 +82,54 @@ describe("useRenameAddressDialogViewModel", () => {
       await result.current.onConfirm();
     });
 
-    expect(renameAddressLabel).toHaveBeenCalledWith({
+    expect(updateAddress).toHaveBeenCalledWith({
       contactId: contact.id,
       addressId: address.id,
       label: "Main ETH",
+      address: address.address,
     });
-    expect(onSaveSuccess).toHaveBeenCalledTimes(1);
+    expect(onSaveSuccess).toHaveBeenCalledWith({
+      currencyId: address.currencyId,
+      inputMethod: null,
+      labelChanged: true,
+      addressChanged: false,
+    });
     expect(onCloseRequest).toHaveBeenCalledTimes(1);
     expect(result.current.isSaving).toBe(false);
+  });
+
+  it("should still notify save success when currencyId is missing", async () => {
+    const onCloseRequest = jest.fn();
+    const onSaveSuccess = jest.fn();
+    const { result } = renderHook(() =>
+      useRenameAddressDialogViewModel({
+        contactId: contact.id,
+        addressId: address.id,
+        currentLabel: address.label,
+        currentAddress: address.address,
+        currencyId: undefined,
+        existingLabels: [],
+        editPort: createEditPort(),
+        isRequestedOpen: true,
+        onCloseRequest,
+        onSaveSuccess,
+      }),
+    );
+
+    act(() => {
+      result.current.onDraftLabelChange("Main ETH");
+    });
+
+    await act(async () => {
+      await result.current.onConfirm();
+    });
+
+    expect(onSaveSuccess).toHaveBeenCalledWith({
+      currencyId: undefined,
+      inputMethod: null,
+      labelChanged: true,
+      addressChanged: false,
+    });
+    expect(onCloseRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
+++ b/features/flow/contacts/src/steps/EditAddress/useRenameAddressViewModel.ts
@@ -5,6 +5,7 @@ import type {
   ContactId,
 } from "@domain/entity-contact";
 import { useCallback, useMemo } from "react";
+import type { AddAddressEntryState } from "../AddAddress/types";
 import type { ContactAddressEditPort } from "../Detail/model/ports";
 import { createRenameAddressController } from "./model/controller";
 import type { RenameAddressViewModel } from "./types";
@@ -18,18 +19,27 @@ export function useRenameAddressViewModel(
   contactId: ContactId,
   addressId: ContactAddressId,
   currentLabel: string,
+  currentAddress: ContactAddress["address"] | undefined,
   draftLabel: string,
+  addressEntry: AddAddressEntryState,
   existingLabels: readonly ContactAddressLabel[],
   editPort: ContactAddressEditPort,
 ): UseRenameAddressViewModelResult {
   const controller = useMemo(() => createRenameAddressController(editPort), [editPort]);
   const viewModel = useMemo(
-    () => controller.getViewModel(draftLabel, currentLabel, existingLabels),
-    [controller, currentLabel, draftLabel, existingLabels],
+    () =>
+      controller.getViewModel(
+        draftLabel,
+        currentLabel,
+        currentAddress,
+        addressEntry,
+        existingLabels,
+      ),
+    [addressEntry, controller, currentAddress, currentLabel, draftLabel, existingLabels],
   );
   const save = useCallback(
-    () => controller.save(contactId, addressId, draftLabel, existingLabels),
-    [addressId, contactId, controller, draftLabel, existingLabels],
+    () => controller.save(contactId, addressId, draftLabel, addressEntry, existingLabels),
+    [addressEntry, addressId, contactId, controller, draftLabel, existingLabels],
   );
 
   return {

--- a/features/platform/contacts/src/contactDeviceIntentsPort.test.ts
+++ b/features/platform/contacts/src/contactDeviceIntentsPort.test.ts
@@ -52,6 +52,7 @@ describe("createMockContactDeviceIntentsPort", () => {
         contact,
         address,
         label: ContactAddressLabelSchema.parse("Treasury"),
+        updatedAddress: address.address,
       }),
     ).resolves.toMatchObject({
       blockchainFamily: address.device.blockchainFamily,

--- a/features/platform/contacts/src/contactDeviceIntentsPort.ts
+++ b/features/platform/contacts/src/contactDeviceIntentsPort.ts
@@ -33,6 +33,7 @@ export type EditExternalAddressScopeIntentInput = Readonly<{
   contact: Contact;
   address: ContactAddress;
   label: ContactAddressLabel;
+  updatedAddress: ContactAddressValue;
 }>;
 
 export type ContactDeviceIntentsPort = Readonly<{


### PR DESCRIPTION
<!-- Create all pull requests in Draft. Automated checks must pass before making your pull request "Ready for review". See CONTRIBUTING.md for guidelines. -->

### 📝 Description

Users could only change the address **label** in Contacts Edit Address. This PR lets them update the **wallet address** as well, using the same validation rules as Add Address.

Stacked on #20881 (shared address-entry helpers). App wiring is #20882.

**Flow (`@features/flow-contacts`)**
- Edit Address dialog includes an editable address input, pre-filled with the saved value
- Address validation reuses the Add Address pipeline (format, ENS, sanctions, unavailable states)
- Save is blocked until both label and address are valid and at least one value changed
- `ContactAddressEditPort` extended from label-only rename to `updateAddress` (label + address)
- Validation state fixes: stale async results no longer stick after invalid → valid transitions; restoring the original address short-circuits without re-validation

**Platform (`@features/platform-contacts`)**
- `editExternalAddressScope` device intent accepts `updatedAddress`

Desktop/mobile adapter wiring, analytics, and integration tests are in #20882.

https://github.com/user-attachments/assets/bd7cc0e3-b4b4-4d29-a445-48ad67b6cf90

### 🔗 Context

[LIVE-35836](https://ledgerhq.atlassian.net/browse/LIVE-35836)

[LIVE-35836]: https://ledgerhq.atlassian.net/browse/LIVE-35836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ